### PR TITLE
fix(resume): scope backend prep before session bind

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -575,14 +575,25 @@ class SessionHandler(BaseHandler):
 
         return client
 
-    async def _prepare_backend_for_resume(self, agent: str) -> None:
-        """Refresh backend runtime so resumed sessions can pick up fresh auth state."""
+    async def _prepare_backend_for_resume(
+        self,
+        agent: str,
+        *,
+        base_session_id: str,
+        session_key: str,
+        working_path: str,
+    ) -> None:
+        """Let the backend prepare scoped runtime state before a resume bind."""
         agent_service = getattr(self.controller, "agent_service", None)
         backend = getattr(agent_service, "agents", {}).get(agent) if agent_service else None
-        refresh = getattr(backend, "refresh_auth_state", None)
-        if callable(refresh):
-            logger.info("Refreshing %s runtime before resuming session", agent)
-            await refresh()
+        prepare = getattr(backend, "prepare_resume_binding", None)
+        if callable(prepare):
+            logger.info("Preparing %s runtime before resuming session %s", agent, base_session_id)
+            await prepare(
+                base_session_id=base_session_id,
+                session_key=session_key,
+                working_path=working_path,
+            )
 
     async def handle_resume_session_submission(
         self,
@@ -606,8 +617,6 @@ class SessionHandler(BaseHandler):
                 available_agents = set(self.controller.agent_service.agents.keys())
                 if agent not in available_agents:
                     raise ValueError(f"Agent '{agent}' is not enabled.")
-
-            await self._prepare_backend_for_resume(agent)
 
             reuse_thread = True
             if host_message_ts and thread_id and thread_id == host_message_ts:
@@ -708,12 +717,19 @@ class SessionHandler(BaseHandler):
                     platform_specific={"is_dm": is_dm},
                 )
             base_session_id = self.get_base_session_id(mapping_context)
+            working_path = self.get_working_path(mapping_context)
+
+            await self._prepare_backend_for_resume(
+                agent,
+                base_session_id=base_session_id,
+                session_key=session_key,
+                working_path=working_path,
+            )
 
             # OpenCode session mappings use composite keys that include
             # working_path so that cwd changes create new sessions.
             mapping_key = base_session_id
             if agent == "opencode":
-                working_path = self.get_working_path(mapping_context)
                 mapping_key = f"{base_session_id}:{working_path}"
 
             self.sessions.set_agent_session_mapping(session_key, agent, mapping_key, session_id)

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -575,6 +575,15 @@ class SessionHandler(BaseHandler):
 
         return client
 
+    async def _prepare_backend_for_resume(self, agent: str) -> None:
+        """Refresh backend runtime so resumed sessions can pick up fresh auth state."""
+        agent_service = getattr(self.controller, "agent_service", None)
+        backend = getattr(agent_service, "agents", {}).get(agent) if agent_service else None
+        refresh = getattr(backend, "refresh_auth_state", None)
+        if callable(refresh):
+            logger.info("Refreshing %s runtime before resuming session", agent)
+            await refresh()
+
     async def handle_resume_session_submission(
         self,
         user_id: str,
@@ -597,6 +606,8 @@ class SessionHandler(BaseHandler):
                 available_agents = set(self.controller.agent_service.agents.keys())
                 if agent not in available_agents:
                     raise ValueError(f"Agent '{agent}' is not enabled.")
+
+            await self._prepare_backend_for_resume(agent)
 
             reuse_thread = True
             if host_message_ts and thread_id and thread_id == host_message_ts:

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -173,6 +173,16 @@ class BaseAgent(ABC):
         """Clear session state for a given session scope key. Returns cleared count."""
         return 0
 
+    async def prepare_resume_binding(
+        self,
+        *,
+        base_session_id: str,
+        session_key: str,
+        working_path: str,
+    ) -> None:
+        """Prepare backend runtime before binding a resumed session."""
+        return None
+
     async def handle_stop(self, request: AgentRequest) -> bool:
         """Attempt to interrupt an in-flight task. Returns True if handled."""
         return False

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -215,6 +215,21 @@ class ClaudeAgent(BaseAgent):
 
         logger.info("Refreshed Claude auth state across %d runtime session(s)", len(session_ids))
 
+    async def prepare_resume_binding(
+        self,
+        *,
+        base_session_id: str,
+        session_key: str,
+        working_path: str,
+    ) -> None:
+        """Drop only the target Claude runtime session before rebinding it."""
+        composite_key = f"{base_session_id}:{working_path}"
+        if composite_key not in self.claude_sessions and composite_key not in self.receiver_tasks:
+            return
+
+        await self._cleanup_runtime_session(composite_key)
+        logger.info("Prepared Claude runtime for resumed session %s", composite_key)
+
     async def _cleanup_runtime_session(
         self,
         composite_key: str,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -228,6 +228,41 @@ class CodexAgent(BaseAgent):
 
         logger.info("Refreshed Codex auth state across %d transport(s)", len(transports))
 
+    async def prepare_resume_binding(
+        self,
+        *,
+        base_session_id: str,
+        session_key: str,
+        working_path: str,
+    ) -> None:
+        """Restart a Codex transport only when the resumed session owns that cwd."""
+        transport = self._transports.get(working_path)
+        if transport is None:
+            return
+
+        affected_sessions = self._session_mgr.sessions_for_cwd(working_path)
+        other_sessions = [session_id for session_id in affected_sessions if session_id != base_session_id]
+        if other_sessions:
+            logger.info(
+                "Skipping Codex resume preparation for %s; cwd=%s is shared by %d other session(s)",
+                base_session_id,
+                working_path,
+                len(other_sessions),
+            )
+            return
+
+        try:
+            await transport.stop()
+        except Exception as exc:
+            logger.warning("Failed to stop Codex transport during resume preparation: %s", exc)
+            return
+
+        self._transports.pop(working_path, None)
+        self._transport_last_activity.pop(working_path, None)
+        self._session_mgr.invalidate_thread(base_session_id)
+        self._turn_registry.clear_session(base_session_id)
+        logger.info("Prepared Codex runtime for resumed session %s", base_session_id)
+
     async def shutdown_runtime(self) -> None:
         """Stop all app-server transports during vibe-remote shutdown."""
         if not hasattr(self, "_transport_last_activity"):

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -283,6 +283,36 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(session_key, agent._pending_reactions)
         self.assertNotIn(session_key, agent._pending_requests)
 
+    async def test_prepare_resume_binding_cleans_only_target_runtime_session(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        target_key = "wechat_o9:/tmp/work"
+        other_key = "wechat_o10:/tmp/work"
+        target_client = _StubClient()
+        other_client = _StubClient()
+        controller.claude_sessions[target_key] = target_client
+        controller.claude_sessions[other_key] = other_client
+        controller.receiver_tasks[target_key] = asyncio.create_task(asyncio.sleep(3600))
+        controller.receiver_tasks[other_key] = asyncio.create_task(asyncio.sleep(3600))
+        await asyncio.sleep(0)
+
+        await agent.prepare_resume_binding(
+            base_session_id="wechat_o9",
+            session_key="wechat-user",
+            working_path="/tmp/work",
+        )
+
+        self.assertTrue(target_client.disconnected)
+        self.assertFalse(other_client.disconnected)
+        self.assertNotIn(target_key, controller.claude_sessions)
+        self.assertIn(other_key, controller.claude_sessions)
+        self.assertNotIn(target_key, controller.receiver_tasks)
+        self.assertIn(other_key, controller.receiver_tasks)
+
+        controller.receiver_tasks[other_key].cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await controller.receiver_tasks[other_key]
+
     async def test_receiver_auth_error_prefers_oauth_recovery_message(self):
         controller = _StubController()
         controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -285,6 +285,61 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(invalidated, ["session-1", "session-2"])
         self.assertEqual(cleared_sessions, ["session-1", "session-2"])
 
+    async def test_prepare_resume_binding_restarts_unshared_transport(self):
+        agent = object.__new__(CodexAgent)
+        stop_calls = []
+
+        async def stop_transport():
+            stop_calls.append("stop")
+
+        agent._transports = {"/tmp/work": SimpleNamespace(stop=stop_transport)}
+        agent._transport_last_activity = {"/tmp/work": 1.0}
+        invalidated = []
+        cleared_sessions = []
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
+            invalidate_thread=lambda base_session_id: invalidated.append(base_session_id),
+        )
+        agent._turn_registry = SimpleNamespace(clear_session=lambda base_session_id: cleared_sessions.append(base_session_id))
+
+        await agent.prepare_resume_binding(
+            base_session_id="session-1",
+            session_key="scope-1",
+            working_path="/tmp/work",
+        )
+
+        self.assertEqual(stop_calls, ["stop"])
+        self.assertEqual(agent._transports, {})
+        self.assertEqual(agent._transport_last_activity, {})
+        self.assertEqual(invalidated, ["session-1"])
+        self.assertEqual(cleared_sessions, ["session-1"])
+
+    async def test_prepare_resume_binding_skips_shared_transport(self):
+        agent = object.__new__(CodexAgent)
+        stop_transport = AsyncMock()
+        transport = SimpleNamespace(stop=stop_transport)
+        agent._transports = {"/tmp/work": transport}
+        agent._transport_last_activity = {"/tmp/work": 1.0}
+        invalidated = []
+        cleared_sessions = []
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=lambda cwd: ["session-1", "session-2"] if cwd == "/tmp/work" else [],
+            invalidate_thread=lambda base_session_id: invalidated.append(base_session_id),
+        )
+        agent._turn_registry = SimpleNamespace(clear_session=lambda base_session_id: cleared_sessions.append(base_session_id))
+
+        await agent.prepare_resume_binding(
+            base_session_id="session-1",
+            session_key="scope-1",
+            working_path="/tmp/work",
+        )
+
+        stop_transport.assert_not_awaited()
+        self.assertIs(agent._transports["/tmp/work"], transport)
+        self.assertEqual(agent._transport_last_activity, {"/tmp/work": 1.0})
+        self.assertEqual(invalidated, [])
+        self.assertEqual(cleared_sessions, [])
+
     async def test_evict_idle_transports_stops_idle_codex_runtime(self):
         agent = object.__new__(CodexAgent)
         stop_calls = []

--- a/tests/test_resume_session.py
+++ b/tests/test_resume_session.py
@@ -171,30 +171,36 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("sess_dm", im_client.messages[0][2])
         self.assertIn("Send your next message directly", im_client.messages[1][2])
 
-    async def test_handle_resume_session_submission_refreshes_codex_runtime(self):
+    async def test_handle_resume_session_submission_prepares_resume_binding(self):
         settings = _StubSettingsManager()
         im_client = _StubIMClient()
         ctrl = _StubController()
         ctrl.init_minimal(im_client, settings, _StubConfig())
-        codex_agent = type("CodexAgent", (), {"refresh_auth_state": AsyncMock()})()
+        ctrl.im_client.should_use_thread_for_reply = lambda: True
+        codex_agent = type("CodexAgent", (), {"prepare_resume_binding": AsyncMock()})()
         ctrl.agent_service = type("A", (), {"agents": {"claude": object(), "codex": codex_agent}})()
 
         await ctrl.session_handler.handle_resume_session_submission(
             user_id="U999",
-            channel_id="DXYZ",
-            thread_id=None,
+            channel_id="C111",
+            thread_id="169999.123",
             agent="codex",
-            session_id="sess_dm",
+            session_id="sess_abc",
         )
 
-        codex_agent.refresh_auth_state.assert_awaited_once()
+        codex_agent.prepare_resume_binding.assert_awaited_once_with(
+            base_session_id="slack_169999.123",
+            session_key="slack::C111",
+            working_path="/Users/cyh/vibe-remote",
+        )
 
-    async def test_handle_resume_session_submission_refreshes_claude_runtime(self):
+    async def test_handle_resume_session_submission_prepares_claude_binding(self):
         settings = _StubSettingsManager()
         im_client = _StubIMClient()
         ctrl = _StubController()
         ctrl.init_minimal(im_client, settings, _StubConfig())
-        claude_agent = type("ClaudeAgent", (), {"refresh_auth_state": AsyncMock()})()
+        ctrl.im_client.should_use_thread_for_reply = lambda: True
+        claude_agent = type("ClaudeAgent", (), {"prepare_resume_binding": AsyncMock()})()
         ctrl.agent_service = type("A", (), {"agents": {"claude": claude_agent, "codex": object()}})()
 
         await ctrl.session_handler.handle_resume_session_submission(
@@ -205,9 +211,13 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
             session_id="sess_abc",
         )
 
-        claude_agent.refresh_auth_state.assert_awaited_once()
+        claude_agent.prepare_resume_binding.assert_awaited_once_with(
+            base_session_id="slack_169999.123",
+            session_key="slack::C111",
+            working_path="/Users/cyh/vibe-remote",
+        )
 
-    async def test_handle_resume_session_submission_skips_runtime_refresh_when_backend_has_no_hook(self):
+    async def test_handle_resume_session_submission_skips_resume_prepare_when_backend_has_no_hook(self):
         settings = _StubSettingsManager()
         im_client = _StubIMClient()
         ctrl = _StubController()

--- a/tests/test_resume_session.py
+++ b/tests/test_resume_session.py
@@ -171,6 +171,62 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("sess_dm", im_client.messages[0][2])
         self.assertIn("Send your next message directly", im_client.messages[1][2])
 
+    async def test_handle_resume_session_submission_refreshes_codex_runtime(self):
+        settings = _StubSettingsManager()
+        im_client = _StubIMClient()
+        ctrl = _StubController()
+        ctrl.init_minimal(im_client, settings, _StubConfig())
+        codex_agent = type("CodexAgent", (), {"refresh_auth_state": AsyncMock()})()
+        ctrl.agent_service = type("A", (), {"agents": {"claude": object(), "codex": codex_agent}})()
+
+        await ctrl.session_handler.handle_resume_session_submission(
+            user_id="U999",
+            channel_id="DXYZ",
+            thread_id=None,
+            agent="codex",
+            session_id="sess_dm",
+        )
+
+        codex_agent.refresh_auth_state.assert_awaited_once()
+
+    async def test_handle_resume_session_submission_refreshes_claude_runtime(self):
+        settings = _StubSettingsManager()
+        im_client = _StubIMClient()
+        ctrl = _StubController()
+        ctrl.init_minimal(im_client, settings, _StubConfig())
+        claude_agent = type("ClaudeAgent", (), {"refresh_auth_state": AsyncMock()})()
+        ctrl.agent_service = type("A", (), {"agents": {"claude": claude_agent, "codex": object()}})()
+
+        await ctrl.session_handler.handle_resume_session_submission(
+            user_id="U123",
+            channel_id="C111",
+            thread_id="169999.123",
+            agent="claude",
+            session_id="sess_abc",
+        )
+
+        claude_agent.refresh_auth_state.assert_awaited_once()
+
+    async def test_handle_resume_session_submission_skips_runtime_refresh_when_backend_has_no_hook(self):
+        settings = _StubSettingsManager()
+        im_client = _StubIMClient()
+        ctrl = _StubController()
+        ctrl.init_minimal(im_client, settings, _StubConfig())
+        ctrl.agent_service = type("A", (), {"agents": {"claude": object(), "codex": object()}})()
+
+        await ctrl.session_handler.handle_resume_session_submission(
+            user_id="U123",
+            channel_id="C111",
+            thread_id="169999.123",
+            agent="claude",
+            session_id="sess_abc",
+        )
+
+        self.assertEqual(len(settings.set_calls), 1)
+        self.assertEqual(settings.set_calls[0][0], "slack::C111")
+        self.assertEqual(settings.set_calls[0][1], "claude")
+        self.assertEqual(settings.set_calls[0][3], "sess_abc")
+
     async def test_handle_resume_session_submission_discord_dm_uses_channel_session_key(self):
         settings = _StubSettingsManager()
         im_client = _StubIMClient()


### PR DESCRIPTION
## Summary
- move resume-time backend preparation to the final bound session instead of resetting the whole backend up front
- add a scoped `prepare_resume_binding(...)` backend hook and use it from session binding
- clean only the target Claude runtime session; restart a Codex transport only when that `cwd` is not shared by other sessions

## Why
The original implementation called backend-wide `refresh_auth_state()` during `/resume`, which could interrupt unrelated in-flight conversations. This update keeps the auth/runtime preparation tied to the session being rebound and skips the Codex restart when a shared transport would affect other sessions.

## Testing
- `ruff check core/handlers/session_handler.py modules/agents/base.py modules/agents/claude_agent.py modules/agents/codex/agent.py tests/test_resume_session.py tests/test_claude_agent_sessions.py tests/test_codex_agent.py`
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_resume_session.py::ResumeSessionTests::test_handle_resume_session_submission_prepares_resume_binding tests/test_resume_session.py::ResumeSessionTests::test_handle_resume_session_submission_prepares_claude_binding tests/test_resume_session.py::ResumeSessionTests::test_handle_resume_session_submission_skips_resume_prepare_when_backend_has_no_hook tests/test_claude_agent_sessions.py::ClaudeAgentSessionTests::test_prepare_resume_binding_cleans_only_target_runtime_session tests/test_claude_agent_sessions.py::ClaudeAgentSessionTests::test_refresh_auth_state_disconnects_runtime_sessions tests/test_codex_agent.py::CodexAgentStopTests::test_prepare_resume_binding_restarts_unshared_transport tests/test_codex_agent.py::CodexAgentStopTests::test_prepare_resume_binding_skips_shared_transport`

## Evidence
- unit: updated targeted resume/runtime preparation coverage for session handler, Claude, and Codex
- contract: not changed
- scenario: not changed
- residual manual checks: not run
