### PR TITLE
fix(models): merge local CLI model lists for claude and codex

### DIFF
--- a/modules/agents/opencode/__init__.py
+++ b/modules/agents/opencode/__init__.py
@@ -3,18 +3,33 @@
 This package contains the refactored OpenCode agent implementation split into
 smaller modules.
 
-Public entrypoints:
-- OpenCodeAgent: the agent backend used by the rest of vibe-remote
-- OpenCodeServerManager: manages the shared OpenCode server process
+Utility helpers are imported eagerly so lightweight callers can use them
+without pulling in the server/runtime dependency chain. Agent/server objects
+are resolved lazily via ``__getattr__``.
 """
 
-from .agent import OpenCodeAgent
-from .server import OpenCodeServerManager
-from .utils import build_codex_reasoning_options, build_reasoning_effort_options
+from .utils import (
+    build_claude_reasoning_options,
+    build_codex_reasoning_options,
+    build_reasoning_effort_options,
+)
 
 __all__ = [
     "OpenCodeAgent",
     "OpenCodeServerManager",
+    "build_claude_reasoning_options",
     "build_codex_reasoning_options",
     "build_reasoning_effort_options",
 ]
+
+
+def __getattr__(name: str):
+    if name == "OpenCodeAgent":
+        from .agent import OpenCodeAgent
+
+        return OpenCodeAgent
+    if name == "OpenCodeServerManager":
+        from .server import OpenCodeServerManager
+
+        return OpenCodeServerManager
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -323,7 +323,16 @@ def build_reasoning_effort_options(
 
 _CODEX_REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh"]
 _CLAUDE_REASONING_EFFORTS = ["low", "medium", "high"]
-_CLAUDE_MAX_MODEL_MARKERS = ["claude-opus-4-6"]
+
+
+def _supports_claude_max_reasoning(target_model: Optional[str]) -> bool:
+    normalized_model = (target_model or "").strip().lower()
+    if not normalized_model:
+        return False
+    return (
+        normalized_model in {"opus", "opus[1m]"}
+        or normalized_model.startswith("claude-opus-4-6")
+    )
 
 
 def build_codex_reasoning_options() -> List[Dict[str, str]]:
@@ -351,9 +360,8 @@ def build_claude_reasoning_options(target_model: Optional[str]) -> List[Dict[str
     is only valid for Opus 4.6.
     """
 
-    normalized_model = (target_model or "").strip().lower()
     efforts = list(_CLAUDE_REASONING_EFFORTS)
-    if normalized_model and any(marker in normalized_model for marker in _CLAUDE_MAX_MODEL_MARKERS):
+    if _supports_claude_max_reasoning(target_model):
         efforts.append("max")
 
     options: List[Dict[str, str]] = [{"value": "__default__", "label": "(Default)"}]

--- a/tests/test_claude_reasoning_options.py
+++ b/tests/test_claude_reasoning_options.py
@@ -39,6 +39,24 @@ def test_claude_reasoning_options_do_not_add_max_for_sonnet_46() -> None:
     assert [item["value"] for item in options] == ["__default__", "low", "medium", "high"]
 
 
+def test_claude_reasoning_options_add_max_for_opus_aliases() -> None:
+    assert [item["value"] for item in build_claude_reasoning_options("opus")] == [
+        "__default__",
+        "low",
+        "medium",
+        "high",
+        "max",
+    ]
+    assert [item["value"] for item in build_claude_reasoning_options("opus[1m]")] == [
+        "__default__",
+        "low",
+        "medium",
+        "high",
+        "max",
+    ]
+
+
 def test_normalize_claude_reasoning_effort_drops_invalid_max() -> None:
     assert normalize_claude_reasoning_effort("claude-sonnet-4-6", "max") is None
     assert normalize_claude_reasoning_effort("claude-opus-4-6", "max") == "max"
+    assert normalize_claude_reasoning_effort("opus", "max") == "max"

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -179,6 +179,132 @@ def test_install_codex_detects_binary_via_npm_prefix(monkeypatch, tmp_path):
     assert calls[0][1]["PATH"].split(api.os.pathsep)[0] == str(npm_path.parent)
 
 
+def test_claude_models_merge_builtin_cli_and_settings(monkeypatch, tmp_path):
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "model": "opus[1m]",
+                "env": {
+                    "ANTHROPIC_MODEL": "claude-sonnet-4-6",
+                    "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5-20251001",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    cli_bundle = tmp_path / "claude-cli.js"
+    cli_bundle.write_text(
+        '\n'.join(
+            [
+                'const OPUS_ID = "claude-opus-4-6";',
+                'const SONNET_ID = "claude-sonnet-4-6";',
+                'const HAIKU_ID = "claude-haiku-4-5";',
+                'const PREV_SONNET_ID = "claude-sonnet-4-5";',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(api, "resolve_cli_path", lambda binary: str(cli_bundle) if binary == "claude" else None)
+
+    result = api.claude_models()
+
+    assert result["ok"] is True
+    assert result["models"][:4] == [
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "claude-opus-4-5",
+    ]
+    assert "opus" in result["models"]
+    assert "sonnet" in result["models"]
+    assert "haiku" in result["models"]
+    assert "opus[1m]" in result["models"]
+    assert "claude-haiku-4-5-20251001" in result["models"]
+    assert result["models"].count("claude-sonnet-4-6") == 1
+    assert [item["value"] for item in result["reasoning_options"]["opus"]] == [
+        "__default__",
+        "low",
+        "medium",
+        "high",
+        "max",
+    ]
+
+
+def test_codex_models_prefers_cli_cache_and_filters_hidden_models(monkeypatch, tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"slug": "gpt-5.1", "visibility": "hide", "priority": 9},
+                    {"slug": "gpt-5.3-codex-spark", "visibility": "list", "priority": 6},
+                    {"slug": "gpt-5.4-mini", "visibility": "list", "priority": 3},
+                    {"slug": "gpt-5.4", "visibility": "list", "priority": 1},
+                    {"slug": "gpt-5.1-codex-mini", "visibility": "list", "priority": 19},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (codex_dir / "config.toml").write_text(
+        '\n'.join(
+            [
+                'model = "gpt-5.1"',
+                "[notice.model_migrations]",
+                '"gpt-5.2" = "gpt-5.4"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
+
+    result = api.codex_models()
+
+    assert result["ok"] is True
+    assert result["models"][:3] == [
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+    ]
+    assert "gpt-5.3-codex-spark" in result["models"]
+    assert "gpt-5.1-codex-mini" in result["models"]
+    assert "gpt-5.1" in result["models"]
+    assert "gpt-5.2" in result["models"]
+    assert result["models"].count("gpt-5.4") == 1
+
+
+def test_codex_models_falls_back_when_cli_cache_missing(monkeypatch, tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "config.toml").write_text(
+        '\n'.join(
+            [
+                'model = "custom-codex-model"',
+                "[notice.model_migrations]",
+                '"legacy-codex" = "gpt-5.4"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
+
+    result = api.codex_models()
+
+    assert result["ok"] is True
+    assert result["models"][:3] == ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]
+    assert "custom-codex-model" in result["models"]
+    assert "legacy-codex" in result["models"]
+    assert "gpt-5.1-codex-max" in result["models"]
+    assert "gpt-5.1-codex-mini" in result["models"]
+
+
 def test_setup_opencode_permission_preserves_existing_json_fields(monkeypatch, tmp_path):
     config_path = tmp_path / ".config" / "opencode" / "opencode.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -987,57 +988,81 @@ def claude_agents(cwd: Optional[str] = None) -> dict:
 
 
 def claude_models() -> dict:
-    """Best-effort list of Claude Code model options.
+    """Best-effort merged list of Claude Code model options.
 
     Claude Code does not expose a stable `list models` CLI subcommand.
-    We derive suggestions from:
-    - Common aliases mentioned by `claude --help` (opus/sonnet/haiku)
-    - Common full model names (claude-opus-4, claude-sonnet-4, etc.)
-    - ~/.claude/settings.json `model`
-    - ~/.claude/settings.json `env` model variables (if present)
+    We merge suggestions from:
+    - Built-in known model ids and aliases
+    - The locally installed Claude CLI bundle (when available)
+    - ~/.claude/settings.json model/env values
     """
 
-    # Common full model names (latest versions)
-    options: list[str] = [
+    def _append_unique(options: list[str], seen: set[str], value: object) -> None:
+        if not isinstance(value, str):
+            return
+        model = value.strip()
+        if not model or model in seen:
+            return
+        seen.add(model)
+        options.append(model)
+
+    built_in_options = [
         "claude-opus-4-6",
         "claude-sonnet-4-6",
+        "claude-haiku-4-5",
         "claude-opus-4-5",
         "claude-sonnet-4-5",
-        "claude-haiku-4-5",
         "claude-opus-4",
         "claude-sonnet-4",
         "claude-haiku-4",
+        "opus",
+        "sonnet",
+        "haiku",
     ]
+
+    options: list[str] = []
+    seen: set[str] = set()
+
+    for model in built_in_options:
+        _append_unique(options, seen, model)
+
+    claude_path = resolve_cli_path("claude")
+    if claude_path:
+        cli_bundle_candidates = [
+            Path(claude_path).resolve(),
+            Path(claude_path).resolve().parent / "cli.js",
+        ]
+        cli_bundle_path = next((path for path in cli_bundle_candidates if path.exists() and path.is_file()), None)
+        if cli_bundle_path is not None:
+            try:
+                bundle_text = cli_bundle_path.read_text(encoding="utf-8", errors="ignore")
+                for match in re.findall(r"claude-(?:opus|sonnet|haiku)-\d+(?:-\d+)*(?:-\d{8})?", bundle_text):
+                    _append_unique(options, seen, match)
+            except Exception as exc:
+                logger.warning("Failed to inspect Claude CLI bundle: %s", exc, exc_info=True)
 
     settings_path = Path.home() / ".claude" / "settings.json"
     try:
         if settings_path.exists() and settings_path.is_file():
             data = json.loads(settings_path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
-                model = data.get("model")
-                # Only add full model names (e.g., "claude-sonnet-4"), not aliases like "opus"
-                if isinstance(model, str) and model.strip() and model.strip().startswith("claude-"):
-                    options.append(model.strip())
+                _append_unique(options, seen, data.get("model"))
                 env = data.get("env")
                 if isinstance(env, dict):
                     for key in (
                         "ANTHROPIC_MODEL",
                         "ANTHROPIC_SMALL_FAST_MODEL",
                     ):
-                        value = env.get(key)
-                        # Only add full model names
-                        if isinstance(value, str) and value.strip() and value.strip().startswith("claude-"):
-                            options.append(value.strip())
+                        _append_unique(options, seen, env.get(key))
     except Exception as exc:
         logger.warning("Failed to read Claude settings.json: %s", exc, exc_info=True)
 
     from modules.agents.opencode.utils import build_claude_reasoning_options
 
-    uniq = sorted({x for x in options if x})
     reasoning_options = {"": build_claude_reasoning_options(None)}
-    for model in uniq:
+    for model in options:
         reasoning_options[model] = build_claude_reasoning_options(model)
-    return {"ok": True, "models": uniq, "reasoning_options": reasoning_options}
+    return {"ok": True, "models": options, "reasoning_options": reasoning_options}
 
 
 def install_agent(name: str) -> dict:
@@ -1166,25 +1191,68 @@ def install_agent(name: str) -> dict:
 
 
 def codex_models() -> dict:
-    """Best-effort list of Codex model options.
+    """Best-effort merged list of Codex model options.
 
     Codex CLI does not expose a stable `list models` command.
-    We derive suggestions from:
-    - Common OpenAI model names (gpt-5, etc.)
-    - ~/.codex/config.toml (if present)
+    We merge suggestions from:
+    - Built-in known model ids
+    - ~/.codex/models_cache.json (maintained by Codex CLI)
+    - ~/.codex/config.toml (user-selected model and migration hints)
     """
 
-    # Common OpenAI model names used with Codex
-    options: list[str] = [
-        # GPT series (newest first)
+    def _append_unique(options: list[str], seen: set[str], value: object) -> None:
+        if not isinstance(value, str):
+            return
+        model = value.strip()
+        if not model or model in seen:
+            return
+        seen.add(model)
+        options.append(model)
+
+    built_in_options: list[str] = [
         "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
         "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
         "gpt-5.2-codex",
         "gpt-5.2",
+        "gpt-5.1-codex-max",
+        "gpt-5.1-codex-mini",
         "gpt-5.1",
         "gpt-5",
     ]
-    config_path = Path.home() / ".codex" / "config.toml"
+
+    options: list[str] = []
+    seen: set[str] = set()
+    codex_home = Path.home() / ".codex"
+    models_cache_path = codex_home / "models_cache.json"
+    config_path = codex_home / "config.toml"
+
+    for model in built_in_options:
+        _append_unique(options, seen, model)
+
+    try:
+        if models_cache_path.exists() and models_cache_path.is_file():
+            cache_data = json.loads(models_cache_path.read_text(encoding="utf-8"))
+            models = cache_data.get("models")
+            if isinstance(models, list):
+                visible_models: list[tuple[int, int, str]] = []
+                for index, item in enumerate(models):
+                    if not isinstance(item, dict):
+                        continue
+                    slug = item.get("slug")
+                    if not isinstance(slug, str) or not slug.strip():
+                        continue
+                    priority = item.get("priority")
+                    if not isinstance(priority, int):
+                        priority = 10**9
+                    visible_models.append((priority, index, slug.strip()))
+
+                for _, _, slug in sorted(visible_models):
+                    _append_unique(options, seen, slug)
+    except Exception as exc:
+        logger.warning("Failed to read Codex models_cache.json: %s", exc, exc_info=True)
 
     try:
         if config_path.exists() and config_path.is_file():
@@ -1194,28 +1262,22 @@ def codex_models() -> dict:
                 tomllib = None
 
             if tomllib is None:
-                uniq = sorted({x for x in options if x})
-                return {"ok": True, "models": uniq}
+                return {"ok": True, "models": options}
 
             data = tomllib.loads(config_path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
-                model = data.get("model")
-                if isinstance(model, str) and model.strip():
-                    options.append(model.strip())
+                _append_unique(options, seen, data.get("model"))
                 notice = data.get("notice")
                 if isinstance(notice, dict):
                     migrations = notice.get("model_migrations")
                     if isinstance(migrations, dict):
                         for k, v in migrations.items():
-                            if isinstance(k, str) and k.strip():
-                                options.append(k.strip())
-                            if isinstance(v, str) and v.strip():
-                                options.append(v.strip())
+                            _append_unique(options, seen, k)
+                            _append_unique(options, seen, v)
     except Exception as exc:
         logger.warning("Failed to read Codex config.toml: %s", exc, exc_info=True)
 
-    uniq = sorted({x for x in options if x})
-    return {"ok": True, "models": uniq}
+    return {"ok": True, "models": options}
 
 
 def _lark_api_base(domain: str = "feishu") -> str:


### PR DESCRIPTION
## What
- merge built-in and locally discoverable model lists for Codex and Claude
- include Claude local model aliases/config values in the returned model list
- allow Claude Opus aliases like `opus` and `opus[1m]` to expose `max` reasoning
- add regression coverage for merged model list behavior

## Why
The previous implementation relied mostly on a hand-maintained static list. That caused Codex to miss newer models already available in the local CLI, and Claude could miss the user's actual configured model when it was stored as an alias.

## How To Test
- `PYTHONPATH=. pytest -q tests/test_ui_api.py`
- `PYTHONPATH=. pytest -q tests/test_claude_reasoning_options.py`
- `ruff check vibe/api.py modules/agents/opencode/utils.py modules/agents/opencode/__init__.py tests/test_ui_api.py tests/test_claude_reasoning_options.py`

## Risks / Follow-ups
- Claude model discovery still relies on best-effort extraction from the local CLI bundle because Claude Code does not expose a stable list-models command or local cache like Codex.
- Merging all locally discoverable Claude models intentionally keeps some older or snapshot-style model ids visible.
