### PR TITLE
Improve multi-agent wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Vibe Remote lets you operate coding agents via IM. Type in Slack or Telegram to 
 - **Work from anywhere**: Control coding sessions over Slack/Telegram; no IDE tether.
 - **Extensible by design**: Starts with Claude Code and Codex, built to support additional coding agents/CLIs.
 - **Multi-agent routing**: Route each Slack channel / Telegram chat to Claude Code or Codex by editing `agent_routes.yaml`.
-- **Session persistence by thread + path**: Each Slack thread/Telegram chat maintains its own Claude session and working dir; auto‑resume via saved mappings.
+- **Session persistence by thread + path**: Each Slack thread/Telegram chat maintains its own agent session and working dir; auto‑resume via saved mappings.
 - **Interactive Slack UX**: `/start` menu + Settings/CWD modals; buttons over commands for faster flow.
 
 > Recommendation: Prefer Slack as the primary platform. Threaded conversations enable parallel subtasks and keep channel history tidy — each subtask stays in its own thread.
@@ -138,7 +138,7 @@ telegram:
 - Slack routes use channel IDs; Telegram routes use chat IDs. Unlisted channels fall back to the per-platform default (then to the global `default`). `agent_routes.yaml` is gitignored so each environment can customize it safely.
 
 - See [docs/CODEX_SETUP.md](docs/CODEX_SETUP.md) for a step‑by‑step guide to installing Codex CLI and configuring routing.
-- No file? Everything routes to Claude.
+- No file? Everything routes to the global default agent (Claude unless overridden).
 
 ### App
 
@@ -174,7 +174,7 @@ telegram:
 
 ## Roadmap
 
-- Additional coding CLIs/agents beyond Claude Code
+- Additional coding CLIs/agents beyond the current built-in set
 - More IM platforms (Discord, Teams)
 - File upload/attachments piping to coding sessions
 - Advanced session policies & permissions

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -27,7 +27,7 @@ Vibe Remote 把 AI 写代码搬到聊天软件。你在 Slack/Telegram 输入意
 - **随时随地**：不被 IDE 束缚，直接在 Slack/Telegram 中远程操控编码会话。
 - **为扩展而生**：目前已支持 Claude Code + Codex，并可扩展到更多 coding agents/CLIs。
 - **多 Agent 路由**：为不同 Slack Channel / Telegram Chat 指定 Agent，互不干扰。
-- **按线程 + 路径持久化**：每个 Slack 线程/Telegram 对话都维持独立 Claude 会话与工作目录，并通过持久化映射自动恢复。
+- **按线程 + 路径持久化**：每个 Slack 线程/Telegram 对话都维持独立 Agent 会话与工作目录，并通过持久化映射自动恢复。
 - **Slack 交互式体验**：`/start` 菜单 + Settings/CWD 模态，按钮优先于命令，更快上手。
 
 > 推荐：优先使用 Slack 作为主要平台。其线程模型更适合并行子任务，也能保持频道历史整洁（每个子任务都在各自的线程里）。
@@ -136,7 +136,7 @@ telegram:
 ```
 
 - Slack 使用频道 ID，Telegram 使用聊天 ID。未命中的频道会落到平台默认值，然后回退到全局 `default`。`agent_routes.yaml` 已被 `.gitignore` 排除，可在不同环境独立配置。
-- 若未提供文件，则所有渠道继续使用 Claude。参见 [docs/CODEX_SETUP.md](docs/CODEX_SETUP.md) 获取更完整的 Codex 配置示例。
+- 若未提供文件，则所有渠道沿用全局默认 Agent（默认是 Claude）。参见 [docs/CODEX_SETUP.md](docs/CODEX_SETUP.md) 获取更完整的 Codex 配置示例。
 
 ### 应用
 
@@ -172,7 +172,7 @@ telegram:
 
 ## Roadmap
 
-- 扩展到更多编码 CLI/agents（超越 Claude Code）
+- 扩展到更多编码 CLI/agents（超越当前内置 Agent）
 - 更多 IM 平台（Discord、Teams）
 - 文件上传/附件到编码会话的管道化
 - 更细粒度的会话策略与权限

--- a/docs/SLACK_SETUP.md
+++ b/docs/SLACK_SETUP.md
@@ -309,11 +309,11 @@ The bot supports multiple ways to interact:
 
 - `/stop` - Stop the current Vibe Remote session
 
-#### Sending Messages to Claude
+#### Sending Messages to Your Agent
 
 After using `/start`, simply type your message in the channel. The bot will:
 
-1. Send your message to Claude Code
+1. Send your message to the configured coding agent
 2. Stream the response back in real-time
 3. Maintain conversation context for follow-ups
 
@@ -322,7 +322,7 @@ After using `/start`, simply type your message in the channel. The bot will:
 The Slack bot automatically uses threads to organize conversations:
 
 - Each user's messages are grouped in a thread
-- Responses from Claude Code appear in the same thread
+- Responses from the configured agent appear in the same thread
 - This keeps channel history clean and organized
 
 ## Troubleshooting

--- a/docs/SLACK_SETUP_ZH.md
+++ b/docs/SLACK_SETUP_ZH.md
@@ -165,7 +165,7 @@ Usage Hint: 启动 Vibe Remote 并显示菜单
 2. 填写 **"Command"** 字段：`/start`
 3. **"Request URL"** 留空
 4. 填写 **"Short Description"**：`打开带有交互按钮的主菜单`
-5. 填写 **"Usage Hint"**：`启动 Claude Code 机器人并显示菜单`
+5. 填写 **"Usage Hint"**：`启动 Agent 会话并显示菜单`
 6. ✅ 勾选"Escape channels, users, and links"
 7. 点击 **"Save"**
 8. 返回 Slash Commands 页面
@@ -184,7 +184,7 @@ Usage Hint: 停止当前机器人会话
 1. 点击 **"Create New Command"**
 2. 填写 **"Command"** 字段：`/stop`
 3. **"Request URL"** 留空
-4. 填写 **"Short Description"**：`停止 Claude Code 机器人会话`
+4. 填写 **"Short Description"**：`停止当前 Agent 会话`
 5. 填写 **"Usage Hint"**：`停止当前机器人会话`
 6. ✅ 勾选"Escape channels, users, and links"
 7. 点击 **"Save"**
@@ -309,11 +309,11 @@ python main.py
 
 - `/stop` - 停止当前 Vibe Remote 会话
 
-#### 向 Claude 发送消息
+#### 向 Agent 发送消息
 
 使用 `/start` 后，只需在频道中输入你的消息。机器人将：
 
-1. 将你的消息发送到 Claude Code
+1. 将你的消息发送到已配置的 Agent
 2. 实时流式传输响应
 3. 为后续消息维护对话上下文
 
@@ -322,7 +322,7 @@ python main.py
 Slack 机器人自动使用线程来组织对话：
 
 - 每个用户的消息都分组在一个线程中
-- Claude Code 的响应出现在同一线程中
+- Agent 的响应出现在同一线程中
 - 这使频道历史记录保持整洁有序
 
 ## 故障排除

--- a/docs/TELEGRAM_SETUP.md
+++ b/docs/TELEGRAM_SETUP.md
@@ -82,7 +82,7 @@ TELEGRAM_BOT_TOKEN=your-bot-token-here
 # Optional: Whitelist specific chat IDs (null = all chats allowed)
 TELEGRAM_CHAT_ID=[-1001234567890,987654321]
 
-# Working directory for Claude Code
+# Default working directory for the coding agent
 CLAUDE_CWD=/path/to/your/project
 ```
 
@@ -140,11 +140,11 @@ The bot should now be running and ready to accept commands.
 - `/set_cwd <path>` - Change working directory
 - `/settings` - Configure message visibility and preferences
 
-### Sending Messages to Claude
+### Sending Messages to Your Agent
 
-After starting the bot, simply send any message and it will be forwarded to Claude Code. The bot will:
+After starting the bot, simply send any message and it will be forwarded to your configured agent. The bot will:
 
-1. Send your message to Claude Code
+1. Send your message to the configured agent
 2. Stream the response back in real-time
 3. Maintain conversation context for follow-ups
 
@@ -153,7 +153,7 @@ After starting the bot, simply send any message and it will be forwarded to Clau
 When using the bot in groups:
 
 - Messages must start with `/` to be processed as commands
-- Regular messages are processed as Claude queries
+- Regular messages are processed as agent queries
 - The bot maintains separate sessions for each chat
 
 ## Features
@@ -171,14 +171,14 @@ The bot supports Telegram's MarkdownV2 format:
 
 The settings command provides inline keyboard buttons for:
 
-- Show/hide raw Claude output
+- Show/hide raw agent output
 - Show/hide thinking process
 - Reset session
 - Return to main menu
 
 ### Real-time Streaming
 
-Messages from Claude are streamed in real-time:
+Messages from your agent are streamed in real-time:
 
 - Long messages are automatically split
 - Code blocks are properly formatted

--- a/docs/TELEGRAM_SETUP_ZH.md
+++ b/docs/TELEGRAM_SETUP_ZH.md
@@ -82,7 +82,7 @@ TELEGRAM_BOT_TOKEN=your-bot-token-here
 # 可选：白名单特定聊天 ID（null = 允许所有聊天）
 TELEGRAM_CHAT_ID=[-1001234567890,987654321]
 
-# Claude Code 的工作目录
+# 编码 Agent 的默认工作目录
 CLAUDE_CWD=/path/to/your/project
 ```
 
@@ -140,11 +140,11 @@ python main.py
 - `/set_cwd <路径>` - 更改工作目录
 - `/settings` - 配置消息可见性和偏好设置
 
-### 向 Claude 发送消息
+### 向 Agent 发送消息
 
-启动机器人后，只需发送任何消息，它就会被转发到 Claude Code。机器人将：
+启动机器人后，只需发送任何消息，它就会被转发到已配置的 Agent。机器人将：
 
-1. 将你的消息发送到 Claude Code
+1. 将你的消息发送到已配置的 Agent
 2. 实时流式传输响应
 3. 为后续消息维护对话上下文
 
@@ -153,7 +153,7 @@ python main.py
 在群组中使用机器人时：
 
 - 消息必须以 `/` 开头才能作为命令处理
-- 常规消息作为 Claude 查询处理
+- 常规消息作为 Agent 查询处理
 - 机器人为每个聊天维护独立的会话
 
 ## 功能特性
@@ -171,14 +171,14 @@ python main.py
 
 设置命令提供内联键盘按钮：
 
-- 显示/隐藏原始 Claude 输出
+- 显示/隐藏原始 Agent 输出
 - 显示/隐藏思考过程
 - 重置会话
 - 返回主菜单
 
 ### 实时流式传输
 
-来自 Claude 的消息实时流式传输：
+来自 Agent 的消息实时流式传输：
 
 - 长消息自动分割
 - 代码块正确格式化

--- a/modules/agents/__init__.py
+++ b/modules/agents/__init__.py
@@ -1,7 +1,28 @@
+from typing import Optional
+
 from .base import BaseAgent, AgentRequest, AgentMessage
 from .claude_agent import ClaudeAgent
 from .codex_agent import CodexAgent
 from .service import AgentService
+
+
+def get_agent_display_name(agent_name: Optional[str], fallback: Optional[str] = None) -> str:
+    """Return a friendly, title-cased display name for an agent identifier."""
+    normalized_map = {
+        "claude": "Claude",
+        "codex": "Codex",
+    }
+
+    candidate = (agent_name or fallback or "Agent").strip()
+    if not candidate:
+        candidate = "Agent"
+
+    normalized = candidate.lower()
+    friendly = normalized_map.get(normalized)
+    if friendly:
+        return friendly
+
+    return candidate.replace("_", " ").title()
 
 __all__ = [
     "AgentMessage",
@@ -10,4 +31,5 @@ __all__ = [
     "ClaudeAgent",
     "CodexAgent",
     "AgentService",
+    "get_agent_display_name",
 ]

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -802,7 +802,7 @@ class SlackBot(BaseIMClient):
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "Choose which message types to *hide* from Claude Code output. Hidden messages won't appear in your Slack workspace.",
+                        "text": "Choose which message types to *hide* from agent output. Hidden messages won't appear in your Slack workspace.",
                     },
                 },
                 {"type": "divider"},
@@ -840,7 +840,7 @@ class SlackBot(BaseIMClient):
         descriptions = {
             "system": "System initialization and status messages",
             "response": "Tool execution responses and results",
-            "assistant": "Claude's messages and explanations",
+            "assistant": "Agent responses and explanations",
             "result": "Final execution results and summaries",
         }
         return descriptions.get(msg_type, f"{msg_type} messages")


### PR DESCRIPTION
## Summary
- generalize user-facing copy so instructions reference the routed agent instead of Claude only
- centralize agent display name helper and reuse it across command/settings handlers
- update Slack/Telegram docs and UI hints to match multi-agent behavior
