### PR TITLE
fix(claude): preserve scheduled reply session anchors

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -358,7 +358,8 @@ class SessionHandler(BaseHandler):
         subagent_reasoning_effort: Optional[str] = None,
     ) -> ClaudeSDKClient:
         """Get existing Claude session or create a new one"""
-        base_session_id, working_path, composite_key = self.get_session_info(context)
+        turn_source = str((context.platform_specific or {}).get("turn_source") or "human")
+        base_session_id, working_path, composite_key = self.get_session_info(context, source=turn_source)
 
         settings_key = self._get_settings_key(context)
         session_key = self._get_session_key(context)

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -358,8 +358,14 @@ class SessionHandler(BaseHandler):
         subagent_reasoning_effort: Optional[str] = None,
     ) -> ClaudeSDKClient:
         """Get existing Claude session or create a new one"""
-        turn_source = str((context.platform_specific or {}).get("turn_source") or "human")
-        base_session_id, working_path, composite_key = self.get_session_info(context, source=turn_source)
+        payload = context.platform_specific or {}
+        turn_source = str(payload.get("turn_source") or "human")
+        base_session_id = str(payload.get("turn_base_session_id") or "").strip()
+        working_path = self.get_working_path(context)
+        if base_session_id:
+            composite_key = f"{base_session_id}:{working_path}"
+        else:
+            base_session_id, working_path, composite_key = self.get_session_info(context, source=turn_source)
 
         settings_key = self._get_settings_key(context)
         session_key = self._get_session_key(context)

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -209,6 +209,100 @@ def test_session_handler_expands_tilde_in_claude_cli_path(monkeypatch, tmp_path:
     assert captured["options"].cli_path == str(Path("~/bin/claude").expanduser())
 
 
+def test_session_handler_uses_scheduled_turn_source_for_dm_anchor(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _ScheduledSessions:
+        def __init__(self) -> None:
+            self.lookup = None
+
+        def get_claude_session_id(self, settings_key, base_session_id):
+            self.lookup = (settings_key, base_session_id)
+            return None
+
+        @staticmethod
+        def get_agent_session_id(settings_key, base_session_id, agent_name):
+            return None
+
+    class _ScheduledSettingsManager:
+        def __init__(self) -> None:
+            self.sessions = _ScheduledSessions()
+
+        @staticmethod
+        def get_channel_settings(settings_key):
+            return None
+
+        @staticmethod
+        def get_channel_routing(settings_key):
+            return None
+
+    class _ScheduledController:
+        def __init__(self, working_path: Path) -> None:
+            self.config = _Config()
+            self.im_client = type(
+                "IM",
+                (),
+                {
+                    "formatter": None,
+                    "should_use_thread_for_dm_session": lambda self: True,
+                    "should_use_thread_for_reply": lambda self: True,
+                },
+            )()
+            self.settings_manager = _ScheduledSettingsManager()
+            self.platform_settings_managers = {"slack": self.settings_manager}
+            self.session_manager = object()
+            self.claude_sessions = {}
+            self.receiver_tasks = {}
+            self.stored_session_mappings = {}
+            self._working_path = working_path
+
+        def get_cwd(self, context) -> str:
+            return str(self._working_path)
+
+        @staticmethod
+        def _get_settings_key(context) -> str:
+            return context.user_id if (context.platform_specific or {}).get("is_dm") else context.channel_id
+
+        @staticmethod
+        def _get_session_key(context) -> str:
+            settings_key = _ScheduledController._get_settings_key(context)
+            return f"{getattr(context, 'platform', None) or 'test'}::{settings_key}"
+
+        def get_settings_manager_for_context(self, context=None):
+            return self.settings_manager
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _ScheduledController(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(
+        user_id="U123",
+        channel_id="D123",
+        message_id="scheduled:task-1:exec-1",
+        platform="slack",
+        platform_specific={"is_dm": True, "turn_source": "scheduled"},
+    )
+
+    client = _run_session(handler, context)
+
+    assert captured["connected"] is True
+    assert controller.settings_manager.sessions.lookup is not None
+    settings_key, base_session_id = controller.settings_manager.sessions.lookup
+    assert settings_key == "slack::U123"
+    assert base_session_id.startswith("slack_scheduled-")
+    assert base_session_id != "slack_scheduled:task-1:exec-1"
+    assert getattr(client, "_vibe_runtime_base_session_id") == base_session_id
+    assert getattr(client, "_vibe_runtime_session_key") == f"{base_session_id}:{tmp_path}"
+
+
 def test_session_handler_evicts_idle_claude_session(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, Any] = {}
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -283,12 +283,17 @@ def test_session_handler_uses_scheduled_turn_source_for_dm_anchor(monkeypatch, t
 
     controller = _ScheduledController(tmp_path)
     handler = SessionHandler(controller)
+    precomputed_base = "slack_scheduled-anchor-123"
     context = MessageContext(
         user_id="U123",
         channel_id="D123",
         message_id="scheduled:task-1:exec-1",
         platform="slack",
-        platform_specific={"is_dm": True, "turn_source": "scheduled"},
+        platform_specific={
+            "is_dm": True,
+            "turn_source": "scheduled",
+            "turn_base_session_id": precomputed_base,
+        },
     )
 
     client = _run_session(handler, context)
@@ -297,8 +302,7 @@ def test_session_handler_uses_scheduled_turn_source_for_dm_anchor(monkeypatch, t
     assert controller.settings_manager.sessions.lookup is not None
     settings_key, base_session_id = controller.settings_manager.sessions.lookup
     assert settings_key == "slack::U123"
-    assert base_session_id.startswith("slack_scheduled-")
-    assert base_session_id != "slack_scheduled:task-1:exec-1"
+    assert base_session_id == precomputed_base
     assert getattr(client, "_vibe_runtime_base_session_id") == base_session_id
     assert getattr(client, "_vibe_runtime_session_key") == f"{base_session_id}:{tmp_path}"
 


### PR DESCRIPTION
## Summary
- preserve the scheduled turn source when Claude resolves its session base
- keep scheduled channel-posted Slack replies anchored to the original session instead of forking a new one
- add a regression test covering scheduled DM/thread anchor resolution in `SessionHandler`

## Why
A scheduled task with `session_key=slack::user::...` and `post_to=channel` was creating the correct provisional anchor in the shared turn pipeline, but Claude recalculated the base session as if the turn were human-originated. That mismatch prevented the post-send alias from binding the outbound Slack message back to the original session, so a thread reply started a fresh session.

## Testing
- `pytest -q tests/test_claude_cli_path.py tests/test_session_handler_base_id.py -q`
- `ruff check core/handlers/session_handler.py tests/test_claude_cli_path.py`

## Evidence
- Unit: updated `tests/test_claude_cli_path.py`
- Contract: not updated
- Scenario: not updated
- Residual manual checks: confirmed the failing remote Slack flow from logs on `ai@13.250.182.139`, including the missing alias and the new session created for reply thread `1776272745.794879`

## Risks / Follow-ups
- This fix targets Claude session resolution. OpenCode/Codex should be unaffected because they already consume the base session produced earlier in the turn pipeline.
