### PR TITLE
fix(slack): avoid rate-limit by defaulting to bot-member channels

### DIFF
--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -9,7 +9,7 @@ export type ApiContextType = {
   detectCli: (binary: string) => Promise<any>;
   installAgent: (name: string) => Promise<InstallResult>;
   slackAuthTest: (botToken: string) => Promise<any>;
-  slackChannels: (botToken: string) => Promise<any>;
+  slackChannels: (botToken: string, browseAll?: boolean) => Promise<any>;
   slackManifest: () => Promise<{ ok: boolean; manifest?: string; manifest_compact?: string; error?: string }>;
   doctor: () => Promise<any>;
   opencodeOptions: (cwd: string) => Promise<any>;
@@ -116,7 +116,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     detectCli: (binary) => getJson(`/cli/detect?binary=${encodeURIComponent(binary)}`),
     installAgent: (name) => postJson(`/agent/${encodeURIComponent(name)}/install`, {}),
     slackAuthTest: (botToken) => postJson('/slack/auth_test', { bot_token: botToken }),
-    slackChannels: (botToken) => postJson('/slack/channels', { bot_token: botToken }),
+    slackChannels: (botToken, browseAll) => postJson('/slack/channels', { bot_token: botToken, browse_all: browseAll || false }),
     slackManifest: () => getJson('/slack/manifest'),
     doctor: () => postJson('/doctor', {}),
     opencodeOptions: (cwd) => postJson('/opencode/options', { cwd }),

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -128,6 +128,8 @@
     "title": "Channel Settings",
     "subtitle": "Enable channels and configure per-channel routing.",
     "refreshList": "Refresh List",
+    "browseAll": "Browse All Channels",
+    "showingAll": "Showing all workspace channels",
     "cantFindChannel": "Can't find your channel?",
     "inviteBotHint": "Invite the bot to your channel first:\n1. Open the channel, click ⚙️ Settings → Integrations → Add apps\n2. Or type /invite @YourBotName in the channel",
     "enabledCount": "{{count}} enabled",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -128,6 +128,8 @@
     "title": "频道设置",
     "subtitle": "启用频道并配置每个频道的路由",
     "refreshList": "刷新列表",
+    "browseAll": "浏览所有频道",
+    "showingAll": "已显示工作区所有频道",
     "cantFindChannel": "找不到你想要的频道？",
     "inviteBotHint": "请先将 Bot 邀请到频道：\n1. 打开频道，点击 ⚙️ 设置 → 集成 → 添加应用\n2. 或在频道中输入 /invite @你的Bot名称",
     "enabledCount": "已启用 {{count}} 个",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -132,19 +132,64 @@ def slack_auth_test(bot_token: str) -> dict:
         return {"ok": False, "error": str(exc)}
 
 
-def list_channels(bot_token: str) -> dict:
-    try:
-        from slack_sdk.web import WebClient
+def list_channels(bot_token: str, browse_all: bool = False) -> dict:
+    """List Slack channels.
 
-        client = WebClient(token=bot_token)
-        channels = []
-        cursor = None
+    When *browse_all* is False (default), only channels the bot has joined are
+    returned via ``users_conversations``.  This is very fast and avoids hitting
+    Slack rate-limits even in large workspaces.
+
+    When *browse_all* is True, all visible channels in the workspace are
+    returned via ``conversations_list``.  Rate-limit retries with exponential
+    back-off are applied automatically.
+    """
+    import time
+
+    from slack_sdk.errors import SlackApiError
+    from slack_sdk.web import WebClient
+
+    client = WebClient(token=bot_token)
+    channels: list[dict] = []
+    cursor = None
+
+    try:
         while True:
-            response = client.conversations_list(
-                types="public_channel,private_channel",
-                limit=200,
-                cursor=cursor,
-            )
+            for attempt in range(5):
+                try:
+                    if browse_all:
+                        response = client.conversations_list(
+                            types="public_channel,private_channel",
+                            exclude_archived=True,
+                            limit=200,
+                            cursor=cursor,
+                        )
+                    else:
+                        response = client.users_conversations(
+                            types="public_channel,private_channel",
+                            exclude_archived=True,
+                            limit=200,
+                            cursor=cursor,
+                        )
+                    break  # success
+                except SlackApiError as e:
+                    if e.response.status_code == 429:
+                        retry_after = int(e.response.headers.get("Retry-After", 1))
+                        wait = max(retry_after, 2**attempt)
+                        logger.warning(
+                            "Slack rate-limited (429), retrying after %ds (attempt %d/5)",
+                            wait,
+                            attempt + 1,
+                        )
+                        time.sleep(wait)
+                    else:
+                        raise
+            else:
+                # Exhausted retries
+                return {
+                    "ok": False,
+                    "error": "Slack rate-limit exceeded after 5 retries",
+                }
+
             for channel in response.get("channels", []):
                 channels.append(
                     {
@@ -156,7 +201,8 @@ def list_channels(bot_token: str) -> dict:
             cursor = response.get("response_metadata", {}).get("next_cursor")
             if not cursor:
                 break
-        return {"ok": True, "channels": channels}
+
+        return {"ok": True, "channels": channels, "is_member_only": not browse_all}
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -263,7 +263,12 @@ def slack_channels():
     from vibe import api
 
     payload = request.json or {}
-    return jsonify(api.list_channels(payload.get("bot_token", "")))
+    return jsonify(
+        api.list_channels(
+            payload.get("bot_token", ""),
+            browse_all=payload.get("browse_all", False),
+        )
+    )
 
 
 @app.route("/doctor", methods=["POST"])


### PR DESCRIPTION
## Summary

- Default channel listing now uses `users_conversations` (bot-joined channels only) instead of `conversations_list` (all workspace channels), reducing API calls from potentially hundreds to 1-2
- Added "Browse All Channels" button for users who need to see/configure channels the bot hasn't joined yet
- Added automatic retry with exponential backoff (up to 5 attempts) for Slack 429 rate-limit errors

## Problem

Workspaces with many channels (thousands) cause the channel settings page to fire many consecutive `conversations_list` API calls, triggering Slack's Tier 2 rate limit (~20 req/min).

## Solution

**Backend (`vibe/api.py`):**
- `list_channels()` defaults to `users_conversations` — only returns channels the bot has joined (typically <50, 1-2 API calls)
- New `browse_all` parameter switches to `conversations_list` for full workspace listing
- 429 responses are handled with retry + exponential backoff (respects `Retry-After` header)

**Frontend:**
- Default view shows bot-member channels (fast, no rate-limit risk)
- "Browse All Channels" button loads all workspace channels on demand
- i18n updated for both EN and ZH

## How to test

1. Start vibe with a workspace that has many channels
2. Open Channel Settings — should load quickly (bot-member channels only)
3. Click "Browse All Channels" — loads all channels with loading indicator
4. Verify refresh button works in both modes