### PR TITLE
fix(setup): unify platform credential checks

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -236,6 +236,28 @@ class V2Config:
     reply_enhancements: bool = True  # Enable file sending & quick-reply buttons
     language: str = "en"  # Global language setting (see vibe/i18n)
 
+    def enabled_platforms(self) -> list[str]:
+        return list(self.platforms.enabled)
+
+    def platform_has_credentials(self, platform: str) -> bool:
+        if platform == "slack":
+            return bool(self.slack.bot_token)
+        if platform == "discord":
+            return bool(self.discord and self.discord.bot_token)
+        if platform == "telegram":
+            return bool(self.telegram and self.telegram.bot_token)
+        if platform == "lark":
+            return bool(self.lark and self.lark.app_id and self.lark.app_secret)
+        if platform == "wechat":
+            return bool(self.wechat and self.wechat.bot_token)
+        raise ValueError(f"Unsupported platform: {platform}")
+
+    def configured_platforms(self) -> list[str]:
+        return [platform for platform in self.enabled_platforms() if self.platform_has_credentials(platform)]
+
+    def has_configured_platform_credentials(self) -> bool:
+        return bool(self.configured_platforms())
+
     @classmethod
     def load(cls, config_path: Optional[Path] = None) -> "V2Config":
         paths.ensure_data_dirs()

--- a/tests/test_cli_setup_status.py
+++ b/tests/test_cli_setup_status.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vibe import cli
+
+
+def _config_with_setup_state(*, ready: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        ui=SimpleNamespace(setup_host="127.0.0.1", setup_port=5123, open_browser=False),
+        slack=SimpleNamespace(bot_token=""),
+        has_configured_platform_credentials=lambda: ready,
+    )
+
+
+def test_cmd_vibe_marks_setup_when_no_enabled_platform_has_credentials(capsys) -> None:
+    config = _config_with_setup_state(ready=False)
+
+    with (
+        patch("vibe.cli.paths.ensure_data_dirs"),
+        patch("vibe.cli._ensure_config", return_value=config),
+        patch("vibe.cli.runtime.stop_service"),
+        patch("vibe.cli.runtime.stop_ui"),
+        patch("vibe.cli.runtime.start_service", return_value=101),
+        patch("vibe.cli.runtime.start_ui", return_value=202),
+        patch("vibe.cli.runtime.write_status"),
+        patch("vibe.cli._write_status") as write_status,
+    ):
+        cli.cmd_vibe()
+
+    write_status.assert_called_once_with("setup", "missing platform credentials")
+
+
+def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured(capsys) -> None:
+    config = _config_with_setup_state(ready=True)
+
+    with (
+        patch("vibe.cli.paths.ensure_data_dirs"),
+        patch("vibe.cli._ensure_config", return_value=config),
+        patch("vibe.cli.runtime.stop_service"),
+        patch("vibe.cli.runtime.stop_ui"),
+        patch("vibe.cli.runtime.start_service", return_value=101),
+        patch("vibe.cli.runtime.start_ui", return_value=202),
+        patch("vibe.cli.runtime.write_status"),
+        patch("vibe.cli._write_status") as write_status,
+    ):
+        cli.cmd_vibe()
+
+    write_status.assert_called_once_with("starting")

--- a/tests/test_v2_config_platform_credentials.py
+++ b/tests/test_v2_config_platform_credentials.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from config.v2_config import (
+    AgentsConfig,
+    DiscordConfig,
+    LarkConfig,
+    PlatformsConfig,
+    RuntimeConfig,
+    SlackConfig,
+    TelegramConfig,
+    UiConfig,
+    UpdateConfig,
+    V2Config,
+    WeChatConfig,
+)
+
+
+def _base_config(**overrides) -> V2Config:
+    payload = {
+        "mode": "self_host",
+        "version": "v2",
+        "platform": "slack",
+        "platforms": PlatformsConfig(enabled=["slack"], primary="slack"),
+        "slack": SlackConfig(bot_token=""),
+        "runtime": RuntimeConfig(default_cwd="."),
+        "agents": AgentsConfig(),
+        "ui": UiConfig(),
+        "update": UpdateConfig(),
+    }
+    payload.update(overrides)
+    return V2Config(**payload)
+
+
+def test_platform_has_credentials_supports_telegram() -> None:
+    config = _base_config(
+        platform="telegram",
+        platforms=PlatformsConfig(enabled=["telegram"], primary="telegram"),
+        telegram=TelegramConfig(bot_token="123456:test-token"),
+    )
+
+    assert config.platform_has_credentials("telegram") is True
+    assert config.configured_platforms() == ["telegram"]
+    assert config.has_configured_platform_credentials() is True
+
+
+def test_configured_platforms_only_counts_enabled_platforms() -> None:
+    config = _base_config(
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack"], primary="slack"),
+        slack=SlackConfig(bot_token=""),
+        discord=DiscordConfig(bot_token="configured-but-disabled"),
+    )
+
+    assert config.platform_has_credentials("discord") is True
+    assert config.configured_platforms() == []
+    assert config.has_configured_platform_credentials() is False
+
+
+def test_configured_platforms_support_all_platform_types() -> None:
+    config = _base_config(
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack", "discord", "telegram", "lark", "wechat"], primary="slack"),
+        slack=SlackConfig(bot_token="xoxb-test"),
+        discord=DiscordConfig(bot_token="discord-token"),
+        telegram=TelegramConfig(bot_token="123456:test-token"),
+        lark=LarkConfig(app_id="app-id", app_secret="app-secret"),
+        wechat=WeChatConfig(bot_token="wechat-token"),
+    )
+
+    assert config.configured_platforms() == ["slack", "discord", "telegram", "lark", "wechat"]
+
+
+def test_platform_has_credentials_rejects_unknown_platform() -> None:
+    config = _base_config()
+
+    with pytest.raises(ValueError, match="Unsupported platform"):
+        config.platform_has_credentials("unknown")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,7 @@ import { StatusProvider } from './context/StatusContext';
 import { ApiProvider, useApi } from './context/ApiContext';
 import { ToastProvider } from './context/ToastContext';
 import { useEffect, useState } from 'react';
-import { getEnabledPlatforms } from './lib/platforms';
+import { hasConfiguredPlatformCredentials } from './lib/platforms';
 
 // Wrapper to check if setup is needed
 const AuthGuard = ({ children }: { children: any }) => {
@@ -32,17 +32,7 @@ const AuthGuard = ({ children }: { children: any }) => {
 
         getConfig().then(config => {
             if (cancelled) return;
-            const enabledPlatforms = getEnabledPlatforms(config);
-            const hasToken = enabledPlatforms.some((platform) =>
-              platform === 'discord'
-                ? !!config?.discord?.bot_token
-                : platform === 'lark'
-                  ? !!(config?.lark?.app_id && config?.lark?.app_secret)
-                  : platform === 'wechat'
-                    ? !!config?.wechat?.bot_token
-                    : !!config?.slack?.bot_token
-            );
-            setNeedsSetup(!config || !config.mode || !hasToken);
+            setNeedsSetup(!config || !config.mode || !hasConfiguredPlatformCredentials(config));
             setLoading(false);
         }).catch(() => {
              if (cancelled) return;

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -2,6 +2,14 @@ export const ALL_PLATFORMS = ['slack', 'discord', 'telegram', 'lark', 'wechat'] 
 
 export type PlatformName = (typeof ALL_PLATFORMS)[number];
 
+const PLATFORM_CREDENTIAL_CHECKS: Record<PlatformName, (data: any) => boolean> = {
+  slack: (data) => !!data?.slack?.bot_token,
+  discord: (data) => !!data?.discord?.bot_token,
+  telegram: (data) => !!data?.telegram?.bot_token,
+  lark: (data) => !!(data?.lark?.app_id && data?.lark?.app_secret),
+  wechat: (data) => !!data?.wechat?.bot_token,
+};
+
 export const getEnabledPlatforms = (data: any): PlatformName[] => {
   const enabled = data?.platforms?.enabled;
   if (Array.isArray(enabled) && enabled.length > 0) {
@@ -23,6 +31,14 @@ export const getPrimaryPlatform = (data: any): PlatformName => {
     return primary as PlatformName;
   }
   return enabled[0] || 'slack';
+};
+
+export const platformHasCredentials = (data: any, platform: PlatformName): boolean => {
+  return PLATFORM_CREDENTIAL_CHECKS[platform](data);
+};
+
+export const hasConfiguredPlatformCredentials = (data: any): boolean => {
+  return getEnabledPlatforms(data).some((platform) => platformHasCredentials(data, platform));
 };
 
 export const platformSupportsChannels = (platform: string): boolean => !['wechat'].includes(platform);

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1779,8 +1779,14 @@ def cmd_vibe():
     runtime.stop_service()
     runtime.stop_ui()
 
-    if not config.slack.bot_token:
-        _write_status("setup", "missing Slack bot token")
+    has_configured_platform_credentials = getattr(config, "has_configured_platform_credentials", None)
+    if callable(has_configured_platform_credentials):
+        ready = bool(has_configured_platform_credentials())
+    else:
+        ready = bool(getattr(getattr(config, "slack", None), "bot_token", ""))
+
+    if not ready:
+        _write_status("setup", "missing platform credentials")
     else:
         _write_status("starting")
 


### PR DESCRIPTION
## Summary
- centralize per-platform credential checks in shared frontend helpers and V2Config methods
- use the shared credential predicate for the setup guard and CLI startup status instead of Slack-specific checks
- add regression tests covering Telegram and non-Slack configured platforms

## Validation
- ruff check config/v2_config.py vibe/cli.py tests/test_cli_setup_status.py tests/test_v2_config_platform_credentials.py
- pytest tests/test_v2_config_platform_credentials.py tests/test_cli_setup_status.py
- npm run build
