### PR TITLE
fix(claude): enable bypassPermissions mode for autonomous execution

### DIFF
--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -43,7 +43,7 @@ class AppCompatConfig:
 
 def to_app_config(v2: V2Config) -> AppCompatConfig:
     claude = ClaudeCompatConfig(
-        permission_mode="default",
+        permission_mode="bypassPermissions",
         cwd=v2.runtime.default_cwd,
         system_prompt=None,
     )


### PR DESCRIPTION
## Summary
- Changed Claude Code SDK `permission_mode` from `"default"` to `"bypassPermissions"`
- Enables fully autonomous agent execution without user approval prompts

## Background
Currently, the Claude agent uses `permission_mode="default"` in `config/v2_compat.py:46`, which requires users to manually approve each tool use during execution. This breaks the autonomous workflow and creates a poor user experience.

## Changes
- Updated `to_app_config()` to set `permission_mode="bypassPermissions"` 
- Aligns Claude agent behavior with Codex/OpenCode agents that use `--dangerously-bypass-approvals`

## Impact
- Claude agent will now execute tools autonomously without interrupting users for approval
- Consistent behavior across all agent backends (Claude, Codex, OpenCode)
- Better user experience for automated workflows

## Testing
- Verified `permission_mode` values from `claude_code_sdk.ClaudeCodeOptions` documentation
- Confirmed `"bypassPermissions"` is the correct mode for autonomous execution