### PR TITLE
chore(snapshot): capture pending working tree diff

### DIFF
--- a/.agents/skills/use-sentry-cli-debug/SKILL.md
+++ b/.agents/skills/use-sentry-cli-debug/SKILL.md
@@ -2,7 +2,7 @@
 name: use-sentry-cli-debug
 slug: use-sentry-cli-debug
 description: Use the official Sentry CLI to investigate issues, events, traces, and logs for Vibe Remote without committing Sentry credentials into the repository.
-version: 0.1.0
+version: 0.1.1
 ---
 
 # Use Sentry CLI Debug
@@ -16,6 +16,20 @@ Use this skill when the user asks to inspect Sentry issues, events, traces, logs
 3. Keep output small. Prefer `--json --fields ...`, `--limit ...`, and `jq` when filtering.
 4. Stay read-only by default. Do not resolve, mute, delete, or otherwise mutate Sentry state unless the user explicitly asks.
 5. Verify CLI context before debugging. Run `sentry auth status`, then confirm the target org/project if auto-detection looks ambiguous.
+
+## Issue Status Guidance
+
+When the user asks how to mark an issue that is already fixed on `master` but not yet released or validated in a real environment, recommend `Resolved in next release`.
+
+Use that status for this specific state:
+
+- code is merged to `master`
+- the fix is not released yet, or not verified in the real target environment yet
+- the user does not want to mark it as fully resolved now
+
+Do not recommend plain `Resolved` for that case unless the user explicitly wants it.
+
+If the current `sentry` CLI build cannot mutate issue state directly, say so plainly and recommend changing the status in the Sentry UI or via a targeted API call only when the user explicitly asks you to perform the mutation.
 
 ## Prerequisites
 

--- a/core/watches.py
+++ b/core/watches.py
@@ -18,7 +18,6 @@ from core.scheduled_tasks import TaskExecutionStore
 logger = logging.getLogger(__name__)
 
 DEFAULT_RETRY_EXIT_CODE = 75
-WATCH_RECONCILE_INTERVAL_SECONDS = 2.0
 
 
 def _utc_now_iso() -> str:
@@ -334,7 +333,7 @@ class ManagedWatchService:
                 raise
             except Exception as exc:
                 logger.error("Managed watch reconcile failed: %s", exc, exc_info=True)
-            await asyncio.sleep(WATCH_RECONCILE_INTERVAL_SECONDS)
+            await asyncio.sleep(2)
 
     def reconcile_watches(self) -> None:
         desired_ids = {watch.id for watch in self.store.list_watches() if watch.enabled}
@@ -438,10 +437,6 @@ class ManagedWatchService:
 
             if result.timed_out or result.exit_code == 124:
                 error_text = "timed out"
-                if watch.mode == "forever" and 124 in set(watch.retry_exit_codes):
-                    self.store.mark_cycle_result(watch.id, exit_code=124, error=error_text, disable=False)
-                    await asyncio.sleep(watch.retry_delay_seconds)
-                    continue
                 self._enqueue_failure_hook(
                     watch,
                     exit_code=124,

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -40,7 +40,6 @@ from modules.agents.native_sessions.types import NativeResumeSession
 logger = logging.getLogger(__name__)
 
 _UNSET = object()
-_SLACK_SECTION_TEXT_LIMIT = 3000
 
 
 class SlackBot(BaseIMClient):
@@ -135,61 +134,16 @@ class SlackBot(BaseIMClient):
             return None
         return record
 
-    def _persist_bound_dm_channel(self, user_id: str, record: Any, dm_channel_id: str) -> None:
-        normalized_channel_id = str(dm_channel_id or "").strip()
-        if not normalized_channel_id:
-            return
-        existing_channel_id = str(getattr(record, "dm_chat_id", "") or "").strip()
-        if existing_channel_id == normalized_channel_id:
-            return
-        setattr(record, "dm_chat_id", normalized_channel_id)
-        if self.settings_manager is None:
-            return
-        store_getter = getattr(self.settings_manager, "get_store", None)
-        if not callable(store_getter):
-            return
-        try:
-            store = store_getter()
-        except Exception:
-            logger.debug("Failed to access settings store for Slack DM persistence", exc_info=True)
-            return
-        try:
-            store.update_user(user_id, record, platform="slack")
-        except TypeError:
-            store.update_user(user_id, record)
-        except Exception:
-            logger.debug("Failed to persist Slack dm_chat_id for %s", user_id, exc_info=True)
-            return
-        logger.info("Updated recorded Slack dm_chat_id for user %s to %s", user_id, normalized_channel_id)
-
-    async def _match_bound_dm_channel(self, user_id: Optional[str], channel_id: Optional[str]) -> Optional[bool]:
+    def _match_bound_dm_channel(self, user_id: Optional[str], channel_id: Optional[str]) -> Optional[bool]:
         if not user_id or not channel_id:
             return None
         record = self._get_bound_user_record(user_id)
         if record is None:
             return None
         dm_chat_id = str(getattr(record, "dm_chat_id", "") or "").strip()
-        if dm_chat_id == channel_id:
-            return True
-        if dm_chat_id and dm_chat_id != channel_id:
-            logger.warning(
-                "Slack DM channel mismatch for user %s: recorded=%s incoming=%s",
-                user_id,
-                dm_chat_id,
-                channel_id,
-            )
-
-        try:
-            canonical_dm_channel = await self._open_dm_channel(user_id)
-        except Exception as exc:
-            logger.warning("Failed to resolve canonical Slack DM channel for user %s: %s", user_id, exc)
+        if not dm_chat_id:
             return None
-        canonical_dm_channel = str(canonical_dm_channel or "").strip()
-        if not canonical_dm_channel:
-            logger.warning("Slack returned no canonical DM channel for user %s during DM validation", user_id)
-            return None
-        self._persist_bound_dm_channel(user_id, record, canonical_dm_channel)
-        return canonical_dm_channel == channel_id
+        return dm_chat_id == channel_id
 
     def _is_duplicate_event(self, event_id: Optional[str]) -> bool:
         """Deduplicate Slack events using event_id with a short TTL."""
@@ -328,9 +282,9 @@ class SlackBot(BaseIMClient):
         return isinstance(channel_id, str) and channel_id.startswith("D")
 
     def _is_dm_context(self, context: MessageContext) -> bool:
-        if bool((context.platform_specific or {}).get("is_dm", False)):
-            return True
-        return self._channel_looks_like_dm(context.channel_id)
+        if not bool((context.platform_specific or {}).get("is_dm", False)) and not self._channel_looks_like_dm(context.channel_id):
+            return False
+        return self._match_bound_dm_channel(context.user_id, context.channel_id) is not False
 
     async def _open_dm_channel(self, user_id: str) -> Optional[str]:
         self._ensure_clients()
@@ -370,105 +324,6 @@ class SlackBot(BaseIMClient):
             context.thread_id = None
             return await self.web_client.chat_postMessage(**kwargs)
 
-    @staticmethod
-    def _find_text_split_index(text: str, max_chars: int) -> int:
-        minimum_boundary = max_chars // 2
-        for separator in ("\n\n", "\n", " "):
-            index = text.rfind(separator, 0, max_chars + 1)
-            if index >= minimum_boundary:
-                candidate = index + len(separator)
-                return candidate if candidate <= max_chars else index
-        return max_chars
-
-    @classmethod
-    def _split_text(cls, text: str, max_chars: int) -> List[str]:
-        if len(text) <= max_chars:
-            return [text]
-
-        chunks: List[str] = []
-        remaining = text
-        while len(remaining) > max_chars:
-            split_at = cls._find_text_split_index(remaining, max_chars)
-            chunks.append(remaining[:split_at])
-            remaining = remaining[split_at:]
-        if remaining:
-            chunks.append(remaining)
-        return chunks
-
-    @classmethod
-    def _get_visible_text(cls, text: str, max_chars: int = _SLACK_SECTION_TEXT_LIMIT) -> str:
-        return cls._split_text(text, max_chars)[-1]
-
-    @staticmethod
-    def _build_section_block(text: str, parse_mode: Optional[str] = None) -> Dict[str, Any]:
-        return {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn" if parse_mode == "markdown" else "plain_text",
-                "text": text,
-            },
-        }
-
-    def _build_button_blocks(
-        self,
-        text: Optional[str],
-        keyboard: InlineKeyboard,
-        parse_mode: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
-        blocks: List[Dict[str, Any]] = []
-        if text:
-            blocks.append(self._build_section_block(text, parse_mode=parse_mode))
-
-        for row_idx, row in enumerate(keyboard.buttons):
-            elements = []
-            for button in row:
-                elements.append(
-                    {
-                        "type": "button",
-                        "text": {"type": "plain_text", "text": button.text},
-                        "action_id": button.callback_data,
-                        "value": button.callback_data,
-                    }
-                )
-
-            blocks.append(
-                {
-                    "type": "actions",
-                    "block_id": f"actions_{row_idx}",
-                    "elements": elements,
-                }
-            )
-
-        return blocks
-
-    async def _send_prepared_text_message(
-        self,
-        context: MessageContext,
-        text: str,
-        parse_mode: Optional[str] = None,
-        reply_to: Optional[str] = None,
-    ):
-        kwargs = {"channel": context.channel_id, "text": text}
-
-        if context.thread_id:
-            kwargs["thread_ts"] = context.thread_id
-            if context.platform_specific and context.platform_specific.get("reply_broadcast"):
-                kwargs["reply_broadcast"] = True
-        elif reply_to:
-            kwargs["thread_ts"] = reply_to
-
-        if parse_mode == "markdown":
-            kwargs["mrkdwn"] = True
-
-        if "\n" in text and len(text) <= _SLACK_SECTION_TEXT_LIMIT:
-            kwargs["blocks"] = [self._build_section_block(text, parse_mode=parse_mode)]
-
-        return await self._post_message_with_dm_recovery(
-            context,
-            kwargs,
-            log_label="message send",
-        )
-
     async def send_dm(self, user_id: str, text: str, **kwargs) -> Optional[str]:
         """Send a direct message to a Slack user by opening a DM channel first."""
         self._ensure_clients()
@@ -500,11 +355,41 @@ class SlackBot(BaseIMClient):
             if parse_mode == "markdown":
                 text = self._convert_markdown_to_slack_mrkdwn(text)
 
-            response = await self._send_prepared_text_message(
+            # Prepare message kwargs
+            kwargs = {"channel": context.channel_id, "text": text}
+
+            # Handle thread replies
+            if context.thread_id:
+                kwargs["thread_ts"] = context.thread_id
+                # Optionally broadcast to channel
+                if context.platform_specific and context.platform_specific.get("reply_broadcast"):
+                    kwargs["reply_broadcast"] = True
+            elif reply_to:
+                # If reply_to is specified, use it as thread timestamp
+                kwargs["thread_ts"] = reply_to
+
+            # Handle formatting
+            if parse_mode == "markdown":
+                kwargs["mrkdwn"] = True
+
+            # Workaround: ensure multi-line content is preserved. Slack sometimes collapses
+            # rich_text rendering for bot messages; sending with blocks+mrkdwn forces line breaks.
+            if "\n" in text and "blocks" not in kwargs and len(text) <= 3000:
+                kwargs["blocks"] = [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn" if parse_mode == "markdown" else "plain_text",
+                            "text": text,
+                        },
+                    }
+                ]
+
+            # Send message
+            response = await self._post_message_with_dm_recovery(
                 context,
-                text,
-                parse_mode=parse_mode,
-                reply_to=reply_to,
+                kwargs,
+                log_label="message send",
             )
 
             # Mark thread as active if we sent a message to a thread
@@ -1090,14 +975,38 @@ class SlackBot(BaseIMClient):
             if parse_mode == "markdown":
                 text = self._convert_markdown_to_slack_mrkdwn(text)
 
-            chunks = self._split_text(text, _SLACK_SECTION_TEXT_LIMIT)
-            for chunk in chunks[:-1]:
-                await self._send_prepared_text_message(context, chunk, parse_mode=parse_mode)
-            text = chunks[-1]
+            # Convert our generic keyboard to Slack blocks
+            blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn" if parse_mode == "markdown" else "plain_text",
+                        "text": text,
+                        "verbatim": True,
+                    },
+                }
+            ]
 
-            blocks = self._build_button_blocks(text, keyboard, parse_mode=parse_mode)
-            if blocks and blocks[0].get("type") == "section":
-                blocks[0]["text"]["verbatim"] = True
+            # Add action blocks for buttons
+            for row_idx, row in enumerate(keyboard.buttons):
+                elements = []
+                for button in row:
+                    elements.append(
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": button.text},
+                            "action_id": button.callback_data,
+                            "value": button.callback_data,
+                        }
+                    )
+
+                blocks.append(
+                    {
+                        "type": "actions",
+                        "block_id": f"actions_{row_idx}",
+                        "elements": elements,
+                    }
+                )
 
             # Prepare message kwargs
             kwargs = {
@@ -1145,11 +1054,43 @@ class SlackBot(BaseIMClient):
             kwargs = {"channel": context.channel_id, "ts": message_id}
 
             if text is not None:
-                kwargs["text"] = self._get_visible_text(text) if keyboard else text
+                kwargs["text"] = text
 
             if keyboard:
-                visible_text = kwargs.get("text") if isinstance(kwargs.get("text"), str) else None
-                kwargs["blocks"] = self._build_button_blocks(visible_text, keyboard, parse_mode=parse_mode)
+                # Convert keyboard to blocks (similar to send_message_with_buttons)
+                blocks = []
+                if text:
+                    blocks.append(
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn" if parse_mode == "markdown" else "plain_text",
+                                "text": text,
+                            },
+                        }
+                    )
+
+                for row_idx, row in enumerate(keyboard.buttons):
+                    elements = []
+                    for button in row:
+                        elements.append(
+                            {
+                                "type": "button",
+                                "text": {"type": "plain_text", "text": button.text},
+                                "action_id": button.callback_data,
+                                "value": button.callback_data,
+                            }
+                        )
+
+                    blocks.append(
+                        {
+                            "type": "actions",
+                            "block_id": f"actions_{row_idx}",
+                            "elements": elements,
+                        }
+                    )
+
+                kwargs["blocks"] = blocks
 
             await self.web_client.chat_update(**kwargs)
             return True
@@ -1185,16 +1126,22 @@ class SlackBot(BaseIMClient):
             fallback_text = text
             if fallback_text is not None and parse_mode == "markdown":
                 fallback_text = self._convert_markdown_to_slack_mrkdwn(fallback_text)
-            if fallback_text:
-                fallback_text = self._get_visible_text(fallback_text)
 
             if fallback_text is None and isinstance(payload_message, dict):
                 payload_text = payload_message.get("text")
                 if isinstance(payload_text, str):
-                    fallback_text = self._get_visible_text(payload_text)
+                    fallback_text = payload_text
 
             if not blocks and fallback_text:
-                blocks = [self._build_section_block(fallback_text, parse_mode=parse_mode)]
+                blocks = [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn" if parse_mode == "markdown" else "plain_text",
+                            "text": fallback_text,
+                        },
+                    }
+                ]
 
             kwargs = {"channel": context.channel_id, "ts": message_id, "blocks": blocks}
             if fallback_text is not None:
@@ -1289,16 +1236,15 @@ class SlackBot(BaseIMClient):
 
             channel_id = event.get("channel")
             user_id = event.get("user")
+            dm_match = self._match_bound_dm_channel(user_id, channel_id)
+            if dm_match is False:
+                logger.warning(
+                    "Ignoring Slack DM-like message from mismatched channel %s for user %s",
+                    channel_id,
+                    user_id,
+                )
+                return
             is_dm = self._channel_looks_like_dm(channel_id)
-            if is_dm:
-                dm_match = await self._match_bound_dm_channel(user_id, channel_id)
-                if dm_match is False:
-                    logger.warning(
-                        "Ignoring Slack DM-like message from mismatched channel %s for user %s",
-                        channel_id,
-                        user_id,
-                    )
-                    return
 
             # Check if this message contains a bot mention.
             # In channels, app_mention will handle it. In DMs, Slack does not
@@ -1355,13 +1301,9 @@ class SlackBot(BaseIMClient):
                     thread_ts = event.get("thread_ts")
                     # If we have settings_manager, check if thread is active
                     if self.settings_manager:
-                        thread_active = (
-                            self.sessions.is_thread_active(user_id, channel_id, thread_ts) if self.sessions else False
-                        )
+                        thread_active = self.sessions.is_thread_active(user_id, channel_id, thread_ts) if self.sessions else False
                         scheduled_thread_active = (
-                            self.sessions.is_thread_active("scheduled", channel_id, thread_ts)
-                            if self.sessions
-                            else False
+                            self.sessions.is_thread_active("scheduled", channel_id, thread_ts) if self.sessions else False
                         )
                         if not thread_active and not scheduled_thread_active:
                             logger.debug(f"Ignoring message in inactive thread {thread_ts}: '{text}'")

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -4,7 +4,6 @@ import io
 import json
 import sys
 from contextlib import redirect_stderr
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -281,121 +280,6 @@ def test_watch_add_returns_structured_error_when_startup_fails(tmp_path: Path) -
     assert payload["hint"].startswith("Inspect the stored watch error")
     assert payload["example"] == "vibe watch show abc"
     assert payload["help_command"] == "vibe watch show abc"
-
-
-def test_wait_for_watch_startup_accepts_stably_running_watch(tmp_path: Path) -> None:
-    store = ManagedWatchStore(tmp_path / "watches.json")
-    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
-    watch = store.add_watch(
-        name="Stable watch",
-        session_key="slack::channel::C123",
-        command=["python3", "wait.py"],
-        shell_command=None,
-        prefix=None,
-        cwd=None,
-        mode="forever",
-        timeout_seconds=600,
-        lifetime_timeout_seconds=0,
-        retry_exit_codes=[75],
-        retry_delay_seconds=30,
-        post_to=None,
-        deliver_key=None,
-    )
-    watch.last_started_at = (datetime.now(timezone.utc) - timedelta(seconds=2)).isoformat()
-    store.upsert_watch(watch)
-    runtime_store.write(
-        {
-            "watches": {
-                watch.id: {
-                    "running": True,
-                    "pid": 1234,
-                    "started_at": (datetime.now(timezone.utc) - timedelta(seconds=2)).isoformat(),
-                    "updated_at": datetime.now(timezone.utc).isoformat(),
-                }
-            }
-        }
-    )
-
-    resolved_watch, runtime_entry = cli._wait_for_watch_startup(
-        store,
-        runtime_store,
-        watch.id,
-        timeout_seconds=0.2,
-        poll_interval_seconds=0.01,
-        stable_running_seconds=1.5,
-    )
-
-    assert resolved_watch.id == watch.id
-    assert runtime_entry["running"] is True
-
-
-def test_default_watch_startup_timeout_exceeds_reconcile_and_stable_windows() -> None:
-    timeout_seconds = cli._default_watch_startup_timeout_seconds(
-        stable_running_seconds=cli.WATCH_STARTUP_STABLE_RUNNING_SECONDS
-    )
-
-    assert timeout_seconds > cli.WATCH_RECONCILE_INTERVAL_SECONDS + cli.WATCH_STARTUP_STABLE_RUNNING_SECONDS
-
-
-def test_wait_for_watch_startup_rejects_watch_that_fails_before_stable_window(tmp_path: Path) -> None:
-    store = ManagedWatchStore(tmp_path / "watches.json")
-    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
-    watch = store.add_watch(
-        name="Flaky watch",
-        session_key="slack::channel::C123",
-        command=["python3", "wait.py"],
-        shell_command=None,
-        prefix=None,
-        cwd=None,
-        mode="forever",
-        timeout_seconds=600,
-        lifetime_timeout_seconds=0,
-        retry_exit_codes=[75],
-        retry_delay_seconds=30,
-        post_to=None,
-        deliver_key=None,
-    )
-    watch.last_started_at = datetime.now(timezone.utc).isoformat()
-    store.upsert_watch(watch)
-    runtime_store.write(
-        {
-            "watches": {
-                watch.id: {
-                    "running": True,
-                    "pid": 1234,
-                    "started_at": datetime.now(timezone.utc).isoformat(),
-                    "updated_at": datetime.now(timezone.utc).isoformat(),
-                }
-            }
-        }
-    )
-
-    monotonic_values = iter([0.0, 0.05, 0.1, 0.15, 0.2])
-
-    def _fail_watch(_seconds: float) -> None:
-        failed = store.get_watch(watch.id)
-        assert failed is not None
-        failed.enabled = False
-        failed.last_error = "waiter crashed"
-        failed.last_exit_code = 1
-        store.upsert_watch(failed)
-        runtime_store.write({"watches": {}})
-
-    with (
-        patch("vibe.cli.time.monotonic", side_effect=lambda: next(monotonic_values)),
-        patch("vibe.cli.time.sleep", side_effect=_fail_watch),
-    ):
-        with pytest.raises(cli.TaskCliError) as exc:
-            cli._wait_for_watch_startup(
-                store,
-                runtime_store,
-                watch.id,
-                timeout_seconds=0.2,
-                poll_interval_seconds=0.01,
-                stable_running_seconds=1.5,
-            )
-
-    assert exc.value.code == "watch_startup_failed"
 
 
 def test_watch_list_brief_includes_runtime_state(tmp_path: Path, capsys) -> None:

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -186,7 +186,13 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
             thread_id="1710000000.000100",
             platform_specific={"is_dm": True},
         )
-        keyboard = InlineKeyboard(buttons=[[InlineButton(text="One", callback_data="choose:1")]])
+        keyboard = InlineKeyboard(
+            buttons=[
+                [
+                    InlineButton(text="One", callback_data="choose:1")
+                ]
+            ]
+        )
 
         message_ts = await slack.send_message_with_buttons(context, "hello", keyboard, parse_mode="markdown")
 
@@ -195,108 +201,6 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(sent_thread_ts, ["1710000000.000100", None])
         self.assertEqual(context.channel_id, "D999")
         self.assertIsNone(context.thread_id)
-
-    async def test_send_message_recovers_stale_dm_context_even_when_bound_channel_changed(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        sent_channels = []
-
-        class _WebClient:
-            def __init__(self):
-                self.fail_once = True
-
-            async def chat_postMessage(self, **kwargs):
-                sent_channels.append(kwargs["channel"])
-                if self.fail_once:
-                    self.fail_once = False
-                    raise sys.modules["slack_sdk.errors"].SlackApiError(
-                        "channel missing",
-                        response={"error": "channel_not_found"},
-                    )
-                return {"ts": "1710000000.000003"}
-
-            async def conversations_open(self, users):
-                assert users == ["U123"]
-                return {"ok": True, "channel": {"id": "D999"}}
-
-        class _Store:
-            def maybe_reload(self):
-                return None
-
-            def get_user(self, user_id, platform=None):
-                if user_id == "U123":
-                    return SimpleNamespace(dm_chat_id="D999")
-                return None
-
-        class _SettingsManager:
-            def get_store(self):
-                return _Store()
-
-        slack.web_client = _WebClient()
-        slack.set_settings_manager(_SettingsManager())
-        context = MessageContext(
-            user_id="U123",
-            channel_id="D_OLD",
-            thread_id="1710000000.000100",
-            platform_specific={"is_dm": True},
-        )
-
-        message_ts = await slack.send_message(context, "hello", parse_mode="markdown")
-
-        self.assertEqual(message_ts, "1710000000.000003")
-        self.assertEqual(sent_channels, ["D_OLD", "D999"])
-        self.assertEqual(context.channel_id, "D999")
-        self.assertIsNone(context.thread_id)
-
-    async def test_send_message_with_buttons_splits_long_text_before_button_block(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        sent_payloads = []
-
-        class _WebClient:
-            async def chat_postMessage(self, **kwargs):
-                sent_payloads.append(kwargs)
-                return {"ts": f"1710000000.00000{len(sent_payloads)}"}
-
-        slack.web_client = _WebClient()
-        context = MessageContext(user_id="U123", channel_id="C123")
-        keyboard = InlineKeyboard(buttons=[[InlineButton(text="One", callback_data="choose:1")]])
-        text = "\n\n".join([f"Paragraph {index} {'x' * 120}" for index in range(30)])
-
-        message_ts = await slack.send_message_with_buttons(context, text, keyboard, parse_mode="markdown")
-
-        self.assertEqual(message_ts, "1710000000.000002")
-        self.assertEqual(len(sent_payloads), 2)
-        self.assertEqual(sent_payloads[0]["text"] + sent_payloads[1]["text"], text)
-        self.assertTrue(all(len(payload["text"]) <= 3000 for payload in sent_payloads))
-        self.assertFalse(any(block["type"] == "actions" for block in sent_payloads[0].get("blocks", [])))
-        self.assertEqual(sent_payloads[1]["blocks"][0]["type"], "section")
-        self.assertEqual(sent_payloads[1]["blocks"][1]["type"], "actions")
-
-    async def test_remove_inline_keyboard_uses_visible_chunk_for_long_text(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        updates = []
-
-        class _WebClient:
-            async def chat_update(self, **kwargs):
-                updates.append(kwargs)
-                return {"ok": True}
-
-        slack.web_client = _WebClient()
-        context = MessageContext(user_id="U123", channel_id="C123")
-        text = "\n\n".join([f"Paragraph {index} {'x' * 120}" for index in range(30)])
-
-        ok = await slack.remove_inline_keyboard(context, "1710000000.000002", text=text, parse_mode="markdown")
-
-        self.assertTrue(ok)
-        self.assertEqual(len(updates), 1)
-        self.assertLessEqual(len(updates[0]["text"]), 3000)
-        self.assertEqual(updates[0]["text"], slack._get_visible_text(text))
-        self.assertEqual(updates[0]["blocks"][0]["type"], "section")
-
-    def test_split_text_keeps_boundary_chunk_within_limit(self):
-        chunks = SlackBot._split_text("a" * 3000 + " " + "b", 3000)
-
-        self.assertEqual(chunks, ["a" * 3000, " b"])
-        self.assertTrue(all(len(chunk) <= 3000 for chunk in chunks))
 
     async def test_get_user_info_prefers_normalized_profile_names(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
@@ -399,11 +303,6 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
                     return SimpleNamespace(dm_chat_id="D_REAL")
                 return None
 
-            def find_channel(self, channel_id, platform=None):
-                if channel_id == "C123":
-                    return SimpleNamespace(enabled=True)
-                return None
-
             def is_bound_user(self, user_id, platform=None):
                 return user_id == "U123"
 
@@ -414,15 +313,9 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
             def get_require_mention(self, _channel_id, global_default=False):
                 return global_default
 
-        class _WebClient:
-            async def conversations_open(self, users):
-                assert users == ["U123"]
-                return {"ok": True, "channel": {"id": "D_REAL"}}
-
         async def _on_message(_context, _text):
             received["called"] = True
 
-        slack.web_client = _WebClient()
         slack.set_settings_manager(_SettingsManager())
         slack.register_callbacks(on_message=_on_message)
 
@@ -442,274 +335,6 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         await slack._handle_event(payload)
 
         self.assertFalse(received["called"])
-
-    async def test_bound_user_message_repairs_missing_dm_channel_binding(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        received = {}
-        updates = []
-
-        class _Store:
-            def maybe_reload(self):
-                return None
-
-            def get_user(self, user_id, platform=None):
-                if user_id == "U123":
-                    return SimpleNamespace(dm_chat_id="")
-                return None
-
-            def update_user(self, user_id, settings, platform=None):
-                updates.append((user_id, getattr(settings, "dm_chat_id", ""), platform))
-
-            def is_bound_user(self, user_id, platform=None):
-                return user_id == "U123"
-
-        class _SettingsManager:
-            def get_store(self):
-                return _Store()
-
-            def get_require_mention(self, _channel_id, global_default=False):
-                return global_default
-
-        class _WebClient:
-            async def conversations_open(self, users):
-                assert users == ["U123"]
-                return {"ok": True, "channel": {"id": "D_REAL"}}
-
-        async def _on_message(_context, text):
-            received["text"] = text
-
-        slack.web_client = _WebClient()
-        slack.set_settings_manager(_SettingsManager())
-        slack.register_callbacks(on_message=_on_message)
-
-        payload = {
-            "event_id": "evt-dm-repair-missing-binding",
-            "team_id": "T1",
-            "authorizations": [{"user_id": "U_BOT"}],
-            "event": {
-                "type": "message",
-                "channel": "D_REAL",
-                "user": "U123",
-                "text": "hello",
-                "ts": "1710000000.000255",
-            },
-        }
-
-        await slack._handle_event(payload)
-
-        self.assertEqual(received, {"text": "hello"})
-        self.assertEqual(updates, [("U123", "D_REAL", "slack")])
-
-    async def test_bound_user_missing_dm_channel_still_ignores_wrong_dm(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        received = {"called": False}
-
-        class _Store:
-            def maybe_reload(self):
-                return None
-
-            def get_user(self, user_id, platform=None):
-                if user_id == "U123":
-                    return SimpleNamespace(dm_chat_id="")
-                return None
-
-            def update_user(self, user_id, settings, platform=None):
-                return None
-
-            def is_bound_user(self, user_id, platform=None):
-                return user_id == "U123"
-
-        class _SettingsManager:
-            def get_store(self):
-                return _Store()
-
-            def get_require_mention(self, _channel_id, global_default=False):
-                return global_default
-
-        class _WebClient:
-            async def conversations_open(self, users):
-                assert users == ["U123"]
-                return {"ok": True, "channel": {"id": "D_REAL"}}
-
-        async def _on_message(_context, _text):
-            received["called"] = True
-
-        slack.web_client = _WebClient()
-        slack.set_settings_manager(_SettingsManager())
-        slack.register_callbacks(on_message=_on_message)
-
-        payload = {
-            "event_id": "evt-dm-missing-binding-wrong-channel",
-            "team_id": "T1",
-            "authorizations": [{"user_id": "U_BOT"}],
-            "event": {
-                "type": "message",
-                "channel": "D_OTHER",
-                "user": "U123",
-                "text": "hello",
-                "ts": "1710000000.000257",
-            },
-        }
-
-        await slack._handle_event(payload)
-
-        self.assertFalse(received["called"])
-
-    async def test_bound_user_mismatched_dm_channel_lookup_error_falls_back_to_processing(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        received = {}
-
-        class _Store:
-            def maybe_reload(self):
-                return None
-
-            def get_user(self, user_id, platform=None):
-                if user_id == "U123":
-                    return SimpleNamespace(dm_chat_id="D_STALE")
-                return None
-
-            def is_bound_user(self, user_id, platform=None):
-                return user_id == "U123"
-
-        class _SettingsManager:
-            def get_store(self):
-                return _Store()
-
-            def get_require_mention(self, _channel_id, global_default=False):
-                return global_default
-
-        class _WebClient:
-            async def conversations_open(self, users):
-                raise sys.modules["slack_sdk.errors"].SlackApiError(
-                    "rate limited",
-                    response={"error": "ratelimited"},
-                )
-
-        async def _on_message(_context, text):
-            received["text"] = text
-
-        slack.web_client = _WebClient()
-        slack.set_settings_manager(_SettingsManager())
-        slack.register_callbacks(on_message=_on_message)
-
-        payload = {
-            "event_id": "evt-dm-lookup-error",
-            "team_id": "T1",
-            "authorizations": [{"user_id": "U_BOT"}],
-            "event": {
-                "type": "message",
-                "channel": "D_REAL",
-                "user": "U123",
-                "text": "hello after lookup error",
-                "ts": "1710000000.0002575",
-            },
-        }
-
-        await slack._handle_event(payload)
-
-        self.assertEqual(received, {"text": "hello after lookup error"})
-
-    async def test_bound_user_mismatched_dm_channel_missing_lookup_result_falls_back_to_processing(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        received = {}
-
-        class _Store:
-            def maybe_reload(self):
-                return None
-
-            def get_user(self, user_id, platform=None):
-                if user_id == "U123":
-                    return SimpleNamespace(dm_chat_id="D_STALE")
-                return None
-
-            def is_bound_user(self, user_id, platform=None):
-                return user_id == "U123"
-
-        class _SettingsManager:
-            def get_store(self):
-                return _Store()
-
-            def get_require_mention(self, _channel_id, global_default=False):
-                return global_default
-
-        class _WebClient:
-            async def conversations_open(self, users):
-                return {"ok": False, "error": "ratelimited"}
-
-        async def _on_message(_context, text):
-            received["text"] = text
-
-        slack.web_client = _WebClient()
-        slack.set_settings_manager(_SettingsManager())
-        slack.register_callbacks(on_message=_on_message)
-
-        payload = {
-            "event_id": "evt-dm-lookup-none",
-            "team_id": "T1",
-            "authorizations": [{"user_id": "U_BOT"}],
-            "event": {
-                "type": "message",
-                "channel": "D_REAL",
-                "user": "U123",
-                "text": "hello after empty lookup",
-                "ts": "1710000000.0002576",
-            },
-        }
-
-        await slack._handle_event(payload)
-
-        self.assertEqual(received, {"text": "hello after empty lookup"})
-
-    async def test_bound_user_channel_message_is_not_blocked_by_dm_guard(self):
-        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        received = {}
-
-        class _Store:
-            def maybe_reload(self):
-                return None
-
-            def get_user(self, user_id, platform=None):
-                if user_id == "U123":
-                    return SimpleNamespace(dm_chat_id="D_REAL")
-                return None
-
-            def find_channel(self, channel_id, platform=None):
-                if channel_id == "C123":
-                    return SimpleNamespace(enabled=True)
-                return None
-
-            def is_bound_user(self, user_id, platform=None):
-                return user_id == "U123"
-
-        class _SettingsManager:
-            def get_store(self):
-                return _Store()
-
-            def get_require_mention(self, _channel_id, global_default=False):
-                return global_default
-
-        async def _on_message(_context, text):
-            received["text"] = text
-
-        slack.set_settings_manager(_SettingsManager())
-        slack.register_callbacks(on_message=_on_message)
-
-        payload = {
-            "event_id": "evt-bound-user-channel-message",
-            "team_id": "T1",
-            "authorizations": [{"user_id": "U_BOT"}],
-            "event": {
-                "type": "message",
-                "channel": "C123",
-                "user": "U123",
-                "text": "hello from channel",
-                "ts": "1710000000.000258",
-            },
-        }
-
-        await slack._handle_event(payload)
-
-        self.assertEqual(received, {"text": "hello from channel"})
 
     async def test_bound_user_message_from_recorded_dm_channel_still_processes(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1,6 +1,5 @@
 import json
 import os
-import pytest
 import signal
 import sys
 from pathlib import Path
@@ -100,13 +99,12 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
 
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/usr/local/bin/vibe")
     monkeypatch.setattr(cli, "get_restart_command", lambda vibe_path=None: [vibe_path or "vibe"])
-    monkeypatch.setattr(cli, "get_restart_environment", lambda vibe_path=None: None)
     monkeypatch.setattr(cli, "get_safe_cwd", lambda: "/tmp")
     monkeypatch.setattr(
         cli.api,
         "_spawn_delayed_restart",
-        lambda command, cwd, delay_seconds=2.0, env=None: scheduled.update(
-            {"command": command, "cwd": cwd, "delay_seconds": delay_seconds, "env": env}
+        lambda command, cwd, delay_seconds=2.0: scheduled.update(
+            {"command": command, "cwd": cwd, "delay_seconds": delay_seconds}
         ),
     )
     monkeypatch.setattr(cli, "cmd_stop", lambda: stop_called.append(True))
@@ -117,7 +115,6 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
         "command": ["/usr/local/bin/vibe", "restart"],
         "cwd": "/tmp",
         "delay_seconds": 60,
-        "env": None,
     }
     assert stop_called == []
     assert start_called == []
@@ -125,34 +122,6 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "Restart scheduled in 1 minute." in output
     assert "delayed restart will run in the background" in output
-
-
-def test_cmd_restart_schedules_delayed_restart_with_import_env(monkeypatch):
-    scheduled = {}
-
-    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: None)
-    monkeypatch.setattr(
-        cli,
-        "get_restart_command",
-        lambda vibe_path=None: [sys.executable, "-c", "from vibe.cli import main; main()"],
-    )
-    monkeypatch.setattr(cli, "get_restart_environment", lambda vibe_path=None: {"PYTHONPATH": "/repo"})
-    monkeypatch.setattr(cli, "get_safe_cwd", lambda: "/tmp")
-    monkeypatch.setattr(
-        cli.api,
-        "_spawn_delayed_restart",
-        lambda command, cwd, delay_seconds=2.0, env=None: scheduled.update(
-            {"command": command, "cwd": cwd, "delay_seconds": delay_seconds, "env": env}
-        ),
-    )
-
-    assert cli._cmd_restart_with_delay(5) == 0
-    assert scheduled == {
-        "command": [sys.executable, "-c", "from vibe.cli import main; main()", "restart"],
-        "cwd": "/tmp",
-        "delay_seconds": 5,
-        "env": {"PYTHONPATH": "/repo"},
-    }
 
 
 def test_cmd_restart_runs_synchronously_by_default(monkeypatch):
@@ -172,14 +141,6 @@ def test_restart_parser_accepts_delay_seconds():
 
     assert args.command == "restart"
     assert args.delay_seconds == 60
-
-
-@pytest.mark.parametrize("raw_value", ["nan", "inf", "-inf"])
-def test_restart_parser_rejects_non_finite_delay_seconds(raw_value):
-    parser = cli.build_parser()
-
-    with pytest.raises(SystemExit):
-        parser.parse_args(["restart", "--delay-seconds", raw_value])
 
 
 def test_stop_pid_handles_process_lookup_race(monkeypatch):

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -165,46 +165,6 @@ def test_managed_watch_service_forever_timeout_disables_and_enqueues_failure(tmp
     assert saved.last_exit_code == 124
 
 
-def test_managed_watch_service_forever_timeout_retries_when_explicitly_allowed(tmp_path: Path) -> None:
-    store = ManagedWatchStore(tmp_path / "watches.json")
-    request_store = TaskExecutionStore(tmp_path / "task_requests")
-    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
-    watch = store.add_watch(
-        name="Retry timeout forever",
-        session_key="slack::channel::C123",
-        command=["python3", "-c", "import time; time.sleep(0.2)"],
-        shell_command=None,
-        prefix="Should keep waiting.",
-        cwd=None,
-        mode="forever",
-        timeout_seconds=0.05,
-        lifetime_timeout_seconds=0,
-        retry_exit_codes=[75, 124],
-        retry_delay_seconds=0.01,
-        post_to=None,
-        deliver_key=None,
-    )
-    service = ManagedWatchService(
-        controller=SimpleNamespace(),
-        store=store,
-        request_store=request_store,
-        runtime_store=runtime_store,
-    )
-
-    async def _run() -> None:
-        service.start()
-        await asyncio.sleep(0.2)
-        await service.stop()
-
-    asyncio.run(_run())
-
-    saved = store.get_watch(watch.id)
-    assert saved is not None
-    assert saved.enabled is True
-    assert saved.last_exit_code == 124
-    assert request_store.list_pending() == []
-
-
 def test_managed_watch_service_stop_terminates_running_waiter(tmp_path: Path) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     request_store = TaskExecutionStore(tmp_path / "task_requests")
@@ -344,7 +304,7 @@ def test_managed_watch_service_forever_retries_only_allowed_exit_code(tmp_path: 
     watch = store.add_watch(
         name="Retry waiter",
         session_key="slack::channel::C123",
-        command=[sys.executable, "-c", "import sys; sys.exit(75)"],
+        command=["/bin/sh", "-lc", "exit 75"],
         shell_command=None,
         prefix="Retry only.",
         cwd=None,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import logging
-import math
 import os
 import shlex
 import shutil
@@ -30,26 +29,17 @@ from config.v2_config import (
     V2Config,
 )
 from core.scheduled_tasks import ScheduledTaskStore, TaskExecutionStore, parse_session_key
-from core.watches import (
-    DEFAULT_RETRY_EXIT_CODE,
-    WATCH_RECONCILE_INTERVAL_SECONDS,
-    ManagedWatchStore,
-    WatchRuntimeStateStore,
-)
+from core.watches import DEFAULT_RETRY_EXIT_CODE, ManagedWatchStore, WatchRuntimeStateStore
 from vibe import __version__, api, runtime
 from vibe.upgrade import (
     build_upgrade_plan,
     cache_running_vibe_path,
     get_latest_version_info,
     get_restart_command,
-    get_restart_environment,
     get_safe_cwd,
 )
 
 logger = logging.getLogger(__name__)
-
-WATCH_STARTUP_STABLE_RUNNING_SECONDS = 1.5
-WATCH_STARTUP_JITTER_BUFFER_SECONDS = 1.0
 
 
 class VibeArgumentParser(argparse.ArgumentParser):
@@ -119,8 +109,6 @@ def _print_task_error(exc: Exception, *, help_command: str | None = None) -> Non
 
 def _non_negative_float(value: str) -> float:
     parsed = float(value)
-    if not math.isfinite(parsed):
-        raise argparse.ArgumentTypeError("must be finite")
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be >= 0")
     return parsed
@@ -839,34 +827,15 @@ def _watch_payload(watch, runtime_entry: Optional[dict[str, object]], *, brief: 
     return payload
 
 
-def _seconds_since_iso(timestamp: object) -> float | None:
-    if not isinstance(timestamp, str) or not timestamp.strip():
-        return None
-    try:
-        started_at = datetime.fromisoformat(timestamp)
-    except ValueError:
-        return None
-    if started_at.tzinfo is None:
-        started_at = started_at.replace(tzinfo=timezone.utc)
-    return max(0.0, (datetime.now(timezone.utc) - started_at).total_seconds())
-
-
-def _default_watch_startup_timeout_seconds(*, stable_running_seconds: float = WATCH_STARTUP_STABLE_RUNNING_SECONDS) -> float:
-    return WATCH_RECONCILE_INTERVAL_SECONDS + stable_running_seconds + WATCH_STARTUP_JITTER_BUFFER_SECONDS
-
-
 def _wait_for_watch_startup(
     store: ManagedWatchStore,
     runtime_store: WatchRuntimeStateStore,
     watch_id: str,
     *,
-    timeout_seconds: float | None = None,
+    timeout_seconds: float = 4.0,
     poll_interval_seconds: float = 0.1,
-    stable_running_seconds: float = WATCH_STARTUP_STABLE_RUNNING_SECONDS,
 ):
     inspect_command = f"vibe watch show {watch_id}"
-    if timeout_seconds is None:
-        timeout_seconds = _default_watch_startup_timeout_seconds(stable_running_seconds=stable_running_seconds)
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         store.maybe_reload()
@@ -890,12 +859,12 @@ def _wait_for_watch_startup(
                 help_command=inspect_command,
                 details={"watch": _watch_payload(watch, runtime_entry)},
             )
-        if watch.mode == "once" and watch.last_finished_at and not watch.last_error and watch.last_exit_code == 0:
-            return watch, runtime_entry
         if runtime_entry and runtime_entry.get("running"):
-            stable_for = _seconds_since_iso(runtime_entry.get("started_at")) or _seconds_since_iso(watch.last_started_at)
-            if stable_for is not None and stable_for >= stable_running_seconds:
-                return watch, runtime_entry
+            return watch, runtime_entry
+        if watch.last_started_at:
+            return watch, runtime_entry
+        if watch.mode == "once" and watch.last_finished_at:
+            return watch, runtime_entry
         time.sleep(poll_interval_seconds)
 
     store.maybe_reload()
@@ -1994,12 +1963,7 @@ def _format_restart_delay(delay_seconds: float) -> str:
 def _schedule_delayed_restart(delay_seconds: float) -> int:
     current_vibe_path = cache_running_vibe_path()
     restart_command = [*get_restart_command(vibe_path=current_vibe_path), "restart"]
-    api._spawn_delayed_restart(
-        restart_command,
-        get_safe_cwd(),
-        delay_seconds=delay_seconds,
-        env=get_restart_environment(vibe_path=current_vibe_path),
-    )
+    api._spawn_delayed_restart(restart_command, get_safe_cwd(), delay_seconds=delay_seconds)
     print(f"Restart scheduled in {_format_restart_delay(delay_seconds)}.")
     print("This command exits immediately; the delayed restart will run in the background.")
     return 0


### PR DESCRIPTION
## Summary
- snapshot the current uncommitted main-worktree diff onto a clean branch from `master`
- preserve the exact local working-tree state for review instead of trying to reinterpret or clean it up first
- make the remaining diff against `master` visible in a standalone PR

## Context
This PR is a snapshot for inspection.
It is not framed as a ready-to-merge feature PR.

Relative to current `master`, this snapshot mainly:
- removes the recent Slack DM mismatch / recovery changes
- removes the recent watch startup stability / timeout handling changes and related CLI coverage
- tweaks the local `use-sentry-cli-debug` skill text

## Validation
- `ruff check core/watches.py modules/im/slack.py tests/test_cli_watch_command.py tests/test_slack_dm_mentions.py tests/test_vibe_cli.py tests/test_watches.py vibe/cli.py`
- `.venv/bin/python -m pytest tests/test_cli_watch_command.py tests/test_vibe_cli.py tests/test_watches.py tests/test_slack_dm_mentions.py`
- `git diff --check`

## Risks / Follow-ups
- this diff appears rollback-heavy versus `master`, so it should be reviewed as a working-tree snapshot rather than assumed to be intended product direction
