### PR TITLE
fix(regression): persist agent runtime state

### DIFF
--- a/docker-compose.three-regression.yml
+++ b/docker-compose.three-regression.yml
@@ -25,7 +25,8 @@ services:
       - "${THREE_REGRESSION_PORT:-15130}:5123"
     volumes:
       - ./_tmp/three-regression/vibe:/data/vibe_remote
-      - ./_tmp/three-regression/shared-home/.claude/settings.json:/root/.claude/settings.json:ro
-      - ./_tmp/three-regression/shared-home/.codex/config.toml:/root/.codex/config.toml:ro
-      - ./_tmp/three-regression/shared-home/.codex/auth.json:/root/.codex/auth.json:ro
-      - ./_tmp/three-regression/shared-home/.config/opencode/opencode.json:/root/.config/opencode/opencode.json:ro
+      - ./_tmp/three-regression/shared-home/.claude:/root/.claude
+      - ./_tmp/three-regression/shared-home/.claude.json:/root/.claude.json
+      - ./_tmp/three-regression/shared-home/.codex:/root/.codex
+      - ./_tmp/three-regression/shared-home/.config/opencode:/root/.config/opencode
+      - ./_tmp/three-regression/shared-home/.local/share/opencode:/root/.local/share/opencode

--- a/scripts/prepare_three_regression.py
+++ b/scripts/prepare_three_regression.py
@@ -272,6 +272,23 @@ def _write_text(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _ensure_shared_home(output_root: Path, reset_mode: str = "none") -> Path:
+    if reset_mode == "all":
+        shared_root = output_root / "shared-home"
+        if shared_root.exists():
+            shutil.rmtree(shared_root)
+
+    shared_root = output_root / "shared-home"
+    for subdir in (
+        ".claude",
+        ".codex",
+        ".config/opencode",
+        ".local/share/opencode",
+    ):
+        (shared_root / subdir).mkdir(parents=True, exist_ok=True)
+    return shared_root
+
+
 def _ensure_vibe_dir(vibe_dir: Path, reset_mode: str = "none") -> None:
     if reset_mode not in RESET_MODES:
         allowed = ", ".join(sorted(RESET_MODES))
@@ -398,8 +415,11 @@ def _build_opencode_payload() -> dict:
 
 
 def _write_shared_agent_configs(output_root: Path) -> None:
-    shared_root = output_root / "shared-home"
+    shared_root = _ensure_shared_home(output_root)
     _write_json(shared_root / ".claude" / "settings.json", _build_claude_settings_payload())
+    claude_state_path = shared_root / ".claude.json"
+    if not claude_state_path.exists():
+        _write_text(claude_state_path, "{}\n")
     _write_text(shared_root / ".codex" / "config.toml", _build_codex_config_toml())
     _write_json(shared_root / ".codex" / "auth.json", _build_codex_auth_payload())
     _write_json(shared_root / ".config" / "opencode" / "opencode.json", _build_opencode_payload())
@@ -412,6 +432,7 @@ def prepare(output_root: Path, reset_mode: str = "none") -> None:
     for name, pdef in PLATFORM_DEFS.items():
         _require_envs(pdef["required_envs"])
 
+    _ensure_shared_home(output_root, reset_mode=reset_mode)
     _write_shared_agent_configs(output_root)
 
     vibe_dir = output_root / "vibe"

--- a/scripts/run_three_regression.sh
+++ b/scripts/run_three_regression.sh
@@ -157,6 +157,47 @@ Unified regression environment is ready:
 EOF
 }
 
+container_exists() {
+    local cid
+    cid="$("$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" ps -q vibe 2>/dev/null || true)"
+    [ -n "$cid" ]
+}
+
+snapshot_container_path() {
+    local container_path="$1"
+    local host_parent="$2"
+    local host_name="$3"
+
+    if ! "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T vibe sh -lc "test -e '$container_path'" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    mkdir -p "$host_parent"
+    "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T vibe sh -lc \
+        "tar --ignore-failed-read --warning=no-file-changed -C \"$(dirname "$container_path")\" -cf - \"$(basename "$container_path")\"" \
+        | tar -C "$host_parent" -xf - || true
+}
+
+snapshot_agent_runtime_state() {
+    if [ "$RESET_MODE" = "all" ]; then
+        return 0
+    fi
+
+    if ! container_exists; then
+        return 0
+    fi
+
+    local shared_root="$OUTPUT_ROOT/shared-home"
+    mkdir -p "$shared_root"
+
+    echo "Snapshotting agent runtime state from existing regression container..."
+    snapshot_container_path "/root/.claude" "$shared_root" ".claude"
+    snapshot_container_path "/root/.claude.json" "$shared_root" ".claude.json"
+    snapshot_container_path "/root/.codex" "$shared_root" ".codex"
+    snapshot_container_path "/root/.config/opencode" "$shared_root/.config" "opencode"
+    snapshot_container_path "/root/.local/share/opencode" "$shared_root/.local/share" "opencode"
+}
+
 wait_for_service() {
     local port="$1"
     local url="http://127.0.0.1:${port}"
@@ -176,6 +217,7 @@ wait_for_service() {
 
 case "$MODE" in
     down)
+        snapshot_agent_runtime_state
         "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" down --remove-orphans
         exit 0
         ;;
@@ -191,6 +233,8 @@ case "$MODE" in
         exit 0
         ;;
 esac
+
+snapshot_agent_runtime_state
 
 echo "Stopping previous regression container..."
 "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true


### PR DESCRIPTION
## What\nPersist regression container runtime state for Claude, Codex, and OpenCode so thread/session restore survives container rebuilds.\n\n## Why\nThe regression environment previously preserved only config files and . After a rebuild, backend-local conversation state was lost, so old thread mappings pointed at sessions that no longer existed.\n\n## Changes\n- mount persistent shared-home directories/files for Claude, Codex, and OpenCode runtime state\n- initialize shared-home directories during regression prepare, while only wiping them on \n- snapshot agent runtime state from the currently running regression container before /, so existing sessions are migrated into the new persistent mounts\n- keep snapshot merge non-destructive so mounted state is not deleted during later restarts\n\n## Validation\n- \n- \n- All checks passed!\n- rebuilt regression env with the new script and confirmed host persisted state for Claude/Codex/OpenCode\n- direct backend resume probes after restart:\n  - Codex  on existing thread id: success\n  - OpenCode session lookup on existing session id: success\n  - Claude new session created after fix survives restart and resumes successfully\n\n## Notes\nOld Claude sessions that had already lost their local project files before this fix cannot be reconstructed retroactively. New Claude sessions created after this patch are persisted under shared-home and resume correctly across restarts.