### PR TITLE
refactor(platforms): add IM platform registry

### DIFF
--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from importlib import import_module
 from typing import Any
 
@@ -22,6 +22,8 @@ class PlatformCapabilities:
 class PlatformDescriptor:
     id: str
     config_key: str
+    config_module: str
+    config_class: str
     client_module: str
     client_class: str
     formatter_module: str
@@ -38,7 +40,22 @@ class PlatformDescriptor:
         return f"platform.{self.id}.desc"
 
     def get_config(self, app_config: Any) -> Any:
+        platform_configs = getattr(app_config, "platform_configs", None)
+        if isinstance(platform_configs, dict) and self.id in platform_configs:
+            return platform_configs[self.id]
         return getattr(app_config, self.config_key, None)
+
+    def get_config_class(self) -> type[Any]:
+        return _load_attr(self.config_module, self.config_class)
+
+    def create_config(self, payload: dict[str, Any]) -> Any:
+        config_cls = self.get_config_class()
+        valid_fields = {field.name for field in fields(config_cls)}
+        platform_config = config_cls(**{key: value for key, value in payload.items() if key in valid_fields})
+        validate = getattr(platform_config, "validate", None)
+        if callable(validate):
+            validate()
+        return platform_config
 
     def has_credentials(self, app_config: Any) -> bool:
         platform_config = self.get_config(app_config)
@@ -77,6 +94,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
     "slack": PlatformDescriptor(
         id="slack",
         config_key="slack",
+        config_module="config.v2_config",
+        config_class="SlackConfig",
         client_module="modules.im.slack",
         client_class="SlackBot",
         formatter_module="modules.im.formatters",
@@ -93,6 +112,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
     "discord": PlatformDescriptor(
         id="discord",
         config_key="discord",
+        config_module="config.v2_config",
+        config_class="DiscordConfig",
         client_module="modules.im.discord",
         client_class="DiscordBot",
         formatter_module="modules.im.formatters",
@@ -110,6 +131,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
     "telegram": PlatformDescriptor(
         id="telegram",
         config_key="telegram",
+        config_module="config.v2_config",
+        config_class="TelegramConfig",
         client_module="modules.im.telegram",
         client_class="TelegramBot",
         formatter_module="modules.im.formatters",
@@ -128,6 +151,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
     "lark": PlatformDescriptor(
         id="lark",
         config_key="lark",
+        config_module="config.v2_config",
+        config_class="LarkConfig",
         client_module="modules.im.feishu",
         client_class="FeishuBot",
         formatter_module="modules.im.formatters",
@@ -146,6 +171,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
     "wechat": PlatformDescriptor(
         id="wechat",
         config_key="wechat",
+        config_module="config.v2_config",
+        config_class="WeChatConfig",
         client_module="modules.im.wechat",
         client_class="WeChatBot",
         formatter_module="modules.im.formatters",

--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -1,0 +1,185 @@
+"""Single source of truth for IM platform metadata and capabilities."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from importlib import import_module
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PlatformCapabilities:
+    supports_channels: bool
+    supports_threads: bool
+    supports_buttons: bool
+    supports_quick_replies: bool
+    supports_message_editing: bool
+    markdown_upload_returns_message_id: bool = False
+    quick_reply_single_column: bool = False
+
+
+@dataclass(frozen=True)
+class PlatformDescriptor:
+    id: str
+    config_key: str
+    client_module: str
+    client_class: str
+    formatter_module: str
+    formatter_class: str
+    credential_fields: tuple[str, ...]
+    capabilities: PlatformCapabilities
+
+    @property
+    def title_key(self) -> str:
+        return f"platform.{self.id}.title"
+
+    @property
+    def description_key(self) -> str:
+        return f"platform.{self.id}.desc"
+
+    def get_config(self, app_config: Any) -> Any:
+        return getattr(app_config, self.config_key, None)
+
+    def has_credentials(self, app_config: Any) -> bool:
+        platform_config = self.get_config(app_config)
+        if platform_config is None:
+            return False
+        return all(bool(getattr(platform_config, field, None)) for field in self.credential_fields)
+
+    def create_client(self, app_config: Any) -> Any:
+        platform_config = self.get_config(app_config)
+        if platform_config is None:
+            raise ValueError(f"{self.id.title()} configuration not found")
+        client_cls = _load_attr(self.client_module, self.client_class)
+        return client_cls(platform_config)
+
+    def create_formatter(self) -> Any:
+        formatter_cls = _load_attr(self.formatter_module, self.formatter_class)
+        return formatter_cls()
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "config_key": self.config_key,
+            "title_key": self.title_key,
+            "description_key": self.description_key,
+            "credential_fields": list(self.credential_fields),
+            "capabilities": asdict(self.capabilities),
+        }
+
+
+def _load_attr(module_name: str, attr_name: str) -> Any:
+    module = import_module(module_name)
+    return getattr(module, attr_name)
+
+
+PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
+    "slack": PlatformDescriptor(
+        id="slack",
+        config_key="slack",
+        client_module="modules.im.slack",
+        client_class="SlackBot",
+        formatter_module="modules.im.formatters",
+        formatter_class="SlackFormatter",
+        credential_fields=("bot_token",),
+        capabilities=PlatformCapabilities(
+            supports_channels=True,
+            supports_threads=True,
+            supports_buttons=True,
+            supports_quick_replies=True,
+            supports_message_editing=True,
+        ),
+    ),
+    "discord": PlatformDescriptor(
+        id="discord",
+        config_key="discord",
+        client_module="modules.im.discord",
+        client_class="DiscordBot",
+        formatter_module="modules.im.formatters",
+        formatter_class="DiscordFormatter",
+        credential_fields=("bot_token",),
+        capabilities=PlatformCapabilities(
+            supports_channels=True,
+            supports_threads=True,
+            supports_buttons=True,
+            supports_quick_replies=True,
+            supports_message_editing=True,
+            markdown_upload_returns_message_id=True,
+        ),
+    ),
+    "telegram": PlatformDescriptor(
+        id="telegram",
+        config_key="telegram",
+        client_module="modules.im.telegram",
+        client_class="TelegramBot",
+        formatter_module="modules.im.formatters",
+        formatter_class="TelegramFormatter",
+        credential_fields=("bot_token",),
+        capabilities=PlatformCapabilities(
+            supports_channels=True,
+            supports_threads=False,
+            supports_buttons=True,
+            supports_quick_replies=True,
+            supports_message_editing=True,
+            markdown_upload_returns_message_id=True,
+            quick_reply_single_column=True,
+        ),
+    ),
+    "lark": PlatformDescriptor(
+        id="lark",
+        config_key="lark",
+        client_module="modules.im.feishu",
+        client_class="FeishuBot",
+        formatter_module="modules.im.formatters",
+        formatter_class="FeishuFormatter",
+        credential_fields=("app_id", "app_secret"),
+        capabilities=PlatformCapabilities(
+            supports_channels=True,
+            supports_threads=True,
+            supports_buttons=True,
+            supports_quick_replies=True,
+            supports_message_editing=True,
+            markdown_upload_returns_message_id=True,
+            quick_reply_single_column=True,
+        ),
+    ),
+    "wechat": PlatformDescriptor(
+        id="wechat",
+        config_key="wechat",
+        client_module="modules.im.wechat",
+        client_class="WeChatBot",
+        formatter_module="modules.im.formatters",
+        formatter_class="WeChatFormatter",
+        credential_fields=("bot_token",),
+        capabilities=PlatformCapabilities(
+            supports_channels=False,
+            supports_threads=False,
+            supports_buttons=False,
+            supports_quick_replies=False,
+            supports_message_editing=False,
+        ),
+    ),
+}
+
+
+def platform_descriptors() -> list[PlatformDescriptor]:
+    return list(PLATFORM_REGISTRY.values())
+
+
+def supported_platform_ids() -> list[str]:
+    return list(PLATFORM_REGISTRY.keys())
+
+
+def supported_platform_set() -> set[str]:
+    return set(PLATFORM_REGISTRY)
+
+
+def get_platform_descriptor(platform: str) -> PlatformDescriptor:
+    try:
+        return PLATFORM_REGISTRY[platform]
+    except KeyError as err:
+        raise ValueError(f"Unsupported platform: {platform}") from err
+
+
+def platform_catalog_payload() -> list[dict[str, Any]]:
+    return [descriptor.to_public_dict() for descriptor in platform_descriptors()]

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -8,6 +8,13 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from config import paths
+from config.platform_registry import (
+    get_platform_descriptor,
+    platform_catalog_payload,
+    platform_descriptors,
+    supported_platform_ids,
+    supported_platform_set,
+)
 from modules.im.base import BaseIMConfig
 from vibe.i18n import normalize_language
 
@@ -120,6 +127,15 @@ class WeChatConfig(BaseIMConfig):
         pass
 
 
+PLATFORM_CONFIG_CLASSES: dict[str, type[BaseIMConfig]] = {
+    "slack": SlackConfig,
+    "discord": DiscordConfig,
+    "telegram": TelegramConfig,
+    "lark": LarkConfig,
+    "wechat": WeChatConfig,
+}
+
+
 @dataclass
 class GatewayConfig:
     relay_url: Optional[str] = None
@@ -198,7 +214,7 @@ class PlatformsConfig:
     primary: str = "slack"
 
     def validate(self) -> None:
-        supported = {"slack", "discord", "telegram", "lark", "wechat"}
+        supported = supported_platform_set()
         normalized: list[str] = []
         for platform in self.enabled:
             if platform not in supported:
@@ -208,7 +224,8 @@ class PlatformsConfig:
         if not normalized:
             raise ValueError("Config 'platforms.enabled' must contain at least one platform")
         if self.primary not in supported:
-            raise ValueError("Config 'platforms.primary' must be 'slack', 'discord', 'telegram', 'lark', or 'wechat'")
+            supported_text = "', '".join(supported_platform_ids())
+            raise ValueError(f"Config 'platforms.primary' must be one of: '{supported_text}'")
         if self.primary not in normalized:
             normalized.insert(0, self.primary)
         self.enabled = normalized
@@ -256,8 +273,11 @@ class V2Config:
             raise ValueError("Config 'mode' must be 'self_host' or 'saas'")
 
         platform = payload.get("platform") or "slack"
-        if platform not in {"slack", "discord", "telegram", "lark", "wechat"}:
-            raise ValueError("Config 'platform' must be 'slack', 'discord', 'telegram', 'lark', or 'wechat'")
+        try:
+            get_platform_descriptor(platform)
+        except ValueError as err:
+            supported_text = "', '".join(supported_platform_ids())
+            raise ValueError(f"Config 'platform' must be one of: '{supported_text}'") from err
 
         platforms_payload = payload.get("platforms")
         if platforms_payload is not None and not isinstance(platforms_payload, dict):
@@ -278,63 +298,30 @@ class V2Config:
         platforms.validate()
         platform = platforms.primary
 
-        slack_payload = payload.get("slack") or {}
-        if not isinstance(slack_payload, dict):
-            raise ValueError("Config 'slack' must be an object")
+        platform_configs: dict[str, Optional[BaseIMConfig]] = {}
+        for descriptor in platform_descriptors():
+            platform_payload = payload.get(descriptor.config_key)
+            if descriptor.id == "slack":
+                platform_payload = platform_payload or {}
+                if isinstance(platform_payload, dict) and "require_mention" not in platform_payload:
+                    platform_payload = dict(platform_payload)
+                    platform_payload["require_mention"] = False
+            if platform_payload is not None and not isinstance(platform_payload, dict):
+                raise ValueError(f"Config '{descriptor.config_key}' must be an object")
+            if platform_payload is None:
+                platform_configs[descriptor.id] = None
+                continue
 
-        if "require_mention" not in slack_payload:
-            slack_payload = dict(slack_payload)
-            slack_payload["require_mention"] = False
-
-        slack = SlackConfig(**_filter_dataclass_fields(SlackConfig, slack_payload))
-        slack.validate()
-
-        discord_payload = payload.get("discord")
-        if discord_payload is not None and not isinstance(discord_payload, dict):
-            raise ValueError("Config 'discord' must be an object")
-        discord = None
-        if discord_payload is not None:
-            discord = DiscordConfig(**_filter_dataclass_fields(DiscordConfig, discord_payload))
-            discord.validate()
-
-        telegram_payload = payload.get("telegram")
-        if telegram_payload is not None and not isinstance(telegram_payload, dict):
-            raise ValueError("Config 'telegram' must be an object")
-        telegram = None
-        if telegram_payload is not None:
-            telegram = TelegramConfig(**_filter_dataclass_fields(TelegramConfig, telegram_payload))
-            telegram.validate()
-
-        lark_payload = payload.get("lark")
-        if lark_payload is not None and not isinstance(lark_payload, dict):
-            raise ValueError("Config 'lark' must be an object")
-        lark = None
-        if lark_payload is not None:
-            lark = LarkConfig(**_filter_dataclass_fields(LarkConfig, lark_payload))
-            lark.validate()
-
-        wechat_payload = payload.get("wechat")
-        if wechat_payload is not None and not isinstance(wechat_payload, dict):
-            raise ValueError("Config 'wechat' must be an object")
-        wechat = None
-        if wechat_payload is not None:
-            wechat = WeChatConfig(**_filter_dataclass_fields(WeChatConfig, wechat_payload))
-            wechat.validate()
+            config_class = PLATFORM_CONFIG_CLASSES[descriptor.id]
+            platform_config = config_class(**_filter_dataclass_fields(config_class, platform_payload))
+            platform_config.validate()
+            platform_configs[descriptor.id] = platform_config
 
         # Validate that every enabled platform has its config section present.
-        # The old single-platform check (``if platform == "discord"``) only
-        # guarded the primary; with multi-platform enabled we must ensure ALL
-        # enabled platforms have valid credentials so that the runtime won't
-        # crash on startup with a config that was already persisted to disk.
         for _ep in platforms.enabled:
-            if _ep == "discord" and discord is None:
-                raise ValueError("Config 'discord' must be provided when discord is enabled")
-            if _ep == "telegram" and telegram is None:
-                raise ValueError("Config 'telegram' must be provided when telegram is enabled")
-            if _ep == "lark" and lark is None:
-                raise ValueError("Config 'lark' must be provided when lark is enabled")
-            if _ep == "wechat" and wechat is None:
-                raise ValueError("Config 'wechat' must be provided when wechat is enabled")
+            descriptor = get_platform_descriptor(_ep)
+            if platform_configs[descriptor.id] is None:
+                raise ValueError(f"Config '{descriptor.config_key}' must be provided when {_ep} is enabled")
 
         gateway_payload = payload.get("gateway")
         if gateway_payload is not None and not isinstance(gateway_payload, dict):
@@ -413,11 +400,11 @@ class V2Config:
             platforms=platforms,
             mode=mode,
             version=payload.get("version", "v2"),
-            slack=slack,
-            discord=discord,
-            telegram=telegram,
-            lark=lark,
-            wechat=wechat,
+            slack=platform_configs["slack"],
+            discord=platform_configs["discord"],
+            telegram=platform_configs["telegram"],
+            lark=platform_configs["lark"],
+            wechat=platform_configs["wechat"],
             runtime=runtime,
             agents=agents,
             gateway=gateway,
@@ -435,6 +422,12 @@ class V2Config:
         path = config_path or paths.get_config_path()
         self.platforms.validate()
         self.platform = self.platforms.primary
+        platform_payload = {
+            descriptor.config_key: (
+                getattr(self, descriptor.config_key).__dict__ if getattr(self, descriptor.config_key, None) else None
+            )
+            for descriptor in platform_descriptors()
+        }
         payload = {
             "platform": self.platform,
             "platforms": {
@@ -443,11 +436,7 @@ class V2Config:
             },
             "mode": self.mode,
             "version": self.version,
-            "slack": self.slack.__dict__,
-            "discord": self.discord.__dict__ if self.discord else None,
-            "telegram": self.telegram.__dict__ if self.telegram else None,
-            "lark": self.lark.__dict__ if self.lark else None,
-            "wechat": self.wechat.__dict__ if self.wechat else None,
+            **platform_payload,
             "runtime": {
                 "default_cwd": self.runtime.default_cwd,
                 "log_level": self.runtime.log_level,
@@ -479,3 +468,27 @@ class V2Config:
 
     def enabled_platforms(self) -> list[str]:
         return list(self.platforms.enabled)
+
+    def platform_has_credentials(self, platform: str) -> bool:
+        return get_platform_descriptor(platform).has_credentials(self)
+
+    def configured_platforms(self) -> list[str]:
+        return [platform for platform in self.enabled_platforms() if self.platform_has_credentials(platform)]
+
+    def missing_platform_credentials(self) -> list[str]:
+        return [platform for platform in self.enabled_platforms() if not self.platform_has_credentials(platform)]
+
+    def has_configured_platform_credentials(self) -> bool:
+        return bool(self.configured_platforms())
+
+    def platform_catalog(self) -> list[dict]:
+        return platform_catalog_payload()
+
+    def setup_state(self) -> dict:
+        configured = self.configured_platforms()
+        missing = self.missing_platform_credentials()
+        return {
+            "needs_setup": not bool(self.mode) or not bool(configured),
+            "configured_platforms": configured,
+            "missing_credentials": missing,
+        }

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -127,15 +127,6 @@ class WeChatConfig(BaseIMConfig):
         pass
 
 
-PLATFORM_CONFIG_CLASSES: dict[str, type[BaseIMConfig]] = {
-    "slack": SlackConfig,
-    "discord": DiscordConfig,
-    "telegram": TelegramConfig,
-    "lark": LarkConfig,
-    "wechat": WeChatConfig,
-}
-
-
 @dataclass
 class GatewayConfig:
     relay_url: Optional[str] = None
@@ -244,6 +235,7 @@ class V2Config:
     telegram: Optional[TelegramConfig] = None
     lark: Optional[LarkConfig] = None
     wechat: Optional[WeChatConfig] = None
+    platform_configs: dict[str, BaseIMConfig] = field(default_factory=dict)
     gateway: Optional[GatewayConfig] = None
     ui: UiConfig = field(default_factory=UiConfig)
     update: UpdateConfig = field(default_factory=UpdateConfig)
@@ -312,10 +304,7 @@ class V2Config:
                 platform_configs[descriptor.id] = None
                 continue
 
-            config_class = PLATFORM_CONFIG_CLASSES[descriptor.id]
-            platform_config = config_class(**_filter_dataclass_fields(config_class, platform_payload))
-            platform_config.validate()
-            platform_configs[descriptor.id] = platform_config
+            platform_configs[descriptor.id] = descriptor.create_config(platform_payload)
 
         # Validate that every enabled platform has its config section present.
         for _ep in platforms.enabled:
@@ -405,6 +394,7 @@ class V2Config:
             telegram=platform_configs["telegram"],
             lark=platform_configs["lark"],
             wechat=platform_configs["wechat"],
+            platform_configs={key: value for key, value in platform_configs.items() if value is not None},
             runtime=runtime,
             agents=agents,
             gateway=gateway,
@@ -423,9 +413,7 @@ class V2Config:
         self.platforms.validate()
         self.platform = self.platforms.primary
         platform_payload = {
-            descriptor.config_key: (
-                getattr(self, descriptor.config_key).__dict__ if getattr(self, descriptor.config_key, None) else None
-            )
+            descriptor.config_key: (descriptor.get_config(self).__dict__ if descriptor.get_config(self) else None)
             for descriptor in platform_descriptors()
         }
         payload = {

--- a/core/controller.py
+++ b/core/controller.py
@@ -7,10 +7,10 @@ import logging
 import threading
 from typing import Optional, Dict, Any
 from config import paths
+from config.platform_registry import get_platform_descriptor
 from config.v2_config import DEFAULT_AGENT_BACKEND, DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
 from modules.im import BaseIMClient, MessageContext, IMFactory
 from modules.im.multi import MultiIMClient
-from modules.im.formatters import SlackFormatter, DiscordFormatter, TelegramFormatter
 from modules.agent_router import AgentRouter
 from modules.agents.service import AgentService
 from modules.claude_client import ClaudeClient
@@ -128,19 +128,7 @@ class Controller:
         return self.native_session_service
 
     def _create_formatter(self, platform: str):
-        if platform == "discord":
-            return DiscordFormatter()
-        if platform == "telegram":
-            return TelegramFormatter()
-        if platform == "lark":
-            from modules.im.formatters.feishu_formatter import FeishuFormatter
-
-            return FeishuFormatter()
-        if platform == "wechat":
-            from modules.im.formatters.wechat_formatter import WeChatFormatter
-
-            return WeChatFormatter()
-        return SlackFormatter()
+        return get_platform_descriptor(platform).create_formatter()
 
     def _inject_runtime_dependencies(self, platform: str, client: BaseIMClient) -> None:
         settings_manager = self.platform_settings_managers[platform]
@@ -181,21 +169,13 @@ class Controller:
                 self.config.include_user_info = v2_config.include_user_info
                 self.config.reply_enhancements = v2_config.reply_enhancements
 
-                # Sync global require_mention into the IM client's platform config
                 for platform, client in self.im_clients.items():
                     im_cfg = getattr(client, "config", None)
                     if im_cfg is None or not hasattr(im_cfg, "require_mention"):
                         continue
-                    if platform == "lark" and v2_config.lark:
-                        im_cfg.require_mention = v2_config.lark.require_mention
-                    elif platform == "slack":
-                        im_cfg.require_mention = v2_config.slack.require_mention
-                    elif platform == "discord" and v2_config.discord:
-                        im_cfg.require_mention = v2_config.discord.require_mention
-                    elif platform == "telegram" and v2_config.telegram:
-                        im_cfg.require_mention = v2_config.telegram.require_mention
-                    elif platform == "wechat" and v2_config.wechat:
-                        im_cfg.require_mention = v2_config.wechat.require_mention
+                    latest_platform_config = get_platform_descriptor(platform).get_config(v2_config)
+                    if latest_platform_config is not None and hasattr(latest_platform_config, "require_mention"):
+                        im_cfg.require_mention = latest_platform_config.require_mention
 
                 self._config_mtime = mtime
         except Exception as err:

--- a/core/handlers/command_handlers.py
+++ b/core/handlers/command_handlers.py
@@ -4,6 +4,7 @@ import logging
 import os
 import time
 from typing import Any, Optional
+from config.platform_registry import get_platform_descriptor
 from modules.agents import get_agent_display_name
 from modules.agents.native_sessions.types import NativeResumeSession
 from modules.agents.base import AgentRequest
@@ -29,7 +30,7 @@ class CommandHandlers(BaseHandler):
         """Get context for channel messages (no thread)"""
         # Send command responses directly to channel, not in thread/topic
         platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
-        if platform in {"slack", "discord", "lark"}:
+        if get_platform_descriptor(platform).capabilities.supports_threads:
             return MessageContext(
                 user_id=context.user_id,
                 channel_id=context.channel_id,
@@ -370,6 +371,7 @@ class CommandHandlers(BaseHandler):
         """Handle /start command with interactive buttons"""
         im_client = self._get_im_client(context)
         platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
+        platform_capabilities = get_platform_descriptor(platform).capabilities
         platform_name = str(platform).capitalize()
 
         is_dm = bool((context.platform_specific or {}).get("is_dm", False))
@@ -418,14 +420,13 @@ class CommandHandlers(BaseHandler):
         )
 
         # For non-interactive platforms, use traditional text message
-        if platform not in {"slack", "discord", "lark", "telegram"}:
+        if not platform_capabilities.supports_buttons:
             user_name = self._resolve_user_display_name(user_info, self._t("command.start.userFallback"))
-            show_channel = platform != "wechat"
             message_text = self._build_non_interactive_start_message(
                 platform_name=platform_name,
                 agent_display_name=agent_display_name,
                 user_name=user_name,
-                show_channel=show_channel,
+                show_channel=platform_capabilities.supports_channels,
                 channel_name=channel_info.get("name", "Unknown"),
                 supports_threads=supports_threads,
             )

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -11,6 +11,7 @@ import asyncio
 from pathlib import Path
 from typing import Optional
 
+from config.platform_registry import get_platform_descriptor
 from modules.im import MessageContext
 from core.reply_enhancer import process_reply, strip_file_links, strip_silent_blocks
 from vibe.i18n import t as i18n_t
@@ -30,6 +31,12 @@ class ConsolidatedMessageDispatcher:
         self._consolidated_message_buffers: dict[str, str] = {}
         self._consolidated_message_locks: dict[str, asyncio.Lock] = {}
         self._thread_current_message_id: dict[str, str] = {}
+
+    def _get_platform(self, context: MessageContext) -> str:
+        return context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
+
+    def _capabilities(self, context: MessageContext):
+        return get_platform_descriptor(self._get_platform(context)).capabilities
 
     def _get_settings_key(self, context: MessageContext) -> str:
         return self.controller._get_settings_key(context)
@@ -169,9 +176,7 @@ class ConsolidatedMessageDispatcher:
         return len(text) <= self._get_result_max_chars(context)
 
     def _supports_quick_replies(self, context: MessageContext) -> bool:
-        return (
-            context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
-        ) != "wechat"
+        return self._capabilities(context).supports_quick_replies
 
     def _supports_message_editing(self, im_client, context: MessageContext) -> bool:
         supports_editing = getattr(im_client, "supports_message_editing", None)
@@ -180,17 +185,12 @@ class ConsolidatedMessageDispatcher:
                 return bool(supports_editing(context))
             except TypeError:
                 return bool(supports_editing())
-        return (
-            context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
-        ) != "wechat"
+        return self._capabilities(context).supports_message_editing
 
     def _attachment_id_can_anchor_delivery(self, context: MessageContext) -> bool:
-        platform = (
-            context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
-        )
         # Only treat attachment uploads as scheduled anchors on platforms where
         # upload_markdown() returns the posted message ID rather than a file ID.
-        return platform in {"discord", "telegram", "lark"}
+        return self._capabilities(context).markdown_upload_returns_message_id
 
     @staticmethod
     def _is_video_path(path: str) -> bool:
@@ -633,10 +633,7 @@ class ConsolidatedMessageDispatcher:
             callback = f"quick_reply:{btn.text}"
             row.append(InlineButton(text=btn.text, callback_data=callback))
 
-        platform = (
-            context.platform or (context.platform_specific or {}).get("platform") or self.controller.config.platform
-        )
-        rows = [[button] for button in row] if platform in {"lark", "telegram"} else [row]
+        rows = [[button] for button in row] if self._capabilities(context).quick_reply_single_column else [row]
         keyboard = InlineKeyboard(buttons=rows)
         return await im_client.send_message_with_buttons(
             context,

--- a/docs/plans/platform-registry-refactor.md
+++ b/docs/plans/platform-registry-refactor.md
@@ -1,0 +1,37 @@
+# Platform Registry Refactor Plan
+
+## Background
+
+Platform behavior is currently encoded in multiple places: V2 config validation,
+IM client creation, formatter selection, setup readiness checks, and frontend
+platform helpers. Adding Telegram exposed the risk: one missed frontend
+credential branch caused setup to keep redirecting even though Telegram had a
+valid token.
+
+## Goal
+
+Create a single platform registry that owns platform identity, config linkage,
+client and formatter construction, credential readiness, and capability flags.
+Both backend and frontend should consume registry-derived data for generic
+platform decisions.
+
+## Design
+
+- Add `config.platform_registry` with `PlatformDescriptor` and
+  `PlatformCapabilities`.
+- Keep platform-specific setup forms and platform API endpoints separate, but
+  remove duplicated generic platform lists and credential checks.
+- Expose registry metadata through config payloads and a catalog endpoint so the
+  UI can render platform choices and capability-gated navigation from backend
+  data.
+- Make setup readiness a backend-computed `setup_state` so the frontend guard no
+  longer reimplements credential rules.
+
+## Todo
+
+- [x] Add registry and descriptor tests.
+- [x] Wire V2 config validation and setup readiness to the registry.
+- [x] Wire IM factory and controller formatter selection to the registry.
+- [x] Expose `platform_catalog` and `setup_state` in Web UI API payloads.
+- [x] Move frontend generic platform helpers to catalog/capability data.
+- [x] Run focused Python tests, Ruff on changed Python, and UI build.

--- a/modules/im/factory.py
+++ b/modules/im/factory.py
@@ -1,14 +1,9 @@
 """Factory for creating IM platform clients"""
 
 import logging
-from typing import Union, TYPE_CHECKING
 
 from .base import BaseIMClient
 from .multi import MultiIMClient
-
-# Use delayed imports to avoid circular import issues
-if TYPE_CHECKING:
-    from config.v2_config import V2Config
 
 logger = logging.getLogger(__name__)
 
@@ -37,49 +32,14 @@ class IMFactory:
         Raises:
             ValueError: If platform is not supported
         """
-        # Dynamic imports to avoid circular dependency
-        from .slack import SlackBot
-        from .discord import DiscordBot
-        from .telegram import TelegramBot
+        from config.platform_registry import get_platform_descriptor
 
         enabled_platforms = list(getattr(config, "enabled_platforms", lambda: [getattr(config, "platform", "slack")])())
         clients: dict[str, BaseIMClient] = {}
         for platform in enabled_platforms:
-            if platform == "slack":
-                if not config.slack:
-                    raise ValueError("Slack configuration not found")
-                logger.info("Creating Slack client")
-                clients[platform] = SlackBot(config.slack)
-                continue
-            if platform == "discord":
-                if not config.discord:
-                    raise ValueError("Discord configuration not found")
-                logger.info("Creating Discord client")
-                clients[platform] = DiscordBot(config.discord)
-                continue
-            if platform == "telegram":
-                if not getattr(config, "telegram", None):
-                    raise ValueError("Telegram configuration not found")
-                logger.info("Creating Telegram client")
-                clients[platform] = TelegramBot(config.telegram)
-                continue
-            if platform == "lark":
-                from .feishu import FeishuBot
-
-                if not config.lark:
-                    raise ValueError("Lark configuration not found")
-                logger.info("Creating Lark/Feishu client")
-                clients[platform] = FeishuBot(config.lark)
-                continue
-            if platform == "wechat":
-                from .wechat import WeChatBot
-
-                if not config.wechat:
-                    raise ValueError("WeChat configuration not found")
-                logger.info("Creating WeChat client")
-                clients[platform] = WeChatBot(config.wechat)
-                continue
-            raise ValueError(f"Unsupported platform: {platform}")
+            descriptor = get_platform_descriptor(platform)
+            logger.info("Creating %s client", platform)
+            clients[platform] = descriptor.create_client(config)
         return clients
 
     @staticmethod
@@ -89,7 +49,9 @@ class IMFactory:
         Returns:
             List of supported platform names
         """
-        return ["slack", "discord", "telegram", "lark", "wechat"]
+        from config.platform_registry import supported_platform_ids
+
+        return supported_platform_ids()
 
     @staticmethod
     def validate_platform_config(config) -> None:
@@ -101,30 +63,11 @@ class IMFactory:
         Raises:
             ValueError: If configuration is invalid
         """
+        from config.platform_registry import get_platform_descriptor
+
         for platform in getattr(config, "enabled_platforms", lambda: [getattr(config, "platform", "slack")])():
-            if platform == "slack":
-                if config.slack is None:
-                    raise ValueError("Missing configuration for platform: slack")
-                config.slack.validate()
-                continue
-            if platform == "discord":
-                if config.discord is None:
-                    raise ValueError("Missing configuration for platform: discord")
-                config.discord.validate()
-                continue
-            if platform == "telegram":
-                if getattr(config, "telegram", None) is None:
-                    raise ValueError("Missing configuration for platform: telegram")
-                config.telegram.validate()
-                continue
-            if platform == "lark":
-                if config.lark is None:
-                    raise ValueError("Missing configuration for platform: lark")
-                config.lark.validate()
-                continue
-            if platform == "wechat":
-                if config.wechat is None:
-                    raise ValueError("Missing configuration for platform: wechat")
-                config.wechat.validate()
-                continue
-            raise ValueError(f"Unsupported platform: {platform}")
+            descriptor = get_platform_descriptor(platform)
+            platform_config = descriptor.get_config(config)
+            if platform_config is None:
+                raise ValueError(f"Missing configuration for platform: {platform}")
+            platform_config.validate()

--- a/tests/test_cli_setup_status.py
+++ b/tests/test_cli_setup_status.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from vibe import cli
+
+
+def _config_with_setup_state(*, ready: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        ui=SimpleNamespace(setup_host="127.0.0.1", setup_port=5123, open_browser=False),
+        slack=SimpleNamespace(bot_token=""),
+        has_configured_platform_credentials=lambda: ready,
+    )
+
+
+def test_cmd_vibe_marks_setup_when_no_enabled_platform_has_credentials() -> None:
+    config = _config_with_setup_state(ready=False)
+
+    with (
+        patch("vibe.cli.paths.ensure_data_dirs"),
+        patch("vibe.cli._ensure_config", return_value=config),
+        patch("vibe.cli.runtime.stop_service"),
+        patch("vibe.cli.runtime.stop_ui"),
+        patch("vibe.cli.runtime.start_service", return_value=101),
+        patch("vibe.cli.runtime.start_ui", return_value=202),
+        patch("vibe.cli.runtime.write_status"),
+        patch("vibe.cli._write_status") as write_status,
+    ):
+        cli.cmd_vibe()
+
+    write_status.assert_called_once_with("setup", "missing platform credentials")
+
+
+def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured() -> None:
+    config = _config_with_setup_state(ready=True)
+
+    with (
+        patch("vibe.cli.paths.ensure_data_dirs"),
+        patch("vibe.cli._ensure_config", return_value=config),
+        patch("vibe.cli.runtime.stop_service"),
+        patch("vibe.cli.runtime.stop_ui"),
+        patch("vibe.cli.runtime.start_service", return_value=101),
+        patch("vibe.cli.runtime.start_ui", return_value=202),
+        patch("vibe.cli.runtime.write_status"),
+        patch("vibe.cli._write_status") as write_status,
+    ):
+        cli.cmd_vibe()
+
+    write_status.assert_called_once_with("starting")

--- a/tests/test_platform_registry.py
+++ b/tests/test_platform_registry.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import config.platform_registry as platform_registry
+from config.platform_registry import PlatformCapabilities, PlatformDescriptor, get_platform_descriptor
+from config.v2_config import PlatformsConfig, V2Config
+from modules.im.factory import IMFactory
+
+
+def test_platform_catalog_exposes_capability_flags() -> None:
+    catalog = {item["id"]: item for item in platform_registry.platform_catalog_payload()}
+
+    assert catalog["slack"]["capabilities"]["supports_threads"] is True
+    assert catalog["telegram"]["capabilities"]["supports_threads"] is False
+    assert catalog["wechat"]["capabilities"]["supports_buttons"] is False
+    assert catalog["wechat"]["capabilities"]["supports_channels"] is False
+
+
+def test_credential_readiness_comes_from_platform_descriptor() -> None:
+    config = SimpleNamespace(lark=SimpleNamespace(app_id="cli_a", app_secret="secret"))
+
+    assert get_platform_descriptor("lark").has_credentials(config) is True
+
+    config.lark.app_secret = ""
+    assert get_platform_descriptor("lark").has_credentials(config) is False
+
+
+def test_registry_addition_drives_platform_validation_and_readiness(monkeypatch) -> None:
+    descriptor = PlatformDescriptor(
+        id="mockchat",
+        config_key="mockchat",
+        client_module="unused",
+        client_class="Unused",
+        formatter_module="unused",
+        formatter_class="Unused",
+        credential_fields=("token",),
+        capabilities=PlatformCapabilities(
+            supports_channels=True,
+            supports_threads=False,
+            supports_buttons=False,
+            supports_quick_replies=False,
+            supports_message_editing=False,
+        ),
+    )
+    monkeypatch.setitem(platform_registry.PLATFORM_REGISTRY, descriptor.id, descriptor)
+
+    platforms = PlatformsConfig(enabled=["mockchat"], primary="mockchat")
+    platforms.validate()
+
+    fake_config = SimpleNamespace(
+        mode="self_host",
+        platforms=platforms,
+        mockchat=SimpleNamespace(token="configured"),
+    )
+    fake_config.enabled_platforms = V2Config.enabled_platforms.__get__(fake_config)
+    fake_config.platform_has_credentials = V2Config.platform_has_credentials.__get__(fake_config)
+    fake_config.configured_platforms = V2Config.configured_platforms.__get__(fake_config)
+
+    assert fake_config.configured_platforms() == ["mockchat"]
+    assert "mockchat" in IMFactory.get_supported_platforms()

--- a/tests/test_platform_registry.py
+++ b/tests/test_platform_registry.py
@@ -26,10 +26,18 @@ def test_credential_readiness_comes_from_platform_descriptor() -> None:
     assert get_platform_descriptor("lark").has_credentials(config) is False
 
 
+def test_descriptors_resolve_config_classes() -> None:
+    config = get_platform_descriptor("telegram").create_config({"bot_token": "123456:test-token"})
+
+    assert config.bot_token == "123456:test-token"
+
+
 def test_registry_addition_drives_platform_validation_and_readiness(monkeypatch) -> None:
     descriptor = PlatformDescriptor(
         id="mockchat",
         config_key="mockchat",
+        config_module="config.v2_config",
+        config_class="SlackConfig",
         client_module="unused",
         client_class="Unused",
         formatter_module="unused",

--- a/tests/test_v2_config_platform_registry.py
+++ b/tests/test_v2_config_platform_registry.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from config.v2_config import (
+    AgentsConfig,
+    DiscordConfig,
+    LarkConfig,
+    PlatformsConfig,
+    RuntimeConfig,
+    SlackConfig,
+    TelegramConfig,
+    UiConfig,
+    UpdateConfig,
+    V2Config,
+    WeChatConfig,
+)
+from vibe import api
+
+
+def _base_config(**overrides) -> V2Config:
+    payload = {
+        "mode": "self_host",
+        "version": "v2",
+        "platform": "slack",
+        "platforms": PlatformsConfig(enabled=["slack"], primary="slack"),
+        "slack": SlackConfig(bot_token=""),
+        "runtime": RuntimeConfig(default_cwd="."),
+        "agents": AgentsConfig(),
+        "ui": UiConfig(),
+        "update": UpdateConfig(),
+    }
+    payload.update(overrides)
+    return V2Config(**payload)
+
+
+def test_setup_state_counts_telegram_credentials() -> None:
+    config = _base_config(
+        platform="telegram",
+        platforms=PlatformsConfig(enabled=["telegram"], primary="telegram"),
+        telegram=TelegramConfig(bot_token="123456:test-token"),
+    )
+
+    assert config.platform_has_credentials("telegram") is True
+    assert config.configured_platforms() == ["telegram"]
+    assert config.setup_state() == {
+        "needs_setup": False,
+        "configured_platforms": ["telegram"],
+        "missing_credentials": [],
+    }
+
+
+def test_setup_state_only_counts_enabled_platforms() -> None:
+    config = _base_config(
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack"], primary="slack"),
+        slack=SlackConfig(bot_token=""),
+        discord=DiscordConfig(bot_token="configured-but-disabled"),
+    )
+
+    assert config.platform_has_credentials("discord") is True
+    assert config.configured_platforms() == []
+    assert config.setup_state()["needs_setup"] is True
+
+
+def test_config_payload_includes_platform_catalog_and_setup_state() -> None:
+    config = _base_config(
+        platforms=PlatformsConfig(enabled=["slack", "discord", "telegram", "lark", "wechat"], primary="slack"),
+        slack=SlackConfig(bot_token="xoxb-test"),
+        discord=DiscordConfig(bot_token="discord-token"),
+        telegram=TelegramConfig(bot_token="123456:test-token"),
+        lark=LarkConfig(app_id="app-id", app_secret="app-secret"),
+        wechat=WeChatConfig(bot_token="wechat-token"),
+    )
+
+    payload = api.config_to_payload(config)
+
+    assert [platform["id"] for platform in payload["platform_catalog"]] == [
+        "slack",
+        "discord",
+        "telegram",
+        "lark",
+        "wechat",
+    ]
+    assert payload["setup_state"]["configured_platforms"] == ["slack", "discord", "telegram", "lark", "wechat"]
+    assert payload["setup_state"]["needs_setup"] is False

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,6 @@ import { StatusProvider } from './context/StatusContext';
 import { ApiProvider, useApi } from './context/ApiContext';
 import { ToastProvider } from './context/ToastContext';
 import { useEffect, useState } from 'react';
-import { getEnabledPlatforms } from './lib/platforms';
 
 // Wrapper to check if setup is needed
 const AuthGuard = ({ children }: { children: any }) => {
@@ -32,17 +31,7 @@ const AuthGuard = ({ children }: { children: any }) => {
 
         getConfig().then(config => {
             if (cancelled) return;
-            const enabledPlatforms = getEnabledPlatforms(config);
-            const hasToken = enabledPlatforms.some((platform) =>
-              platform === 'discord'
-                ? !!config?.discord?.bot_token
-                : platform === 'lark'
-                  ? !!(config?.lark?.app_id && config?.lark?.app_secret)
-                  : platform === 'wechat'
-                    ? !!config?.wechat?.bot_token
-                    : !!config?.slack?.bot_token
-            );
-            setNeedsSetup(!config || !config.mode || !hasToken);
+            setNeedsSetup(!config || !config.mode || config?.setup_state?.needs_setup !== false);
             setLoading(false);
         }).catch(() => {
              if (cancelled) return;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,6 +10,7 @@ import { StatusProvider } from './context/StatusContext';
 import { ApiProvider, useApi } from './context/ApiContext';
 import { ToastProvider } from './context/ToastContext';
 import { useEffect, useState } from 'react';
+import { hasConfiguredPlatformCredentials } from './lib/platforms';
 
 // Wrapper to check if setup is needed
 const AuthGuard = ({ children }: { children: any }) => {
@@ -31,7 +32,11 @@ const AuthGuard = ({ children }: { children: any }) => {
 
         getConfig().then(config => {
             if (cancelled) return;
-            setNeedsSetup(!config || !config.mode || config?.setup_state?.needs_setup !== false);
+            const setupState = config?.setup_state;
+            const setupReady = typeof setupState?.needs_setup === 'boolean'
+                ? setupState.needs_setup === false
+                : hasConfiguredPlatformCredentials(config);
+            setNeedsSetup(!config || !config.mode || !setupReady);
             setLoading(false);
         }).catch(() => {
              if (cancelled) return;

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -31,13 +31,17 @@ export const AppShell: React.FC = () => {
   const api = useApi();
   const location = useLocation();
   const [enabledPlatforms, setEnabledPlatforms] = useState<string[]>([]);
+  const [config, setConfig] = useState<any>(null);
 
   useEffect(() => {
-    api.getConfig().then((c: any) => setEnabledPlatforms(getEnabledPlatforms(c))).catch(() => {});
+    api.getConfig().then((c: any) => {
+      setConfig(c);
+      setEnabledPlatforms(getEnabledPlatforms(c));
+    }).catch(() => {});
   }, []);
 
   const isRunning = status.state === 'running';
-  const hasChannelPlatforms = enabledPlatforms.some(platformSupportsChannels);
+  const hasChannelPlatforms = enabledPlatforms.some((platform) => platformSupportsChannels(config, platform));
 
   if (location.pathname === '/setup') {
     return <Outlet />;

--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -141,7 +141,7 @@ export const Wizard: React.FC = () => {
     });
 
     // Channel steps: merge into a single step with platform tabs (instead of one step per platform)
-    const channelPlatforms = enabledPlatforms.filter(platformSupportsChannels);
+    const channelPlatforms = enabledPlatforms.filter((platform) => platformSupportsChannels(data, platform));
     const channelStep = channelPlatforms.length > 0
       ? [{ id: 'channels', title: t('nav.channels'), component: (props: any) => <ChannelList {...props} wizardPlatforms={channelPlatforms} /> }]
       : [];
@@ -159,9 +159,21 @@ export const Wizard: React.FC = () => {
 
   useEffect(() => {
     const bootstrap = async () => {
+      let platformCatalog: any[] = [];
+      try {
+        const catalog = await api.getPlatformCatalog();
+        platformCatalog = catalog?.platforms || [];
+      } catch {
+        // Config payloads from newer backends also include the catalog.
+      }
+
       try {
         const config = await api.getConfig();
-        const enabledPlatforms = getEnabledPlatforms(config);
+        const configWithCatalog = {
+          ...config,
+          platform_catalog: config.platform_catalog || platformCatalog,
+        };
+        const enabledPlatforms = getEnabledPlatforms(configWithCatalog);
         const settingsEntries = await Promise.all(
           enabledPlatforms.map(async (platform) => [platform, await api.getSettings(platform)] as const)
         );
@@ -169,7 +181,7 @@ export const Wizard: React.FC = () => {
           settingsEntries.map(([platform, settings]) => [platform, settings.channels || {}])
         );
           setData({
-            ...config,
+            ...configWithCatalog,
             channelConfigsByPlatform,
             default_backend: config.agents?.default_backend,
             agents: {
@@ -180,7 +192,10 @@ export const Wizard: React.FC = () => {
           });
 
       } catch {
-        // ignore
+        setData((current: any) => ({
+          ...current,
+          platform_catalog: platformCatalog,
+        }));
       } finally {
         setLoaded(true);
       }

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -193,7 +193,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
         confirmedGuildAllowlistRef.current = allowlist;
         applySelectedGuildIds(allowlist);
         setSelectedGuild(allowlist[0] || '');
-        const defaultPlatform = forcedPlatform || getEnabledPlatforms(c).find(platformSupportsChannels) || c?.platform || 'slack';
+        const defaultPlatform = forcedPlatform || getEnabledPlatforms(c).find((p) => platformSupportsChannels(c, p)) || c?.platform || 'slack';
         setPagePlatform(defaultPlatform);
         api.getSettings(defaultPlatform).then(s => {
           setConfigs(s.channels || {});
@@ -205,7 +205,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
   const platform = isWizardMultiPlatform
     ? wizardActivePlatform
     : (forcedPlatform || pagePlatform || config.platform || data.platform || 'slack');
-  const channelPlatforms = getEnabledPlatforms(config).filter(platformSupportsChannels);
+  const channelPlatforms = getEnabledPlatforms(config).filter((p) => platformSupportsChannels(config, p));
   const knownDiscordGuilds = [
     ...guilds,
     ...selectedGuildIds

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
-import { ALL_PLATFORMS, getEnabledPlatforms, getPrimaryPlatform } from '../../lib/platforms';
+import { getEnabledPlatforms, getPlatformCatalog, getPrimaryPlatform } from '../../lib/platforms';
 
 interface PlatformSelectionProps {
   data: any;
@@ -12,6 +12,7 @@ interface PlatformSelectionProps {
 export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNext, onBack }) => {
   const { t } = useTranslation();
   const initialPlatforms = useMemo(() => getEnabledPlatforms(data), [data]);
+  const platformCatalog = useMemo(() => getPlatformCatalog(data), [data]);
   const [selected, setSelected] = useState<string[]>(initialPlatforms);
   const [primary, setPrimary] = useState<string>(getPrimaryPlatform(data));
 
@@ -36,7 +37,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
   };
 
   const handleContinue = () => {
-    const normalized = selected.length ? selected : ['slack'];
+    const normalized = selected.length ? selected : [platformCatalog[0]?.id || 'slack'];
     const resolvedPrimary = normalized.includes(primary) ? primary : normalized[0];
     onNext({
       platform: resolvedPrimary,
@@ -55,7 +56,8 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 flex-1">
-        {ALL_PLATFORMS.map((option) => {
+        {platformCatalog.map((platform) => {
+          const option = platform.id;
           const active = selected.includes(option);
           return (
             <button
@@ -69,8 +71,8 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
             >
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <div className="text-lg font-semibold text-text">{t(`platform.${option}.title`)}</div>
-                  <div className="text-sm text-muted mt-2">{t(`platform.${option}.desc`)}</div>
+                  <div className="text-lg font-semibold text-text">{t(platform.title_key || `platform.${option}.title`)}</div>
+                  <div className="text-sm text-muted mt-2">{t(platform.description_key || `platform.${option}.desc`)}</div>
                 </div>
                 <div
                   className={clsx(
@@ -95,19 +97,22 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
         <div className="text-sm font-medium text-text">{t('platform.primaryTitle')}</div>
         <p className="text-xs text-muted mt-1">{t('platform.primaryDesc')}</p>
         <div className="mt-3 flex flex-wrap gap-2">
-          {selected.map((platform) => (
-            <button
-              key={platform}
-              type="button"
-              onClick={() => setPrimary(platform)}
-              className={clsx(
-                'px-3 py-1.5 rounded-full text-sm border transition-colors',
-                primary === platform ? 'bg-accent text-white border-accent' : 'bg-bg text-text border-border hover:border-accent/60'
-              )}
-            >
-              {t(`platform.${platform}.title`)}
-            </button>
-          ))}
+          {selected.map((platform) => {
+            const descriptor = platformCatalog.find((item) => item.id === platform);
+            return (
+              <button
+                key={platform}
+                type="button"
+                onClick={() => setPrimary(platform)}
+                className={clsx(
+                  'px-3 py-1.5 rounded-full text-sm border transition-colors',
+                  primary === platform ? 'bg-accent text-white border-accent' : 'bg-bg text-text border-border hover:border-accent/60'
+                )}
+              >
+                {t(descriptor?.title_key || `platform.${platform}.title`)}
+              </button>
+            );
+          })}
         </div>
       </div>
 

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from '../lib/apiFetch';
 
 export type ApiContextType = {
   getConfig: () => Promise<any>;
+  getPlatformCatalog: () => Promise<any>;
   saveConfig: (payload: any) => Promise<any>;
   getSettings: (platform?: string) => Promise<any>;
   saveSettings: (payload: any, platform?: string) => Promise<any>;
@@ -143,6 +144,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   const value: ApiContextType = {
     getConfig: () => getJson('/config'),
+    getPlatformCatalog: () => getJson('/platforms'),
     saveConfig: (payload) => postJson('/config', payload),
     getSettings: (platform) => getJson(platform ? `/settings?platform=${encodeURIComponent(platform)}` : '/settings'),
     saveSettings: (payload, platform) => postJson('/settings', platform ? { ...payload, platform } : payload),

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -33,6 +33,67 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_message_editing: true,
     },
   },
+  {
+    id: 'discord',
+    config_key: 'discord',
+    title_key: 'platform.discord.title',
+    description_key: 'platform.discord.desc',
+    credential_fields: ['bot_token'],
+    capabilities: {
+      supports_channels: true,
+      supports_threads: true,
+      supports_buttons: true,
+      supports_quick_replies: true,
+      supports_message_editing: true,
+      markdown_upload_returns_message_id: true,
+    },
+  },
+  {
+    id: 'telegram',
+    config_key: 'telegram',
+    title_key: 'platform.telegram.title',
+    description_key: 'platform.telegram.desc',
+    credential_fields: ['bot_token'],
+    capabilities: {
+      supports_channels: true,
+      supports_threads: false,
+      supports_buttons: true,
+      supports_quick_replies: true,
+      supports_message_editing: true,
+      markdown_upload_returns_message_id: true,
+      quick_reply_single_column: true,
+    },
+  },
+  {
+    id: 'lark',
+    config_key: 'lark',
+    title_key: 'platform.lark.title',
+    description_key: 'platform.lark.desc',
+    credential_fields: ['app_id', 'app_secret'],
+    capabilities: {
+      supports_channels: true,
+      supports_threads: true,
+      supports_buttons: true,
+      supports_quick_replies: true,
+      supports_message_editing: true,
+      markdown_upload_returns_message_id: true,
+      quick_reply_single_column: true,
+    },
+  },
+  {
+    id: 'wechat',
+    config_key: 'wechat',
+    title_key: 'platform.wechat.title',
+    description_key: 'platform.wechat.desc',
+    credential_fields: ['bot_token'],
+    capabilities: {
+      supports_channels: false,
+      supports_threads: false,
+      supports_buttons: false,
+      supports_quick_replies: false,
+      supports_message_editing: false,
+    },
+  },
 ];
 
 export const getPlatformCatalog = (data: any): PlatformDescriptor[] => {
@@ -79,3 +140,17 @@ export const platformHasCapability = (
 
 export const platformSupportsChannels = (data: any, platform: string): boolean =>
   platformHasCapability(data, platform, 'supports_channels');
+
+export const platformHasCredentials = (data: any, platform: string): boolean => {
+  const descriptor = getPlatformDescriptor(data, platform);
+  const configKey = descriptor?.config_key || platform;
+  const credentialFields = descriptor?.credential_fields || [];
+  const platformConfig = data?.[configKey];
+  if (!platformConfig || credentialFields.length === 0) {
+    return false;
+  }
+  return credentialFields.every((field) => !!platformConfig?.[field]);
+};
+
+export const hasConfiguredPlatformCredentials = (data: any): boolean =>
+  getEnabledPlatforms(data).some((platform) => platformHasCredentials(data, platform));

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -25,6 +25,7 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
     config_key: 'slack',
     title_key: 'platform.slack.title',
     description_key: 'platform.slack.desc',
+    credential_fields: ['bot_token'],
     capabilities: {
       supports_channels: true,
       supports_threads: true,

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -1,28 +1,81 @@
-export const ALL_PLATFORMS = ['slack', 'discord', 'telegram', 'lark', 'wechat'] as const;
+export type PlatformName = string;
 
-export type PlatformName = (typeof ALL_PLATFORMS)[number];
+export type PlatformCapabilities = {
+  supports_channels?: boolean;
+  supports_threads?: boolean;
+  supports_buttons?: boolean;
+  supports_quick_replies?: boolean;
+  supports_message_editing?: boolean;
+  markdown_upload_returns_message_id?: boolean;
+  quick_reply_single_column?: boolean;
+};
+
+export type PlatformDescriptor = {
+  id: PlatformName;
+  config_key?: string;
+  title_key?: string;
+  description_key?: string;
+  credential_fields?: string[];
+  capabilities?: PlatformCapabilities;
+};
+
+const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
+  {
+    id: 'slack',
+    config_key: 'slack',
+    title_key: 'platform.slack.title',
+    description_key: 'platform.slack.desc',
+    capabilities: {
+      supports_channels: true,
+      supports_threads: true,
+      supports_buttons: true,
+      supports_quick_replies: true,
+      supports_message_editing: true,
+    },
+  },
+];
+
+export const getPlatformCatalog = (data: any): PlatformDescriptor[] => {
+  const catalog = data?.platform_catalog || data?.platforms_catalog || data?.catalog?.platforms;
+  if (Array.isArray(catalog) && catalog.length > 0) {
+    return catalog.filter((platform: any): platform is PlatformDescriptor => typeof platform?.id === 'string');
+  }
+  return LEGACY_FALLBACK_CATALOG;
+};
+
+export const getPlatformIds = (data: any): PlatformName[] => getPlatformCatalog(data).map((platform) => platform.id);
 
 export const getEnabledPlatforms = (data: any): PlatformName[] => {
+  const catalogIds = new Set(getPlatformIds(data));
   const enabled = data?.platforms?.enabled;
   if (Array.isArray(enabled) && enabled.length > 0) {
-    return enabled.filter((platform: string): platform is PlatformName =>
-      (ALL_PLATFORMS as readonly string[]).includes(platform)
-    );
+    const filtered = enabled.filter((platform: string): platform is PlatformName => catalogIds.has(platform));
+    if (filtered.length > 0) return filtered;
   }
   const legacy = data?.platform;
-  if ((ALL_PLATFORMS as readonly string[]).includes(legacy)) {
+  if (catalogIds.has(legacy)) {
     return [legacy as PlatformName];
   }
-  return ['slack'];
+  return [getPlatformCatalog(data)[0]?.id || 'slack'];
 };
 
 export const getPrimaryPlatform = (data: any): PlatformName => {
   const enabled = getEnabledPlatforms(data);
   const primary = data?.platforms?.primary;
-  if ((ALL_PLATFORMS as readonly string[]).includes(primary) && enabled.includes(primary as PlatformName)) {
+  if (enabled.includes(primary)) {
     return primary as PlatformName;
   }
-  return enabled[0] || 'slack';
+  return enabled[0] || getPlatformCatalog(data)[0]?.id || 'slack';
 };
 
-export const platformSupportsChannels = (platform: string): boolean => !['wechat'].includes(platform);
+export const getPlatformDescriptor = (data: any, platform: string): PlatformDescriptor | undefined =>
+  getPlatformCatalog(data).find((descriptor) => descriptor.id === platform);
+
+export const platformHasCapability = (
+  data: any,
+  platform: string,
+  capability: keyof PlatformCapabilities
+): boolean => !!getPlatformDescriptor(data, platform)?.capabilities?.[capability];
+
+export const platformSupportsChannels = (data: any, platform: string): boolean =>
+  platformHasCapability(data, platform, 'supports_channels');

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -301,6 +301,8 @@ def config_to_payload(config: V2Config) -> dict:
             "enabled": config.platforms.enabled,
             "primary": config.platforms.primary,
         },
+        "platform_catalog": config.platform_catalog(),
+        "setup_state": config.setup_state(),
         "mode": config.mode,
         "version": config.version,
         "slack": {
@@ -331,6 +333,12 @@ def config_to_payload(config: V2Config) -> dict:
         "reply_enhancements": config.reply_enhancements,
     }
     return payload
+
+
+def get_platform_catalog() -> dict:
+    from config.platform_registry import platform_catalog_payload
+
+    return {"platforms": platform_catalog_payload()}
 
 
 def get_settings(platform: Optional[str] = None) -> dict:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -295,6 +295,12 @@ def save_config(payload: dict) -> V2Config:
 
 
 def config_to_payload(config: V2Config) -> dict:
+    from config.platform_registry import platform_descriptors
+
+    platform_payload = {
+        descriptor.config_key: (descriptor.get_config(config).__dict__ if descriptor.get_config(config) else None)
+        for descriptor in platform_descriptors()
+    }
     payload = {
         "platform": config.platform,
         "platforms": {
@@ -305,14 +311,7 @@ def config_to_payload(config: V2Config) -> dict:
         "setup_state": config.setup_state(),
         "mode": config.mode,
         "version": config.version,
-        "slack": {
-            **config.slack.__dict__,
-            "require_mention": config.slack.require_mention,
-        },
-        "discord": config.discord.__dict__ if config.discord else None,
-        "telegram": config.telegram.__dict__ if config.telegram else None,
-        "lark": config.lark.__dict__ if config.lark else None,
-        "wechat": config.wechat.__dict__ if config.wechat else None,
+        **platform_payload,
         "runtime": {
             "default_cwd": config.runtime.default_cwd,
             "log_level": config.runtime.log_level,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1779,8 +1779,14 @@ def cmd_vibe():
     runtime.stop_service()
     runtime.stop_ui()
 
-    if not config.slack.bot_token:
-        _write_status("setup", "missing Slack bot token")
+    has_configured_platform_credentials = getattr(config, "has_configured_platform_credentials", None)
+    if callable(has_configured_platform_credentials):
+        ready = bool(has_configured_platform_credentials())
+    else:
+        ready = bool(getattr(getattr(config, "slack", None), "bot_token", ""))
+
+    if not ready:
+        _write_status("setup", "missing platform credentials")
     else:
         _write_status("starting")
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -341,6 +341,13 @@ def config_get():
     return jsonify(api.config_to_payload(config))
 
 
+@app.route("/platforms", methods=["GET"])
+def platforms_get():
+    from vibe import api
+
+    return jsonify(api.get_platform_catalog())
+
+
 @app.route("/settings", methods=["GET"])
 def settings_get():
     from vibe import api


### PR DESCRIPTION
## Summary

- add a backend IM platform registry with descriptors for config keys, client factories, formatter factories, credential fields, and capability flags
- route V2 config validation, setup readiness, IM client creation, formatter selection, and selected runtime capability checks through the registry
- expose `platform_catalog` and backend-computed `setup_state` to the UI, and make the setup guard/channel navigation consume those fields instead of duplicating credential/platform logic
- add regression coverage for Telegram-only setup readiness and descriptor-driven platform extension behavior

## Evidence

- Unit: `PYTHONPATH=$PWD python3 -m pytest tests/test_platform_registry.py tests/test_v2_config_platform_registry.py tests/test_cli_setup_status.py tests/test_api_save_config_merge.py tests/test_multi_platform_runtime.py tests/test_v2_compat_platforms.py tests/test_ui_api.py`
- Contract/API: config payload now includes registry-derived `platform_catalog` and `setup_state`; `/platforms` returns the catalog without requiring an existing config
- Frontend: `npm run build`
- Lint: `uv run ruff check config/platform_registry.py config/v2_config.py core/controller.py core/handlers/command_handlers.py core/message_dispatcher.py modules/im/factory.py vibe/api.py vibe/cli.py vibe/ui_server.py tests/test_platform_registry.py tests/test_v2_config_platform_registry.py tests/test_cli_setup_status.py`

## Scenarios

- Scenario catalog: no scenario IDs changed; this is a shared platform metadata and setup-readiness refactor.

## Risks / Follow-ups

- Platform-specific setup forms remain intentionally platform-specific in the UI. The generic selection, setup guard, channel capability checks, client creation, and credential readiness now come from the registry.
- Additional capability flags can be moved into the descriptor over time as more platform-specific branches are retired.
