### PR TITLE
fix(slack): stop DM cross-talk on mismatched channels

### DIFF
--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -109,6 +109,43 @@ class SlackBot(BaseIMClient):
         lang = self._get_lang(channel_id)
         return i18n_t(key, lang, **kwargs)
 
+    def _get_bound_user_record(self, user_id: Optional[str]) -> Optional[Any]:
+        if not user_id or self.settings_manager is None:
+            return None
+        store_getter = getattr(self.settings_manager, "get_store", None)
+        if not callable(store_getter):
+            return None
+        try:
+            store = store_getter()
+        except Exception:
+            logger.debug("Failed to access settings store for Slack DM validation", exc_info=True)
+            return None
+        try:
+            store.maybe_reload()
+        except Exception:
+            logger.debug("Failed to reload settings store before Slack DM validation", exc_info=True)
+        try:
+            record = store.get_user(user_id, platform="slack")
+        except TypeError:
+            record = store.get_user(user_id)
+        except Exception:
+            logger.debug("Failed to read bound Slack user record for %s", user_id, exc_info=True)
+            return None
+        if record is None:
+            return None
+        return record
+
+    def _match_bound_dm_channel(self, user_id: Optional[str], channel_id: Optional[str]) -> Optional[bool]:
+        if not user_id or not channel_id:
+            return None
+        record = self._get_bound_user_record(user_id)
+        if record is None:
+            return None
+        dm_chat_id = str(getattr(record, "dm_chat_id", "") or "").strip()
+        if not dm_chat_id:
+            return None
+        return dm_chat_id == channel_id
+
     def _is_duplicate_event(self, event_id: Optional[str]) -> bool:
         """Deduplicate Slack events using event_id with a short TTL."""
         if not event_id:
@@ -242,10 +279,13 @@ class SlackBot(BaseIMClient):
             return text
 
     @staticmethod
-    def _is_dm_context(context: MessageContext) -> bool:
-        if bool((context.platform_specific or {}).get("is_dm", False)):
-            return True
-        return isinstance(context.channel_id, str) and context.channel_id.startswith("D")
+    def _channel_looks_like_dm(channel_id: Optional[str]) -> bool:
+        return isinstance(channel_id, str) and channel_id.startswith("D")
+
+    def _is_dm_context(self, context: MessageContext) -> bool:
+        if not bool((context.platform_specific or {}).get("is_dm", False)) and not self._channel_looks_like_dm(context.channel_id):
+            return False
+        return self._match_bound_dm_channel(context.user_id, context.channel_id) is not False
 
     async def _open_dm_channel(self, user_id: str) -> Optional[str]:
         self._ensure_clients()
@@ -1203,7 +1243,16 @@ class SlackBot(BaseIMClient):
                     return
 
             channel_id = event.get("channel")
-            is_dm = isinstance(channel_id, str) and channel_id.startswith("D")
+            user_id = event.get("user")
+            dm_match = self._match_bound_dm_channel(user_id, channel_id)
+            if dm_match is False:
+                logger.warning(
+                    "Ignoring Slack DM-like message from mismatched channel %s for user %s",
+                    channel_id,
+                    user_id,
+                )
+                return
+            is_dm = self._channel_looks_like_dm(channel_id)
 
             # Check if this message contains a bot mention.
             # In channels, app_mention will handle it. In DMs, Slack does not
@@ -1231,7 +1280,6 @@ class SlackBot(BaseIMClient):
             has_shared_content = self._has_shared_attachments(event)
 
             # Ignore messages without user or without actual text/files/shared content
-            user_id = event.get("user")
             if not user_id:
                 logger.debug("Ignoring Slack message without user id")
                 return
@@ -1250,7 +1298,7 @@ class SlackBot(BaseIMClient):
                     channel_id, global_default=self.config.require_mention
                 )
 
-            if effective_require_mention and not channel_id.startswith("D"):
+            if effective_require_mention and not is_dm:
                 # In channel main thread: require mention (silently ignore)
                 if not is_thread_reply:
                     logger.debug(f"Ignoring non-mention message in channel: '{text}'")

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -328,15 +328,9 @@ class SlackBot(BaseIMClient):
         return isinstance(channel_id, str) and channel_id.startswith("D")
 
     def _is_dm_context(self, context: MessageContext) -> bool:
-        if not bool((context.platform_specific or {}).get("is_dm", False)) and not self._channel_looks_like_dm(context.channel_id):
-            return False
-        record = self._get_bound_user_record(context.user_id)
-        if record is None:
+        if bool((context.platform_specific or {}).get("is_dm", False)):
             return True
-        dm_chat_id = str(getattr(record, "dm_chat_id", "") or "").strip()
-        if not dm_chat_id:
-            return True
-        return dm_chat_id == context.channel_id
+        return self._channel_looks_like_dm(context.channel_id)
 
     async def _open_dm_channel(self, user_id: str) -> Optional[str]:
         self._ensure_clients()

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -179,10 +179,15 @@ class SlackBot(BaseIMClient):
                 channel_id,
             )
 
-        canonical_dm_channel = await self._open_dm_channel(user_id)
+        try:
+            canonical_dm_channel = await self._open_dm_channel(user_id)
+        except Exception as exc:
+            logger.warning("Failed to resolve canonical Slack DM channel for user %s: %s", user_id, exc)
+            return None
         canonical_dm_channel = str(canonical_dm_channel or "").strip()
         if not canonical_dm_channel:
-            return None if not dm_chat_id else False
+            logger.warning("Slack returned no canonical DM channel for user %s during DM validation", user_id)
+            return None
         self._persist_bound_dm_channel(user_id, record, canonical_dm_channel)
         return canonical_dm_channel == channel_id
 

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -135,16 +135,56 @@ class SlackBot(BaseIMClient):
             return None
         return record
 
-    def _match_bound_dm_channel(self, user_id: Optional[str], channel_id: Optional[str]) -> Optional[bool]:
+    def _persist_bound_dm_channel(self, user_id: str, record: Any, dm_channel_id: str) -> None:
+        normalized_channel_id = str(dm_channel_id or "").strip()
+        if not normalized_channel_id:
+            return
+        existing_channel_id = str(getattr(record, "dm_chat_id", "") or "").strip()
+        if existing_channel_id == normalized_channel_id:
+            return
+        setattr(record, "dm_chat_id", normalized_channel_id)
+        if self.settings_manager is None:
+            return
+        store_getter = getattr(self.settings_manager, "get_store", None)
+        if not callable(store_getter):
+            return
+        try:
+            store = store_getter()
+        except Exception:
+            logger.debug("Failed to access settings store for Slack DM persistence", exc_info=True)
+            return
+        try:
+            store.update_user(user_id, record, platform="slack")
+        except TypeError:
+            store.update_user(user_id, record)
+        except Exception:
+            logger.debug("Failed to persist Slack dm_chat_id for %s", user_id, exc_info=True)
+            return
+        logger.info("Updated recorded Slack dm_chat_id for user %s to %s", user_id, normalized_channel_id)
+
+    async def _match_bound_dm_channel(self, user_id: Optional[str], channel_id: Optional[str]) -> Optional[bool]:
         if not user_id or not channel_id:
             return None
         record = self._get_bound_user_record(user_id)
         if record is None:
             return None
         dm_chat_id = str(getattr(record, "dm_chat_id", "") or "").strip()
-        if not dm_chat_id:
-            return None
-        return dm_chat_id == channel_id
+        if dm_chat_id == channel_id:
+            return True
+        if dm_chat_id and dm_chat_id != channel_id:
+            logger.warning(
+                "Slack DM channel mismatch for user %s: recorded=%s incoming=%s",
+                user_id,
+                dm_chat_id,
+                channel_id,
+            )
+
+        canonical_dm_channel = await self._open_dm_channel(user_id)
+        canonical_dm_channel = str(canonical_dm_channel or "").strip()
+        if not canonical_dm_channel:
+            return None if not dm_chat_id else False
+        self._persist_bound_dm_channel(user_id, record, canonical_dm_channel)
+        return canonical_dm_channel == channel_id
 
     def _is_duplicate_event(self, event_id: Optional[str]) -> bool:
         """Deduplicate Slack events using event_id with a short TTL."""
@@ -285,7 +325,13 @@ class SlackBot(BaseIMClient):
     def _is_dm_context(self, context: MessageContext) -> bool:
         if not bool((context.platform_specific or {}).get("is_dm", False)) and not self._channel_looks_like_dm(context.channel_id):
             return False
-        return self._match_bound_dm_channel(context.user_id, context.channel_id) is not False
+        record = self._get_bound_user_record(context.user_id)
+        if record is None:
+            return True
+        dm_chat_id = str(getattr(record, "dm_chat_id", "") or "").strip()
+        if not dm_chat_id:
+            return True
+        return dm_chat_id == context.channel_id
 
     async def _open_dm_channel(self, user_id: str) -> Optional[str]:
         self._ensure_clients()
@@ -1244,15 +1290,16 @@ class SlackBot(BaseIMClient):
 
             channel_id = event.get("channel")
             user_id = event.get("user")
-            dm_match = self._match_bound_dm_channel(user_id, channel_id)
-            if dm_match is False:
-                logger.warning(
-                    "Ignoring Slack DM-like message from mismatched channel %s for user %s",
-                    channel_id,
-                    user_id,
-                )
-                return
             is_dm = self._channel_looks_like_dm(channel_id)
+            if is_dm:
+                dm_match = await self._match_bound_dm_channel(user_id, channel_id)
+                if dm_match is False:
+                    logger.warning(
+                        "Ignoring Slack DM-like message from mismatched channel %s for user %s",
+                        channel_id,
+                        user_id,
+                    )
+                    return
 
             # Check if this message contains a bot mention.
             # In channels, app_mention will handle it. In DMs, Slack does not

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -3,6 +3,7 @@ import unittest
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 
 from config.v2_config import SlackConfig
 from modules.im.base import InlineButton, InlineKeyboard, MessageContext
@@ -327,6 +328,98 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
                 "user": "U123",
                 "text": "<@U_BOT> hello",
                 "ts": "1710000000.000200",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"text": "hello"})
+
+    async def test_bound_user_message_from_mismatched_dm_channel_is_ignored(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {"called": False}
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="D_REAL")
+                return None
+
+            def is_bound_user(self, user_id, platform=None):
+                return user_id == "U123"
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        async def _on_message(_context, _text):
+            received["called"] = True
+
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-dm-mismatch",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "D_OTHER",
+                "user": "U123",
+                "text": "hello",
+                "ts": "1710000000.000250",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertFalse(received["called"])
+
+    async def test_bound_user_message_from_recorded_dm_channel_still_processes(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {}
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="D_REAL")
+                return None
+
+            def is_bound_user(self, user_id, platform=None):
+                return user_id == "U123"
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        async def _on_message(_context, text):
+            received["text"] = text
+
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-dm-match",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "D_REAL",
+                "user": "U123",
+                "text": "hello",
+                "ts": "1710000000.000260",
             },
         }
 

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -348,6 +348,11 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
                     return SimpleNamespace(dm_chat_id="D_REAL")
                 return None
 
+            def find_channel(self, channel_id, platform=None):
+                if channel_id == "C123":
+                    return SimpleNamespace(enabled=True)
+                return None
+
             def is_bound_user(self, user_id, platform=None):
                 return user_id == "U123"
 
@@ -358,9 +363,15 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
             def get_require_mention(self, _channel_id, global_default=False):
                 return global_default
 
+        class _WebClient:
+            async def conversations_open(self, users):
+                assert users == ["U123"]
+                return {"ok": True, "channel": {"id": "D_REAL"}}
+
         async def _on_message(_context, _text):
             received["called"] = True
 
+        slack.web_client = _WebClient()
         slack.set_settings_manager(_SettingsManager())
         slack.register_callbacks(on_message=_on_message)
 
@@ -380,6 +391,169 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         await slack._handle_event(payload)
 
         self.assertFalse(received["called"])
+
+    async def test_bound_user_message_repairs_missing_dm_channel_binding(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {}
+        updates = []
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="")
+                return None
+
+            def update_user(self, user_id, settings, platform=None):
+                updates.append((user_id, getattr(settings, "dm_chat_id", ""), platform))
+
+            def is_bound_user(self, user_id, platform=None):
+                return user_id == "U123"
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        class _WebClient:
+            async def conversations_open(self, users):
+                assert users == ["U123"]
+                return {"ok": True, "channel": {"id": "D_REAL"}}
+
+        async def _on_message(_context, text):
+            received["text"] = text
+
+        slack.web_client = _WebClient()
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-dm-repair-missing-binding",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "D_REAL",
+                "user": "U123",
+                "text": "hello",
+                "ts": "1710000000.000255",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"text": "hello"})
+        self.assertEqual(updates, [("U123", "D_REAL", "slack")])
+
+    async def test_bound_user_missing_dm_channel_still_ignores_wrong_dm(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {"called": False}
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="")
+                return None
+
+            def update_user(self, user_id, settings, platform=None):
+                return None
+
+            def is_bound_user(self, user_id, platform=None):
+                return user_id == "U123"
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        class _WebClient:
+            async def conversations_open(self, users):
+                assert users == ["U123"]
+                return {"ok": True, "channel": {"id": "D_REAL"}}
+
+        async def _on_message(_context, _text):
+            received["called"] = True
+
+        slack.web_client = _WebClient()
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-dm-missing-binding-wrong-channel",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "D_OTHER",
+                "user": "U123",
+                "text": "hello",
+                "ts": "1710000000.000257",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertFalse(received["called"])
+
+    async def test_bound_user_channel_message_is_not_blocked_by_dm_guard(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {}
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="D_REAL")
+                return None
+
+            def find_channel(self, channel_id, platform=None):
+                if channel_id == "C123":
+                    return SimpleNamespace(enabled=True)
+                return None
+
+            def is_bound_user(self, user_id, platform=None):
+                return user_id == "U123"
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        async def _on_message(_context, text):
+            received["text"] = text
+
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-bound-user-channel-message",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C123",
+                "user": "U123",
+                "text": "hello from channel",
+                "ts": "1710000000.000258",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"text": "hello from channel"})
 
     async def test_bound_user_message_from_recorded_dm_channel_still_processes(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -196,6 +196,57 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(context.channel_id, "D999")
         self.assertIsNone(context.thread_id)
 
+    async def test_send_message_recovers_stale_dm_context_even_when_bound_channel_changed(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        sent_channels = []
+
+        class _WebClient:
+            def __init__(self):
+                self.fail_once = True
+
+            async def chat_postMessage(self, **kwargs):
+                sent_channels.append(kwargs["channel"])
+                if self.fail_once:
+                    self.fail_once = False
+                    raise sys.modules["slack_sdk.errors"].SlackApiError(
+                        "channel missing",
+                        response={"error": "channel_not_found"},
+                    )
+                return {"ts": "1710000000.000003"}
+
+            async def conversations_open(self, users):
+                assert users == ["U123"]
+                return {"ok": True, "channel": {"id": "D999"}}
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="D999")
+                return None
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+        slack.web_client = _WebClient()
+        slack.set_settings_manager(_SettingsManager())
+        context = MessageContext(
+            user_id="U123",
+            channel_id="D_OLD",
+            thread_id="1710000000.000100",
+            platform_specific={"is_dm": True},
+        )
+
+        message_ts = await slack.send_message(context, "hello", parse_mode="markdown")
+
+        self.assertEqual(message_ts, "1710000000.000003")
+        self.assertEqual(sent_channels, ["D_OLD", "D999"])
+        self.assertEqual(context.channel_id, "D999")
+        self.assertIsNone(context.thread_id)
+
     async def test_send_message_with_buttons_splits_long_text_before_button_block(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         sent_payloads = []

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -504,6 +504,111 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(received["called"])
 
+    async def test_bound_user_mismatched_dm_channel_lookup_error_falls_back_to_processing(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {}
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="D_STALE")
+                return None
+
+            def is_bound_user(self, user_id, platform=None):
+                return user_id == "U123"
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        class _WebClient:
+            async def conversations_open(self, users):
+                raise sys.modules["slack_sdk.errors"].SlackApiError(
+                    "rate limited",
+                    response={"error": "ratelimited"},
+                )
+
+        async def _on_message(_context, text):
+            received["text"] = text
+
+        slack.web_client = _WebClient()
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-dm-lookup-error",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "D_REAL",
+                "user": "U123",
+                "text": "hello after lookup error",
+                "ts": "1710000000.0002575",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"text": "hello after lookup error"})
+
+    async def test_bound_user_mismatched_dm_channel_missing_lookup_result_falls_back_to_processing(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {}
+
+        class _Store:
+            def maybe_reload(self):
+                return None
+
+            def get_user(self, user_id, platform=None):
+                if user_id == "U123":
+                    return SimpleNamespace(dm_chat_id="D_STALE")
+                return None
+
+            def is_bound_user(self, user_id, platform=None):
+                return user_id == "U123"
+
+        class _SettingsManager:
+            def get_store(self):
+                return _Store()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        class _WebClient:
+            async def conversations_open(self, users):
+                return {"ok": False, "error": "ratelimited"}
+
+        async def _on_message(_context, text):
+            received["text"] = text
+
+        slack.web_client = _WebClient()
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-dm-lookup-none",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "D_REAL",
+                "user": "U123",
+                "text": "hello after empty lookup",
+                "ts": "1710000000.0002576",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"text": "hello after empty lookup"})
+
     async def test_bound_user_channel_message_is_not_blocked_by_dm_guard(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         received = {}


### PR DESCRIPTION
## Summary
- reject Slack DM-like inbound events when the bound user's recorded `dm_chat_id` does not match the event channel
- reuse the same bound-DM validation in DM recovery so replies do not get redirected into the bot/user DM after a mismatched inbound event
- add regression coverage for both mismatched and recorded Slack DM channels

## Why
A bound Slack user could trigger Vibe Remote from a different `D...` channel. The runtime treated any `D...` channel as a bot DM, routed the turn into the user's DM session, and could then recover delivery by reopening the actual bot DM. That produced cross-talk: the user sent a message elsewhere, but the bot replied in its own DM with the user.

## Testing
- `python3 -m pytest tests/test_slack_dm_mentions.py`
- `ruff check modules/im/slack.py tests/test_slack_dm_mentions.py`
- `git diff --check`

## Evidence
- unit: updated `tests/test_slack_dm_mentions.py`
- contract: not updated
- scenario: not updated
- manual: not run

## Risk / Follow-up
- bound Slack users without a persisted `dm_chat_id` still fall back to the old DM heuristic until their binding metadata is refreshed
