### PR TITLE
feat(slack): add link unfurl suppression config

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -35,6 +35,7 @@ class SlackConfig(BaseIMConfig):
     team_name: Optional[str] = None
     app_id: Optional[str] = None
     require_mention: bool = False
+    disable_link_unfurl: bool = False
 
     def validate(self) -> None:
         # Allow empty token for initial setup

--- a/docs/plans/v2/05_config_model.md
+++ b/docs/plans/v2/05_config_model.md
@@ -24,6 +24,7 @@ V2 stores all user data under `~/.vibe_remote/` as JSON files. The model preserv
 - `team_name`: Slack workspace name (SaaS OAuth)
 - `app_id`: Slack app ID (optional, for diagnostics)
 - `signing_secret`: optional for SaaS relay validation
+- `disable_link_unfurl`: bool, suppress Slack link and media previews on outbound messages
 
 ### gateway
 

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -426,6 +426,12 @@ class SlackBot(BaseIMClient):
             return None
         return resp.get("channel", {}).get("id")
 
+    async def _chat_post_message(self, **kwargs):
+        if getattr(self.config, "disable_link_unfurl", False):
+            kwargs["unfurl_links"] = False
+            kwargs["unfurl_media"] = False
+        return await self.web_client.chat_postMessage(**kwargs)
+
     async def _post_message_with_dm_recovery(
         self,
         context: MessageContext,
@@ -434,7 +440,7 @@ class SlackBot(BaseIMClient):
         log_label: str,
     ):
         try:
-            return await self.web_client.chat_postMessage(**kwargs)
+            return await self._chat_post_message(**kwargs)
         except SlackApiError as err:
             error_code = err.response.get("error") if getattr(err, "response", None) else None
             if error_code != "channel_not_found" or not self._is_dm_context(context) or not context.user_id:
@@ -454,7 +460,7 @@ class SlackBot(BaseIMClient):
             kwargs.pop("thread_ts", None)
             context.channel_id = recovered_channel_id
             context.thread_id = None
-            return await self.web_client.chat_postMessage(**kwargs)
+            return await self._chat_post_message(**kwargs)
 
     @staticmethod
     def _find_text_split_index(text: str, max_chars: int) -> int:
@@ -564,7 +570,7 @@ class SlackBot(BaseIMClient):
                 return None
             msg_kwargs = {"channel": dm_channel, "text": text}
             msg_kwargs.update(kwargs)
-            result = await self.web_client.chat_postMessage(**msg_kwargs)
+            result = await self._chat_post_message(**msg_kwargs)
             return result.get("ts")
         except Exception as e:
             logger.error("Failed to send DM to Slack user %s: %s", user_id, e)
@@ -3940,7 +3946,7 @@ class SlackBot(BaseIMClient):
 
         try:
             self._ensure_clients()
-            await self.web_client.chat_postMessage(channel=channel_id, text=msg)
+            await self._chat_post_message(channel=channel_id, text=msg)
         except Exception as e:
             logger.error(f"Failed to send auth denial message: {e}")
 
@@ -3948,7 +3954,7 @@ class SlackBot(BaseIMClient):
         """Send unauthorized access message to channel"""
         try:
             self._ensure_clients()
-            await self.web_client.chat_postMessage(
+            await self._chat_post_message(
                 channel=channel_id,
                 text=f"❌ {self._t('error.channelNotEnabled', channel_id)}",
             )

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -22,6 +22,7 @@ def _full_config_payload() -> dict:
             "team_name": None,
             "app_id": None,
             "require_mention": False,
+            "disable_link_unfurl": False,
         },
         "discord": {
             "bot_token": "discord-token-1234567890",
@@ -115,6 +116,17 @@ def test_save_config_accepts_typing_ack_mode(monkeypatch, tmp_path):
     updated = api.save_config({**_full_config_payload(), "ack_mode": "typing"})
 
     assert updated.ack_mode == "typing"
+
+
+def test_save_config_accepts_slack_disable_link_unfurl(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    payload = _full_config_payload()
+    payload["slack"]["disable_link_unfurl"] = True
+
+    updated = api.save_config(payload)
+
+    assert updated.slack.disable_link_unfurl is True
 
 
 def test_save_config_preserves_platforms_metadata(monkeypatch, tmp_path):

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -125,6 +125,87 @@ class _ResponseLike:
 
 
 class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_send_message_does_not_set_unfurl_params_by_default(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        sent_payloads = []
+
+        class _WebClient:
+            async def chat_postMessage(self, **kwargs):
+                sent_payloads.append(kwargs)
+                return {"ts": "1710000000.000010"}
+
+        slack.web_client = _WebClient()
+        context = MessageContext(user_id="U123", channel_id="C123")
+
+        message_ts = await slack.send_message(context, "https://example.com", parse_mode="markdown")
+
+        self.assertEqual(message_ts, "1710000000.000010")
+        self.assertNotIn("unfurl_links", sent_payloads[0])
+        self.assertNotIn("unfurl_media", sent_payloads[0])
+
+    async def test_send_message_disables_link_unfurl_when_configured(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", disable_link_unfurl=True))
+        sent_payloads = []
+
+        class _WebClient:
+            async def chat_postMessage(self, **kwargs):
+                sent_payloads.append(kwargs)
+                return {"ts": "1710000000.000011"}
+
+        slack.web_client = _WebClient()
+        context = MessageContext(user_id="U123", channel_id="C123")
+
+        message_ts = await slack.send_message(context, "https://example.com", parse_mode="markdown")
+
+        self.assertEqual(message_ts, "1710000000.000011")
+        self.assertIs(sent_payloads[0]["unfurl_links"], False)
+        self.assertIs(sent_payloads[0]["unfurl_media"], False)
+
+    async def test_send_dm_disables_link_unfurl_when_configured(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", disable_link_unfurl=True))
+        sent_payloads = []
+
+        class _WebClient:
+            async def conversations_open(self, users):
+                return {"ok": True, "channel": {"id": "D123"}}
+
+            async def chat_postMessage(self, **kwargs):
+                sent_payloads.append(kwargs)
+                return {"ts": "1710000000.000012"}
+
+        slack.web_client = _WebClient()
+
+        message_ts = await slack.send_dm("U123", "https://example.com")
+
+        self.assertEqual(message_ts, "1710000000.000012")
+        self.assertEqual(sent_payloads[0]["channel"], "D123")
+        self.assertIs(sent_payloads[0]["unfurl_links"], False)
+        self.assertIs(sent_payloads[0]["unfurl_media"], False)
+
+    async def test_send_message_with_buttons_disables_link_unfurl_when_configured(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test", disable_link_unfurl=True))
+        sent_payloads = []
+
+        class _WebClient:
+            async def chat_postMessage(self, **kwargs):
+                sent_payloads.append(kwargs)
+                return {"ts": "1710000000.000013"}
+
+        slack.web_client = _WebClient()
+        context = MessageContext(user_id="U123", channel_id="C123")
+        keyboard = InlineKeyboard(buttons=[[InlineButton(text="Open", callback_data="open")]])
+
+        message_ts = await slack.send_message_with_buttons(
+            context,
+            "https://example.com",
+            keyboard,
+            parse_mode="markdown",
+        )
+
+        self.assertEqual(message_ts, "1710000000.000013")
+        self.assertIs(sent_payloads[0]["unfurl_links"], False)
+        self.assertIs(sent_payloads[0]["unfurl_media"], False)
+
     async def test_send_message_recovers_dm_channel_after_channel_not_found(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         sent_channels = []

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -438,6 +438,42 @@ export const Dashboard: React.FC = () => {
                                 : t('common.disabled')}
                         </button>
                     </div>
+                    {enabledPlatforms.includes('slack') && (
+                        <div className="flex justify-between items-center">
+                            <span className="text-muted flex items-center gap-1">
+                                {t('dashboard.slackLinkPreviews')}
+                                <span className="relative group">
+                                    <Info size={12} className="text-muted/50 cursor-help" />
+                                    <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-text text-bg text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 w-60 text-center">
+                                        {t('dashboard.slackLinkPreviewsHint')}
+                                    </span>
+                                </span>
+                            </span>
+                            <button
+                                onClick={() => {
+                                    setSettingsMessage(null);
+                                    const newConfig = {
+                                        ...config,
+                                        slack: {
+                                            ...(config.slack || {}),
+                                            disable_link_unfurl: !config.slack?.disable_link_unfurl,
+                                        },
+                                    };
+                                    setConfig(newConfig);
+                                    autoSaveMessageConfig(newConfig);
+                                }}
+                                className={`px-2 py-1 rounded text-xs font-semibold border ${
+                                    config.slack?.disable_link_unfurl
+                                        ? 'bg-success/10 text-success border-success/20'
+                                        : 'bg-neutral-100 text-muted border-border'
+                                }`}
+                            >
+                                {config.slack?.disable_link_unfurl
+                                    ? t('common.enabled')
+                                    : t('common.disabled')}
+                            </button>
+                        </div>
+                    )}
                     <div className="flex justify-between items-center">
                         <span className="text-muted">{t('dashboard.allowedChannels')}</span>
                         <Link to="/channels" className="text-xs text-accent hover:underline font-medium">{t('common.manageChannels')}</Link>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -477,6 +477,8 @@
     "includeUserInfoHint": "Prepend [username<user_id>] to messages sent to agents",
     "replyEnhancements": "Reply Enhancements",
     "replyEnhancementsHint": "Enable file attachments and quick-reply buttons in agent responses",
+    "slackLinkPreviews": "Suppress Slack Link Previews",
+    "slackLinkPreviewsHint": "Disable Slack URL and media preview cards for messages sent by Vibe Remote",
     "allowedChannels": "Allowed Groups",
     "consoleServer": "Console Server",
     "host": "Host",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -477,6 +477,8 @@
     "includeUserInfoHint": "在发给 Agent 的消息前添加 [用户名<用户ID>]",
     "replyEnhancements": "增强回复",
     "replyEnhancementsHint": "启用 Agent 回复中的文件附件和快捷回复按钮",
+    "slackLinkPreviews": "关闭 Slack 链接预览",
+    "slackLinkPreviewsHint": "关闭 Vibe Remote 发送到 Slack 的 URL 和媒体预览卡片",
     "allowedChannels": "允许的群组",
     "consoleServer": "控制台服务器",
     "host": "主机",


### PR DESCRIPTION
## Summary

- Add `slack.disable_link_unfurl` with a default of `false`.
- Route Slack `chat.postMessage` calls through one helper that suppresses link and media unfurls when the flag is enabled.
- Add a Dashboard message-handling toggle for Slack and document the config field.

Fixes #201.

## Validation

- `npm run build`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/test_slack_dm_mentions.py tests/test_slack_app_mention_empty.py tests/test_api_save_config_merge.py`
- `uv run ruff check config/v2_config.py modules/im/slack.py tests/test_slack_dm_mentions.py tests/test_api_save_config_merge.py`

## Evidence layers

- Unit: Slack outbound payload and config save tests.
- Contract: Not changed.
- Scenario: Not changed.
- Residual manual checks: Slack client rendering still needs real-workspace confirmation.
