### PR TITLE
refactor(prompt): refine user context guidance

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -61,20 +61,18 @@ def get_user_preferences_path() -> Path:
     return get_state_dir() / "user_preferences.md"
 
 
-_USER_PREFERENCES_TEMPLATE = """# User Preferences
+_USER_PREFERENCES_TEMPLATE = """# User Context and Preferences
 
-Use this file for stable long-term preferences and recurring rules.
-Prefer user-specific notes under `## Users`.
-Use `## Shared` only for rules that truly apply across users.
-Keep entries short, factual, deduplicated, and free of secrets unless the user explicitly asks.
-Prefer durable preferences over one-off requests.
-
-## Shared
-- Add cross-user rules here only when they are broadly useful.
+Use this file for durable user context, stable preferences, and recurring working patterns.
+Prefer adding notes under `## Users`.
+Keep entries short, factual, reusable, deduplicated, and free of secrets unless the user explicitly asks.
 
 ## Users
 ### platform/user_id
-- Add stable preferences for this user here.
+- Add stable notes about how this user prefers to communicate, work, and make decisions.
+
+## Shared
+- Add cross-user notes here only when they are genuinely reusable.
 """
 
 

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -209,13 +209,18 @@ Rules:
 
 _USER_PREFERENCES_PROMPT = """\
 
-## 4. User preference file
-A shared user preference file is available at `{preferences_path}`.
-When useful, you may read it to learn stable habits, preferences, and recurring rules.
+## 4. User Context and Preferences
+A shared user context and preferences file is available at `{preferences_path}`.
+
+From first principles, serving the user better means thinking proactively about how to make full use of the available context, reduce repetitive communication, and make judgments that better fit the user's habits. For example, the user may currently be receiving your messages through an IM channel, possibly on a mobile device or in a fragmented-attention context.
+
+Use this file proactively when it is helpful, especially when it can help you understand the user's stable habits, preferences, or working style, reduce repeated questions, and choose among multiple reasonable ways to proceed in a way that better fits the user.
+
+You do not need to read it for every simple request; but if consulting it could improve personalization, efficiency, or continuity, prefer checking it early.
+
 You may also update it, usually in the current user's section: `{user_section}`.
-Only write to a shared section when a rule truly applies across users.
-Prefer durable preferences over one-off requests.
-Keep it short, factual, deduplicated, and free of secrets unless the user explicitly asks.
+Only record durable, factual, reusable information there.
+Keep entries short, deduplicated, and free of secrets unless the user explicitly asks.
 """
 
 

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -73,7 +73,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("## 1. Send files", prompt)
         self.assertIn("Vibe Remote provides optional capabilities:", prompt)
         self.assertNotIn("## 2. Quick-reply buttons", prompt)
-        self.assertIn("## 4. User preference file", prompt)
+        self.assertIn("## 4. User Context and Preferences", prompt)
         self.assertIn("`/tmp/user_preferences.md`", prompt)
         self.assertIn("`<platform>/<user_id>`", prompt)
 
@@ -97,11 +97,14 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Current thread ID: `171717.123`", prompt)
         self.assertIn("If `--timezone` is omitted, the task uses the local system timezone at creation time.", prompt)
         self.assertIn("Run `vibe task add --help` or `vibe hook send --help` for the full command reference.", prompt)
-        self.assertIn("When useful, you may read it to learn stable habits, preferences, and recurring rules.", prompt)
+        self.assertIn("A shared user context and preferences file is available at ", prompt)
+        self.assertIn("/tmp/user_preferences.md", prompt)
+        self.assertIn("From first principles, serving the user better means thinking proactively about how to make full use of the available context", prompt)
+        self.assertIn("Use this file proactively when it is helpful", prompt)
+        self.assertIn("You do not need to read it for every simple request; but if consulting it could improve personalization, efficiency, or continuity, prefer checking it early.", prompt)
         self.assertIn("usually in the current user's section: `slack/U1`.", prompt)
-        self.assertIn("Only write to a shared section when a rule truly applies across users.", prompt)
-        self.assertIn("Prefer durable preferences over one-off requests.", prompt)
-        self.assertIn("Keep it short, factual, deduplicated, and free of secrets unless the user explicitly asks.", prompt)
+        self.assertIn("Only record durable, factual, reusable information there.", prompt)
+        self.assertIn("Keep entries short, deduplicated, and free of secrets unless the user explicitly asks.", prompt)
 
     def test_prompt_uses_fallback_platform_for_unannotated_context(self):
         context = MessageContext(

--- a/tests/test_v2_paths.py
+++ b/tests/test_v2_paths.py
@@ -21,8 +21,8 @@ def test_ensure_data_dirs(tmp_path, monkeypatch):
     preferences_path = tmp_path / ".vibe_remote" / "state" / "user_preferences.md"
     assert preferences_path.exists()
     text = preferences_path.read_text(encoding="utf-8")
-    assert "# User Preferences" in text
-    assert "Prefer user-specific notes under `## Users`." in text
+    assert "# User Context and Preferences" in text
+    assert "Prefer adding notes under `## Users`." in text
     assert "### platform/user_id" in text
-    assert "Prefer durable preferences over one-off requests." in text
+    assert "communicate, work, and make decisions." in text
     assert "free of secrets unless the user explicitly asks." in text


### PR DESCRIPTION
## Summary
- refine the injected user preference guidance into broader user context and preferences guidance
- encourage selective, proactive use of the file without making it mandatory
- simplify the default user preferences template so it better guides reusable notes

## Testing
- `ruff check core/reply_enhancer.py config/paths.py tests/test_reply_enhancer_platform.py tests/test_v2_paths.py`
- `./.venv/bin/python -m pytest tests/test_reply_enhancer_platform.py tests/test_v2_paths.py`

## Notes
- `uv run pytest ...` still triggers the existing editable build path, which currently fails in a fresh worktree if `ui/dist` has not been built yet
