### PR TITLE
fix(wechat): clear typing indicator on agent errors

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -378,9 +378,9 @@ class MessageHandler(BaseHandler):
             # Use try/except to safely access possibly-unbound local variables
             try:
                 try:
-                    # Try using request object if it was created
-                    if request.ack_reaction_message_id:  # type: ignore[possibly-undefined]
-                        await self._remove_ack_reaction(context, request)  # type: ignore[possibly-undefined]
+                    # Try using request object if it was created. This also
+                    # clears typing indicators, which do not have a reaction ID.
+                    await self._remove_ack_reaction(context, request)  # type: ignore[possibly-undefined]
                 except NameError:
                     # request not defined yet, try using local variables
                     if (

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -294,6 +294,26 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(controller.im_client.reactions, [])
         self.assertGreaterEqual(len(controller.im_client.typing_calls), 1)
 
+    async def test_wechat_typing_is_cleared_when_agent_processing_raises(self):
+        controller = _StubController(platform="wechat", ack_mode="message", typing_result=True)
+        captured_requests = []
+
+        async def _raise_after_request(agent_name, request):
+            captured_requests.append(request)
+            raise RuntimeError("agent failed")
+
+        controller.agent_service.handle_message = _raise_after_request
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(user_id="wx-user", channel_id="wx-chat", message_id="m1")
+
+        await handler.handle_user_message(context, "hello")
+
+        self.assertEqual(controller.im_client.clear_calls, [("wx-chat", "wx-user")])
+        self.assertFalse(captured_requests[0].typing_indicator_active)
+        self.assertIsNone(captured_requests[0].typing_indicator_task)
+        self.assertEqual(controller.im_client.sent_messages, [("wx-chat", "Error: agent failed")])
+
     async def test_telegram_reaction_mode_matches_global_ack_strategy(self):
         controller = _StubController(platform="telegram", ack_mode="reaction", typing_result=True)
         handler = MessageHandler(controller)


### PR DESCRIPTION
## What

- Fix the message-handler exception cleanup path so an already-created request always uses the unified ack cleanup helper.
- Add coverage for WeChat typing indicators when agent processing raises after typing has started.

## Why

WeChat uses typing indicators instead of reaction or message acknowledgements. If agent processing raised after the request was built, the old fallback only cleaned up when a reaction message ID existed. For WeChat that field is empty, so the typing keepalive task could keep refreshing the indicator and leave "typing" visible.

## Testing

- `python3 -m pytest tests/test_message_handler_typing.py tests/test_wechat_bot.py`
- `python3 -m pytest tests/test_message_handler_typing.py tests/test_message_handler_auth_setup.py tests/test_codex_agent.py tests/test_codex_event_handler.py`
- `ruff check core/handlers/message_handler.py tests/test_message_handler_typing.py`

## Evidence Layers

- Unit: added a WeChat typing cleanup regression test.
- Contract: reused the existing unified ack cleanup contract for request-created exception paths.
- Scenario: agent processing raises after WeChat typing starts.
- Residual manual checks: real WeChat IM regression not run yet.
