### PR TITLE
feat(cli): add delayed restart scheduling

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -187,15 +187,15 @@ The key difference between commands:
 
 | Command | Main Service | OpenCode Server |
 |---------|--------------|-----------------|
-| `vibe` | Restart | **Preserved** |
+| `vibe restart` | Restart | **Terminated** |
 | `vibe stop` | Stop | **Terminated** |
 
 ### Why This Matters
 
-When you run `vibe` to restart:
-- Any **running OpenCode tasks continue uninterrupted**
-- The new Vibe Remote instance "adopts" the existing OpenCode server
-- Session state is preserved
+When you run `vibe restart`:
+- The main service restarts cleanly
+- The UI restarts too
+- The OpenCode server is terminated as part of the restart
 
 When you run `vibe stop`:
 - **Everything stops cleanly**
@@ -206,10 +206,16 @@ When you run `vibe stop`:
 
 ### Daily Restart
 
-Just want to restart Vibe Remote without interrupting work:
+If an agent is triggering the restart from an active conversation, prefer the delayed form for a better user experience:
 
 ```bash
-vibe
+vibe restart --delay-seconds 60
+```
+
+Just want to restart Vibe Remote immediately:
+
+```bash
+vibe restart
 ```
 
 ### Update OpenCode Configuration
@@ -217,7 +223,7 @@ vibe
 After editing `~/.config/opencode/opencode.json`:
 
 ```bash
-vibe stop && vibe
+vibe restart --delay-seconds 60
 ```
 
 ### Update OpenCode Binary
@@ -225,7 +231,7 @@ vibe stop && vibe
 After installing a new version of OpenCode:
 
 ```bash
-vibe stop && vibe
+vibe restart --delay-seconds 60
 ```
 
 ### Update Vibe Remote
@@ -233,7 +239,7 @@ vibe stop && vibe
 ```bash
 vibe upgrade
 # Then restart:
-vibe stop && vibe
+vibe restart --delay-seconds 60
 ```
 
 ### Troubleshooting
@@ -247,8 +253,8 @@ vibe status
 # Run diagnostics
 vibe doctor
 
-# Full restart (stops everything including OpenCode)
-vibe stop && vibe
+# Prefer delayed restart when triggered by an agent
+vibe restart --delay-seconds 60
 ```
 
 ## Web UI Controls
@@ -257,8 +263,8 @@ The web UI (`http://127.0.0.1:5123`) provides the same controls:
 
 | Button | Equivalent CLI | OpenCode Behavior |
 |--------|---------------|-------------------|
-| **Start** | `vibe` | Preserved |
-| **Restart** | `vibe` | Preserved |
+| **Start** | `vibe` | Starts on demand |
+| **Restart** | `vibe restart` | Terminated |
 | **Stop** | `vibe stop` | Terminated |
 
 ## File Locations

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -187,15 +187,15 @@ Vibe Remote 管理两类进程：
 
 | 命令 | 主服务 | OpenCode 服务器 |
 |------|--------|-----------------|
-| `vibe` | 重启 | **保留** |
+| `vibe restart` | 重启 | **终止** |
 | `vibe stop` | 停止 | **终止** |
 
 ### 为什么这很重要
 
-当你运行 `vibe` 重启时：
-- **正在运行的 OpenCode 任务会继续执行**，不会中断
-- 新的 Vibe Remote 实例会「认领」现有的 OpenCode 服务器
-- 会话状态得以保留
+当你运行 `vibe restart` 时：
+- 主服务会被干净地重启
+- UI 也会一起重启
+- OpenCode 服务器会在重启过程中被终止
 
 当你运行 `vibe stop` 时：
 - **一切都会干净地停止**
@@ -206,10 +206,16 @@ Vibe Remote 管理两类进程：
 
 ### 日常重启
 
-只想重启 Vibe Remote，不中断正在进行的工作：
+如果是 Agent 在当前会话里触发重启，默认优先用延迟参数，用户体验更好：
 
 ```bash
-vibe
+vibe restart --delay-seconds 60
+```
+
+如果就是要立刻重启 Vibe Remote：
+
+```bash
+vibe restart
 ```
 
 ### 更新 OpenCode 配置
@@ -217,7 +223,7 @@ vibe
 修改 `~/.config/opencode/opencode.json` 后：
 
 ```bash
-vibe stop && vibe
+vibe restart --delay-seconds 60
 ```
 
 ### 更新 OpenCode 程序
@@ -225,7 +231,7 @@ vibe stop && vibe
 安装新版本 OpenCode 后：
 
 ```bash
-vibe stop && vibe
+vibe restart --delay-seconds 60
 ```
 
 ### 更新 Vibe Remote
@@ -233,7 +239,7 @@ vibe stop && vibe
 ```bash
 vibe upgrade
 # 然后重启：
-vibe stop && vibe
+vibe restart --delay-seconds 60
 ```
 
 ### 故障排查
@@ -247,8 +253,8 @@ vibe status
 # 运行诊断
 vibe doctor
 
-# 完全重启（停止所有服务包括 OpenCode）
-vibe stop && vibe
+# 如果是 Agent 触发，优先延迟重启
+vibe restart --delay-seconds 60
 ```
 
 ## Web UI 控制
@@ -257,8 +263,8 @@ Web UI (`http://127.0.0.1:5123`) 提供相同的控制功能：
 
 | 按钮 | 等效 CLI | OpenCode 行为 |
 |------|---------|---------------|
-| **Start** | `vibe` | 保留 |
-| **Restart** | `vibe` | 保留 |
+| **Start** | `vibe` | 按需启动 |
+| **Restart** | `vibe restart` | 终止 |
 | **Stop** | `vibe stop` | 终止 |
 
 ## 文件位置

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -554,7 +554,25 @@ vibe stop
 vibe restart
 ```
 
-- equivalent lifecycle intent: stop, wait briefly, start again
+- stops the main service
+- stops the UI server
+- terminates the OpenCode server too
+- starts the service again after a brief wait
+
+Optional async scheduling:
+
+```bash
+vibe restart --delay-seconds 60
+```
+
+- prints a confirmation immediately
+- exits without waiting
+- runs the restart in the background after the specified delay
+
+Recommended usage:
+
+- prefer `vibe restart --delay-seconds 60` when an agent triggers the restart from an active conversation
+- use plain `vibe restart` when the user explicitly wants the restart to happen immediately
 
 ### `vibe status`
 
@@ -598,7 +616,7 @@ vibe upgrade
 ```
 
 - upgrades Vibe Remote using the selected upgrade plan
-- recommends `vibe stop && vibe` after success
+- usually recommends `vibe restart --delay-seconds 60` after success
 
 ## 5.2 `vibe task`
 

--- a/docs/COMMANDS_ZH.md
+++ b/docs/COMMANDS_ZH.md
@@ -533,7 +533,25 @@ vibe stop
 vibe restart
 ```
 
-- 语义上等价于先停再启
+- 停止主服务
+- 停止 UI 服务
+- 同时终止 OpenCode server
+- 短暂等待后重新启动服务
+
+可选的异步延迟执行：
+
+```bash
+vibe restart --delay-seconds 60
+```
+
+- 会立即打印确认信息
+- 当前命令立刻返回
+- 到达指定延迟后在后台执行重启
+
+推荐用法：
+
+- 如果是 Agent 在活跃会话里触发重启，优先使用 `vibe restart --delay-seconds 60`
+- 只有用户明确要求立刻重启时，再使用普通 `vibe restart`
 
 ### `vibe status`
 
@@ -577,7 +595,7 @@ vibe upgrade
 ```
 
 - 按升级计划升级 Vibe Remote
-- 成功后通常建议再执行 `vibe stop && vibe`
+- 成功后通常建议再执行 `vibe restart --delay-seconds 60`
 
 ## 5.2 `vibe task`
 

--- a/docs/opencode-poll-loop-refactor/TESTING_GUIDE.md
+++ b/docs/opencode-poll-loop-refactor/TESTING_GUIDE.md
@@ -279,7 +279,7 @@ vibe
 
 **Steps:**
 1. Send prompt with question
-2. **Before answering**, restart Vibe: `vibe stop && vibe`
+2. **Before answering**, restart Vibe: `vibe restart`
 3. Check session status
 4. Try to answer question
 

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -34,7 +34,7 @@ Follow this skill as an operations playbook for agents, not as end-user marketin
 6. Only touch the target platform scope in `settings.json`.
 7. Do not hand-edit `sessions.json` unless the user explicitly asks for low-level recovery work.
 8. Tell the user whether the change is global or scope-specific.
-9. After config changes, recommend `vibe doctor` and usually `vibe stop && vibe`.
+9. After config changes, recommend `vibe doctor` and usually `vibe restart --delay-seconds 60`.
 
 ## Runtime Layout
 
@@ -85,8 +85,10 @@ python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$TARGET_FILE"
 
 ```bash
 vibe doctor
-vibe stop && vibe
+vibe restart --delay-seconds 60
 ```
+
+Use plain `vibe restart` only when the user explicitly wants an immediate restart. For agent-triggered restarts during an active conversation, prefer the delayed form so the agent can send its final reply before the service goes down.
 
 8. Summarize the exact keys changed.
 
@@ -577,6 +579,8 @@ Action:
 Main commands:
 
 - `vibe`: start or restart Vibe Remote; preserves the OpenCode server when possible
+- `vibe restart --delay-seconds 60`: preferred agent-safe restart; returns immediately and restarts later in the background
+- `vibe restart`: immediate full restart; use only when the user explicitly wants it now
 - `vibe status`: inspect runtime status
 - `vibe stop`: stop Vibe Remote and the OpenCode server
 - `vibe doctor`: validate config, CLI availability, and runtime health
@@ -586,7 +590,7 @@ Main commands:
 
 Useful checks:
 
-- config does not apply: run `vibe doctor`, then `vibe stop && vibe`
+- config does not apply: run `vibe doctor`, then prefer `vibe restart --delay-seconds 60`
 - backend missing: confirm the backend is enabled and the CLI path is executable
 - channel does not respond: verify the right `settings.json` scope exists and `enabled` is `true`
 - wrong repository/cwd: inspect `custom_cwd` and `runtime.default_cwd`

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -279,6 +279,18 @@ def test_get_restart_environment_adds_source_root_for_python_fallback(monkeypatc
     assert env["PYTHONPATH"] == f"{source_root}{os.pathsep}/existing/path"
 
 
+def test_get_restart_environment_normalizes_relative_pythonpath_entries(monkeypatch, tmp_path):
+    monkeypatch.delenv("VIBE_CURRENT_EXECUTABLE", raising=False)
+    monkeypatch.setattr("vibe.upgrade.shutil.which", lambda *args, **kwargs: None)
+    monkeypatch.chdir(tmp_path)
+
+    env = get_restart_environment(argv0="python", base_env={"PYTHONPATH": f".{os.pathsep}src"})
+
+    source_root = str(Path(__file__).resolve().parents[1])
+    assert env is not None
+    assert env["PYTHONPATH"] == f"{source_root}{os.pathsep}{tmp_path}{os.pathsep}{tmp_path / 'src'}"
+
+
 def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "vibe-remote", "--upgrade"],

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -16,6 +16,7 @@ from vibe.upgrade import (
     get_current_vibe_bin_dir,
     get_latest_version_info,
     get_restart_command,
+    get_restart_environment,
     get_running_vibe_path,
     get_safe_cwd,
 )
@@ -267,6 +268,17 @@ def test_get_restart_command_falls_back_to_python_module(monkeypatch):
     assert command == ["/usr/bin/python3", "-c", "from vibe.cli import main; main()"]
 
 
+def test_get_restart_environment_adds_source_root_for_python_fallback(monkeypatch):
+    monkeypatch.delenv("VIBE_CURRENT_EXECUTABLE", raising=False)
+    monkeypatch.setattr("vibe.upgrade.shutil.which", lambda *args, **kwargs: None)
+
+    env = get_restart_environment(argv0="python", base_env={"PYTHONPATH": "/existing/path"})
+
+    source_root = str(Path(__file__).resolve().parents[1])
+    assert env is not None
+    assert env["PYTHONPATH"] == f"{source_root}{os.pathsep}/existing/path"
+
+
 def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "vibe-remote", "--upgrade"],
@@ -278,6 +290,7 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
     monkeypatch.setattr(api, "get_restart_command", lambda **kwargs: ["/custom/bin/vibe"])
+    monkeypatch.setattr(api, "get_restart_environment", lambda **kwargs: None)
     monkeypatch.setattr(api, "_delayed_restart_helper_command", lambda: ["/usr/bin/python3"])
 
     def fake_run(cmd, **kwargs):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -92,6 +92,57 @@ def test_cli_stop_opencode_server_uses_runtime_helpers(tmp_path, monkeypatch):
     assert not pid_file.exists()
 
 
+def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
+    scheduled = {}
+    stop_called = []
+    start_called = []
+
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/usr/local/bin/vibe")
+    monkeypatch.setattr(cli, "get_restart_command", lambda vibe_path=None: [vibe_path or "vibe"])
+    monkeypatch.setattr(cli, "get_safe_cwd", lambda: "/tmp")
+    monkeypatch.setattr(
+        cli.api,
+        "_spawn_delayed_restart",
+        lambda command, cwd, delay_seconds=2.0: scheduled.update(
+            {"command": command, "cwd": cwd, "delay_seconds": delay_seconds}
+        ),
+    )
+    monkeypatch.setattr(cli, "cmd_stop", lambda: stop_called.append(True))
+    monkeypatch.setattr(cli, "cmd_vibe", lambda: start_called.append(True))
+
+    assert cli._cmd_restart_with_delay(60) == 0
+    assert scheduled == {
+        "command": ["/usr/local/bin/vibe", "restart"],
+        "cwd": "/tmp",
+        "delay_seconds": 60,
+    }
+    assert stop_called == []
+    assert start_called == []
+
+    output = capsys.readouterr().out
+    assert "Restart scheduled in 1 minute." in output
+    assert "delayed restart will run in the background" in output
+
+
+def test_cmd_restart_runs_synchronously_by_default(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(cli, "cmd_stop", lambda: calls.append("stop") or 0)
+    monkeypatch.setattr(cli, "cmd_vibe", lambda: calls.append("start") or 0)
+    monkeypatch.setattr(cli.time, "sleep", lambda seconds: calls.append(("sleep", seconds)))
+
+    assert cli._cmd_restart_with_delay(0) == 0
+    assert calls == ["stop", ("sleep", 3), "start"]
+
+
+def test_restart_parser_accepts_delay_seconds():
+    parser = cli.build_parser()
+    args = parser.parse_args(["restart", "--delay-seconds", "60"])
+
+    assert args.command == "restart"
+    assert args.delay_seconds == 60
+
+
 def test_stop_pid_handles_process_lookup_race(monkeypatch):
     monkeypatch.setattr(runtime.os, "name", "posix", raising=False)
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -99,12 +99,13 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
 
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/usr/local/bin/vibe")
     monkeypatch.setattr(cli, "get_restart_command", lambda vibe_path=None: [vibe_path or "vibe"])
+    monkeypatch.setattr(cli, "get_restart_environment", lambda vibe_path=None: None)
     monkeypatch.setattr(cli, "get_safe_cwd", lambda: "/tmp")
     monkeypatch.setattr(
         cli.api,
         "_spawn_delayed_restart",
-        lambda command, cwd, delay_seconds=2.0: scheduled.update(
-            {"command": command, "cwd": cwd, "delay_seconds": delay_seconds}
+        lambda command, cwd, delay_seconds=2.0, env=None: scheduled.update(
+            {"command": command, "cwd": cwd, "delay_seconds": delay_seconds, "env": env}
         ),
     )
     monkeypatch.setattr(cli, "cmd_stop", lambda: stop_called.append(True))
@@ -115,6 +116,7 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
         "command": ["/usr/local/bin/vibe", "restart"],
         "cwd": "/tmp",
         "delay_seconds": 60,
+        "env": None,
     }
     assert stop_called == []
     assert start_called == []
@@ -122,6 +124,34 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "Restart scheduled in 1 minute." in output
     assert "delayed restart will run in the background" in output
+
+
+def test_cmd_restart_schedules_delayed_restart_with_import_env(monkeypatch):
+    scheduled = {}
+
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "get_restart_command",
+        lambda vibe_path=None: [sys.executable, "-c", "from vibe.cli import main; main()"],
+    )
+    monkeypatch.setattr(cli, "get_restart_environment", lambda vibe_path=None: {"PYTHONPATH": "/repo"})
+    monkeypatch.setattr(cli, "get_safe_cwd", lambda: "/tmp")
+    monkeypatch.setattr(
+        cli.api,
+        "_spawn_delayed_restart",
+        lambda command, cwd, delay_seconds=2.0, env=None: scheduled.update(
+            {"command": command, "cwd": cwd, "delay_seconds": delay_seconds, "env": env}
+        ),
+    )
+
+    assert cli._cmd_restart_with_delay(5) == 0
+    assert scheduled == {
+        "command": [sys.executable, "-c", "from vibe.cli import main; main()", "restart"],
+        "cwd": "/tmp",
+        "delay_seconds": 5,
+        "env": {"PYTHONPATH": "/repo"},
+    }
 
 
 def test_cmd_restart_runs_synchronously_by_default(monkeypatch):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pytest
 import signal
 import sys
 from pathlib import Path
@@ -171,6 +172,14 @@ def test_restart_parser_accepts_delay_seconds():
 
     assert args.command == "restart"
     assert args.delay_seconds == 60
+
+
+@pytest.mark.parametrize("raw_value", ["nan", "inf", "-inf"])
+def test_restart_parser_rejects_non_finite_delay_seconds(raw_value):
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["restart", "--delay-seconds", raw_value])
 
 
 def test_stop_pid_handles_process_lookup_race(monkeypatch):

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -33,6 +33,7 @@ from vibe.upgrade import (
     build_upgrade_plan,
     get_latest_version_info,
     get_restart_command,
+    get_restart_environment,
     get_running_vibe_path,
     get_safe_cwd,
 )
@@ -71,11 +72,16 @@ def _delayed_restart_helper_command() -> list[str]:
     raise FileNotFoundError("No stable Python launcher available for delayed restart helper")
 
 
-def _spawn_delayed_restart(command: list[str], cwd: str, delay_seconds: float = 2.0) -> None:
+def _spawn_delayed_restart(
+    command: list[str],
+    cwd: str,
+    delay_seconds: float = 2.0,
+    env: dict[str, str] | None = None,
+) -> None:
     helper_code = (
         "import subprocess, time\n"
         f"time.sleep({delay_seconds!r})\n"
-        f"subprocess.Popen({command!r}, cwd={cwd!r}, stdout=subprocess.DEVNULL, "
+        f"subprocess.Popen({command!r}, cwd={cwd!r}, env={env!r}, stdout=subprocess.DEVNULL, "
         "stderr=subprocess.DEVNULL, close_fds=True)\n"
     )
     helper_cmd = [*_delayed_restart_helper_command(), "-c", helper_code]
@@ -779,6 +785,7 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                 _spawn_delayed_restart(
                     get_restart_command(vibe_path=current_vibe_path),
                     safe_cwd,
+                    env=get_restart_environment(vibe_path=current_vibe_path),
                 )
                 restarting = True
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -41,6 +41,7 @@ from vibe.upgrade import (
     cache_running_vibe_path,
     get_latest_version_info,
     get_restart_command,
+    get_restart_environment,
     get_safe_cwd,
 )
 
@@ -1990,7 +1991,12 @@ def _format_restart_delay(delay_seconds: float) -> str:
 def _schedule_delayed_restart(delay_seconds: float) -> int:
     current_vibe_path = cache_running_vibe_path()
     restart_command = [*get_restart_command(vibe_path=current_vibe_path), "restart"]
-    api._spawn_delayed_restart(restart_command, get_safe_cwd(), delay_seconds=delay_seconds)
+    api._spawn_delayed_restart(
+        restart_command,
+        get_safe_cwd(),
+        delay_seconds=delay_seconds,
+        env=get_restart_environment(vibe_path=current_vibe_path),
+    )
     print(f"Restart scheduled in {_format_restart_delay(delay_seconds)}.")
     print("This command exits immediately; the delayed restart will run in the background.")
     return 0

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import math
 import os
 import shlex
 import shutil
@@ -118,6 +119,8 @@ def _print_task_error(exc: Exception, *, help_command: str | None = None) -> Non
 
 def _non_negative_float(value: str) -> float:
     parsed = float(value)
+    if not math.isfinite(parsed):
+        raise argparse.ArgumentTypeError("must be finite")
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be >= 0")
     return parsed

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -36,7 +36,13 @@ from core.watches import (
     WatchRuntimeStateStore,
 )
 from vibe import __version__, api, runtime
-from vibe.upgrade import build_upgrade_plan, cache_running_vibe_path, get_latest_version_info, get_safe_cwd
+from vibe.upgrade import (
+    build_upgrade_plan,
+    cache_running_vibe_path,
+    get_latest_version_info,
+    get_restart_command,
+    get_safe_cwd,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +113,13 @@ def _print_task_error(exc: Exception, *, help_command: str | None = None) -> Non
         if help_command:
             payload["help_command"] = help_command
     print(json.dumps(payload, indent=2), file=sys.stderr)
+
+
+def _non_negative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
 
 
 def _task_examples_text() -> str:
@@ -1945,7 +1958,7 @@ def cmd_upgrade():
         if result.returncode == 0:
             print("\033[32mUpgrade successful!\033[0m")
             print("Please restart vibe to use the new version:")
-            print("  vibe stop && vibe")
+            print("  vibe restart")
             return 0
         else:
             print(f"\033[31mUpgrade failed:\033[0m\n{result.stderr}")
@@ -1957,6 +1970,36 @@ def cmd_upgrade():
 
 def cmd_restart():
     """Restart all services (stop + start)."""
+    return _cmd_restart_with_delay(0.0)
+
+
+def _format_restart_delay(delay_seconds: float) -> str:
+    if delay_seconds == int(delay_seconds):
+        whole_seconds = int(delay_seconds)
+        if whole_seconds % 60 == 0:
+            minutes = whole_seconds // 60
+            if minutes == 1:
+                return "1 minute"
+            return f"{minutes} minutes"
+        if whole_seconds == 1:
+            return "1 second"
+        return f"{whole_seconds} seconds"
+    return f"{delay_seconds:g} seconds"
+
+
+def _schedule_delayed_restart(delay_seconds: float) -> int:
+    current_vibe_path = cache_running_vibe_path()
+    restart_command = [*get_restart_command(vibe_path=current_vibe_path), "restart"]
+    api._spawn_delayed_restart(restart_command, get_safe_cwd(), delay_seconds=delay_seconds)
+    print(f"Restart scheduled in {_format_restart_delay(delay_seconds)}.")
+    print("This command exits immediately; the delayed restart will run in the background.")
+    return 0
+
+
+def _cmd_restart_with_delay(delay_seconds: float) -> int:
+    if delay_seconds > 0:
+        return _schedule_delayed_restart(delay_seconds)
+
     print("Restarting vibe services...")
     cmd_stop()
     print("Waiting 3 seconds...")
@@ -1969,7 +2012,13 @@ def build_parser():
     subparsers = parser.add_subparsers(dest="command")
 
     subparsers.add_parser("stop", help="Stop all services")
-    subparsers.add_parser("restart", help="Restart all services")
+    restart_parser = subparsers.add_parser("restart", help="Restart all services")
+    restart_parser.add_argument(
+        "--delay-seconds",
+        type=_non_negative_float,
+        default=0,
+        help="Schedule the restart to run asynchronously after N seconds, then exit immediately.",
+    )
     subparsers.add_parser("status", help="Show service status")
     subparsers.add_parser("doctor", help="Run diagnostics")
     subparsers.add_parser("version", help="Show version")
@@ -2327,7 +2376,7 @@ def main():
     if args.command == "stop":
         sys.exit(cmd_stop())
     if args.command == "restart":
-        sys.exit(cmd_restart())
+        sys.exit(_cmd_restart_with_delay(args.delay_seconds))
     if args.command == "status":
         sys.exit(cmd_status())
     if args.command == "doctor":

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -148,6 +148,50 @@ def get_restart_command(
     return [python_executable or sys.executable, "-c", "from vibe.cli import main; main()"]
 
 
+def _get_source_checkout_root() -> str | None:
+    source_root = Path(__file__).resolve().parent.parent
+    if not source_root.is_dir():
+        return None
+    if not (source_root / "pyproject.toml").is_file():
+        return None
+    if not (source_root / "vibe" / "__init__.py").is_file():
+        return None
+    return str(source_root)
+
+
+def get_restart_environment(
+    *,
+    vibe_path: str | None = None,
+    argv0: str | None = None,
+    search_path: str | None = None,
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str] | None:
+    resolved = get_running_vibe_path(vibe_path=vibe_path, argv0=argv0, search_path=search_path)
+    if resolved:
+        return None
+
+    source_root = _get_source_checkout_root()
+    if not source_root:
+        return None
+
+    env = dict(base_env or os.environ)
+    pythonpath = env.get("PYTHONPATH")
+    if pythonpath:
+        normalized_root = os.path.abspath(source_root)
+        normalized_entries = {
+            os.path.abspath(os.path.expanduser(entry))
+            for entry in pythonpath.split(os.pathsep)
+            if entry
+        }
+        if normalized_root in normalized_entries:
+            return env
+        env["PYTHONPATH"] = os.pathsep.join((source_root, pythonpath))
+        return env
+
+    env["PYTHONPATH"] = source_root
+    return env
+
+
 def get_restart_shell_command(
     *,
     vibe_path: str | None = None,

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -159,6 +159,22 @@ def _get_source_checkout_root() -> str | None:
     return str(source_root)
 
 
+def _normalize_pythonpath_entries(pythonpath: str) -> list[str]:
+    normalized_entries: list[str] = []
+    seen_entries: set[str] = set()
+
+    for entry in pythonpath.split(os.pathsep):
+        if not entry:
+            continue
+        normalized_entry = os.path.abspath(os.path.expanduser(entry))
+        if normalized_entry in seen_entries:
+            continue
+        seen_entries.add(normalized_entry)
+        normalized_entries.append(normalized_entry)
+
+    return normalized_entries
+
+
 def get_restart_environment(
     *,
     vibe_path: str | None = None,
@@ -178,14 +194,10 @@ def get_restart_environment(
     pythonpath = env.get("PYTHONPATH")
     if pythonpath:
         normalized_root = os.path.abspath(source_root)
-        normalized_entries = {
-            os.path.abspath(os.path.expanduser(entry))
-            for entry in pythonpath.split(os.pathsep)
-            if entry
-        }
-        if normalized_root in normalized_entries:
-            return env
-        env["PYTHONPATH"] = os.pathsep.join((source_root, pythonpath))
+        normalized_entries = _normalize_pythonpath_entries(pythonpath)
+        if normalized_root not in normalized_entries:
+            normalized_entries.insert(0, normalized_root)
+        env["PYTHONPATH"] = os.pathsep.join(normalized_entries)
         return env
 
     env["PYTHONPATH"] = source_root


### PR DESCRIPTION
## Summary
- add `vibe restart --delay-seconds <seconds>` so agent-triggered restarts can be scheduled asynchronously
- keep plain `vibe restart` as the immediate synchronous restart path
- update CLI docs, commands reference, testing guide, and `use-vibe-remote` skill to prefer the delayed form during active conversations

## Why
Agent-invoked restarts currently cut off the active shell command immediately. A delayed background restart gives the agent time to send a final reply before Vibe Remote goes down.

## Testing
- `uv run ruff check vibe/cli.py tests/test_vibe_cli.py`
- `/Users/cyh/vibe-remote/.venv/bin/python -m pytest -q tests/test_vibe_cli.py`

## Risks / Follow-ups
- this is a delayed restart, not a strict post-turn restart; long-running turns can still be interrupted if they exceed the scheduled delay
- no UI control changes are included in this PR
