### PR TITLE
fix(wechat): send progress logs as separate messages

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -173,6 +173,17 @@ class ConsolidatedMessageDispatcher:
             context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
         ) != "wechat"
 
+    def _supports_message_editing(self, im_client, context: MessageContext) -> bool:
+        supports_editing = getattr(im_client, "supports_message_editing", None)
+        if callable(supports_editing):
+            try:
+                return bool(supports_editing(context))
+            except TypeError:
+                return bool(supports_editing())
+        return (
+            context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
+        ) != "wechat"
+
     def _attachment_id_can_anchor_delivery(self, context: MessageContext) -> bool:
         platform = (
             context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
@@ -263,6 +274,28 @@ class ConsolidatedMessageDispatcher:
         encoded = text.encode("utf-8")
         truncated = encoded[:target_bytes].decode("utf-8", errors="ignore")
         return truncated.rstrip() + ellipsis
+
+    async def _send_unconsolidated_log_message(
+        self,
+        im_client,
+        context: MessageContext,
+        text: str,
+    ) -> Optional[str]:
+        target_context = self._get_target_context(context)
+        max_bytes = self._get_consolidated_max_bytes(context)
+        chunks = self._split_result_text_by_bytes(text, max_bytes)
+        first_message_id: Optional[str] = None
+
+        for chunk in chunks:
+            try:
+                message_id = await im_client.send_message(target_context, chunk, parse_mode="markdown")
+            except Exception as err:
+                logger.error("Failed to send Log Message: %s", err, exc_info=True)
+                return first_message_id
+            if first_message_id is None:
+                first_message_id = message_id
+
+        return first_message_id
 
     async def emit_agent_message(
         self,
@@ -474,6 +507,9 @@ class ConsolidatedMessageDispatcher:
 
         if not chunk:
             return None
+
+        if not self._supports_message_editing(im_client, context):
+            return await self._send_unconsolidated_log_message(im_client, context, chunk)
 
         consolidated_key = self._get_consolidated_message_key(context)
         lock = self._get_consolidated_message_lock(consolidated_key)

--- a/modules/im/base.py
+++ b/modules/im/base.py
@@ -138,6 +138,10 @@ class BaseIMClient(ABC):
         # Default implementation - subclasses should override
         return False
 
+    def supports_message_editing(self, context: Optional[MessageContext] = None) -> bool:
+        """Whether sent messages can be edited after delivery."""
+        return True
+
     def should_use_thread_for_dm_session(self) -> bool:
         """Check if DM conversations should use thread-based session IDs.
 

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -199,6 +199,11 @@ class MultiIMClient(BaseIMClient):
             context, text, keyboard, parse_mode=parse_mode
         )
 
+    def supports_message_editing(self, context: Optional[MessageContext] = None) -> bool:
+        if context is None:
+            return all(client.supports_message_editing() for client in self.clients.values())
+        return self.get_client_for_context(context).supports_message_editing(context)
+
     async def upload_markdown(
         self, context: MessageContext, title: str, content: str, filetype: str = "markdown"
     ) -> str:

--- a/modules/im/wechat.py
+++ b/modules/im/wechat.py
@@ -507,6 +507,9 @@ class WeChatBot(BaseIMClient):
     # Sending messages
     # ------------------------------------------------------------------
 
+    def supports_message_editing(self, context: Optional[MessageContext] = None) -> bool:
+        return False
+
     async def send_message(
         self,
         context: MessageContext,

--- a/tests/test_message_dispatcher_platform_limits.py
+++ b/tests/test_message_dispatcher_platform_limits.py
@@ -11,13 +11,18 @@ from modules.im import MessageContext
 
 
 class _StubIMClient:
-    def __init__(self, max_bytes: int | None = None):
+    def __init__(self, max_bytes: int | None = None, *, supports_editing: bool = True):
         self.sent = []
+        self.edit_calls = []
         self._next_id = 1
         self._max_bytes = max_bytes
+        self._supports_editing = supports_editing
 
     def should_use_thread_for_reply(self):
         return False
+
+    def supports_message_editing(self, context=None):
+        return self._supports_editing
 
     async def send_message(self, context, text, parse_mode=None, reply_to=None):
         if self._max_bytes is not None and len(text.encode("utf-8")) > self._max_bytes:
@@ -28,6 +33,7 @@ class _StubIMClient:
         return message_id
 
     async def edit_message(self, context, message_id, text=None, keyboard=None, parse_mode=None):
+        self.edit_calls.append((context.channel_id, context.thread_id, message_id, text, parse_mode))
         return False
 
 
@@ -51,7 +57,7 @@ class _StubController:
     def __init__(self, platform: str, *, max_bytes: int | None = None):
         self.config = type("Config", (), {"platform": platform, "reply_enhancements": False})()
         self.session_handler = _StubSessionHandler()
-        self.im_client = _StubIMClient(max_bytes=max_bytes)
+        self.im_client = _StubIMClient(max_bytes=max_bytes, supports_editing=platform != "wechat")
 
     def _get_settings_key(self, context):
         return context.channel_id
@@ -91,6 +97,23 @@ class MessageDispatcherPlatformLimitTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(message_id)
         self.assertGreater(len(controller.im_client.sent), 1)
         self.assertTrue(all(len(text.encode("utf-8")) <= 1900 for _, _, text, _ in controller.im_client.sent))
+        self.assertEqual(controller.im_client.edit_calls, [])
+
+    async def test_wechat_log_messages_send_individually_without_append_edit(self):
+        controller = _StubController("wechat")
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="wechat-user", channel_id="wechat-user", platform="wechat")
+
+        first_id = await dispatcher.emit_agent_message(context, "system", "cwd: /tmp/project")
+        second_id = await dispatcher.emit_agent_message(context, "assistant", "running command")
+        third_id = await dispatcher.emit_agent_message(context, "toolcall", "exec_command")
+
+        self.assertEqual((first_id, second_id, third_id), ("bot-msg-1", "bot-msg-2", "bot-msg-3"))
+        self.assertEqual(
+            [text for _, _, text, _ in controller.im_client.sent],
+            ["cwd: /tmp/project", "running command", "exec_command"],
+        )
+        self.assertEqual(controller.im_client.edit_calls, [])
 
     def test_result_split_boundary_never_exceeds_platform_limit(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController("wechat"))

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -20,9 +20,10 @@ class _StubConfig(BaseIMConfig):
 
 
 class _StubClient(BaseIMClient):
-    def __init__(self, name: str):
+    def __init__(self, name: str, *, supports_editing: bool = True):
         super().__init__(_StubConfig())
         self.name = name
+        self._supports_editing = supports_editing
         self.sent = []
         self.removed = []
         self.dismissed = []
@@ -36,6 +37,9 @@ class _StubClient(BaseIMClient):
 
     async def edit_message(self, context, message_id, text=None, keyboard=None, parse_mode=None):
         return True
+
+    def supports_message_editing(self, context=None):
+        return self._supports_editing
 
     async def remove_inline_keyboard(self, context, message_id, text=None, parse_mode=None):
         self.removed.append((context.platform, message_id, text))
@@ -100,6 +104,15 @@ def test_multi_im_client_routes_send_by_context_platform():
 
     assert slack.sent == []
     assert wechat.sent == [("wechat", "c", "hello")]
+
+
+def test_multi_im_client_routes_message_edit_capability_by_context_platform():
+    slack = _StubClient("slack")
+    wechat = _StubClient("wechat", supports_editing=False)
+    client = MultiIMClient({"slack": slack, "wechat": wechat}, primary_platform="slack")
+
+    assert client.supports_message_editing(MessageContext(user_id="u", channel_id="c", platform="slack"))
+    assert not client.supports_message_editing(MessageContext(user_id="u", channel_id="c", platform="wechat"))
 
 
 def test_multi_im_client_annotates_inbound_context_platform():


### PR DESCRIPTION
## What

- Add an IM client capability for message editing support.
- Mark WeChat as non-editable and route visible system/assistant/toolcall progress logs through one-send-per-event delivery.
- Keep editable platforms on the existing consolidated edit-and-append behavior.

## Why

WeChat cannot edit previously sent messages. The old fallback still built a consolidated buffer, so later assistant/tool/system updates could be resent as an appended block instead of a fresh message.

## Testing

- `python3 -m pytest tests/test_message_dispatcher_platform_limits.py tests/test_message_dispatcher_scheduled.py tests/test_message_dispatcher_result_fallback.py tests/test_message_dispatcher_file_uploads.py tests/test_reply_enhancer_platform.py tests/test_multi_platform_runtime.py`
- `ruff check core/message_dispatcher.py modules/im/base.py modules/im/multi.py modules/im/wechat.py tests/test_message_dispatcher_platform_limits.py tests/test_multi_platform_runtime.py`

## Evidence Layers

- Unit: updated dispatcher and multi-platform routing tests.
- Contract: IM client editing capability now routes through the multi-platform wrapper.
- Scenario: WeChat visible system/assistant/toolcall progress messages are covered as separate sends.
- Residual manual checks: cross-platform regression container not run; change is isolated to dispatcher behavior and capability routing.
