### PR TITLE
fix(codex): suppress retry notification noise

### DIFF
--- a/modules/agents/codex/event_handler.py
+++ b/modules/agents/codex/event_handler.py
@@ -23,6 +23,8 @@ class CodexEventHandler:
         self._agent = agent
         # turnId → (accumulated_text, parse_mode)
         self._pending_assistant: dict[str, Tuple[str, Optional[str]]] = {}
+        # turnId → terminal error message captured from `error` notifications
+        self._terminal_errors: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -95,6 +97,7 @@ class CodexEventHandler:
         if status == "interrupted":
             # Turn was interrupted — discard pending text, no result message
             self._pending_assistant.pop(turn_id, None)
+            self._terminal_errors.pop(turn_id, None)
             if is_current:
                 await self._agent._remove_ack_reaction(request)
             return
@@ -102,11 +105,11 @@ class CodexEventHandler:
         if status == "failed":
             # Turn failed — emit error, discard pending text
             self._pending_assistant.pop(turn_id, None)
+            error_msg = self._terminal_errors.pop(turn_id, None)
             if is_current:
-                error_obj = turn_obj.get("error", {}) if isinstance(turn_obj, dict) else {}
-                error_msg = (
-                    error_obj.get("message", "Unknown error") if isinstance(error_obj, dict) else "Unknown error"
-                )
+                if not error_msg:
+                    error_obj = turn_obj.get("error", {}) if isinstance(turn_obj, dict) else {}
+                    error_msg = self._extract_error_message(error_obj)
                 await self._agent.controller.emit_agent_message(
                     request.context,
                     "notify",
@@ -118,10 +121,12 @@ class CodexEventHandler:
         # Stale turn completion — discard pending text, no side effects
         if not is_current:
             self._pending_assistant.pop(turn_id, None)
+            self._terminal_errors.pop(turn_id, None)
             logger.debug("Ignoring stale turn/completed for turn %s (current: %s)", turn_id, current_turn)
             return
 
         pending = self._pending_assistant.pop(turn_id, None)
+        self._terminal_errors.pop(turn_id, None)
         if pending:
             pending_text, pending_parse_mode = pending
             await self._agent.emit_result_message(
@@ -230,14 +235,28 @@ class CodexEventHandler:
 
     async def _on_error(self, params: dict[str, Any], request: AgentRequest) -> None:
         error = params.get("error", {})
-        message = error.get("message", "Unknown error") if isinstance(error, dict) else str(error)
-        will_retry = params.get("willRetry", False)
-        suffix = " (will retry)" if will_retry else ""
+        message = self._extract_error_message(error)
+        will_retry = params.get("willRetry") is True
+        turn_id = params.get("turnId", "")
+
+        if will_retry:
+            logger.info("Suppressing transient Codex error for turn %s: %s", turn_id or "<unknown>", message)
+            return
+
+        if turn_id:
+            self._terminal_errors[turn_id] = message
+            return
+
         await self._agent.controller.emit_agent_message(
             request.context,
             "notify",
-            f"❌ Codex error: {message}{suffix}",
+            f"❌ Codex error: {message}",
         )
+
+    def _extract_error_message(self, error: Any) -> str:
+        if isinstance(error, dict):
+            return error.get("message", "Unknown error")
+        return str(error)
 
     async def _on_agent_message_delta(self, params: dict[str, Any], request: AgentRequest) -> None:
         # Streaming delta — currently we accumulate at item/completed level,
@@ -266,6 +285,7 @@ class CodexEventHandler:
     def clear_pending(self, turn_id: str) -> None:
         """Discard buffered text for a turn (e.g. on interruption)."""
         self._pending_assistant.pop(turn_id, None)
+        self._terminal_errors.pop(turn_id, None)
 
     # ------------------------------------------------------------------
     # Dispatch table

--- a/tests/test_codex_event_handler.py
+++ b/tests/test_codex_event_handler.py
@@ -1,0 +1,91 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+_EVENT_HANDLER_PATH = Path(__file__).resolve().parents[1] / "modules/agents/codex/event_handler.py"
+_SPEC = importlib.util.spec_from_file_location("test_codex_event_handler_module", _EVENT_HANDLER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+CodexEventHandler = _MODULE.CodexEventHandler
+
+
+class _StubSessionManager:
+    def __init__(self, active_turn: str):
+        self.active_turn = active_turn
+
+    def get_active_turn(self, base_session_id: str):
+        return self.active_turn
+
+    def clear_active_turn(self, base_session_id: str) -> None:
+        self.active_turn = None
+
+
+class _StubAgent:
+    def __init__(self, active_turn: str):
+        self._session_mgr = _StubSessionManager(active_turn)
+        self._active_requests = {}
+        self.controller = SimpleNamespace(emit_agent_message=AsyncMock())
+        self.emit_result_message = AsyncMock()
+        self._remove_ack_reaction = AsyncMock()
+
+
+class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_retrying_error_is_suppressed(self):
+        agent = _StubAgent(active_turn="turn-1")
+        handler = CodexEventHandler(agent)
+        request = SimpleNamespace(base_session_id="session-1", context=object(), started_at=0)
+
+        await handler._on_error(
+            {
+                "error": {"message": "Reconnecting... 5/5"},
+                "willRetry": True,
+                "turnId": "turn-1",
+            },
+            request,
+        )
+
+        agent.controller.emit_agent_message.assert_not_awaited()
+
+    async def test_terminal_turn_error_is_emitted_once_on_completion(self):
+        agent = _StubAgent(active_turn="turn-1")
+        handler = CodexEventHandler(agent)
+        request = SimpleNamespace(base_session_id="session-1", context=object(), started_at=0)
+
+        await handler._on_error(
+            {
+                "error": {"message": "unexpected status 401 Unauthorized:"},
+                "willRetry": False,
+                "turnId": "turn-1",
+            },
+            request,
+        )
+
+        agent.controller.emit_agent_message.assert_not_awaited()
+
+        await handler._on_turn_completed(
+            {
+                "turn": {
+                    "id": "turn-1",
+                    "status": "failed",
+                    "error": {"message": "fallback message"},
+                }
+            },
+            request,
+        )
+
+        agent.controller.emit_agent_message.assert_awaited_once_with(
+            request.context,
+            "notify",
+            "❌ Codex turn failed: unexpected status 401 Unauthorized:",
+        )
+        agent._remove_ack_reaction.assert_awaited_once_with(request)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- suppress transient Codex `error` notifications when app-server marks them as retryable
- cache terminal turn errors by `turnId` so failed turns emit one final notify instead of duplicate retry noise
- add focused regression tests for retry suppression and final failure delivery

## Testing
- `python3 -m pytest tests/test_codex_event_handler.py`
- `ruff check modules/agents/codex/event_handler.py tests/test_codex_event_handler.py`

## Risks / Follow-ups
- this change only affects Codex app-server error presentation in vibe-remote and does not alter Codex CLI retry behavior itself
- periodic upstream reconnects still need separate investigation