### PR TITLE
fix(slack): restore empty mention menu

### DIFF
--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -1420,7 +1420,7 @@ class SlackBot(BaseIMClient):
             route_text = raw_text
             agent_text = raw_text
 
-            had_dm_mention_only = False
+            had_mention_only = False
             bot_user_id = await self._get_bot_user_id(payload)
             bot_mention = f"<@{bot_user_id}>" if bot_user_id else None
             has_bot_mention = self._has_specific_mention(raw_text, bot_user_id)
@@ -1434,11 +1434,14 @@ class SlackBot(BaseIMClient):
             if has_bot_mention:
                 if is_dm:
                     route_text = cleaned_text
-                    had_dm_mention_only = not route_text
-                    if had_dm_mention_only:
+                    had_mention_only = not route_text
+                    if had_mention_only:
                         agent_text = ""
                 elif await self._is_slack_connect_channel(channel_id):
                     route_text = self._strip_specific_mention(raw_text, bot_user_id, anywhere=True)
+                    had_mention_only = not route_text
+                    if had_mention_only:
+                        agent_text = ""
                     handled_bot_mention_in_message_event = True
                     logger.info("Processing Slack Connect message event with bot mention: '%s'", event.get("text"))
                 else:
@@ -1457,7 +1460,7 @@ class SlackBot(BaseIMClient):
             if not user_id:
                 logger.debug("Ignoring Slack message without user id")
                 return
-            if not route_text and not file_attachments and not has_shared_content and not had_dm_mention_only:
+            if not route_text and not file_attachments and not has_shared_content and not had_mention_only:
                 logger.debug("Ignoring Slack message with empty text and no files")
                 return
 
@@ -1621,9 +1624,7 @@ class SlackBot(BaseIMClient):
             # Extract shared/forwarded message content (defer appending until after command check)
             shared_text = await self._extract_shared_message_content(event)
 
-            if not route_text and not file_attachments and not shared_text:
-                logger.debug("Ignoring Slack app_mention with empty text and no files")
-                return
+            had_mention_only = not route_text and not file_attachments and not shared_text
 
             context = MessageContext(
                 user_id=event.get("user"),
@@ -1662,7 +1663,7 @@ class SlackBot(BaseIMClient):
                 logger.warning(f"Command '{command}' not found in callbacks")
 
             # Append shared content to user text (after command parsing)
-            agent_text = raw_text
+            agent_text = "" if had_mention_only else raw_text
             if shared_text:
                 if agent_text:
                     agent_text = f"{agent_text}\n\n{shared_text}"

--- a/tests/test_slack_app_mention_empty.py
+++ b/tests/test_slack_app_mention_empty.py
@@ -113,12 +113,15 @@ class _ResponseLike:
 
 
 class SlackAppMentionEmptyTests(unittest.IsolatedAsyncioTestCase):
-    async def test_empty_app_mention_does_not_activate_or_dispatch(self):
+    async def test_empty_app_mention_dispatches_empty_message_for_start_menu(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
-        received = {"called": False}
+        received = {}
 
-        async def _on_message(_context, _text):
-            received["called"] = True
+        async def _on_message(context, text):
+            received["channel_id"] = context.channel_id
+            received["thread_id"] = context.thread_id
+            received["text"] = text
+            received["control_text"] = (context.platform_specific or {}).get("control_text")
 
         slack.register_callbacks(on_message=_on_message)
         slack.settings_manager = object()
@@ -134,15 +137,23 @@ class SlackAppMentionEmptyTests(unittest.IsolatedAsyncioTestCase):
                 "type": "app_mention",
                 "channel": "C123",
                 "user": "U123",
-                "text": "<@U_BOT>",
+                "text": "<@U_BOT> \n \t",
                 "ts": "1710000000.000700",
             },
         }
 
         await slack._handle_event(payload)
 
-        self.assertFalse(received["called"])
-        slack.sessions.mark_thread_active.assert_not_called()
+        self.assertEqual(
+            received,
+            {
+                "channel_id": "C123",
+                "thread_id": "1710000000.000700",
+                "text": "",
+                "control_text": "",
+            },
+        )
+        slack.sessions.mark_thread_active.assert_called_once_with("U123", "C123", "1710000000.000700")
 
 
 class SlackFileAttachmentTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -831,6 +831,46 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_slack_connect_mention_only_falls_back_as_empty_message(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
+        received = {}
+
+        class _WebClient:
+            async def conversations_info(self, channel):
+                return {"channel": {"id": channel, "is_ext_shared": True}}
+
+        async def _on_message(context, text):
+            received["text"] = text
+            received["thread_id"] = context.thread_id
+            received["control_text"] = (context.platform_specific or {}).get("control_text")
+
+        slack.web_client = _WebClient()
+        slack.register_callbacks(on_message=_on_message)
+
+        payload = {
+            "event_id": "evt-slack-connect-mention-only",
+            "team_id": "T1",
+            "authorizations": [{"user_id": "U_BOT"}],
+            "event": {
+                "type": "message",
+                "channel": "C_CONNECT",
+                "user": "U123",
+                "text": "<@U_BOT> \n",
+                "ts": "1710000000.000355",
+            },
+        }
+
+        await slack._handle_event(payload)
+
+        self.assertEqual(
+            received,
+            {
+                "text": "",
+                "thread_id": "1710000000.000355",
+                "control_text": "",
+            },
+        )
+
     async def test_slack_connect_mid_text_mention_is_forwarded_raw_in_message_fallback(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
         received = {}


### PR DESCRIPTION
## Summary
- let Slack app_mention events with only the bot mention continue as an empty user turn
- apply the same empty-mention behavior to Slack Connect message-event fallback
- keep mention-with-content behavior unchanged so agents still see the raw Slack mention text

## Evidence
- Unit: pytest tests/test_slack_app_mention_empty.py tests/test_slack_dm_mentions.py
- Unit: pytest tests/test_message_handler_typing.py tests/test_message_handler_attachments.py
- Lint: ruff check modules/im/slack.py tests/test_slack_app_mention_empty.py tests/test_slack_dm_mentions.py
- Whitespace: git diff --check

## Risk
- Low. The change only affects Slack events where the text becomes empty after stripping this bot mention and there are no files or shared content.
