### PR TITLE
fix(slack): handle connect mentions and thin file events

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -126,6 +126,7 @@ class MessageHandler(BaseHandler):
         typing_indicator_task = None
         try:
             is_human = source == self.TURN_SOURCE_HUMAN
+            control_message = self._get_control_message(context, message) if is_human else message
 
             # Record user activity for auto-update idle detection
             if is_human and hasattr(self.controller, "update_checker"):
@@ -134,7 +135,7 @@ class MessageHandler(BaseHandler):
             # If message is empty AND no files attached (e.g., user just @mentioned bot without text),
             # trigger the /start command instead of sending empty message to agent
             has_files = bool(context.files)
-            if (not message or not message.strip()) and not has_files:
+            if (not control_message or not control_message.strip()) and not has_files:
                 if is_human:
                     await self.controller.command_handler.handle_start(context, "")
                 return None
@@ -159,14 +160,14 @@ class MessageHandler(BaseHandler):
             if is_human and not has_files:
                 maybe_consume_setup_reply = getattr(self.controller.agent_auth_service, "maybe_consume_setup_reply", None)
                 if callable(maybe_consume_setup_reply):
-                    consumed = await maybe_consume_setup_reply(context, message)
+                    consumed = await maybe_consume_setup_reply(context, control_message)
                     if consumed:
                         return None
 
             # Skip automatic cleanup; receiver tasks are retained until shutdown
 
             # Allow "stop" shortcut inside Slack threads
-            if is_human and context.thread_id and message.strip().lower() in ["stop", "/stop"]:
+            if is_human and context.thread_id and control_message.strip().lower() in ["stop", "/stop"]:
                 if await self._handle_inline_stop(context):
                     return None
 
@@ -228,7 +229,7 @@ class MessageHandler(BaseHandler):
                     parse_subagent_prefix,
                 )
 
-                parsed = parse_subagent_prefix(message)
+                parsed = parse_subagent_prefix(control_message)
                 if parsed:
                     normalized = normalize_subagent_name(parsed.name)
                     if agent_name == "opencode":
@@ -430,6 +431,14 @@ class MessageHandler(BaseHandler):
         bot_mention = payload.get("bot_mention")
         if isinstance(bot_mention, str) and bot_mention.strip():
             return f"[Agent Identity] Slack bot mention: {bot_mention.strip()}\n{message}"
+        return message
+
+    @staticmethod
+    def _get_control_message(context: MessageContext, message: str) -> str:
+        payload = context.platform_specific or {}
+        control_text = payload.get("control_text")
+        if isinstance(control_text, str):
+            return control_text
         return message
 
     async def handle_callback_query(self, context: MessageContext, callback_data: str):

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -750,16 +750,20 @@ class MessageHandler(BaseHandler):
 
             try:
                 im_client = self._get_im_client(context)
-                # Download the file content
-                if hasattr(im_client, "download_file") and attachment.url:
+                # Download the file content. Some platforms receive a thin
+                # attachment event first and resolve the actual URL from
+                # platform metadata such as a Slack file id.
+                can_download = hasattr(im_client, "download_file_to_path") or hasattr(im_client, "download_file")
+                if can_download:
                     # Platform-agnostic download info dict
                     file_info = {
                         "url": attachment.url,
-                        "url_private_download": attachment.url,  # Slack compat
                         "name": attachment.name,
                         "size": attachment.size,
                         "platform": context.platform,
                     }
+                    if attachment.url:
+                        file_info["url_private_download"] = attachment.url  # Slack compat
                     attachment_data = getattr(attachment, "__dict__", {})
                     for key, value in attachment_data.items():
                         if key in {"name", "mimetype", "url", "content", "local_path", "size"}:

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -135,7 +135,7 @@ class MessageHandler(BaseHandler):
             # If message is empty AND no files attached (e.g., user just @mentioned bot without text),
             # trigger the /start command instead of sending empty message to agent
             has_files = bool(context.files)
-            if (not control_message or not control_message.strip()) and not has_files:
+            if (not message or not message.strip()) and not has_files:
                 if is_human:
                     await self.controller.command_handler.handle_start(context, "")
                 return None

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -336,6 +336,8 @@ class MessageHandler(BaseHandler):
             # Prepend user identity when include_user_info is enabled
             if is_human and self.config.include_user_info:
                 message = await self._prepend_user_info(context, message)
+            if is_human:
+                message = self._prepend_agent_identity(context, message)
 
             message = self._append_attachment_errors(message, attachment_errors)
 
@@ -421,6 +423,14 @@ class MessageHandler(BaseHandler):
         name = self._sanitize_identity(raw_name)
         uid = self._sanitize_identity(context.user_id)
         return f"[{name}<{uid}>] {message}"
+
+    def _prepend_agent_identity(self, context: MessageContext, message: str) -> str:
+        """Add platform identity context without rewriting the user's message."""
+        payload = context.platform_specific or {}
+        bot_mention = payload.get("bot_mention")
+        if isinstance(bot_mention, str) and bot_mention.strip():
+            return f"[Agent Identity] Slack bot mention: {bot_mention.strip()}\n{message}"
+        return message
 
     async def handle_callback_query(self, context: MessageContext, callback_data: str):
         """Route callback queries to appropriate handlers"""

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -1416,6 +1416,8 @@ class SlackBot(BaseIMClient):
                 if is_dm:
                     route_text = cleaned_text
                     had_dm_mention_only = not route_text
+                    if had_dm_mention_only:
+                        agent_text = ""
                 elif await self._is_slack_connect_channel(channel_id):
                     route_text = self._strip_specific_mention(raw_text, bot_user_id, anywhere=True)
                     handled_bot_mention_in_message_event = True

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -1393,7 +1393,7 @@ class SlackBot(BaseIMClient):
                     text = cleaned_text
                     had_dm_mention_only = not text
                 elif await self._is_slack_connect_channel(channel_id):
-                    text = cleaned_text
+                    text = self._strip_specific_mention(text, bot_user_id, anywhere=True)
                     handled_bot_mention_in_message_event = True
                     logger.info("Processing Slack Connect message event with bot mention: '%s'", event.get("text"))
                 else:

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -358,6 +358,8 @@ class SlackBot(BaseIMClient):
         if bot_user_id and bot_profile.get("user_id") == bot_user_id:
             return True
         config_app_id = getattr(self.config, "app_id", None)
+        if config_app_id and event.get("app_id") == config_app_id:
+            return True
         return bool(config_app_id and bot_profile.get("app_id") == config_app_id)
 
     @staticmethod

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -77,6 +77,8 @@ class SlackBot(BaseIMClient):
         self._user_info_cache: Dict[str, Dict[str, Any]] = {}
         self._channel_info_cache: Dict[str, Dict[str, Any]] = {}
         self._bot_user_id: Optional[str] = None
+        self._bot_id: Optional[str] = None
+        self._bot_identity_lookup_attempted = False
         self._stop_event: Optional[asyncio.Event] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._on_ready: Optional[Callable] = None
@@ -283,27 +285,40 @@ class SlackBot(BaseIMClient):
         payload_user_id = self._extract_bot_user_id_from_payload(payload or {})
         if payload_user_id:
             self._bot_user_id = payload_user_id
+            if not self._bot_id:
+                await self._hydrate_bot_identity()
             return payload_user_id
 
         if self._bot_user_id:
+            if not self._bot_id:
+                await self._hydrate_bot_identity()
             return self._bot_user_id
+
+        await self._hydrate_bot_identity()
+        return self._bot_user_id
+
+    async def _hydrate_bot_identity(self) -> None:
+        if (self._bot_user_id and self._bot_id) or self._bot_identity_lookup_attempted:
+            return
 
         self._ensure_clients()
         auth_test = getattr(self.web_client, "auth_test", None)
         if not callable(auth_test):
-            return None
+            return
 
         try:
             response = await auth_test()
         except Exception as exc:
-            logger.debug("Failed to resolve Slack bot user id: %s", exc)
-            return None
+            logger.debug("Failed to resolve Slack bot identity: %s", exc)
+            return
 
-        user_id = response.get("user_id") if isinstance(response, dict) else None
+        self._bot_identity_lookup_attempted = True
+        user_id = self._slack_response_get(response, "user_id")
         if isinstance(user_id, str) and user_id:
             self._bot_user_id = user_id
-            return user_id
-        return None
+        bot_id = self._slack_response_get(response, "bot_id")
+        if isinstance(bot_id, str) and bot_id:
+            self._bot_id = bot_id
 
     @staticmethod
     def _has_specific_mention(text: str, user_id: Optional[str]) -> bool:
@@ -356,6 +371,8 @@ class SlackBot(BaseIMClient):
         if bot_user_id and event.get("user") == bot_user_id:
             return True
         if bot_user_id and bot_profile.get("user_id") == bot_user_id:
+            return True
+        if self._bot_id and event.get("bot_id") == self._bot_id:
             return True
         config_app_id = getattr(self.config, "app_id", None)
         if config_app_id and event.get("app_id") == config_app_id:

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -73,6 +73,7 @@ class SlackBot(BaseIMClient):
         # Controller reference for update button handling (will be injected later)
         self._controller = None
         self._recent_event_ids: Dict[str, float] = {}
+        self._processed_mention_event_keys: Dict[str, float] = {}
         self._user_info_cache: Dict[str, Dict[str, Any]] = {}
         self._channel_info_cache: Dict[str, Dict[str, Any]] = {}
         self._bot_user_id: Optional[str] = None
@@ -206,6 +207,23 @@ class SlackBot(BaseIMClient):
             return True
         self._recent_event_ids[event_id] = now
         return False
+
+    def _mark_mention_event_processed(self, channel_id: Optional[str], message_id: Optional[str]) -> bool:
+        """Track mention handling across Slack message/app_mention event pairs."""
+        if not channel_id or not message_id:
+            return True
+        now = time.time()
+        expiry = now - 300
+        for key in list(self._processed_mention_event_keys.keys()):
+            if self._processed_mention_event_keys[key] < expiry:
+                del self._processed_mention_event_keys[key]
+
+        key = f"{channel_id}:{message_id}"
+        if key in self._processed_mention_event_keys:
+            logger.debug("Ignoring duplicate Slack mention event for %s", key)
+            return False
+        self._processed_mention_event_keys[key] = now
+        return True
 
     def get_default_parse_mode(self) -> str:
         """Get the default parse mode for Slack"""
@@ -1398,6 +1416,11 @@ class SlackBot(BaseIMClient):
                 logger.debug("Ignoring Slack message with empty text and no files")
                 return
 
+            if handled_bot_mention_in_message_event and not self._mark_mention_event_processed(
+                channel_id, event.get("ts")
+            ):
+                return
+
             # Check if we require mention in channels (not DMs)
             # For threads: only respond if the bot is active in that thread
             is_thread_reply = event.get("thread_ts") is not None
@@ -1510,6 +1533,8 @@ class SlackBot(BaseIMClient):
             # Handle @mentions
             channel_id = event.get("channel")
             user_id_mention = event.get("user")
+            if not self._mark_mention_event_processed(channel_id, event.get("ts")):
+                return
 
             # Remove the mention from the text first so we can parse commands for auth
             text = self._strip_specific_mention(

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -351,6 +351,15 @@ class SlackBot(BaseIMClient):
             return True
         return self._channel_looks_like_dm(context.channel_id)
 
+    def _is_own_bot_message(self, event: Dict[str, Any], bot_user_id: Optional[str]) -> bool:
+        bot_profile = event.get("bot_profile") if isinstance(event.get("bot_profile"), dict) else {}
+        if bot_user_id and event.get("user") == bot_user_id:
+            return True
+        if bot_user_id and bot_profile.get("user_id") == bot_user_id:
+            return True
+        config_app_id = getattr(self.config, "app_id", None)
+        return bool(config_app_id and bot_profile.get("app_id") == config_app_id)
+
     @staticmethod
     def _slack_response_get(response: Any, key: str) -> Any:
         getter = getattr(response, "get", None)
@@ -1358,10 +1367,6 @@ class SlackBot(BaseIMClient):
             if self._controller and hasattr(self._controller, "_refresh_config_from_disk"):
                 self._controller._refresh_config_from_disk()
 
-            # Ignore bot messages
-            if event.get("bot_id"):
-                return
-
             # Check for file attachments first
             slack_files = event.get("files", [])
             has_files = bool(slack_files)
@@ -1376,7 +1381,8 @@ class SlackBot(BaseIMClient):
                     return
 
             channel_id = event.get("channel")
-            user_id = event.get("user")
+            bot_profile = event.get("bot_profile") if isinstance(event.get("bot_profile"), dict) else {}
+            user_id = event.get("user") or bot_profile.get("user_id") or event.get("bot_id")
             is_dm = self._channel_looks_like_dm(channel_id)
             if is_dm:
                 dm_match = await self._match_bound_dm_channel(user_id, channel_id)
@@ -1388,26 +1394,34 @@ class SlackBot(BaseIMClient):
                     )
                     return
 
-            # Check if this message contains a bot mention.
-            # In channels, app_mention will handle it. In DMs, Slack does not
-            # emit app_mention, so we strip the mention and continue.
-            text = (event.get("text") or "").strip()
+            # Check if this message contains a bot mention. Use a normalized
+            # copy for routing/commands while preserving the raw Slack text for
+            # the agent.
+            raw_text = (event.get("text") or "").strip()
+            route_text = raw_text
+            agent_text = raw_text
 
             had_dm_mention_only = False
             bot_user_id = await self._get_bot_user_id(payload)
-            has_bot_mention = self._has_specific_mention(text, bot_user_id)
-            cleaned_text = self._strip_specific_mention(text, bot_user_id)
+            bot_mention = f"<@{bot_user_id}>" if bot_user_id else None
+            has_bot_mention = self._has_specific_mention(raw_text, bot_user_id)
+            cleaned_text = self._strip_specific_mention(raw_text, bot_user_id)
             handled_bot_mention_in_message_event = False
+            if event.get("bot_id"):
+                if self._is_own_bot_message(event, bot_user_id):
+                    return
+                if not has_bot_mention:
+                    return
             if has_bot_mention:
                 if is_dm:
-                    text = cleaned_text
-                    had_dm_mention_only = not text
+                    route_text = cleaned_text
+                    had_dm_mention_only = not route_text
                 elif await self._is_slack_connect_channel(channel_id):
-                    text = self._strip_specific_mention(text, bot_user_id, anywhere=True)
+                    route_text = self._strip_specific_mention(raw_text, bot_user_id, anywhere=True)
                     handled_bot_mention_in_message_event = True
                     logger.info("Processing Slack Connect message event with bot mention: '%s'", event.get("text"))
                 else:
-                    logger.info(f"Skipping message event with bot mention: '{text}'")
+                    logger.info(f"Skipping message event with bot mention: '{raw_text}'")
                     return
 
             # Extract file attachments (slack_files already checked above)
@@ -1422,7 +1436,7 @@ class SlackBot(BaseIMClient):
             if not user_id:
                 logger.debug("Ignoring Slack message without user id")
                 return
-            if not text and not file_attachments and not has_shared_content and not had_dm_mention_only:
+            if not route_text and not file_attachments and not has_shared_content and not had_dm_mention_only:
                 logger.debug("Ignoring Slack message with empty text and no files")
                 return
 
@@ -1447,7 +1461,7 @@ class SlackBot(BaseIMClient):
                 if handled_bot_mention_in_message_event:
                     logger.debug("Processing message event because Slack Connect bot mention was already detected")
                 elif not is_thread_reply:
-                    logger.debug(f"Ignoring non-mention message in channel: '{text}'")
+                    logger.debug(f"Ignoring non-mention message in channel: '{route_text}'")
                     return
 
                 # In thread: check if bot is active in this thread
@@ -1464,18 +1478,18 @@ class SlackBot(BaseIMClient):
                             else False
                         )
                         if not thread_active and not scheduled_thread_active:
-                            logger.debug(f"Ignoring message in inactive thread {thread_ts}: '{text}'")
+                            logger.debug(f"Ignoring message in inactive thread {thread_ts}: '{route_text}'")
                             return
                     else:
                         # Without settings_manager, fall back to ignoring non-mention in threads
-                        logger.debug(f"No settings_manager, ignoring thread message: '{text}'")
+                        logger.debug(f"No settings_manager, ignoring thread message: '{route_text}'")
                         return
 
             auth = self.check_authorization(
                 user_id=user_id,
                 channel_id=channel_id,
                 is_dm=is_dm,
-                text=text,
+                text=route_text,
                 settings_manager=self.settings_manager,
             )
             if not auth.allowed:
@@ -1489,7 +1503,7 @@ class SlackBot(BaseIMClient):
                 shared_text = await self._extract_shared_message_content(event)
                 # If shared content extraction found nothing and we have no text/files,
                 # there's nothing to process
-                if not shared_text and not text and not file_attachments:
+                if not shared_text and not route_text and not file_attachments:
                     logger.debug("Ignoring shared message with no extractable content")
                     return
 
@@ -1506,6 +1520,8 @@ class SlackBot(BaseIMClient):
                     "team_id": payload.get("team_id"),
                     "event": event,
                     "is_dm": is_dm,
+                    "bot_user_id": bot_user_id,
+                    "bot_mention": bot_mention,
                 },
                 files=file_attachments,
             )
@@ -1516,10 +1532,11 @@ class SlackBot(BaseIMClient):
                 logger.info(f"Marked thread {thread_id} as active due to Slack Connect @mention")
 
             # Handle slash commands in regular messages (before appending shared content)
-            # Use only the user's original text for command detection
+            # Use mention-normalized text for internal command detection;
+            # keep agent_text as the original Slack message.
             if await self.dispatch_text_command(
                 context,
-                text,
+                route_text,
                 allow_plain_bind=self.should_allow_plain_bind(
                     user_id=user_id,
                     is_dm=is_dm,
@@ -1530,14 +1547,14 @@ class SlackBot(BaseIMClient):
 
             # Append shared content to user text (after command parsing)
             if shared_text:
-                if text:
-                    text = f"{text}\n\n{shared_text}"
+                if agent_text:
+                    agent_text = f"{agent_text}\n\n{shared_text}"
                 else:
-                    text = shared_text
+                    agent_text = shared_text
 
             # Handle as regular message
             if self.on_message_callback:
-                await self.on_message_callback(context, text)
+                await self.on_message_callback(context, agent_text)
 
         elif event_type == "app_mention":
             # Handle @mentions
@@ -1546,15 +1563,18 @@ class SlackBot(BaseIMClient):
             if not self._mark_mention_event_processed(channel_id, event.get("ts")):
                 return
 
+            raw_text = (event.get("text") or "").strip()
+            bot_user_id = await self._get_bot_user_id(payload)
+            bot_mention = f"<@{bot_user_id}>" if bot_user_id else None
             # Remove the mention from the text first so we can parse commands for auth
-            text = self._strip_specific_mention(
-                event.get("text", ""),
-                await self._get_bot_user_id(payload),
+            route_text = self._strip_specific_mention(
+                raw_text,
+                bot_user_id,
                 anywhere=True,
             ).strip()
 
             # Parse command action for proper admin-protected auth check
-            parsed_command = self.parse_text_command(text)
+            parsed_command = self.parse_text_command(route_text)
             auth_action = parsed_command[0] if parsed_command else ""
 
             # Centralized auth gate (app_mention is always in a channel, not DM)
@@ -1579,7 +1599,7 @@ class SlackBot(BaseIMClient):
             # Extract shared/forwarded message content (defer appending until after command check)
             shared_text = await self._extract_shared_message_content(event)
 
-            if not text and not file_attachments and not shared_text:
+            if not route_text and not file_attachments and not shared_text:
                 logger.debug("Ignoring Slack app_mention with empty text and no files")
                 return
 
@@ -1592,6 +1612,8 @@ class SlackBot(BaseIMClient):
                     "team_id": payload.get("team_id"),
                     "event": event,
                     "is_dm": channel_id.startswith("D"),
+                    "bot_user_id": bot_user_id,
+                    "bot_mention": bot_mention,
                 },
                 files=file_attachments,
             )
@@ -1602,7 +1624,7 @@ class SlackBot(BaseIMClient):
                     self.sessions.mark_thread_active(event.get("user"), channel_id, thread_id)
                 logger.info(f"Marked thread {thread_id} as active due to @mention")
 
-            logger.info(f"App mention processed: original='{event.get('text')}', cleaned='{text}'")
+            logger.info(f"App mention processed: original='{event.get('text')}', cleaned='{route_text}'")
 
             # Check if this is a command after mention (command already parsed above for auth)
             if parsed_command:
@@ -1617,16 +1639,17 @@ class SlackBot(BaseIMClient):
                 logger.warning(f"Command '{command}' not found in callbacks")
 
             # Append shared content to user text (after command parsing)
+            agent_text = raw_text
             if shared_text:
-                if text:
-                    text = f"{text}\n\n{shared_text}"
+                if agent_text:
+                    agent_text = f"{agent_text}\n\n{shared_text}"
                 else:
-                    text = shared_text
+                    agent_text = shared_text
 
             # Handle as regular message
-            logger.info(f"Handling as regular message: '{text}'")
+            logger.info(f"Handling as regular message: '{agent_text}'")
             if self.on_message_callback:
-                await self.on_message_callback(context, text)
+                await self.on_message_callback(context, agent_text)
 
     async def _handle_slash_command(self, payload: Dict[str, Any]):
         """Handle native Slack slash commands"""

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -351,6 +351,16 @@ class SlackBot(BaseIMClient):
             return True
         return self._channel_looks_like_dm(context.channel_id)
 
+    @staticmethod
+    def _slack_response_get(response: Any, key: str) -> Any:
+        getter = getattr(response, "get", None)
+        if callable(getter):
+            return getter(key)
+        try:
+            return response[key]
+        except Exception:
+            return None
+
     async def _get_channel_info_cached(self, channel_id: Optional[str]) -> Dict[str, Any]:
         if not channel_id:
             return {}
@@ -365,7 +375,7 @@ class SlackBot(BaseIMClient):
 
         try:
             response = await conversations_info(channel=channel_id)
-            channel = response.get("channel") if isinstance(response, dict) else None
+            channel = self._slack_response_get(response, "channel")
             if isinstance(channel, dict):
                 self._channel_info_cache[channel_id] = channel
                 return channel
@@ -740,7 +750,7 @@ class SlackBot(BaseIMClient):
 
         try:
             response = await self.web_client.files_info(file=file_id)
-            slack_file = response.get("file") if isinstance(response, dict) else None
+            slack_file = self._slack_response_get(response, "file")
             if not isinstance(slack_file, dict) or not slack_file:
                 return file_info
             resolved = {**file_info, **slack_file}

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -74,6 +74,7 @@ class SlackBot(BaseIMClient):
         self._controller = None
         self._recent_event_ids: Dict[str, float] = {}
         self._user_info_cache: Dict[str, Dict[str, Any]] = {}
+        self._channel_info_cache: Dict[str, Dict[str, Any]] = {}
         self._bot_user_id: Optional[str] = None
         self._stop_event: Optional[asyncio.Event] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -332,6 +333,35 @@ class SlackBot(BaseIMClient):
             return True
         return self._channel_looks_like_dm(context.channel_id)
 
+    async def _get_channel_info_cached(self, channel_id: Optional[str]) -> Dict[str, Any]:
+        if not channel_id:
+            return {}
+        cached = self._channel_info_cache.get(channel_id)
+        if cached is not None:
+            return cached
+
+        self._ensure_clients()
+        conversations_info = getattr(self.web_client, "conversations_info", None)
+        if not callable(conversations_info):
+            return {}
+
+        try:
+            response = await conversations_info(channel=channel_id)
+            channel = response.get("channel") if isinstance(response, dict) else None
+            if isinstance(channel, dict):
+                self._channel_info_cache[channel_id] = channel
+                return channel
+        except SlackApiError as err:
+            error_code = getattr(err, "response", {}).get("error") if getattr(err, "response", None) else None
+            logger.debug("Failed to fetch Slack channel info for %s: %s", channel_id, error_code or err)
+        except Exception as err:
+            logger.debug("Failed to fetch Slack channel info for %s: %s", channel_id, err)
+        return {}
+
+    async def _is_slack_connect_channel(self, channel_id: Optional[str]) -> bool:
+        channel = await self._get_channel_info_cached(channel_id)
+        return bool(channel.get("is_ext_shared"))
+
     async def _open_dm_channel(self, user_id: str) -> Optional[str]:
         self._ensure_clients()
         resp = await self.web_client.conversations_open(users=[user_id])
@@ -582,7 +612,8 @@ class SlackBot(BaseIMClient):
         Returns:
             File content as bytes, or None if download fails
         """
-        url = file_info.get("url_private_download") or file_info.get("url_private")
+        file_info = await self._resolve_downloadable_file_info(file_info)
+        url = file_info.get("url_private_download") or file_info.get("url_private") or file_info.get("url")
         if not url:
             logger.warning(f"No download URL for file: {file_info.get('name')}")
             return None
@@ -634,7 +665,8 @@ class SlackBot(BaseIMClient):
         max_bytes: Optional[int] = None,
         timeout_seconds: int = 30,
     ) -> FileDownloadResult:
-        url = file_info.get("url_private_download") or file_info.get("url_private")
+        file_info = await self._resolve_downloadable_file_info(file_info)
+        url = file_info.get("url_private_download") or file_info.get("url_private") or file_info.get("url")
         if not url:
             logger.warning(f"No download URL for file: {file_info.get('name')}")
             return FileDownloadResult(False, "No download URL available")
@@ -679,6 +711,30 @@ class SlackBot(BaseIMClient):
             logger.error(f"Error downloading Slack file: {e}")
             return FileDownloadResult(False, f"Download error: {e}")
 
+    async def _resolve_downloadable_file_info(self, file_info: Dict[str, Any]) -> Dict[str, Any]:
+        """Best-effort hydrate a thin Slack file event before download."""
+        if file_info.get("url_private_download") or file_info.get("url_private") or file_info.get("url"):
+            return file_info
+
+        file_id = file_info.get("slack_file_id") or file_info.get("id") or file_info.get("file_id")
+        if not file_id or not self.web_client:
+            return file_info
+
+        try:
+            response = await self.web_client.files_info(file=file_id)
+            slack_file = response.get("file") if isinstance(response, dict) else None
+            if not isinstance(slack_file, dict) or not slack_file:
+                return file_info
+            resolved = {**file_info, **slack_file}
+            resolved.setdefault("slack_file_id", file_id)
+            return resolved
+        except SlackApiError as err:
+            error_code = getattr(err, "response", {}).get("error") if getattr(err, "response", None) else None
+            logger.warning("Failed to resolve Slack file info for %s: %s", file_id, error_code or err)
+        except Exception as err:
+            logger.warning("Failed to resolve Slack file info for %s: %s", file_id, err)
+        return file_info
+
     def _extract_file_attachments(self, files: List[Dict[str, Any]]) -> List[FileAttachment]:
         """Convert Slack file objects to FileAttachment list.
 
@@ -690,12 +746,16 @@ class SlackBot(BaseIMClient):
         """
         attachments = []
         for f in files:
+            file_id = f.get("id")
+            name = f.get("name") or f.get("title") or file_id or "slack-file"
             attachment = FileAttachment(
-                name=f.get("name", "unknown"),
+                name=name,
                 mimetype=f.get("mimetype", "application/octet-stream"),
                 url=f.get("url_private_download") or f.get("url_private"),
                 size=f.get("size"),
             )
+            if file_id:
+                attachment.__dict__["slack_file_id"] = file_id
             attachments.append(attachment)
         return attachments
 
@@ -1309,10 +1369,15 @@ class SlackBot(BaseIMClient):
             bot_user_id = await self._get_bot_user_id(payload)
             has_bot_mention = self._has_specific_mention(text, bot_user_id)
             cleaned_text = self._strip_specific_mention(text, bot_user_id)
+            handled_bot_mention_in_message_event = False
             if has_bot_mention:
                 if is_dm:
                     text = cleaned_text
                     had_dm_mention_only = not text
+                elif await self._is_slack_connect_channel(channel_id):
+                    text = cleaned_text
+                    handled_bot_mention_in_message_event = True
+                    logger.info("Processing Slack Connect message event with bot mention: '%s'", event.get("text"))
                 else:
                     logger.info(f"Skipping message event with bot mention: '{text}'")
                     return
@@ -1346,12 +1411,14 @@ class SlackBot(BaseIMClient):
 
             if effective_require_mention and not is_dm:
                 # In channel main thread: require mention (silently ignore)
-                if not is_thread_reply:
+                if handled_bot_mention_in_message_event:
+                    logger.debug("Processing message event because Slack Connect bot mention was already detected")
+                elif not is_thread_reply:
                     logger.debug(f"Ignoring non-mention message in channel: '{text}'")
                     return
 
                 # In thread: check if bot is active in this thread
-                if is_thread_reply:
+                elif is_thread_reply:
                     thread_ts = event.get("thread_ts")
                     # If we have settings_manager, check if thread is active
                     if self.settings_manager:
@@ -1409,6 +1476,11 @@ class SlackBot(BaseIMClient):
                 },
                 files=file_attachments,
             )
+
+            if handled_bot_mention_in_message_event and self.settings_manager and thread_id:
+                if self.sessions:
+                    self.sessions.mark_thread_active(user_id, channel_id, thread_id)
+                logger.info(f"Marked thread {thread_id} as active due to Slack Connect @mention")
 
             # Handle slash commands in regular messages (before appending shared content)
             # Use only the user's original text for command detection

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -1524,6 +1524,7 @@ class SlackBot(BaseIMClient):
                     "is_dm": is_dm,
                     "bot_user_id": bot_user_id,
                     "bot_mention": bot_mention,
+                    "control_text": route_text,
                 },
                 files=file_attachments,
             )
@@ -1616,6 +1617,7 @@ class SlackBot(BaseIMClient):
                     "is_dm": channel_id.startswith("D"),
                     "bot_user_id": bot_user_id,
                     "bot_mention": bot_mention,
+                    "control_text": route_text,
                 },
                 files=file_attachments,
             )

--- a/tests/test_message_handler_attachments.py
+++ b/tests/test_message_handler_attachments.py
@@ -16,8 +16,13 @@ from modules.im.base import FileAttachment, FileDownloadResult
 def _load_message_handler_class():
     with patch.dict(sys.modules, {}, clear=False):
         agents_module = types.ModuleType("modules.agents")
-        setattr(agents_module, "AgentRequest", type("AgentRequest", (), {}))
+        agents_module.__path__ = []
+        agent_request = type("AgentRequest", (), {})
+        setattr(agents_module, "AgentRequest", agent_request)
         sys.modules["modules.agents"] = agents_module
+        agents_base_module = types.ModuleType("modules.agents.base")
+        setattr(agents_base_module, "AgentRequest", agent_request)
+        sys.modules["modules.agents.base"] = agents_base_module
 
         core_pkg = types.ModuleType("core")
         core_pkg.__path__ = [str(ROOT / "core")]
@@ -208,6 +213,29 @@ class MessageHandlerAttachmentTests(unittest.IsolatedAsyncioTestCase):
         file_info = im_client.stream_calls[0][0]
         self.assertEqual(file_info["cdn_info"]["encrypt_query_param"], "encrypted-param")
         self.assertEqual(file_info["wechat_item"]["aeskey"], "00112233445566778899aabbccddeeff")
+
+    async def test_process_file_attachments_allows_platform_download_without_url(self):
+        im_client = _StubIMClient(download_result=b"%PDF-1.7\n", stream_result=True)
+        handler = MessageHandler(_StubController(im_client))
+        attachment = FileAttachment(
+            name="F123",
+            mimetype="application/pdf",
+            url=None,
+            size=1024,
+        )
+        attachment.__dict__["slack_file_id"] = "F123"
+        context = MessageContext(user_id="U1", channel_id="C1", platform="slack", files=[attachment])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("config.paths.get_attachments_dir", return_value=Path(tmpdir)):
+                processed, errors = await handler._process_file_attachments(context, "/tmp/work")
+
+        self.assertIsNotNone(processed)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(im_client.stream_calls), 1)
+        file_info = im_client.stream_calls[0][0]
+        self.assertIsNone(file_info["url"])
+        self.assertEqual(file_info["slack_file_id"], "F123")
 
     def test_append_attachment_errors_uses_error_text_without_file_paths(self):
         handler = MessageHandler(_StubController(_StubIMClient()))

--- a/tests/test_message_handler_attachments.py
+++ b/tests/test_message_handler_attachments.py
@@ -249,6 +249,21 @@ class MessageHandlerAttachmentTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Download failed with HTTP 403", message)
         self.assertNotIn("/.vibe_remote/attachments/", message)
 
+    def test_prepend_agent_identity_keeps_original_message_text(self):
+        handler = MessageHandler(_StubController(_StubIMClient()))
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={"bot_mention": "<@U_BOT>"},
+        )
+
+        message = handler._prepend_agent_identity(context, "please <@U_BOT> help <@U_OTHER>")
+
+        self.assertEqual(
+            message,
+            "[Agent Identity] Slack bot mention: <@U_BOT>\nplease <@U_BOT> help <@U_OTHER>",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -142,12 +142,18 @@ class _StubAgentService:
     def __init__(self):
         self.default_agent = "codex"
         self.requests = []
+        self.stop_requests = []
         self.error = None
+        self.stop_result = True
 
     async def handle_message(self, agent_name, request):
         if self.error is not None:
             raise self.error
         self.requests.append((agent_name, request))
+
+    async def handle_stop(self, agent_name, request):
+        self.stop_requests.append((agent_name, request))
+        return self.stop_result
 
 
 class _StubController:
@@ -165,6 +171,7 @@ class _StubController:
         self.agent_service = _StubAgentService()
         self.settings_handler = type("Settings", (), {})()
         self.command_handler = type("Cmd", (), {"handle_start": staticmethod(lambda context, args: None)})()
+        self.agent_auth_service = type("Auth", (), {})()
 
     def update_thread_message_id(self, context):
         return None
@@ -316,6 +323,49 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         result = await handler._prepend_user_info(context, "hello")
 
         self.assertEqual(result, "[WeChat User<wx-user>] hello")
+
+    async def test_control_text_handles_mentioned_inline_stop(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            thread_id="T1",
+            message_id="m1",
+            platform="slack",
+            platform_specific={"control_text": "stop"},
+        )
+
+        await handler.handle_user_message(context, "<@U_BOT> stop")
+
+        self.assertEqual(len(controller.agent_service.stop_requests), 1)
+        self.assertEqual(controller.agent_service.requests, [])
+
+    async def test_control_text_routes_mentioned_subagent_prefix(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            message_id="m1",
+            platform="slack",
+            platform_specific={"bot_mention": "<@U_BOT>", "control_text": "reviewer: check this"},
+        )
+
+        from modules.agents.subagent_router import SubagentDefinition
+
+        with patch(
+            "modules.agents.subagent_router.load_codex_subagent",
+            return_value=SubagentDefinition(name="reviewer"),
+        ):
+            await handler.handle_user_message(context, "<@U_BOT> reviewer: check this")
+
+        _, request = controller.agent_service.requests[0]
+        self.assertEqual(request.subagent_name, "reviewer")
+        self.assertEqual(request.subagent_key, "reviewer")
+        self.assertEqual(request.message, "[Agent Identity] Slack bot mention: <@U_BOT>\ncheck this")
 
     async def test_scheduled_turn_returns_error_string_after_notifying_im(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -342,6 +342,25 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(controller.agent_service.stop_requests), 1)
         self.assertEqual(controller.agent_service.requests, [])
 
+    async def test_empty_fallback_uses_agent_message_not_control_text(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        controller.command_handler.handle_start = AsyncMock()
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            message_id="m1",
+            platform="slack",
+            platform_specific={"bot_mention": "<@U_BOT>", "control_text": ""},
+        )
+
+        await handler.handle_user_message(context, "<@U_BOT>\n\nshared content")
+
+        controller.command_handler.handle_start.assert_not_awaited()
+        _, request = controller.agent_service.requests[0]
+        self.assertIn("shared content", request.message)
+
     async def test_control_text_routes_mentioned_subagent_prefix(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
         handler = MessageHandler(controller)

--- a/tests/test_slack_app_mention_empty.py
+++ b/tests/test_slack_app_mention_empty.py
@@ -104,6 +104,14 @@ _install_slack_stubs()
 SlackBot = _load_local_slack_bot()
 
 
+class _ResponseLike:
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
 class SlackAppMentionEmptyTests(unittest.IsolatedAsyncioTestCase):
     async def test_empty_app_mention_does_not_activate_or_dispatch(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
@@ -152,13 +160,13 @@ class SlackFileAttachmentTests(unittest.IsolatedAsyncioTestCase):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         slack.web_client = SimpleNamespace(
             files_info=AsyncMock(
-                return_value={
+                return_value=_ResponseLike({
                     "file": {
                         "id": "F123",
                         "name": "report.pdf",
                         "url_private_download": "https://files.slack.test/report.pdf",
                     }
-                }
+                })
             )
         )
 

--- a/tests/test_slack_app_mention_empty.py
+++ b/tests/test_slack_app_mention_empty.py
@@ -137,5 +137,37 @@ class SlackAppMentionEmptyTests(unittest.IsolatedAsyncioTestCase):
         slack.sessions.mark_thread_active.assert_not_called()
 
 
+class SlackFileAttachmentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_extract_file_attachments_preserves_file_id_when_url_missing(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+
+        attachments = slack._extract_file_attachments([{"id": "F123", "mimetype": "application/pdf"}])
+
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].name, "F123")
+        self.assertIsNone(attachments[0].url)
+        self.assertEqual(attachments[0].__dict__["slack_file_id"], "F123")
+
+    async def test_resolve_downloadable_file_info_hydrates_thin_file_event(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        slack.web_client = SimpleNamespace(
+            files_info=AsyncMock(
+                return_value={
+                    "file": {
+                        "id": "F123",
+                        "name": "report.pdf",
+                        "url_private_download": "https://files.slack.test/report.pdf",
+                    }
+                }
+            )
+        )
+
+        resolved = await slack._resolve_downloadable_file_info({"slack_file_id": "F123", "name": "F123"})
+
+        self.assertEqual(resolved["name"], "report.pdf")
+        self.assertEqual(resolved["url_private_download"], "https://files.slack.test/report.pdf")
+        slack.web_client.files_info.assert_awaited_once_with(file="F123")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -333,7 +333,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(user_info["real_name"], "Alex")
         self.assertEqual(user_info["name"], "cyh")
 
-    async def test_dm_mention_only_preserves_raw_text_for_agent(self):
+    async def test_dm_mention_only_falls_through_as_empty_message(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         received = {}
 
@@ -364,7 +364,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
             {
                 "channel_id": "D123",
                 "thread_id": "1710000000.000100",
-                "text": "<@U_BOT>",
+                "text": "",
             },
         )
 

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -922,6 +922,33 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(received["called"])
 
+    async def test_own_bot_message_with_top_level_app_id_is_ignored(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", app_id="A_SELF"))
+        received = {"called": False}
+
+        async def _on_message(_context, _text):
+            received["called"] = True
+
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-own-bot-top-level-app",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "bot_id": "B_SELF",
+                "app_id": "A_SELF",
+                "text": "<@U_BOT> loop",
+                "ts": "1710000000.000358",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertFalse(received["called"])
+
     async def test_slack_connect_channel_mention_marks_thread_active(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
         marked = []

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -333,7 +333,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(user_info["real_name"], "Alex")
         self.assertEqual(user_info["name"], "cyh")
 
-    async def test_dm_mention_only_falls_through_as_empty_message(self):
+    async def test_dm_mention_only_preserves_raw_text_for_agent(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         received = {}
 
@@ -364,11 +364,11 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
             {
                 "channel_id": "D123",
                 "thread_id": "1710000000.000100",
-                "text": "",
+                "text": "<@U_BOT>",
             },
         )
 
-    async def test_dm_mention_with_text_strips_mention(self):
+    async def test_dm_mention_with_text_preserves_raw_text_for_agent(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         received = {}
 
@@ -392,7 +392,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         await slack._handle_event(payload)
 
-        self.assertEqual(received, {"text": "hello"})
+        self.assertEqual(received, {"text": "<@U_BOT> hello"})
 
     async def test_bound_user_message_from_mismatched_dm_channel_is_ignored(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
@@ -802,6 +802,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         async def _on_message(context, text):
             received["text"] = text
             received["thread_id"] = context.thread_id
+            received["bot_mention"] = (context.platform_specific or {}).get("bot_mention")
 
         slack.web_client = _WebClient()
         slack.register_callbacks(on_message=_on_message)
@@ -821,9 +822,16 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         await slack._handle_event(payload)
 
-        self.assertEqual(received, {"text": "please help", "thread_id": "1710000000.000350"})
+        self.assertEqual(
+            received,
+            {
+                "text": "<@U_BOT> please help",
+                "thread_id": "1710000000.000350",
+                "bot_mention": "<@U_BOT>",
+            },
+        )
 
-    async def test_slack_connect_mid_text_mention_is_stripped_in_message_fallback(self):
+    async def test_slack_connect_mid_text_mention_is_forwarded_raw_in_message_fallback(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
         received = {}
 
@@ -852,7 +860,67 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         await slack._handle_event(payload)
 
-        self.assertEqual(received, {"text": "please help"})
+        self.assertEqual(received, {"text": "please <@U_BOT> help"})
+
+    async def test_slack_connect_other_bot_mention_is_forwarded_raw(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
+        received = {}
+
+        class _WebClient:
+            async def conversations_info(self, channel):
+                return {"channel": {"id": channel, "is_ext_shared": True}}
+
+        async def _on_message(context, text):
+            received["user_id"] = context.user_id
+            received["text"] = text
+
+        slack.web_client = _WebClient()
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-slack-connect-other-bot-mention",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "bot_id": "B_OTHER",
+                "bot_profile": {"user_id": "U_OTHER_BOT"},
+                "text": "handoff to <@U_BOT> please",
+                "ts": "1710000000.000356",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"user_id": "U_OTHER_BOT", "text": "handoff to <@U_BOT> please"})
+
+    async def test_own_bot_message_is_ignored_even_when_mentioned(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", app_id="A_SELF"))
+        received = {"called": False}
+
+        async def _on_message(_context, _text):
+            received["called"] = True
+
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-own-bot-mention",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "bot_id": "B_SELF",
+                "bot_profile": {"user_id": "U_BOT", "app_id": "A_SELF"},
+                "text": "<@U_BOT> loop",
+                "ts": "1710000000.000357",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertFalse(received["called"])
 
     async def test_slack_connect_channel_mention_marks_thread_active(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
@@ -938,7 +1006,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         await slack._handle_event(message_payload)
         await slack._handle_event(app_mention_payload)
 
-        self.assertEqual(received, ["please help"])
+        self.assertEqual(received, ["<@U_BOT> please help"])
 
     async def test_slack_connect_app_mention_then_message_is_handled_once(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
@@ -982,7 +1050,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         await slack._handle_event(app_mention_payload)
         await slack._handle_event(message_payload)
 
-        self.assertEqual(received, ["please help"])
+        self.assertEqual(received, ["<@U_BOT> please help"])
 
     async def test_dm_preserves_non_bot_mentions(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
@@ -1008,7 +1076,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         await slack._handle_event(payload)
 
-        self.assertEqual(received, {"text": "summarize what <@U_OTHER> said"})
+        self.assertEqual(received, {"text": "<@U_BOT> summarize what <@U_OTHER> said"})
 
     async def test_channel_message_with_other_mentions_is_not_skipped(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
@@ -1086,7 +1154,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         await slack._handle_event(payload)
 
-        self.assertEqual(received, {"text": "summarize what <@U_OTHER> said"})
+        self.assertEqual(received, {"text": "<@U_BOT> summarize what <@U_OTHER> said"})
 
 
 if __name__ == "__main__":

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -783,6 +783,80 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(received["called"])
 
+    async def test_slack_connect_channel_mention_falls_back_to_message_event(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
+        received = {}
+
+        class _WebClient:
+            async def conversations_info(self, channel):
+                return {"channel": {"id": channel, "is_ext_shared": True}}
+
+        async def _on_message(context, text):
+            received["text"] = text
+            received["thread_id"] = context.thread_id
+
+        slack.web_client = _WebClient()
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-slack-connect-mention",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "<@U_BOT> please help",
+                "ts": "1710000000.000350",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"text": "please help", "thread_id": "1710000000.000350"})
+
+    async def test_slack_connect_channel_mention_marks_thread_active(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
+        marked = []
+
+        class _WebClient:
+            async def conversations_info(self, channel):
+                return {"channel": {"id": channel, "is_ext_shared": True}}
+
+        class _Sessions:
+            def mark_thread_active(self, user_id, channel_id, thread_id):
+                marked.append((user_id, channel_id, thread_id))
+
+        class _SettingsManager:
+            sessions = _Sessions()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        async def _on_message(_context, _text):
+            return None
+
+        slack.web_client = _WebClient()
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-slack-connect-mark-thread",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "<@U_BOT> please help",
+                "ts": "1710000000.000360",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(marked, [("U123", "C_CONNECT", "1710000000.000360")])
+
     async def test_dm_preserves_non_bot_mentions(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         received = {}

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -857,6 +857,94 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(marked, [("U123", "C_CONNECT", "1710000000.000360")])
 
+    async def test_slack_connect_message_then_app_mention_is_handled_once(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
+        received = []
+
+        class _WebClient:
+            async def conversations_info(self, channel):
+                return {"channel": {"id": channel, "is_ext_shared": True}}
+
+        async def _on_message(_context, text):
+            received.append(text)
+
+        slack.web_client = _WebClient()
+        slack.register_callbacks(on_message=_on_message)
+
+        message_payload = {
+            "event_id": "evt-slack-connect-message-first",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "<@U_BOT> please help",
+                "ts": "1710000000.000370",
+            },
+        }
+        app_mention_payload = {
+            "event_id": "evt-slack-connect-app-mention-second",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "app_mention",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "<@U_BOT> please help",
+                "ts": "1710000000.000370",
+            },
+        }
+
+        await slack._handle_event(message_payload)
+        await slack._handle_event(app_mention_payload)
+
+        self.assertEqual(received, ["please help"])
+
+    async def test_slack_connect_app_mention_then_message_is_handled_once(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
+        received = []
+
+        class _WebClient:
+            async def conversations_info(self, channel):
+                return {"channel": {"id": channel, "is_ext_shared": True}}
+
+        async def _on_message(_context, text):
+            received.append(text)
+
+        slack.web_client = _WebClient()
+        slack.register_callbacks(on_message=_on_message)
+
+        app_mention_payload = {
+            "event_id": "evt-slack-connect-app-mention-first",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "app_mention",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "<@U_BOT> please help",
+                "ts": "1710000000.000380",
+            },
+        }
+        message_payload = {
+            "event_id": "evt-slack-connect-message-second",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "<@U_BOT> please help",
+                "ts": "1710000000.000380",
+            },
+        }
+
+        await slack._handle_event(app_mention_payload)
+        await slack._handle_event(message_payload)
+
+        self.assertEqual(received, ["please help"])
+
     async def test_dm_preserves_non_bot_mentions(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         received = {}

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -949,6 +949,37 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(received["called"])
 
+    async def test_own_bot_message_with_auth_test_bot_id_is_ignored_without_app_id(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        received = {"called": False}
+
+        class _WebClient:
+            async def auth_test(self):
+                return {"user_id": "U_BOT", "bot_id": "B_SELF"}
+
+        async def _on_message(_context, _text):
+            received["called"] = True
+
+        slack.web_client = _WebClient()
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-own-bot-auth-bot-id",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "bot_id": "B_SELF",
+                "text": "<@U_BOT> loop",
+                "ts": "1710000000.000359",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertFalse(received["called"])
+
     async def test_slack_connect_channel_mention_marks_thread_active(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
         marked = []

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -815,6 +815,37 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(received, {"text": "please help", "thread_id": "1710000000.000350"})
 
+    async def test_slack_connect_mid_text_mention_is_stripped_in_message_fallback(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
+        received = {}
+
+        class _WebClient:
+            async def conversations_info(self, channel):
+                return {"channel": {"id": channel, "is_ext_shared": True}}
+
+        async def _on_message(_context, text):
+            received["text"] = text
+
+        slack.web_client = _WebClient()
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-slack-connect-mid-text-mention",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "please <@U_BOT> help",
+                "ts": "1710000000.000355",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, {"text": "please help"})
+
     async def test_slack_connect_channel_mention_marks_thread_active(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
         marked = []

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -116,6 +116,14 @@ _install_slack_stubs()
 from modules.im.slack import SlackBot
 
 
+class _ResponseLike:
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
 class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
     async def test_send_message_recovers_dm_channel_after_channel_not_found(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
@@ -789,7 +797,7 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
 
         class _WebClient:
             async def conversations_info(self, channel):
-                return {"channel": {"id": channel, "is_ext_shared": True}}
+                return _ResponseLike({"channel": {"id": channel, "is_ext_shared": True}})
 
         async def _on_message(context, text):
             received["text"] = text


### PR DESCRIPTION
## Summary
- handle Slack Connect channel @mentions from message events when app_mention is not delivered
- preserve Slack mention text in the message passed to the agent, while using normalized control text only for routing, commands, setup replies, inline stop, and subagent prefix parsing
- hydrate Slack file attachments that arrive as thin events with only a file id before download
- keep existing normal-channel app_mention behavior unchanged and add focused regression tests

## Evidence
- Unit: `pytest tests/test_message_handler_attachments.py tests/test_message_handler_typing.py tests/test_slack_dm_mentions.py tests/test_slack_app_mention_empty.py`
- Lint: `ruff check core/handlers/message_handler.py modules/im/slack.py tests/test_message_handler_attachments.py tests/test_message_handler_typing.py tests/test_slack_dm_mentions.py tests/test_slack_app_mention_empty.py`
- Contract: not applicable; no protocol/schema change
- Scenario: no catalog scenario updated; covered by focused Slack and handler unit regressions
- Manual: not run in Docker regression yet

## Root Cause Notes
- Slack Connect: non-DM `message` events with bot mentions were skipped because the handler assumed an `app_mention` event would always follow. Slack Connect channels can deliver only the `message` event, so the mention was lost.
- Mentions: the adapter previously reused mention-stripped text as the agent input. The fix now separates internal control text from the raw Slack text the agent sees.
- Attachments: the message handler rejected attachments without a URL before platform downloaders could resolve them. Slack can send thin file events where the file id is enough to hydrate the private download URL via `files.info`.

## Risk
- Slack Connect fallback performs a cached `conversations.info` lookup only when a non-DM message event contains the bot mention.
- Attachment hydration preserves existing URL-based downloads and only adds a file-id fallback.
- Other bot messages are still ignored unless they explicitly mention this bot; this avoids self-looping while allowing bot-to-bot handoffs.
