### PR TITLE
fix(opencode): use variant instead of reasoningEffort in API requests

### DIFF
--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -489,7 +489,7 @@ class OpenCodeServerManager:
         if model:
             body["model"] = model
         if reasoning_effort:
-            body["reasoningEffort"] = reasoning_effort
+            body["variant"] = reasoning_effort
 
         async with session.post(
             f"{self.base_url}/session/{session_id}/message",
@@ -524,7 +524,7 @@ class OpenCodeServerManager:
         if model:
             body["model"] = model
         if reasoning_effort:
-            body["reasoningEffort"] = reasoning_effort
+            body["variant"] = reasoning_effort
 
         async with session.post(
             f"{self.base_url}/session/{session_id}/prompt_async",


### PR DESCRIPTION
## Summary

- Fix channel reasoning effort settings not taking effect with OpenCode

## Root Cause

OpenCode's `prompt_async` and `message` API endpoints use `variant` (not `reasoningEffort`) as the request body field for reasoning effort control. The `PromptInput` Zod schema validates and strips unknown fields, so `reasoningEffort` was silently discarded — making channel-level reasoning effort settings completely non-functional.

## Changes

- `modules/agents/opencode/server.py`: Change `body["reasoningEffort"]` → `body["variant"]` in both `send_message()` and `prompt_async()` methods.

## How It Works

OpenCode maps variant names (e.g. `"high"`, `"max"`) to provider-specific options:
- Anthropic: `thinking.budgetTokens`  
- OpenAI: `reasoningEffort` + `reasoningSummary`
- Google: `thinkingConfig.thinkingBudget`

The existing Slack UI already builds dropdown options from model variant names, so the values are already compatible.

## How to Test

1. Set a reasoning effort (e.g. "high" or "max") in channel Agent Settings
2. Send a message to the channel
3. Verify the model uses the configured reasoning level (check OpenCode session logs or response quality)