### PR TITLE
fix(watch): preflight watcher script paths

### DIFF
--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -29,7 +29,7 @@ Prefer `vibe watch` when the wait should be inspectable, pausable, resumable, or
   Main entrypoint. Starts a managed background watch and sends a follow-up hook after the waiter succeeds or reaches a terminal failure.
 - `vibe watch list`, `vibe watch show`, `vibe watch pause`, `vibe watch resume`, `vibe watch remove`
   Use these to inspect and manage the watch after creation.
-- `scripts/wait_pr.py`
+- `skills/background-watch-hook/scripts/wait_pr.py`
   Bundled waiter example for one common case: GitHub PR review activity.
 
 ## Use `vibe watch` First
@@ -155,13 +155,14 @@ This separation matters: a forever watch can still use a bounded timeout for eac
 
 This skill ships bundled GitHub waiters:
 
-- `scripts/wait_pr.py`
+- `skills/background-watch-hook/scripts/wait_pr.py`
   Waits for GitHub PR review activity, including reviews, inline review comments, PR conversation comments, PR status transitions such as `draft -> open`, `open -> merged`, or `open -> closed`, and the special Codex `+1` reaction on the PR body. It can also wait for newly opened PRs in a repository.
-- `scripts/wait_issue.py`
+- `skills/background-watch-hook/scripts/wait_issue.py`
   Waits for GitHub issue activity, either newly opened issues in a repository or new comments on a single issue.
 
 Use bundled waiters as examples or as ready-to-run building blocks. The main skill is still `vibe watch`; the waiter is only the thing that blocks until the condition is met.
 When running a bundled script through `uv`, prefer `uv run --no-project ...` so the script does not accidentally attach itself to an unrelated parent project.
+When using a relative script path, prefer setting `--cwd` so the creation-time script check and the managed runtime agree about where the script lives.
 Bundled GitHub waiters use exit code `75` for retryable startup errors such as temporary network failures or GitHub `408/429/5xx` responses.
 
 ## GitHub Example Waiter
@@ -173,10 +174,11 @@ One-shot watch:
 ```bash
 vibe watch add \
   --session-key "slack::channel::C123::thread::171717.123" \
+  --cwd /path/to/repo \
   --name "Watch PR 151 reviews" \
   --prefix "PR #151 has new review activity. Fetch the latest review state, summarize actionable items, and continue handling them if needed." \
   -- \
-  uv run --no-project scripts/wait_pr.py \
+  uv run --no-project skills/background-watch-hook/scripts/wait_pr.py \
     --repo cyhhao/vibe-remote \
     --pr 151 \
     --interval 60
@@ -187,10 +189,11 @@ Catch up on existing activity first:
 ```bash
 vibe watch add \
   --session-key "slack::channel::C123::thread::171717.123" \
+  --cwd /path/to/repo \
   --name "Catch up PR 151 reviews" \
   --prefix "PR #151 already has review activity. Fetch the latest review state and continue handling it if needed." \
   -- \
-  uv run --no-project scripts/wait_pr.py \
+  uv run --no-project skills/background-watch-hook/scripts/wait_pr.py \
     --repo cyhhao/vibe-remote \
     --pr 151 \
     --catch-up
@@ -201,13 +204,14 @@ Stay armed for future activity:
 ```bash
 vibe watch add \
   --session-key "slack::channel::C123::thread::171717.123" \
+  --cwd /path/to/repo \
   --name "Monitor PR 151 reviews" \
   --forever \
   --timeout 21600 \
   --lifetime-timeout 86400 \
   --prefix "PR #151 has new review activity. Fetch the latest review state, summarize actionable items, and continue handling them if needed." \
   -- \
-  uv run --no-project scripts/wait_pr.py \
+  uv run --no-project skills/background-watch-hook/scripts/wait_pr.py \
     --repo cyhhao/vibe-remote \
     --pr 151 \
     --interval 60
@@ -227,10 +231,11 @@ New PRs in a repository:
 ```bash
 vibe watch add \
   --session-key "slack::channel::C123::thread::171717.123" \
+  --cwd /path/to/repo \
   --name "Watch new PRs" \
   --prefix "The repository has new pull requests. Review the new PRs and continue as needed." \
   -- \
-  uv run --no-project scripts/wait_pr.py \
+  uv run --no-project skills/background-watch-hook/scripts/wait_pr.py \
     --repo cyhhao/vibe-remote \
     --new-prs \
     --interval 60
@@ -239,8 +244,8 @@ vibe watch add \
 New issues or issue comments:
 
 ```bash
-uv run --no-project scripts/wait_issue.py --repo cyhhao/vibe-remote --new-issues --interval 60
-uv run --no-project scripts/wait_issue.py --repo cyhhao/vibe-remote --issue 157 --interval 60
+uv run --no-project skills/background-watch-hook/scripts/wait_issue.py --repo cyhhao/vibe-remote --new-issues --interval 60
+uv run --no-project skills/background-watch-hook/scripts/wait_issue.py --repo cyhhao/vibe-remote --issue 157 --interval 60
 ```
 
 ## Practical Advice

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -486,6 +486,36 @@ def test_watch_add_does_not_treat_shell_command_string_as_script(
     assert payload["watch"]["command"] == ["bash", "-lc", "sleep 1; echo done"]
 
 
+def test_watch_add_accepts_shell_command_with_control_operator_after_script(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    _write_script(tmp_path / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            "python3 scripts/wait.py; echo done",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["shell_command"] == "python3 scripts/wait.py; echo done"
+
+
 def test_watch_add_accepts_shell_command_with_home_expansion(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:
@@ -638,6 +668,29 @@ def test_watch_add_rejects_shell_command_with_escaped_glob_literal(
     assert payload["code"] == "invalid_watch_script"
     assert payload["details"]["script"] == "scripts/*.py"
     assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "[*].py").resolve())
+
+
+def test_watch_add_rejects_shell_command_with_escaped_space_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            r"python3 scripts/my\ script.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/my script.py"
+    assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "my script.py").resolve())
 
 
 def test_watch_add_rejects_exec_command_with_literal_tilde_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -299,6 +299,35 @@ def test_watch_add_skips_uv_option_values_before_script_probe(
     assert payload["watch"]["command"] == ["uv", "run", "--project", str(project_dir), "scripts/wait.py"]
 
 
+def test_watch_add_preflights_script_after_uv_global_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "uv",
+            "--directory",
+            str(repo_root),
+            "run",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.py"
+    assert payload["details"]["checked_from"] == str(repo_root.resolve())
+
+
 def test_watch_add_preflights_script_after_valueless_uv_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     args = _parse_watch_add(
         [
@@ -413,6 +442,68 @@ def test_watch_add_preflights_plain_python_filename(monkeypatch: pytest.MonkeyPa
     assert result == 1
     assert payload["code"] == "invalid_watch_script"
     assert payload["details"]["script"] == "waiter"
+
+
+def test_watch_add_allows_python_compact_module_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3",
+            "-mhttp.server",
+            "8000",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["command"] == ["python3", "-mhttp.server", "8000"]
+
+
+def test_watch_add_allows_python_compact_command_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3",
+            "-cprint(1)",
+            "foo",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["command"] == ["python3", "-cprint(1)", "foo"]
 
 
 def test_watch_add_preflights_script_after_shell_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -292,6 +292,30 @@ def test_watch_add_preflights_script_after_valueless_uv_flag(monkeypatch: pytest
     assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "wait.py").resolve())
 
 
+def test_watch_add_preflights_script_after_uv_refresh_package(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "uv",
+            "run",
+            "--refresh-package",
+            "foo",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.py"
+
+
 def test_watch_add_preflights_script_after_python_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     args = _parse_watch_add(
         [
@@ -365,6 +389,68 @@ def test_watch_add_does_not_treat_shell_command_string_as_script(
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["watch"]["command"] == ["bash", "-lc", "sleep 1; echo done"]
+
+
+def test_watch_add_accepts_shell_command_with_home_expansion(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    home_dir = tmp_path / "home"
+    _write_script(home_dir / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            "python3 $HOME/scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["shell_command"] == "python3 $HOME/scripts/wait.py"
+
+
+def test_watch_add_accepts_shell_command_with_glob_expansion(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    _write_script(tmp_path / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            "python3 scripts/*.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["shell_command"] == "python3 scripts/*.py"
 
 
 def test_watch_add_resolves_script_from_uv_directory_override(

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -292,6 +292,81 @@ def test_watch_add_preflights_script_after_valueless_uv_flag(monkeypatch: pytest
     assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "wait.py").resolve())
 
 
+def test_watch_add_preflights_script_after_python_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3",
+            "-u",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.py"
+
+
+def test_watch_add_preflights_script_after_shell_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "bash",
+            "-e",
+            "scripts/wait.sh",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.sh"
+
+
+def test_watch_add_does_not_treat_shell_command_string_as_script(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "bash",
+            "-lc",
+            "sleep 1; echo done",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["command"] == ["bash", "-lc", "sleep 1; echo done"]
+
+
 def test_watch_add_resolves_script_from_uv_directory_override(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -49,6 +49,11 @@ def _startup_ok(store: ManagedWatchStore, runtime_store: WatchRuntimeStateStore,
     return store.get_watch(watch_id), runtime_store.load().get("watches", {}).get(watch_id)
 
 
+def _write_script(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("print('ok')\n")
+
+
 def test_watch_help_describes_session_key_guidance(capsys) -> None:
     parser = cli.build_parser()
 
@@ -143,9 +148,94 @@ def test_watch_add_rejects_missing_cwd() -> None:
     assert payload["code"] == "invalid_watch_cwd"
 
 
-def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:
+def test_watch_add_rejects_missing_relative_script_from_current_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "uv",
+            "run",
+            "--no-project",
+            "scripts/wait_pr.py",
+            "--repo",
+            "cyhhao/vibe-remote",
+            "--pr",
+            "178",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait_pr.py"
+    assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "wait_pr.py").resolve())
+
+
+def test_watch_add_rejects_missing_relative_script_from_explicit_cwd(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--cwd",
+            str(repo_root),
+            "--shell",
+            "python3 scripts/wait.py",
+        ]
+    )
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["resolved_path"] == str((repo_root / "scripts" / "wait.py").resolve())
+    assert payload["details"]["checked_from"] == str(repo_root.resolve())
+
+
+def test_watch_add_accepts_existing_relative_script_from_current_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    script_path = tmp_path / "scripts" / "wait.py"
+    script_path.parent.mkdir()
+    script_path.write_text("print('ok')\n")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["command"] == ["python3", "scripts/wait.py"]
+
+
+def test_watch_add_creates_shell_watch(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    _write_script(tmp_path / "scripts" / "wait.py")
     args = _parse_watch_add(
         [
             "--session-key",
@@ -158,6 +248,8 @@ def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:
             "python3 scripts/wait.py",
         ]
     )
+
+    monkeypatch.chdir(tmp_path)
 
     with (
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
@@ -177,9 +269,12 @@ def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:
     assert payload["watch"]["retry_exit_codes"] == [75]
 
 
-def test_watch_add_creates_exec_watch_with_retry_codes(tmp_path: Path, capsys) -> None:
+def test_watch_add_creates_exec_watch_with_retry_codes(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    _write_script(tmp_path / "scripts" / "wait.py")
     args = _parse_watch_add(
         [
             "--session-key",
@@ -200,6 +295,8 @@ def test_watch_add_creates_exec_watch_with_retry_codes(tmp_path: Path, capsys) -
             "42",
         ]
     )
+
+    monkeypatch.chdir(tmp_path)
 
     with (
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
@@ -247,9 +344,12 @@ def test_watch_add_persists_absolute_cwd(tmp_path: Path, capsys, monkeypatch: py
     assert payload["watch"]["cwd"] == str(workdir.resolve())
 
 
-def test_watch_add_returns_structured_error_when_startup_fails(tmp_path: Path) -> None:
+def test_watch_add_returns_structured_error_when_startup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    _write_script(tmp_path / "scripts" / "wait.py")
     args = _parse_watch_add(
         [
             "--session-key",
@@ -258,6 +358,8 @@ def test_watch_add_returns_structured_error_when_startup_fails(tmp_path: Path) -
             "python3 scripts/wait.py",
         ]
     )
+
+    monkeypatch.chdir(tmp_path)
 
     with (
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -176,7 +176,7 @@ def test_watch_add_rejects_missing_relative_script_from_current_cwd(monkeypatch:
     assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "wait_pr.py").resolve())
 
 
-def test_watch_add_rejects_missing_relative_script_from_explicit_cwd(tmp_path: Path) -> None:
+def test_watch_add_defers_shell_command_path_failures_to_startup(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     args = _parse_watch_add(
@@ -194,9 +194,7 @@ def test_watch_add_rejects_missing_relative_script_from_explicit_cwd(tmp_path: P
         result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
 
     assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["resolved_path"] == str((repo_root / "scripts" / "wait.py").resolve())
-    assert payload["details"]["checked_from"] == str(repo_root.resolve())
+    assert payload["code"] == "watch_startup_failed"
 
 
 def test_watch_add_accepts_existing_relative_script_from_current_cwd(
@@ -516,183 +514,6 @@ def test_watch_add_accepts_shell_command_with_control_operator_after_script(
     assert payload["watch"]["shell_command"] == "python3 scripts/wait.py; echo done"
 
 
-def test_watch_add_accepts_shell_command_with_home_expansion(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
-) -> None:
-    store = ManagedWatchStore(tmp_path / "watches.json")
-    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
-    home_dir = tmp_path / "home"
-    _write_script(home_dir / "scripts" / "wait.py")
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            "python3 $HOME/scripts/wait.py",
-        ]
-    )
-
-    monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.chdir(tmp_path)
-
-    with (
-        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
-        patch("vibe.cli._watch_store", return_value=store),
-        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
-        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
-    ):
-        result = cli.cmd_watch_add(args)
-
-    assert result == 0
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["shell_command"] == "python3 $HOME/scripts/wait.py"
-
-
-def test_watch_add_rejects_shell_command_with_single_quoted_home_literal(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    home_dir = tmp_path / "home"
-    _write_script(home_dir / "scripts" / "wait.py")
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            "python3 '$HOME/scripts/wait.py'",
-        ]
-    )
-
-    monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.chdir(tmp_path)
-
-    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
-
-    assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["script"] == "$HOME/scripts/wait.py"
-
-
-def test_watch_add_rejects_shell_command_with_mixed_quoted_home_literal(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    home_dir = tmp_path / "home"
-    _write_script(home_dir / "scripts" / "wait.py")
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            "python3 '$HOME'/scripts/wait.py",
-        ]
-    )
-
-    monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.chdir(tmp_path)
-
-    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
-
-    assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["script"] == "$HOME/scripts/wait.py"
-
-
-def test_watch_add_rejects_shell_command_with_quoted_glob_literal(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    _write_script(tmp_path / "scripts" / "wait.py")
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            'python3 "scripts/*.py"',
-        ]
-    )
-
-    monkeypatch.chdir(tmp_path)
-
-    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
-
-    assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["script"] == "scripts/*.py"
-
-
-def test_watch_add_rejects_shell_command_with_escaped_home_literal(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    home_dir = tmp_path / "home"
-    _write_script(home_dir / "scripts" / "wait.py")
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            r"python3 \$HOME/scripts/wait.py",
-        ]
-    )
-
-    monkeypatch.setenv("HOME", str(home_dir))
-    monkeypatch.chdir(tmp_path)
-
-    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
-
-    assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["script"] == "$HOME/scripts/wait.py"
-
-
-def test_watch_add_rejects_shell_command_with_escaped_glob_literal(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    _write_script(tmp_path / "scripts" / "wait.py")
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            r"python3 scripts/\*.py",
-        ]
-    )
-
-    monkeypatch.chdir(tmp_path)
-
-    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
-
-    assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["script"] == "scripts/*.py"
-    assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "[*].py").resolve())
-
-
-def test_watch_add_rejects_shell_command_with_escaped_space_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            r"python3 scripts/my\ script.py",
-        ]
-    )
-
-    monkeypatch.chdir(tmp_path)
-
-    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
-
-    assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["script"] == "scripts/my script.py"
-    assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "my script.py").resolve())
-
-
 def test_watch_add_rejects_exec_command_with_literal_tilde_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     _write_script(home_dir / "scripts" / "wait.py")
@@ -717,18 +538,17 @@ def test_watch_add_rejects_exec_command_with_literal_tilde_path(monkeypatch: pyt
     assert payload["details"]["script"] == "~/scripts/wait.py"
 
 
-def test_watch_add_accepts_shell_command_with_glob_expansion(
+def test_watch_add_allows_shell_command_without_path_preflight(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
-    _write_script(tmp_path / "scripts" / "wait.py")
     args = _parse_watch_add(
         [
             "--session-key",
             "slack::channel::C123",
             "--shell",
-            "python3 scripts/*.py",
+            r"python3 scripts/my\ script.py; echo done",
         ]
     )
 
@@ -744,33 +564,7 @@ def test_watch_add_accepts_shell_command_with_glob_expansion(
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["shell_command"] == "python3 scripts/*.py"
-
-
-def test_watch_add_rejects_shell_command_when_first_glob_match_is_not_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    scripts_dir = tmp_path / "scripts"
-    (scripts_dir / "00_dir.py").mkdir(parents=True)
-    _write_script(scripts_dir / "10_wait.py")
-    args = _parse_watch_add(
-        [
-            "--session-key",
-            "slack::channel::C123",
-            "--shell",
-            "python3 scripts/*.py",
-        ]
-    )
-
-    monkeypatch.chdir(tmp_path)
-
-    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
-
-    assert result == 1
-    assert payload["code"] == "invalid_watch_script"
-    assert payload["details"]["script"] == "scripts/*.py"
-    assert payload["details"]["resolved_path"] == str((scripts_dir / "00_dir.py").resolve())
+    assert payload["watch"]["shell_command"] == r"python3 scripts/my\ script.py; echo done"
 
 
 def test_watch_add_preflights_versioned_python_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -232,6 +232,77 @@ def test_watch_add_accepts_existing_relative_script_from_current_cwd(
     assert payload["watch"]["command"] == ["python3", "scripts/wait.py"]
 
 
+def test_watch_add_skips_uv_option_values_before_script_probe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_script(tmp_path / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "uv",
+            "run",
+            "--project",
+            str(project_dir),
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["command"] == ["uv", "run", "--project", str(project_dir), "scripts/wait.py"]
+
+
+def test_watch_add_resolves_script_from_uv_directory_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    repo_root = tmp_path / "repo"
+    _write_script(repo_root / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "uv",
+            "run",
+            "--directory",
+            str(repo_root),
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["command"] == ["uv", "run", "--directory", str(repo_root), "scripts/wait.py"]
+
+
 def test_watch_add_creates_shell_watch(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -543,6 +543,31 @@ def test_watch_add_rejects_shell_command_with_single_quoted_home_literal(
     assert payload["details"]["script"] == "$HOME/scripts/wait.py"
 
 
+def test_watch_add_rejects_shell_command_with_mixed_quoted_home_literal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home_dir = tmp_path / "home"
+    _write_script(home_dir / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            "python3 '$HOME'/scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "$HOME/scripts/wait.py"
+
+
 def test_watch_add_rejects_shell_command_with_quoted_glob_literal(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -591,6 +591,55 @@ def test_watch_add_rejects_shell_command_with_quoted_glob_literal(
     assert payload["details"]["script"] == "scripts/*.py"
 
 
+def test_watch_add_rejects_shell_command_with_escaped_home_literal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home_dir = tmp_path / "home"
+    _write_script(home_dir / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            r"python3 \$HOME/scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "$HOME/scripts/wait.py"
+
+
+def test_watch_add_rejects_shell_command_with_escaped_glob_literal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_script(tmp_path / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            r"python3 scripts/\*.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/*.py"
+    assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "[*].py").resolve())
+
+
 def test_watch_add_rejects_exec_command_with_literal_tilde_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     _write_script(home_dir / "scripts" / "wait.py")
@@ -643,6 +692,32 @@ def test_watch_add_accepts_shell_command_with_glob_expansion(
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["watch"]["shell_command"] == "python3 scripts/*.py"
+
+
+def test_watch_add_rejects_shell_command_when_first_glob_match_is_not_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    scripts_dir = tmp_path / "scripts"
+    (scripts_dir / "00_dir.py").mkdir(parents=True)
+    _write_script(scripts_dir / "10_wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            "python3 scripts/*.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/*.py"
+    assert payload["details"]["resolved_path"] == str((scripts_dir / "00_dir.py").resolve())
 
 
 def test_watch_add_preflights_versioned_python_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -338,6 +338,31 @@ def test_watch_add_preflights_script_after_python_flag(monkeypatch: pytest.Monke
     assert payload["details"]["script"] == "scripts/wait.py"
 
 
+def test_watch_add_preflights_script_after_python_long_option_value(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3",
+            "--check-hash-based-pycs",
+            "always",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.py"
+
+
 def test_watch_add_preflights_script_after_shell_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     args = _parse_watch_add(
         [
@@ -545,6 +570,34 @@ def test_watch_add_preflights_versioned_python_runner(monkeypatch: pytest.Monkey
     assert result == 1
     assert payload["code"] == "invalid_watch_script"
     assert payload["details"]["script"] == "scripts/wait.py"
+
+
+def test_watch_add_rejects_exec_uv_directory_with_literal_tilde(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _write_script(repo_root / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "uv",
+            "run",
+            "--directory",
+            "~/repo",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.py"
+    assert payload["details"]["checked_from"] == str((tmp_path / "~/repo").resolve())
 
 
 def test_watch_add_resolves_script_from_uv_directory_override(

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -423,6 +423,30 @@ def test_watch_add_accepts_shell_command_with_home_expansion(
     assert payload["watch"]["shell_command"] == "python3 $HOME/scripts/wait.py"
 
 
+def test_watch_add_rejects_exec_command_with_literal_tilde_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    _write_script(home_dir / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3",
+            "~/scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "~/scripts/wait.py"
+
+
 def test_watch_add_accepts_shell_command_with_glob_expansion(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:
@@ -451,6 +475,27 @@ def test_watch_add_accepts_shell_command_with_glob_expansion(
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["watch"]["shell_command"] == "python3 scripts/*.py"
+
+
+def test_watch_add_preflights_versioned_python_runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3.11",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.py"
 
 
 def test_watch_add_resolves_script_from_uv_directory_override(

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -360,6 +360,55 @@ def test_watch_add_preflights_script_after_shell_flag(monkeypatch: pytest.Monkey
     assert payload["details"]["script"] == "scripts/wait.sh"
 
 
+def test_watch_add_preflights_script_after_shell_long_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "bash",
+            "--norc",
+            "scripts/wait.sh",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.sh"
+
+
+def test_watch_add_preflights_script_after_shell_option_with_value(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    rcfile = tmp_path / "bashrc"
+    rcfile.write_text("# rc\n")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "bash",
+            "--rcfile",
+            str(rcfile),
+            "scripts/wait.sh",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.sh"
+
+
 def test_watch_add_does_not_treat_shell_command_string_as_script(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -363,6 +363,27 @@ def test_watch_add_preflights_script_after_python_long_option_value(
     assert payload["details"]["script"] == "scripts/wait.py"
 
 
+def test_watch_add_preflights_plain_python_filename(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "python3",
+            "waiter",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "waiter"
+
+
 def test_watch_add_preflights_script_after_shell_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     args = _parse_watch_add(
         [
@@ -495,6 +516,54 @@ def test_watch_add_accepts_shell_command_with_home_expansion(
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["watch"]["shell_command"] == "python3 $HOME/scripts/wait.py"
+
+
+def test_watch_add_rejects_shell_command_with_single_quoted_home_literal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home_dir = tmp_path / "home"
+    _write_script(home_dir / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            "python3 '$HOME/scripts/wait.py'",
+        ]
+    )
+
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "$HOME/scripts/wait.py"
+
+
+def test_watch_add_rejects_shell_command_with_quoted_glob_literal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_script(tmp_path / "scripts" / "wait.py")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--shell",
+            'python3 "scripts/*.py"',
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/*.py"
 
 
 def test_watch_add_rejects_exec_command_with_literal_tilde_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -268,6 +268,30 @@ def test_watch_add_skips_uv_option_values_before_script_probe(
     assert payload["watch"]["command"] == ["uv", "run", "--project", str(project_dir), "scripts/wait.py"]
 
 
+def test_watch_add_preflights_script_after_valueless_uv_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "uv",
+            "run",
+            "-n",
+            "scripts/wait.py",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "invalid_watch_script"
+    assert payload["details"]["script"] == "scripts/wait.py"
+    assert payload["details"]["resolved_path"] == str((tmp_path / "scripts" / "wait.py").resolve())
+
+
 def test_watch_add_resolves_script_from_uv_directory_override(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -230,6 +230,39 @@ def test_watch_add_accepts_existing_relative_script_from_current_cwd(
     assert payload["watch"]["command"] == ["python3", "scripts/wait.py"]
 
 
+def test_watch_add_allows_path_resolved_script_executable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--",
+            "wait_pr.py",
+            "--repo",
+            "cyhhao/vibe-remote",
+            "--pr",
+            "179",
+        ]
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(store, runtime_store, args[2])),
+    ):
+        result = cli.cmd_watch_add(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["watch"]["command"] == ["wait_pr.py", "--repo", "cyhhao/vibe-remote", "--pr", "179"]
+
+
 def test_watch_add_skips_uv_option_values_before_script_probe(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -229,9 +229,9 @@ def _watch_examples_text() -> str:
     return dedent(
         """\
         Examples:
-          vibe watch add --session-key 'slack::channel::C123' --name 'Wait for export' --shell 'python3 scripts/wait_for_export.py'
-          vibe watch add --session-key 'slack::channel::C123::thread::171717.123' --post-to channel --prefix 'The CI job finished.' -- python3 scripts/wait_for_ci.py --build 42
-          vibe watch add --session-key 'slack::channel::C123' --forever --retry-exit-code 75 --retry-delay 60 --shell 'bash scripts/wait_for_log_pattern.sh'
+          vibe watch add --session-key 'slack::channel::C123' --cwd /path/to/repo --name 'Wait for export' --shell 'python3 scripts/wait_for_export.py'
+          vibe watch add --session-key 'slack::channel::C123::thread::171717.123' --cwd /path/to/repo --post-to channel --prefix 'The CI job finished.' -- python3 scripts/wait_for_ci.py --build 42
+          vibe watch add --session-key 'slack::channel::C123' --forever --retry-exit-code 75 --retry-delay 60 -- uv run --no-project /path/to/repo/skills/background-watch-hook/scripts/wait_pr.py --repo cyhhao/vibe-remote --pr 153
           vibe watch list --brief
           vibe watch show 12ab34cd56ef
           vibe watch pause 12ab34cd56ef
@@ -262,12 +262,14 @@ def _watch_add_examples_text() -> str:
           Terminal failures also send a follow-up and disable the watch.
           In forever mode, failures are retried only when the waiter exits with an allowed `--retry-exit-code`.
           Pass either --shell '<command>' or a command after '--'.
+          Creation-time script checks resolve relative script paths from --cwd when provided, otherwise from the current CLI working directory.
+          If the managed watch must run from a different directory later, prefer an absolute script path or set --cwd explicitly.
           --timeout applies to each cycle. --lifetime-timeout applies only to the whole forever watch lifetime.
 
         Examples:
-          vibe watch add --session-key 'slack::channel::C123' --shell 'python3 scripts/wait_for_export.py'
+          vibe watch add --session-key 'slack::channel::C123' --cwd /path/to/repo --shell 'python3 scripts/wait_for_export.py'
           vibe watch add --session-key 'slack::channel::C123::thread::171717.123' --post-to channel --prefix 'The export finished.' -- bash -lc 'sleep 120; echo done'
-          vibe watch add --session-key 'slack::channel::C123' --forever --timeout 600 --lifetime-timeout 86400 --retry-exit-code 75 --retry-delay 30 -- uv run --no-project scripts/wait_pr.py --repo cyhhao/vibe-remote --pr 153
+          vibe watch add --session-key 'slack::channel::C123' --forever --timeout 600 --lifetime-timeout 86400 --retry-exit-code 75 --retry-delay 30 -- uv run --no-project /path/to/repo/skills/background-watch-hook/scripts/wait_pr.py --repo cyhhao/vibe-remote --pr 153
         """
     )
 
@@ -784,6 +786,81 @@ def _resolve_watch_command(args, *, help_command: str) -> tuple[list[str], Optio
         code="missing_watch_command",
         hint="Pass a shell command with --shell, or add the watcher executable and its args after '--'.",
         help_command=help_command,
+    )
+
+
+def _looks_like_script_path(token: str) -> bool:
+    if not token or token == "--" or token.startswith("-"):
+        return False
+    path = Path(token)
+    return path.is_absolute() or path.suffix in {".py", ".sh", ".bash", ".zsh"} or "/" in token or "\\" in token
+
+
+def _extract_watch_script_path(tokens: list[str]) -> str | None:
+    if not tokens:
+        return None
+
+    runner = Path(tokens[0]).name
+    if runner in {"python", "python3", "bash", "sh"}:
+        if len(tokens) > 1 and _looks_like_script_path(tokens[1]):
+            return tokens[1]
+        return None
+
+    if runner == "uv" and len(tokens) > 2 and tokens[1] == "run":
+        for token in tokens[2:]:
+            if _looks_like_script_path(token):
+                return token
+        return None
+
+    return None
+
+
+def _resolve_watch_script_probe(command: list[str], shell_command: str | None) -> str | None:
+    if shell_command:
+        try:
+            return _extract_watch_script_path(shlex.split(shell_command))
+        except ValueError:
+            return None
+    return _extract_watch_script_path(command)
+
+
+def _validate_watch_script_preflight(
+    command: list[str],
+    shell_command: str | None,
+    *,
+    cwd: str | None,
+    help_command: str,
+) -> None:
+    script_path = _resolve_watch_script_probe(command, shell_command)
+    if not script_path:
+        return
+
+    candidate = Path(script_path).expanduser()
+    checked_from = None
+    if not candidate.is_absolute():
+        checked_from = str(Path(cwd).resolve() if cwd else Path.cwd().resolve())
+        candidate = (Path(checked_from) / candidate).resolve()
+
+    if candidate.is_file():
+        return
+
+    hint = "Fix the script path or use an absolute path."
+    if checked_from is not None:
+        hint = (
+            "Fix the script path, create the watch from the directory that contains it, "
+            "pass --cwd, or use an absolute path."
+        )
+
+    raise TaskCliError(
+        f"watch script not found: {script_path}",
+        code="invalid_watch_script",
+        hint=hint,
+        help_command=help_command,
+        details={
+            "script": script_path,
+            "resolved_path": str(candidate),
+            "checked_from": checked_from,
+        },
     )
 
 
@@ -1366,6 +1443,8 @@ def cmd_watch_add(args):
                     details={"cwd": cwd},
                 )
             cwd = str(resolved)
+
+        _validate_watch_script_preflight(command, shell_command, cwd=cwd, help_command="vibe watch add --help")
 
         retry_exit_codes = sorted(set(args.retry_exit_code or [DEFAULT_RETRY_EXIT_CODE]))
         store = _watch_store()

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -837,7 +837,7 @@ UV_RUN_OPTIONS_WITH_VALUES = {
     "--config-file",
 }
 
-UV_RUN_SHORT_OPTIONS_WITH_VALUES = {"-w", "-i", "-f", "-U", "-P", "-C", "-n", "-p", "-m"}
+UV_RUN_SHORT_OPTIONS_WITH_VALUES = {"-w", "-i", "-f", "-P", "-C", "-p"}
 
 
 def _split_uv_run_command(tokens: list[str]) -> tuple[list[str], str | None]:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -886,6 +886,43 @@ def _split_uv_run_command(tokens: list[str]) -> tuple[list[str], str | None]:
     return [], effective_cwd
 
 
+def _split_uv_command(tokens: list[str]) -> tuple[str | None, list[str], str | None]:
+    effective_cwd: str | None = None
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return None, [], effective_cwd
+        if token == "run":
+            return token, [tokens[0], *tokens[index:]], effective_cwd
+        if token == "--directory":
+            if index + 1 < len(tokens):
+                effective_cwd = tokens[index + 1]
+            index += 2
+            continue
+        if token.startswith("--directory="):
+            effective_cwd = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token in UV_RUN_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if token in UV_RUN_SHORT_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if token.startswith("--") and "=" in token:
+            index += 1
+            continue
+        if token.startswith("-") and len(token) > 2 and token[:2] in UV_RUN_SHORT_OPTIONS_WITH_VALUES:
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token, tokens[index:], effective_cwd
+    return None, [], effective_cwd
+
+
 def _extract_python_script_path(tokens: list[str]) -> str | None:
     index = 1
     while index < len(tokens):
@@ -894,6 +931,8 @@ def _extract_python_script_path(tokens: list[str]) -> str | None:
             index += 1
             break
         if token in PYTHON_OPTIONS_WITHOUT_SCRIPT:
+            return None
+        if any(token.startswith(option) and token != option for option in PYTHON_OPTIONS_WITHOUT_SCRIPT):
             return None
         if token in PYTHON_OPTIONS_WITH_VALUES:
             index += 2
@@ -931,10 +970,12 @@ def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | No
     if runner in {"bash", "sh"}:
         return _extract_shell_script_path(tokens), None
 
-    if runner == "uv" and len(tokens) > 2 and tokens[1] == "run":
-        inner_tokens, effective_cwd = _split_uv_run_command(tokens)
-        script_path, nested_cwd = _extract_watch_script_probe_from_tokens(inner_tokens)
-        return script_path, nested_cwd or effective_cwd
+    if runner == "uv":
+        subcommand, uv_tokens, global_cwd = _split_uv_command(tokens)
+        if subcommand == "run":
+            inner_tokens, effective_cwd = _split_uv_run_command(uv_tokens)
+            script_path, nested_cwd = _extract_watch_script_probe_from_tokens(inner_tokens)
+            return script_path, nested_cwd or effective_cwd or global_cwd
 
     if _looks_like_script_path(tokens[0]):
         return tokens[0], None

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -796,32 +796,113 @@ def _looks_like_script_path(token: str) -> bool:
     return path.is_absolute() or path.suffix in {".py", ".sh", ".bash", ".zsh"} or "/" in token or "\\" in token
 
 
-def _extract_watch_script_path(tokens: list[str]) -> str | None:
+UV_RUN_OPTIONS_WITH_VALUES = {
+    "--extra",
+    "--no-extra",
+    "--group",
+    "--no-group",
+    "--only-group",
+    "--env-file",
+    "--with",
+    "--with-editable",
+    "--with-requirements",
+    "--package",
+    "--python-platform",
+    "--index",
+    "--default-index",
+    "--index-url",
+    "--extra-index-url",
+    "--find-links",
+    "--index-strategy",
+    "--keyring-provider",
+    "--upgrade-package",
+    "--resolution",
+    "--prerelease",
+    "--fork-strategy",
+    "--exclude-newer",
+    "--exclude-newer-package",
+    "--reinstall-package",
+    "--link-mode",
+    "--config-setting",
+    "--config-settings-package",
+    "--no-build-isolation-package",
+    "--no-build-package",
+    "--no-binary-package",
+    "--cache-dir",
+    "--python",
+    "--color",
+    "--allow-insecure-host",
+    "--directory",
+    "--project",
+    "--config-file",
+}
+
+UV_RUN_SHORT_OPTIONS_WITH_VALUES = {"-w", "-i", "-f", "-U", "-P", "-C", "-n", "-p", "-m"}
+
+
+def _split_uv_run_command(tokens: list[str]) -> tuple[list[str], str | None]:
+    effective_cwd: str | None = None
+    index = 2
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return tokens[index + 1 :], effective_cwd
+        if token == "--directory":
+            if index + 1 < len(tokens):
+                effective_cwd = tokens[index + 1]
+            index += 2
+            continue
+        if token.startswith("--directory="):
+            effective_cwd = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token in UV_RUN_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if token in UV_RUN_SHORT_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if token.startswith("--") and "=" in token:
+            index += 1
+            continue
+        if token.startswith("-") and len(token) > 2 and token[:2] in UV_RUN_SHORT_OPTIONS_WITH_VALUES:
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return tokens[index:], effective_cwd
+    return [], effective_cwd
+
+
+def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | None, str | None]:
     if not tokens:
-        return None
+        return None, None
 
     runner = Path(tokens[0]).name
     if runner in {"python", "python3", "bash", "sh"}:
         if len(tokens) > 1 and _looks_like_script_path(tokens[1]):
-            return tokens[1]
-        return None
+            return tokens[1], None
+        return None, None
 
     if runner == "uv" and len(tokens) > 2 and tokens[1] == "run":
-        for token in tokens[2:]:
-            if _looks_like_script_path(token):
-                return token
-        return None
+        inner_tokens, effective_cwd = _split_uv_run_command(tokens)
+        script_path, nested_cwd = _extract_watch_script_probe_from_tokens(inner_tokens)
+        return script_path, nested_cwd or effective_cwd
 
-    return None
+    if _looks_like_script_path(tokens[0]):
+        return tokens[0], None
+
+    return None, None
 
 
-def _resolve_watch_script_probe(command: list[str], shell_command: str | None) -> str | None:
+def _resolve_watch_script_probe(command: list[str], shell_command: str | None) -> tuple[str | None, str | None]:
     if shell_command:
         try:
-            return _extract_watch_script_path(shlex.split(shell_command))
+            return _extract_watch_script_probe_from_tokens(shlex.split(shell_command))
         except ValueError:
-            return None
-    return _extract_watch_script_path(command)
+            return None, None
+    return _extract_watch_script_probe_from_tokens(command)
 
 
 def _validate_watch_script_preflight(
@@ -831,14 +912,20 @@ def _validate_watch_script_preflight(
     cwd: str | None,
     help_command: str,
 ) -> None:
-    script_path = _resolve_watch_script_probe(command, shell_command)
+    script_path, probe_cwd = _resolve_watch_script_probe(command, shell_command)
     if not script_path:
         return
 
     candidate = Path(script_path).expanduser()
     checked_from = None
     if not candidate.is_absolute():
-        checked_from = str(Path(cwd).resolve() if cwd else Path.cwd().resolve())
+        base_dir = Path(cwd).resolve() if cwd else Path.cwd().resolve()
+        if probe_cwd:
+            probe_base = Path(probe_cwd).expanduser()
+            if not probe_base.is_absolute():
+                probe_base = (base_dir / probe_base).resolve()
+            base_dir = probe_base
+        checked_from = str(base_dir)
         candidate = (Path(checked_from) / candidate).resolve()
 
     if candidate.is_file():

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -916,7 +916,7 @@ def _extract_python_script_path(tokens: list[str]) -> str | None:
             continue
         break
 
-    if index < len(tokens) and _looks_like_script_path(tokens[index]):
+    if index < len(tokens) and tokens[index] != "-":
         return tokens[index]
     return None
 
@@ -943,7 +943,7 @@ def _extract_shell_script_path(tokens: list[str]) -> str | None:
             continue
         break
 
-    if index < len(tokens) and _looks_like_script_path(tokens[index]):
+    if index < len(tokens) and tokens[index] != "-":
         return tokens[index]
     return None
 
@@ -970,14 +970,39 @@ def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | No
     return None, None
 
 
-def _resolve_watch_preflight_base_dir(cwd: str | None, probe_cwd: str | None, *, shell_expansion: bool) -> Path:
+def _detect_shell_quote_mode(shell_command: str, token: str) -> str | None:
+    if f"'{token}'" in shell_command:
+        return "'"
+    if f'"{token}"' in shell_command:
+        return '"'
+    return None
+
+
+def _expand_shell_token(token: str, *, quote_mode: str | None) -> str:
+    if quote_mode == "'":
+        return token
+    if quote_mode == '"':
+        return os.path.expandvars(token)
+    return os.path.expandvars(os.path.expanduser(token))
+
+
+def _resolve_watch_preflight_base_dir(
+    cwd: str | None,
+    probe_cwd: str | None,
+    *,
+    shell_expansion: bool,
+    shell_command: str | None = None,
+) -> Path:
     base_dir = Path(cwd).resolve() if cwd else Path.cwd().resolve()
     if not probe_cwd:
         return base_dir
 
     probe_value = probe_cwd
     if shell_expansion:
-        probe_value = os.path.expandvars(os.path.expanduser(probe_value))
+        probe_value = _expand_shell_token(
+            probe_value,
+            quote_mode=_detect_shell_quote_mode(shell_command or "", probe_cwd),
+        )
 
     probe_base = Path(probe_value)
     if not probe_base.is_absolute():
@@ -985,11 +1010,14 @@ def _resolve_watch_preflight_base_dir(cwd: str | None, probe_cwd: str | None, *,
     return probe_base
 
 
-def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path) -> list[Path]:
-    expanded = os.path.expandvars(os.path.expanduser(script_path))
+def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path, quote_mode: str | None) -> list[Path]:
+    expanded = _expand_shell_token(script_path, quote_mode=quote_mode)
     pattern_path = Path(expanded)
     if not pattern_path.is_absolute():
         pattern_path = base_dir / pattern_path
+
+    if quote_mode is not None:
+        return [pattern_path.resolve()]
 
     matches = [Path(match).resolve() for match in glob.glob(str(pattern_path))]
     if matches:
@@ -1017,11 +1045,20 @@ def _validate_watch_script_preflight(
     if not script_path:
         return
 
-    base_dir = _resolve_watch_preflight_base_dir(cwd, probe_cwd, shell_expansion=bool(shell_command))
+    base_dir = _resolve_watch_preflight_base_dir(
+        cwd,
+        probe_cwd,
+        shell_expansion=bool(shell_command),
+        shell_command=shell_command,
+    )
     checked_from = None if Path(script_path).is_absolute() else str(base_dir)
 
     if shell_command:
-        candidates = _resolve_shell_script_candidates(script_path, base_dir=base_dir)
+        candidates = _resolve_shell_script_candidates(
+            script_path,
+            base_dir=base_dir,
+            quote_mode=_detect_shell_quote_mode(shell_command, script_path),
+        )
         if any(candidate.is_file() for candidate in candidates):
             return
         candidate = candidates[0]

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -847,6 +847,7 @@ UV_RUN_SHORT_OPTIONS_WITH_VALUES = {"-w", "-i", "-f", "-P", "-C", "-p"}
 
 PYTHON_OPTIONS_WITH_VALUES = {"-W", "-X"}
 PYTHON_OPTIONS_WITHOUT_SCRIPT = {"-c", "-m"}
+PYTHON_LONG_OPTIONS_WITH_VALUES = {"--check-hash-based-pycs"}
 SHELL_LONG_OPTIONS_WITH_VALUES = {"--init-file", "--rcfile"}
 SHELL_SHORT_OPTIONS_WITH_VALUES = {"-o", "-O"}
 
@@ -898,7 +899,13 @@ def _extract_python_script_path(tokens: list[str]) -> str | None:
         if token in PYTHON_OPTIONS_WITH_VALUES:
             index += 2
             continue
+        if token in PYTHON_LONG_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
         if any(token.startswith(f"{option}=") for option in PYTHON_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
+        if any(token.startswith(f"{option}=") for option in PYTHON_LONG_OPTIONS_WITH_VALUES):
             index += 1
             continue
         if any(token.startswith(option) and token != option for option in PYTHON_OPTIONS_WITH_VALUES):
@@ -963,12 +970,16 @@ def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | No
     return None, None
 
 
-def _resolve_watch_preflight_base_dir(cwd: str | None, probe_cwd: str | None) -> Path:
+def _resolve_watch_preflight_base_dir(cwd: str | None, probe_cwd: str | None, *, shell_expansion: bool) -> Path:
     base_dir = Path(cwd).resolve() if cwd else Path.cwd().resolve()
     if not probe_cwd:
         return base_dir
 
-    probe_base = Path(os.path.expandvars(os.path.expanduser(probe_cwd)))
+    probe_value = probe_cwd
+    if shell_expansion:
+        probe_value = os.path.expandvars(os.path.expanduser(probe_value))
+
+    probe_base = Path(probe_value)
     if not probe_base.is_absolute():
         probe_base = (base_dir / probe_base).resolve()
     return probe_base
@@ -1006,7 +1017,7 @@ def _validate_watch_script_preflight(
     if not script_path:
         return
 
-    base_dir = _resolve_watch_preflight_base_dir(cwd, probe_cwd)
+    base_dir = _resolve_watch_preflight_base_dir(cwd, probe_cwd, shell_expansion=bool(shell_command))
     checked_from = None if Path(script_path).is_absolute() else str(base_dir)
 
     if shell_command:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1,5 +1,4 @@
 import argparse
-import glob
 import json
 import logging
 import math
@@ -921,6 +920,28 @@ def _extract_python_script_path(tokens: list[str]) -> str | None:
     return None
 
 
+def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | None, str | None]:
+    if not tokens:
+        return None, None
+
+    runner = Path(tokens[0]).name
+    if _PYTHON_RUNNER_RE.fullmatch(runner):
+        return _extract_python_script_path(tokens), None
+
+    if runner in {"bash", "sh"}:
+        return _extract_shell_script_path(tokens), None
+
+    if runner == "uv" and len(tokens) > 2 and tokens[1] == "run":
+        inner_tokens, effective_cwd = _split_uv_run_command(tokens)
+        script_path, nested_cwd = _extract_watch_script_probe_from_tokens(inner_tokens)
+        return script_path, nested_cwd or effective_cwd
+
+    if _looks_like_script_path(tokens[0]):
+        return tokens[0], None
+
+    return None, None
+
+
 def _extract_shell_script_path(tokens: list[str]) -> str | None:
     index = 1
     while index < len(tokens):
@@ -947,271 +968,24 @@ def _extract_shell_script_path(tokens: list[str]) -> str | None:
         return tokens[index]
     return None
 
-
-_SHELL_CONTROL_CHARS = ";|&()<>"
-
-
-def _shell_control_operator_at(command: str, index: int) -> str | None:
-    char = command[index]
-    if char not in _SHELL_CONTROL_CHARS:
-        return None
-
-    if index + 1 < len(command):
-        pair = command[index : index + 2]
-        if pair in {"&&", "||", "<<", ">>", "|&", "<>", ";&"}:
-            return pair
-    return char
-
-
-def _tokenize_shell_command(shell_command: str) -> tuple[list[str], list[list[str]]]:
-    tokens: list[str] = []
-    grouped_fragments: list[list[str]] = []
-    length = len(shell_command)
-    index = 0
-
-    while index < length:
-        while index < length and shell_command[index].isspace():
-            index += 1
-        if index >= length:
-            break
-
-        operator = _shell_control_operator_at(shell_command, index)
-        if operator is not None:
-            tokens.append(operator)
-            grouped_fragments.append([operator])
-            index += len(operator)
-            continue
-
-        fragments: list[str] = []
-        unquoted: list[str] = []
-        while index < length:
-            operator = _shell_control_operator_at(shell_command, index)
-            if operator is not None:
-                break
-
-            char = shell_command[index]
-            if char.isspace():
-                break
-
-            if char == "'":
-                if unquoted:
-                    fragments.append("".join(unquoted))
-                    unquoted = []
-                start = index
-                index += 1
-                while index < length and shell_command[index] != "'":
-                    index += 1
-                if index >= length:
-                    raise ValueError("No closing quotation")
-                index += 1
-                fragments.append(shell_command[start:index])
-                continue
-
-            if char == '"':
-                if unquoted:
-                    fragments.append("".join(unquoted))
-                    unquoted = []
-                start = index
-                index += 1
-                while index < length:
-                    inner = shell_command[index]
-                    if inner == "\\" and index + 1 < length:
-                        index += 2
-                        continue
-                    if inner == '"':
-                        index += 1
-                        break
-                    index += 1
-                else:
-                    raise ValueError("No closing quotation")
-                fragments.append(shell_command[start:index])
-                continue
-
-            if char == "\\" and index + 1 < length:
-                unquoted.append(shell_command[index : index + 2])
-                index += 2
-                continue
-
-            unquoted.append(char)
-            index += 1
-
-        if unquoted:
-            fragments.append("".join(unquoted))
-
-        raw_token = "".join(fragments)
-        normalized = shlex.split(raw_token)
-        if len(normalized) != 1:
-            raise ValueError("Unable to normalize shell token")
-        tokens.append(normalized[0])
-        grouped_fragments.append(fragments or [raw_token])
-
-    return tokens, grouped_fragments
-
-
-def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | None, str | None]:
-    if not tokens:
-        return None, None
-
-    runner = Path(tokens[0]).name
-    if _PYTHON_RUNNER_RE.fullmatch(runner):
-        return _extract_python_script_path(tokens), None
-
-    if runner in {"bash", "sh"}:
-        return _extract_shell_script_path(tokens), None
-
-    if runner == "uv" and len(tokens) > 2 and tokens[1] == "run":
-        inner_tokens, effective_cwd = _split_uv_run_command(tokens)
-        script_path, nested_cwd = _extract_watch_script_probe_from_tokens(inner_tokens)
-        return script_path, nested_cwd or effective_cwd
-
-    if _looks_like_script_path(tokens[0]):
-        return tokens[0], None
-
-    return None, None
-
-
-def _raw_shell_fragment_quote_mode(fragment: str) -> str | None:
-    if len(fragment) >= 2 and fragment[0] == fragment[-1] == "'":
-        return "'"
-    if len(fragment) >= 2 and fragment[0] == fragment[-1] == '"':
-        return '"'
-    return None
-
-
-_ESCAPED_SHELL_DOLLAR = "\0VIBE_WATCH_ESCAPED_DOLLAR\0"
-_ESCAPED_SHELL_TILDE = "\0VIBE_WATCH_ESCAPED_TILDE\0"
-
-
-def _expand_shell_fragment(fragment: str, *, first_fragment: bool) -> tuple[str, bool]:
-    quote_mode = _raw_shell_fragment_quote_mode(fragment)
-    if quote_mode == "'":
-        return glob.escape(fragment[1:-1]), False
-
-    if quote_mode == '"':
-        content = fragment[1:-1]
-        parts: list[str] = []
-        index = 0
-        while index < len(content):
-            char = content[index]
-            if char == "\\" and index + 1 < len(content):
-                next_char = content[index + 1]
-                if next_char == "$":
-                    parts.append(_ESCAPED_SHELL_DOLLAR)
-                    index += 2
-                    continue
-                if next_char in {'"', "\\"}:
-                    parts.append(next_char)
-                    index += 2
-                    continue
-            parts.append(char)
-            index += 1
-        text = "".join(parts)
-        text = os.path.expandvars(text)
-        text = text.replace(_ESCAPED_SHELL_DOLLAR, "$")
-        return glob.escape(text), False
-
-    parts = []
-    allow_glob = False
-    index = 0
-    while index < len(fragment):
-        char = fragment[index]
-        if char == "\\" and index + 1 < len(fragment):
-            next_char = fragment[index + 1]
-            if next_char == "$":
-                parts.append(_ESCAPED_SHELL_DOLLAR)
-            elif first_fragment and not parts and next_char == "~":
-                parts.append(_ESCAPED_SHELL_TILDE)
-            elif next_char in "*?[":
-                parts.append(glob.escape(next_char))
-            else:
-                parts.append(next_char)
-            index += 2
-            continue
-        if char in "*?[":
-            allow_glob = True
-        parts.append(char)
-        index += 1
-
-    text = "".join(parts)
-    if first_fragment and text.startswith("~"):
-        text = os.path.expanduser(text)
-    text = os.path.expandvars(text)
-    text = text.replace(_ESCAPED_SHELL_DOLLAR, "$")
-    text = text.replace(_ESCAPED_SHELL_TILDE, "~")
-    return text, allow_glob
-
-
-def _expand_shell_fragments(fragments: list[str]) -> tuple[str, bool]:
-    expanded_parts: list[str] = []
-    allow_glob = False
-    for index, fragment in enumerate(fragments):
-        text, fragment_allows_glob = _expand_shell_fragment(
-            fragment,
-            first_fragment=index == 0,
-        )
-        expanded_parts.append(text)
-        allow_glob = allow_glob or fragment_allows_glob
-
-    return "".join(expanded_parts), allow_glob
-
-
 def _resolve_watch_preflight_base_dir(
     cwd: str | None,
     probe_cwd: str | None,
-    *,
-    shell_expansion: bool,
-    shell_fragments: list[str] | None = None,
 ) -> Path:
     base_dir = Path(cwd).resolve() if cwd else Path.cwd().resolve()
     if not probe_cwd:
         return base_dir
 
-    probe_value = probe_cwd
-    if shell_expansion and shell_fragments is not None:
-        probe_value, _ = _expand_shell_fragments(shell_fragments)
-
-    probe_base = Path(probe_value)
+    probe_base = Path(probe_cwd)
     if not probe_base.is_absolute():
         probe_base = (base_dir / probe_base).resolve()
     return probe_base
 
 
-def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path, shell_fragments: list[str] | None) -> list[Path]:
-    expanded, allow_glob = _expand_shell_fragments(shell_fragments or [script_path])
-    pattern_path = Path(expanded)
-    if not pattern_path.is_absolute():
-        pattern_path = base_dir / pattern_path
-
-    if not allow_glob:
-        return [pattern_path.resolve()]
-
-    matches = [Path(match).resolve() for match in sorted(glob.glob(str(pattern_path)))]
-    if matches:
-        return matches
-    return [pattern_path.resolve()]
-
-
 def _resolve_watch_script_probe(
     command: list[str],
-    shell_command: str | None,
-) -> tuple[str | None, str | None, list[str] | None, list[str] | None]:
-    if shell_command:
-        try:
-            tokens, grouped_fragments = _tokenize_shell_command(shell_command)
-            script_path, probe_cwd = _extract_watch_script_probe_from_tokens(tokens)
-            script_fragments = None
-            probe_cwd_fragments = None
-            if script_path is not None:
-                script_index = tokens.index(script_path)
-                script_fragments = grouped_fragments[script_index]
-            if probe_cwd is not None:
-                probe_cwd_index = tokens.index(probe_cwd)
-                probe_cwd_fragments = grouped_fragments[probe_cwd_index]
-            return script_path, probe_cwd, script_fragments, probe_cwd_fragments
-        except ValueError:
-            return None, None, None, None
-    script_path, probe_cwd = _extract_watch_script_probe_from_tokens(command)
-    return script_path, probe_cwd, None, None
+) -> tuple[str | None, str | None]:
+    return _extract_watch_script_probe_from_tokens(command)
 
 
 def _validate_watch_script_preflight(
@@ -1221,33 +995,23 @@ def _validate_watch_script_preflight(
     cwd: str | None,
     help_command: str,
 ) -> None:
-    script_path, probe_cwd, script_fragments, probe_cwd_fragments = _resolve_watch_script_probe(command, shell_command)
+    if shell_command:
+        return
+
+    script_path, probe_cwd = _resolve_watch_script_probe(command)
     if not script_path:
         return
 
     base_dir = _resolve_watch_preflight_base_dir(
         cwd,
         probe_cwd,
-        shell_expansion=bool(shell_command),
-        shell_fragments=probe_cwd_fragments,
     )
     checked_from = None if Path(script_path).is_absolute() else str(base_dir)
-
-    if shell_command:
-        candidates = _resolve_shell_script_candidates(
-            script_path,
-            base_dir=base_dir,
-            shell_fragments=script_fragments,
-        )
-        candidate = candidates[0]
-        if candidate.is_file():
-            return
-    else:
-        candidate = Path(script_path)
-        if not candidate.is_absolute():
-            candidate = (base_dir / candidate).resolve()
-        if candidate.is_file():
-            return
+    candidate = Path(script_path)
+    if not candidate.is_absolute():
+        candidate = (base_dir / candidate).resolve()
+    if candidate.is_file():
+        return
 
     hint = "Fix the script path or use an absolute path."
     if checked_from is not None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -948,31 +948,104 @@ def _extract_shell_script_path(tokens: list[str]) -> str | None:
     return None
 
 
+_SHELL_CONTROL_CHARS = ";|&()<>"
+
+
+def _shell_control_operator_at(command: str, index: int) -> str | None:
+    char = command[index]
+    if char not in _SHELL_CONTROL_CHARS:
+        return None
+
+    if index + 1 < len(command):
+        pair = command[index : index + 2]
+        if pair in {"&&", "||", "<<", ">>", "|&", "<>", ";&"}:
+            return pair
+    return char
+
+
 def _tokenize_shell_command(shell_command: str) -> tuple[list[str], list[list[str]]]:
-    raw_lexer = shlex.shlex(shell_command, posix=False)
-    raw_lexer.whitespace_split = True
-    raw_lexer.commenters = ""
-    raw_fragments = list(raw_lexer)
-    normalized_tokens = shlex.split(shell_command)
-
+    tokens: list[str] = []
     grouped_fragments: list[list[str]] = []
-    raw_index = 0
-    for token in normalized_tokens:
-        parts: list[str] = []
-        combined = ""
-        while raw_index < len(raw_fragments) and combined != token:
-            fragment = raw_fragments[raw_index]
-            raw_index += 1
-            parts.append(fragment)
-            combined += "".join(shlex.split(fragment))
-            if combined == token:
-                break
-        if combined != token:
-            grouped_fragments.append([token])
-            continue
-        grouped_fragments.append(parts)
+    length = len(shell_command)
+    index = 0
 
-    return normalized_tokens, grouped_fragments
+    while index < length:
+        while index < length and shell_command[index].isspace():
+            index += 1
+        if index >= length:
+            break
+
+        operator = _shell_control_operator_at(shell_command, index)
+        if operator is not None:
+            tokens.append(operator)
+            grouped_fragments.append([operator])
+            index += len(operator)
+            continue
+
+        fragments: list[str] = []
+        unquoted: list[str] = []
+        while index < length:
+            operator = _shell_control_operator_at(shell_command, index)
+            if operator is not None:
+                break
+
+            char = shell_command[index]
+            if char.isspace():
+                break
+
+            if char == "'":
+                if unquoted:
+                    fragments.append("".join(unquoted))
+                    unquoted = []
+                start = index
+                index += 1
+                while index < length and shell_command[index] != "'":
+                    index += 1
+                if index >= length:
+                    raise ValueError("No closing quotation")
+                index += 1
+                fragments.append(shell_command[start:index])
+                continue
+
+            if char == '"':
+                if unquoted:
+                    fragments.append("".join(unquoted))
+                    unquoted = []
+                start = index
+                index += 1
+                while index < length:
+                    inner = shell_command[index]
+                    if inner == "\\" and index + 1 < length:
+                        index += 2
+                        continue
+                    if inner == '"':
+                        index += 1
+                        break
+                    index += 1
+                else:
+                    raise ValueError("No closing quotation")
+                fragments.append(shell_command[start:index])
+                continue
+
+            if char == "\\" and index + 1 < length:
+                unquoted.append(shell_command[index : index + 2])
+                index += 2
+                continue
+
+            unquoted.append(char)
+            index += 1
+
+        if unquoted:
+            fragments.append("".join(unquoted))
+
+        raw_token = "".join(fragments)
+        normalized = shlex.split(raw_token)
+        if len(normalized) != 1:
+            raise ValueError("Unable to normalize shell token")
+        tokens.append(normalized[0])
+        grouped_fragments.append(fragments or [raw_token])
+
+    return tokens, grouped_fragments
 
 
 def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | None, str | None]:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import json
 import logging
 import math
@@ -821,6 +822,7 @@ UV_RUN_OPTIONS_WITH_VALUES = {
     "--fork-strategy",
     "--exclude-newer",
     "--exclude-newer-package",
+    "--refresh-package",
     "--reinstall-package",
     "--link-mode",
     "--config-setting",
@@ -947,6 +949,29 @@ def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | No
     return None, None
 
 
+def _resolve_watch_preflight_base_dir(cwd: str | None, probe_cwd: str | None) -> Path:
+    base_dir = Path(cwd).resolve() if cwd else Path.cwd().resolve()
+    if not probe_cwd:
+        return base_dir
+
+    probe_base = Path(os.path.expandvars(os.path.expanduser(probe_cwd)))
+    if not probe_base.is_absolute():
+        probe_base = (base_dir / probe_base).resolve()
+    return probe_base
+
+
+def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path) -> list[Path]:
+    expanded = os.path.expandvars(os.path.expanduser(script_path))
+    pattern_path = Path(expanded)
+    if not pattern_path.is_absolute():
+        pattern_path = base_dir / pattern_path
+
+    matches = [Path(match).resolve() for match in glob.glob(str(pattern_path))]
+    if matches:
+        return matches
+    return [pattern_path.resolve()]
+
+
 def _resolve_watch_script_probe(command: list[str], shell_command: str | None) -> tuple[str | None, str | None]:
     if shell_command:
         try:
@@ -967,20 +992,20 @@ def _validate_watch_script_preflight(
     if not script_path:
         return
 
-    candidate = Path(script_path).expanduser()
-    checked_from = None
-    if not candidate.is_absolute():
-        base_dir = Path(cwd).resolve() if cwd else Path.cwd().resolve()
-        if probe_cwd:
-            probe_base = Path(probe_cwd).expanduser()
-            if not probe_base.is_absolute():
-                probe_base = (base_dir / probe_base).resolve()
-            base_dir = probe_base
-        checked_from = str(base_dir)
-        candidate = (Path(checked_from) / candidate).resolve()
+    base_dir = _resolve_watch_preflight_base_dir(cwd, probe_cwd)
+    checked_from = None if Path(script_path).expanduser().is_absolute() else str(base_dir)
 
-    if candidate.is_file():
-        return
+    if shell_command:
+        candidates = _resolve_shell_script_candidates(script_path, base_dir=base_dir)
+        if any(candidate.is_file() for candidate in candidates):
+            return
+        candidate = candidates[0]
+    else:
+        candidate = Path(script_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = (base_dir / candidate).resolve()
+        if candidate.is_file():
+            return
 
     hint = "Fix the script path or use an absolute path."
     if checked_from is not None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -847,6 +847,8 @@ UV_RUN_SHORT_OPTIONS_WITH_VALUES = {"-w", "-i", "-f", "-P", "-C", "-p"}
 
 PYTHON_OPTIONS_WITH_VALUES = {"-W", "-X"}
 PYTHON_OPTIONS_WITHOUT_SCRIPT = {"-c", "-m"}
+SHELL_LONG_OPTIONS_WITH_VALUES = {"--init-file", "--rcfile"}
+SHELL_SHORT_OPTIONS_WITH_VALUES = {"-o", "-O"}
 
 
 def _split_uv_run_command(tokens: list[str]) -> tuple[list[str], str | None]:
@@ -919,7 +921,15 @@ def _extract_shell_script_path(tokens: list[str]) -> str | None:
         if token == "--":
             index += 1
             break
-        if token == "-c" or (token.startswith("-") and "c" in token[1:]):
+        if token == "-c":
+            return None
+        if token in SHELL_LONG_OPTIONS_WITH_VALUES or token in SHELL_SHORT_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if any(token.startswith(f"{option}=") for option in SHELL_LONG_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
+        if token.startswith("-") and not token.startswith("--") and "c" in token[1:]:
             return None
         if token.startswith("-"):
             index += 1

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1005,26 +1005,79 @@ def _raw_shell_fragment_quote_mode(fragment: str) -> str | None:
     return None
 
 
+_ESCAPED_SHELL_DOLLAR = "\0VIBE_WATCH_ESCAPED_DOLLAR\0"
+_ESCAPED_SHELL_TILDE = "\0VIBE_WATCH_ESCAPED_TILDE\0"
+
+
+def _expand_shell_fragment(fragment: str, *, first_fragment: bool) -> tuple[str, bool]:
+    quote_mode = _raw_shell_fragment_quote_mode(fragment)
+    if quote_mode == "'":
+        return glob.escape(fragment[1:-1]), False
+
+    if quote_mode == '"':
+        content = fragment[1:-1]
+        parts: list[str] = []
+        index = 0
+        while index < len(content):
+            char = content[index]
+            if char == "\\" and index + 1 < len(content):
+                next_char = content[index + 1]
+                if next_char == "$":
+                    parts.append(_ESCAPED_SHELL_DOLLAR)
+                    index += 2
+                    continue
+                if next_char in {'"', "\\"}:
+                    parts.append(next_char)
+                    index += 2
+                    continue
+            parts.append(char)
+            index += 1
+        text = "".join(parts)
+        text = os.path.expandvars(text)
+        text = text.replace(_ESCAPED_SHELL_DOLLAR, "$")
+        return glob.escape(text), False
+
+    parts = []
+    allow_glob = False
+    index = 0
+    while index < len(fragment):
+        char = fragment[index]
+        if char == "\\" and index + 1 < len(fragment):
+            next_char = fragment[index + 1]
+            if next_char == "$":
+                parts.append(_ESCAPED_SHELL_DOLLAR)
+            elif first_fragment and not parts and next_char == "~":
+                parts.append(_ESCAPED_SHELL_TILDE)
+            elif next_char in "*?[":
+                parts.append(glob.escape(next_char))
+            else:
+                parts.append(next_char)
+            index += 2
+            continue
+        if char in "*?[":
+            allow_glob = True
+        parts.append(char)
+        index += 1
+
+    text = "".join(parts)
+    if first_fragment and text.startswith("~"):
+        text = os.path.expanduser(text)
+    text = os.path.expandvars(text)
+    text = text.replace(_ESCAPED_SHELL_DOLLAR, "$")
+    text = text.replace(_ESCAPED_SHELL_TILDE, "~")
+    return text, allow_glob
+
+
 def _expand_shell_fragments(fragments: list[str]) -> tuple[str, bool]:
     expanded_parts: list[str] = []
     allow_glob = False
     for index, fragment in enumerate(fragments):
-        quote_mode = _raw_shell_fragment_quote_mode(fragment)
-        text = "".join(shlex.split(fragment))
-
-        if quote_mode == "'":
-            expanded_parts.append(glob.escape(text))
-            continue
-
-        if quote_mode == '"':
-            expanded_parts.append(glob.escape(os.path.expandvars(text)))
-            continue
-
-        if index == 0:
-            text = os.path.expanduser(text)
-        text = os.path.expandvars(text)
+        text, fragment_allows_glob = _expand_shell_fragment(
+            fragment,
+            first_fragment=index == 0,
+        )
         expanded_parts.append(text)
-        allow_glob = True
+        allow_glob = allow_glob or fragment_allows_glob
 
     return "".join(expanded_parts), allow_glob
 
@@ -1059,7 +1112,7 @@ def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path, shell_
     if not allow_glob:
         return [pattern_path.resolve()]
 
-    matches = [Path(match).resolve() for match in glob.glob(str(pattern_path))]
+    matches = [Path(match).resolve() for match in sorted(glob.glob(str(pattern_path)))]
     if matches:
         return matches
     return [pattern_path.resolve()]
@@ -1113,9 +1166,9 @@ def _validate_watch_script_preflight(
             base_dir=base_dir,
             shell_fragments=script_fragments,
         )
-        if any(candidate.is_file() for candidate in candidates):
-            return
         candidate = candidates[0]
+        if candidate.is_file():
+            return
     else:
         candidate = Path(script_path)
         if not candidate.is_absolute():

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import re
 import shlex
 import shutil
 import signal
@@ -797,6 +798,9 @@ def _looks_like_script_path(token: str) -> bool:
     return path.is_absolute() or path.suffix in {".py", ".sh", ".bash", ".zsh"} or "/" in token or "\\" in token
 
 
+_PYTHON_RUNNER_RE = re.compile(r"^python(?:\d+(?:\.\d+)*)?$")
+
+
 UV_RUN_OPTIONS_WITH_VALUES = {
     "--extra",
     "--no-extra",
@@ -932,7 +936,7 @@ def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | No
         return None, None
 
     runner = Path(tokens[0]).name
-    if runner in {"python", "python3"}:
+    if _PYTHON_RUNNER_RE.fullmatch(runner):
         return _extract_python_script_path(tokens), None
 
     if runner in {"bash", "sh"}:
@@ -993,7 +997,7 @@ def _validate_watch_script_preflight(
         return
 
     base_dir = _resolve_watch_preflight_base_dir(cwd, probe_cwd)
-    checked_from = None if Path(script_path).expanduser().is_absolute() else str(base_dir)
+    checked_from = None if Path(script_path).is_absolute() else str(base_dir)
 
     if shell_command:
         candidates = _resolve_shell_script_candidates(script_path, base_dir=base_dir)
@@ -1001,7 +1005,7 @@ def _validate_watch_script_preflight(
             return
         candidate = candidates[0]
     else:
-        candidate = Path(script_path).expanduser()
+        candidate = Path(script_path)
         if not candidate.is_absolute():
             candidate = (base_dir / candidate).resolve()
         if candidate.is_file():

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -948,6 +948,33 @@ def _extract_shell_script_path(tokens: list[str]) -> str | None:
     return None
 
 
+def _tokenize_shell_command(shell_command: str) -> tuple[list[str], list[list[str]]]:
+    raw_lexer = shlex.shlex(shell_command, posix=False)
+    raw_lexer.whitespace_split = True
+    raw_lexer.commenters = ""
+    raw_fragments = list(raw_lexer)
+    normalized_tokens = shlex.split(shell_command)
+
+    grouped_fragments: list[list[str]] = []
+    raw_index = 0
+    for token in normalized_tokens:
+        parts: list[str] = []
+        combined = ""
+        while raw_index < len(raw_fragments) and combined != token:
+            fragment = raw_fragments[raw_index]
+            raw_index += 1
+            parts.append(fragment)
+            combined += "".join(shlex.split(fragment))
+            if combined == token:
+                break
+        if combined != token:
+            grouped_fragments.append([token])
+            continue
+        grouped_fragments.append(parts)
+
+    return normalized_tokens, grouped_fragments
+
+
 def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | None, str | None]:
     if not tokens:
         return None, None
@@ -970,20 +997,36 @@ def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | No
     return None, None
 
 
-def _detect_shell_quote_mode(shell_command: str, token: str) -> str | None:
-    if f"'{token}'" in shell_command:
+def _raw_shell_fragment_quote_mode(fragment: str) -> str | None:
+    if len(fragment) >= 2 and fragment[0] == fragment[-1] == "'":
         return "'"
-    if f'"{token}"' in shell_command:
+    if len(fragment) >= 2 and fragment[0] == fragment[-1] == '"':
         return '"'
     return None
 
 
-def _expand_shell_token(token: str, *, quote_mode: str | None) -> str:
-    if quote_mode == "'":
-        return token
-    if quote_mode == '"':
-        return os.path.expandvars(token)
-    return os.path.expandvars(os.path.expanduser(token))
+def _expand_shell_fragments(fragments: list[str]) -> tuple[str, bool]:
+    expanded_parts: list[str] = []
+    allow_glob = False
+    for index, fragment in enumerate(fragments):
+        quote_mode = _raw_shell_fragment_quote_mode(fragment)
+        text = "".join(shlex.split(fragment))
+
+        if quote_mode == "'":
+            expanded_parts.append(glob.escape(text))
+            continue
+
+        if quote_mode == '"':
+            expanded_parts.append(glob.escape(os.path.expandvars(text)))
+            continue
+
+        if index == 0:
+            text = os.path.expanduser(text)
+        text = os.path.expandvars(text)
+        expanded_parts.append(text)
+        allow_glob = True
+
+    return "".join(expanded_parts), allow_glob
 
 
 def _resolve_watch_preflight_base_dir(
@@ -991,18 +1034,15 @@ def _resolve_watch_preflight_base_dir(
     probe_cwd: str | None,
     *,
     shell_expansion: bool,
-    shell_command: str | None = None,
+    shell_fragments: list[str] | None = None,
 ) -> Path:
     base_dir = Path(cwd).resolve() if cwd else Path.cwd().resolve()
     if not probe_cwd:
         return base_dir
 
     probe_value = probe_cwd
-    if shell_expansion:
-        probe_value = _expand_shell_token(
-            probe_value,
-            quote_mode=_detect_shell_quote_mode(shell_command or "", probe_cwd),
-        )
+    if shell_expansion and shell_fragments is not None:
+        probe_value, _ = _expand_shell_fragments(shell_fragments)
 
     probe_base = Path(probe_value)
     if not probe_base.is_absolute():
@@ -1010,13 +1050,13 @@ def _resolve_watch_preflight_base_dir(
     return probe_base
 
 
-def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path, quote_mode: str | None) -> list[Path]:
-    expanded = _expand_shell_token(script_path, quote_mode=quote_mode)
+def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path, shell_fragments: list[str] | None) -> list[Path]:
+    expanded, allow_glob = _expand_shell_fragments(shell_fragments or [script_path])
     pattern_path = Path(expanded)
     if not pattern_path.is_absolute():
         pattern_path = base_dir / pattern_path
 
-    if quote_mode is not None:
+    if not allow_glob:
         return [pattern_path.resolve()]
 
     matches = [Path(match).resolve() for match in glob.glob(str(pattern_path))]
@@ -1025,13 +1065,27 @@ def _resolve_shell_script_candidates(script_path: str, *, base_dir: Path, quote_
     return [pattern_path.resolve()]
 
 
-def _resolve_watch_script_probe(command: list[str], shell_command: str | None) -> tuple[str | None, str | None]:
+def _resolve_watch_script_probe(
+    command: list[str],
+    shell_command: str | None,
+) -> tuple[str | None, str | None, list[str] | None, list[str] | None]:
     if shell_command:
         try:
-            return _extract_watch_script_probe_from_tokens(shlex.split(shell_command))
+            tokens, grouped_fragments = _tokenize_shell_command(shell_command)
+            script_path, probe_cwd = _extract_watch_script_probe_from_tokens(tokens)
+            script_fragments = None
+            probe_cwd_fragments = None
+            if script_path is not None:
+                script_index = tokens.index(script_path)
+                script_fragments = grouped_fragments[script_index]
+            if probe_cwd is not None:
+                probe_cwd_index = tokens.index(probe_cwd)
+                probe_cwd_fragments = grouped_fragments[probe_cwd_index]
+            return script_path, probe_cwd, script_fragments, probe_cwd_fragments
         except ValueError:
-            return None, None
-    return _extract_watch_script_probe_from_tokens(command)
+            return None, None, None, None
+    script_path, probe_cwd = _extract_watch_script_probe_from_tokens(command)
+    return script_path, probe_cwd, None, None
 
 
 def _validate_watch_script_preflight(
@@ -1041,7 +1095,7 @@ def _validate_watch_script_preflight(
     cwd: str | None,
     help_command: str,
 ) -> None:
-    script_path, probe_cwd = _resolve_watch_script_probe(command, shell_command)
+    script_path, probe_cwd, script_fragments, probe_cwd_fragments = _resolve_watch_script_probe(command, shell_command)
     if not script_path:
         return
 
@@ -1049,7 +1103,7 @@ def _validate_watch_script_preflight(
         cwd,
         probe_cwd,
         shell_expansion=bool(shell_command),
-        shell_command=shell_command,
+        shell_fragments=probe_cwd_fragments,
     )
     checked_from = None if Path(script_path).is_absolute() else str(base_dir)
 
@@ -1057,7 +1111,7 @@ def _validate_watch_script_preflight(
         candidates = _resolve_shell_script_candidates(
             script_path,
             base_dir=base_dir,
-            quote_mode=_detect_shell_quote_mode(shell_command, script_path),
+            shell_fragments=script_fragments,
         )
         if any(candidate.is_file() for candidate in candidates):
             return

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -794,7 +794,7 @@ def _looks_like_script_path(token: str) -> bool:
     if not token or token == "--" or token.startswith("-"):
         return False
     path = Path(token)
-    return path.is_absolute() or path.suffix in {".py", ".sh", ".bash", ".zsh"} or "/" in token or "\\" in token
+    return path.is_absolute() or "/" in token or "\\" in token
 
 
 _PYTHON_RUNNER_RE = re.compile(r"^python(?:\d+(?:\.\d+)*)?$")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -839,6 +839,9 @@ UV_RUN_OPTIONS_WITH_VALUES = {
 
 UV_RUN_SHORT_OPTIONS_WITH_VALUES = {"-w", "-i", "-f", "-P", "-C", "-p"}
 
+PYTHON_OPTIONS_WITH_VALUES = {"-W", "-X"}
+PYTHON_OPTIONS_WITHOUT_SCRIPT = {"-c", "-m"}
+
 
 def _split_uv_run_command(tokens: list[str]) -> tuple[list[str], str | None]:
     effective_cwd: str | None = None
@@ -875,15 +878,63 @@ def _split_uv_run_command(tokens: list[str]) -> tuple[list[str], str | None]:
     return [], effective_cwd
 
 
+def _extract_python_script_path(tokens: list[str]) -> str | None:
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in PYTHON_OPTIONS_WITHOUT_SCRIPT:
+            return None
+        if token in PYTHON_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if any(token.startswith(f"{option}=") for option in PYTHON_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
+        if any(token.startswith(option) and token != option for option in PYTHON_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+
+    if index < len(tokens) and _looks_like_script_path(tokens[index]):
+        return tokens[index]
+    return None
+
+
+def _extract_shell_script_path(tokens: list[str]) -> str | None:
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token == "-c" or (token.startswith("-") and "c" in token[1:]):
+            return None
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+
+    if index < len(tokens) and _looks_like_script_path(tokens[index]):
+        return tokens[index]
+    return None
+
+
 def _extract_watch_script_probe_from_tokens(tokens: list[str]) -> tuple[str | None, str | None]:
     if not tokens:
         return None, None
 
     runner = Path(tokens[0]).name
-    if runner in {"python", "python3", "bash", "sh"}:
-        if len(tokens) > 1 and _looks_like_script_path(tokens[1]):
-            return tokens[1], None
-        return None, None
+    if runner in {"python", "python3"}:
+        return _extract_python_script_path(tokens), None
+
+    if runner in {"bash", "sh"}:
+        return _extract_shell_script_path(tokens), None
 
     if runner == "uv" and len(tokens) > 2 and tokens[1] == "run":
         inner_tokens, effective_cwd = _split_uv_run_command(tokens)


### PR DESCRIPTION
## Summary
- add creation-time preflight checks for common watch script commands before persisting the watch
- reject missing `python` / `bash` / `uv run` script paths with a structured CLI error
- update watch help text and the background-watch-hook skill examples to use correct bundled waiter paths and safer invocation patterns

## Testing
- `ruff check vibe/cli.py tests/test_cli_watch_command.py`
- `/Users/cyh/vibe-remote/.venv/bin/python -m pytest tests/test_cli_watch_command.py`

## Notes
- relative script paths are still allowed
- preflight resolves relative scripts from `--cwd` when provided, otherwise from the current CLI working directory at creation time
