### PR TITLE
feat(slack): add i18n support for Slack messages

### DIFF
--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -38,13 +38,13 @@ class RoutingSettings:
 @dataclass
 class ChannelSettings:
     enabled: bool = False
-    show_message_types: List[str] = field(
-        default_factory=lambda: DEFAULT_SHOW_MESSAGE_TYPES.copy()
-    )
+    show_message_types: List[str] = field(default_factory=lambda: DEFAULT_SHOW_MESSAGE_TYPES.copy())
     custom_cwd: Optional[str] = None
     routing: RoutingSettings = field(default_factory=RoutingSettings)
     # Per-channel require_mention override: None=use global default, True=require, False=don't require
     require_mention: Optional[bool] = None
+    # Per-channel language setting: None=use system default, "en", "zh", etc.
+    language: Optional[str] = None
 
 
 @dataclass
@@ -90,12 +90,11 @@ class SettingsStore:
             )
             channels[channel_id] = ChannelSettings(
                 enabled=channel_payload.get("enabled", False),
-                show_message_types=normalize_show_message_types(
-                    channel_payload.get("show_message_types")
-                ),
+                show_message_types=normalize_show_message_types(channel_payload.get("show_message_types")),
                 custom_cwd=channel_payload.get("custom_cwd"),
                 routing=routing,
                 require_mention=channel_payload.get("require_mention"),
+                language=channel_payload.get("language"),
             )
         self.settings = SettingsState(channels=channels)
 
@@ -118,6 +117,7 @@ class SettingsStore:
                     "codex_reasoning_effort": settings.routing.codex_reasoning_effort,
                 },
                 "require_mention": settings.require_mention,
+                "language": settings.language,
             }
         self.settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -40,9 +40,7 @@ class SettingsHandler:
 
         except Exception as e:
             logger.error(f"Error showing settings: {e}")
-            await self.im_client.send_message(
-                context, f"❌ Error showing settings: {str(e)}"
-            )
+            await self.im_client.send_message(context, f"❌ Error showing settings: {str(e)}")
 
     async def _handle_settings_traditional(self, context: MessageContext):
         """Handle settings for non-Slack platforms"""
@@ -74,9 +72,7 @@ class SettingsHandler:
                 row = []
 
         # Add info button on its own row
-        buttons.append(
-            [InlineButton("ℹ️ About Message Types", callback_data="info_msg_types")]
-        )
+        buttons.append([InlineButton("ℹ️ About Message Types", callback_data="info_msg_types")])
 
         keyboard = InlineKeyboard(buttons=buttons)
 
@@ -91,11 +87,7 @@ class SettingsHandler:
     async def _handle_settings_slack(self, context: MessageContext):
         """Handle settings for Slack using modal dialog"""
         # For slash commands or direct triggers, we might have trigger_id
-        trigger_id = (
-            context.platform_specific.get("trigger_id")
-            if context.platform_specific
-            else None
-        )
+        trigger_id = context.platform_specific.get("trigger_id") if context.platform_specific else None
 
         if trigger_id and hasattr(self.im_client, "open_settings_modal"):
             # We have trigger_id, open modal directly
@@ -108,6 +100,9 @@ class SettingsHandler:
             current_require_mention = self.settings_manager.get_require_mention_override(settings_key)
             global_require_mention = self.config.slack.require_mention
 
+            # Get current language override for this channel
+            current_language = self.settings_manager.get_language_override(settings_key)
+
             try:
                 await self.im_client.open_settings_modal(
                     trigger_id,
@@ -117,21 +112,14 @@ class SettingsHandler:
                     context.channel_id,
                     current_require_mention=current_require_mention,
                     global_require_mention=global_require_mention,
+                    current_language=current_language,
                 )
             except Exception as e:
                 logger.error(f"Error opening settings modal: {e}")
-                await self.im_client.send_message(
-                    context, "❌ Failed to open settings. Please try again."
-                )
+                await self.im_client.send_message(context, "❌ Failed to open settings. Please try again.")
         else:
             # No trigger_id, show button to open modal
-            buttons = [
-                [
-                    InlineButton(
-                        text="🛠️ Open Settings", callback_data="open_settings_modal"
-                    )
-                ]
-            ]
+            buttons = [[InlineButton(text="🛠️ Open Settings", callback_data="open_settings_modal")]]
 
             keyboard = InlineKeyboard(buttons=buttons)
 
@@ -146,9 +134,7 @@ class SettingsHandler:
         try:
             # Toggle message type visibility
             settings_key = self._get_settings_key(context)
-            is_shown = self.settings_manager.toggle_show_message_type(
-                settings_key, msg_type
-            )
+            is_shown = self.settings_manager.toggle_show_message_type(settings_key, msg_type)
 
             # Update the keyboard
             user_settings = self.settings_manager.get_user_settings(settings_key)
@@ -173,26 +159,20 @@ class SettingsHandler:
                     buttons.append(row)
                     row = []
 
-            buttons.append(
-                [InlineButton("ℹ️ About Message Types", callback_data="info_msg_types")]
-            )
+            buttons.append([InlineButton("ℹ️ About Message Types", callback_data="info_msg_types")])
 
             keyboard = InlineKeyboard(buttons=buttons)
 
             # Update message
             if context.message_id:
-                await self.im_client.edit_message(
-                    context, context.message_id, keyboard=keyboard
-                )
+                await self.im_client.edit_message(context, context.message_id, keyboard=keyboard)
 
             # Answer callback (for Telegram)
             display_name = display_names.get(msg_type, msg_type)
             action = "shown" if is_shown else "hidden"
 
             # Platform-specific callback answering
-            await self.im_client.send_message(
-                context, f"{display_name} messages are now {action}"
-            )
+            await self.im_client.send_message(context, f"{display_name} messages are now {action}")
 
         except Exception as e:
             logger.error(f"Error toggling message type {msg_type}: {e}")
@@ -225,9 +205,7 @@ class SettingsHandler:
 
         except Exception as e:
             logger.error(f"Error in info_msg_types handler: {e}", exc_info=True)
-            await self.im_client.send_message(
-                context, "❌ Error showing message types info"
-            )
+            await self.im_client.send_message(context, "❌ Error showing message types info")
 
     async def handle_info_how_it_works(self, context: MessageContext):
         """Show information about how the bot works"""
@@ -255,9 +233,7 @@ class SettingsHandler:
 
         except Exception as e:
             logger.error(f"Error in handle_info_how_it_works: {e}", exc_info=True)
-            await self.im_client.send_message(
-                context, "❌ Error showing help information"
-            )
+            await self.im_client.send_message(context, "❌ Error showing help information")
 
     async def handle_routing(self, context: MessageContext):
         """Handle routing command - show agent/model selection"""
@@ -274,17 +250,11 @@ class SettingsHandler:
                 )
         except Exception as e:
             logger.error(f"Error showing routing settings: {e}", exc_info=True)
-            await self.im_client.send_message(
-                context, f"❌ Error showing routing settings: {str(e)}"
-            )
+            await self.im_client.send_message(context, f"❌ Error showing routing settings: {str(e)}")
 
     async def _handle_routing_slack(self, context: MessageContext):
         """Handle routing for Slack using modal dialog"""
-        trigger_id = (
-            context.platform_specific.get("trigger_id")
-            if context.platform_specific
-            else None
-        )
+        trigger_id = context.platform_specific.get("trigger_id") if context.platform_specific else None
 
         if not trigger_id:
             # No trigger_id, show button to open modal
@@ -310,9 +280,7 @@ class SettingsHandler:
 
         # Get registered backends, prioritize opencode first
         all_backends = list(self.controller.agent_service.agents.keys())
-        registered_backends = sorted(
-            all_backends, key=lambda x: (x != "opencode", x)
-        )
+        registered_backends = sorted(all_backends, key=lambda x: (x != "opencode", x))
 
         # Get current backend (from routing or default)
         current_backend = self.controller.resolve_agent_for_context(context)
@@ -344,6 +312,7 @@ class SettingsHandler:
         if "claude" in registered_backends:
             try:
                 from vibe.api import claude_agents as get_claude_agents, claude_models as get_claude_models
+
                 cwd = self.controller.get_cwd(context)
                 agents_result = get_claude_agents(cwd)
                 if agents_result.get("ok"):
@@ -360,6 +329,7 @@ class SettingsHandler:
         if "codex" in registered_backends:
             try:
                 from vibe.api import codex_models as get_codex_models
+
                 models_result = get_codex_models()
                 if models_result.get("ok"):
                     codex_models = models_result.get("models", [])
@@ -383,6 +353,4 @@ class SettingsHandler:
             )
         except Exception as e:
             logger.error(f"Error opening routing modal: {e}", exc_info=True)
-            await self.im_client.send_message(
-                context, "❌ Failed to open settings. Please try again."
-            )
+            await self.im_client.send_message(context, "❌ Failed to open settings. Please try again.")

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -14,6 +14,7 @@ from markdown_to_mrkdwn import SlackMarkdownConverter
 from .base import BaseIMClient, MessageContext, InlineKeyboard, InlineButton
 from config.v2_config import SlackConfig
 from .formatters import SlackFormatter
+from vibe.i18n import t as i18n_t
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,17 @@ class SlackBot(BaseIMClient):
     def set_controller(self, controller):
         """Set the controller reference for handling update button clicks"""
         self._controller = controller
+
+    def _get_lang(self, channel_id: Optional[str] = None) -> str:
+        """Get the language for a channel from settings."""
+        if channel_id and self.settings_manager:
+            return self.settings_manager.get_language(channel_id, default="en")
+        return "en"
+
+    def _t(self, key: str, channel_id: Optional[str] = None, **kwargs) -> str:
+        """Translate a key for the given channel's language."""
+        lang = self._get_lang(channel_id)
+        return i18n_t(key, lang, **kwargs)
 
     def _is_duplicate_event(self, event_id: Optional[str]) -> bool:
         """Deduplicate Slack events using event_id with a short TTL."""
@@ -663,7 +675,7 @@ class SlackBot(BaseIMClient):
             if response_url:
                 await self.send_slash_response(
                     response_url,
-                    "❌ This channel is not enabled. Please go to the control panel to enable it.",
+                    f"❌ {self._t('error.channelNotEnabled', channel_id)}",
                 )
             return
 
@@ -702,7 +714,9 @@ class SlackBot(BaseIMClient):
                 "cwd",
                 "queue",
             ]:
-                await self.send_slash_response(response_url, f"⏳ Processing `/{command}`...")
+                await self.send_slash_response(
+                    response_url, f"⏳ {self._t('common.processing', channel_id, command=command)}"
+                )
 
             await handler(context, payload.get("text", ""))
         elif actual_command in self.slash_command_handlers:
@@ -713,7 +727,7 @@ class SlackBot(BaseIMClient):
             if response_url:
                 await self.send_slash_response(
                     response_url,
-                    f"❌ Unknown command: `/{command}`\n\nPlease use `@Vibe Remote /start` to access all bot features.",
+                    f"❌ {self._t('error.unknownCommand', channel_id, command=command)}",
                 )
 
     async def _handle_interactive(self, payload: Dict[str, Any]):
@@ -735,17 +749,15 @@ class SlackBot(BaseIMClient):
 
             # In Slack modals, `channel` is often missing. We store the originating
             # channel_id in `view.private_metadata` when opening the modal.
-            channel_id = (
-                payload.get("channel", {}).get("id")
-                or payload.get("container", {}).get("channel_id")
-            )
-            
+            channel_id = payload.get("channel", {}).get("id") or payload.get("container", {}).get("channel_id")
+
             # For modal actions, try to extract channel_id from private_metadata JSON
             if not channel_id and isinstance(view, dict):
                 private_metadata = view.get("private_metadata")
                 if private_metadata:
                     try:
                         import json
+
                         metadata = json.loads(private_metadata)
                         channel_id = metadata.get("channel_id") if isinstance(metadata, dict) else private_metadata
                     except (json.JSONDecodeError, TypeError):
@@ -855,12 +867,18 @@ class SlackBot(BaseIMClient):
             else:
                 require_mention = None
 
+            # Extract language setting
+            language_data = values.get("language_block", {}).get("language_select", {})
+            language_value = language_data.get("selected_option", {}).get("value")
+            # Convert to Optional[str]: "__default__" -> None, else use the value
+            language = None if language_value == "__default__" else language_value
+
             # Get channel_id from the view's private_metadata if available
             channel_id = view.get("private_metadata")
 
             # Update settings - need access to settings manager
             if hasattr(self, "_on_settings_update"):
-                await self._on_settings_update(user_id, show_types, channel_id, require_mention)
+                await self._on_settings_update(user_id, show_types, channel_id, require_mention, language)
 
         elif callback_id == "change_cwd_modal":
             # Handle change CWD modal submission
@@ -1235,9 +1253,13 @@ class SlackBot(BaseIMClient):
         channel_id: str = None,
         current_require_mention: object = None,  # None=default, True, False
         global_require_mention: bool = False,
+        current_language: str = None,  # Current language setting
     ):
         """Open a modal dialog for settings"""
         self._ensure_clients()
+
+        # Get translations for the channel's language
+        t = lambda key, **kwargs: self._t(key, channel_id, **kwargs)
 
         # Create options for the multi-select menu
         options = []
@@ -1250,7 +1272,7 @@ class SlackBot(BaseIMClient):
                 "value": msg_type,
                 "description": {
                     "type": "plain_text",
-                    "text": self._get_message_type_description(msg_type),
+                    "text": self._get_message_type_description(msg_type, channel_id),
                     "emoji": True,
                 },
             }
@@ -1274,7 +1296,7 @@ class SlackBot(BaseIMClient):
             "type": "multi_static_select",
             "placeholder": {
                 "type": "plain_text",
-                "text": "Select message types to show",
+                "text": t("modal.settings.showMessageTypesPlaceholder"),
                 "emoji": True,
             },
             "options": options,
@@ -1289,15 +1311,15 @@ class SlackBot(BaseIMClient):
         global_mention_label = "On" if global_require_mention else "Off"
         require_mention_options = [
             {
-                "text": {"type": "plain_text", "text": f"(Default) - {global_mention_label}"},
+                "text": {"type": "plain_text", "text": t("modal.settings.optionDefault", status=global_mention_label)},
                 "value": "__default__",
             },
             {
-                "text": {"type": "plain_text", "text": "Require @mention"},
+                "text": {"type": "plain_text", "text": t("modal.settings.optionRequireMention")},
                 "value": "true",
             },
             {
-                "text": {"type": "plain_text", "text": "Don't require @mention"},
+                "text": {"type": "plain_text", "text": t("modal.settings.optionDontRequireMention")},
                 "value": "false",
             },
         ]
@@ -1314,9 +1336,32 @@ class SlackBot(BaseIMClient):
         require_mention_select = {
             "type": "static_select",
             "action_id": "require_mention_select",
-            "placeholder": {"type": "plain_text", "text": "Select @mention behavior"},
+            "placeholder": {"type": "plain_text", "text": t("modal.settings.selectMentionBehavior")},
             "options": require_mention_options,
             "initial_option": initial_require_mention,
+        }
+
+        # Build language selector
+        language_options = [
+            {"text": {"type": "plain_text", "text": t("language.systemDefault")}, "value": "__default__"},
+            {"text": {"type": "plain_text", "text": "English"}, "value": "en"},
+            {"text": {"type": "plain_text", "text": "中文"}, "value": "zh"},
+        ]
+
+        # Determine initial option for language
+        initial_language = language_options[0]  # System default
+        if current_language:
+            for opt in language_options:
+                if opt["value"] == current_language:
+                    initial_language = opt
+                    break
+
+        language_select = {
+            "type": "static_select",
+            "action_id": "language_select",
+            "placeholder": {"type": "plain_text", "text": t("modal.settings.language")},
+            "options": language_options,
+            "initial_option": initial_language,
         }
 
         # Create the modal view
@@ -1324,15 +1369,35 @@ class SlackBot(BaseIMClient):
             "type": "modal",
             "callback_id": "settings_modal",
             "private_metadata": channel_id or "",  # Store channel_id for later use
-            "title": {"type": "plain_text", "text": "Settings", "emoji": True},
-            "submit": {"type": "plain_text", "text": "Save", "emoji": True},
-            "close": {"type": "plain_text", "text": "Cancel", "emoji": True},
+            "title": {"type": "plain_text", "text": t("modal.settings.title"), "emoji": True},
+            "submit": {"type": "plain_text", "text": t("common.save"), "emoji": True},
+            "close": {"type": "plain_text", "text": t("common.cancel"), "emoji": True},
             "blocks": [
+                {
+                    "type": "input",
+                    "block_id": "language_block",
+                    "element": language_select,
+                    "label": {
+                        "type": "plain_text",
+                        "text": t("modal.settings.language"),
+                        "emoji": True,
+                    },
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": f"_{t('modal.settings.languageHint')}_",
+                        }
+                    ],
+                },
+                {"type": "divider"},
                 {
                     "type": "header",
                     "text": {
                         "type": "plain_text",
-                        "text": "Channel Behavior",
+                        "text": t("modal.settings.channelBehavior"),
                         "emoji": True,
                     },
                 },
@@ -1342,7 +1407,7 @@ class SlackBot(BaseIMClient):
                     "element": require_mention_select,
                     "label": {
                         "type": "plain_text",
-                        "text": "Require @mention to respond",
+                        "text": t("modal.settings.requireMention"),
                         "emoji": True,
                     },
                 },
@@ -1351,7 +1416,7 @@ class SlackBot(BaseIMClient):
                     "elements": [
                         {
                             "type": "mrkdwn",
-                            "text": "_When enabled, the bot only responds when @mentioned in channels (DMs always work)._",
+                            "text": f"_{t('modal.settings.requireMentionHint')}_",
                         }
                     ],
                 },
@@ -1360,7 +1425,7 @@ class SlackBot(BaseIMClient):
                     "type": "header",
                     "text": {
                         "type": "plain_text",
-                        "text": "Message Visibility",
+                        "text": t("modal.settings.messageVisibility"),
                         "emoji": True,
                     },
                 },
@@ -1368,7 +1433,7 @@ class SlackBot(BaseIMClient):
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "Choose which message types to *show* from agent output. Unselected types won't appear in your Slack workspace.",
+                        "text": t("modal.settings.messageVisibilityDesc"),
                     },
                 },
                 {
@@ -1377,7 +1442,7 @@ class SlackBot(BaseIMClient):
                     "element": multi_select_element,
                     "label": {
                         "type": "plain_text",
-                        "text": "Show these message types:",
+                        "text": t("modal.settings.showMessageTypes"),
                         "emoji": True,
                     },
                     "optional": True,
@@ -1387,7 +1452,7 @@ class SlackBot(BaseIMClient):
                     "elements": [
                         {
                             "type": "mrkdwn",
-                            "text": "_💡 Tip: You can show/hide message types at any time. Changes apply immediately to new messages._",
+                            "text": f"_💡 {t('modal.settings.tip')}_",
                         }
                     ],
                 },
@@ -1400,18 +1465,17 @@ class SlackBot(BaseIMClient):
             logger.error(f"Error opening modal: {e}")
             raise
 
-    def _get_message_type_description(self, msg_type: str) -> str:
+    def _get_message_type_description(self, msg_type: str, channel_id: str = None) -> str:
         """Get description for a message type"""
-        descriptions = {
-            "system": "System initialization and status messages",
-            "toolcall": "Agent tool name + params (one line)",
-            "assistant": "Agent responses and explanations",
-        }
-        return descriptions.get(msg_type, f"{msg_type} messages")
+        key = f"messageType.{msg_type}Desc"
+        return self._t(key, channel_id)
 
     async def open_change_cwd_modal(self, trigger_id: str, current_cwd: str, channel_id: str = None):
         """Open a modal dialog for changing working directory"""
         self._ensure_clients()
+
+        # Get translations for the channel's language
+        t = lambda key, **kwargs: self._t(key, channel_id, **kwargs)
 
         # Create the modal view
         view = {
@@ -1420,17 +1484,17 @@ class SlackBot(BaseIMClient):
             "private_metadata": channel_id or "",  # Store channel_id for later use
             "title": {
                 "type": "plain_text",
-                "text": "Change Working Directory",
+                "text": t("modal.cwd.title"),
                 "emoji": True,
             },
-            "submit": {"type": "plain_text", "text": "Change", "emoji": True},
-            "close": {"type": "plain_text", "text": "Cancel", "emoji": True},
+            "submit": {"type": "plain_text", "text": t("common.change"), "emoji": True},
+            "close": {"type": "plain_text", "text": t("common.cancel"), "emoji": True},
             "blocks": [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"Current working directory:\n`{current_cwd}`",
+                        "text": f"{t('modal.cwd.current')}\n`{current_cwd}`",
                     },
                 },
                 {"type": "divider"},
@@ -1442,19 +1506,19 @@ class SlackBot(BaseIMClient):
                         "action_id": "new_cwd_input",
                         "placeholder": {
                             "type": "plain_text",
-                            "text": "Enter new directory path",
+                            "text": t("modal.cwd.placeholder"),
                             "emoji": True,
                         },
                         "initial_value": current_cwd,
                     },
                     "label": {
                         "type": "plain_text",
-                        "text": "New Working Directory:",
+                        "text": t("modal.cwd.new"),
                         "emoji": True,
                     },
                     "hint": {
                         "type": "plain_text",
-                        "text": "Use absolute path (e.g., /home/user/project) or ~ for home directory",
+                        "text": t("modal.cwd.hint"),
                         "emoji": True,
                     },
                 },
@@ -1463,7 +1527,7 @@ class SlackBot(BaseIMClient):
                     "elements": [
                         {
                             "type": "mrkdwn",
-                            "text": "💡 _Tip: The directory will be created if it doesn't exist._",
+                            "text": f"💡 _{t('modal.cwd.tip')}_",
                         }
                     ],
                 },
@@ -1632,9 +1696,7 @@ class SlackBot(BaseIMClient):
             logger.error(f"Error opening resume modal: {e}")
             raise
 
-    async def _handle_resume_modal_manual_input(
-        self, view: Dict[str, Any], action: Dict[str, Any]
-    ):
+    async def _handle_resume_modal_manual_input(self, view: Dict[str, Any], action: Dict[str, Any]):
         """Handle manual_input changes in resume_session_modal - dynamically show/hide agent_block."""
         import json
 
@@ -2777,7 +2839,7 @@ class SlackBot(BaseIMClient):
             self._ensure_clients()
             await self.web_client.chat_postMessage(
                 channel=channel_id,
-                text="❌ This channel is not enabled. Please go to the control panel to enable it.",
+                text=f"❌ {self._t('error.channelNotEnabled', channel_id)}",
             )
         except Exception as e:
             logger.error(f"Failed to send unauthorized message to {channel_id}: {e}")

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -583,6 +583,51 @@ class SettingsManager:
         return None
 
     # ---------------------------------------------
+    # Per-channel language management
+    # ---------------------------------------------
+    def get_language(self, channel_id: Union[int, str], default: str = "en") -> str:
+        """Get effective language for a channel.
+
+        Args:
+            channel_id: The channel to check
+            default: The default language to use if not set
+
+        Returns:
+            Language code (e.g., "en", "zh").
+            Uses per-channel setting if set, otherwise falls back to default.
+        """
+        self._reload_if_changed()
+        key = str(channel_id)
+        channel_settings = self.store.settings.channels.get(key)
+
+        if channel_settings is not None and channel_settings.language is not None:
+            return channel_settings.language
+
+        return default
+
+    def set_language(self, channel_id: Union[int, str], language: Optional[str]) -> None:
+        """Set per-channel language.
+
+        Args:
+            channel_id: The channel to configure
+            language: Language code (e.g., "en", "zh") or None to use default
+        """
+        key = str(channel_id)
+        channel_settings = self.store.get_channel(key)
+        channel_settings.language = language
+        self.store.update_channel(key, channel_settings)
+        logger.info(f"Updated language for channel {key}: {language}")
+
+    def get_language_override(self, channel_id: Union[int, str]) -> Optional[str]:
+        """Get the raw per-channel language override (may be None)."""
+        self._reload_if_changed()
+        key = str(channel_id)
+        channel_settings = self.store.settings.channels.get(key)
+        if channel_settings is not None:
+            return channel_settings.language
+        return None
+
+    # ---------------------------------------------
     # Active polls management (for poll restoration on restart)
     # ---------------------------------------------
     def add_active_poll(

--- a/vibe/i18n/__init__.py
+++ b/vibe/i18n/__init__.py
@@ -1,0 +1,117 @@
+"""
+Backend i18n module for Slack messages.
+Supports language setting synchronized with Web UI.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+
+class I18n:
+    """Internationalization manager for backend messages."""
+
+    _instance: Optional["I18n"] = None
+    _translations: Dict[str, Dict[str, Any]] = {}
+
+    def __init__(self):
+        self._load_translations()
+
+    @classmethod
+    def get_instance(cls) -> "I18n":
+        """Get singleton instance."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reload(cls) -> None:
+        """Reload translations from files."""
+        if cls._instance is not None:
+            cls._instance._load_translations()
+
+    def _load_translations(self) -> None:
+        """Load all translation files from the i18n directory."""
+        i18n_dir = Path(__file__).parent
+        self._translations = {}
+        for lang_file in i18n_dir.glob("*.json"):
+            lang = lang_file.stem
+            try:
+                self._translations[lang] = json.loads(lang_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, IOError):
+                # Skip invalid files
+                pass
+
+    def get_available_languages(self) -> list[str]:
+        """Get list of available language codes."""
+        return list(self._translations.keys())
+
+    def t(self, key: str, lang: str = "en", **kwargs: Any) -> str:
+        """
+        Translate a key with optional interpolation.
+
+        Args:
+            key: Dot-separated key path (e.g., "modal.settings.title")
+            lang: Language code (e.g., "en", "zh")
+            **kwargs: Interpolation values (e.g., name="John" for "{name}")
+
+        Returns:
+            Translated string, or key if not found
+        """
+        # Get translations for the requested language, fallback to English
+        translations = self._translations.get(lang)
+        if translations is None:
+            translations = self._translations.get("en", {})
+
+        # Navigate nested keys: "modal.settings.title" -> translations["modal"]["settings"]["title"]
+        parts = key.split(".")
+        value: Any = translations
+        for part in parts:
+            if isinstance(value, dict):
+                value = value.get(part)
+                if value is None:
+                    # Key not found, try English fallback
+                    if lang != "en":
+                        return self.t(key, "en", **kwargs)
+                    return key
+            else:
+                return key
+
+        if not isinstance(value, str):
+            return key
+
+        # Interpolate variables: {name} -> value of kwargs["name"]
+        if kwargs:
+            for k, v in kwargs.items():
+                value = value.replace(f"{{{k}}}", str(v))
+
+        return value
+
+
+def get_translator(lang: str = "en") -> Callable[..., str]:
+    """
+    Get a translator function bound to a specific language.
+
+    Args:
+        lang: Language code
+
+    Returns:
+        A function that translates keys in the specified language
+    """
+    i18n = I18n.get_instance()
+    return lambda key, **kwargs: i18n.t(key, lang, **kwargs)
+
+
+def t(key: str, lang: str = "en", **kwargs: Any) -> str:
+    """
+    Shortcut function to translate a key.
+
+    Args:
+        key: Dot-separated key path
+        lang: Language code
+        **kwargs: Interpolation values
+
+    Returns:
+        Translated string
+    """
+    return I18n.get_instance().t(key, lang, **kwargs)

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -1,0 +1,164 @@
+{
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "submit": "Submit",
+    "change": "Change",
+    "resume": "Resume",
+    "default": "(Default)",
+    "selectOne": "Select one",
+    "selectOneOrMore": "Select one or more",
+    "processing": "Processing `/{command}`..."
+  },
+  "error": {
+    "channelNotEnabled": "This channel is not enabled. Please go to the control panel to enable it.",
+    "unknownCommand": "Unknown command: `/{command}`\n\nPlease use `@Vibe Remote /start` to access all bot features.",
+    "clearSession": "Error clearing session: {error}",
+    "settingsFailed": "Failed to open settings. Please try again.",
+    "cwdChangeFailed": "Failed to open directory change dialog. Please try again.",
+    "resumeFailed": "Failed to open resume dialog. Please try again.",
+    "stopFailed": "Error sending stop command: {error}",
+    "cwdSetFailed": "Error setting working directory: {error}",
+    "cwdCreateFailed": "Cannot create directory: {error}",
+    "cwdNotDirectory": "Path exists but is not a directory: `{path}`",
+    "cwdGetFailed": "Error getting working directory: {error}"
+  },
+  "success": {
+    "settingsUpdated": "Settings updated successfully!",
+    "cwdChanged": "Working directory changed to:\n`{path}`",
+    "sessionResumed": "Resumed {agent} session.\nSession ID: `{sessionId}`",
+    "routingUpdated": "Agent routing updated!"
+  },
+  "modal": {
+    "settings": {
+      "title": "Settings",
+      "channelBehavior": "Channel Behavior",
+      "requireMention": "Require @mention to respond",
+      "requireMentionHint": "When enabled, the bot only responds when @mentioned in channels (DMs always work).",
+      "messageVisibility": "Message Visibility",
+      "messageVisibilityDesc": "Choose which message types to *show* from agent output. Unselected types won't appear in your Slack workspace.",
+      "showMessageTypes": "Show these message types:",
+      "showMessageTypesPlaceholder": "Select message types to show",
+      "tip": "You can show/hide message types at any time. Changes apply immediately to new messages.",
+      "selectMentionBehavior": "Select @mention behavior",
+      "optionDefault": "(Default) - {status}",
+      "optionRequireMention": "Require @mention",
+      "optionDontRequireMention": "Don't require @mention",
+      "language": "Language / \u8bed\u8a00",
+      "languageHint": "Changes the language for bot messages in Slack."
+    },
+    "cwd": {
+      "title": "Change Working Directory",
+      "current": "Current working directory:",
+      "new": "New Working Directory:",
+      "placeholder": "Enter new directory path",
+      "hint": "Use absolute path (e.g., /home/user/project) or ~ for home directory",
+      "tip": "The directory will be created if it doesn't exist."
+    },
+    "resume": {
+      "title": "Resume Session",
+      "description": "Select a saved session or paste a session ID to resume work in this thread.",
+      "pickExisting": "Pick an existing session",
+      "selectSession": "Select a session",
+      "pasteId": "Or paste a session ID",
+      "pasteIdPlaceholder": "e.g., ses_12345",
+      "agentBackend": "Agent backend",
+      "selectAgentBackend": "Select agent backend",
+      "showingFirst100": "Showing the first 100 saved sessions. Paste a session ID below for others.",
+      "noSessionsFound": "No stored sessions found. Paste a session ID below to resume."
+    },
+    "routing": {
+      "title": "Agent Settings",
+      "currentBackend": "Current Backend:",
+      "backend": "Backend",
+      "selectBackend": "Select backend",
+      "opencodeSettings": "OpenCode Settings",
+      "opencodeAgent": "OpenCode Agent",
+      "selectOpencodeAgent": "Select OpenCode agent",
+      "model": "Model",
+      "selectModel": "Select model",
+      "reasoningEffort": "Reasoning Effort (Thinking Mode)",
+      "selectReasoningEffort": "Select reasoning effort",
+      "claudeSettings": "Claude Settings",
+      "claudeAgent": "Claude Agent",
+      "selectClaudeAgent": "Select Claude agent",
+      "codexSettings": "Codex Settings",
+      "codexReasoningEffort": "Reasoning Effort",
+      "tip": "Select (Default) to use the backend's configured defaults."
+    },
+    "question": {
+      "opencode": "OpenCode",
+      "claudeCode": "Claude Code"
+    }
+  },
+  "command": {
+    "start": {
+      "welcome": "Welcome to Vibe Remote!",
+      "greeting": "Hello {name}!",
+      "platform": "Platform: {platform}",
+      "agent": "Agent: {agent}",
+      "channel": "Channel: {channel}",
+      "quickActions": "Quick Actions:",
+      "quickActionsDesc": "Use the buttons below to manage your {agent} sessions, or simply type any message to start chatting with {agent}!",
+      "directMessage": "Direct Message"
+    },
+    "clear": {
+      "noSessions": "No active sessions to clear.\nSession state has been reset.",
+      "cleared": "Cleared active sessions for:\n{details}\nAll sessions reset.",
+      "sessionItem": "{agent} \u2192 {count} session(s)"
+    },
+    "cwd": {
+      "current": "Current Working Directory:",
+      "exists": "Directory exists",
+      "notExists": "Directory does not exist",
+      "hint": "This is where Agent will execute commands",
+      "usage": "Usage: /set_cwd <path>",
+      "changeInstructions": "To change working directory, use:\n`/set_cwd <path>`\n\nExample:\n`/set_cwd ~/projects/myapp`",
+      "clickButton": "Click the 'Change Work Dir' button in the @Vibe Remote /start menu to change working directory."
+    },
+    "resume": {
+      "slackOnly": "Resume is currently available only on Slack. Continue in the same thread to auto-resume.",
+      "clickButton": "Please click the Resume button inside Slack to open the picker.",
+      "noStoredSessions": "No stored sessions found. You can still paste a session ID manually in the resume modal."
+    },
+    "stop": {
+      "noActiveSession": "No active session to stop for this channel."
+    }
+  },
+  "button": {
+    "currentDir": "Current Dir",
+    "changeDir": "Change Work Dir",
+    "clearSession": "Clear All Session",
+    "settings": "Settings",
+    "resumeSession": "Resume Session",
+    "agentSettings": "Agent Settings",
+    "howItWorks": "How it Works"
+  },
+  "messageType": {
+    "system": "System",
+    "assistant": "Assistant",
+    "toolcall": "Toolcall",
+    "systemDesc": "System initialization and status messages",
+    "assistantDesc": "Agent responses and explanations",
+    "toolcallDesc": "Agent tool name + params (one line)"
+  },
+  "backend": {
+    "claude": "ClaudeCode",
+    "codex": "Codex",
+    "opencode": "OpenCode"
+  },
+  "reasoning": {
+    "none": "None",
+    "minimal": "Minimal",
+    "low": "Low",
+    "medium": "Medium",
+    "high": "High",
+    "xhigh": "Extra High",
+    "max": "Max"
+  },
+  "language": {
+    "systemDefault": "(System Default)",
+    "en": "English",
+    "zh": "\u4e2d\u6587"
+  }
+}

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -1,0 +1,164 @@
+{
+  "common": {
+    "save": "\u4fdd\u5b58",
+    "cancel": "\u53d6\u6d88",
+    "submit": "\u63d0\u4ea4",
+    "change": "\u66f4\u6539",
+    "resume": "\u6062\u590d",
+    "default": "(\u9ed8\u8ba4)",
+    "selectOne": "\u9009\u62e9\u4e00\u4e2a",
+    "selectOneOrMore": "\u9009\u62e9\u4e00\u4e2a\u6216\u591a\u4e2a",
+    "processing": "\u6b63\u5728\u5904\u7406 `/{command}`..."
+  },
+  "error": {
+    "channelNotEnabled": "\u6b64\u9891\u9053\u672a\u542f\u7528\u3002\u8bf7\u524d\u5f80\u63a7\u5236\u9762\u677f\u542f\u7528\u5b83\u3002",
+    "unknownCommand": "\u672a\u77e5\u547d\u4ee4\uff1a`/{command}`\n\n\u8bf7\u4f7f\u7528 `@Vibe Remote /start` \u8bbf\u95ee\u6240\u6709\u673a\u5668\u4eba\u529f\u80fd\u3002",
+    "clearSession": "\u6e05\u9664\u4f1a\u8bdd\u65f6\u51fa\u9519\uff1a{error}",
+    "settingsFailed": "\u65e0\u6cd5\u6253\u5f00\u8bbe\u7f6e\u3002\u8bf7\u91cd\u8bd5\u3002",
+    "cwdChangeFailed": "\u65e0\u6cd5\u6253\u5f00\u76ee\u5f55\u66f4\u6539\u5bf9\u8bdd\u6846\u3002\u8bf7\u91cd\u8bd5\u3002",
+    "resumeFailed": "\u65e0\u6cd5\u6253\u5f00\u6062\u590d\u5bf9\u8bdd\u6846\u3002\u8bf7\u91cd\u8bd5\u3002",
+    "stopFailed": "\u53d1\u9001\u505c\u6b62\u547d\u4ee4\u65f6\u51fa\u9519\uff1a{error}",
+    "cwdSetFailed": "\u8bbe\u7f6e\u5de5\u4f5c\u76ee\u5f55\u65f6\u51fa\u9519\uff1a{error}",
+    "cwdCreateFailed": "\u65e0\u6cd5\u521b\u5efa\u76ee\u5f55\uff1a{error}",
+    "cwdNotDirectory": "\u8def\u5f84\u5b58\u5728\u4f46\u4e0d\u662f\u76ee\u5f55\uff1a`{path}`",
+    "cwdGetFailed": "\u83b7\u53d6\u5de5\u4f5c\u76ee\u5f55\u65f6\u51fa\u9519\uff1a{error}"
+  },
+  "success": {
+    "settingsUpdated": "\u8bbe\u7f6e\u66f4\u65b0\u6210\u529f\uff01",
+    "cwdChanged": "\u5de5\u4f5c\u76ee\u5f55\u5df2\u66f4\u6539\u4e3a\uff1a\n`{path}`",
+    "sessionResumed": "\u5df2\u6062\u590d {agent} \u4f1a\u8bdd\u3002\n\u4f1a\u8bddID\uff1a`{sessionId}`",
+    "routingUpdated": "Agent \u8def\u7531\u5df2\u66f4\u65b0\uff01"
+  },
+  "modal": {
+    "settings": {
+      "title": "\u8bbe\u7f6e",
+      "channelBehavior": "\u9891\u9053\u884c\u4e3a",
+      "requireMention": "\u9700\u8981 @\u63d0\u53ca\u624d\u54cd\u5e94",
+      "requireMentionHint": "\u542f\u7528\u540e\uff0c\u673a\u5668\u4eba\u4ec5\u5728\u88ab @\u63d0\u53ca\u65f6\u624d\u5728\u9891\u9053\u4e2d\u54cd\u5e94\uff08\u79c1\u4fe1\u59cb\u7ec8\u6709\u6548\uff09\u3002",
+      "messageVisibility": "\u6d88\u606f\u53ef\u89c1\u6027",
+      "messageVisibilityDesc": "\u9009\u62e9\u8981\u4ece Agent \u8f93\u51fa\u4e2d*\u663e\u793a*\u7684\u6d88\u606f\u7c7b\u578b\u3002\u672a\u9009\u4e2d\u7684\u7c7b\u578b\u5c06\u4e0d\u4f1a\u5728\u60a8\u7684 Slack \u5de5\u4f5c\u533a\u4e2d\u663e\u793a\u3002",
+      "showMessageTypes": "\u663e\u793a\u8fd9\u4e9b\u6d88\u606f\u7c7b\u578b\uff1a",
+      "showMessageTypesPlaceholder": "\u9009\u62e9\u8981\u663e\u793a\u7684\u6d88\u606f\u7c7b\u578b",
+      "tip": "\u60a8\u53ef\u4ee5\u968f\u65f6\u663e\u793a/\u9690\u85cf\u6d88\u606f\u7c7b\u578b\u3002\u66f4\u6539\u4f1a\u7acb\u5373\u5e94\u7528\u4e8e\u65b0\u6d88\u606f\u3002",
+      "selectMentionBehavior": "\u9009\u62e9 @\u63d0\u53ca\u884c\u4e3a",
+      "optionDefault": "(\u9ed8\u8ba4) - {status}",
+      "optionRequireMention": "\u9700\u8981 @\u63d0\u53ca",
+      "optionDontRequireMention": "\u4e0d\u9700\u8981 @\u63d0\u53ca",
+      "language": "\u8bed\u8a00 / Language",
+      "languageHint": "\u66f4\u6539 Slack \u4e2d\u673a\u5668\u4eba\u6d88\u606f\u7684\u8bed\u8a00\u3002"
+    },
+    "cwd": {
+      "title": "\u66f4\u6539\u5de5\u4f5c\u76ee\u5f55",
+      "current": "\u5f53\u524d\u5de5\u4f5c\u76ee\u5f55\uff1a",
+      "new": "\u65b0\u5de5\u4f5c\u76ee\u5f55\uff1a",
+      "placeholder": "\u8f93\u5165\u65b0\u7684\u76ee\u5f55\u8def\u5f84",
+      "hint": "\u4f7f\u7528\u7edd\u5bf9\u8def\u5f84\uff08\u4f8b\u5982 /home/user/project\uff09\u6216 ~ \u8868\u793a\u4e3b\u76ee\u5f55",
+      "tip": "\u5982\u679c\u76ee\u5f55\u4e0d\u5b58\u5728\uff0c\u5c06\u4f1a\u81ea\u52a8\u521b\u5efa\u3002"
+    },
+    "resume": {
+      "title": "\u6062\u590d\u4f1a\u8bdd",
+      "description": "\u9009\u62e9\u4e00\u4e2a\u5df2\u4fdd\u5b58\u7684\u4f1a\u8bdd\u6216\u7c98\u8d34\u4f1a\u8bdd ID \u4ee5\u5728\u6b64\u7ebf\u7a0b\u4e2d\u7ee7\u7eed\u5de5\u4f5c\u3002",
+      "pickExisting": "\u9009\u62e9\u4e00\u4e2a\u5df2\u6709\u4f1a\u8bdd",
+      "selectSession": "\u9009\u62e9\u4e00\u4e2a\u4f1a\u8bdd",
+      "pasteId": "\u6216\u7c98\u8d34\u4f1a\u8bdd ID",
+      "pasteIdPlaceholder": "\u4f8b\u5982 ses_12345",
+      "agentBackend": "Agent \u540e\u7aef",
+      "selectAgentBackend": "\u9009\u62e9 Agent \u540e\u7aef",
+      "showingFirst100": "\u663e\u793a\u524d 100 \u4e2a\u5df2\u4fdd\u5b58\u7684\u4f1a\u8bdd\u3002\u5982\u9700\u5176\u4ed6\u4f1a\u8bdd\uff0c\u8bf7\u5728\u4e0b\u65b9\u7c98\u8d34\u4f1a\u8bdd ID\u3002",
+      "noSessionsFound": "\u672a\u627e\u5230\u5df2\u5b58\u50a8\u7684\u4f1a\u8bdd\u3002\u8bf7\u5728\u4e0b\u65b9\u7c98\u8d34\u4f1a\u8bdd ID \u4ee5\u6062\u590d\u3002"
+    },
+    "routing": {
+      "title": "Agent \u8bbe\u7f6e",
+      "currentBackend": "\u5f53\u524d\u540e\u7aef\uff1a",
+      "backend": "\u540e\u7aef",
+      "selectBackend": "\u9009\u62e9\u540e\u7aef",
+      "opencodeSettings": "OpenCode \u8bbe\u7f6e",
+      "opencodeAgent": "OpenCode Agent",
+      "selectOpencodeAgent": "\u9009\u62e9 OpenCode Agent",
+      "model": "\u6a21\u578b",
+      "selectModel": "\u9009\u62e9\u6a21\u578b",
+      "reasoningEffort": "\u63a8\u7406\u5f3a\u5ea6\uff08\u601d\u8003\u6a21\u5f0f\uff09",
+      "selectReasoningEffort": "\u9009\u62e9\u63a8\u7406\u5f3a\u5ea6",
+      "claudeSettings": "Claude \u8bbe\u7f6e",
+      "claudeAgent": "Claude Agent",
+      "selectClaudeAgent": "\u9009\u62e9 Claude Agent",
+      "codexSettings": "Codex \u8bbe\u7f6e",
+      "codexReasoningEffort": "\u63a8\u7406\u5f3a\u5ea6",
+      "tip": "\u9009\u62e9\u201c(\u9ed8\u8ba4)\u201d\u4ee5\u4f7f\u7528\u540e\u7aef\u7684\u914d\u7f6e\u9ed8\u8ba4\u503c\u3002"
+    },
+    "question": {
+      "opencode": "OpenCode",
+      "claudeCode": "Claude Code"
+    }
+  },
+  "command": {
+    "start": {
+      "welcome": "\u6b22\u8fce\u4f7f\u7528 Vibe Remote\uff01",
+      "greeting": "\u4f60\u597d {name}\uff01",
+      "platform": "\u5e73\u53f0\uff1a{platform}",
+      "agent": "Agent\uff1a{agent}",
+      "channel": "\u9891\u9053\uff1a{channel}",
+      "quickActions": "\u5feb\u6377\u64cd\u4f5c\uff1a",
+      "quickActionsDesc": "\u4f7f\u7528\u4e0b\u65b9\u6309\u94ae\u7ba1\u7406\u60a8\u7684 {agent} \u4f1a\u8bdd\uff0c\u6216\u76f4\u63a5\u8f93\u5165\u4efb\u4f55\u6d88\u606f\u5f00\u59cb\u4e0e {agent} \u804a\u5929\uff01",
+      "directMessage": "\u79c1\u4fe1"
+    },
+    "clear": {
+      "noSessions": "\u6ca1\u6709\u8981\u6e05\u9664\u7684\u6d3b\u52a8\u4f1a\u8bdd\u3002\n\u4f1a\u8bdd\u72b6\u6001\u5df2\u91cd\u7f6e\u3002",
+      "cleared": "\u5df2\u6e05\u9664\u7684\u6d3b\u52a8\u4f1a\u8bdd\uff1a\n{details}\n\u6240\u6709\u4f1a\u8bdd\u5df2\u91cd\u7f6e\u3002",
+      "sessionItem": "{agent} \u2192 {count} \u4e2a\u4f1a\u8bdd"
+    },
+    "cwd": {
+      "current": "\u5f53\u524d\u5de5\u4f5c\u76ee\u5f55\uff1a",
+      "exists": "\u76ee\u5f55\u5b58\u5728",
+      "notExists": "\u76ee\u5f55\u4e0d\u5b58\u5728",
+      "hint": "\u8fd9\u662f Agent \u6267\u884c\u547d\u4ee4\u7684\u4f4d\u7f6e",
+      "usage": "\u7528\u6cd5\uff1a/set_cwd <\u8def\u5f84>",
+      "changeInstructions": "\u8981\u66f4\u6539\u5de5\u4f5c\u76ee\u5f55\uff0c\u8bf7\u4f7f\u7528\uff1a\n`/set_cwd <\u8def\u5f84>`\n\n\u793a\u4f8b\uff1a\n`/set_cwd ~/projects/myapp`",
+      "clickButton": "\u8bf7\u70b9\u51fb @Vibe Remote /start \u83dc\u5355\u4e2d\u7684\u201c\u66f4\u6539\u5de5\u4f5c\u76ee\u5f55\u201d\u6309\u94ae\u6765\u66f4\u6539\u5de5\u4f5c\u76ee\u5f55\u3002"
+    },
+    "resume": {
+      "slackOnly": "\u6062\u590d\u529f\u80fd\u76ee\u524d\u4ec5\u5728 Slack \u4e0a\u53ef\u7528\u3002\u5728\u540c\u4e00\u7ebf\u7a0b\u4e2d\u7ee7\u7eed\u53ef\u81ea\u52a8\u6062\u590d\u3002",
+      "clickButton": "\u8bf7\u5728 Slack \u4e2d\u70b9\u51fb\u201c\u6062\u590d\u201d\u6309\u94ae\u6253\u5f00\u9009\u62e9\u5668\u3002",
+      "noStoredSessions": "\u672a\u627e\u5230\u5df2\u5b58\u50a8\u7684\u4f1a\u8bdd\u3002\u60a8\u4ecd\u53ef\u4ee5\u5728\u6062\u590d\u5bf9\u8bdd\u6846\u4e2d\u624b\u52a8\u7c98\u8d34\u4f1a\u8bdd ID\u3002"
+    },
+    "stop": {
+      "noActiveSession": "\u6b64\u9891\u9053\u6ca1\u6709\u8981\u505c\u6b62\u7684\u6d3b\u52a8\u4f1a\u8bdd\u3002"
+    }
+  },
+  "button": {
+    "currentDir": "\u5f53\u524d\u76ee\u5f55",
+    "changeDir": "\u66f4\u6539\u5de5\u4f5c\u76ee\u5f55",
+    "clearSession": "\u6e05\u9664\u6240\u6709\u4f1a\u8bdd",
+    "settings": "\u8bbe\u7f6e",
+    "resumeSession": "\u6062\u590d\u4f1a\u8bdd",
+    "agentSettings": "Agent \u8bbe\u7f6e",
+    "howItWorks": "\u5982\u4f55\u5de5\u4f5c"
+  },
+  "messageType": {
+    "system": "\u7cfb\u7edf",
+    "assistant": "\u52a9\u624b",
+    "toolcall": "\u5de5\u5177\u8c03\u7528",
+    "systemDesc": "\u7cfb\u7edf\u521d\u59cb\u5316\u548c\u72b6\u6001\u6d88\u606f",
+    "assistantDesc": "Agent \u7684\u56de\u590d\u548c\u89e3\u91ca",
+    "toolcallDesc": "Agent \u5de5\u5177\u540d\u79f0 + \u53c2\u6570\uff08\u5355\u884c\uff09"
+  },
+  "backend": {
+    "claude": "ClaudeCode",
+    "codex": "Codex",
+    "opencode": "OpenCode"
+  },
+  "reasoning": {
+    "none": "\u65e0",
+    "minimal": "\u6700\u5c0f",
+    "low": "\u4f4e",
+    "medium": "\u4e2d",
+    "high": "\u9ad8",
+    "xhigh": "\u8d85\u9ad8",
+    "max": "\u6700\u5927"
+  },
+  "language": {
+    "systemDefault": "(\u7cfb\u7edf\u9ed8\u8ba4)",
+    "en": "English",
+    "zh": "\u4e2d\u6587"
+  }
+}


### PR DESCRIPTION
## Summary

- Add backend i18n module (`vibe/i18n/`) with English and Chinese translations
- Add language selector in Slack Settings modal, synced with web UI language configuration
- Apply translations to Slack modals (Settings, Change CWD) and error messages

## Changes

### New Files
- `vibe/i18n/__init__.py` - i18n module with `t()` translation function
- `vibe/i18n/en.json` - English translations
- `vibe/i18n/zh.json` - Chinese translations

### Modified Files
- `config/v2_settings.py` - Add `language` field to `ChannelSettings`
- `modules/settings_manager.py` - Add language management methods (`get_language`, `set_language`)
- `modules/im/slack.py` - Add i18n support to modals, add language selector
- `core/controller.py` - Handle language setting in settings update
- `core/handlers/settings_handler.py` - Pass current language when opening settings modal

## How to Test

1. Open Slack Settings modal via `/start` -> Settings button
2. Select language (English/中文/System Default) 
3. Save settings
4. The language setting is persisted per-channel
5. Modal text should reflect the selected language on next open

## Follow-up Work

- Apply i18n to more Slack messages (command_handlers.py, etc.)
- Add more translated strings as needed