### PR TITLE
fix(lark): preserve result attachment fallback

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 from modules.im import MessageContext
 from core.reply_enhancer import process_reply, strip_file_links, strip_silent_blocks
+from vibe.i18n import t as i18n_t
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,13 @@ class ConsolidatedMessageDispatcher:
         if callable(getter):
             return getter(context)
         return self.controller.im_client
+
+    def _t(self, key: str, **kwargs) -> str:
+        translator = getattr(self.controller, "_t", None)
+        if callable(translator):
+            return translator(key, **kwargs)
+        lang = getattr(getattr(self.controller, "config", None), "language", "en")
+        return i18n_t(key, lang, **kwargs)
 
     def _get_target_context(self, context: MessageContext) -> MessageContext:
         payload = dict(context.platform_specific or {})
@@ -165,6 +173,14 @@ class ConsolidatedMessageDispatcher:
             context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
         ) != "wechat"
 
+    def _attachment_id_can_anchor_delivery(self, context: MessageContext) -> bool:
+        platform = (
+            context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
+        )
+        # Only treat attachment uploads as scheduled anchors on platforms where
+        # upload_markdown() returns the posted message ID rather than a file ID.
+        return platform in {"discord", "telegram", "lark"}
+
     @staticmethod
     def _is_video_path(path: str) -> bool:
         return Path(path).suffix.lower() in {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"}
@@ -285,6 +301,8 @@ class ConsolidatedMessageDispatcher:
         if canonical_type == "result":
             target_context = self._get_target_context(context)
             primary_message_id: Optional[str] = None
+            scheduled_anchor_message_id: Optional[str] = None
+            delivered_as_attachment = False
 
             # --- Reply enhancements: extract file links & quick-reply buttons ---
             reply_enhancements_on = getattr(self.controller.config, "reply_enhancements", True)
@@ -305,12 +323,14 @@ class ConsolidatedMessageDispatcher:
                             enhanced.buttons,
                             parse_mode,
                         )
+                        scheduled_anchor_message_id = primary_message_id
                     except Exception as err:
                         logger.warning("Failed to send result with quick replies, falling back: %s", err)
                         try:
                             primary_message_id = await im_client.send_message(
                                 target_context, display_text, parse_mode=parse_mode
                             )
+                            scheduled_anchor_message_id = primary_message_id
                         except Exception as fallback_err:
                             logger.error("Failed to send fallback result message: %s", fallback_err)
                 else:
@@ -318,6 +338,7 @@ class ConsolidatedMessageDispatcher:
                         primary_message_id = await im_client.send_message(
                             target_context, display_text, parse_mode=parse_mode
                         )
+                        scheduled_anchor_message_id = primary_message_id
                     except Exception as err:
                         logger.error("Failed to send result message: %s", err)
             elif self._should_split_long_result(context):
@@ -329,12 +350,14 @@ class ConsolidatedMessageDispatcher:
                         enhanced.buttons if enhanced else [],
                         parse_mode,
                     )
+                    scheduled_anchor_message_id = primary_message_id
                 except Exception as err:
                     logger.error("Failed to send split result messages: %s", err)
             else:
                 summary = self._build_result_summary(display_text, self._get_result_max_chars(context))
                 try:
                     primary_message_id = await im_client.send_message(target_context, summary, parse_mode=parse_mode)
+                    scheduled_anchor_message_id = primary_message_id
                 except Exception as err:
                     logger.error("Failed to send result summary: %s", err)
 
@@ -344,27 +367,82 @@ class ConsolidatedMessageDispatcher:
                     or self.controller.config.platform
                 ) in {"slack", "discord", "telegram", "lark"} and hasattr(im_client, "upload_markdown"):
                     try:
-                        await im_client.upload_markdown(
+                        attachment_message_id = await im_client.upload_markdown(
                             target_context,
                             title="result.md",
                             content=display_text,
                             filetype="markdown",
                         )
+                        if primary_message_id is None:
+                            primary_message_id = attachment_message_id
+                            delivered_as_attachment = True
+                            if self._attachment_id_can_anchor_delivery(context):
+                                scheduled_anchor_message_id = attachment_message_id
                     except Exception as err:
                         logger.warning(f"Failed to upload result attachment: {err}")
                         await im_client.send_message(
                             target_context,
-                            "Failed to upload attachment. Want me to split the result into multiple messages?",
+                            self._t("error.resultAttachmentUploadFailed"),
                             parse_mode=parse_mode,
                         )
+
+            # --- Fallback: card content rejected (e.g. table over limit) ---
+            if primary_message_id is None and display_text:
+                logger.warning("All direct result sends failed; attempting fallback delivery")
+                file_uploaded = False
+
+                # Fallback 1: upload full content as .md file.
+                if hasattr(im_client, "upload_markdown"):
+                    try:
+                        primary_message_id = await im_client.upload_markdown(
+                            target_context,
+                            title="result.md",
+                            content=display_text,
+                            filetype="markdown",
+                        )
+                        file_uploaded = True
+                        delivered_as_attachment = True
+                        if self._attachment_id_can_anchor_delivery(context):
+                            scheduled_anchor_message_id = primary_message_id
+                        logger.info("Result delivered as .md file attachment (fallback)")
+                    except Exception as upload_err:
+                        logger.warning("upload_markdown fallback failed: %s", upload_err)
+
+                # Fallback 2: split into multiple messages.
+                if not file_uploaded:
+                    try:
+                        primary_message_id = await self._send_split_result_messages(
+                            im_client,
+                            target_context,
+                            display_text,
+                            enhanced.buttons if enhanced else [],
+                            parse_mode,
+                        )
+                        scheduled_anchor_message_id = primary_message_id
+                        logger.info("Result delivered via split messages (fallback)")
+                    except Exception as split_err:
+                        logger.error("Split message fallback also failed: %s", split_err)
+
+            # Explain attachment-only delivery or total failure once all attempts settle.
+            try:
+                if delivered_as_attachment:
+                    notice = self._t("info.resultDeliveredAsAttachment")
+                elif primary_message_id is None and display_text:
+                    notice = self._t("error.resultDeliveryFailed")
+                else:
+                    notice = None
+                if notice:
+                    await im_client.send_message(target_context, notice, parse_mode="markdown")
+            except Exception:
+                logger.error("Failed to send delivery status notification")
 
             # Upload extracted file attachments
             if enhanced and enhanced.files:
                 await self._upload_file_links(im_client, target_context, enhanced.files)
 
-            if primary_message_id:
+            if scheduled_anchor_message_id:
                 try:
-                    self.controller.session_handler.finalize_scheduled_delivery(context, primary_message_id)
+                    self.controller.session_handler.finalize_scheduled_delivery(context, scheduled_anchor_message_id)
                 except Exception as err:
                     logger.warning("Failed to finalize scheduled delivery anchor: %s", err)
 

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.message_dispatcher import ConsolidatedMessageDispatcher
+from modules.im import MessageContext
+
+
+class _StubSettingsManager:
+    def _canonicalize_message_type(self, message_type):
+        return message_type
+
+    def is_message_type_hidden(self, settings_key, canonical_type):
+        return False
+
+
+class _StubSessionHandler:
+    def __init__(self):
+        self.calls = []
+
+    def finalize_scheduled_delivery(self, context, sent_message_id):
+        self.calls.append((context.channel_id, context.thread_id, sent_message_id))
+
+
+class _StubIMClient:
+    def __init__(self, *, fail_first_send: bool = False, upload_id: str = "file-1"):
+        self.sent_messages = []
+        self.uploaded_markdowns = []
+        self._next_id = 1
+        self._fail_first_send = fail_first_send
+        self._send_attempts = 0
+        self._upload_id = upload_id
+
+    def should_use_thread_for_reply(self):
+        return False
+
+    async def send_message(self, context, text, parse_mode=None, reply_to=None):
+        self._send_attempts += 1
+        if self._fail_first_send and self._send_attempts == 1:
+            raise RuntimeError("inline send failed")
+        self.sent_messages.append((context.channel_id, text, parse_mode))
+        message_id = f"msg-{self._next_id}"
+        self._next_id += 1
+        return message_id
+
+    async def upload_markdown(self, context, title, content, filetype="markdown"):
+        self.uploaded_markdowns.append((context.channel_id, title, content, filetype))
+        return self._upload_id
+
+
+class _StubController:
+    def __init__(
+        self,
+        *,
+        platform: str = "lark",
+        language: str = "en",
+        fail_first_send: bool = False,
+        upload_id: str = "file-1",
+    ):
+        self.config = type(
+            "Config",
+            (),
+            {"platform": platform, "language": language, "reply_enhancements": False},
+        )()
+        self.session_handler = _StubSessionHandler()
+        self.im_client = _StubIMClient(fail_first_send=fail_first_send, upload_id=upload_id)
+
+    def _get_settings_key(self, context):
+        return context.channel_id
+
+    def _get_session_key(self, context):
+        return f"{context.platform}::{context.channel_id}"
+
+    def get_settings_manager_for_context(self, context):
+        return _StubSettingsManager()
+
+    def get_im_client_for_context(self, context):
+        return self.im_client
+
+
+class MessageDispatcherResultFallbackTests(unittest.IsolatedAsyncioTestCase):
+    async def test_summary_upload_becomes_primary_anchor_without_duplicate_upload(self):
+        controller = _StubController(platform="lark", language="en", fail_first_send=True)
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="U1", channel_id="C1", platform="lark")
+        long_text = "x" * 35000
+
+        message_id = await dispatcher.emit_agent_message(context, "result", long_text)
+
+        self.assertEqual(message_id, "file-1")
+        self.assertEqual(
+            controller.im_client.uploaded_markdowns,
+            [("C1", "result.md", long_text, "markdown")],
+        )
+        self.assertEqual(
+            controller.im_client.sent_messages,
+            [("C1", "⚠️ The message could not be sent inline, so I sent it as `result.md` above.", "markdown")],
+        )
+        self.assertEqual(controller.session_handler.calls, [("C1", None, "file-1")])
+
+    async def test_attachment_only_notice_uses_configured_language(self):
+        controller = _StubController(platform="lark", language="zh", fail_first_send=True)
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="U1", channel_id="C1", platform="lark")
+        text = "| A | B |\n| - | - |\n| 1 | 2 |"
+
+        message_id = await dispatcher.emit_agent_message(context, "result", text)
+
+        self.assertEqual(message_id, "file-1")
+        self.assertEqual(
+            controller.im_client.uploaded_markdowns,
+            [("C1", "result.md", text, "markdown")],
+        )
+        self.assertEqual(
+            controller.im_client.sent_messages,
+            [("C1", "⚠️ 这条消息无法以内联形式发送，所以我已将完整内容作为 `result.md` 发在上方。", "markdown")],
+        )
+        self.assertEqual(controller.session_handler.calls, [("C1", None, "file-1")])
+
+    async def test_slack_attachment_only_fallback_does_not_finalize_with_file_id(self):
+        controller = _StubController(platform="slack", language="en", fail_first_send=True, upload_id="F123")
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C1",
+            thread_id="171717.123",
+            platform="slack",
+            platform_specific={
+                "turn_source": "scheduled",
+                "turn_base_session_id": "slack_171717.123",
+                "scheduled_delivery_alias": {
+                    "mode": "sent_message",
+                    "session_key": "slack::C1",
+                    "clear_source": False,
+                },
+            },
+        )
+        text = "| A | B |\n| - | - |\n| 1 | 2 |"
+
+        message_id = await dispatcher.emit_agent_message(context, "result", text)
+
+        self.assertEqual(message_id, "F123")
+        self.assertEqual(
+            controller.im_client.uploaded_markdowns,
+            [("C1", "result.md", text, "markdown")],
+        )
+        self.assertEqual(
+            controller.im_client.sent_messages,
+            [("C1", "⚠️ The message could not be sent inline, so I sent it as `result.md` above.", "markdown")],
+        )
+        self.assertEqual(controller.session_handler.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -45,7 +45,9 @@
     "opencodeQuestionUnsupportedWechat": "OpenCode interactive questions are temporarily disabled on WeChat. Please send a follow-up message instead.",
     "sessionReset": "Session error detected. Session has been reset. Please try your message again.",
     "sessionConnectionLost": "Connection to Claude was lost. Please try your message again.",
-    "sessionGeneric": "An error occurred: {error}"
+    "sessionGeneric": "An error occurred: {error}",
+    "resultAttachmentUploadFailed": "Failed to upload attachment. Want me to split the result into multiple messages?",
+    "resultDeliveryFailed": "⚠️ Message delivery failed. The content may be too long or incompatible. Ask me to resend it."
   },
   "success": {
     "settingsUpdated": "Settings updated successfully!",
@@ -103,7 +105,8 @@
     "howItWorksSettingsDesc": "Mention @bot to switch agents, models, reasoning effort, or hide verbose message types.",
     "howItWorksFooter": "Just type to chat with {agent}. No special commands needed!",
     "genericTitle": "Info: {topic}",
-    "genericFooter": "This feature is coming soon!"
+    "genericFooter": "This feature is coming soon!",
+    "resultDeliveredAsAttachment": "⚠️ The message could not be sent inline, so I sent it as `result.md` above."
   },
   "modal": {
     "settings": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -45,7 +45,9 @@
     "opencodeQuestionUnsupportedWechat": "微信平台暂时不支持 OpenCode 的交互式提问。请直接再发一条消息继续。",
     "sessionReset": "检测到会话错误。会话已重置，请重试。",
     "sessionConnectionLost": "与 Claude 的连接已断开，请重试。",
-    "sessionGeneric": "发生错误：{error}"
+    "sessionGeneric": "发生错误：{error}",
+    "resultAttachmentUploadFailed": "附件上传失败。要我改成拆分成多条消息发送吗？",
+    "resultDeliveryFailed": "⚠️ 消息投递失败，内容可能过长或格式不兼容。你可以让我重新发送一次。"
   },
   "success": {
     "settingsUpdated": "设置更新成功！",
@@ -103,7 +105,8 @@
     "howItWorksSettingsDesc": "通过 @bot 随时切换 Agent、模型、推理强度，或隐藏冗余消息类型。",
     "howItWorksFooter": "直接输入消息即可与 {agent} 对话，无需特殊命令！",
     "genericTitle": "信息：{topic}",
-    "genericFooter": "该功能即将上线！"
+    "genericFooter": "该功能即将上线！",
+    "resultDeliveredAsAttachment": "⚠️ 这条消息无法以内联形式发送，所以我已将完整内容作为 `result.md` 发在上方。"
   },
   "modal": {
     "settings": {


### PR DESCRIPTION
## Summary

- restore the Lark/Feishu result fallback from #189 on top of current `master`
- preserve the follow-up fixes from #191: attachment delivery IDs, scheduled anchors, Slack file ID handling, and localized notices
- add regression coverage for attachment-only result delivery

## Why

PR #194 re-submitted the original #189 fallback, but it did not include the #191 follow-up fixes. This PR carries the complete version forward so Feishu card-limit failures can still deliver the full result as `result.md` without regressing scheduled delivery state.

## Changes

- when inline result delivery fails, upload the full result as `result.md` before attempting split-message fallback
- keep the returned delivery ID separate from the scheduled-delivery anchor so Slack `F...` file IDs are not treated as message anchors
- move result fallback notices through backend i18n
- cover Lark attachment-only delivery, localized notices, and Slack scheduled fallback behavior in tests

## Validation

- `python3 -m pytest -q tests/test_message_dispatcher_result_fallback.py tests/test_message_dispatcher_scheduled.py tests/test_reply_enhancer_platform.py`
- `python3 -m json.tool vibe/i18n/en.json`
- `python3 -m json.tool vibe/i18n/zh.json`
- `python3 -m py_compile core/message_dispatcher.py tests/test_message_dispatcher_result_fallback.py`
- `ruff check core/message_dispatcher.py tests/test_message_dispatcher_result_fallback.py`

## Notes

- closes the gap left by #194, which was closed because it only carried the #189 version without the #191 follow-up fixes
