### PR TITLE
fix(feishu): preserve wrapped post text and image parsing

### DIFF
--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -1457,6 +1457,8 @@ class FeishuBot(BaseIMClient):
             file_attachments = None
             if msg_type in ("file", "image", "media"):
                 file_attachments = self._extract_file_attachments(message_id, msg_content, msg_type)
+            elif msg_type == "post":
+                file_attachments = self._extract_post_images(message_id, msg_content)
 
             # Check for shared/forwarded messages
             shared_text = None
@@ -1583,8 +1585,49 @@ class FeishuBot(BaseIMClient):
                     line_parts.append(element.get("text", element.get("href", "")))
                 elif tag == "at":
                     line_parts.append(element.get("user_name", ""))
+                elif tag == "img":
+                    line_parts.append("[image]")
             parts.append("".join(line_parts))
         return "\n".join(parts).strip()
+
+    def _extract_post_images(
+        self, message_id: str, msg_content: Dict[str, Any]
+    ) -> Optional[List[FileAttachment]]:
+        """Extract image attachments from a Feishu 'post' (rich text) message.
+
+        Post messages embed images as elements with tag='img' and an image_key.
+        This method walks the post content structure and creates FileAttachment
+        objects for each embedded image, using the same download URL pattern as
+        standalone image messages.
+        """
+        attachments: List[FileAttachment] = []
+        # Post structure may be wrapped in a language key: {"zh_cn": {"content": [...]}}
+        # or directly: {"content": [...]}
+        content_body = msg_content
+        for lang_key in ("zh_cn", "en_us", "ja_jp"):
+            if lang_key in msg_content:
+                content_body = msg_content[lang_key]
+                break
+        for line in content_body.get("content", []):
+            for element in line:
+                if element.get("tag") == "img":
+                    image_key = element.get("image_key", "")
+                    if not image_key:
+                        continue
+                    url = (
+                        f"{self.config.api_base_url}/open-apis/im/v1/messages/{message_id}/resources/{image_key}?type=image"
+                        if message_id and image_key
+                        else None
+                    )
+                    attachments.append(
+                        FileAttachment(
+                            name=f"{image_key}.image",
+                            mimetype="image/unknown",
+                            url=url,
+                            size=None,
+                        )
+                    )
+        return attachments if attachments else None
 
     def _handle_card_action(self, event_data: Dict[str, Any]):
         """Handle card.action.trigger event (button clicks)."""

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -1568,14 +1568,31 @@ class FeishuBot(BaseIMClient):
         except Exception as exc:
             logger.error("Error handling Feishu message event: %s", exc, exc_info=True)
 
+    def _get_post_content_body(self, content: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize a Feishu/Lark post payload to the body holding title/content."""
+        if isinstance(content.get("content"), list):
+            return content
+
+        for lang_key in ("zh_cn", "en_us", "ja_jp"):
+            candidate = content.get(lang_key)
+            if isinstance(candidate, dict) and isinstance(candidate.get("content"), list):
+                return candidate
+
+        for value in content.values():
+            if isinstance(value, dict) and isinstance(value.get("content"), list):
+                return value
+
+        return content
+
     def _extract_post_text(self, content: Dict[str, Any]) -> str:
         """Extract plain text from a Feishu 'post' (rich text) message."""
         parts: List[str] = []
+        content_body = self._get_post_content_body(content)
         # Post structure: {"title": "...", "content": [[{"tag": "text", "text": "..."}, ...]]}
-        title = content.get("title", "")
+        title = content_body.get("title", "")
         if title:
             parts.append(title)
-        for line in content.get("content", []):
+        for line in content_body.get("content", []):
             line_parts = []
             for element in line:
                 tag = element.get("tag", "")
@@ -1601,13 +1618,7 @@ class FeishuBot(BaseIMClient):
         standalone image messages.
         """
         attachments: List[FileAttachment] = []
-        # Post structure may be wrapped in a language key: {"zh_cn": {"content": [...]}}
-        # or directly: {"content": [...]}
-        content_body = msg_content
-        for lang_key in ("zh_cn", "en_us", "ja_jp"):
-            if lang_key in msg_content:
-                content_body = msg_content[lang_key]
-                break
+        content_body = self._get_post_content_body(msg_content)
         for line in content_body.get("content", []):
             for element in line:
                 if element.get("tag") == "img":

--- a/tests/test_feishu_post_messages.py
+++ b/tests/test_feishu_post_messages.py
@@ -1,0 +1,134 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from config.v2_config import LarkConfig
+from core.auth import AuthResult
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _install_opencode_utils_module() -> None:
+    if "aiohttp" not in sys.modules:
+        sys.modules["aiohttp"] = types.ModuleType("aiohttp")
+
+    if "modules.agents.opencode.utils" in sys.modules:
+        return
+
+    if "modules.agents" not in sys.modules:
+        agents_mod = types.ModuleType("modules.agents")
+        agents_mod.__path__ = [str(ROOT / "modules" / "agents")]
+        sys.modules["modules.agents"] = agents_mod
+    if "modules.agents.opencode" not in sys.modules:
+        opencode_mod = types.ModuleType("modules.agents.opencode")
+        opencode_mod.__path__ = [str(ROOT / "modules" / "agents" / "opencode")]
+        sys.modules["modules.agents.opencode"] = opencode_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "modules.agents.opencode.utils",
+        ROOT / "modules" / "agents" / "opencode" / "utils.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["modules.agents.opencode.utils"] = module
+    spec.loader.exec_module(module)
+
+
+_install_opencode_utils_module()
+
+from modules.im.feishu import FeishuBot
+
+
+class FeishuPostMessageTests(unittest.IsolatedAsyncioTestCase):
+    def _make_bot(self) -> FeishuBot:
+        return FeishuBot(LarkConfig(app_id="app-id", app_secret="app-secret"))
+
+    def test_extract_post_text_handles_language_wrapped_content(self):
+        bot = self._make_bot()
+        text = bot._extract_post_text(
+            {
+                "zh_cn": {
+                    "title": "日报",
+                    "content": [
+                        [{"tag": "text", "text": "hello"}],
+                        [{"tag": "img", "image_key": "img_123"}],
+                    ],
+                }
+            }
+        )
+
+        self.assertEqual(text, "日报\nhello\n[image]")
+
+    def test_extract_post_images_handles_language_wrapped_content(self):
+        bot = self._make_bot()
+        attachments = bot._extract_post_images(
+            "om_123",
+            {
+                "zh_cn": {
+                    "content": [
+                        [{"tag": "img", "image_key": "img_123"}],
+                        [{"tag": "text", "text": "hello"}],
+                    ]
+                }
+            },
+        )
+
+        self.assertIsNotNone(attachments)
+        assert attachments is not None
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].name, "img_123.image")
+        self.assertEqual(
+            attachments[0].url,
+            "https://open.feishu.cn/open-apis/im/v1/messages/om_123/resources/img_123?type=image",
+        )
+
+    async def test_async_handle_message_keeps_text_and_images_for_wrapped_post(self):
+        bot = self._make_bot()
+        bot.check_authorization = lambda **kwargs: AuthResult(allowed=True, is_dm=True)
+        bot.dispatch_text_command = AsyncMock(return_value=False)
+        bot.on_message_callback = AsyncMock()
+
+        event_data = {
+            "sender": {
+                "sender_type": "user",
+                "sender_id": {"open_id": "ou_user"},
+            },
+            "message": {
+                "chat_id": "oc_chat",
+                "chat_type": "p2p",
+                "message_id": "om_123",
+                "message_type": "post",
+                "content": json.dumps(
+                    {
+                        "zh_cn": {
+                            "title": "日报",
+                            "content": [
+                                [{"tag": "text", "text": "hello"}],
+                                [{"tag": "img", "image_key": "img_123"}],
+                            ],
+                        }
+                    }
+                ),
+            },
+        }
+
+        await bot._async_handle_message(event_data)
+
+        bot.on_message_callback.assert_awaited_once()
+        args = bot.on_message_callback.await_args.args
+        context, text = args
+        self.assertEqual(text, "日报\nhello\n[image]")
+        self.assertIsNotNone(context.files)
+        assert context.files is not None
+        self.assertEqual(len(context.files), 1)
+        self.assertEqual(context.files[0].name, "img_123.image")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- carry the Feishu post-image fix from `fix/feishu-post-images-base` into `master`
- normalize wrapped Feishu/Lark `post` payload parsing so text and images use the same extracted body
- add regression tests for language-wrapped `post` messages to prevent silent text loss

Fixes #183

## Why

PR #184 fixed embedded image extraction for `msg_type=post`, but text parsing still read only the top-level payload. When Feishu/Lark wrapped the rich-text body under language keys such as `zh_cn`, image extraction worked while text and title could still be dropped.

This follow-up makes the parser normalize the post body once and reuse it for both text and attachment extraction.

## Testing

- unit: `python3 -m pytest tests/test_feishu_post_messages.py tests/test_feishu_event_dispatcher.py tests/test_feishu_routing_card.py`
- unit: `ruff check modules/im/feishu.py tests/test_feishu_post_messages.py`
- contract: not updated
- scenario: not updated
- residual manual checks: not run in this turn

## Notes

- `uv run pytest ...` in this worktree currently fails before test execution because editable package build expects `ui/dist` to exist; the targeted `python3 -m pytest ...` run above passes.
