### PR TITLE
fix(reaction): decouple :eyes: lifecycle from agent implementations

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -205,11 +205,10 @@ class MessageHandler:
                     )
                 except Exception as err:
                     logger.debug(f"Failed to add subagent reaction: {err}")
-                if ack_reaction_message_id and ack_reaction_emoji:
-                    try:
-                        await self.im_client.remove_reaction(context, ack_reaction_message_id, ack_reaction_emoji)
-                    except Exception as err:
-                        logger.debug(f"Failed to remove reaction ack for subagent: {err}")
+                # Keep :eyes: alive — the agent will remove it on result/error
+                # via the normal ack_reaction lifecycle.  Previously :eyes: was
+                # removed here immediately, leaving no processing indicator
+                # for the entire duration of the subagent run.
 
             # Process file attachments if present
             processed_files = None
@@ -230,9 +229,9 @@ class MessageHandler:
                 subagent_key=matched_prefix,
                 subagent_model=subagent_model,
                 subagent_reasoning_effort=subagent_reasoning_effort,
-                # Pass reaction info for agents to remove when result is sent
-                ack_reaction_message_id=ack_reaction_message_id if not subagent_name else None,
-                ack_reaction_emoji=ack_reaction_emoji if not subagent_name else None,
+                # Reaction info — agent removes :eyes: on result/error
+                ack_reaction_message_id=ack_reaction_message_id,
+                ack_reaction_emoji=ack_reaction_emoji,
                 files=processed_files,
             )
             try:
@@ -258,7 +257,6 @@ class MessageHandler:
                     if (
                         ack_reaction_message_id  # type: ignore[possibly-undefined]
                         and ack_reaction_emoji  # type: ignore[possibly-undefined]
-                        and not subagent_name  # type: ignore[possibly-undefined]
                     ):
                         await self.im_client.remove_reaction(context, ack_reaction_message_id, ack_reaction_emoji)
             except Exception as cleanup_err:
@@ -405,9 +403,7 @@ class MessageHandler:
     async def _handle_missing_agent(self, context: MessageContext, agent_name: str):
         """Notify user when a requested agent backend is unavailable."""
         target = agent_name or self.controller.agent_service.default_agent
-        msg = (
-            f"❌ {self._t('error.agentNotConfigured', agent=target)}"
-        )
+        msg = f"❌ {self._t('error.agentNotConfigured', agent=target)}"
         await self.im_client.send_message(context, msg)
 
     async def _delete_ack(self, channel_id: str, request: AgentRequest):

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -380,20 +380,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             finally:
                 request.ack_message_id = None
 
-    async def _remove_ack_reaction(self, request: AgentRequest) -> None:
-        """Remove acknowledgement reaction on error paths."""
-        if request.ack_reaction_message_id and request.ack_reaction_emoji:
-            try:
-                await self.im_client.remove_reaction(
-                    request.context,
-                    request.ack_reaction_message_id,
-                    request.ack_reaction_emoji,
-                )
-            except Exception as err:
-                logger.debug(f"Could not remove ack reaction: {err}")
-            finally:
-                request.ack_reaction_message_id = None
-                request.ack_reaction_emoji = None
+    # _remove_ack_reaction is inherited from BaseAgent
 
     async def restore_active_polls(self) -> int:
         """Restore active poll loops that were interrupted by vibe-remote restart."""


### PR DESCRIPTION
## Summary

- **Root cause fix**: Claude agent's `_receive_messages` had a `finally` block that unconditionally cleared all pending reactions. When the receiver ended normally (stream exhausted after result), it would also clear reactions that belonged to newly queued messages — causing :eyes: to disappear while the agent was still processing.
- **Subagent fix**: Previously, :eyes: was immediately removed and replaced with :robot_face: when a subagent prefix was detected. Now :eyes: stays alive through the normal lifecycle and gets removed on result/error like any other request.
- **Decouple reaction from agents**: Removed duplicate `_remove_ack_reaction` implementations from CodexAgent and OpenCodeAgent — they now inherit the single implementation from BaseAgent.

## Changes

| File | What changed |
|------|-------------|
| `modules/agents/base.py` | Single source of truth for `_remove_ack_reaction`; improved docstring |
| `modules/agents/claude_agent.py` | Replaced `finally` with explicit `CancelledError` handler; removed dead `_remove_ack_reaction_direct` |
| `modules/agents/codex_agent.py` | Removed duplicate `_remove_ack_reaction` (inherits from BaseAgent) |
| `modules/agents/opencode/agent.py` | Removed duplicate `_remove_ack_reaction` (inherits from BaseAgent) |
| `core/handlers/message_handler.py` | Subagent path no longer removes :eyes: early; reaction info always passed to agent |

## How to test

1. Send a message to any agent — :eyes: should appear and stay until result/error
2. Send a message with a subagent prefix (e.g. `@reviewer ...`) — :eyes: should stay alongside :robot_face: until completion
3. Send two messages quickly in the same Claude thread — second message's :eyes: should not disappear when first result arrives
4. Use `/stop` or `/clear` — :eyes: should be removed properly

## Risks

- If the Claude SDK stream ends without sending a `ResultMessage` AND without raising an exception (silent close), the :eyes: reaction will remain. This is a deliberate trade-off: it's better to leave a stale indicator than to prematurely remove one for an in-flight request.