### PR TITLE
feat(ui): add show hidden directories toggle to directory browser

### DIFF
--- a/ui/src/components/ui/directory-browser.tsx
+++ b/ui/src/components/ui/directory-browser.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { Folder, FolderOpen, ChevronRight, ArrowUp, X, Check, RefreshCw } from 'lucide-react';
+import { Folder, FolderOpen, ChevronRight, ArrowUp, X, Check, RefreshCw, Eye, EyeOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useApi } from '../../context/ApiContext';
 import clsx from 'clsx';
@@ -26,6 +26,7 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
   const [dirs, setDirs] = useState<{ name: string; path: string }[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showHidden, setShowHidden] = useState(false);
 
   // Guard against setState after unmount / stale responses
   const mountedRef = useRef(true);
@@ -45,12 +46,13 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
   }, [onClose]);
 
   const browse = useCallback(
-    async (path: string) => {
+    async (path: string, hidden?: boolean) => {
       const id = ++reqIdRef.current;
       setLoading(true);
       setError(null);
+      const useHidden = hidden ?? showHidden;
       try {
-        const result = await api.browseDirectory(path);
+        const result = await api.browseDirectory(path, useHidden);
         if (!mountedRef.current || reqIdRef.current !== id) return;
         if (result.ok) {
           setCurrentPath(result.path ?? path);
@@ -68,7 +70,7 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
         }
       }
     },
-    [api],
+    [api, showHidden],
   );
 
   useEffect(() => {
@@ -106,9 +108,25 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
           <h3 className="font-semibold text-text text-sm">{t('directoryBrowser.title')}</h3>
-          <button onClick={onClose} className="text-muted hover:text-text transition-colors">
-            <X size={16} />
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                const next = !showHidden;
+                setShowHidden(next);
+                browse(currentPath, next);
+              }}
+              className={clsx(
+                'p-1 rounded transition-colors',
+                showHidden ? 'text-accent' : 'text-muted hover:text-text',
+              )}
+              title={showHidden ? t('directoryBrowser.hideHidden') : t('directoryBrowser.showHidden')}
+            >
+              {showHidden ? <Eye size={15} /> : <EyeOff size={15} />}
+            </button>
+            <button onClick={onClose} className="text-muted hover:text-text transition-colors">
+              <X size={16} />
+            </button>
+          </div>
         </div>
 
         {/* Breadcrumb */}

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -27,7 +27,7 @@ export type ApiContextType = {
   getLogs: (lines?: number) => Promise<{ logs: LogEntry[]; total: number }>;
   getVersion: () => Promise<VersionInfo>;
   doUpgrade: () => Promise<UpgradeResult>;
-  browseDirectory: (path: string) => Promise<{ ok: boolean; path?: string; parent?: string | null; dirs?: { name: string; path: string }[]; error?: string }>;
+  browseDirectory: (path: string, showHidden?: boolean) => Promise<{ ok: boolean; path?: string; parent?: string | null; dirs?: { name: string; path: string }[]; error?: string }>;
 };
 
 export type LogEntry = {
@@ -142,7 +142,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     getLogs: (lines = 500) => postJson('/logs', { lines }),
     getVersion: () => getJson('/version'),
     doUpgrade: () => postJson('/upgrade', {}),
-    browseDirectory: (path) => postJson('/browse', { path }),
+    browseDirectory: (path, showHidden) => postJson('/browse', { path, show_hidden: showHidden || false }),
   };
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -415,6 +415,8 @@
   "directoryBrowser": {
     "title": "Browse Directory",
     "select": "Select",
-    "empty": "No subdirectories"
+    "empty": "No subdirectories",
+    "showHidden": "Show hidden directories",
+    "hideHidden": "Hide hidden directories"
   }
 }

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -415,6 +415,8 @@
   "directoryBrowser": {
     "title": "浏览目录",
     "select": "选择",
-    "empty": "没有子目录"
+    "empty": "没有子目录",
+    "showHidden": "显示隐藏目录",
+    "hideHidden": "隐藏隐藏目录"
   }
 }

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -26,7 +26,7 @@ _OPENCODE_OPTIONS_CACHE: dict[str, dict] = {}
 _OPENCODE_OPTIONS_TTL_SECONDS = 30.0
 
 
-def browse_directory(path: str) -> dict:
+def browse_directory(path: str, show_hidden: bool = False) -> dict:
     """List sub-directories of *path* for the directory browser UI.
 
     Symlinks are not followed when scanning entries.
@@ -46,7 +46,7 @@ def browse_directory(path: str) -> dict:
         entries: list[dict[str, str]] = []
         try:
             for entry in sorted(os.scandir(abs_path), key=lambda e: e.name.lower()):
-                if entry.name.startswith("."):
+                if not show_hidden and entry.name.startswith("."):
                     continue
                 if entry.is_dir(follow_symlinks=False):
                     entries.append({"name": entry.name, "path": str(target / entry.name)})

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -478,7 +478,12 @@ def browse_directory():
     from vibe import api
 
     payload = request.json or {}
-    return jsonify(api.browse_directory(payload.get("path", "~")))
+    return jsonify(
+        api.browse_directory(
+            payload.get("path", "~"),
+            show_hidden=bool(payload.get("show_hidden", False)),
+        )
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- 目录浏览器 header 新增眼睛图标开关，点击可显示/隐藏以 `.` 开头的目录（如 `.config`、`.ssh`）
- 默认关闭，切换时即时刷新目录列表

## Changes

- `vibe/api.py` — `browse_directory()` 新增 `show_hidden` 参数
- `vibe/ui_server.py` — `/browse` 路由传递 `show_hidden`
- `ui/src/context/ApiContext.tsx` — `browseDirectory` 增加 `showHidden` 参数
- `ui/src/components/ui/directory-browser.tsx` — Eye/EyeOff 切换按钮，toggle 后重新请求
- `ui/src/i18n/en.json` / `zh.json` — tooltip 文案