### PR TITLE
fix(session): include working_path in OpenCode session mapping key

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -348,7 +348,14 @@ class SessionHandler(BaseHandler):
             )
             base_session_id = self.get_base_session_id(mapping_context)
 
-            self.sessions.set_agent_session_mapping(settings_key, agent, base_session_id, session_id)
+            # OpenCode session mappings use composite keys that include
+            # working_path so that cwd changes create new sessions.
+            mapping_key = base_session_id
+            if agent == "opencode":
+                working_path = self.get_working_path(mapping_context)
+                mapping_key = f"{base_session_id}:{working_path}"
+
+            self.sessions.set_agent_session_mapping(settings_key, agent, mapping_key, session_id)
             self.sessions.mark_thread_active(user_id, context.channel_id, mapped_thread)
         except Exception as e:
             logger.error(f"Error resuming session: {e}", exc_info=True)

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -114,15 +114,53 @@ class OpenCodeSessionManager:
             os.makedirs(working_path, exist_ok=True)
 
     async def get_or_create_session_id(self, request: AgentRequest, server: OpenCodeServerManager) -> Optional[str]:
-        """Get a cached OpenCode session id, or create a new session."""
+        """Get a cached OpenCode session id, or create a new session.
+
+        The session mapping key includes working_path so that changing the
+        working directory (e.g. via the Web UI) automatically creates a new
+        session instead of reusing the old one anchored to a stale directory.
+        This mirrors how Claude sessions use composite_key = base:working_path.
+        """
 
         sessions = getattr(self._settings_manager, "sessions", self._settings_manager)
 
+        # Include working_path in the mapping key so cwd changes create new sessions
+        composite_session_key = f"{request.base_session_id}:{request.working_path}"
+
         session_id = sessions.get_agent_session_id(
             request.settings_key,
-            request.base_session_id,
+            composite_session_key,
             agent_name=self._agent_name,
         )
+
+        # Legacy fallback: migrate sessions stored under the old key format
+        # (base_session_id only, without working_path) so existing users
+        # don't lose session continuity on upgrade.
+        if not session_id:
+            legacy_id = sessions.get_agent_session_id(
+                request.settings_key,
+                request.base_session_id,
+                agent_name=self._agent_name,
+            )
+            if legacy_id:
+                if await server.get_session(legacy_id, request.working_path):
+                    sessions.set_agent_session_mapping(
+                        request.settings_key,
+                        self._agent_name,
+                        composite_session_key,
+                        legacy_id,
+                    )
+                    logger.info(
+                        "Migrated legacy OpenCode session %s to composite key for %s",
+                        legacy_id,
+                        request.base_session_id,
+                    )
+                    return legacy_id
+                else:
+                    logger.info(
+                        "Legacy OpenCode session %s no longer valid, will create new session",
+                        legacy_id,
+                    )
 
         if not session_id:
             try:
@@ -135,7 +173,7 @@ class OpenCodeSessionManager:
                     sessions.set_agent_session_mapping(
                         request.settings_key,
                         self._agent_name,
-                        request.base_session_id,
+                        composite_session_key,
                         session_id,
                     )
                     logger.info(f"Created OpenCode session {session_id} for {request.base_session_id}")
@@ -158,7 +196,7 @@ class OpenCodeSessionManager:
                 sessions.set_agent_session_mapping(
                     request.settings_key,
                     self._agent_name,
-                    request.base_session_id,
+                    composite_session_key,
                     new_session_id,
                 )
                 logger.info(f"Recreated OpenCode session {new_session_id} for {request.base_session_id}")


### PR DESCRIPTION
## Summary
- Fix working directory changes not taking effect after restart for OpenCode sessions
- OpenCode session mappings used `(settings_key, base_session_id)` as key — **without cwd** — so the old session was always reused regardless of cwd changes
- Include `working_path` in the composite session key, matching the pattern Claude sessions already use
- Fix `/resume` handler to write composite key for OpenCode
- Add legacy fallback to migrate old-format mappings so existing users don't lose session continuity on upgrade

## Root Cause
The session mapping in `sessions.json` mapped `base_session_id → opencode_session_id` without considering the working directory. When the user changed cwd via Web UI and restarted, the lookup still found the old session_id (created in the old directory) and reused it. `/new` was the only workaround because it clears the entire session mapping.

Claude sessions were not affected because they already use `composite_key = f"{base_session_id}:{working_path}"`.

## Impact
All platforms using OpenCode (WeChat, Slack, Discord, Feishu).

## Changes
- `modules/agents/opencode/session.py`: Use `f"{base_session_id}:{working_path}"` as mapping key; add legacy key fallback with auto-migration
- `core/handlers/session_handler.py`: `/resume` writes composite key for OpenCode sessions

## How to Test
1. Configure a user with a working directory via Web UI
2. Send a message — session is created in that directory
3. Change the working directory in Web UI
4. Restart the service
5. Send a message — should now use the new directory (previously used the old one)