### PR TITLE
refactor(prompt): tighten preference file template

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -63,14 +63,14 @@ def get_user_preferences_path() -> Path:
 
 _USER_PREFERENCES_TEMPLATE = """# User Preferences
 
-Use this file for stable long-term habits, preferences, and recurring rules.
+Use this file for stable long-term preferences and recurring rules.
 Prefer user-specific notes under `## Users`.
-Only put rules under `## Shared` when they truly apply across users.
-Keep it concise, factual, and deduplicated.
-Do not store secrets here unless the user explicitly asks.
+Use `## Shared` only for rules that truly apply across users.
+Keep entries short, factual, deduplicated, and free of secrets unless the user explicitly asks.
+Prefer durable preferences over one-off requests.
 
 ## Shared
-- Add rules here only when they truly apply across users.
+- Add cross-user rules here only when they are broadly useful.
 
 ## Users
 ### platform/user_id

--- a/tests/test_v2_paths.py
+++ b/tests/test_v2_paths.py
@@ -24,4 +24,5 @@ def test_ensure_data_dirs(tmp_path, monkeypatch):
     assert "# User Preferences" in text
     assert "Prefer user-specific notes under `## Users`." in text
     assert "### platform/user_id" in text
-    assert "Do not store secrets here unless the user explicitly asks." in text
+    assert "Prefer durable preferences over one-off requests." in text
+    assert "free of secrets unless the user explicitly asks." in text


### PR DESCRIPTION
## Summary
- tighten the default `user_preferences.md` template so the shared-vs-user guidance is clearer and more concise
- explicitly prefer durable preferences over one-off requests
- update the template creation test to match the new copy

## Validation
- `ruff check config/paths.py tests/test_v2_paths.py`
- `uv run --no-project --with pytest python -m pytest tests/test_v2_paths.py`
