### PR TITLE
fix(native-sessions): lazy-load sqlite providers

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -13,7 +13,6 @@ from modules.im.formatters import SlackFormatter, DiscordFormatter
 from modules.agent_router import AgentRouter
 from modules.agents.service import AgentService
 from modules.claude_client import ClaudeClient
-from modules.agents.native_sessions import AgentNativeSessionService
 from modules.session_manager import SessionManager
 from modules.settings_manager import SettingsManager, MultiSettingsManager
 from core.handlers import (
@@ -98,7 +97,7 @@ class Controller:
         self.settings_manager = MultiSettingsManager(self.enabled_platforms, primary_platform=self.primary_platform)
         self.platform_settings_managers = self.settings_manager.managers
         self.sessions = self.settings_manager.sessions
-        self.native_session_service = AgentNativeSessionService()
+        self.native_session_service = None
 
         # Migrate legacy per-channel language into global config
         self._migrate_language_from_settings()
@@ -113,6 +112,13 @@ class Controller:
         # Inject settings_manager into IM client if supported
         for platform, client in self.im_clients.items():
             self._inject_runtime_dependencies(platform, client)
+
+    def get_native_session_service(self):
+        if self.native_session_service is None:
+            from modules.agents.native_sessions.service import AgentNativeSessionService
+
+            self.native_session_service = AgentNativeSessionService()
+        return self.native_session_service
 
     def _create_formatter(self, platform: str):
         if platform == "discord":

--- a/core/handlers/command_handlers.py
+++ b/core/handlers/command_handlers.py
@@ -5,7 +5,7 @@ import os
 import time
 from typing import Any, Optional
 from modules.agents import get_agent_display_name
-from modules.agents.native_sessions import NativeResumeSession
+from modules.agents.native_sessions.types import NativeResumeSession
 from modules.agents.base import AgentRequest
 from modules.im import MessageContext, InlineKeyboard, InlineButton
 
@@ -129,7 +129,11 @@ class CommandHandlers(BaseHandler):
         limit: int = 100,
     ) -> tuple[str, list[NativeResumeSession]]:
         working_path = self.controller.get_cwd(context)
-        native_session_service = getattr(self.controller, "native_session_service", None)
+        service_getter = getattr(self.controller, "get_native_session_service", None)
+        if callable(service_getter):
+            native_session_service = service_getter()
+        else:
+            native_session_service = getattr(self.controller, "native_session_service", None)
         if native_session_service is None:
             return working_path, []
         sessions = native_session_service.list_recent_sessions(working_path, limit=limit)

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -245,7 +245,11 @@ class SessionHandler(BaseHandler):
         agent: str,
         session_id: str,
     ) -> str:
-        native_session_service = getattr(self.controller, "native_session_service", None)
+        service_getter = getattr(self.controller, "get_native_session_service", None)
+        if callable(service_getter):
+            native_session_service = service_getter()
+        else:
+            native_session_service = getattr(self.controller, "native_session_service", None)
         if native_session_service is None:
             return ""
         try:

--- a/modules/agents/native_sessions/__init__.py
+++ b/modules/agents/native_sessions/__init__.py
@@ -1,6 +1,10 @@
 """Backend-native session catalog helpers for the resume picker."""
 
-from .service import AgentNativeSessionService
+from .display import format_display_summary, format_display_time
 from .types import NativeResumeSession
 
-__all__ = ["AgentNativeSessionService", "NativeResumeSession"]
+__all__ = [
+    "NativeResumeSession",
+    "format_display_summary",
+    "format_display_time",
+]

--- a/modules/agents/native_sessions/display.py
+++ b/modules/agents/native_sessions/display.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from .base import build_tail_preview
+from .types import NativeResumeSession
+
+
+def format_display_time(item: NativeResumeSession) -> str:
+    dt = item.updated_at or item.created_at
+    if not dt:
+        return "--"
+    now = datetime.now()
+    if dt.year == now.year:
+        return dt.strftime("%m-%d %H:%M")
+    return dt.strftime("%Y-%m-%d")
+
+
+def format_display_summary(item: NativeResumeSession) -> str:
+    tail = item.last_agent_tail or build_tail_preview(item.native_session_id)
+    suffix = tail.lstrip(".") or item.native_session_id[-10:]
+    return f"{item.agent_prefix}...{suffix}"

--- a/modules/agents/native_sessions/providers.py
+++ b/modules/agents/native_sessions/providers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class NativeSessionProviderSpec:
+    agent_name: str
+    module_path: str
+    class_name: str
+
+
+DEFAULT_PROVIDER_SPECS: tuple[NativeSessionProviderSpec, ...] = (
+    NativeSessionProviderSpec(
+        agent_name="opencode",
+        module_path="modules.agents.native_sessions.opencode",
+        class_name="OpenCodeNativeSessionProvider",
+    ),
+    NativeSessionProviderSpec(
+        agent_name="claude",
+        module_path="modules.agents.native_sessions.claude",
+        class_name="ClaudeNativeSessionProvider",
+    ),
+    NativeSessionProviderSpec(
+        agent_name="codex",
+        module_path="modules.agents.native_sessions.codex",
+        class_name="CodexNativeSessionProvider",
+    ),
+)

--- a/modules/agents/native_sessions/service.py
+++ b/modules/agents/native_sessions/service.py
@@ -1,25 +1,41 @@
 from __future__ import annotations
 
+import importlib
 import logging
 from collections import Counter
-from datetime import datetime
 
-from .base import NativeSessionProvider, build_tail_preview
-from .claude import ClaudeNativeSessionProvider
-from .codex import CodexNativeSessionProvider
-from .opencode import OpenCodeNativeSessionProvider
+from .base import NativeSessionProvider
+from .providers import DEFAULT_PROVIDER_SPECS, NativeSessionProviderSpec
 from .types import NativeResumeSession
 
 logger = logging.getLogger(__name__)
 
 
 class AgentNativeSessionService:
-    def __init__(self, providers: list[NativeSessionProvider] | None = None):
-        self.providers = providers or [
-            OpenCodeNativeSessionProvider(),
-            ClaudeNativeSessionProvider(),
-            CodexNativeSessionProvider(),
-        ]
+    def __init__(
+        self,
+        providers: list[NativeSessionProvider] | None = None,
+        provider_specs: tuple[NativeSessionProviderSpec, ...] = DEFAULT_PROVIDER_SPECS,
+    ):
+        self._providers = providers
+        self._provider_specs = provider_specs
+
+    @property
+    def providers(self) -> list[NativeSessionProvider]:
+        if self._providers is None:
+            self._providers = self._load_default_providers()
+        return self._providers
+
+    def _load_default_providers(self) -> list[NativeSessionProvider]:
+        providers: list[NativeSessionProvider] = []
+        for spec in self._provider_specs:
+            try:
+                module = importlib.import_module(spec.module_path)
+                provider_cls = getattr(module, spec.class_name)
+                providers.append(provider_cls())
+            except Exception as exc:
+                logger.warning("Failed to load %s native session provider: %s", spec.agent_name, exc)
+        return providers
 
     def list_recent_sessions(self, working_path: str, limit: int = 100) -> list[NativeResumeSession]:
         items: list[NativeResumeSession] = []
@@ -83,22 +99,6 @@ class AgentNativeSessionService:
 
         selected.sort(key=lambda item: (-item.sort_ts, item.agent_prefix, item.native_session_id))
         return selected
-
-    @staticmethod
-    def format_display_time(item: NativeResumeSession) -> str:
-        dt = item.updated_at or item.created_at
-        if not dt:
-            return "--"
-        now = datetime.now()
-        if dt.year == now.year:
-            return dt.strftime("%m-%d %H:%M")
-        return dt.strftime("%Y-%m-%d")
-
-    @staticmethod
-    def format_display_summary(item: NativeResumeSession) -> str:
-        tail = item.last_agent_tail or build_tail_preview(item.native_session_id)
-        suffix = tail.lstrip(".") or item.native_session_id[-10:]
-        return f"{item.agent_prefix}...{suffix}"
 
     def get_session(
         self,

--- a/modules/im/discord.py
+++ b/modules/im/discord.py
@@ -30,7 +30,8 @@ from modules.agents.opencode.utils import (
     resolve_opencode_default_model,
     resolve_opencode_provider_preferences,
 )
-from modules.agents.native_sessions import AgentNativeSessionService, NativeResumeSession
+from modules.agents.native_sessions.display import format_display_summary, format_display_time
+from modules.agents.native_sessions.types import NativeResumeSession
 
 logger = logging.getLogger(__name__)
 
@@ -1231,12 +1232,12 @@ class DiscordBot(BaseIMClient):
 
         options = []
         for item in sessions:
-            label = AgentNativeSessionService.format_display_summary(item)
+            label = format_display_summary(item)
             options.append(
                 discord.SelectOption(
                     label=label[:100],
                     value=f"{item.agent}|{item.native_session_id}",
-                    description=AgentNativeSessionService.format_display_time(item)[:100],
+                    description=format_display_time(item)[:100],
                 )
             )
         if len(options) > 25:

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -29,7 +29,8 @@ from modules.agents.opencode.utils import (
     resolve_opencode_allowed_providers,
     resolve_opencode_provider_preferences,
 )
-from modules.agents.native_sessions import AgentNativeSessionService, NativeResumeSession
+from modules.agents.native_sessions.display import format_display_summary, format_display_time
+from modules.agents.native_sessions.types import NativeResumeSession
 
 logger = logging.getLogger(__name__)
 
@@ -2666,8 +2667,8 @@ class FeishuBot(BaseIMClient):
                 if item.agent not in allowed_agents:
                     continue
                 label = (
-                    f"{AgentNativeSessionService.format_display_summary(item)}"
-                    f" · {AgentNativeSessionService.format_display_time(item)}"
+                    f"{format_display_summary(item)}"
+                    f" · {format_display_time(item)}"
                 )
                 session_options.append(
                     {

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -34,7 +34,8 @@ from modules.agents.opencode.utils import (
     resolve_opencode_allowed_providers,
     resolve_opencode_provider_preferences,
 )
-from modules.agents.native_sessions import AgentNativeSessionService, NativeResumeSession
+from modules.agents.native_sessions.display import format_display_summary, format_display_time
+from modules.agents.native_sessions.types import NativeResumeSession
 
 logger = logging.getLogger(__name__)
 
@@ -2381,8 +2382,8 @@ class SlackBot(BaseIMClient):
                 break
             if item.agent not in allowed_agents:
                 continue
-            label = AgentNativeSessionService.format_display_summary(item)
-            desc = AgentNativeSessionService.format_display_time(item)
+            label = format_display_summary(item)
+            desc = format_display_time(item)
             session_options.append(
                 {
                     "text": {"type": "plain_text", "text": label[:75], "emoji": True},

--- a/tests/test_native_session_providers.py
+++ b/tests/test_native_session_providers.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 import json
@@ -7,6 +10,7 @@ from modules.agents.native_sessions import claude as claude_module
 from modules.agents.native_sessions.claude import ClaudeNativeSessionProvider, encode_project_path
 from modules.agents.native_sessions import codex as codex_module
 from modules.agents.native_sessions.codex import CodexNativeSessionProvider
+from modules.agents.native_sessions import service as service_module
 from modules.agents.native_sessions.service import AgentNativeSessionService
 from modules.agents.native_sessions.types import NativeResumeSession
 
@@ -192,6 +196,74 @@ def test_native_session_service_preserves_agent_visibility_when_limited() -> Non
 
     assert len(items) == 5
     assert {item.agent for item in items} == {"opencode", "claude", "codex"}
+
+
+def test_native_session_service_loads_default_providers_lazily(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _StubProvider:
+        agent_name = "claude"
+
+        def list_metadata(self, working_path: str) -> list[NativeResumeSession]:
+            return []
+
+        def hydrate_preview(self, item: NativeResumeSession) -> NativeResumeSession:
+            return item
+
+    def _fake_import_module(module_path: str):
+        calls.append(module_path)
+        return SimpleNamespace(ClaudeNativeSessionProvider=_StubProvider)
+
+    monkeypatch.setattr(service_module.importlib, "import_module", _fake_import_module)
+    service = AgentNativeSessionService(
+        provider_specs=(
+            service_module.NativeSessionProviderSpec(
+                agent_name="claude",
+                module_path="modules.agents.native_sessions.claude",
+                class_name="ClaudeNativeSessionProvider",
+            ),
+        )
+    )
+
+    assert calls == []
+
+    assert service.list_recent_sessions("/tmp/project", limit=5) == []
+    assert calls == ["modules.agents.native_sessions.claude"]
+
+
+def test_native_session_lightweight_imports_do_not_require_sqlite() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(repo_root) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    script = """
+import importlib.abc
+
+class BlockSqlite(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "sqlite3" or fullname.startswith("sqlite3.") or fullname == "_sqlite3":
+            raise ImportError("blocked sqlite for test")
+        return None
+
+import sys
+sys.meta_path.insert(0, BlockSqlite())
+
+for module_name in [
+    "modules.agents.native_sessions",
+    "core.handlers.command_handlers",
+    "core.handlers.session_handler",
+]:
+    __import__(module_name)
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr or completed.stdout
 
 
 def test_build_tail_preview_strips_edge_symbols() -> None:

--- a/tests/test_resume_session.py
+++ b/tests/test_resume_session.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 from core.controller import Controller
 from core.handlers.command_handlers import CommandHandlers
 from core.handlers.session_handler import SessionHandler
-from modules.agents.native_sessions import NativeResumeSession
+from modules.agents.native_sessions.types import NativeResumeSession
 from modules.im import MessageContext
 from config.v2_config import SlackConfig
 


### PR DESCRIPTION
## Summary
- decouple native session display/types from provider loading so startup imports stay lightweight
- lazy-load the native session service and default providers only when `/resume` session access is actually used
- add regression coverage for sqlite-blocked imports and provider lazy loading

## Testing
- `ruff check core/controller.py core/handlers/command_handlers.py core/handlers/session_handler.py modules/agents/native_sessions modules/im/slack.py modules/im/discord.py modules/im/feishu.py tests/test_native_session_providers.py tests/test_resume_session.py`
- `python3 -m pytest tests/test_native_session_providers.py`
- manual repro: block `sqlite3` imports and confirm lightweight modules still import; service creation succeeds and only provider loading warns on access

## Notes
- `python3 -m pytest tests/test_resume_session.py` is still blocked locally by missing dependency `apscheduler`, unrelated to this change

Fixes #139
