### PR TITLE
fix(ui): add 3s delay between stop and start on Web UI restart

### DIFF
--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -167,8 +167,11 @@ def control():
         _stop_opencode_server()
         runtime.write_status("stopped")
     elif action == "restart":
+        import time
+
         runtime.stop_service()
         _stop_opencode_server()
+        time.sleep(3)
         runtime.ensure_config()
         service_pid = runtime.start_service()
         runtime.write_status("running", "restarted", service_pid, status.get("ui_pid"))


### PR DESCRIPTION
## Summary

- Add a 3-second delay between stop and start in the Web UI restart flow, matching `vibe restart` CLI behavior

## Problem

The Web UI restart handler sends SIGTERM to the old service process and immediately spawns a new one. Since `stop_process()` doesn't wait for the process to actually exit, the new process could start while the old one is still cleaning up, risking port conflicts or state file corruption.

The CLI `vibe restart` already has a `time.sleep(3)` grace period between `cmd_stop()` and `cmd_vibe()`.

## Changes

- `vibe/ui_server.py`: Add `time.sleep(3)` after stopping service and OpenCode server, before starting the new service.