### PR TITLE
fix: Features text, duration format, and Feishu image MIME detection

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -507,6 +507,16 @@ class MessageHandler:
                     }
                     content = await self.im_client.download_file(file_info)
                     if content:
+                        # Detect actual MIME type from magic bytes for images
+                        # (some platforms don't provide accurate MIME, e.g. Feishu)
+                        detected = self._detect_image_mime(content)
+                        if detected:
+                            attachment.mimetype = detected[0]
+                            # Fix filename extension to match actual type
+                            ext = detected[1]
+                            base = os.path.splitext(attachment.name)[0]
+                            attachment.name = f"{base}{ext}"
+
                         # Generate filename: {timestamp}_{original_name}
                         timestamp = int(time.time())
                         safe_name = self._sanitize_filename(attachment.name)
@@ -536,6 +546,26 @@ class MessageHandler:
                 continue
 
         return processed if processed else None
+
+    def _detect_image_mime(self, data: bytes) -> Optional[tuple]:
+        """Detect image MIME type from magic bytes.
+
+        Returns:
+            (mimetype, extension) tuple if recognized image, else None.
+        """
+        if len(data) < 12:
+            return None
+        if data[:3] == b"\xff\xd8\xff":
+            return ("image/jpeg", ".jpg")
+        if data[:8] == b"\x89PNG\r\n\x1a\n":
+            return ("image/png", ".png")
+        if data[:4] == b"GIF8":
+            return ("image/gif", ".gif")
+        if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            return ("image/webp", ".webp")
+        if data[:2] == b"BM":
+            return ("image/bmp", ".bmp")
+        return None
 
     def _sanitize_filename(self, filename: str) -> str:
         """Sanitize filename to be safe for filesystem.

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -833,10 +833,12 @@ class FeishuBot(BaseIMClient):
                 if message_id and image_key
                 else None
             )
+            # Don't assume PNG — use generic mimetype; actual type is
+            # detected from magic bytes after download in message_handler.
             attachments.append(
                 FileAttachment(
-                    name=f"{image_key}.png",
-                    mimetype="image/png",
+                    name=f"{image_key}.image",
+                    mimetype="image/unknown",
                     url=url,
                     size=None,
                 )

--- a/modules/im/formatters/base_formatter.py
+++ b/modules/im/formatters/base_formatter.py
@@ -336,8 +336,8 @@ class BaseMarkdownFormatter(ABC):
     ) -> str:
         """Format result message.
 
-        Format: ⏱️_Success_: 2m 24s  (when show_duration=True)
-                ⏱️_Success_           (when show_duration=False)
+        Format: ⏱️ Success: 2m 24s  (when show_duration=True)
+                ⏱️ Success           (when show_duration=False)
         """
         subtype_display = subtype.capitalize() if subtype else "Done"
 
@@ -351,9 +351,9 @@ class BaseMarkdownFormatter(ABC):
             else:
                 duration_str = f"{seconds}s"
 
-            result_text = f"⏱️{self.format_italic(subtype_display)}: {duration_str}"
+            result_text = f"⏱️ {subtype_display}: {duration_str}"
         else:
-            result_text = f"⏱️{self.format_italic(subtype_display)}"
+            result_text = f"⏱️ {subtype_display}"
 
         if result:
             result_text += f"\n\n{result}"

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -91,7 +91,7 @@
     "howItWorksWorkDirLabel": "File Attachments",
     "howItWorksWorkDirDesc": "Attach images or files to your message — the agent can read them directly.",
     "howItWorksSettingsLabel": "Flexible Settings",
-    "howItWorksSettingsDesc": "Use /start → Settings to switch agents, models, reasoning effort, or hide verbose message types.",
+    "howItWorksSettingsDesc": "Mention @bot to switch agents, models, reasoning effort, or hide verbose message types.",
     "howItWorksFooter": "Just type to chat with {agent}. No special commands needed!",
     "genericTitle": "Info: {topic}",
     "genericFooter": "This feature is coming soon!"

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -91,7 +91,7 @@
     "howItWorksWorkDirLabel": "文件附件",
     "howItWorksWorkDirDesc": "直接在消息中附带图片或文件，Agent 可以读取。",
     "howItWorksSettingsLabel": "灵活设置",
-    "howItWorksSettingsDesc": "通过 /start → 设置，随时切换 Agent、模型、推理强度，或隐藏冗余消息类型。",
+    "howItWorksSettingsDesc": "通过 @bot 随时切换 Agent、模型、推理强度，或隐藏冗余消息类型。",
     "howItWorksFooter": "直接输入消息即可与 {agent} 对话，无需特殊命令！",
     "genericTitle": "信息：{topic}",
     "genericFooter": "该功能即将上线！"


### PR DESCRIPTION
## Summary

- **Features 文案**: 将 "/start → 设置" 改为 "@bot"，突出灵活切换 Agent/模型/推理强度/隐藏冗余消息
- **耗时格式**: 去掉 success 文本的 italic 下划线包裹（`⏱️_Success_` → `⏱️ Success`）
- **飞书图片 MIME 修复**: 不再对所有图片硬编码 `image/png`，下载后从 magic bytes 检测实际格式（JPEG/PNG/GIF/WEBP/BMP），自动修正 mimetype 和文件扩展名，修复 OpenCode `APIError: image was specified using image/png but appears to be image/jpeg`

## Changes

- `vibe/i18n/en.json` / `zh.json` — Settings tip rewrite
- `modules/im/formatters/base_formatter.py` — Remove `format_italic()` from `format_result_message()`
- `modules/im/feishu.py` — Use `image/unknown` + `.image` instead of hardcoded `image/png` + `.png`
- `core/handlers/message_handler.py` — Add `_detect_image_mime()` magic-byte detection after download (platform-agnostic)