### PR TITLE
fix(opencode): fallback text extraction when last message has no text parts

### DIFF
--- a/modules/agents/opencode/message_processor.py
+++ b/modules/agents/opencode/message_processor.py
@@ -26,7 +26,7 @@ class OpenCodeMessageProcessorMixin:
         if not text_parts and parts:
             part_types = [p.get("type") for p in parts]
             msg_id = response.get("info", {}).get("id", "unknown")
-            logger.warning(
+            logger.info(
                 "OpenCode message %s has no text parts; part types: %s",
                 msg_id,
                 part_types,

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -273,7 +273,7 @@ class OpenCodePollLoop:
                         if not msg_error:
                             error_retry_count = 0
                         final_text = self._agent._extract_response_text(last_message)
-                        if not final_text:
+                        if not final_text and not msg_error:
                             logger.warning(
                                 "Last message %s has no text parts (finish=%s); "
                                 "searching earlier messages for response text",


### PR DESCRIPTION
## Summary

Fixes false `(No response from OpenCode)` results when the agent's final response text is in an earlier message, not the last one.

## Problem

When OpenCode completes a turn, the poll loop extracts text from the **last** assistant message only. If the last message contains only tool calls or step markers (e.g., a final `TodoWrite` call) with no `type: "text"` parts, `_extract_response_text` returns empty — causing `(No response from OpenCode)` to be displayed even though the actual response text exists in an earlier message.

**Observed in production**: A long research response (~5 min) was generated and visible in logs, but the user saw `(No response from OpenCode)` because the final completed message was a tool-call-only message.

## Changes

- **`poll_loop.py`**: Added `_fallback_extract_text()` that walks backward through all session messages when the last message has no text. Applied to both `run_prompt_poll` and `run_restored_poll_loop`.
- **`message_processor.py`**: Upgraded log level from `debug` to `warning` when a message has no text parts, with message ID for traceability.

## How to test

1. Trigger a long OpenCode task that ends with a tool call (e.g., `TodoWrite`) after the main response text
2. Verify the response text is correctly delivered instead of `(No response from OpenCode)`
3. Check logs for `"Fallback: found response text in message..."` when the fallback path is triggered