### PR TITLE
fix(ui): stop OpenCode server on restart and add error logging

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -743,8 +743,8 @@ class Controller:
 
                 if not inspect.iscoroutinefunction(stop_attr):
                     stop_attr()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to stop IM client: %s", e)
 
         # Best-effort async shutdown for IM clients
         try:
@@ -759,8 +759,8 @@ class Controller:
                         pass
                 else:
                     shutdown_attr()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Failed to shutdown IM client: %s", e)
 
         # Stop OpenCode server if running
         try:

--- a/modules/agents/subagent_router.py
+++ b/modules/agents/subagent_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 from dataclasses import dataclass
@@ -7,6 +8,8 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 _PREFIX_PATTERN = re.compile(r"^([^\s:：]+)\s*[:：]\s*(.*)$", re.DOTALL)
@@ -105,7 +108,8 @@ def _find_claude_agent_dirs(root: Path) -> Iterable[Path]:
 def _parse_claude_agent_definition(path: Path) -> Optional[SubagentDefinition]:
     try:
         text = path.read_text(encoding="utf-8")
-    except Exception:
+    except Exception as e:
+        logger.debug("Failed to read subagent definition file %s: %s", path, e)
         return None
 
     if not text.startswith("---"):
@@ -118,7 +122,8 @@ def _parse_claude_agent_definition(path: Path) -> Optional[SubagentDefinition]:
     header = parts[1]
     try:
         data = _yaml_safe_load(header)
-    except Exception:
+    except Exception as e:
+        logger.debug("Failed to parse YAML header in subagent definition %s: %s", path, e)
         return None
 
     name = data.get("name")

--- a/modules/claude_client.py
+++ b/modules/claude_client.py
@@ -91,8 +91,9 @@ class ClaudeClient:
             else:
                 # If not under cwd, just return the path as is
                 return full_path
-        except:
+        except Exception as e:
             # Fallback to original path if any error
+            logger.debug("Failed to get relative path for %s: %s", full_path, e)
             return full_path
 
     def _format_tool_use_block(

--- a/modules/im/formatters/base_formatter.py
+++ b/modules/im/formatters/base_formatter.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Optional, List, Tuple, Any, Dict
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class BaseMarkdownFormatter(ABC):
@@ -614,7 +617,8 @@ class BaseMarkdownFormatter(ABC):
             try:
                 input_json = json.dumps(tool_input, indent=2, ensure_ascii=False)
                 tool_info += f"\n{self.format_code_block(input_json, 'json')}"
-            except:
+            except Exception as e:
+                logger.debug("Failed to serialize tool input as JSON: %s", e)
                 tool_info += f"\n{self.format_code_block(str(tool_input))}"
 
         return tool_info

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -775,8 +775,8 @@ class SlackBot(BaseIMClient):
                 )
                 try:
                     await self._send_unauthorized_message(channel_id)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Failed to send unauthorized message to channel %s: %s", channel_id, e)
                 return
 
             view = payload.get("view", {})

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -168,6 +168,7 @@ def control():
         runtime.write_status("stopped")
     elif action == "restart":
         runtime.stop_service()
+        _stop_opencode_server()
         runtime.ensure_config()
         service_pid = runtime.start_service()
         runtime.write_status("running", "restarted", service_pid, status.get("ui_pid"))


### PR DESCRIPTION
## Summary

- Fix: UI Dashboard restart action now properly stops the OpenCode server before restarting the main service (aligning with `vibe stop` behavior)
- Improvement: Add error logging to previously silent exception handlers for better debugging

## Changes

### Bug Fix
- `vibe/ui_server.py`: Add `_stop_opencode_server()` call in restart action

### Logging Improvements
| File | Change |
|------|--------|
| `vibe/cli.py` | Add logger, log exceptions in `_stop_opencode_server()` |
| `modules/claude_client.py` | Log path relativization failures |
| `modules/im/formatters/base_formatter.py` | Log JSON serialization failures |
| `modules/agents/opencode_agent.py` | Log process operations, session management failures |
| `modules/agents/subagent_router.py` | Log file reading, YAML parsing failures |
| `core/controller.py` | Log IM client stop/shutdown failures |
| `modules/im/slack.py` | Log unauthorized message sending failures |

## Testing
- All 13 existing tests pass