### PR TITLE
fix(tasks): harden scheduled task store reloads

### DIFF
--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -27,6 +27,14 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _path_signature(path: Path) -> Optional[tuple[int, int, int]]:
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size, stat.st_ino)
+
+
 @dataclass(frozen=True)
 class ParsedSessionKey:
     platform: str
@@ -167,21 +175,21 @@ class TaskExecutionRequest:
 class ScheduledTaskStore:
     def __init__(self, path: Optional[Path] = None):
         self.path = path or (paths.get_state_dir() / "scheduled_tasks.json")
-        self._mtime: float = 0
+        self._signature: Optional[tuple[int, int, int]] = None
         self._tasks: Dict[str, ScheduledTask] = {}
         self.load()
 
     def load(self) -> None:
         if not self.path.exists():
             self._tasks = {}
-            self._mtime = 0
+            self._signature = None
             return
         try:
             payload = json.loads(self.path.read_text(encoding="utf-8"))
         except Exception as exc:
             logger.error("Failed to load scheduled tasks: %s", exc)
             self._tasks = {}
-            self._mtime = 0
+            self._signature = None
             return
 
         raw_tasks = payload.get("tasks", []) if isinstance(payload, dict) else []
@@ -192,20 +200,11 @@ class ScheduledTaskStore:
             task = ScheduledTask.from_dict(item)
             tasks[task.id] = task
         self._tasks = tasks
-        try:
-            self._mtime = self.path.stat().st_mtime
-        except FileNotFoundError:
-            self._mtime = 0
+        self._signature = _path_signature(self.path)
 
     def maybe_reload(self) -> bool:
-        try:
-            mtime = self.path.stat().st_mtime
-        except FileNotFoundError:
-            mtime = 0
-        if mtime == 0 and self._mtime != 0:
-            self.load()
-            return True
-        if mtime <= self._mtime:
+        signature = _path_signature(self.path)
+        if signature == self._signature:
             return False
         self.load()
         return True
@@ -223,7 +222,7 @@ class ScheduledTaskStore:
             json.dump(payload, handle, indent=2)
             tmp_path = Path(handle.name)
         tmp_path.replace(self.path)
-        self._mtime = self.path.stat().st_mtime
+        self._signature = _path_signature(self.path)
 
     def list_tasks(self) -> list[ScheduledTask]:
         return sorted(self._tasks.values(), key=lambda item: (item.created_at, item.id))

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -185,6 +185,28 @@ def test_mark_task_result_skips_deleted_task_after_reload(tmp_path: Path) -> Non
     assert reloaded.get_task(task.id) is None
 
 
+def test_store_reload_uses_size_when_mtime_does_not_change(tmp_path: Path) -> None:
+    path = tmp_path / "scheduled_tasks.json"
+    writer = ScheduledTaskStore(path)
+    task = writer.add_task(
+        session_key="slack::channel::C123",
+        prompt="send digest",
+        schedule_type="cron",
+        cron="0 * * * *",
+        timezone_name="Asia/Shanghai",
+    )
+    before = path.stat()
+
+    remover = ScheduledTaskStore(path)
+    assert remover.remove_task(task.id) is True
+
+    after = path.stat()
+    writer._signature = (after.st_mtime_ns, before.st_size, after.st_ino)
+
+    assert writer.maybe_reload() is True
+    assert writer.get_task(task.id) is None
+
+
 def test_service_rejects_unsupported_platform_at_runtime() -> None:
     controller = SimpleNamespace(platform_settings_managers={"slack": object()})
     service = ScheduledTaskService(controller=controller, store=ScheduledTaskStore(Path("/tmp/nonexistent-scheduled.json")))


### PR DESCRIPTION
## Summary
- replace `ScheduledTaskStore`'s mtime-only change detection with a stronger file signature
- prevent `mark_task_result()` from resurrecting deleted tasks when multiple writers share `scheduled_tasks.json`
- add a deterministic regression test for same-mtime file replacements

## Changes
- add `_path_signature()` based on `st_mtime_ns`, `st_size`, and `st_ino`
- store and compare the full signature in `load()`, `maybe_reload()`, and `_save()`
- keep the existing `mark_task_result()` flow, but make reload detection reliable across atomic file replacements
- add a regression test that simulates unchanged mtime with a changed file size

## Validation
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_scheduled_tasks.py`
- `uv run ruff check core/scheduled_tasks.py tests/test_scheduled_tasks.py`
- confirmed the issue reproduces in the Docker regression container on current master before the fix
