### PR TITLE
fix(lark): fallback to .md file when card content exceeds Feishu limits

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -349,6 +349,60 @@ class ConsolidatedMessageDispatcher:
                             parse_mode=parse_mode,
                         )
 
+            # --- Fallback: card content rejected (e.g. table over limit) ---
+            if primary_message_id is None and display_text:
+                logger.warning("All direct result sends failed; attempting fallback delivery")
+                _file_uploaded = False
+
+                # Fallback 1: upload full content as .md file
+                if hasattr(im_client, "upload_markdown"):
+                    try:
+                        await im_client.upload_markdown(
+                            target_context,
+                            title="result.md",
+                            content=display_text,
+                            filetype="markdown",
+                        )
+                        _file_uploaded = True
+                        logger.info("Result delivered as .md file attachment (fallback)")
+                    except Exception as _upload_err:
+                        logger.warning("upload_markdown fallback failed: %s", _upload_err)
+
+                # Fallback 2: split into multiple messages
+                if not _file_uploaded:
+                    try:
+                        primary_message_id = await self._send_split_result_messages(
+                            im_client,
+                            target_context,
+                            display_text,
+                            enhanced.buttons if enhanced else [],
+                            parse_mode,
+                        )
+                        logger.info("Result delivered via split messages (fallback)")
+                    except Exception as _split_err:
+                        logger.error("Split message fallback also failed: %s", _split_err)
+
+                # Notify user about delivery status
+                try:
+                    if _file_uploaded:
+                        _notice = (
+                            "\u26a0\ufe0f Message format exceeded platform limits "
+                            "(e.g. too many tables). Sent as result.md file instead."
+                        )
+                    elif primary_message_id is None:
+                        _notice = (
+                            "\u26a0\ufe0f Message delivery failed — content may be "
+                            "too long or incompatible. Please ask me to resend."
+                        )
+                    else:
+                        _notice = None
+                    if _notice:
+                        await im_client.send_message(
+                            target_context, _notice, parse_mode="markdown"
+                        )
+                except Exception:
+                    logger.error("Failed to send delivery status notification")
+
             # Upload extracted file attachments
             if enhanced and enhanced.files:
                 await self._upload_file_links(im_client, target_context, enhanced.files)


### PR DESCRIPTION
## Summary

- When Feishu rejects an interactive card (e.g. `ErrCode 11310: card table number over limit`), fall back to uploading the full content as a `.md` file attachment, then try splitting into multiple messages
- When all delivery attempts fail, send a short notification so the user knows the message was lost

Re-submission of #189, now targeting `master` instead of a staging branch.

## Changes

**`core/message_dispatcher.py`** — added fallback chain in the `result` message dispatch path (after all existing send attempts):

1. **Fallback 1**: Upload full content via `upload_markdown()` as a `result.md` file (uses `msg_type="file"`, not affected by card table limits)
2. **Fallback 2**: If file upload fails, split into multiple smaller card messages via `_send_split_result_messages()`
3. **Notification**: Send a short message explaining what happened (file uploaded / delivery failed)

## Reproduction

Tested on `v2.2.11` — sending a response with 9 markdown tables triggers `ErrCode 11310` and the message is silently lost:

```
09:48:04 WARNING - Failed to send result with quick replies: ErrCode: 11310; card table number over limit
09:48:05 ERROR   - Failed to send fallback result message: ErrCode: 11310; card table number over limit
(no further delivery attempt — message lost)
```

With this patch, the fallback chain catches the failure and uploads `result.md` instead.

## Test plan

- [x] Verified Python syntax passes (`py_compile`)
- [x] Reproduced silent message loss on v2.2.11 with 9-table content
- [x] Confirmed fallback worked correctly in previous staging deployment (Apr 15 13:21 log)
- [ ] Verify no regression for normal (within-limit) messages
- [ ] Verify behavior on other platforms (Slack, Discord, WeChat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)