### PR TITLE
fix(claude): apply model from routing on every request instead of freezing at session creation

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -144,8 +144,18 @@ class SessionHandler(BaseHandler):
         explicit_effort = subagent_reasoning_effort or (routing.claude_reasoning_effort if routing else None)
 
         if composite_key in self.claude_sessions and not effective_agent:
-            logger.info(f"Using existing Claude SDK client for {base_session_id} at {working_path}")
-            return self.claude_sessions[composite_key]
+            client = self.claude_sessions[composite_key]
+            # Apply current model from routing on every request, consistent with
+            # how OpenCode/Codex pass the model on each prompt/turn call.
+            current_model = explicit_model or self.config.claude.default_model
+            try:
+                await client.set_model(current_model)
+            except Exception as e:
+                logger.warning(f"Failed to update model on cached Claude session: {e}")
+            logger.info(
+                f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
+            )
+            return client
 
         if effective_agent:
             cached_base = f"{base_session_id}:{effective_agent}"
@@ -156,8 +166,23 @@ class SessionHandler(BaseHandler):
                 agent_name="claude",
             )
             if cached_key in self.claude_sessions:
-                logger.info("Using Claude subagent session for %s at %s", cached_base, working_path)
-                return self.claude_sessions[cached_key]
+                client = self.claude_sessions[cached_key]
+                # Apply explicit model override from routing/subagent params,
+                # consistent with how OpenCode/Codex pass the model per request.
+                # When no explicit override, keep the agent frontmatter model
+                # that was set at session creation.
+                if explicit_model:
+                    try:
+                        await client.set_model(explicit_model)
+                    except Exception as e:
+                        logger.warning(f"Failed to update model on cached Claude subagent session: {e}")
+                logger.info(
+                    "Using Claude subagent session for %s at %s (model_override=%s)",
+                    cached_base,
+                    working_path,
+                    explicit_model,
+                )
+                return client
             # Always use agent-specific key when effective_agent is set
             # This ensures session continuity even on first use
             composite_key = cached_key


### PR DESCRIPTION
## Summary

- Claude Code 缓存的 session 在用户通过 routing modal 切换 model 后不生效，必须新建会话才能使用新 model
- 根因：`get_or_create_claude_session()` 返回缓存 client 时直接跳过了 model 解析，model 被"冻结"在 session 创建时
- OpenCode 和 Codex 每次请求都从 routing 重新读取 model 并传入 `prompt_async()` / `turn/start`，不存在此问题

## Fix

在两个 cached-session 返回路径上，调用 Claude SDK 的 `client.set_model()` 将当前 routing 中的 model 设上去，与 OpenCode/Codex 的行为对齐：

- **普通会话**: 每次 `set_model(explicit_model or default_model)`
- **Subagent 会话**: 有显式 override 时 `set_model(explicit_model)`，无 override 时保留 agent frontmatter 的 model

## How to test

1. 在某个频道/DM 里用 Claude Code backend 发送一条消息（创建 session）
2. 通过 routing modal 或 Web UI 切换 model（如 sonnet → opus）
3. 在同一个会话中发送下一条消息
4. 验证新消息使用了切换后的 model（可通过日志中的 `model=` 字段确认）