### PR TITLE
refactor(prompt): streamline injected guidance

### DIFF
--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -159,7 +159,9 @@ _FILES_PROMPT = """\
 Vibe Remote is a middleware layer that connects AI agents to IM platforms such as Slack. \
 The user is interacting with you through an IM app via Vibe Remote forwarding.
 
-Vibe Remote also supports optional reply enhancements you can use when helpful:
+If the user asks you to configure, repair, or operate Vibe Remote itself, read `https://github.com/cyhhao/vibe-remote/raw/master/skills/use-vibe-remote/SKILL.md` before making changes. Use it for configuration file locations, scope rules, routing behavior, scheduled-task operations, and troubleshooting steps.
+
+Vibe Remote provides optional capabilities:
 
 ## 1. Send files
 You can send a local file to the user by using a Markdown link with the `file://` protocol:
@@ -204,17 +206,10 @@ Rules:
 - Run `vibe task add --help` or `vibe hook send --help` for the full command reference.
 """
 
-_VIBE_SKILL_PROMPT = """\
-
-## 4. Vibe Remote skill
-When the user asks you to configure, repair, or operate Vibe Remote itself, read `https://github.com/cyhhao/vibe-remote/raw/master/skills/use-vibe-remote/SKILL.md` before making changes.
-Use that skill for configuration file locations, scope rules, routing behavior, scheduled-task operations, and troubleshooting steps.
-"""
-
 
 _USER_PREFERENCES_PROMPT = """\
 
-## 5. User preference file
+## 4. User preference file
 A shared user preference file is available at `{preferences_path}`.
 When useful, you may read it to learn stable habits, preferences, and recurring rules.
 You may also update it, usually in the current user's section: `{user_section}`.
@@ -270,7 +265,6 @@ def build_reply_enhancements_prompt(
         prompt += _QUICK_REPLIES_PROMPT
     if context is not None:
         prompt += _build_scheduled_tasks_prompt(context, fallback_platform=fallback_platform)
-    prompt += _VIBE_SKILL_PROMPT
     prompt += _build_user_preferences_prompt(context, fallback_platform=fallback_platform)
     return prompt
 

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -66,11 +66,14 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         with patch.object(paths, "get_user_preferences_path", return_value=Path("/tmp/user_preferences.md")):
             prompt = build_reply_enhancements_prompt(include_quick_replies=False)
 
+        self.assertIn(
+            "If the user asks you to configure, repair, or operate Vibe Remote itself, read `https://github.com/cyhhao/vibe-remote/raw/master/skills/use-vibe-remote/SKILL.md` before making changes.",
+            prompt,
+        )
         self.assertIn("## 1. Send files", prompt)
-        self.assertIn("Vibe Remote also supports optional reply enhancements you can use when helpful:", prompt)
+        self.assertIn("Vibe Remote provides optional capabilities:", prompt)
         self.assertNotIn("## 2. Quick-reply buttons", prompt)
-        self.assertIn("https://github.com/cyhhao/vibe-remote/raw/master/skills/use-vibe-remote/SKILL.md", prompt)
-        self.assertIn("## 5. User preference file", prompt)
+        self.assertIn("## 4. User preference file", prompt)
         self.assertIn("`/tmp/user_preferences.md`", prompt)
         self.assertIn("`<platform>/<user_id>`", prompt)
 
@@ -94,7 +97,6 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Current thread ID: `171717.123`", prompt)
         self.assertIn("If `--timezone` is omitted, the task uses the local system timezone at creation time.", prompt)
         self.assertIn("Run `vibe task add --help` or `vibe hook send --help` for the full command reference.", prompt)
-        self.assertIn("https://github.com/cyhhao/vibe-remote/raw/master/skills/use-vibe-remote/SKILL.md", prompt)
         self.assertIn("When useful, you may read it to learn stable habits, preferences, and recurring rules.", prompt)
         self.assertIn("usually in the current user's section: `slack/U1`.", prompt)
         self.assertIn("Only write to a shared section when a rule truly applies across users.", prompt)


### PR DESCRIPTION
## Summary
- streamline the injected Vibe Remote prompt copy so the skill guidance appears up front instead of as a separate section
- tighten the task vs hook wording and clarify that the user preference file should prefer durable preferences over one-off requests
- update prompt tests and keep the injected guidance compact while preserving behavior

## Validation
- `ruff check core/reply_enhancer.py tests/test_reply_enhancer_platform.py`
- `uv run --no-project --with apscheduler --with pytest --with pytest-asyncio python -m pytest tests/test_reply_enhancer_platform.py`
- `uv run --no-project --with apscheduler --with tiktoken python ...` (`gpt-5` tokenizer estimate: 703 tokens)
