### PR TITLE
feat(tasks): inject scheduled task guidance

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -385,6 +385,7 @@ class SessionHandler(BaseHandler):
             reply_prompt = build_reply_enhancements_prompt(
                 include_quick_replies=platform != "wechat",
                 context=context,
+                fallback_platform=platform,
             )
 
             if base_prompt:

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -205,10 +205,14 @@ Examples:
 """
 
 
-def _build_scheduled_tasks_prompt(context: MessageContext) -> str:
+def _build_scheduled_tasks_prompt(context: MessageContext, *, fallback_platform: Optional[str] = None) -> str:
     from core.scheduled_tasks import build_session_key_for_context
 
-    default_key = build_session_key_for_context(context, include_thread=False).to_key(include_thread=False)
+    default_key = build_session_key_for_context(
+        context,
+        include_thread=False,
+        fallback_platform=fallback_platform,
+    ).to_key(include_thread=False)
     thread_id = context.thread_id or "(none)"
     if context.thread_id:
         session_key_with_thread = f"{default_key}::thread::{context.thread_id}"
@@ -225,6 +229,7 @@ def build_reply_enhancements_prompt(
     *,
     include_quick_replies: bool = True,
     context: Optional[MessageContext] = None,
+    fallback_platform: Optional[str] = None,
 ) -> str:
     """Build the reply-enhancement prompt for the current platform/backend."""
 
@@ -232,7 +237,7 @@ def build_reply_enhancements_prompt(
     if include_quick_replies:
         prompt += _QUICK_REPLIES_PROMPT
     if context is not None:
-        prompt += _build_scheduled_tasks_prompt(context)
+        prompt += _build_scheduled_tasks_prompt(context, fallback_platform=fallback_platform)
     return prompt
 
 

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -75,9 +75,14 @@ def parse_session_key(value: str) -> ParsedSessionKey:
     )
 
 
-def build_session_key_for_context(context: MessageContext, *, include_thread: bool = False) -> ParsedSessionKey:
+def build_session_key_for_context(
+    context: MessageContext,
+    *,
+    include_thread: bool = False,
+    fallback_platform: Optional[str] = None,
+) -> ParsedSessionKey:
     payload = context.platform_specific or {}
-    platform = context.platform or payload.get("platform") or ""
+    platform = context.platform or payload.get("platform") or fallback_platform or ""
     is_dm = bool(payload.get("is_dm", False))
     scope_type = "user" if is_dm else "channel"
     scope_id = context.user_id if is_dm else context.channel_id

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -274,6 +274,7 @@ class CodexAgent(BaseAgent):
             params["developerInstructions"] = build_reply_enhancements_prompt(
                 include_quick_replies=platform != "wechat",
                 context=request.context,
+                fallback_platform=platform,
             )
 
         resp = await transport.send_request("thread/start", params)

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -243,6 +243,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 reply_system = build_reply_enhancements_prompt(
                     include_quick_replies=platform != "wechat",
                     context=request.context,
+                    fallback_platform=platform,
                 )
 
             request_tools = {"question": False} if platform == "wechat" else None

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -83,6 +83,22 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Current thread ID: `171717.123`", prompt)
         self.assertIn("slack::channel::C1::thread::171717.123", prompt)
 
+    def test_prompt_uses_fallback_platform_for_unannotated_context(self):
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            thread_id="171717.123",
+            platform_specific={"is_dm": False},
+        )
+
+        prompt = build_reply_enhancements_prompt(
+            include_quick_replies=True,
+            context=context,
+            fallback_platform="slack",
+        )
+
+        self.assertIn("Default session key: `slack::channel::C1`", prompt)
+
     def test_file_links_with_parentheses_are_preserved(self):
         enhanced = process_reply("![video](file:///Users/test/SaveTwitter.Net_GABV3XNWYAARAZz(gif).mp4)")
 

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -75,6 +75,19 @@ def test_build_session_key_for_context_defaults_to_threadless_scope() -> None:
     assert parsed.thread_id is None
 
 
+def test_build_session_key_for_context_uses_fallback_platform() -> None:
+    context = MessageContext(
+        user_id="U123",
+        channel_id="C123",
+        thread_id="171717.123",
+        platform_specific={"is_dm": False},
+    )
+
+    parsed = build_session_key_for_context(context, fallback_platform="slack")
+
+    assert parsed.to_key(include_thread=False) == "slack::channel::C123"
+
+
 def test_store_round_trip_persists_task(tmp_path: Path) -> None:
     store = ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
     task = store.add_task(


### PR DESCRIPTION
## Summary
- extend the shared reply-enhancement prompt with scheduled task guidance so agents know how to call `vibe task add`
- inject current conversation targeting into Claude, OpenCode, and Codex prompt instructions using a default threadless session key plus a separate current thread id
- add regression coverage for the new prompt content and the threadless session-key helper

## Testing
- `npm run build` (in `ui/`)
- `uv run ruff check core/reply_enhancer.py core/scheduled_tasks.py core/handlers/session_handler.py modules/agents/opencode/agent.py modules/agents/codex/agent.py tests/test_reply_enhancer_platform.py tests/test_scheduled_tasks.py`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_reply_enhancer_platform.py tests/test_scheduled_tasks.py tests/test_message_handler_typing.py tests/test_discord_reply_anchor.py tests/test_message_dispatcher_scheduled.py tests/test_session_handler_base_id.py`

## Risks / Follow-ups
- the injected prompt currently explains the scheduled-task CLI in English only
- if we later want stricter agent behavior, we can tighten the examples or add explicit do/don't rules per platform
