### PR TITLE
fix(notify): strip scoped-key prefix before send_dm to admins

### DIFF
--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -292,14 +292,17 @@ class UpdateChecker:
     def _get_admin_user_ids(self) -> list:
         """Get admin user IDs from the settings store.
 
-        Returns a list of admin user IDs, or empty list if none configured.
+        Returns a list of raw platform user IDs (without scoped prefix)
+        for admins on the current platform, or empty list if none configured.
         """
         try:
             if hasattr(self.controller, "settings_manager"):
                 store = self.controller.settings_manager.get_store()
-                if store and hasattr(store, "get_admins"):
-                    admins = store.get_admins()
-                    return list(admins.keys())
+                if store:
+                    platform = getattr(self.controller.config, "platform", "slack")
+                    # get_users_for_platform() returns raw IDs (e.g. "U0E0FM3QT")
+                    # unlike get_admins() which returns scoped keys (e.g. "slack::U0E0FM3QT").
+                    return [uid for uid, user in store.get_users_for_platform(platform).items() if user.is_admin]
         except Exception as e:
             logger.warning(f"Failed to get admin user IDs: {e}")
         return []


### PR DESCRIPTION
## Summary
- Fix `user_not_found` error when sending version update DMs to admin users
- `_get_admin_user_ids()` was returning scoped keys (e.g. `slack::U0E0FM3QT`) from `get_admins()` and passing them directly to `send_dm()`, which caused the Slack API `conversations.open` to reject them
- Use `get_users_for_platform()` (which returns raw platform IDs) instead, filtered by `is_admin`

## Root Cause
Users in `v2_settings` are stored with scoped keys like `slack::U0E0FM3QT`. The old code called `store.get_admins()` without a platform parameter and used the dict keys as-is. These scoped keys were passed to `send_dm()` → Slack API `conversations.open(users=["slack::U0E0FM3QT"])`, which is not a valid Slack user ID.

## Impact
All platforms affected (Slack, Discord, Feishu) — admins on any platform would never receive version update notifications.

## How to Test
1. Configure an admin user via the Web UI
2. Trigger a version update check (or wait for periodic check)
3. Verify the admin receives the DM with the update notification