### PR TITLE
fix(regression): enable opencode permissions

### DIFF
--- a/scripts/prepare_three_regression.py
+++ b/scripts/prepare_three_regression.py
@@ -374,6 +374,7 @@ def _build_opencode_payload() -> dict:
     anthropic_key = _optional("THREE_REGRESSION_OPENCODE_ANTHROPIC_API_KEY") or _env("ANTHROPIC_API_KEY")
 
     return {
+        "permission": "allow",
         "provider": {
             "openai": {
                 "options": {

--- a/tests/test_prepare_three_regression.py
+++ b/tests/test_prepare_three_regression.py
@@ -113,6 +113,7 @@ def test_prepare_generates_unified_state(tmp_path: Path, monkeypatch: pytest.Mon
     opencode_config = json.loads(
         (tmp_path / "shared-home" / ".config" / "opencode" / "opencode.json").read_text(encoding="utf-8")
     )
+    assert opencode_config["permission"] == "allow"
     assert opencode_config["provider"]["openai"]["options"]["baseURL"] == "https://ai-relay.example/v1"
 
 


### PR DESCRIPTION
## Summary
- set regression OpenCode config to write `permission: "allow"`
- add coverage so the generated regression `opencode.json` keeps this field
- prevent Docker regression from silently falling back to OpenCode's default `external_directory` ask behavior

## Validation
- `python3 -m pytest tests/test_prepare_three_regression.py`
- `ruff check scripts/prepare_three_regression.py tests/test_prepare_three_regression.py`
