### PR TITLE
fix(codex,dispatcher): prevent cascading send failures and stale thread deadloop

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -146,7 +146,10 @@ class ConsolidatedMessageDispatcher:
 
         if canonical_type == "notify":
             target_context = self._get_target_context(context)
-            await im_client.send_message(target_context, text, parse_mode=parse_mode)
+            try:
+                await im_client.send_message(target_context, text, parse_mode=parse_mode)
+            except Exception as err:
+                logger.error("Failed to send notify message: %s", err)
             return
 
         if canonical_type == "result":
@@ -163,18 +166,31 @@ class ConsolidatedMessageDispatcher:
 
             if len(display_text) <= self._get_result_max_chars():
                 if enhanced and enhanced.buttons and self._supports_quick_replies():
-                    await self._send_with_quick_replies(
-                        im_client,
-                        target_context,
-                        display_text,
-                        enhanced.buttons,
-                        parse_mode,
-                    )
+                    try:
+                        await self._send_with_quick_replies(
+                            im_client,
+                            target_context,
+                            display_text,
+                            enhanced.buttons,
+                            parse_mode,
+                        )
+                    except Exception as err:
+                        logger.warning("Failed to send result with quick replies, falling back: %s", err)
+                        try:
+                            await im_client.send_message(target_context, display_text, parse_mode=parse_mode)
+                        except Exception as fallback_err:
+                            logger.error("Failed to send fallback result message: %s", fallback_err)
                 else:
-                    await im_client.send_message(target_context, display_text, parse_mode=parse_mode)
+                    try:
+                        await im_client.send_message(target_context, display_text, parse_mode=parse_mode)
+                    except Exception as err:
+                        logger.error("Failed to send result message: %s", err)
             else:
                 summary = self._build_result_summary(display_text, self._get_result_max_chars())
-                await im_client.send_message(target_context, summary, parse_mode=parse_mode)
+                try:
+                    await im_client.send_message(target_context, summary, parse_mode=parse_mode)
+                except Exception as err:
+                    logger.error("Failed to send result summary: %s", err)
 
                 if self.controller.config.platform in {"slack", "discord", "lark"} and hasattr(
                     im_client, "upload_markdown"

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -73,8 +73,9 @@ class CodexAgent(BaseAgent):
             await self._remove_ack_reaction(request)
             return
 
-        # Track settings_key for scoped clear
+        # Track settings_key and cwd for scoped invalidation
         self._session_mgr.set_settings_key(request.base_session_id, request.settings_key)
+        self._session_mgr.set_cwd(request.base_session_id, request.working_path)
 
         await self._delete_ack(request)
 
@@ -112,50 +113,32 @@ class CodexAgent(BaseAgent):
                     if interrupted_request:
                         await self._remove_ack_reaction(interrupted_request)
 
-                # Build input items
-                input_items = self._build_input(request)
-
-                # Read configuration overrides using settings_key (user_id for DM, channel_id for channels)
-                channel_settings = self.settings_manager.get_channel_settings(request.settings_key)
-                routing = channel_settings.routing if channel_settings else None
-                effective_model = (routing.codex_model if routing else None) or self.codex_config.default_model
-                effective_effort = routing.codex_reasoning_effort if routing else None
-
-                # Start a new turn
-                turn_params: Dict[str, Any] = {
-                    "threadId": thread_id,
-                    "input": input_items,
-                    # Enforce non-interactive execution for Codex backend.
-                    "approvalPolicy": "never",
-                    "sandbox": "danger-full-access",
-                }
-                if effective_model:
-                    turn_params["model"] = effective_model
-                if effective_effort:
-                    turn_params["effort"] = effective_effort
-
-                self._turn_registry.begin_turn_start(request, thread_id)
-                resp = await transport.send_request("turn/start", turn_params)
-                # turn/start returns Turn directly OR may nest under "turn"
-                turn_id = resp.get("id", "")
-                if not turn_id:
-                    turn_obj = resp.get("turn")
-                    if isinstance(turn_obj, dict):
-                        turn_id = turn_obj.get("id", "")
-                if not turn_id:
-                    turn_id = self._turn_registry.get_bootstrapped_turn_id(request.base_session_id, request) or ""
-                if not turn_id:
-                    raise RuntimeError("Codex turn/start returned no turn id")
-                turn_state = self._turn_registry.finalize_turn_start_response(turn_id, request)
-                logger.info(
-                    "Codex turn started: thread=%s turn=%s session=%s state=%s",
-                    thread_id,
-                    turn_id,
-                    request.composite_session_id,
-                    "registered" if turn_state else "already-finished",
-                )
+                thread_id = await self._start_turn(transport, request, thread_id)
 
             except Exception as e:
+                # Safety net: if the thread is stale (e.g. Codex server-side
+                # expiry, or the proactive invalidation in _get_or_create_transport
+                # was bypassed by a race), invalidate and retry once.
+                if "thread not found" in str(e).lower():
+                    logger.warning(
+                        "Stale Codex thread for session %s, clearing and retrying: %s",
+                        request.base_session_id,
+                        e,
+                    )
+                    self._session_mgr.invalidate_thread(request.base_session_id)
+                    self._turn_registry.clear_session(request.base_session_id)
+                    self.sessions.clear_agent_session_mapping(
+                        request.settings_key,
+                        self.name,
+                        request.base_session_id,
+                    )
+                    try:
+                        thread_id = await self._start_or_resume_thread(transport, request)
+                        await self._start_turn(transport, request, thread_id)
+                        return  # retry succeeded
+                    except Exception as retry_err:
+                        e = retry_err  # fall through to normal error handling
+
                 self._turn_registry.clear_pending_turn_start(request.base_session_id, request)
                 logger.error("Error in Codex handle_message: %s", e, exc_info=True)
                 await self.controller.emit_agent_message(
@@ -200,12 +183,9 @@ class CodexAgent(BaseAgent):
         """Clear sessions scoped to a specific settings_key."""
         self.sessions.clear_agent_sessions(settings_key, self.name)
 
-        # Get base_session_ids to clear before removing them
-        to_clear = [
-            bid
-            for bid in self._session_mgr.all_base_sessions()
-            if self._session_mgr.get_settings_key(bid) == settings_key
-        ]
+        # Use settings_key index (not _threads) so sessions with
+        # invalidated threads are still cleaned up properly.
+        to_clear = self._session_mgr.get_sessions_by_settings_key(settings_key)
 
         count = self._session_mgr.clear_by_settings_key(settings_key)
 
@@ -239,6 +219,19 @@ class CodexAgent(BaseAgent):
             # Stop stale transport if any
             if existing:
                 await existing.stop()
+                # The new app-server process won't know about threads/turns
+                # from the old process.  Invalidate only sessions bound to
+                # this cwd so healthy sessions on other cwds are unaffected.
+                affected = self._session_mgr.sessions_for_cwd(cwd)
+                for bid in affected:
+                    self._session_mgr.invalidate_thread(bid)
+                    self._turn_registry.clear_session(bid)
+                if affected:
+                    logger.info(
+                        "Invalidated %d stale Codex session(s) after transport restart for cwd=%s",
+                        len(affected),
+                        cwd,
+                    )
 
             transport = CodexTransport(
                 binary=self.codex_config.binary,
@@ -329,6 +322,54 @@ class CodexAgent(BaseAgent):
                 logger.warning("Failed to resume Codex thread %s: %s, starting new", persisted, e)
 
         return await self._start_thread(transport, request)
+
+    async def _start_turn(
+        self,
+        transport: CodexTransport,
+        request: AgentRequest,
+        thread_id: str,
+    ) -> str:
+        """Build input, configure overrides, and send turn/start to Codex."""
+        input_items = self._build_input(request)
+
+        channel_settings = self.settings_manager.get_channel_settings(request.settings_key)
+        routing = channel_settings.routing if channel_settings else None
+        effective_model = (routing.codex_model if routing else None) or self.codex_config.default_model
+        effective_effort = routing.codex_reasoning_effort if routing else None
+
+        turn_params: Dict[str, Any] = {
+            "threadId": thread_id,
+            "input": input_items,
+            "approvalPolicy": "never",
+            "sandbox": "danger-full-access",
+        }
+        if effective_model:
+            turn_params["model"] = effective_model
+        if effective_effort:
+            turn_params["effort"] = effective_effort
+
+        self._turn_registry.begin_turn_start(request, thread_id)
+        resp = await transport.send_request("turn/start", turn_params)
+
+        turn_id = resp.get("id", "")
+        if not turn_id:
+            turn_obj = resp.get("turn")
+            if isinstance(turn_obj, dict):
+                turn_id = turn_obj.get("id", "")
+        if not turn_id:
+            turn_id = self._turn_registry.get_bootstrapped_turn_id(request.base_session_id, request) or ""
+        if not turn_id:
+            raise RuntimeError("Codex turn/start returned no turn id")
+
+        turn_state = self._turn_registry.finalize_turn_start_response(turn_id, request)
+        logger.info(
+            "Codex turn started: thread=%s turn=%s session=%s state=%s",
+            thread_id,
+            turn_id,
+            request.composite_session_id,
+            "registered" if turn_state else "already-finished",
+        )
+        return thread_id
 
     # ------------------------------------------------------------------
     # Input building

--- a/modules/agents/codex/session.py
+++ b/modules/agents/codex/session.py
@@ -20,6 +20,8 @@ class CodexSessionManager:
         self._threads: dict[str, str] = {}
         # base_session_id → settings_key (for scoped clear)
         self._settings_keys: dict[str, str] = {}
+        # base_session_id → working directory (for cwd-scoped invalidation)
+        self._cwds: dict[str, str] = {}
 
     # -- Thread mapping ---------------------------------------------------
 
@@ -30,6 +32,10 @@ class CodexSessionManager:
         self._threads[base_session_id] = thread_id
         logger.info("Session %s → Codex thread %s", base_session_id, thread_id)
 
+    def invalidate_thread(self, base_session_id: str) -> None:
+        """Remove only the thread_id, preserving settings_key and cwd metadata."""
+        self._threads.pop(base_session_id, None)
+
     # -- Settings-key tracking --------------------------------------------
 
     def set_settings_key(self, base_session_id: str, settings_key: str) -> None:
@@ -37,6 +43,15 @@ class CodexSessionManager:
 
     def get_settings_key(self, base_session_id: str) -> Optional[str]:
         return self._settings_keys.get(base_session_id)
+
+    # -- Cwd tracking -----------------------------------------------------
+
+    def set_cwd(self, base_session_id: str, cwd: str) -> None:
+        self._cwds[base_session_id] = cwd
+
+    def sessions_for_cwd(self, cwd: str) -> list[str]:
+        """Return base_session_ids associated with a given working directory."""
+        return [bid for bid, stored_cwd in self._cwds.items() if stored_cwd == cwd]
 
     def get_sessions_by_settings_key(self, settings_key: str) -> list[str]:
         """Return base_session_ids associated with a given settings_key."""
@@ -48,6 +63,7 @@ class CodexSessionManager:
         for bid in to_remove:
             self._threads.pop(bid, None)
             self._settings_keys.pop(bid, None)
+            self._cwds.pop(bid, None)
         return len(to_remove)
 
     # -- Cleanup ----------------------------------------------------------
@@ -56,12 +72,14 @@ class CodexSessionManager:
         """Remove all state for a session."""
         self._threads.pop(base_session_id, None)
         self._settings_keys.pop(base_session_id, None)
+        self._cwds.pop(base_session_id, None)
 
     def clear_all(self) -> int:
         """Remove all tracked sessions. Returns count cleared."""
         count = len(self._threads)
         self._threads.clear()
         self._settings_keys.clear()
+        self._cwds.clear()
         return count
 
     def all_thread_ids(self) -> list[str]:

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -263,6 +263,7 @@ class CodexAgentHandleMessageTests(unittest.IsolatedAsyncioTestCase):
         agent._get_or_create_transport = AsyncMock(return_value=transport)
         agent._session_mgr = SimpleNamespace(
             set_settings_key=lambda base_session_id, settings_key: None,
+            set_cwd=lambda base_session_id, cwd: None,
             get_thread_id=lambda base_session_id: "thread-1",
         )
 


### PR DESCRIPTION
## Summary

Fixes two interrelated bugs reported by a WeChat user:

- **WeChat send_message code=-2 cascading failures**: When WeChat API returns errors, unprotected `send_message` calls in the `result` and `notify` paths of `message_dispatcher.emit_agent_message` propagated RuntimeError all the way up to the Codex `_notify_worker`, silently dropping `turn/completed` notifications. The user never received their result.
- **Codex "thread not found" deadloop**: When a Codex app-server process was replaced (e.g. after settings change), the in-memory `_session_mgr._threads` cache retained stale thread_ids from the old process. Every subsequent message used the stale id, got rejected by the new Codex process, and the error handler did not clear the stale state — forming an unrecoverable loop.

## Changes

### `core/message_dispatcher.py`
- Wrap `send_message` in `notify` and `result` paths with try/except (matching existing pattern for consolidated log messages)
- Add quick-reply send failure → plain text fallback cascade

### `modules/agents/codex/agent.py`
- **Transport rebuild**: After stopping a stale transport, invalidate thread cache and turn registry for sessions bound to that cwd (scoped, not global)
- **Stale thread retry**: Detect `"thread not found"` RPC errors (case-insensitive), clear stale state from both in-memory cache and persisted SessionsFacade, retry once with a fresh thread
- **Extract `_start_turn()`** method for DRY retry logic
- **`clear_sessions()`**: Use `get_sessions_by_settings_key()` as enumeration source instead of `_threads.keys()`, so sessions with invalidated threads are still cleaned up

### `modules/agents/codex/session.py`
- Add `invalidate_thread()` — removes only the thread_id, preserving settings_key and cwd metadata
- Add `set_cwd()` / `sessions_for_cwd()` for cwd-scoped invalidation
- Fix `clear_by_settings_key()` to also clean up `_cwds`

### `tests/test_codex_agent.py`
- Update test stub to include `set_cwd` method

## How to test

1. Configure WeChat platform with a session that returns API errors (code=-2)
2. Verify result messages are logged as errors but do not crash the notification pipeline
3. Restart Codex app-server mid-session and send a new message — should auto-recover with a fresh thread instead of deadlooping