### PR TITLE
fix(routing): scope agent settings to active backend

### DIFF
--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -6,6 +6,7 @@ from config.v2_config import V2Config, SlackConfig, DiscordConfig, TelegramConfi
 
 @dataclass
 class ClaudeCompatConfig:
+    enabled: bool
     permission_mode: str
     cwd: str
     system_prompt: Optional[str] = None
@@ -21,6 +22,7 @@ class ClaudeCompatConfig:
 
 @dataclass
 class CodexCompatConfig:
+    enabled: bool
     binary: str
     extra_args: list[str]
     default_model: Optional[str] = None
@@ -28,6 +30,7 @@ class CodexCompatConfig:
 
 @dataclass
 class OpenCodeCompatConfig:
+    enabled: bool
     binary: str
     port: int
     request_timeout_seconds: int
@@ -63,6 +66,7 @@ class AppCompatConfig:
 
 def to_app_config(v2: V2Config) -> AppCompatConfig:
     claude = ClaudeCompatConfig(
+        enabled=v2.agents.claude.enabled,
         permission_mode="bypassPermissions",
         cwd=v2.runtime.default_cwd,
         system_prompt=None,
@@ -72,6 +76,7 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
     codex = None
     if v2.agents.codex.enabled:
         codex = CodexCompatConfig(
+            enabled=True,
             binary=v2.agents.codex.cli_path,
             extra_args=[],
             default_model=v2.agents.codex.default_model,
@@ -79,6 +84,7 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
     opencode = None
     if v2.agents.opencode.enabled:
         opencode = OpenCodeCompatConfig(
+            enabled=True,
             binary=v2.agents.opencode.cli_path,
             port=4096,
             request_timeout_seconds=60,

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -419,6 +419,7 @@ class SettingsHandler(BaseHandler):
         self,
         context: MessageContext,
         selected_backend: Optional[str] = None,
+        include_all_backend_data: bool = False,
     ) -> RoutingModalData:
         """Collect backend/agent/model data for routing modal renderers."""
         settings_key = self._get_settings_key(context)
@@ -431,6 +432,7 @@ class SettingsHandler(BaseHandler):
             enabled_backends = [current_backend]
         registered_backends = sorted(enabled_backends, key=lambda x: (x != "opencode", x))
         active_backend = selected_backend if selected_backend in registered_backends else current_backend
+        backends_to_load = set(registered_backends) if include_all_backend_data else {active_backend}
 
         opencode_agents = []
         opencode_models = {}
@@ -440,7 +442,7 @@ class SettingsHandler(BaseHandler):
         codex_agents = []
         codex_models = []
 
-        if active_backend == "opencode":
+        if "opencode" in backends_to_load:
             try:
                 opencode_agent = self.controller.agent_service.agents.get("opencode")
                 if opencode_agent and hasattr(opencode_agent, "_get_server"):
@@ -454,7 +456,7 @@ class SettingsHandler(BaseHandler):
             except Exception as e:
                 logger.warning(f"Failed to fetch OpenCode data: {e}")
 
-        if active_backend == "claude":
+        if "claude" in backends_to_load:
             try:
                 from vibe.api import claude_agents as get_claude_agents, claude_models as get_claude_models
 
@@ -468,7 +470,7 @@ class SettingsHandler(BaseHandler):
             except Exception as e:
                 logger.warning(f"Failed to fetch Claude data: {e}")
 
-        if active_backend == "codex":
+        if "codex" in backends_to_load:
             try:
                 from vibe.api import codex_agents as get_codex_agents, codex_models as get_codex_models
 
@@ -542,7 +544,7 @@ class SettingsHandler(BaseHandler):
     async def _handle_routing_discord(self, context: MessageContext):
         im_client = self._get_im_client(context)
         interaction = context.platform_specific.get("interaction") if context.platform_specific else None
-        routing_data = await self._gather_routing_modal_data(context)
+        routing_data = await self._gather_routing_modal_data(context, include_all_backend_data=True)
 
         try:
             await im_client.run_on_client_loop(
@@ -558,7 +560,7 @@ class SettingsHandler(BaseHandler):
 
     async def _handle_routing_telegram(self, context: MessageContext):
         im_client = self._get_im_client(context)
-        routing_data = await self._gather_routing_modal_data(context)
+        routing_data = await self._gather_routing_modal_data(context, include_all_backend_data=True)
         try:
             await im_client.run_on_client_loop(
                 im_client.open_routing_modal(
@@ -578,7 +580,7 @@ class SettingsHandler(BaseHandler):
         Feishu card can display selectors for all available options.
         """
         im_client = self._get_im_client(context)
-        routing_data = await self._gather_routing_modal_data(context)
+        routing_data = await self._gather_routing_modal_data(context, include_all_backend_data=True)
 
         try:
             await im_client.run_on_client_loop(

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -703,6 +703,9 @@ class SettingsHandler(BaseHandler):
             current_routing = routing_data.current_routing
             registered_backends = routing_data.registered_backends
             current_backend = routing_data.current_backend
+            visible_selected_backend = (
+                selected_backend if selected_backend in registered_backends else current_backend
+            )
 
             if hasattr(im_client, "update_routing_modal"):
                 await im_client.update_routing_modal(  # type: ignore[attr-defined]
@@ -719,7 +722,7 @@ class SettingsHandler(BaseHandler):
                     claude_models=routing_data.claude_models,
                     codex_agents=routing_data.codex_agents,
                     codex_models=routing_data.codex_models,
-                    selected_backend=selected_backend,
+                    selected_backend=visible_selected_backend,
                     selected_opencode_agent=selection.selected_opencode_agent,
                     selected_opencode_model=selection.selected_opencode_model,
                     selected_opencode_reasoning=selection.selected_opencode_reasoning,

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -415,14 +415,22 @@ class SettingsHandler(BaseHandler):
                 context, f"❌ {self._t('error.routingFailed', error=str(e))}"
             )
 
-    async def _gather_routing_modal_data(self, context: MessageContext) -> RoutingModalData:
+    async def _gather_routing_modal_data(
+        self,
+        context: MessageContext,
+        selected_backend: Optional[str] = None,
+    ) -> RoutingModalData:
         """Collect backend/agent/model data for routing modal renderers."""
         settings_key = self._get_settings_key(context)
         current_routing = self._get_settings_manager(context).get_channel_routing(settings_key)
 
         all_backends = list(self.controller.agent_service.agents.keys())
-        registered_backends = sorted(all_backends, key=lambda x: (x != "opencode", x))
         current_backend = self.controller.resolve_agent_for_context(context)
+        enabled_backends = [backend for backend in all_backends if self._is_backend_enabled(backend)]
+        if not enabled_backends and current_backend:
+            enabled_backends = [current_backend]
+        registered_backends = sorted(enabled_backends, key=lambda x: (x != "opencode", x))
+        active_backend = selected_backend if selected_backend in registered_backends else current_backend
 
         opencode_agents = []
         opencode_models = {}
@@ -432,7 +440,7 @@ class SettingsHandler(BaseHandler):
         codex_agents = []
         codex_models = []
 
-        if "opencode" in registered_backends:
+        if active_backend == "opencode":
             try:
                 opencode_agent = self.controller.agent_service.agents.get("opencode")
                 if opencode_agent and hasattr(opencode_agent, "_get_server"):
@@ -446,7 +454,7 @@ class SettingsHandler(BaseHandler):
             except Exception as e:
                 logger.warning(f"Failed to fetch OpenCode data: {e}")
 
-        if "claude" in registered_backends:
+        if active_backend == "claude":
             try:
                 from vibe.api import claude_agents as get_claude_agents, claude_models as get_claude_models
 
@@ -460,7 +468,7 @@ class SettingsHandler(BaseHandler):
             except Exception as e:
                 logger.warning(f"Failed to fetch Claude data: {e}")
 
-        if "codex" in registered_backends:
+        if active_backend == "codex":
             try:
                 from vibe.api import codex_agents as get_codex_agents, codex_models as get_codex_models
 
@@ -486,6 +494,12 @@ class SettingsHandler(BaseHandler):
             codex_agents=codex_agents,
             codex_models=codex_models,
         )
+
+    def _is_backend_enabled(self, backend: str) -> bool:
+        backend_config = getattr(self.config, backend, None)
+        if backend_config is None:
+            return False
+        return bool(getattr(backend_config, "enabled", True))
 
     async def _handle_routing_slack(self, context: MessageContext):
         """Handle routing for Slack using modal dialog"""
@@ -676,11 +690,11 @@ class SettingsHandler(BaseHandler):
             )
             im_client = self._get_im_client(context)
 
-            routing_data = await self._gather_routing_modal_data(context)
+            current_backend = self.controller.resolve_agent_for_context(context)
+            selected_backend = selection.selected_backend or current_backend
+            routing_data = await self._gather_routing_modal_data(context, selected_backend=selected_backend)
             current_routing = routing_data.current_routing
             registered_backends = routing_data.registered_backends
-            current_backend = routing_data.current_backend
-            selected_backend = selection.selected_backend or current_backend
 
             if hasattr(im_client, "update_routing_modal"):
                 await im_client.update_routing_modal(  # type: ignore[attr-defined]

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -436,6 +436,7 @@ class SettingsHandler(BaseHandler):
             active_backend = current_backend
         if selected_backend in registered_backends:
             active_backend = selected_backend
+        visible_current_backend = current_backend if current_backend in registered_backends else active_backend
         backends_to_load = set(registered_backends) if include_all_backend_data else {active_backend}
 
         opencode_agents = []
@@ -490,7 +491,7 @@ class SettingsHandler(BaseHandler):
 
         return RoutingModalData(
             registered_backends=registered_backends,
-            current_backend=current_backend,
+            current_backend=visible_current_backend,
             current_routing=current_routing,
             opencode_agents=opencode_agents,
             opencode_models=opencode_models,
@@ -696,11 +697,12 @@ class SettingsHandler(BaseHandler):
             )
             im_client = self._get_im_client(context)
 
-            current_backend = self.controller.resolve_agent_for_context(context)
-            selected_backend = selection.selected_backend or current_backend
+            resolved_backend = self.controller.resolve_agent_for_context(context)
+            selected_backend = selection.selected_backend or resolved_backend
             routing_data = await self._gather_routing_modal_data(context, selected_backend=selected_backend)
             current_routing = routing_data.current_routing
             registered_backends = routing_data.registered_backends
+            current_backend = routing_data.current_backend
 
             if hasattr(im_client, "update_routing_modal"):
                 await im_client.update_routing_modal(  # type: ignore[attr-defined]

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -431,7 +431,11 @@ class SettingsHandler(BaseHandler):
         if not enabled_backends and current_backend:
             enabled_backends = [current_backend]
         registered_backends = sorted(enabled_backends, key=lambda x: (x != "opencode", x))
-        active_backend = selected_backend if selected_backend in registered_backends else current_backend
+        active_backend = registered_backends[0] if registered_backends else current_backend
+        if current_backend in registered_backends:
+            active_backend = current_backend
+        if selected_backend in registered_backends:
+            active_backend = selected_backend
         backends_to_load = set(registered_backends) if include_all_backend_data else {active_backend}
 
         opencode_agents = []

--- a/docs/plans/routing-current-backend-and-claude-catalog.md
+++ b/docs/plans/routing-current-backend-and-claude-catalog.md
@@ -1,0 +1,29 @@
+# Routing Current Backend And Claude Catalog
+
+## Background
+
+Slack Agent Settings currently gathers backend data before opening the modal.
+In practice this can trigger expensive Claude model discovery even when the
+user is currently routed to OpenCode, causing the Slack trigger to expire.
+
+## Goal
+
+1. Only load backend-specific data for the backend the user is currently using
+   when the routing modal first opens.
+2. Stop scanning the local Claude installation during normal runtime model
+   discovery.
+3. Ship a repository-owned Claude model catalog plus a script that regenerates
+   that catalog from the current Claude installation when maintainers want to
+   refresh it for a release.
+
+## Plan
+
+1. Add a tracked Claude model catalog file and make runtime model discovery read
+   from it, while still merging explicit user-configured model values.
+2. Add a maintainer script that scans the current Claude installation bundle,
+   infers model ids, and rewrites the tracked catalog file.
+3. Update routing modal data collection so initial modal open fetches only the
+   current backend, while modal refresh fetches only the currently selected
+   backend.
+4. Add focused tests for the new catalog behavior and backend-scoped routing
+   modal data loading.

--- a/scripts/update_claude_model_catalog.py
+++ b/scripts/update_claude_model_catalog.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vibe.api import resolve_cli_path
+from vibe.claude_model_catalog import (
+    get_catalog_path,
+    infer_bundle_path_from_cli,
+    infer_models_from_bundle,
+    write_catalog_models,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Regenerate the tracked Claude model catalog from the current Claude installation bundle."
+    )
+    parser.add_argument("--cli-path", help="Explicit Claude CLI path. Defaults to resolve_cli_path('claude').")
+    parser.add_argument("--bundle-path", help="Explicit Claude bundle path to scan.")
+    parser.add_argument(
+        "--output",
+        help="Output catalog path. Defaults to vibe/data/claude_models.json in this repository.",
+    )
+    args = parser.parse_args()
+
+    output_path = Path(args.output).expanduser().resolve() if args.output else get_catalog_path(REPO_ROOT / "vibe")
+
+    bundle_path: Path | None = None
+    if args.bundle_path:
+        bundle_path = Path(args.bundle_path).expanduser().resolve()
+    else:
+        cli_path = args.cli_path or resolve_cli_path("claude")
+        bundle_path = infer_bundle_path_from_cli(cli_path)
+
+    if bundle_path is None or not bundle_path.exists():
+        print("Could not find a Claude bundle to scan.", file=sys.stderr)
+        return 1
+
+    models = infer_models_from_bundle(bundle_path)
+    if not models:
+        print(f"No Claude models inferred from {bundle_path}", file=sys.stderr)
+        return 1
+
+    written_path = write_catalog_models(models, output_path)
+    print(f"Wrote {len(models)} Claude models to {written_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from unittest.mock import patch
 
 from config.v2_settings import RoutingSettings
 from core.handlers.settings_handler import SettingsHandler
+from modules.im import MessageContext
 
 
 class _StubSettingsManager:
@@ -128,3 +130,119 @@ def test_handle_routing_update_handles_first_codex_save_without_existing_routing
     assert settings_manager.saved_routing.codex_model == "gpt-5.4"
     assert settings_manager.saved_routing.codex_reasoning_effort == "high"
     send_message.assert_not_awaited()
+
+
+class _RoutingSettingsManager:
+    def get_channel_routing(self, settings_key: str) -> RoutingSettings | None:
+        assert settings_key == "slack::D0APS47LPU2"
+        return None
+
+
+class _FakeOpenCodeServer:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def ensure_running(self) -> None:
+        self.calls.append("ensure_running")
+
+    async def get_available_agents(self, directory: str) -> list[dict]:
+        self.calls.append(f"agents:{directory}")
+        return [{"name": "build"}]
+
+    async def get_available_models(self, directory: str) -> dict:
+        self.calls.append(f"models:{directory}")
+        return {"providers": []}
+
+    async def get_default_config(self, directory: str) -> dict:
+        self.calls.append(f"config:{directory}")
+        return {"model": "openai/gpt-5"}
+
+
+class _FakeOpenCodeAgent:
+    def __init__(self, server: _FakeOpenCodeServer) -> None:
+        self.server = server
+
+    async def _get_server(self) -> _FakeOpenCodeServer:
+        return self.server
+
+
+def _make_routing_handler() -> tuple[SettingsHandler, _FakeOpenCodeServer]:
+    server = _FakeOpenCodeServer()
+    controller = SimpleNamespace(
+        config=SimpleNamespace(
+            platform="slack",
+            language="en",
+            opencode=SimpleNamespace(enabled=True),
+            claude=SimpleNamespace(enabled=True),
+            codex=SimpleNamespace(enabled=True),
+        ),
+        im_client=SimpleNamespace(send_message=AsyncMock()),
+        settings_manager=_RoutingSettingsManager(),
+        _get_settings_key=lambda context: "slack::D0APS47LPU2",
+        _get_lang=lambda: "en",
+        resolve_agent_for_context=lambda context: "opencode",
+        get_cwd=lambda context: "/tmp/workspace",
+        agent_service=SimpleNamespace(
+            agents={
+                "opencode": _FakeOpenCodeAgent(server),
+                "claude": object(),
+                "codex": object(),
+            }
+        ),
+    )
+    return SettingsHandler(controller), server
+
+
+def test_gather_routing_modal_data_only_fetches_current_backend() -> None:
+    handler, server = _make_routing_handler()
+    context = MessageContext(user_id="U1", channel_id="D0APS47LPU2", platform="slack")
+
+    with patch("vibe.api.claude_models", side_effect=AssertionError("claude should not be fetched")), patch(
+        "vibe.api.claude_agents", side_effect=AssertionError("claude should not be fetched")
+    ), patch("vibe.api.codex_models", side_effect=AssertionError("codex should not be fetched")), patch(
+        "vibe.api.codex_agents", side_effect=AssertionError("codex should not be fetched")
+    ):
+        data = asyncio.run(handler._gather_routing_modal_data(context))
+
+    assert data.current_backend == "opencode"
+    assert data.registered_backends == ["opencode", "claude", "codex"]
+    assert server.calls == [
+        "ensure_running",
+        "agents:/tmp/workspace",
+        "models:/tmp/workspace",
+        "config:/tmp/workspace",
+    ]
+
+
+def test_gather_routing_modal_data_fetches_selected_backend_on_modal_update() -> None:
+    handler, server = _make_routing_handler()
+    context = MessageContext(user_id="U1", channel_id="D0APS47LPU2", platform="slack")
+
+    with patch("vibe.api.claude_agents", return_value={"ok": True, "agents": [{"id": "reviewer"}]}), patch(
+        "vibe.api.claude_models", return_value={"ok": True, "models": ["claude-sonnet-4-6"]}
+    ), patch("vibe.api.codex_models", side_effect=AssertionError("codex should not be fetched")), patch(
+        "vibe.api.codex_agents", side_effect=AssertionError("codex should not be fetched")
+    ):
+        data = asyncio.run(handler._gather_routing_modal_data(context, selected_backend="claude"))
+
+    assert data.current_backend == "opencode"
+    assert data.claude_agents == [{"id": "reviewer"}]
+    assert data.claude_models == ["claude-sonnet-4-6"]
+    assert server.calls == []
+
+
+def test_gather_routing_modal_data_hides_disabled_backends() -> None:
+    handler, server = _make_routing_handler()
+    handler.config.claude.enabled = False
+    handler.config.codex.enabled = False
+    context = MessageContext(user_id="U1", channel_id="D0APS47LPU2", platform="slack")
+
+    data = asyncio.run(handler._gather_routing_modal_data(context))
+
+    assert data.registered_backends == ["opencode"]
+    assert server.calls == [
+        "ensure_running",
+        "agents:/tmp/workspace",
+        "models:/tmp/workspace",
+        "config:/tmp/workspace",
+    ]

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -271,3 +271,27 @@ def test_gather_routing_modal_data_hides_disabled_backends() -> None:
         "models:/tmp/workspace",
         "config:/tmp/workspace",
     ]
+
+
+def test_gather_routing_modal_data_falls_back_to_visible_backend_when_current_is_disabled() -> None:
+    handler, server = _make_routing_handler()
+    handler.config.claude.enabled = False
+    context = MessageContext(user_id="U1", channel_id="D0APS47LPU2", platform="slack")
+    handler.controller.resolve_agent_for_context = lambda context: "claude"
+
+    with patch("vibe.api.claude_models", side_effect=AssertionError("claude should not be fetched")), patch(
+        "vibe.api.claude_agents", side_effect=AssertionError("claude should not be fetched")
+    ), patch("vibe.api.codex_models", side_effect=AssertionError("codex should not be fetched")), patch(
+        "vibe.api.codex_agents", side_effect=AssertionError("codex should not be fetched")
+    ):
+        data = asyncio.run(handler._gather_routing_modal_data(context))
+
+    assert data.current_backend == "claude"
+    assert data.registered_backends == ["opencode", "codex"]
+    assert data.opencode_agents == [{"name": "build"}]
+    assert server.calls == [
+        "ensure_running",
+        "agents:/tmp/workspace",
+        "models:/tmp/workspace",
+        "config:/tmp/workspace",
+    ]

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -231,6 +231,31 @@ def test_gather_routing_modal_data_fetches_selected_backend_on_modal_update() ->
     assert server.calls == []
 
 
+def test_gather_routing_modal_data_prefetches_all_backends_when_requested() -> None:
+    handler, server = _make_routing_handler()
+    context = MessageContext(user_id="U1", channel_id="D0APS47LPU2", platform="telegram")
+
+    with patch("vibe.api.claude_agents", return_value={"ok": True, "agents": [{"id": "reviewer"}]}), patch(
+        "vibe.api.claude_models", return_value={"ok": True, "models": ["claude-sonnet-4-6"]}
+    ), patch("vibe.api.codex_agents", return_value={"ok": True, "agents": [{"id": "builder"}]}), patch(
+        "vibe.api.codex_models", return_value={"ok": True, "models": ["gpt-5.4"]}
+    ):
+        data = asyncio.run(handler._gather_routing_modal_data(context, include_all_backend_data=True))
+
+    assert data.registered_backends == ["opencode", "claude", "codex"]
+    assert data.opencode_agents == [{"name": "build"}]
+    assert data.claude_agents == [{"id": "reviewer"}]
+    assert data.claude_models == ["claude-sonnet-4-6"]
+    assert data.codex_agents == [{"id": "builder"}]
+    assert data.codex_models == ["gpt-5.4"]
+    assert server.calls == [
+        "ensure_running",
+        "agents:/tmp/workspace",
+        "models:/tmp/workspace",
+        "config:/tmp/workspace",
+    ]
+
+
 def test_gather_routing_modal_data_hides_disabled_backends() -> None:
     handler, server = _make_routing_handler()
     handler.config.claude.enabled = False

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -323,3 +323,4 @@ def test_handle_routing_modal_update_uses_visible_current_backend() -> None:
 
     assert len(update_calls) == 1
     assert update_calls[0]["current_backend"] == "opencode"
+    assert update_calls[0]["selected_backend"] == "opencode"

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from config.v2_settings import RoutingSettings
 from core.handlers.settings_handler import SettingsHandler
+from core.modals import RoutingModalSelection
 from modules.im import MessageContext
 
 
@@ -286,7 +287,7 @@ def test_gather_routing_modal_data_falls_back_to_visible_backend_when_current_is
     ):
         data = asyncio.run(handler._gather_routing_modal_data(context))
 
-    assert data.current_backend == "claude"
+    assert data.current_backend == "opencode"
     assert data.registered_backends == ["opencode", "codex"]
     assert data.opencode_agents == [{"name": "build"}]
     assert server.calls == [
@@ -295,3 +296,30 @@ def test_gather_routing_modal_data_falls_back_to_visible_backend_when_current_is
         "models:/tmp/workspace",
         "config:/tmp/workspace",
     ]
+
+
+def test_handle_routing_modal_update_uses_visible_current_backend() -> None:
+    handler, _server = _make_routing_handler()
+    handler.config.claude.enabled = False
+    handler.controller.resolve_agent_for_context = lambda context: "claude"
+    update_calls = []
+
+    async def _update_routing_modal(**kwargs):
+        update_calls.append(kwargs)
+
+    handler._get_im_client = lambda context: SimpleNamespace(update_routing_modal=_update_routing_modal)
+    selection = RoutingModalSelection(selected_backend="opencode")
+
+    asyncio.run(
+        handler.handle_routing_modal_update(
+            user_id="U1",
+            channel_id="D0APS47LPU2",
+            view_id="view-1",
+            view_hash="hash-1",
+            selection=selection,
+            platform="slack",
+        )
+    )
+
+    assert len(update_calls) == 1
+    assert update_calls[0]["current_backend"] == "opencode"

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -251,7 +251,7 @@ def test_install_codex_detects_binary_via_npm_prefix(monkeypatch, tmp_path):
     assert calls[0][0] == [str(npm_path), "install", "-g", "@openai/codex"]
     assert calls[0][1]["PATH"].split(api.os.pathsep)[0] == str(npm_path.parent)
 
-def test_claude_models_merge_builtin_cli_and_settings(monkeypatch, tmp_path):
+def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
     claude_dir = tmp_path / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
     (claude_dir / "settings.json").write_text(
@@ -266,21 +266,18 @@ def test_claude_models_merge_builtin_cli_and_settings(monkeypatch, tmp_path):
         ),
         encoding="utf-8",
     )
-    cli_bundle = tmp_path / "claude-cli.js"
-    cli_bundle.write_text(
-        '\n'.join(
-            [
-                'const OPUS_ID = "claude-opus-4-6";',
-                'const SONNET_ID = "claude-sonnet-4-6";',
-                'const HAIKU_ID = "claude-haiku-4-5";',
-                'const PREV_SONNET_ID = "claude-sonnet-4-5";',
-            ]
-        ),
-        encoding="utf-8",
-    )
 
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
-    monkeypatch.setattr(api, "resolve_cli_path", lambda binary: str(cli_bundle) if binary == "claude" else None)
+    monkeypatch.setattr(
+        api,
+        "load_catalog_models",
+        lambda: [
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "claude-opus-4-5",
+        ],
+    )
 
     result = api.claude_models()
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -37,6 +37,7 @@ from vibe.upgrade import (
     get_running_vibe_path,
     get_safe_cwd,
 )
+from vibe.claude_model_catalog import DEFAULT_CLAUDE_MODEL_ALIASES, load_catalog_models
 from modules.agents.subagent_router import list_codex_subagents
 
 
@@ -1077,8 +1078,7 @@ def claude_models() -> dict:
 
     Claude Code does not expose a stable `list models` CLI subcommand.
     We merge suggestions from:
-    - Built-in known model ids and aliases
-    - The locally installed Claude CLI bundle (when available)
+    - The repository-owned Claude model catalog
     - ~/.claude/settings.json model/env values
     """
 
@@ -1091,40 +1091,14 @@ def claude_models() -> dict:
         seen.add(model)
         options.append(model)
 
-    built_in_options = [
-        "claude-opus-4-6",
-        "claude-sonnet-4-6",
-        "claude-haiku-4-5",
-        "claude-opus-4-5",
-        "claude-sonnet-4-5",
-        "claude-opus-4",
-        "claude-sonnet-4",
-        "claude-haiku-4",
-        "opus",
-        "sonnet",
-        "haiku",
-    ]
-
     options: list[str] = []
     seen: set[str] = set()
 
-    for model in built_in_options:
+    for model in load_catalog_models():
         _append_unique(options, seen, model)
 
-    claude_path = resolve_cli_path("claude")
-    if claude_path:
-        cli_bundle_candidates = [
-            Path(claude_path).resolve(),
-            Path(claude_path).resolve().parent / "cli.js",
-        ]
-        cli_bundle_path = next((path for path in cli_bundle_candidates if path.exists() and path.is_file()), None)
-        if cli_bundle_path is not None:
-            try:
-                bundle_text = cli_bundle_path.read_text(encoding="utf-8", errors="ignore")
-                for match in re.findall(r"claude-(?:opus|sonnet|haiku)-\d+(?:-\d+)*(?:-\d{8})?", bundle_text):
-                    _append_unique(options, seen, match)
-            except Exception as exc:
-                logger.warning("Failed to inspect Claude CLI bundle: %s", exc, exc_info=True)
+    for model in DEFAULT_CLAUDE_MODEL_ALIASES:
+        _append_unique(options, seen, model)
 
     settings_path = Path.home() / ".claude" / "settings.json"
     try:

--- a/vibe/claude_model_catalog.py
+++ b/vibe/claude_model_catalog.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import mmap
+import re
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_CLAUDE_MODEL_ALIASES: tuple[str, ...] = ("opus", "sonnet", "haiku")
+FALLBACK_CLAUDE_MODELS: tuple[str, ...] = (
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "claude-opus-4-5",
+    "claude-sonnet-4-5",
+    "claude-opus-4",
+    "claude-sonnet-4",
+    "claude-haiku-4",
+)
+
+_CLAUDE_FAMILY_ORDER = {
+    "opus": 0,
+    "sonnet": 1,
+    "haiku": 2,
+}
+_CLAUDE_MODEL_PATTERN = re.compile(rb"claude-(?:opus|sonnet|haiku)-\d+(?:-\d+)*(?:-\d{8})?")
+
+
+def get_catalog_path(repo_root: Path | None = None) -> Path:
+    base_dir = repo_root if repo_root is not None else Path(__file__).resolve().parent
+    return base_dir / "data" / "claude_models.json"
+
+
+def load_catalog_models(path: Path | None = None) -> list[str]:
+    catalog_path = path or get_catalog_path()
+    try:
+        payload = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return list(FALLBACK_CLAUDE_MODELS)
+    except Exception:
+        return list(FALLBACK_CLAUDE_MODELS)
+
+    models = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(models, list):
+        return list(FALLBACK_CLAUDE_MODELS)
+
+    normalized = _dedupe_str_values(models)
+    return normalized or list(FALLBACK_CLAUDE_MODELS)
+
+
+def infer_bundle_path_from_cli(cli_path: str | None) -> Path | None:
+    if not cli_path:
+        return None
+
+    resolved = Path(cli_path).expanduser().resolve()
+    candidates = (
+        resolved,
+        resolved.parent / "cli.js",
+    )
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    return None
+
+
+def infer_models_from_bundle(bundle_path: Path) -> list[str]:
+    matches: set[str] = set()
+    with bundle_path.open("rb") as handle, mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mapped:
+        for match in _CLAUDE_MODEL_PATTERN.finditer(mapped):
+            matches.add(match.group(0).decode("utf-8"))
+    return sort_catalog_models(matches)
+
+
+def sort_catalog_models(models: Iterable[str]) -> list[str]:
+    normalized = _dedupe_str_values(models)
+
+    def sort_key(model: str) -> tuple[int, tuple[int, ...], str]:
+        parts = model.split("-")
+        family = parts[1] if len(parts) > 1 else ""
+        version_numbers = tuple(-int(part) for part in parts[2:] if part.isdigit())
+        return (
+            _CLAUDE_FAMILY_ORDER.get(family, len(_CLAUDE_FAMILY_ORDER)),
+            version_numbers,
+            model,
+        )
+
+    return sorted(normalized, key=sort_key)
+
+
+def write_catalog_models(models: Iterable[str], path: Path | None = None) -> Path:
+    catalog_path = path or get_catalog_path()
+    catalog_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "models": sort_catalog_models(models),
+    }
+    catalog_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return catalog_path
+
+
+def _dedupe_str_values(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        candidate = value.strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        normalized.append(candidate)
+    return normalized

--- a/vibe/data/claude_models.json
+++ b/vibe/data/claude_models.json
@@ -1,0 +1,24 @@
+{
+  "models": [
+    "claude-opus-4",
+    "claude-opus-4-20250514",
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-1",
+    "claude-opus-4-1-20250805",
+    "claude-opus-4-0",
+    "claude-sonnet-4",
+    "claude-sonnet-4-20250514",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-4-5-20250514",
+    "claude-sonnet-4-0",
+    "claude-sonnet-3-7",
+    "claude-haiku-4",
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
+    "claude-haiku-3-5"
+  ]
+}


### PR DESCRIPTION
## Summary
- only load routing modal data for the current backend on first open, and only for the selected backend during modal refresh
- hide disabled backends from Agent Settings so Slack users do not see routes that are not actually available
- replace runtime Claude bundle scanning with a repo-owned model catalog plus a maintainer script to refresh the catalog for releases

## Why
Slack Agent Settings was timing out because the modal path did unnecessary backend discovery before opening the view. On affected machines this could trigger expensive Claude model discovery and let the Slack trigger expire.

## Testing
- `python3 -m pytest tests/test_settings_handler.py`
- `python3 -m pytest tests/test_ui_api.py -k claude_models_merge_catalog_and_settings`
- `python3 -m ruff check config/v2_compat.py core/handlers/settings_handler.py vibe/api.py vibe/claude_model_catalog.py scripts/update_claude_model_catalog.py tests/test_ui_api.py tests/test_settings_handler.py`
- `python3 scripts/update_claude_model_catalog.py --output /tmp/claude_models_test.json`

## Evidence
- unit: updated `tests/test_settings_handler.py` and `tests/test_ui_api.py`
- contract: not updated
- scenario: not updated
- residual manual checks: Slack Agent Settings open/refresh flow still needs live verification against a real workspace

## Risks / Follow-ups
- wheel packaging for the new Claude catalog file was not fully verified in this environment because `hatchling.build` is unavailable locally
