### PR TITLE
fix(feishu): extract images from post (rich text) messages

### DIFF
--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -1457,6 +1457,8 @@ class FeishuBot(BaseIMClient):
             file_attachments = None
             if msg_type in ("file", "image", "media"):
                 file_attachments = self._extract_file_attachments(message_id, msg_content, msg_type)
+            elif msg_type == "post":
+                file_attachments = self._extract_post_images(message_id, msg_content)
 
             # Check for shared/forwarded messages
             shared_text = None
@@ -1583,8 +1585,49 @@ class FeishuBot(BaseIMClient):
                     line_parts.append(element.get("text", element.get("href", "")))
                 elif tag == "at":
                     line_parts.append(element.get("user_name", ""))
+                elif tag == "img":
+                    line_parts.append("[image]")
             parts.append("".join(line_parts))
         return "\n".join(parts).strip()
+
+    def _extract_post_images(
+        self, message_id: str, msg_content: Dict[str, Any]
+    ) -> Optional[List[FileAttachment]]:
+        """Extract image attachments from a Feishu 'post' (rich text) message.
+
+        Post messages embed images as elements with tag='img' and an image_key.
+        This method walks the post content structure and creates FileAttachment
+        objects for each embedded image, using the same download URL pattern as
+        standalone image messages.
+        """
+        attachments: List[FileAttachment] = []
+        # Post structure may be wrapped in a language key: {"zh_cn": {"content": [...]}}
+        # or directly: {"content": [...]}
+        content_body = msg_content
+        for lang_key in ("zh_cn", "en_us", "ja_jp"):
+            if lang_key in msg_content:
+                content_body = msg_content[lang_key]
+                break
+        for line in content_body.get("content", []):
+            for element in line:
+                if element.get("tag") == "img":
+                    image_key = element.get("image_key", "")
+                    if not image_key:
+                        continue
+                    url = (
+                        f"{self.config.api_base_url}/open-apis/im/v1/messages/{message_id}/resources/{image_key}?type=image"
+                        if message_id and image_key
+                        else None
+                    )
+                    attachments.append(
+                        FileAttachment(
+                            name=f"{image_key}.image",
+                            mimetype="image/unknown",
+                            url=url,
+                            size=None,
+                        )
+                    )
+        return attachments if attachments else None
 
     def _handle_card_action(self, event_data: Dict[str, Any]):
         """Handle card.action.trigger event (button clicks)."""


### PR DESCRIPTION
## Summary

- Feishu encodes pasted screenshots as `msg_type=post` (rich text) with embedded `{"tag": "img", "image_key": "xxx"}` elements, **not** as standalone `msg_type=image` messages
- Two co-dependent defects in `modules/im/feishu.py` caused these images to be silently dropped with no error or warning
- This PR fixes both defects so pasted screenshots are correctly downloaded and forwarded to the agent

Fixes #183

## Changes

**`modules/im/feishu.py`** — 3 targeted changes, +43 lines, 0 deletions:

### 1. `_extract_post_text()` — handle `img` tags
Added `elif tag == "img": line_parts.append("[image]")` so that image-only post messages generate non-empty text and are not silently discarded by the early return check.

### 2. New method `_extract_post_images()`
Walks the post content structure (handling multi-language wrappers like `zh_cn`/`en_us`/`ja_jp`), extracts `image_key` from `img` elements, and constructs `FileAttachment` objects using the same download URL pattern as standalone image messages:
```
/open-apis/im/v1/messages/{message_id}/resources/{image_key}?type=image
```

### 3. `_async_handle_message()` — call image extraction for `post`
Added `elif msg_type == "post": file_attachments = self._extract_post_images(...)` to the file attachment extraction block, so post messages are handled alongside `file`, `image`, and `media` types.

## Root Cause Analysis

**Defect 1** — `_extract_post_text()` only processed `text`, `a`, and `at` tags. The `img` tag was silently skipped, producing an empty string for image-only posts.

**Defect 2** — File attachment extraction was gated on `msg_type in ("file", "image", "media")`, which excluded `"post"`. The `file_attachments` variable stayed `None` for all post messages.

**Combined effect**: Image-only posts hit the early return (`if not text and not file_attachments: return`) and were silently discarded. Posts with text + images passed through but lost all images.

**Why other platforms don't have this bug**: Telegram and Slack extract files based on whether files exist in the payload, not based on message type. Feishu was the only platform gating file extraction on `msg_type`.

## Testing

Tested manually on vibe-remote v2.2.10 with Feishu WebSocket mode:

| Test | Result |
|------|--------|
| Paste screenshot (Ctrl+V) in p2p chat | ✅ Image downloaded and forwarded to agent |
| Post with text + image | ✅ Both text and image received |
| Image-only post (no text) | ✅ `[image]` placeholder + attachment received |
| Standalone `msg_type=image` (unchanged path) | ✅ Still works as before |
| `msg_type=text` (unchanged path) | ✅ Still works as before |