### PR TITLE
fix(ci): remove --first-parent from commit collection to include feat…

### DIFF
--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -93,10 +93,10 @@ jobs:
           if [ -z "$PREV" ]; then
             RANGE="$TAG"
             echo "No previous tag found. Summarizing commits reachable by $TAG (limited)."
-            git log --first-parent --no-merges --pretty=format:'- %h %s' "$TAG" -n "$MAX_COMMITS" > commits.txt
+            git log --no-merges --pretty=format:'- %h %s' "$TAG" -n "$MAX_COMMITS" > commits.txt
           else
             RANGE="$PREV..$TAG"
-            git log --first-parent --no-merges --pretty=format:'- %h %s' "$RANGE" -n "$MAX_COMMITS" > commits.txt
+            git log --no-merges --pretty=format:'- %h %s' "$RANGE" -n "$MAX_COMMITS" > commits.txt
           fi
 
           echo "range=$RANGE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
…ure branch commits

The --first-parent --no-merges combination produced 0 commits when all work came through merge PRs, causing the LLM to generate minimal release notes. Removing --first-parent lets git traverse into feature branches and collect all real work commits (e.g. 0 -> 17 for v2.2.1).