### PR TITLE
fix(api): remove home-directory restriction from directory browser

### DIFF
--- a/vibe/api.py
+++ b/vibe/api.py
@@ -29,27 +29,19 @@ _OPENCODE_OPTIONS_TTL_SECONDS = 30.0
 def browse_directory(path: str) -> dict:
     """List sub-directories of *path* for the directory browser UI.
 
-    Restricted to the user's home directory tree.  Symlinks are not
-    followed when scanning entries, preventing escape via crafted links.
+    Symlinks are not followed when scanning entries.
 
     Returns ``{"ok": True, "path": <abs>, "parent": <abs|None>, "dirs": [...]}``
     where each entry in *dirs* is ``{"name": ..., "path": ...}``.
     """
     try:
-        home = Path.home().resolve()
         target = Path(os.path.expanduser(path or "~")).resolve()
-
-        # Restrict browsing to within the user's home directory
-        try:
-            target.relative_to(home)
-        except ValueError:
-            return {"ok": False, "error": "path_out_of_scope"}
 
         if not target.is_dir():
             return {"ok": False, "error": f"Not a directory: {target}"}
 
         abs_path = str(target)
-        parent = str(target.parent) if target != home else None
+        parent = str(target.parent) if target.parent != target else None
 
         entries: list[dict[str, str]] = []
         try:


### PR DESCRIPTION
## Summary

- 去掉目录浏览器的 `$HOME` 限制，允许用户浏览和选择任意目录（如 `/opt`、`/srv`）
- 上级目录按钮改为在文件系统根目录 `/` 停止，而非 home 目录
- 此修复原本在 PR #59 合并后才推到分支，未进入 master

## Changes

- `vibe/api.py` — 移除 `relative_to(home)` 检查和 `path_out_of_scope` 错误，`parent` 判断改为 `target.parent != target`