### PR TITLE
fix(wechat): support upload_full_url CDN responses

### DIFF
--- a/modules/im/wechat_cdn.py
+++ b/modules/im/wechat_cdn.py
@@ -9,6 +9,7 @@ Ported from the TypeScript reference implementation.
 """
 
 import base64
+import html
 import hashlib
 import logging
 import os
@@ -143,15 +144,31 @@ def _build_cdn_download_url(cdn_base_url: str, encrypted_query_param: str) -> st
     return f"{cdn_base_url}/download?encrypted_query_param={quote(encrypted_query_param)}"
 
 
+def _resolve_cdn_upload_url(cdn_base_url: str, upload_resp: Dict[str, Any], filekey: str, label: str) -> str:
+    """Resolve a CDN upload URL from legacy or full-url getUploadUrl responses."""
+    upload_full_url = upload_resp.get("upload_full_url")
+    if upload_full_url:
+        return html.unescape(str(upload_full_url))
+
+    upload_param = upload_resp.get("upload_param")
+    if upload_param:
+        return _build_cdn_upload_url(cdn_base_url, str(upload_param), filekey)
+
+    logger.error(
+        "%s: getUploadUrl returned neither upload_param nor upload_full_url, resp=%s",
+        label,
+        upload_resp,
+    )
+    raise RuntimeError(f"{label}: getUploadUrl returned no upload target")
+
+
 # ---------------------------------------------------------------------------
 # CDN upload / download
 # ---------------------------------------------------------------------------
 
 
 async def upload_buffer_to_cdn(
-    cdn_base_url: str,
-    upload_param: str,
-    filekey: str,
+    upload_url: str,
     data: bytes,
     aes_key: bytes,
 ) -> str:
@@ -161,9 +178,7 @@ async def upload_buffer_to_cdn(
     times on server errors (5xx); client errors (4xx) abort immediately.
 
     Args:
-        cdn_base_url: Base URL of the CDN (e.g. ``https://cdn.example.com``).
-        upload_param: Encrypted query param from ``get_upload_url``.
-        filekey: File key for the upload.
+        upload_url: Fully resolved upload URL from ``get_upload_url``.
         data: Raw plaintext bytes to upload.
         aes_key: 16-byte AES key for encryption.
 
@@ -175,8 +190,7 @@ async def upload_buffer_to_cdn(
             the expected header.
     """
     ciphertext = aes_ecb_encrypt(data, aes_key)
-    url = _build_cdn_upload_url(cdn_base_url, upload_param, filekey)
-    logger.debug("CDN upload: POST url=%s ciphertext_size=%d", url[:80], len(ciphertext))
+    logger.debug("CDN upload: POST url=%s ciphertext_size=%d", upload_url[:80], len(ciphertext))
 
     download_param: Optional[str] = None
     last_error: Optional[Exception] = None
@@ -186,7 +200,7 @@ async def upload_buffer_to_cdn(
         for attempt in range(1, _UPLOAD_MAX_RETRIES + 1):
             try:
                 async with session.post(
-                    url,
+                    upload_url,
                     data=ciphertext,
                     headers={"Content-Type": "application/octet-stream"},
                 ) as resp:
@@ -374,19 +388,10 @@ async def _upload_media_to_cdn(
         },
     )
 
-    upload_param = upload_resp.get("upload_param")
-    if not upload_param:
-        logger.error(
-            "%s: getUploadUrl returned no upload_param, resp=%s",
-            label,
-            upload_resp,
-        )
-        raise RuntimeError(f"{label}: getUploadUrl returned no upload_param")
+    upload_url = _resolve_cdn_upload_url(cdn_base_url, upload_resp, filekey, label)
 
     download_param = await upload_buffer_to_cdn(
-        cdn_base_url=cdn_base_url,
-        upload_param=upload_param,
-        filekey=filekey,
+        upload_url=upload_url,
         data=plaintext,
         aes_key=aes_key,
     )

--- a/tests/test_wechat_cdn.py
+++ b/tests/test_wechat_cdn.py
@@ -1,0 +1,77 @@
+import unittest
+from pathlib import Path
+import sys
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.im import wechat_cdn
+
+
+class WeChatCdnTests(unittest.IsolatedAsyncioTestCase):
+    def test_resolve_cdn_upload_url_accepts_legacy_upload_param(self):
+        url = wechat_cdn._resolve_cdn_upload_url(
+            "https://novac2c.cdn.weixin.qq.com/c2c",
+            {"upload_param": "abc+/="},
+            "file-key",
+            "upload_image_to_cdn",
+        )
+
+        self.assertEqual(
+            url,
+            "https://novac2c.cdn.weixin.qq.com/c2c/upload?encrypted_query_param=abc%2B/%3D&filekey=file-key",
+        )
+
+    def test_resolve_cdn_upload_url_accepts_upload_full_url(self):
+        url = wechat_cdn._resolve_cdn_upload_url(
+            "https://novac2c.cdn.weixin.qq.com/c2c",
+            {
+                "upload_full_url": (
+                    "https://novac2c.cdn.weixin.qq.com/c2c/upload?"
+                    "encrypted_query_param=abc&amp;filekey=file-key&amp;taskid=task-1"
+                )
+            },
+            "ignored-file-key",
+            "upload_image_to_cdn",
+        )
+
+        self.assertEqual(
+            url,
+            "https://novac2c.cdn.weixin.qq.com/c2c/upload?encrypted_query_param=abc&filekey=file-key&taskid=task-1",
+        )
+
+    async def test_upload_image_to_cdn_uses_upload_full_url_response(self):
+        with patch(
+            "modules.im.wechat_cdn.get_upload_url",
+            new=AsyncMock(
+                return_value={
+                    "upload_full_url": (
+                        "https://novac2c.cdn.weixin.qq.com/c2c/upload?"
+                        "encrypted_query_param=abc&filekey=file-key&taskid=task-1"
+                    )
+                }
+            ),
+        ):
+            with patch(
+                "modules.im.wechat_cdn.upload_buffer_to_cdn", new=AsyncMock(return_value="download-param")
+            ) as mock_upload:
+                with patch("os.urandom", side_effect=[bytes.fromhex("11" * 16), bytes.fromhex("22" * 16)]):
+                    with patch.object(Path, "read_bytes", return_value=b"png"):
+                        result = await wechat_cdn.upload_image_to_cdn(
+                            base_url="https://ilinkai.weixin.qq.com",
+                            token="token",
+                            cdn_base_url="https://novac2c.cdn.weixin.qq.com/c2c",
+                            to_user_id="user-1",
+                            file_path="/tmp/photo.png",
+                        )
+
+        self.assertEqual(result["encrypt_query_param"], "download-param")
+        self.assertEqual(result["filekey"], "11111111111111111111111111111111")
+        self.assertEqual(
+            mock_upload.await_args.kwargs["upload_url"],
+            "https://novac2c.cdn.weixin.qq.com/c2c/upload?encrypted_query_param=abc&filekey=file-key&taskid=task-1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
- accept WeChat `getuploadurl` responses that return `upload_full_url`
- keep the legacy `upload_param` path for backward compatibility
- add focused tests for both response shapes

## Why
The WeChat regression container reproduced image upload failures because iLink now returns a full CDN upload URL instead of `upload_param`. The old parser rejected that response before the upload request was even sent.

## How to test
- `ruff check modules/im/wechat_cdn.py tests/test_wechat_cdn.py`
- rebuild the three-regression Docker environment and confirm the WeChat image upload path no longer fails on `getUploadUrl returned no upload_param`
- container-level verification: old `/app` code fails with `upload_full_url`, patched code accepts it and forwards the resolved upload URL

## Risks / follow-ups
- this does not restore an expired WeChat login session; QR re-auth may still be required before manual regression
