### PR TITLE
fix: enable project and local setting sources for Claude Code sessions

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -646,7 +646,7 @@ class AgentAuthService:
         option_kwargs = {
             "cwd": working_path,
             "env": claude_env,
-            "setting_sources": ["user"],
+            "setting_sources": ["user", "project", "local"],
         }
         permission_mode = getattr(getattr(self.controller.config, "claude", None), "permission_mode", None)
         if permission_mode:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -515,7 +515,7 @@ class SessionHandler(BaseHandler):
             "system_prompt": final_system_prompt,
             "resume": stored_claude_session_id if stored_claude_session_id else None,
             "extra_args": extra_args,
-            "setting_sources": ["user"],  # Load user settings from ~/.claude/settings.json
+            "setting_sources": ["user", "project", "local"],  # Load all setting sources (user, project CLAUDE.md, local overrides)
             # Disable AskUserQuestion tool - SDK cannot respond to it programmatically
             # See: https://github.com/anthropics/claude-code/issues/10168
             "disallowed_tools": ["AskUserQuestion"],


### PR DESCRIPTION
## Problem

Vibe Remote hardcodes `setting_sources: ["user"]` when spawning Claude Code sessions via the Python SDK. This restricts Claude Code to loading **only** the global `~/.claude/` configuration, silently disabling all project-level features.

### What breaks

| Feature | Where it lives | Loaded? |
|---------|---------------|---------|
| `CLAUDE.md` (project instructions) | `<repo>/CLAUDE.md` | ❌ Skipped |
| `.claude/CLAUDE.md` | `<repo>/.claude/CLAUDE.md` | ❌ Skipped |
| `.claude/settings.json` (hooks, permissions) | `<repo>/.claude/settings.json` | ❌ Skipped |
| `.claude/rules/*.md` (modular rules) | `<repo>/.claude/rules/` | ❌ Skipped |
| `CLAUDE.local.md` (developer overrides) | `<repo>/CLAUDE.local.md` | ❌ Skipped |
| `~/.claude/CLAUDE.md` (global instructions) | `~/.claude/CLAUDE.md` | ✅ Works |
| `~/.claude/settings.json` (global settings) | `~/.claude/settings.json` | ✅ Works |

### Why this matters

In Claude Code's architecture, **project-level configuration is the primary mechanism for teams** to:

- Define shared coding standards and agent behavior per repository (`CLAUDE.md`)
- Enforce safety rules and behavioral boundaries (`.claude/rules/*.md`)
- Configure project-specific hooks — `UserPromptSubmit` for context injection, `SessionStart` for setup, etc.
- Set project-specific permissions and environment variables
- Allow individual developers to have local overrides (`CLAUDE.local.md`)

Without project sources, **every repository behaves identically** regardless of its `CLAUDE.md`. This makes Vibe Remote unsuitable for multi-repo team environments where different projects need different agent configurations — which is the norm, not the exception.

When Claude Code runs directly via CLI, it loads all three sources (`user`, `project`, `local`) by default. The current `["user"]` restriction breaks feature parity with the CLI.

### Root cause trace

```
Vibe Remote session_handler.py:518
  → setting_sources: ["user"]
    → Python SDK subprocess_cli.py:283
      → --setting-sources user
        → Claude Code main.tsx:511
          → loadSettingSourcesFromFlag("user")
            → constants.ts:128 → ['userSettings']
              → claudemd.ts:887: isSettingSourceEnabled('projectSettings') → false
                → ALL project-level CLAUDE.md, settings, hooks, rules → SKIPPED
```

## Fix

Add `"project"` and `"local"` to `setting_sources`, matching Claude Code's CLI default:

```python
# Before
"setting_sources": ["user"]

# After
"setting_sources": ["user", "project", "local"]
```

Changed in two files:
- `core/handlers/session_handler.py` — main session creation
- `core/agent_auth_service.py` — auth service SDK calls

## Trade-offs

### Benefits
- Restores full Claude Code configuration hierarchy: `user → project → local`
- Project `CLAUDE.md` loaded — team coding standards, agent identity, safety rules all work
- Project hooks loaded — `UserPromptSubmit`, `SessionStart`, etc.
- `CLAUDE.local.md` loaded — individual developer overrides work
- Feature parity with running Claude Code directly via CLI
- No breaking changes — this is additive; users without project configs see zero difference

### Risks
- **Trust boundary**: project-level configs are loaded from the `cwd` directory. If Vibe Remote's `cwd` points to an untrusted directory, that directory's `.claude/` configs would be loaded. In practice, `cwd` is set by the Vibe Remote operator (the person who runs `vibe start`), so this is equivalent to the trust model of running Claude Code directly in that directory.
- Claude Code already has its own trust dialog and safety mechanisms for project-level settings, so the risk is mitigated at the Claude Code layer as well.

## Test plan

- [x] Verified `CLAUDE.md` from project root is loaded into model context
- [x] Verified `UserPromptSubmit` hook from project `.claude/settings.json` fires and injects context
- [x] Verified `.claude/rules/*.md` files are loaded
- [x] Verified global `~/.claude/` configs still load (no regression)
- [x] Verified sessions without project-level configs work normally (no error when files don't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)