### PR TITLE
fix(agents): evict idle claude and codex runtimes

### DIFF
--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -11,6 +11,7 @@ class ClaudeCompatConfig:
     system_prompt: Optional[str] = None
     default_model: Optional[str] = None
     cli_path: Optional[str] = None
+    idle_timeout_seconds: int = 600
 
     def __post_init__(self) -> None:
         self.permission_mode = str(self.permission_mode)
@@ -24,6 +25,7 @@ class CodexCompatConfig:
     binary: str
     extra_args: list[str]
     default_model: Optional[str] = None
+    idle_timeout_seconds: int = 600
 
 
 @dataclass
@@ -68,6 +70,7 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
         system_prompt=None,
         default_model=v2.agents.claude.default_model,
         cli_path=v2.agents.claude.cli_path,
+        idle_timeout_seconds=v2.agents.claude.idle_timeout_seconds,
     )
     codex = None
     if v2.agents.codex.enabled:
@@ -75,6 +78,7 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
             binary=v2.agents.codex.cli_path,
             extra_args=[],
             default_model=v2.agents.codex.default_model,
+            idle_timeout_seconds=v2.agents.codex.idle_timeout_seconds,
         )
     opencode = None
     if v2.agents.opencode.enabled:

--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -1,7 +1,17 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
-from config.v2_config import V2Config, SlackConfig, DiscordConfig, TelegramConfig, LarkConfig, WeChatConfig
+from config.v2_config import (
+    DEFAULT_AGENT_BACKEND,
+    DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS,
+    DEFAULT_OPENCODE_ERROR_RETRY_LIMIT,
+    V2Config,
+    SlackConfig,
+    DiscordConfig,
+    TelegramConfig,
+    LarkConfig,
+    WeChatConfig,
+)
 
 
 @dataclass
@@ -11,7 +21,7 @@ class ClaudeCompatConfig:
     system_prompt: Optional[str] = None
     default_model: Optional[str] = None
     cli_path: Optional[str] = None
-    idle_timeout_seconds: int = 600
+    idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
 
     def __post_init__(self) -> None:
         self.permission_mode = str(self.permission_mode)
@@ -25,7 +35,7 @@ class CodexCompatConfig:
     binary: str
     extra_args: list[str]
     default_model: Optional[str] = None
-    idle_timeout_seconds: int = 600
+    idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
 
 
 @dataclass
@@ -33,7 +43,7 @@ class OpenCodeCompatConfig:
     binary: str
     port: int
     request_timeout_seconds: int
-    error_retry_limit: int = 1  # Max retries on LLM stream errors (0 = no retry)
+    error_retry_limit: int = DEFAULT_OPENCODE_ERROR_RETRY_LIMIT  # Max retries on LLM stream errors (0 = no retry)
 
 
 @dataclass
@@ -54,7 +64,7 @@ class AppCompatConfig:
     show_duration: bool = False
     include_user_info: bool = True
     reply_enhancements: bool = True
-    default_backend: str = "opencode"
+    default_backend: str = DEFAULT_AGENT_BACKEND
 
     def enabled_platforms(self) -> list[str]:
         enabled = self.platforms.get("enabled") if isinstance(self.platforms, dict) else None

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -133,6 +133,7 @@ class ClaudeConfig:
     enabled: bool = True
     cli_path: str = "claude"
     default_model: Optional[str] = None
+    idle_timeout_seconds: int = 600
 
 
 @dataclass
@@ -140,6 +141,7 @@ class CodexConfig:
     enabled: bool = True
     cli_path: str = "codex"
     default_model: Optional[str] = None
+    idle_timeout_seconds: int = 600
 
 
 @dataclass

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 CONFIG_LOCK = threading.RLock()
 
+DEFAULT_AGENT_BACKEND = "opencode"
+DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 600
+DEFAULT_OPENCODE_ERROR_RETRY_LIMIT = 1
+
 
 def _filter_dataclass_fields(dc_class, payload: dict) -> dict:
     """Filter payload to only include fields defined in dataclass."""
@@ -125,7 +129,7 @@ class OpenCodeConfig:
     default_agent: Optional[str] = None
     default_model: Optional[str] = None
     default_reasoning_effort: Optional[str] = None
-    error_retry_limit: int = 1  # Max retries on LLM stream errors (0 = no retry)
+    error_retry_limit: int = DEFAULT_OPENCODE_ERROR_RETRY_LIMIT  # Max retries on LLM stream errors (0 = no retry)
 
 
 @dataclass
@@ -133,7 +137,7 @@ class ClaudeConfig:
     enabled: bool = True
     cli_path: str = "claude"
     default_model: Optional[str] = None
-    idle_timeout_seconds: int = 600
+    idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
 
 
 @dataclass
@@ -141,12 +145,12 @@ class CodexConfig:
     enabled: bool = True
     cli_path: str = "codex"
     default_model: Optional[str] = None
-    idle_timeout_seconds: int = 600
+    idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
 
 
 @dataclass
 class AgentsConfig:
-    default_backend: str = "opencode"
+    default_backend: str = DEFAULT_AGENT_BACKEND
     opencode: OpenCodeConfig = field(default_factory=OpenCodeConfig)
     claude: ClaudeConfig = field(default_factory=ClaudeConfig)
     codex: CodexConfig = field(default_factory=CodexConfig)
@@ -349,7 +353,7 @@ class V2Config:
         claude = ClaudeConfig(**_filter_dataclass_fields(ClaudeConfig, claude_payload))
         codex = CodexConfig(**_filter_dataclass_fields(CodexConfig, codex_payload))
 
-        default_backend = agents_payload.get("default_backend", "opencode")
+        default_backend = agents_payload.get("default_backend", DEFAULT_AGENT_BACKEND)
         if default_backend not in {"opencode", "claude", "codex"}:
             raise ValueError("Config 'agents.default_backend' must be 'opencode', 'claude', or 'codex'")
 

--- a/core/controller.py
+++ b/core/controller.py
@@ -401,8 +401,7 @@ class Controller:
         except Exception as e:
             logger.error("Failed to start watch service: %s", e, exc_info=True)
 
-        claude_timeout = int(max(0, getattr(self.config.claude, "idle_timeout_seconds", 600) or 0))
-        codex_timeout = int(max(0, getattr(getattr(self.config, "codex", None), "idle_timeout_seconds", 600) or 0))
+        claude_timeout, codex_timeout = self._get_idle_cleanup_timeouts()
         if (claude_timeout > 0 or codex_timeout > 0) and (
             self.cleanup_task is None or self.cleanup_task.done()
         ):
@@ -592,10 +591,17 @@ class Controller:
                 self._loop.close()
                 self._loop = None
 
+    def _get_idle_cleanup_timeouts(self) -> tuple[int, int]:
+        """Return normalized idle cleanup timeouts for Claude and Codex."""
+        claude_config = getattr(self.config, "claude", None)
+        codex_config = getattr(self.config, "codex", None)
+        claude_timeout = int(max(0, getattr(claude_config, "idle_timeout_seconds", 600) or 0))
+        codex_timeout = int(max(0, getattr(codex_config, "idle_timeout_seconds", 0) or 0))
+        return claude_timeout, codex_timeout
+
     async def periodic_cleanup(self):
         """Sweep idle backend runtime state without interrupting active work."""
-        claude_timeout = int(max(0, getattr(self.config.claude, "idle_timeout_seconds", 600) or 0))
-        codex_timeout = int(max(0, getattr(getattr(self.config, "codex", None), "idle_timeout_seconds", 600) or 0))
+        claude_timeout, codex_timeout = self._get_idle_cleanup_timeouts()
         enabled_timeouts = [timeout for timeout in (claude_timeout, codex_timeout) if timeout > 0]
         if not enabled_timeouts:
             logger.info("Idle cleanup disabled for Claude and Codex.")

--- a/core/controller.py
+++ b/core/controller.py
@@ -7,6 +7,7 @@ import logging
 import threading
 from typing import Optional, Dict, Any
 from config import paths
+from config.v2_config import DEFAULT_AGENT_BACKEND, DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
 from modules.im import BaseIMClient, MessageContext, IMFactory
 from modules.im.multi import MultiIMClient
 from modules.im.formatters import SlackFormatter, DiscordFormatter, TelegramFormatter
@@ -109,7 +110,7 @@ class Controller:
         self._migrate_language_from_settings()
 
         # Agent routing - use configured default_backend
-        default_backend = getattr(self.config, "default_backend", "opencode")
+        default_backend = getattr(self.config, "default_backend", DEFAULT_AGENT_BACKEND)
         self.agent_router = AgentRouter.from_file(None, platform=self.primary_platform, default_backend=default_backend)
         for platform in self.enabled_platforms:
             if platform not in self.agent_router.platform_routes:
@@ -595,8 +596,14 @@ class Controller:
         """Return normalized idle cleanup timeouts for Claude and Codex."""
         claude_config = getattr(self.config, "claude", None)
         codex_config = getattr(self.config, "codex", None)
-        claude_timeout = int(max(0, getattr(claude_config, "idle_timeout_seconds", 600) or 0))
-        codex_timeout = int(max(0, getattr(codex_config, "idle_timeout_seconds", 0) or 0))
+        claude_timeout = int(
+            max(0, getattr(claude_config, "idle_timeout_seconds", DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS) or 0)
+        )
+        codex_timeout = (
+            int(max(0, getattr(codex_config, "idle_timeout_seconds", DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS) or 0))
+            if codex_config is not None
+            else 0
+        )
         return claude_timeout, codex_timeout
 
     async def periodic_cleanup(self):

--- a/core/controller.py
+++ b/core/controller.py
@@ -48,6 +48,8 @@ class Controller:
         self.claude_sessions: Dict[str, Any] = {}
         self.receiver_tasks: Dict[str, asyncio.Task] = {}
         self.stored_session_mappings: Dict[str, str] = {}
+        self.session_last_activity: Dict[str, float] = {}
+        self.claude_active_sessions: set[str] = set()
 
         # Initialize core modules
         self._init_modules()
@@ -399,6 +401,13 @@ class Controller:
         except Exception as e:
             logger.error("Failed to start watch service: %s", e, exc_info=True)
 
+        claude_timeout = int(max(0, getattr(self.config.claude, "idle_timeout_seconds", 600) or 0))
+        codex_timeout = int(max(0, getattr(getattr(self.config, "codex", None), "idle_timeout_seconds", 600) or 0))
+        if (claude_timeout > 0 or codex_timeout > 0) and (
+            self.cleanup_task is None or self.cleanup_task.done()
+        ):
+            self.cleanup_task = asyncio.create_task(self.periodic_cleanup())
+
     # Utility methods used by handlers
 
     def get_cwd(self, context: MessageContext) -> str:
@@ -584,9 +593,42 @@ class Controller:
                 self._loop = None
 
     async def periodic_cleanup(self):
-        """[Deprecated] Periodic cleanup is disabled in favor of safe on-demand cleanup"""
-        logger.info("periodic_cleanup is deprecated and not scheduled.")
-        return
+        """Sweep idle backend runtime state without interrupting active work."""
+        claude_timeout = int(max(0, getattr(self.config.claude, "idle_timeout_seconds", 600) or 0))
+        codex_timeout = int(max(0, getattr(getattr(self.config, "codex", None), "idle_timeout_seconds", 600) or 0))
+        enabled_timeouts = [timeout for timeout in (claude_timeout, codex_timeout) if timeout > 0]
+        if not enabled_timeouts:
+            logger.info("Idle cleanup disabled for Claude and Codex.")
+            return
+
+        sweep_interval = max(min(enabled_timeouts) // 6, 60)
+        logger.info(
+            "Starting idle cleanup loop (interval=%ss, claude_timeout=%ss, codex_timeout=%ss)",
+            sweep_interval,
+            claude_timeout,
+            codex_timeout,
+        )
+
+        try:
+            while True:
+                await asyncio.sleep(sweep_interval)
+
+                if claude_timeout > 0:
+                    try:
+                        await self.session_handler.evict_idle_sessions(claude_timeout)
+                    except Exception as e:
+                        logger.error("Claude idle cleanup failed: %s", e, exc_info=True)
+
+                if codex_timeout > 0:
+                    codex_agent = self.agent_service.agents.get("codex")
+                    if codex_agent and hasattr(codex_agent, "evict_idle_transports"):
+                        try:
+                            await codex_agent.evict_idle_transports(codex_timeout)
+                        except Exception as e:
+                            logger.error("Codex idle cleanup failed: %s", e, exc_info=True)
+        except asyncio.CancelledError:
+            logger.info("Idle cleanup loop stopped.")
+            raise
 
     def cleanup_sync(self):
         """Best-effort synchronous cleanup without cross-loop awaits"""
@@ -618,8 +660,25 @@ class Controller:
         except Exception as e:
             logger.debug(f"Update checker cleanup skipped: {e}")
 
+        async def _cancel_cleanup_task() -> None:
+            if self.cleanup_task and not self.cleanup_task.done():
+                self.cleanup_task.cancel()
+                try:
+                    await self.cleanup_task
+                except asyncio.CancelledError:
+                    pass
+            self.cleanup_task = None
+
+        _stop_loop_coroutine(_cancel_cleanup_task(), "Idle cleanup task")
         _stop_loop_coroutine(self.scheduled_task_service.stop(), "Scheduled task service")
         _stop_loop_coroutine(self.watch_service.stop(), "Watch service")
+
+        try:
+            codex_agent = self.agent_service.agents.get("codex")
+            if codex_agent and hasattr(codex_agent, "shutdown_runtime"):
+                _stop_loop_coroutine(codex_agent.shutdown_runtime(), "Codex runtime")
+        except Exception as e:
+            logger.debug(f"Codex runtime cleanup skipped: {e}")
 
         # Cancel receiver tasks without awaiting (they may belong to other loops)
         try:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -52,6 +52,11 @@ class SessionHandler(BaseHandler):
         self.active_sessions.discard(composite_key)
         self.session_last_activity.pop(composite_key, None)
 
+    def bind_claude_runtime_session(self, client: ClaudeSDKClient, base_session_id: str, composite_key: str) -> None:
+        """Attach the resolved Claude runtime keys to the connected client."""
+        setattr(client, "_vibe_runtime_base_session_id", base_session_id)
+        setattr(client, "_vibe_runtime_session_key", composite_key)
+
     def get_base_session_id(self, context: MessageContext, source: str = "human") -> str:
         """Get base session ID based on platform and context (without path)"""
         platform = self._get_context_platform(context)
@@ -381,6 +386,7 @@ class SessionHandler(BaseHandler):
             logger.info(
                 f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
             )
+            self.bind_claude_runtime_session(client, base_session_id, composite_key)
             self.touch_session_activity(composite_key)
             return client
 
@@ -409,6 +415,7 @@ class SessionHandler(BaseHandler):
                     working_path,
                     explicit_model,
                 )
+                self.bind_claude_runtime_session(client, cached_base, cached_key)
                 self.touch_session_activity(cached_key)
                 return client
             # Always use agent-specific key when effective_agent is set
@@ -561,6 +568,7 @@ class SessionHandler(BaseHandler):
         await client.connect()
 
         self.claude_sessions[composite_key] = client
+        self.bind_claude_runtime_session(client, base_session_id, composite_key)
         self.touch_session_activity(composite_key)
         logger.info(f"Created new Claude SDK client for {base_session_id} at {working_path}")
 

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1,5 +1,6 @@
 """Session management handlers for Claude SDK sessions"""
 
+import asyncio
 import logging
 import os
 import time
@@ -729,6 +730,8 @@ class SessionHandler(BaseHandler):
                 task.cancel()
                 try:
                     await task
+                except asyncio.CancelledError:
+                    pass
                 except Exception:
                     pass
             del self.receiver_tasks[composite_key]

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -767,11 +767,24 @@ class SessionHandler(BaseHandler):
             if now - last_activity >= idle_timeout:
                 expired.append((composite_key, now - last_activity))
 
+        evicted = 0
         for composite_key, idle_for in expired:
+            current_last_activity = self.session_last_activity.get(composite_key)
+            if composite_key not in self.claude_sessions:
+                self.session_last_activity.pop(composite_key, None)
+                self.active_sessions.discard(composite_key)
+                continue
+            if composite_key in self.active_sessions:
+                continue
+            if current_last_activity is None:
+                continue
+            if time.monotonic() - current_last_activity < idle_timeout:
+                continue
             logger.info("Evicting idle Claude session %s after %.1fs idle", composite_key, idle_for)
             await self.cleanup_session(composite_key)
+            evicted += 1
 
-        return len(expired)
+        return evicted
 
     async def handle_session_error(self, composite_key: str, context: MessageContext, error: Exception):
         """Handle session-related errors"""

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import time
 from typing import Optional, Dict, Any, Tuple
 from uuid import uuid4
 from modules.im import MessageContext
@@ -23,6 +24,33 @@ class SessionHandler(BaseHandler):
         self.claude_sessions = controller.claude_sessions
         self.receiver_tasks = controller.receiver_tasks
         self.stored_session_mappings = controller.stored_session_mappings
+        self.session_last_activity = getattr(controller, "session_last_activity", {})
+        self.active_sessions = getattr(controller, "claude_active_sessions", set())
+        controller.session_last_activity = self.session_last_activity
+        controller.claude_active_sessions = self.active_sessions
+
+    def touch_session_activity(self, composite_key: str) -> None:
+        if composite_key:
+            self.session_last_activity[composite_key] = time.monotonic()
+
+    def mark_session_active(self, composite_key: str) -> None:
+        if not composite_key:
+            return
+        self.active_sessions.add(composite_key)
+        self.touch_session_activity(composite_key)
+
+    def mark_session_idle(self, composite_key: str) -> None:
+        if not composite_key:
+            return
+        self.active_sessions.discard(composite_key)
+        if composite_key in self.claude_sessions:
+            self.touch_session_activity(composite_key)
+
+    def clear_session_tracking(self, composite_key: str) -> None:
+        if not composite_key:
+            return
+        self.active_sessions.discard(composite_key)
+        self.session_last_activity.pop(composite_key, None)
 
     def get_base_session_id(self, context: MessageContext, source: str = "human") -> str:
         """Get base session ID based on platform and context (without path)"""
@@ -353,6 +381,7 @@ class SessionHandler(BaseHandler):
             logger.info(
                 f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
             )
+            self.touch_session_activity(composite_key)
             return client
 
         if effective_agent:
@@ -380,6 +409,7 @@ class SessionHandler(BaseHandler):
                     working_path,
                     explicit_model,
                 )
+                self.touch_session_activity(cached_key)
                 return client
             # Always use agent-specific key when effective_agent is set
             # This ensures session continuity even on first use
@@ -531,6 +561,7 @@ class SessionHandler(BaseHandler):
         await client.connect()
 
         self.claude_sessions[composite_key] = client
+        self.touch_session_activity(composite_key)
         logger.info(f"Created new Claude SDK client for {base_session_id} at {working_path}")
 
         return client
@@ -704,6 +735,32 @@ class SessionHandler(BaseHandler):
                 logger.error(f"Error disconnecting Claude session {composite_key}: {e}")
             del self.claude_sessions[composite_key]
             logger.info(f"Cleaned up Claude session {composite_key}")
+
+        self.clear_session_tracking(composite_key)
+
+    async def evict_idle_sessions(self, idle_timeout: float) -> int:
+        """Disconnect Claude sessions that have been idle beyond the timeout."""
+        if idle_timeout <= 0:
+            return 0
+
+        now = time.monotonic()
+        expired: list[tuple[str, float]] = []
+
+        for composite_key, last_activity in list(self.session_last_activity.items()):
+            if composite_key not in self.claude_sessions:
+                self.session_last_activity.pop(composite_key, None)
+                self.active_sessions.discard(composite_key)
+                continue
+            if composite_key in self.active_sessions:
+                continue
+            if now - last_activity >= idle_timeout:
+                expired.append((composite_key, now - last_activity))
+
+        for composite_key, idle_for in expired:
+            logger.info("Evicting idle Claude session %s after %.1fs idle", composite_key, idle_for)
+            await self.cleanup_session(composite_key)
+
+        return len(expired)
 
     async def handle_session_error(self, composite_key: str, context: MessageContext, error: Exception):
         """Handle session-related errors"""

--- a/modules/agent_router.py
+++ b/modules/agent_router.py
@@ -4,12 +4,14 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
+from config.v2_config import DEFAULT_AGENT_BACKEND
+
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class PlatformRoute:
-    default: str = "opencode"
+    default: str = DEFAULT_AGENT_BACKEND
     overrides: Dict[str, str] = field(default_factory=dict)
 
 
@@ -19,14 +21,14 @@ class AgentRouter:
     def __init__(
         self,
         platform_routes: Dict[str, PlatformRoute],
-        global_default: str = "opencode",
+        global_default: str = DEFAULT_AGENT_BACKEND,
     ):
         self.platform_routes = platform_routes
         self.global_default = global_default
 
     @classmethod
     def from_file(
-        cls, file_path: Optional[str], *, platform: str, default_backend: str = "opencode"
+        cls, file_path: Optional[str], *, platform: str, default_backend: str = DEFAULT_AGENT_BACKEND
     ) -> "AgentRouter":
         routes: Dict[str, PlatformRoute] = {}
         global_default = default_backend

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -65,6 +65,9 @@ class ClaudeAgent(BaseAgent):
                 subagent_model=request.subagent_model,
                 subagent_reasoning_effort=request.subagent_reasoning_effort,
             )
+            mark_session_active = getattr(self.session_handler, "mark_session_active", None)
+            if callable(mark_session_active):
+                mark_session_active(request.composite_session_id)
 
             # Queue reaction BEFORE sending query to avoid race condition where
             # a fast result arrives before the reaction is queued
@@ -93,6 +96,9 @@ class ClaudeAgent(BaseAgent):
                 )
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
+            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+            if callable(mark_session_idle):
+                mark_session_idle(request.composite_session_id)
             # Clean up the specific reaction for this request (not FIFO)
             await self._remove_specific_pending_reaction(request.composite_session_id, context, request)
             self._remove_pending_request(request.composite_session_id, request)
@@ -157,6 +163,9 @@ class ClaudeAgent(BaseAgent):
                 self._pending_assistant_message.pop(composite_id, None)
                 self._pending_reactions.pop(composite_id, None)
                 self._pending_requests.pop(composite_id, None)
+                clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
+                if callable(clear_tracking):
+                    clear_tracking(composite_id)
 
         # Legacy session manager cleanup (best-effort)
         await self.session_manager.clear_session(session_key)
@@ -192,6 +201,9 @@ class ClaudeAgent(BaseAgent):
             self._pending_assistant_message.pop(composite_id, None)
             self._pending_reactions.pop(composite_id, None)
             self._pending_requests.pop(composite_id, None)
+            clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
+            if callable(clear_tracking):
+                clear_tracking(composite_id)
 
         logger.info("Refreshed Claude auth state across %d runtime session(s)", len(session_ids))
 
@@ -233,6 +245,9 @@ class ClaudeAgent(BaseAgent):
         if not preserve_pending_request_state:
             self._pending_reactions.pop(composite_key, None)
             self._pending_requests.pop(composite_key, None)
+        clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
+        if callable(clear_tracking):
+            clear_tracking(composite_key)
 
     async def handle_stop(self, request: AgentRequest) -> bool:
         composite_key = request.composite_session_id
@@ -285,6 +300,9 @@ class ClaudeAgent(BaseAgent):
 
             async for message in client.receive_messages():
                 try:
+                    touch_session_activity = getattr(self.session_handler, "touch_session_activity", None)
+                    if callable(touch_session_activity):
+                        touch_session_activity(composite_key)
                     claude_session_id = self._maybe_capture_session_id(message, base_session_id, session_key)
                     if claude_session_id:
                         logger.info(f"Captured Claude session id {claude_session_id} for {base_session_id}")
@@ -330,6 +348,9 @@ class ClaudeAgent(BaseAgent):
                             "error" if auth_failure_assistant else "",
                             auth_failure_text if auth_failure_assistant else assistant_text,
                         ):
+                            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+                            if callable(mark_session_idle):
+                                mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
@@ -396,6 +417,9 @@ class ClaudeAgent(BaseAgent):
                             getattr(message, "subtype", "") or "",
                             formatted_message,
                         ):
+                            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+                            if callable(mark_session_idle):
+                                mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
                             continue
                         if formatted_message and formatted_message.strip():
@@ -423,6 +447,9 @@ class ClaudeAgent(BaseAgent):
                             getattr(message, "subtype", "") or "",
                             result_text,
                         ):
+                            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+                            if callable(mark_session_idle):
+                                mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
@@ -447,6 +474,9 @@ class ClaudeAgent(BaseAgent):
                         self._discard_pending_reaction(composite_key)
 
                         self._last_assistant_text.pop(composite_key, None)
+                        mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+                        if callable(mark_session_idle):
+                            mark_session_idle(composite_key)
                         session = await self.session_manager.get_or_create_session(context.user_id, context.channel_id)
                         if session:
                             session.session_active[f"{base_session_id}:{working_path}"] = False
@@ -462,11 +492,17 @@ class ClaudeAgent(BaseAgent):
             # or a new message replacing the session).  Clean up reactions
             # because this receiver will never process another result.
             composite_key = f"{base_session_id}:{working_path}"
+            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+            if callable(mark_session_idle):
+                mark_session_idle(composite_key)
             logger.info("Claude receiver cancelled for session %s", composite_key)
             await self._clear_pending_reactions(composite_key, context)
             raise
         except Exception as e:
             composite_key = f"{base_session_id}:{working_path}"
+            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+            if callable(mark_session_idle):
+                mark_session_idle(composite_key)
             logger.error(
                 f"Error in Claude receiver for session {composite_key}: {e}",
                 exc_info=True,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -106,12 +106,10 @@ class ClaudeAgent(BaseAgent):
                 )
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
-            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
-            if callable(mark_session_idle):
-                mark_session_idle(runtime_session_key)
             # Clean up the specific reaction for this request (not FIFO)
             await self._remove_specific_pending_reaction(runtime_session_key, context, request)
             self._remove_pending_request(runtime_session_key, request)
+            self._mark_session_idle_if_no_pending_requests(runtime_session_key)
             await self._remove_ack_reaction(request)
             handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                 context,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -52,6 +52,8 @@ class ClaudeAgent(BaseAgent):
 
     async def handle_message(self, request: AgentRequest) -> None:
         context = request.context
+        runtime_base_session_id = request.base_session_id
+        runtime_session_key = request.composite_session_id
 
         # Question callback handling (disabled - SDK doesn't support AskUserQuestion response)
         # if self.ENABLE_ASK_USER_QUESTION and request.message.startswith("claude_question:"):
@@ -65,43 +67,51 @@ class ClaudeAgent(BaseAgent):
                 subagent_model=request.subagent_model,
                 subagent_reasoning_effort=request.subagent_reasoning_effort,
             )
+            runtime_base_session_id = getattr(client, "_vibe_runtime_base_session_id", runtime_base_session_id)
+            runtime_session_key = getattr(client, "_vibe_runtime_session_key", runtime_session_key)
             mark_session_active = getattr(self.session_handler, "mark_session_active", None)
             if callable(mark_session_active):
-                mark_session_active(request.composite_session_id)
+                mark_session_active(runtime_session_key)
 
             # Queue reaction BEFORE sending query to avoid race condition where
             # a fast result arrives before the reaction is queued
             if request.ack_reaction_message_id and request.ack_reaction_emoji:
-                if request.composite_session_id not in self._pending_reactions:
-                    self._pending_reactions[request.composite_session_id] = []
-                self._pending_reactions[request.composite_session_id].append(
+                if runtime_session_key not in self._pending_reactions:
+                    self._pending_reactions[runtime_session_key] = []
+                self._pending_reactions[runtime_session_key].append(
                     (request.ack_reaction_message_id, request.ack_reaction_emoji)
                 )
-            self._pending_requests.setdefault(request.composite_session_id, []).append(request)
+            self._pending_requests.setdefault(runtime_session_key, []).append(request)
 
             # Prepare message with file attachment info if present
             message = self._prepare_message_with_files(request)
 
-            await client.query(message, session_id=request.composite_session_id)
-            logger.info(f"Sent message to Claude for session {request.composite_session_id}")
+            await client.query(message, session_id=runtime_session_key)
+            logger.info(f"Sent message to Claude for session {runtime_session_key}")
 
             await self._delete_ack(context, request)
 
             if (
-                request.composite_session_id not in self.receiver_tasks
-                or self.receiver_tasks[request.composite_session_id].done()
+                runtime_session_key not in self.receiver_tasks
+                or self.receiver_tasks[runtime_session_key].done()
             ):
-                self.receiver_tasks[request.composite_session_id] = asyncio.create_task(
-                    self._receive_messages(client, request.base_session_id, request.working_path, context)
+                self.receiver_tasks[runtime_session_key] = asyncio.create_task(
+                    self._receive_messages(
+                        client,
+                        runtime_base_session_id,
+                        request.working_path,
+                        context,
+                        composite_key=runtime_session_key,
+                    )
                 )
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
             mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
             if callable(mark_session_idle):
-                mark_session_idle(request.composite_session_id)
+                mark_session_idle(runtime_session_key)
             # Clean up the specific reaction for this request (not FIFO)
-            await self._remove_specific_pending_reaction(request.composite_session_id, context, request)
-            self._remove_pending_request(request.composite_session_id, request)
+            await self._remove_specific_pending_reaction(runtime_session_key, context, request)
+            self._remove_pending_request(runtime_session_key, request)
             await self._remove_ack_reaction(request)
             handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                 context,
@@ -109,7 +119,7 @@ class ClaudeAgent(BaseAgent):
                 f"❌ Claude error: {e}",
             )
             if not handled:
-                await self.session_handler.handle_session_error(request.composite_session_id, context, e)
+                await self.session_handler.handle_session_error(runtime_session_key, context, e)
         finally:
             await self._delete_ack(context, request)
 
@@ -282,11 +292,13 @@ class ClaudeAgent(BaseAgent):
         base_session_id: str,
         working_path: str,
         context: MessageContext,
+        *,
+        composite_key: str | None = None,
     ):
         """Receive messages from Claude SDK client."""
         try:
             session_key = self.controller._get_session_key(context)
-            composite_key = f"{base_session_id}:{working_path}"
+            composite_key = composite_key or f"{base_session_id}:{working_path}"
 
             # Build a request object for question handler
             request = AgentRequest(
@@ -479,7 +491,7 @@ class ClaudeAgent(BaseAgent):
                             mark_session_idle(composite_key)
                         session = await self.session_manager.get_or_create_session(context.user_id, context.channel_id)
                         if session:
-                            session.session_active[f"{base_session_id}:{working_path}"] = False
+                            session.session_active[composite_key] = False
                         continue
 
                     # Ignore UserMessage/tool results; toolcalls are emitted from ToolUseBlock.
@@ -491,7 +503,7 @@ class ClaudeAgent(BaseAgent):
             # Receiver task was explicitly cancelled (e.g. /stop, /clear,
             # or a new message replacing the session).  Clean up reactions
             # because this receiver will never process another result.
-            composite_key = f"{base_session_id}:{working_path}"
+            composite_key = composite_key or f"{base_session_id}:{working_path}"
             mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
             if callable(mark_session_idle):
                 mark_session_idle(composite_key)
@@ -499,7 +511,7 @@ class ClaudeAgent(BaseAgent):
             await self._clear_pending_reactions(composite_key, context)
             raise
         except Exception as e:
-            composite_key = f"{base_session_id}:{working_path}"
+            composite_key = composite_key or f"{base_session_id}:{working_path}"
             mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
             if callable(mark_session_idle):
                 mark_session_idle(composite_key)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -486,11 +486,9 @@ class ClaudeAgent(BaseAgent):
                         self._discard_pending_reaction(composite_key)
 
                         self._last_assistant_text.pop(composite_key, None)
-                        mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
-                        if callable(mark_session_idle):
-                            mark_session_idle(composite_key)
+                        is_idle = self._mark_session_idle_if_no_pending_requests(composite_key)
                         session = await self.session_manager.get_or_create_session(context.user_id, context.channel_id)
-                        if session:
+                        if session and is_idle:
                             session.session_active[composite_key] = False
                         continue
 
@@ -581,6 +579,17 @@ class ClaudeAgent(BaseAgent):
         if not requests:
             self._pending_requests.pop(composite_key, None)
         return request
+
+    def _has_pending_requests(self, composite_key: str) -> bool:
+        return bool(self._pending_requests.get(composite_key))
+
+    def _mark_session_idle_if_no_pending_requests(self, composite_key: str) -> bool:
+        if self._has_pending_requests(composite_key):
+            return False
+        mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
+        if callable(mark_session_idle):
+            mark_session_idle(composite_key)
+        return True
 
     def _remove_pending_request(self, composite_key: str, request: AgentRequest) -> None:
         requests = self._pending_requests.get(composite_key)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -305,7 +305,6 @@ class CodexAgent(BaseAgent):
 
                 self._transports.pop(cwd, None)
                 self._transport_last_activity.pop(cwd, None)
-                self._transport_locks.pop(cwd, None)
 
                 for base_session_id in list(self._session_mgr.sessions_for_cwd(cwd)):
                     session_key = self._session_mgr.get_session_key(base_session_id)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -282,26 +282,40 @@ class CodexAgent(BaseAgent):
             if idle_for < idle_timeout:
                 continue
 
-            logger.info("Evicting idle Codex transport for cwd=%s after %.1fs idle", cwd, idle_for)
-            try:
-                await transport.stop()
-            except Exception as exc:
-                logger.warning("Failed to stop idle Codex transport for cwd=%s: %s", cwd, exc)
-                continue
+            lock = self._transport_locks.setdefault(cwd, asyncio.Lock())
+            async with lock:
+                current_transport = self._transports.get(cwd)
+                current_last_activity = self._transport_last_activity.get(cwd)
+                if current_transport is None or current_transport is not transport:
+                    continue
+                if self._has_active_turns_for_cwd(cwd):
+                    continue
+                if current_last_activity is None:
+                    continue
+                idle_for = time.monotonic() - current_last_activity
+                if idle_for < idle_timeout:
+                    continue
 
-            self._transports.pop(cwd, None)
-            self._transport_last_activity.pop(cwd, None)
-            self._transport_locks.pop(cwd, None)
+                logger.info("Evicting idle Codex transport for cwd=%s after %.1fs idle", cwd, idle_for)
+                try:
+                    await transport.stop()
+                except Exception as exc:
+                    logger.warning("Failed to stop idle Codex transport for cwd=%s: %s", cwd, exc)
+                    continue
 
-            for base_session_id in list(self._session_mgr.sessions_for_cwd(cwd)):
-                session_key = self._session_mgr.get_session_key(base_session_id)
-                if session_key:
-                    self.sessions.clear_agent_session_mapping(session_key, self.name, base_session_id)
-                self._session_mgr.clear(base_session_id)
-                self._turn_registry.clear_session(base_session_id)
-                self._session_locks.pop(base_session_id, None)
+                self._transports.pop(cwd, None)
+                self._transport_last_activity.pop(cwd, None)
+                self._transport_locks.pop(cwd, None)
 
-            evicted += 1
+                for base_session_id in list(self._session_mgr.sessions_for_cwd(cwd)):
+                    session_key = self._session_mgr.get_session_key(base_session_id)
+                    if session_key:
+                        self.sessions.clear_agent_session_mapping(session_key, self.name, base_session_id)
+                    self._session_mgr.clear(base_session_id)
+                    self._turn_registry.clear_session(base_session_id)
+                    self._session_locks.pop(base_session_id, None)
+
+                evicted += 1
 
         return evicted
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -287,6 +287,7 @@ class CodexAgent(BaseAgent):
                 await transport.stop()
             except Exception as exc:
                 logger.warning("Failed to stop idle Codex transport for cwd=%s: %s", cwd, exc)
+                continue
 
             self._transports.pop(cwd, None)
             self._transport_last_activity.pop(cwd, None)
@@ -700,5 +701,8 @@ class CodexAgent(BaseAgent):
     def _has_active_turns_for_cwd(self, cwd: str) -> bool:
         for base_session_id in self._session_mgr.sessions_for_cwd(cwd):
             if self._turn_registry.get_active_turn(base_session_id):
+                return True
+            has_pending_turn_start = getattr(self._turn_registry, "has_pending_turn_start", None)
+            if callable(has_pending_turn_start) and has_pending_turn_start(base_session_id):
                 return True
         return False

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -34,6 +35,7 @@ class CodexAgent(BaseAgent):
         # cwd → CodexTransport (one persistent process per working dir)
         self._transports: Dict[str, CodexTransport] = {}
         self._transport_locks: Dict[str, asyncio.Lock] = {}
+        self._transport_last_activity: Dict[str, float] = {}
 
         self._session_mgr = CodexSessionManager()
         self._turn_registry = CodexTurnRegistry()
@@ -78,6 +80,7 @@ class CodexAgent(BaseAgent):
         # Track session_key and cwd for scoped invalidation
         self._session_mgr.set_session_key(request.base_session_id, request.session_key)
         self._session_mgr.set_cwd(request.base_session_id, request.working_path)
+        self._touch_transport_activity(request.working_path)
 
         await self._delete_ack(request)
 
@@ -207,8 +210,11 @@ class CodexAgent(BaseAgent):
 
     async def refresh_auth_state(self) -> None:
         """Drop app-server runtime state so future turns pick up fresh auth."""
+        if not hasattr(self, "_transport_last_activity"):
+            self._transport_last_activity = {}
         transports = list(self._transports.values())
         self._transports.clear()
+        self._transport_last_activity.clear()
 
         for transport in transports:
             try:
@@ -222,6 +228,82 @@ class CodexAgent(BaseAgent):
 
         logger.info("Refreshed Codex auth state across %d transport(s)", len(transports))
 
+    async def shutdown_runtime(self) -> None:
+        """Stop all app-server transports during vibe-remote shutdown."""
+        if not hasattr(self, "_transport_last_activity"):
+            self._transport_last_activity = {}
+        if not hasattr(self, "_transport_locks"):
+            self._transport_locks = {}
+        if not hasattr(self, "_session_locks"):
+            self._session_locks = {}
+        transports = list(self._transports.values())
+        self._transports.clear()
+        self._transport_last_activity.clear()
+        self._transport_locks.clear()
+
+        for transport in transports:
+            try:
+                await transport.stop()
+            except Exception as exc:
+                logger.warning("Failed to stop Codex transport during shutdown: %s", exc)
+
+        for base_session_id in list(self._session_mgr.all_base_sessions()):
+            session_key = self._session_mgr.get_session_key(base_session_id)
+            if session_key:
+                self.sessions.clear_agent_session_mapping(session_key, self.name, base_session_id)
+            self._session_mgr.clear(base_session_id)
+            self._turn_registry.clear_session(base_session_id)
+
+        self._session_locks.clear()
+        logger.info("Stopped Codex runtime across %d transport(s)", len(transports))
+
+    async def evict_idle_transports(self, idle_timeout: float) -> int:
+        """Stop idle Codex transports and invalidate stale thread mappings."""
+        if idle_timeout <= 0:
+            return 0
+        if not hasattr(self, "_transport_last_activity"):
+            self._transport_last_activity = {}
+        if not hasattr(self, "_transport_locks"):
+            self._transport_locks = {}
+        if not hasattr(self, "_session_locks"):
+            self._session_locks = {}
+
+        now = time.monotonic()
+        evicted = 0
+
+        for cwd, last_activity in list(self._transport_last_activity.items()):
+            transport = self._transports.get(cwd)
+            if transport is None:
+                self._transport_last_activity.pop(cwd, None)
+                continue
+            if self._has_active_turns_for_cwd(cwd):
+                continue
+            idle_for = now - last_activity
+            if idle_for < idle_timeout:
+                continue
+
+            logger.info("Evicting idle Codex transport for cwd=%s after %.1fs idle", cwd, idle_for)
+            try:
+                await transport.stop()
+            except Exception as exc:
+                logger.warning("Failed to stop idle Codex transport for cwd=%s: %s", cwd, exc)
+
+            self._transports.pop(cwd, None)
+            self._transport_last_activity.pop(cwd, None)
+            self._transport_locks.pop(cwd, None)
+
+            for base_session_id in list(self._session_mgr.sessions_for_cwd(cwd)):
+                session_key = self._session_mgr.get_session_key(base_session_id)
+                if session_key:
+                    self.sessions.clear_agent_session_mapping(session_key, self.name, base_session_id)
+                self._session_mgr.clear(base_session_id)
+                self._turn_registry.clear_session(base_session_id)
+                self._session_locks.pop(base_session_id, None)
+
+            evicted += 1
+
+        return evicted
+
     # ------------------------------------------------------------------
     # Transport management
     # ------------------------------------------------------------------
@@ -230,6 +312,7 @@ class CodexAgent(BaseAgent):
         """Return an initialized transport for the given working directory."""
         existing = self._transports.get(cwd)
         if existing and existing.is_initialized:
+            self._touch_transport_activity(cwd)
             return existing
 
         # Serialize creation per cwd
@@ -240,6 +323,7 @@ class CodexAgent(BaseAgent):
             # Double-check after acquiring lock
             existing = self._transports.get(cwd)
             if existing and existing.is_initialized:
+                self._touch_transport_activity(cwd)
                 return existing
 
             # Stop stale transport if any
@@ -271,6 +355,7 @@ class CodexAgent(BaseAgent):
 
             await transport.start()
             self._transports[cwd] = transport
+            self._touch_transport_activity(cwd)
             return transport
 
     # ------------------------------------------------------------------
@@ -517,6 +602,7 @@ class CodexAgent(BaseAgent):
             )
             return
 
+        self._touch_transport_activity(request.working_path)
         await self._event_handler.handle_notification(method, params, request)
 
     async def _on_server_request(
@@ -604,3 +690,15 @@ class CodexAgent(BaseAgent):
                 logger.debug("Could not delete ack message: %s", err)
             finally:
                 request.ack_message_id = None
+
+    def _touch_transport_activity(self, cwd: str) -> None:
+        if not hasattr(self, "_transport_last_activity"):
+            self._transport_last_activity = {}
+        if cwd:
+            self._transport_last_activity[cwd] = time.monotonic()
+
+    def _has_active_turns_for_cwd(self, cwd: str) -> bool:
+        for base_session_id in self._session_mgr.sessions_for_cwd(cwd):
+            if self._turn_registry.get_active_turn(base_session_id):
+                return True
+        return False

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -325,11 +325,6 @@ class CodexAgent(BaseAgent):
 
     async def _get_or_create_transport(self, cwd: str) -> CodexTransport:
         """Return an initialized transport for the given working directory."""
-        existing = self._transports.get(cwd)
-        if existing and existing.is_initialized:
-            self._touch_transport_activity(cwd)
-            return existing
-
         # Serialize creation per cwd
         if cwd not in self._transport_locks:
             self._transport_locks[cwd] = asyncio.Lock()

--- a/modules/agents/codex/turn_state.py
+++ b/modules/agents/codex/turn_state.py
@@ -115,6 +115,9 @@ class CodexTurnRegistry:
             return
         self._pending_turn_starts.pop(base_session_id, None)
 
+    def has_pending_turn_start(self, base_session_id: str) -> bool:
+        return base_session_id in self._pending_turn_starts
+
     def get_turn(self, turn_id: str) -> Optional[CodexTurnState]:
         if not turn_id:
             return None

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -7,6 +7,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
+from config.v2_config import DEFAULT_OPENCODE_ERROR_RETRY_LIMIT
 from modules.agents.base import AgentRequest
 
 from .question_handler import OpenCodeQuestionHandler
@@ -88,7 +89,11 @@ class OpenCodePollLoop:
         final_text: Optional[str] = None
 
         error_retry_count = 0
-        error_retry_limit = getattr(self._agent.opencode_config, "error_retry_limit", 1)
+        error_retry_limit = getattr(
+            self._agent.opencode_config,
+            "error_retry_limit",
+            DEFAULT_OPENCODE_ERROR_RETRY_LIMIT,
+        )
         last_error_message_id: Optional[str] = None
 
         def _relative_path(path: str) -> str:
@@ -339,7 +344,11 @@ class OpenCodePollLoop:
         final_text: Optional[str] = None
 
         error_retry_count = 0
-        error_retry_limit = getattr(self._agent.opencode_config, "error_retry_limit", 1)
+        error_retry_limit = getattr(
+            self._agent.opencode_config,
+            "error_retry_limit",
+            DEFAULT_OPENCODE_ERROR_RETRY_LIMIT,
+        )
         last_error_message_id: Optional[str] = None
 
         started_at = time.monotonic()

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -25,9 +25,13 @@ class _StubSessions:
 class _StubSessionManager:
     def __init__(self):
         self.cleared = []
+        self.session = SimpleNamespace(session_active={})
 
     async def clear_session(self, settings_key):
         self.cleared.append(settings_key)
+
+    async def get_or_create_session(self, user_id, channel_id):
+        return self.session
 
 
 class _StubClient:
@@ -60,6 +64,56 @@ class _StubController:
 
 
 class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_result_keeps_claude_session_active_when_requests_are_queued(self):
+        controller = _StubController()
+        mark_idle_calls = []
+        controller.session_handler = SimpleNamespace(
+            mark_session_idle=lambda composite_key: mark_idle_calls.append(composite_key),
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_: None,
+        )
+        controller._get_session_key = lambda context: "wechat-user"
+        controller.emit_agent_message = AsyncMock()
+
+        agent = ClaudeAgent(controller)
+        agent.emit_result_message = AsyncMock()
+        context = SimpleNamespace(user_id="U1", channel_id="C1")
+        composite_key = "session-1:/tmp/work"
+        queued_request = SimpleNamespace(started_at=None)
+        next_request = SimpleNamespace(started_at=None)
+        agent._pending_requests[composite_key] = [queued_request, next_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:"), ("m2", ":eyes:")]
+        agent._last_assistant_text[composite_key] = "last"
+        controller.session_manager.session.session_active[composite_key] = True
+
+        result_message = type(
+            "ResultMessage",
+            (),
+            {"subtype": "success", "result": "done", "duration_ms": 1},
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield result_message
+
+                return _iterate()
+
+        await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        self.assertEqual(mark_idle_calls, [])
+        agent.emit_result_message.assert_awaited_once_with(
+            context,
+            "done",
+            subtype="success",
+            duration_ms=1,
+            parse_mode="markdown",
+            request=queued_request,
+        )
+        self.assertEqual(agent._pending_requests[composite_key], [next_request])
+        self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
+        self.assertTrue(controller.session_manager.session.session_active[composite_key])
+
     async def test_handle_message_uses_runtime_session_key_for_claude_tracking(self):
         controller = _StubController()
         controller.emit_agent_message = AsyncMock()

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -60,6 +60,64 @@ class _StubController:
 
 
 class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_handle_message_uses_runtime_session_key_for_claude_tracking(self):
+        controller = _StubController()
+        controller.emit_agent_message = AsyncMock()
+        runtime_key = "wechat_o9:reviewer:/tmp/work"
+        client = SimpleNamespace(
+            query=AsyncMock(),
+            _vibe_runtime_base_session_id="wechat_o9:reviewer",
+            _vibe_runtime_session_key=runtime_key,
+        )
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(return_value=client),
+            mark_session_active=SimpleNamespace(),
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_: None,
+        )
+        mark_active_calls = []
+        controller.session_handler.mark_session_active = lambda composite_key: mark_active_calls.append(composite_key)
+
+        agent = ClaudeAgent(controller)
+        agent._prepare_message_with_files = lambda request: request.message
+        agent._delete_ack = AsyncMock()
+        agent._receive_messages = AsyncMock()
+
+        request = SimpleNamespace(
+            context=SimpleNamespace(),
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id="wechat_o9:/tmp/work",
+            session_key="wechat-user",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            ack_message_id=None,
+            ack_reaction_message_id="m1",
+            ack_reaction_emoji=":eyes:",
+            files=None,
+        )
+
+        await agent.handle_message(request)
+        await asyncio.sleep(0)
+
+        controller.session_handler.get_or_create_claude_session.assert_awaited_once()
+        self.assertEqual(mark_active_calls, [runtime_key])
+        client.query.assert_awaited_once_with("hello", session_id=runtime_key)
+        self.assertIn(runtime_key, agent._pending_requests)
+        self.assertIn(runtime_key, agent._pending_reactions)
+        self.assertNotIn(request.composite_session_id, agent._pending_requests)
+        self.assertNotIn(request.composite_session_id, agent._pending_reactions)
+        self.assertIn(runtime_key, controller.receiver_tasks)
+        agent._receive_messages.assert_awaited_once_with(
+            client,
+            "wechat_o9:reviewer",
+            "/tmp/work",
+            request.context,
+            composite_key=runtime_key,
+        )
+
     async def test_clear_sessions_cancels_receiver_tasks_for_cleared_session(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -172,6 +172,55 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             composite_key=runtime_key,
         )
 
+    async def test_handle_message_error_keeps_session_active_when_requests_remain_queued(self):
+        controller = _StubController()
+        mark_idle_calls = []
+        controller.emit_agent_message = AsyncMock()
+        runtime_key = "wechat_o9:reviewer:/tmp/work"
+        queued_request = SimpleNamespace()
+        client = SimpleNamespace(
+            query=AsyncMock(side_effect=RuntimeError("boom")),
+            _vibe_runtime_base_session_id="wechat_o9:reviewer",
+            _vibe_runtime_session_key=runtime_key,
+        )
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(return_value=client),
+            mark_session_active=lambda composite_key: None,
+            mark_session_idle=lambda composite_key: mark_idle_calls.append(composite_key),
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_: None,
+        )
+
+        agent = ClaudeAgent(controller)
+        agent._prepare_message_with_files = lambda request: request.message
+        agent._delete_ack = AsyncMock()
+        agent._remove_ack_reaction = AsyncMock()
+
+        request = SimpleNamespace(
+            context=SimpleNamespace(),
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id="wechat_o9:/tmp/work",
+            session_key="wechat-user",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            ack_message_id=None,
+            ack_reaction_message_id="m1",
+            ack_reaction_emoji=":eyes:",
+            files=None,
+        )
+        agent._pending_requests[runtime_key] = [queued_request]
+        agent._pending_reactions[runtime_key] = [("m2", ":eyes:")]
+
+        await agent.handle_message(request)
+
+        self.assertEqual(mark_idle_calls, [])
+        self.assertEqual(agent._pending_requests[runtime_key], [queued_request])
+        self.assertEqual(agent._pending_reactions[runtime_key], [("m2", ":eyes:")])
+        agent._remove_ack_reaction.assert_awaited_once_with(request)
+
     async def test_clear_sessions_cancels_receiver_tasks_for_cleared_session(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -133,6 +133,8 @@ def test_session_handler_passes_configured_claude_cli_path(monkeypatch, tmp_path
     assert captured["connected"] is True
     assert captured["options"].cli_path == "/usr/local/bin/claude-proxy"
     assert controller.claude_sessions[f"slack_C123:{tmp_path}"] is client
+    assert getattr(client, "_vibe_runtime_base_session_id") == "slack_C123"
+    assert getattr(client, "_vibe_runtime_session_key") == f"slack_C123:{tmp_path}"
 
 
 def test_session_handler_keeps_sdk_default_for_default_claude_binary(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -277,3 +277,38 @@ def test_session_handler_keeps_active_claude_session(monkeypatch, tmp_path: Path
     assert evicted == 0
     assert captured["disconnects"] == 0
     assert composite_key in controller.claude_sessions
+
+
+def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path: Path) -> None:
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    client = _run_session(handler, context)
+    composite_key = f"slack_C123:{tmp_path}"
+
+    async def _exercise_cleanup() -> None:
+        async def _receiver():
+            await asyncio.Future()
+
+        controller.receiver_tasks[composite_key] = asyncio.create_task(_receiver())
+        await asyncio.sleep(0)
+        await handler.cleanup_session(composite_key)
+
+    asyncio.run(_exercise_cleanup())
+
+    assert client.disconnects == 1
+    assert composite_key not in controller.receiver_tasks
+    assert composite_key not in controller.claude_sessions

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -88,6 +88,15 @@ def _run_session(handler: SessionHandler, context: MessageContext):
     return asyncio.run(handler.get_or_create_claude_session(context))
 
 
+class _StubClaudeAgentOptions:
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        if not hasattr(self, "cli_path"):
+            self.cli_path = None
+        self.continue_conversation = False
+
+
 def test_to_app_config_preserves_claude_cli_path() -> None:
     v2 = V2Config(
         mode="self_host",
@@ -112,6 +121,7 @@ def test_session_handler_passes_configured_claude_cli_path(monkeypatch, tmp_path
         async def connect(self) -> None:
             captured["connected"] = True
 
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
     monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
 
     controller = _Controller(tmp_path)
@@ -135,6 +145,7 @@ def test_session_handler_keeps_sdk_default_for_default_claude_binary(monkeypatch
         async def connect(self) -> None:
             captured["connected"] = True
 
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
     monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
 
     controller = _Controller(tmp_path)
@@ -158,6 +169,7 @@ def test_session_handler_passes_non_default_claude_command_name(monkeypatch, tmp
         async def connect(self) -> None:
             captured["connected"] = True
 
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
     monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
 
     controller = _Controller(tmp_path)
@@ -181,6 +193,7 @@ def test_session_handler_expands_tilde_in_claude_cli_path(monkeypatch, tmp_path:
         async def connect(self) -> None:
             captured["connected"] = True
 
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
     monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
 
     controller = _Controller(tmp_path)
@@ -192,3 +205,73 @@ def test_session_handler_expands_tilde_in_claude_cli_path(monkeypatch, tmp_path:
 
     assert captured["connected"] is True
     assert captured["options"].cli_path == str(Path("~/bin/claude").expanduser())
+
+
+def test_session_handler_evicts_idle_claude_session(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    composite_key = f"slack_C123:{tmp_path}"
+    handler.session_last_activity[composite_key] = 0.0
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 1
+    assert captured["disconnects"] == 1
+    assert composite_key not in controller.claude_sessions
+    assert composite_key not in handler.session_last_activity
+
+
+def test_session_handler_keeps_active_claude_session(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    composite_key = f"slack_C123:{tmp_path}"
+    handler.session_last_activity[composite_key] = 0.0
+    handler.active_sessions.add(composite_key)
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 0
+    assert captured["disconnects"] == 0
+    assert composite_key in controller.claude_sessions

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -312,3 +312,45 @@ def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path:
     assert client.disconnects == 1
     assert composite_key not in controller.receiver_tasks
     assert composite_key not in controller.claude_sessions
+
+
+def test_evict_idle_sessions_rechecks_active_state_before_cleanup(monkeypatch, tmp_path: Path) -> None:
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    class _FlippingActiveSet(set):
+        def __init__(self, target_key: str):
+            super().__init__()
+            self.target_key = target_key
+            self._checks = 0
+
+        def __contains__(self, item):
+            if item == self.target_key:
+                self._checks += 1
+                return self._checks >= 2
+            return super().__contains__(item)
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    client = _run_session(handler, context)
+    composite_key = f"slack_C123:{tmp_path}"
+    handler.session_last_activity[composite_key] = 0.0
+    handler.active_sessions = _FlippingActiveSet(composite_key)
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 0
+    assert client.disconnects == 0
+    assert composite_key in controller.claude_sessions

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -414,6 +414,44 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(cleared_turns, [])
         agent.sessions.clear_agent_session_mapping.assert_not_called()
 
+    async def test_evict_idle_transports_revalidates_activity_before_stop(self):
+        agent = object.__new__(CodexAgent)
+        stop_calls = []
+
+        async def stop_transport():
+            stop_calls.append("stop")
+
+        lock = asyncio.Lock()
+        await lock.acquire()
+        agent._transports = {"/tmp/work": SimpleNamespace(stop=stop_transport)}
+        agent._transport_last_activity = {"/tmp/work": 0.0}
+        agent._transport_locks = {"/tmp/work": lock}
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
+            get_session_key=lambda base_session_id: "scope-1",
+            clear=lambda base_session_id: None,
+        )
+        agent._turn_registry = SimpleNamespace(
+            get_active_turn=lambda base_session_id: None,
+            has_pending_turn_start=lambda base_session_id: False,
+            clear_session=lambda base_session_id: None,
+        )
+        agent._session_locks = {"session-1": asyncio.Lock()}
+        agent.sessions = SimpleNamespace(clear_agent_session_mapping=Mock())
+
+        with patch.object(_MODULE.time, "monotonic", return_value=1000.0):
+            eviction_task = asyncio.create_task(agent.evict_idle_transports(600))
+            await asyncio.sleep(0)
+            agent._transport_last_activity["/tmp/work"] = 950.0
+            lock.release()
+            evicted = await eviction_task
+
+        self.assertEqual(evicted, 0)
+        self.assertEqual(stop_calls, [])
+        self.assertIn("/tmp/work", agent._transports)
+        self.assertEqual(agent._transport_last_activity["/tmp/work"], 950.0)
+        agent.sessions.clear_agent_session_mapping.assert_not_called()
+
 
 class _HandleMessageTurnRegistry:
     def __init__(self, active_turn: str | None):

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -318,6 +318,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(cleared_turns, ["session-1"])
         agent.sessions.clear_agent_session_mapping.assert_called_once_with("scope-1", "codex", "session-1")
         self.assertEqual(agent._transports, {})
+        self.assertIn("/tmp/work", agent._transport_locks)
         self.assertEqual(agent._transport_last_activity, {})
 
     async def test_evict_idle_transports_keeps_active_codex_runtime(self):

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -348,6 +348,72 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("/tmp/work", agent._transports)
         agent.sessions.clear_agent_session_mapping.assert_not_called()
 
+    async def test_evict_idle_transports_keeps_pending_turn_start_runtime(self):
+        agent = object.__new__(CodexAgent)
+
+        async def stop_transport():
+            raise AssertionError("pending turn-start transport should not be stopped")
+
+        agent._transports = {"/tmp/work": SimpleNamespace(stop=stop_transport)}
+        agent._transport_last_activity = {"/tmp/work": 0.0}
+        agent._transport_locks = {"/tmp/work": asyncio.Lock()}
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
+            get_session_key=lambda base_session_id: "scope-1",
+            clear=lambda base_session_id: None,
+        )
+        agent._turn_registry = SimpleNamespace(
+            get_active_turn=lambda base_session_id: None,
+            has_pending_turn_start=lambda base_session_id: True,
+            clear_session=lambda base_session_id: None,
+        )
+        agent._session_locks = {"session-1": asyncio.Lock()}
+        agent.sessions = SimpleNamespace(clear_agent_session_mapping=Mock())
+
+        with patch.object(_MODULE.time, "monotonic", return_value=1000.0):
+            evicted = await agent.evict_idle_transports(600)
+
+        self.assertEqual(evicted, 0)
+        self.assertIn("/tmp/work", agent._transports)
+        agent.sessions.clear_agent_session_mapping.assert_not_called()
+
+    async def test_evict_idle_transports_preserves_state_when_stop_fails(self):
+        agent = object.__new__(CodexAgent)
+        cleared_sessions = []
+        cleared_turns = []
+
+        async def stop_transport():
+            raise RuntimeError("boom")
+
+        transport = SimpleNamespace(stop=stop_transport)
+        lock = asyncio.Lock()
+        agent._transports = {"/tmp/work": transport}
+        agent._transport_last_activity = {"/tmp/work": 0.0}
+        agent._transport_locks = {"/tmp/work": lock}
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
+            get_session_key=lambda base_session_id: "scope-1",
+            clear=lambda base_session_id: cleared_sessions.append(base_session_id),
+        )
+        agent._turn_registry = SimpleNamespace(
+            get_active_turn=lambda base_session_id: None,
+            has_pending_turn_start=lambda base_session_id: False,
+            clear_session=lambda base_session_id: cleared_turns.append(base_session_id),
+        )
+        agent._session_locks = {"session-1": asyncio.Lock()}
+        agent.sessions = SimpleNamespace(clear_agent_session_mapping=Mock())
+
+        with patch.object(_MODULE.time, "monotonic", return_value=1000.0):
+            evicted = await agent.evict_idle_transports(600)
+
+        self.assertEqual(evicted, 0)
+        self.assertIs(agent._transports["/tmp/work"], transport)
+        self.assertIs(agent._transport_locks["/tmp/work"], lock)
+        self.assertEqual(agent._transport_last_activity["/tmp/work"], 0.0)
+        self.assertEqual(cleared_sessions, [])
+        self.assertEqual(cleared_turns, [])
+        agent.sessions.clear_agent_session_mapping.assert_not_called()
+
 
 class _HandleMessageTurnRegistry:
     def __init__(self, active_turn: str | None):
@@ -359,6 +425,9 @@ class _HandleMessageTurnRegistry:
 
     def get_active_turn(self, base_session_id: str):
         return self.active_turn
+
+    def has_pending_turn_start(self, base_session_id: str):
+        return False
 
 
 class CodexAgentHandleMessageTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -452,6 +452,25 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._transport_last_activity["/tmp/work"], 950.0)
         agent.sessions.clear_agent_session_mapping.assert_not_called()
 
+    async def test_get_or_create_transport_fast_path_waits_for_transport_lock(self):
+        agent = object.__new__(CodexAgent)
+        lock = asyncio.Lock()
+        await lock.acquire()
+        transport = SimpleNamespace(is_initialized=True)
+        agent._transports = {"/tmp/work": transport}
+        agent._transport_locks = {"/tmp/work": lock}
+        agent._transport_last_activity = {}
+
+        with patch.object(_MODULE.time, "monotonic", return_value=1000.0):
+            transport_task = asyncio.create_task(agent._get_or_create_transport("/tmp/work"))
+            await asyncio.sleep(0)
+            self.assertFalse(transport_task.done())
+            lock.release()
+            resolved = await transport_task
+
+        self.assertIs(resolved, transport)
+        self.assertEqual(agent._transport_last_activity["/tmp/work"], 1000.0)
+
 
 class _HandleMessageTurnRegistry:
     def __init__(self, active_turn: str | None):

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import sys
 import types
@@ -283,6 +284,69 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._transports, {})
         self.assertEqual(invalidated, ["session-1", "session-2"])
         self.assertEqual(cleared_sessions, ["session-1", "session-2"])
+
+    async def test_evict_idle_transports_stops_idle_codex_runtime(self):
+        agent = object.__new__(CodexAgent)
+        stop_calls = []
+        cleared_sessions = []
+        cleared_turns = []
+
+        async def stop_transport():
+            stop_calls.append("stop")
+
+        agent._transports = {"/tmp/work": SimpleNamespace(stop=stop_transport)}
+        agent._transport_last_activity = {"/tmp/work": 0.0}
+        agent._transport_locks = {"/tmp/work": asyncio.Lock()}
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
+            get_session_key=lambda base_session_id: "scope-1",
+            clear=lambda base_session_id: cleared_sessions.append(base_session_id),
+        )
+        agent._turn_registry = SimpleNamespace(
+            get_active_turn=lambda base_session_id: None,
+            clear_session=lambda base_session_id: cleared_turns.append(base_session_id),
+        )
+        agent._session_locks = {"session-1": asyncio.Lock()}
+        agent.sessions = SimpleNamespace(clear_agent_session_mapping=Mock())
+
+        with patch.object(_MODULE.time, "monotonic", return_value=1000.0):
+            evicted = await agent.evict_idle_transports(600)
+
+        self.assertEqual(evicted, 1)
+        self.assertEqual(stop_calls, ["stop"])
+        self.assertEqual(cleared_sessions, ["session-1"])
+        self.assertEqual(cleared_turns, ["session-1"])
+        agent.sessions.clear_agent_session_mapping.assert_called_once_with("scope-1", "codex", "session-1")
+        self.assertEqual(agent._transports, {})
+        self.assertEqual(agent._transport_last_activity, {})
+
+    async def test_evict_idle_transports_keeps_active_codex_runtime(self):
+        agent = object.__new__(CodexAgent)
+
+        async def stop_transport():
+            raise AssertionError("active transport should not be stopped")
+
+        agent._transports = {"/tmp/work": SimpleNamespace(stop=stop_transport)}
+        agent._transport_last_activity = {"/tmp/work": 0.0}
+        agent._transport_locks = {"/tmp/work": asyncio.Lock()}
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
+            get_session_key=lambda base_session_id: "scope-1",
+            clear=lambda base_session_id: None,
+        )
+        agent._turn_registry = SimpleNamespace(
+            get_active_turn=lambda base_session_id: "turn-1",
+            clear_session=lambda base_session_id: None,
+        )
+        agent._session_locks = {"session-1": asyncio.Lock()}
+        agent.sessions = SimpleNamespace(clear_agent_session_mapping=Mock())
+
+        with patch.object(_MODULE.time, "monotonic", return_value=1000.0):
+            evicted = await agent.evict_idle_transports(600)
+
+        self.assertEqual(evicted, 0)
+        self.assertIn("/tmp/work", agent._transports)
+        agent.sessions.clear_agent_session_mapping.assert_not_called()
 
 
 class _HandleMessageTurnRegistry:

--- a/tests/test_controller_idle_cleanup.py
+++ b/tests/test_controller_idle_cleanup.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+from core.controller import Controller
+
+
+def test_idle_cleanup_timeouts_disable_codex_when_backend_config_absent() -> None:
+    controller = object.__new__(Controller)
+    controller.config = SimpleNamespace(
+        claude=SimpleNamespace(idle_timeout_seconds=0),
+        codex=None,
+    )
+
+    claude_timeout, codex_timeout = Controller._get_idle_cleanup_timeouts(controller)
+
+    assert claude_timeout == 0
+    assert codex_timeout == 0
+
+
+def test_idle_cleanup_timeouts_preserve_explicit_codex_timeout() -> None:
+    controller = object.__new__(Controller)
+    controller.config = SimpleNamespace(
+        claude=SimpleNamespace(idle_timeout_seconds=300),
+        codex=SimpleNamespace(idle_timeout_seconds=900),
+    )
+
+    claude_timeout, codex_timeout = Controller._get_idle_cleanup_timeouts(controller)
+
+    assert claude_timeout == 300
+    assert codex_timeout == 900

--- a/tests/test_controller_idle_cleanup.py
+++ b/tests/test_controller_idle_cleanup.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from config.v2_config import DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
 from core.controller import Controller
 
 
@@ -27,3 +28,16 @@ def test_idle_cleanup_timeouts_preserve_explicit_codex_timeout() -> None:
 
     assert claude_timeout == 300
     assert codex_timeout == 900
+
+
+def test_idle_cleanup_timeouts_fall_back_to_shared_default_when_backend_config_omits_value() -> None:
+    controller = object.__new__(Controller)
+    controller.config = SimpleNamespace(
+        claude=SimpleNamespace(),
+        codex=SimpleNamespace(),
+    )
+
+    claude_timeout, codex_timeout = Controller._get_idle_cleanup_timeouts(controller)
+
+    assert claude_timeout == DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
+    assert codex_timeout == DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS

--- a/tests/test_v2_compat_platforms.py
+++ b/tests/test_v2_compat_platforms.py
@@ -10,6 +10,9 @@ from config.v2_config import (
     AgentsConfig,
     ClaudeConfig,
     CodexConfig,
+    DEFAULT_AGENT_BACKEND,
+    DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS,
+    DEFAULT_OPENCODE_ERROR_RETRY_LIMIT,
     DiscordConfig,
     OpenCodeConfig,
     PlatformsConfig,
@@ -72,3 +75,22 @@ def test_to_app_config_preserves_telegram_config():
     assert compat.platform == "telegram"
     assert compat.telegram is not None
     assert compat.telegram.bot_token == "123456:test-token"
+
+
+def test_to_app_config_uses_shared_agent_defaults() -> None:
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        ui=UiConfig(),
+        update=UpdateConfig(),
+    )
+
+    compat = to_app_config(config)
+
+    assert compat.default_backend == DEFAULT_AGENT_BACKEND
+    assert compat.claude.idle_timeout_seconds == DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
+    assert compat.opencode is not None
+    assert compat.opencode.error_retry_limit == DEFAULT_OPENCODE_ERROR_RETRY_LIMIT


### PR DESCRIPTION
## Summary
- add idle eviction for Claude session runtimes instead of keeping subprocesses alive indefinitely
- add idle eviction and shutdown cleanup for Codex app-server transports
- make idle timeouts configurable in agent config and cover the new behavior with focused tests

## Why
Claude sessions were reusing live subprocesses but had no idle reaper, which could accumulate stale Claude processes and file descriptors over time. Codex used the same long-lived runtime pattern per working directory and also lacked idle cleanup.

## How To Test
- `python3 -m pytest tests/test_claude_cli_path.py tests/test_claude_agent_sessions.py tests/test_codex_agent.py`
- `ruff check core/controller.py core/handlers/session_handler.py modules/agents/claude_agent.py modules/agents/codex/agent.py config/v2_config.py config/v2_compat.py tests/test_claude_cli_path.py tests/test_codex_agent.py tests/test_claude_agent_sessions.py`

## Evidence
- Unit: updated Claude and Codex runtime/session tests
- Contract: config compatibility updated for new idle timeout fields
- Scenario: not updated; no scenario catalog entry for this runtime cleanup path
- Residual manual checks: not run

## Risks / Follow-ups
- idle eviction is intentionally conservative and skips active Claude sessions / active Codex turns
- default timeout is 600 seconds for both backends; we can tune it after observing real usage
