### PR TITLE
fix(lark): fallback delivery when Feishu card content exceeds limits

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -349,6 +349,52 @@ class ConsolidatedMessageDispatcher:
                             parse_mode=parse_mode,
                         )
 
+            # --- Fallback: card content rejected (e.g. table over limit) ---
+            if primary_message_id is None and display_text:
+                logger.warning("All direct result sends failed; attempting fallback delivery")
+                _file_uploaded = False
+
+                # Fallback 1: upload full content as .md file
+                if hasattr(im_client, "upload_markdown"):
+                    try:
+                        await im_client.upload_markdown(
+                            target_context,
+                            title="result.md",
+                            content=display_text,
+                            filetype="markdown",
+                        )
+                        _file_uploaded = True
+                        logger.info("Result delivered as .md file attachment (fallback)")
+                    except Exception as _upload_err:
+                        logger.warning("upload_markdown fallback failed: %s", _upload_err)
+
+                # Fallback 2: split into multiple messages
+                if not _file_uploaded:
+                    try:
+                        primary_message_id = await self._send_split_result_messages(
+                            im_client,
+                            target_context,
+                            display_text,
+                            enhanced.buttons if enhanced else [],
+                            parse_mode,
+                        )
+                        logger.info("Result delivered via split messages (fallback)")
+                    except Exception as _split_err:
+                        logger.error("Split message fallback also failed: %s", _split_err)
+
+                # Notify user about delivery status
+                try:
+                    if _file_uploaded:
+                        _notice = "⚠️ 消息格式超限（如表格过多），已作为 result.md 文件发送，请查看上方附件。"
+                    elif primary_message_id is None:
+                        _notice = "⚠️ 消息投递失败，内容可能过长或格式不兼容，请让我重新发送。"
+                    else:
+                        _notice = None
+                    if _notice:
+                        await im_client.send_message(target_context, _notice, parse_mode="markdown")
+                except Exception:
+                    logger.error("Failed to send delivery status notification")
+
             # Upload extracted file attachments
             if enhanced and enhanced.files:
                 await self._upload_file_links(im_client, target_context, enhanced.files)


### PR DESCRIPTION
## Summary

- When Feishu rejects an interactive card (e.g. `ErrCode 11310: card table number over limit`), fall back to uploading the full content as a `.md` file attachment, then try splitting into multiple messages
- When all delivery attempts fail, send a short notification so the user knows the message was lost

Fixes #187 and #188.

## Changes

**`core/message_dispatcher.py`** — added fallback chain in the `result` message dispatch path (after all existing send attempts):

1. **Fallback 1**: Upload full content via `upload_markdown()` as a `result.md` file (uses `msg_type="file"`, not affected by card table limits)
2. **Fallback 2**: If file upload fails, split into multiple smaller card messages via `_send_split_result_messages()`
3. **Notification**: Send a short message explaining what happened (file uploaded / delivery failed)

## Test plan

- [x] Verified Python syntax passes (`py_compile`)
- [x] Tested with 8-table Markdown output on Lark — user received `result.md` file + notification
- [ ] Verify no regression for normal (within-limit) messages
- [ ] Verify behavior on other platforms (Slack, Discord, WeChat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)