### PR TITLE
fix(claude): refresh Opus 4.7 model catalog

### DIFF
--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -325,6 +325,16 @@ _CODEX_REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh"]
 _CLAUDE_REASONING_EFFORTS = ["low", "medium", "high"]
 
 
+def _supports_claude_xhigh_reasoning(target_model: Optional[str]) -> bool:
+    normalized_model = (target_model or "").strip().lower()
+    if not normalized_model:
+        return False
+    return (
+        normalized_model in {"opus", "opus[1m]"}
+        or normalized_model.startswith("claude-opus-4-7")
+    )
+
+
 def _supports_claude_max_reasoning(target_model: Optional[str]) -> bool:
     normalized_model = (target_model or "").strip().lower()
     if not normalized_model:
@@ -332,6 +342,8 @@ def _supports_claude_max_reasoning(target_model: Optional[str]) -> bool:
     return (
         normalized_model in {"opus", "opus[1m]"}
         or normalized_model.startswith("claude-opus-4-6")
+        or normalized_model.startswith("claude-opus-4-7")
+        or normalized_model.startswith("claude-sonnet-4-6")
     )
 
 
@@ -356,11 +368,14 @@ def build_codex_reasoning_options() -> List[Dict[str, str]]:
 def build_claude_reasoning_options(target_model: Optional[str]) -> List[Dict[str, str]]:
     """Return the canonical Claude reasoning-effort option list for a model.
 
-    Claude currently supports `low` / `medium` / `high` broadly, while `max`
-    is only valid for Opus 4.6.
+    Claude currently supports `low` / `medium` / `high` broadly. Newer
+    Opus 4.7 models add `xhigh`; Opus 4.7, Opus 4.6, and Sonnet 4.6
+    also support `max`.
     """
 
     efforts = list(_CLAUDE_REASONING_EFFORTS)
+    if _supports_claude_xhigh_reasoning(target_model):
+        efforts.append("xhigh")
     if _supports_claude_max_reasoning(target_model):
         efforts.append("max")
 

--- a/tests/test_claude_reasoning_options.py
+++ b/tests/test_claude_reasoning_options.py
@@ -27,24 +27,31 @@ def test_claude_reasoning_options_default_to_low_medium_high() -> None:
     assert [item["value"] for item in options] == ["__default__", "low", "medium", "high"]
 
 
+def test_claude_reasoning_options_add_xhigh_for_opus_47() -> None:
+    options = build_claude_reasoning_options("claude-opus-4-7")
+
+    assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "xhigh", "max"]
+
+
 def test_claude_reasoning_options_add_max_for_opus_46() -> None:
     options = build_claude_reasoning_options("claude-opus-4-6")
 
     assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "max"]
 
 
-def test_claude_reasoning_options_do_not_add_max_for_sonnet_46() -> None:
+def test_claude_reasoning_options_add_max_for_sonnet_46() -> None:
     options = build_claude_reasoning_options("claude-sonnet-4-6")
 
-    assert [item["value"] for item in options] == ["__default__", "low", "medium", "high"]
+    assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "max"]
 
 
-def test_claude_reasoning_options_add_max_for_opus_aliases() -> None:
+def test_claude_reasoning_options_add_xhigh_for_opus_aliases() -> None:
     assert [item["value"] for item in build_claude_reasoning_options("opus")] == [
         "__default__",
         "low",
         "medium",
         "high",
+        "xhigh",
         "max",
     ]
     assert [item["value"] for item in build_claude_reasoning_options("opus[1m]")] == [
@@ -52,11 +59,17 @@ def test_claude_reasoning_options_add_max_for_opus_aliases() -> None:
         "low",
         "medium",
         "high",
+        "xhigh",
         "max",
     ]
 
 
-def test_normalize_claude_reasoning_effort_drops_invalid_max() -> None:
-    assert normalize_claude_reasoning_effort("claude-sonnet-4-6", "max") is None
+def test_normalize_claude_reasoning_effort_drops_invalid_efforts() -> None:
+    assert normalize_claude_reasoning_effort("claude-sonnet-4-5", "max") is None
+    assert normalize_claude_reasoning_effort("claude-opus-4-6", "xhigh") is None
+    assert normalize_claude_reasoning_effort("claude-opus-4-7", "xhigh") == "xhigh"
+    assert normalize_claude_reasoning_effort("claude-opus-4-7", "max") == "max"
     assert normalize_claude_reasoning_effort("claude-opus-4-6", "max") == "max"
+    assert normalize_claude_reasoning_effort("claude-sonnet-4-6", "max") == "max"
+    assert normalize_claude_reasoning_effort("opus", "xhigh") == "xhigh"
     assert normalize_claude_reasoning_effort("opus", "max") == "max"

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -299,6 +299,7 @@ def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
         "low",
         "medium",
         "high",
+        "xhigh",
         "max",
     ]
 

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -465,7 +465,18 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
     if (cached?.length) return cached;
 
     const fallback = claudeReasoningOptions[''] || [];
-    if (modelKey.toLowerCase().includes('claude-opus-4-6')) {
+    const normalizedModel = modelKey.toLowerCase();
+    if (normalizedModel.includes('claude-opus-4-7') || normalizedModel === 'opus' || normalizedModel === 'opus[1m]') {
+      const options = [...fallback];
+      if (!options.some((option) => option.value === 'xhigh')) {
+        options.push({ value: 'xhigh', label: 'Extra High' });
+      }
+      if (!options.some((option) => option.value === 'max')) {
+        options.push({ value: 'max', label: 'Max' });
+      }
+      return options;
+    }
+    if (normalizedModel.includes('claude-opus-4-6') || normalizedModel.includes('claude-sonnet-4-6')) {
       return fallback.some((option) => option.value === 'max')
         ? fallback
         : [...fallback, { value: 'max', label: 'Max' }];
@@ -482,6 +493,8 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
         return t('channelList.reasoningMedium');
       case 'high':
         return t('channelList.reasoningHigh');
+      case 'xhigh':
+        return t('channelList.reasoningXHigh');
       case 'max':
         return t('channelList.reasoningMax');
       default:

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -480,7 +480,18 @@ export const UserList: React.FC = () => {
     if (cached?.length) return cached;
 
     const fallback = claudeReasoningOptions[''] || [];
-    if (modelKey.toLowerCase().includes('claude-opus-4-6')) {
+    const normalizedModel = modelKey.toLowerCase();
+    if (normalizedModel.includes('claude-opus-4-7') || normalizedModel === 'opus' || normalizedModel === 'opus[1m]') {
+      const options = [...fallback];
+      if (!options.some((option) => option.value === 'xhigh')) {
+        options.push({ value: 'xhigh', label: 'Extra High' });
+      }
+      if (!options.some((option) => option.value === 'max')) {
+        options.push({ value: 'max', label: 'Max' });
+      }
+      return options;
+    }
+    if (normalizedModel.includes('claude-opus-4-6') || normalizedModel.includes('claude-sonnet-4-6')) {
       return fallback.some((option) => option.value === 'max')
         ? fallback
         : [...fallback, { value: 'max', label: 'Max' }];
@@ -497,6 +508,8 @@ export const UserList: React.FC = () => {
         return t('channelList.reasoningMedium');
       case 'high':
         return t('channelList.reasoningHigh');
+      case 'xhigh':
+        return t('channelList.reasoningXHigh');
       case 'max':
         return t('channelList.reasoningMax');
       default:

--- a/vibe/claude_model_catalog.py
+++ b/vibe/claude_model_catalog.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 DEFAULT_CLAUDE_MODEL_ALIASES: tuple[str, ...] = ("opus", "sonnet", "haiku")
 FALLBACK_CLAUDE_MODELS: tuple[str, ...] = (
+    "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
     "claude-haiku-4-5",

--- a/vibe/data/claude_models.json
+++ b/vibe/data/claude_models.json
@@ -2,7 +2,9 @@
   "models": [
     "claude-opus-4",
     "claude-opus-4-20250514",
+    "claude-opus-4-7",
     "claude-opus-4-6",
+    "claude-opus-4-6-20251101",
     "claude-opus-4-5",
     "claude-opus-4-5-20251101",
     "claude-opus-4-1",


### PR DESCRIPTION
## Summary
- refresh the tracked Claude Code model catalog from the latest Claude Code bundle
- add Claude Opus 4.7 to fallback/catalog model options
- update Claude effort options so Opus 4.7 and aliases expose xhigh/max, while 4.6 models keep max support
- keep Web UI channel/user settings fallback behavior aligned with backend options

## Evidence
- Unit: `uv run pytest tests/test_claude_reasoning_options.py tests/test_ui_api.py -q`
- Contract/UI API: covered by `tests/test_ui_api.py`
- Scenario: no scenario catalog entry applies to this catalog/UI option refresh
- Manual: `npm run build`; `uv run ruff check modules/agents/opencode/utils.py vibe/claude_model_catalog.py tests/test_claude_reasoning_options.py tests/test_ui_api.py`; `git diff --check`

## Notes
- Catalog was regenerated from `@anthropic-ai/claude-code@2.1.111` because the globally installed Claude Code CLI was still `2.1.81` and did not include Opus 4.7.
