### PR TITLE
fix(regression): preserve no-reset auth state

### DIFF
--- a/scripts/prepare_three_regression.py
+++ b/scripts/prepare_three_regression.py
@@ -432,7 +432,7 @@ def _shared_agent_config_paths(output_root: Path) -> tuple[Path, ...]:
 
 
 def _should_write_shared_agent_configs(output_root: Path, *, reset_mode: str) -> bool:
-    return reset_mode == "all" or any(not path.exists() for path in _shared_agent_config_paths(output_root))
+    return reset_mode in {"config", "all"} or any(not path.exists() for path in _shared_agent_config_paths(output_root))
 
 
 def _write_shared_agent_configs(output_root: Path, *, reset_mode: str) -> None:

--- a/scripts/prepare_three_regression.py
+++ b/scripts/prepare_three_regression.py
@@ -290,10 +290,14 @@ def _ensure_shared_home(output_root: Path, reset_mode: str = "none") -> Path:
     return shared_root
 
 
-def _ensure_vibe_dir(vibe_dir: Path, reset_mode: str = "none") -> None:
+def _validate_reset_mode(reset_mode: str) -> None:
     if reset_mode not in RESET_MODES:
         allowed = ", ".join(sorted(RESET_MODES))
         raise SystemExit(f"reset_mode must be one of: {allowed}")
+
+
+def _ensure_vibe_dir(vibe_dir: Path, reset_mode: str = "none") -> None:
+    _validate_reset_mode(reset_mode)
 
     if reset_mode == "all" and vibe_dir.exists():
         shutil.rmtree(vibe_dir)
@@ -416,8 +420,23 @@ def _build_opencode_payload() -> dict:
     }
 
 
-def _write_shared_agent_configs(output_root: Path) -> None:
-    shared_root = _ensure_shared_home(output_root)
+def _shared_agent_config_paths(output_root: Path) -> tuple[Path, ...]:
+    shared_root = output_root / "shared-home"
+    return (
+        shared_root / ".claude" / "settings.json",
+        shared_root / ".claude.json",
+        shared_root / ".codex" / "config.toml",
+        shared_root / ".codex" / "auth.json",
+        shared_root / ".config" / "opencode" / "opencode.json",
+    )
+
+
+def _should_write_shared_agent_configs(output_root: Path, *, reset_mode: str) -> bool:
+    return reset_mode == "all" or any(not path.exists() for path in _shared_agent_config_paths(output_root))
+
+
+def _write_shared_agent_configs(output_root: Path, *, reset_mode: str) -> None:
+    shared_root = _ensure_shared_home(output_root, reset_mode=reset_mode)
     _write_json(shared_root / ".claude" / "settings.json", _build_claude_settings_payload())
     claude_state_path = shared_root / ".claude.json"
     if not claude_state_path.exists():
@@ -428,27 +447,33 @@ def _write_shared_agent_configs(output_root: Path) -> None:
 
 
 def prepare(output_root: Path, reset_mode: str = "none") -> None:
-    _require_envs(("ANTHROPIC_API_KEY", "OPENAI_API_KEY"))
-
-    # Validate platform-specific required env vars
-    for name, pdef in PLATFORM_DEFS.items():
-        _require_envs(pdef["required_envs"])
-
-    _ensure_shared_home(output_root, reset_mode=reset_mode)
-    _write_shared_agent_configs(output_root)
-
+    _validate_reset_mode(reset_mode)
     vibe_dir = output_root / "vibe"
-    _ensure_vibe_dir(vibe_dir, reset_mode=reset_mode)
-
     config_path = vibe_dir / "config" / "config.json"
     settings_path = vibe_dir / "state" / "settings.json"
     sessions_path = vibe_dir / "state" / "sessions.json"
+    needs_config = reset_mode in {"config", "all"} or not config_path.exists()
+    needs_settings = reset_mode in {"config", "all"} or not settings_path.exists()
+    needs_sessions = reset_mode in {"config", "all"} or not sessions_path.exists()
+    needs_shared_agent_configs = _should_write_shared_agent_configs(output_root, reset_mode=reset_mode)
 
-    if reset_mode in {"config", "all"} or not config_path.exists():
+    if needs_shared_agent_configs:
+        _require_envs(("ANTHROPIC_API_KEY", "OPENAI_API_KEY"))
+
+    if needs_config or needs_settings:
+        for pdef in PLATFORM_DEFS.values():
+            _require_envs(pdef["required_envs"])
+
+    if needs_shared_agent_configs:
+        _write_shared_agent_configs(output_root, reset_mode=reset_mode)
+
+    _ensure_vibe_dir(vibe_dir, reset_mode=reset_mode)
+
+    if needs_config:
         _write_json(config_path, _build_config_payload())
-    if reset_mode in {"config", "all"} or not settings_path.exists():
+    if needs_settings:
         _write_json(settings_path, _build_settings_payload())
-    if reset_mode in {"config", "all"} or not sessions_path.exists():
+    if needs_sessions:
         _write_json(sessions_path, {})
 
     summary_lines: list[str] = []

--- a/tests/test_prepare_three_regression.py
+++ b/tests/test_prepare_three_regression.py
@@ -254,6 +254,58 @@ def test_prepare_reset_config_preserves_workdir(tmp_path: Path, monkeypatch: pyt
     assert refreshed["agents"]["default_backend"] == "opencode"
 
 
+def test_prepare_reset_config_rewrites_shared_agent_configs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    module = _load_module()
+    _set_required_env(monkeypatch)
+
+    shared_home = tmp_path / "shared-home"
+    (shared_home / ".claude").mkdir(parents=True)
+    (shared_home / ".codex").mkdir(parents=True)
+    (shared_home / ".config" / "opencode").mkdir(parents=True)
+    (shared_home / ".claude" / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_AUTH_TOKEN": "stale-token"}}),
+        encoding="utf-8",
+    )
+    (shared_home / ".claude.json").write_text('{"keep": true}', encoding="utf-8")
+    (shared_home / ".codex" / "config.toml").write_text('model = "stale-model"\n', encoding="utf-8")
+    (shared_home / ".codex" / "auth.json").write_text('{"OPENAI_API_KEY": "stale-key"}', encoding="utf-8")
+    (shared_home / ".config" / "opencode" / "opencode.json").write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "openai": {"options": {"apiKey": "stale-openai", "baseURL": "https://stale.example/v1"}},
+                    "anthropic": {"options": {"apiKey": "stale-anthropic", "baseURL": "https://stale.example/v1"}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("THREE_REGRESSION_CODEX_MODEL", "gpt-5.4")
+    monkeypatch.setenv("THREE_REGRESSION_CODEX_OPENAI_API_KEY", "sk-codex-new")
+    monkeypatch.setenv("THREE_REGRESSION_OPENCODE_OPENAI_API_KEY", "sk-opencode-new")
+    monkeypatch.setenv("THREE_REGRESSION_OPENCODE_ANTHROPIC_API_KEY", "sk-opencode-anthropic-new")
+    monkeypatch.setenv("THREE_REGRESSION_OPENCODE_OPENAI_BASE_URL", "https://fresh.example/v1")
+    monkeypatch.setenv("THREE_REGRESSION_OPENCODE_ANTHROPIC_BASE_URL", "https://fresh.example/v1")
+    monkeypatch.setenv("THREE_REGRESSION_CLAUDE_AUTH_TOKEN", "sk-claude-fresh")
+
+    module.prepare(tmp_path, reset_mode="config")
+
+    claude_settings = json.loads((shared_home / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    codex_config = (shared_home / ".codex" / "config.toml").read_text(encoding="utf-8")
+    codex_auth = json.loads((shared_home / ".codex" / "auth.json").read_text(encoding="utf-8"))
+    opencode_config = json.loads((shared_home / ".config" / "opencode" / "opencode.json").read_text(encoding="utf-8"))
+
+    assert claude_settings["env"]["ANTHROPIC_AUTH_TOKEN"] == "sk-claude-fresh"
+    assert json.loads((shared_home / ".claude.json").read_text(encoding="utf-8")) == {"keep": True}
+    assert 'model = "gpt-5.4"' in codex_config
+    assert codex_auth["OPENAI_API_KEY"] == "sk-codex-new"
+    assert opencode_config["provider"]["openai"]["options"]["apiKey"] == "sk-opencode-new"
+    assert opencode_config["provider"]["openai"]["options"]["baseURL"] == "https://fresh.example/v1"
+    assert opencode_config["provider"]["anthropic"]["options"]["apiKey"] == "sk-opencode-anthropic-new"
+    assert opencode_config["provider"]["anthropic"]["options"]["baseURL"] == "https://fresh.example/v1"
+
+
 def test_prepare_reset_all_clears_workdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     module = _load_module()
     _set_required_env(monkeypatch)

--- a/tests/test_prepare_three_regression.py
+++ b/tests/test_prepare_three_regression.py
@@ -127,12 +127,87 @@ def test_prepare_preserves_existing_state_without_reset(tmp_path: Path, monkeypa
     (vibe_dir / "config" / "config.json").write_text('{"keep": true}', encoding="utf-8")
     (vibe_dir / "state" / "settings.json").write_text('{"custom": true}', encoding="utf-8")
     (vibe_dir / "state" / "sessions.json").write_text('{"session": true}', encoding="utf-8")
+    shared_home = tmp_path / "shared-home"
+    (shared_home / ".claude").mkdir(parents=True)
+    (shared_home / ".codex").mkdir(parents=True)
+    (shared_home / ".config" / "opencode").mkdir(parents=True)
+    (shared_home / ".claude" / "settings.json").write_text('{"env": {"ANTHROPIC_AUTH_TOKEN": "keep"}}', encoding="utf-8")
+    (shared_home / ".claude.json").write_text('{"keep": true}', encoding="utf-8")
+    (shared_home / ".codex" / "config.toml").write_text('model = "keep"\n', encoding="utf-8")
+    (shared_home / ".codex" / "auth.json").write_text('{"OPENAI_API_KEY": "keep"}', encoding="utf-8")
+    (shared_home / ".config" / "opencode" / "opencode.json").write_text('{"keep": true}', encoding="utf-8")
+
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "THREE_REGRESSION_SLACK_BOT_TOKEN",
+        "THREE_REGRESSION_SLACK_APP_TOKEN",
+        "THREE_REGRESSION_DISCORD_BOT_TOKEN",
+        "THREE_REGRESSION_FEISHU_APP_ID",
+        "THREE_REGRESSION_FEISHU_APP_SECRET",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
     module.prepare(tmp_path)
 
     assert json.loads((vibe_dir / "config" / "config.json").read_text(encoding="utf-8")) == {"keep": True}
     assert json.loads((vibe_dir / "state" / "settings.json").read_text(encoding="utf-8")) == {"custom": True}
     assert json.loads((vibe_dir / "state" / "sessions.json").read_text(encoding="utf-8")) == {"session": True}
+    assert json.loads((shared_home / ".claude" / "settings.json").read_text(encoding="utf-8")) == {
+        "env": {"ANTHROPIC_AUTH_TOKEN": "keep"}
+    }
+    assert json.loads((shared_home / ".claude.json").read_text(encoding="utf-8")) == {"keep": True}
+    assert (shared_home / ".codex" / "config.toml").read_text(encoding="utf-8") == 'model = "keep"\n'
+    assert json.loads((shared_home / ".codex" / "auth.json").read_text(encoding="utf-8")) == {"OPENAI_API_KEY": "keep"}
+    assert json.loads((shared_home / ".config" / "opencode" / "opencode.json").read_text(encoding="utf-8")) == {
+        "keep": True
+    }
+
+
+def test_prepare_without_reset_still_requires_llm_keys_when_shared_configs_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    module = _load_module()
+    _set_required_env(monkeypatch)
+
+    vibe_dir = tmp_path / "vibe"
+    (vibe_dir / "config").mkdir(parents=True)
+    (vibe_dir / "state").mkdir(parents=True)
+    (vibe_dir / "config" / "config.json").write_text('{"keep": true}', encoding="utf-8")
+    (vibe_dir / "state" / "settings.json").write_text('{"custom": true}', encoding="utf-8")
+    (vibe_dir / "state" / "sessions.json").write_text('{"session": true}', encoding="utf-8")
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(SystemExit, match="ANTHROPIC_API_KEY, OPENAI_API_KEY"):
+        module.prepare(tmp_path)
+
+
+def test_prepare_without_reset_still_requires_platform_envs_when_config_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    module = _load_module()
+    _set_required_env(monkeypatch)
+
+    vibe_dir = tmp_path / "vibe"
+    (vibe_dir / "state").mkdir(parents=True)
+    (vibe_dir / "state" / "sessions.json").write_text('{"session": true}', encoding="utf-8")
+    shared_home = tmp_path / "shared-home"
+    (shared_home / ".claude").mkdir(parents=True)
+    (shared_home / ".codex").mkdir(parents=True)
+    (shared_home / ".config" / "opencode").mkdir(parents=True)
+    (shared_home / ".claude" / "settings.json").write_text("{}", encoding="utf-8")
+    (shared_home / ".claude.json").write_text("{}", encoding="utf-8")
+    (shared_home / ".codex" / "config.toml").write_text("", encoding="utf-8")
+    (shared_home / ".codex" / "auth.json").write_text("{}", encoding="utf-8")
+    (shared_home / ".config" / "opencode" / "opencode.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.delenv("THREE_REGRESSION_SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("THREE_REGRESSION_SLACK_APP_TOKEN", raising=False)
+
+    with pytest.raises(SystemExit, match="THREE_REGRESSION_SLACK_BOT_TOKEN, THREE_REGRESSION_SLACK_APP_TOKEN"):
+        module.prepare(tmp_path)
 
 
 def test_prepare_allows_missing_channel_ids(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary
- make `prepare_three_regression.py` validate env only for files it actually needs to generate
- preserve existing shared agent auth/config files during `reset_mode=none` instead of rewriting them every run
- keep strict validation when shared agent configs or platform config/state need to be initialized

## Why
The no-reset regression update flow was blocked by empty `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` values even when the existing regression state already had working persisted auth under `_tmp/three-regression/shared-home`.

That made `./scripts/run_three_regression.sh` overly strict for the common "just rebuild with latest code" path.

## Validation
- `ruff check scripts/prepare_three_regression.py tests/test_prepare_three_regression.py`
- `python3 -m pytest tests/test_prepare_three_regression.py`
- `set -a; . /Users/cyh/vibe-remote/.env.three-regression; set +a; python3 scripts/prepare_three_regression.py --output-root /Users/cyh/vibe-remote/_tmp/three-regression --reset-mode none`
- `git diff --check`

## Evidence
- unit: expanded `tests/test_prepare_three_regression.py`
- manual: reproduced the real no-reset path against the current local regression state with empty global LLM keys

## Risks / Follow-ups
- this only fixes the prepare helper behavior; `run_three_regression.sh` still routes through the helper, but the helper now correctly treats `reset_mode=none` as a preserve-state path
