### PR TITLE
fix(feishu): strip file links from log messages

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -383,11 +383,20 @@ class ConsolidatedMessageDispatcher:
             )
             return None
 
+        reply_enhancements_on = getattr(self.controller.config, "reply_enhancements", True)
+        if reply_enhancements_on:
+            enhanced = process_reply(text)
+            chunk = enhanced.text.strip()
+        else:
+            chunk = text.strip()
+
+        if not chunk:
+            return None
+
         consolidated_key = self._get_consolidated_message_key(context)
         lock = self._get_consolidated_message_lock(consolidated_key)
 
         async with lock:
-            chunk = text.strip()
             max_bytes = self._get_consolidated_max_bytes(context)
             split_threshold = self._get_consolidated_split_threshold(context)
             existing = self._consolidated_message_buffers.get(consolidated_key, "")

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Optional
 
 from modules.im import MessageContext
-from core.reply_enhancer import process_reply
+from core.reply_enhancer import process_reply, strip_file_links
 
 logger = logging.getLogger(__name__)
 
@@ -385,8 +385,7 @@ class ConsolidatedMessageDispatcher:
 
         reply_enhancements_on = getattr(self.controller.config, "reply_enhancements", True)
         if reply_enhancements_on:
-            enhanced = process_reply(text)
-            chunk = enhanced.text.strip()
+            chunk = strip_file_links(text).strip()
         else:
             chunk = text.strip()
 

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -93,6 +93,14 @@ def process_reply(text: str) -> EnhancedReply:
     return EnhancedReply(text=text_clean.rstrip(), files=files, buttons=buttons)
 
 
+def strip_file_links(text: str) -> str:
+    """Remove ``file://`` markdown URLs while preserving the surrounding text."""
+    files = _extract_file_links(text)
+    if not files:
+        return text
+    return _strip_file_links(text)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -221,6 +221,22 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         keyboard = controller.im_client.sent_button_messages[0][3]
         self.assertEqual([[button.text for button in row] for row in keyboard.buttons], [["继续"], ["提交PR"]])
 
+    async def test_lark_log_message_strips_file_links_before_sending(self):
+        controller = _StubController("lark")
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="U1", channel_id="C1", platform="lark")
+
+        await dispatcher.emit_agent_message(
+            context,
+            "assistant",
+            "Preview ready\n\n![screen](file:///tmp/screen-room.png)",
+        )
+
+        self.assertEqual(
+            controller.im_client.sent_messages,
+            [("C1", "Preview ready\n\nscreen", "markdown")],
+        )
+
     async def test_telegram_quick_reply_buttons_use_vertical_layout(self):
         controller = _StubController("telegram")
         dispatcher = ConsolidatedMessageDispatcher(controller)

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -237,6 +237,22 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             [("C1", "Preview ready\n\nscreen", "markdown")],
         )
 
+    async def test_lark_log_message_preserves_button_like_markdown_blocks(self):
+        controller = _StubController("lark")
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="U1", channel_id="C1", platform="lark")
+
+        await dispatcher.emit_agent_message(
+            context,
+            "assistant",
+            "Runbook\n---\n[step one] | [step two]",
+        )
+
+        self.assertEqual(
+            controller.im_client.sent_messages,
+            [("C1", "Runbook\n---\n[step one] | [step two]", "markdown")],
+        )
+
     async def test_telegram_quick_reply_buttons_use_vertical_layout(self):
         controller = _StubController("telegram")
         dispatcher = ConsolidatedMessageDispatcher(controller)


### PR DESCRIPTION
## Summary
- sanitize consolidated log messages with `process_reply()` before sending them to IM clients
- strip `file://` markdown from log-message text without changing result-message attachment uploads
- add a regression test covering the Lark/Feishu log-message path

## Why
Sentry `PYTHON-84` on `release:vibe-remote@2.2.8` shows Feishu card creation failing because log messages include raw `file:///tmp/...` markdown, which Feishu rejects as an invalid image key.

## Validation
- unit: `PYTHONPATH=. /Users/cyh/vibe-remote/venv/bin/pytest tests/test_reply_enhancer_platform.py -q`
- lint: `ruff check core/message_dispatcher.py tests/test_reply_enhancer_platform.py`
- residual manual check: verified with a minimal runtime script that an assistant log message now sends `screen` instead of `file:///tmp/screen-room.png`
