### PR TITLE
fix: add typing_extensions for Python 3.13 compatibility (keeps 3.12 …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ slack-sdk>=3.26.0
 aiohttp>=3.8.0
 telegramify-markdown>=0.5.0
 markdown_to_mrkdwn>=0.2.0
+typing_extensions>=4.12.2


### PR DESCRIPTION
…support)