### PR TITLE
fix(slack): prevent empty mentions from forking codex sessions

### DIFF
--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -307,10 +307,9 @@ class CodexAgent(BaseAgent):
                 self._transport_last_activity.pop(cwd, None)
 
                 for base_session_id in list(self._session_mgr.sessions_for_cwd(cwd)):
-                    session_key = self._session_mgr.get_session_key(base_session_id)
-                    if session_key:
-                        self.sessions.clear_agent_session_mapping(session_key, self.name, base_session_id)
-                    self._session_mgr.clear(base_session_id)
+                    # Keep the persisted thread mapping so a later transport restart
+                    # can resume the same Codex conversation for this Slack thread.
+                    self._session_mgr.invalidate_thread(base_session_id)
                     self._turn_registry.clear_session(base_session_id)
                     self._session_locks.pop(base_session_id, None)
 

--- a/modules/agents/codex/session.py
+++ b/modules/agents/codex/session.py
@@ -76,7 +76,7 @@ class CodexSessionManager:
 
     def clear_all(self) -> int:
         """Remove all tracked sessions. Returns count cleared."""
-        count = len(self._threads)
+        count = len(set(self._threads) | set(self._session_keys) | set(self._cwds))
         self._threads.clear()
         self._session_keys.clear()
         self._cwds.clear()
@@ -88,7 +88,7 @@ class CodexSessionManager:
 
     def all_base_sessions(self) -> list[str]:
         """Return all base session IDs being tracked."""
-        return list(self._threads.keys())
+        return list(set(self._threads) | set(self._session_keys) | set(self._cwds))
 
     def find_base_session_id_for_thread(self, thread_id: str) -> Optional[str]:
         for base_session_id, stored_thread_id in self._threads.items():

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -1444,7 +1444,7 @@ class SlackBot(BaseIMClient):
                 event.get("text", ""),
                 await self._get_bot_user_id(payload),
                 anywhere=True,
-            )
+            ).strip()
 
             # Parse command action for proper admin-protected auth check
             parsed_command = self.parse_text_command(text)
@@ -1469,6 +1469,13 @@ class SlackBot(BaseIMClient):
             slack_files = event.get("files", [])
             file_attachments = self._extract_file_attachments(slack_files) if slack_files else None
 
+            # Extract shared/forwarded message content (defer appending until after command check)
+            shared_text = await self._extract_shared_message_content(event)
+
+            if not text and not file_attachments and not shared_text:
+                logger.debug("Ignoring Slack app_mention with empty text and no files")
+                return
+
             context = MessageContext(
                 user_id=event.get("user"),
                 channel_id=channel_id,
@@ -1482,14 +1489,11 @@ class SlackBot(BaseIMClient):
                 files=file_attachments,
             )
 
-            # Mark thread as active when bot is @mentioned
+            # Mark thread as active only when the mention carries actionable content.
             if self.settings_manager and thread_id:
                 if self.sessions:
                     self.sessions.mark_thread_active(event.get("user"), channel_id, thread_id)
                 logger.info(f"Marked thread {thread_id} as active due to @mention")
-
-            # Extract shared/forwarded message content (defer appending until after command check)
-            shared_text = await self._extract_shared_message_content(event)
 
             logger.info(f"App mention processed: original='{event.get('text')}', cleaned='{text}'")
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -288,7 +288,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
     async def test_evict_idle_transports_stops_idle_codex_runtime(self):
         agent = object.__new__(CodexAgent)
         stop_calls = []
-        cleared_sessions = []
+        invalidated_sessions = []
         cleared_turns = []
 
         async def stop_transport():
@@ -299,8 +299,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         agent._transport_locks = {"/tmp/work": asyncio.Lock()}
         agent._session_mgr = SimpleNamespace(
             sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
-            get_session_key=lambda base_session_id: "scope-1",
-            clear=lambda base_session_id: cleared_sessions.append(base_session_id),
+            invalidate_thread=lambda base_session_id: invalidated_sessions.append(base_session_id),
         )
         agent._turn_registry = SimpleNamespace(
             get_active_turn=lambda base_session_id: None,
@@ -314,9 +313,9 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(evicted, 1)
         self.assertEqual(stop_calls, ["stop"])
-        self.assertEqual(cleared_sessions, ["session-1"])
+        self.assertEqual(invalidated_sessions, ["session-1"])
         self.assertEqual(cleared_turns, ["session-1"])
-        agent.sessions.clear_agent_session_mapping.assert_called_once_with("scope-1", "codex", "session-1")
+        agent.sessions.clear_agent_session_mapping.assert_not_called()
         self.assertEqual(agent._transports, {})
         self.assertIn("/tmp/work", agent._transport_locks)
         self.assertEqual(agent._transport_last_activity, {})
@@ -332,8 +331,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         agent._transport_locks = {"/tmp/work": asyncio.Lock()}
         agent._session_mgr = SimpleNamespace(
             sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
-            get_session_key=lambda base_session_id: "scope-1",
-            clear=lambda base_session_id: None,
+            invalidate_thread=lambda base_session_id: None,
         )
         agent._turn_registry = SimpleNamespace(
             get_active_turn=lambda base_session_id: "turn-1",
@@ -360,8 +358,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         agent._transport_locks = {"/tmp/work": asyncio.Lock()}
         agent._session_mgr = SimpleNamespace(
             sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
-            get_session_key=lambda base_session_id: "scope-1",
-            clear=lambda base_session_id: None,
+            invalidate_thread=lambda base_session_id: None,
         )
         agent._turn_registry = SimpleNamespace(
             get_active_turn=lambda base_session_id: None,
@@ -380,7 +377,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_evict_idle_transports_preserves_state_when_stop_fails(self):
         agent = object.__new__(CodexAgent)
-        cleared_sessions = []
+        invalidated_sessions = []
         cleared_turns = []
 
         async def stop_transport():
@@ -393,8 +390,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         agent._transport_locks = {"/tmp/work": lock}
         agent._session_mgr = SimpleNamespace(
             sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
-            get_session_key=lambda base_session_id: "scope-1",
-            clear=lambda base_session_id: cleared_sessions.append(base_session_id),
+            invalidate_thread=lambda base_session_id: invalidated_sessions.append(base_session_id),
         )
         agent._turn_registry = SimpleNamespace(
             get_active_turn=lambda base_session_id: None,
@@ -411,7 +407,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         self.assertIs(agent._transports["/tmp/work"], transport)
         self.assertIs(agent._transport_locks["/tmp/work"], lock)
         self.assertEqual(agent._transport_last_activity["/tmp/work"], 0.0)
-        self.assertEqual(cleared_sessions, [])
+        self.assertEqual(invalidated_sessions, [])
         self.assertEqual(cleared_turns, [])
         agent.sessions.clear_agent_session_mapping.assert_not_called()
 
@@ -429,8 +425,7 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
         agent._transport_locks = {"/tmp/work": lock}
         agent._session_mgr = SimpleNamespace(
             sessions_for_cwd=lambda cwd: ["session-1"] if cwd == "/tmp/work" else [],
-            get_session_key=lambda base_session_id: "scope-1",
-            clear=lambda base_session_id: None,
+            invalidate_thread=lambda base_session_id: None,
         )
         agent._turn_registry = SimpleNamespace(
             get_active_turn=lambda base_session_id: None,

--- a/tests/test_codex_session.py
+++ b/tests/test_codex_session.py
@@ -1,0 +1,22 @@
+from modules.agents.codex.session import CodexSessionManager
+
+
+def test_all_base_sessions_keeps_invalidated_sessions_visible():
+    manager = CodexSessionManager()
+    manager.set_session_key("session-1", "slack::C1")
+    manager.set_cwd("session-1", "/tmp/work")
+    manager.set_thread_id("session-1", "thread-1")
+
+    manager.invalidate_thread("session-1")
+
+    assert manager.all_base_sessions() == ["session-1"]
+
+
+def test_clear_all_counts_sessions_without_live_thread_ids():
+    manager = CodexSessionManager()
+    manager.set_session_key("session-1", "slack::C1")
+    manager.set_cwd("session-1", "/tmp/work")
+    manager.set_thread_id("session-1", "thread-1")
+    manager.invalidate_thread("session-1")
+
+    assert manager.clear_all() == 1

--- a/tests/test_slack_app_mention_empty.py
+++ b/tests/test_slack_app_mention_empty.py
@@ -1,0 +1,141 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from config.v2_config import SlackConfig
+
+
+def _install_slack_stubs() -> None:
+    if "aiohttp" not in sys.modules:
+        aiohttp_mod = types.ModuleType("aiohttp")
+
+        class _ClientWebSocketResponse:
+            closed = False
+
+        class _ClientSession:
+            async def close(self):
+                return None
+
+        class _ClientTimeout:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        aiohttp_mod.ClientWebSocketResponse = _ClientWebSocketResponse
+        aiohttp_mod.ClientSession = _ClientSession
+        aiohttp_mod.ClientTimeout = _ClientTimeout
+        sys.modules["aiohttp"] = aiohttp_mod
+
+    if "markdown_to_mrkdwn" not in sys.modules:
+        markdown_mod = types.ModuleType("markdown_to_mrkdwn")
+
+        class _SlackMarkdownConverter:
+            def convert(self, text):
+                return text
+
+        markdown_mod.SlackMarkdownConverter = _SlackMarkdownConverter
+        sys.modules["markdown_to_mrkdwn"] = markdown_mod
+
+    if "slack_sdk" not in sys.modules:
+        slack_sdk = types.ModuleType("slack_sdk")
+        web_mod = types.ModuleType("slack_sdk.web")
+        web_async_mod = types.ModuleType("slack_sdk.web.async_client")
+        socket_mode_mod = types.ModuleType("slack_sdk.socket_mode")
+        socket_mode_aiohttp_mod = types.ModuleType("slack_sdk.socket_mode.aiohttp")
+        socket_mode_request_mod = types.ModuleType("slack_sdk.socket_mode.request")
+        socket_mode_response_mod = types.ModuleType("slack_sdk.socket_mode.response")
+        errors_mod = types.ModuleType("slack_sdk.errors")
+
+        class _AsyncWebClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def auth_test(self):
+                return {"user_id": "U_BOT"}
+
+        class _SocketModeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        class _SocketModeRequest:
+            pass
+
+        class _SocketModeResponse:
+            def __init__(self, *args, **kwargs):
+                pass
+
+        class _SlackApiError(Exception):
+            def __init__(self, message="", response=None):
+                super().__init__(message)
+                self.response = response
+
+        web_async_mod.AsyncWebClient = _AsyncWebClient
+        socket_mode_aiohttp_mod.SocketModeClient = _SocketModeClient
+        socket_mode_request_mod.SocketModeRequest = _SocketModeRequest
+        socket_mode_response_mod.SocketModeResponse = _SocketModeResponse
+        errors_mod.SlackApiError = _SlackApiError
+
+        sys.modules["slack_sdk"] = slack_sdk
+        sys.modules["slack_sdk.web"] = web_mod
+        sys.modules["slack_sdk.web.async_client"] = web_async_mod
+        sys.modules["slack_sdk.socket_mode"] = socket_mode_mod
+        sys.modules["slack_sdk.socket_mode.aiohttp"] = socket_mode_aiohttp_mod
+        sys.modules["slack_sdk.socket_mode.request"] = socket_mode_request_mod
+        sys.modules["slack_sdk.socket_mode.response"] = socket_mode_response_mod
+        sys.modules["slack_sdk.errors"] = errors_mod
+
+
+def _load_local_slack_bot():
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+    sys.modules.pop("modules.im.slack", None)
+    spec = importlib.util.spec_from_file_location("modules.im.slack", repo_root / "modules" / "im" / "slack.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["modules.im.slack"] = module
+    spec.loader.exec_module(module)
+    return module.SlackBot
+
+
+_install_slack_stubs()
+SlackBot = _load_local_slack_bot()
+
+
+class SlackAppMentionEmptyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_empty_app_mention_does_not_activate_or_dispatch(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {"called": False}
+
+        async def _on_message(_context, _text):
+            received["called"] = True
+
+        slack.register_callbacks(on_message=_on_message)
+        slack.settings_manager = object()
+        slack.sessions = SimpleNamespace(mark_thread_active=Mock())
+        slack._get_bot_user_id = AsyncMock(return_value="U_BOT")
+        slack._extract_shared_message_content = AsyncMock(return_value=None)
+
+        payload = {
+            "event_id": "evt-app-mention-empty",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "app_mention",
+                "channel": "C123",
+                "user": "U123",
+                "text": "<@U_BOT>",
+                "ts": "1710000000.000700",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertFalse(received["called"])
+        slack.sessions.mark_thread_active.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ignore Slack `app_mention` events that strip down to empty content so reply-only mention callbacks no longer activate a fresh thread or dispatch a blank user message
- keep persisted Codex session mappings across idle transport eviction so the next turn can resume the original Codex thread
- keep invalidated Codex sessions visible to cleanup paths by enumerating session metadata even after the live thread id is cleared

## Root Cause
- Slack can emit an `app_mention` event whose payload is only the bot mention with no text body; the existing Slack handler treated that as a new actionable entrypoint and created a new thread anchor
- Codex idle transport eviction cleared the persisted Slack-thread-to-Codex-session mapping, so a later reply in the same Slack thread could not resume the previous Codex conversation

## Testing
- unit: `PYTHONPATH=/Users/cyh/.worktrees/vibe-remote/fix/slack-empty-mention-codex-session pytest -q tests/test_slack_app_mention_empty.py tests/test_codex_agent.py tests/test_codex_session.py`
- lint: `ruff check modules/im/slack.py modules/agents/codex/agent.py modules/agents/codex/session.py tests/test_slack_app_mention_empty.py tests/test_codex_agent.py tests/test_codex_session.py`
- contract: not updated
- scenario: no scenario catalog entry for this bug
- residual manual checks: Slack live-thread regression verification still needed
