### PR TITLE
feat(message): add include_user_info toggle to prepend user identity to agent messages

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -147,6 +147,7 @@ class V2Config:
     update: UpdateConfig = field(default_factory=UpdateConfig)
     ack_mode: str = "reaction"
     show_duration: bool = True  # Show task duration in result messages
+    include_user_info: bool = False  # Prepend user identity to agent messages
     language: str = "en"  # Global language setting (see vibe/i18n)
 
     @classmethod
@@ -261,6 +262,10 @@ class V2Config:
         if not isinstance(show_duration, bool):
             show_duration = True
 
+        include_user_info = payload.get("include_user_info", False)
+        if not isinstance(include_user_info, bool):
+            include_user_info = False
+
         language = normalize_language(payload.get("language"), default="en")
 
         return cls(
@@ -277,6 +282,7 @@ class V2Config:
             update=update,
             ack_mode=ack_mode,
             show_duration=show_duration,
+            include_user_info=include_user_info,
             language=language,
         )
 
@@ -305,6 +311,7 @@ class V2Config:
             "update": self.update.__dict__,
             "ack_mode": self.ack_mode,
             "show_duration": self.show_duration,
+            "include_user_info": self.include_user_info,
             "language": self.language,
         }
         path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/core/controller.py
+++ b/core/controller.py
@@ -137,7 +137,8 @@ class Controller:
         """Hot-reload mutable message-processing settings from config.json.
 
         Called on every ``_t()`` invocation (guarded by mtime check).
-        Refreshes: language, show_duration, ack_mode, require_mention (global).
+        Refreshes: language, show_duration, ack_mode, include_user_info,
+        require_mention (global).
         """
         try:
             config_path = paths.get_config_path()
@@ -151,6 +152,7 @@ class Controller:
                 self.config.language = v2_config.language
                 self.config.show_duration = v2_config.show_duration
                 self.config.ack_mode = v2_config.ack_mode
+                self.config.include_user_info = v2_config.include_user_info
 
                 # Sync global require_mention into the IM client's platform config
                 platform = getattr(self.config, "platform", "")

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -217,6 +217,10 @@ class MessageHandler:
                 if processed_files:
                     logger.info(f"Processed {len(processed_files)} file attachments for message")
 
+            # Prepend user identity when include_user_info is enabled
+            if self.config.include_user_info:
+                message = await self._prepend_user_info(context, message)
+
             request = AgentRequest(
                 context=context,
                 message=message,
@@ -265,6 +269,25 @@ class MessageHandler:
                 context,
                 self.formatter.format_error(self._t("error.processMessageFailed", error=str(e))),
             )
+
+    @staticmethod
+    def _sanitize_identity(value: str) -> str:
+        """Strip control chars and delimiters that could break the [name<id>] format."""
+        token = (value or "").replace("\n", " ").replace("\r", " ").strip()
+        token = token.replace("[", "(").replace("]", ")").replace("<", "(").replace(">", ")")
+        return token[:80] or "unknown"
+
+    async def _prepend_user_info(self, context: MessageContext, message: str) -> str:
+        """Prepend user identity as [username<user_id>] to the message."""
+        try:
+            user_info = await self.im_client.get_user_info(context.user_id)
+            raw_name = user_info.get("display_name") or user_info.get("name") or "unknown"
+        except Exception as e:
+            logger.debug(f"Failed to fetch user info for {context.user_id}: {e}")
+            raw_name = "unknown"
+        name = self._sanitize_identity(raw_name)
+        uid = self._sanitize_identity(context.user_id)
+        return f"[{name}<{uid}>] {message}"
 
     async def handle_callback_query(self, context: MessageContext, callback_data: str):
         """Route callback queries to appropriate handlers"""

--- a/modules/im/discord.py
+++ b/modules/im/discord.py
@@ -43,6 +43,7 @@ class DiscordBot(BaseIMClient):
         self.settings_manager = None
         self._controller = None
         self._on_ready: Optional[Callable] = None
+        self._user_info_cache: Dict[str, Dict[str, Any]] = {}
 
         self.client.on_ready = self._on_ready_event
         self.client.on_message = self._on_message_event
@@ -321,6 +322,9 @@ class DiscordBot(BaseIMClient):
             return None
 
     async def get_user_info(self, user_id: str) -> Dict[str, Any]:
+        cached = self._user_info_cache.get(user_id)
+        if cached is not None:
+            return cached
         uid = self._to_int_id(user_id)
         if uid is None:
             return {"id": user_id}
@@ -332,7 +336,9 @@ class DiscordBot(BaseIMClient):
                 user = None
         if user is None:
             return {"id": user_id}
-        return {"id": str(user.id), "name": user.name, "display_name": user.display_name}
+        info = {"id": str(user.id), "name": user.name, "display_name": user.display_name}
+        self._user_info_cache[user_id] = info
+        return info
 
     async def get_channel_info(self, channel_id: str) -> Dict[str, Any]:
         channel = await self._fetch_channel(channel_id)

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -100,6 +100,7 @@ class FeishuBot(BaseIMClient):
         self._recent_event_ids: Dict[str, float] = {}
         self._cached_token: Optional[str] = None
         self._token_expires_at: Optional[float] = None
+        self._user_info_cache: Dict[str, Dict[str, Any]] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle / injection
@@ -891,7 +892,10 @@ class FeishuBot(BaseIMClient):
     # User / channel info
     # ------------------------------------------------------------------
     async def get_user_info(self, user_id: str) -> Dict[str, Any]:
-        """Get information about a Feishu user by open_id."""
+        """Get information about a Feishu user by open_id (cached permanently)."""
+        cached = self._user_info_cache.get(user_id)
+        if cached is not None:
+            return cached
         self._ensure_client()
         try:
             token = await self._get_tenant_token()
@@ -904,12 +908,14 @@ class FeishuBot(BaseIMClient):
                     if result.get("code") != 0:
                         return {"id": user_id}
                     user = result.get("data", {}).get("user", {})
-                    return {
+                    info = {
                         "id": user_id,
                         "name": user.get("name", ""),
                         "display_name": user.get("name", ""),
                         "email": user.get("email"),
                     }
+                    self._user_info_cache[user_id] = info
+                    return info
         except Exception as exc:
             logger.error("Error getting Feishu user info: %s", exc)
             return {"id": user_id}

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -57,6 +57,7 @@ class SlackBot(BaseIMClient):
         # Controller reference for update button handling (will be injected later)
         self._controller = None
         self._recent_event_ids: Dict[str, float] = {}
+        self._user_info_cache: Dict[str, Dict[str, Any]] = {}
         self._stop_event: Optional[asyncio.Event] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._on_ready: Optional[Callable] = None
@@ -1529,12 +1530,15 @@ class SlackBot(BaseIMClient):
                 logger.debug(f"Slack web client close failed: {exc}")
 
     async def get_user_info(self, user_id: str) -> Dict[str, Any]:
-        """Get information about a Slack user"""
+        """Get information about a Slack user (cached permanently)"""
+        cached = self._user_info_cache.get(user_id)
+        if cached is not None:
+            return cached
         self._ensure_clients()
         try:
             response = await self.web_client.users_info(user=user_id)
             user = response["user"]
-            return {
+            info = {
                 "id": user["id"],
                 "name": user.get("name"),
                 "real_name": user.get("real_name"),
@@ -1544,7 +1548,9 @@ class SlackBot(BaseIMClient):
             }
         except SlackApiError as e:
             logger.error(f"Error getting user info: {e}")
-            raise
+            info = {"id": user_id}
+        self._user_info_cache[user_id] = info
+        return info
 
     async def get_channel_info(self, channel_id: str) -> Dict[str, Any]:
         """Get information about a Slack channel"""

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -417,6 +417,37 @@ export const Dashboard: React.FC = () => {
                         </button>
                     </div>
                     <div className="flex justify-between items-center">
+                        <span className="text-muted flex items-center gap-1">
+                            {t('dashboard.includeUserInfo')}
+                            <span className="relative group">
+                                <Info size={12} className="text-muted/50 cursor-help" />
+                                <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-text text-bg text-xs rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                                    {t('dashboard.includeUserInfoHint')}
+                                </span>
+                            </span>
+                        </span>
+                        <button
+                            onClick={() => {
+                                setSettingsMessage(null);
+                                const newConfig = {
+                                    ...config,
+                                    include_user_info: !config.include_user_info,
+                                };
+                                setConfig(newConfig);
+                                autoSaveMessageConfig(newConfig);
+                            }}
+                            className={`px-2 py-1 rounded text-xs font-semibold border ${
+                                config.include_user_info
+                                    ? 'bg-success/10 text-success border-success/20'
+                                    : 'bg-neutral-100 text-muted border-border'
+                            }`}
+                        >
+                            {config.include_user_info
+                                ? t('common.enabled')
+                                : t('common.disabled')}
+                        </button>
+                    </div>
+                    <div className="flex justify-between items-center">
                         <span className="text-muted">{t('dashboard.allowedChannels')}</span>
                         <Link to="/channels" className="text-xs text-accent hover:underline font-medium">{t('common.manageChannels')}</Link>
                     </div>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -352,6 +352,8 @@
     "errorRetryLimitHint": "Auto-retry with 'continue' when LLM stream errors occur (0 = no retry)",
     "showDuration": "Show Duration",
     "showDurationHint": "Display task elapsed time in result messages",
+    "includeUserInfo": "Include User Info",
+    "includeUserInfoHint": "Prepend [username<user_id>] to messages sent to agents",
     "allowedChannels": "Allowed Channels",
     "consoleServer": "Console Server",
     "host": "Host",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -352,6 +352,8 @@
     "errorRetryLimitHint": "当 LLM 流式响应出错时，自动发送 'continue' 重试（0 = 不重试）",
     "showDuration": "显示耗时",
     "showDurationHint": "在结果消息中显示任务耗时",
+    "includeUserInfo": "携带用户信息",
+    "includeUserInfoHint": "在发给 Agent 的消息前添加 [用户名<用户ID>]",
     "allowedChannels": "允许的频道",
     "consoleServer": "控制台服务器",
     "host": "主机",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -63,6 +63,7 @@ def config_to_payload(config: V2Config) -> dict:
         "ack_mode": config.ack_mode,
         "language": config.language,
         "show_duration": config.show_duration,
+        "include_user_info": config.include_user_info,
     }
     return payload
 


### PR DESCRIPTION
## Summary
- Add a global **Include User Info** toggle (`include_user_info`) to prepend `[username<user_id>]` to every message forwarded to agent backends (OpenCode / Claude / Codex)
- Configurable via Web UI Dashboard under **Message Handling**, auto-saved with no restart needed
- Default: **off**

## Changes
| Area | Files | What |
|------|-------|------|
| Config | `config/v2_config.py`, `vibe/api.py` | New `include_user_info: bool` field, serialization, hot-reload |
| Core | `core/controller.py`, `core/handlers/message_handler.py` | Hot-reload support, `_prepend_user_info()` with sanitization |
| IM caching | `modules/im/slack.py`, `discord.py`, `feishu.py` | Permanent in-memory cache on `get_user_info()` (one API call per user, ever) |
| UI | `ui/src/components/Dashboard.tsx` | Toggle button in Message Handling section |
| i18n | `ui/src/i18n/en.json`, `zh.json` | English + Chinese translations |

## Message format
When enabled, agent receives:
```
[张三<U123ABC456>] 原始消息内容
```

## Safety
- Username/user_id sanitized (control chars, brackets stripped, 80-char cap) to prevent prompt injection
- Slack API failures produce negative cache entries (no repeated failing calls)
- Consistent `[unknown<user_id>]` fallback on any error path