### PR TITLE
refactor(platforms): drive processing indicators from capabilities

### DIFF
--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -16,6 +16,13 @@ class PlatformCapabilities:
     supports_message_editing: bool
     markdown_upload_returns_message_id: bool = False
     quick_reply_single_column: bool = False
+    supports_processing_typing: bool = False
+    processing_typing_requires_clear: bool = False
+    supports_processing_reaction: bool = False
+    supports_processing_message: bool = True
+    supports_processing_message_delete: bool = False
+    preferred_processing_indicator: str = "typing"
+    force_preferred_processing_indicator: bool = False
 
 
 @dataclass(frozen=True)
@@ -107,6 +114,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_buttons=True,
             supports_quick_replies=True,
             supports_message_editing=True,
+            supports_processing_typing=True,
+            supports_processing_reaction=True,
         ),
     ),
     "discord": PlatformDescriptor(
@@ -126,6 +135,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_quick_replies=True,
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
+            supports_processing_typing=True,
+            supports_processing_reaction=True,
         ),
     ),
     "telegram": PlatformDescriptor(
@@ -146,6 +157,9 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
             quick_reply_single_column=True,
+            supports_processing_typing=True,
+            supports_processing_reaction=True,
+            supports_processing_message_delete=True,
         ),
     ),
     "lark": PlatformDescriptor(
@@ -166,6 +180,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
             quick_reply_single_column=True,
+            supports_processing_reaction=True,
+            preferred_processing_indicator="reaction",
         ),
     ),
     "wechat": PlatformDescriptor(
@@ -184,6 +200,11 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_buttons=False,
             supports_quick_replies=False,
             supports_message_editing=False,
+            supports_processing_typing=True,
+            processing_typing_requires_clear=True,
+            supports_processing_reaction=False,
+            preferred_processing_indicator="typing",
+            force_preferred_processing_indicator=True,
         ),
     ),
 }

--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -16,11 +16,12 @@ class PlatformCapabilities:
     supports_message_editing: bool
     markdown_upload_returns_message_id: bool = False
     quick_reply_single_column: bool = False
-    supports_processing_typing: bool = False
-    processing_typing_requires_clear: bool = False
-    supports_processing_reaction: bool = False
-    supports_processing_message: bool = True
-    supports_processing_message_delete: bool = False
+    supports_typing_indicator: bool = False
+    typing_indicator_requires_clear: bool = False
+    typing_indicator_best_effort: bool = False
+    supports_reaction_indicator: bool = False
+    supports_message_indicator: bool = True
+    supports_message_indicator_delete: bool = False
     preferred_processing_indicator: str = "typing"
     force_preferred_processing_indicator: bool = False
 
@@ -114,8 +115,9 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_buttons=True,
             supports_quick_replies=True,
             supports_message_editing=True,
-            supports_processing_typing=True,
-            supports_processing_reaction=True,
+            supports_typing_indicator=True,
+            typing_indicator_best_effort=True,
+            supports_reaction_indicator=True,
         ),
     ),
     "discord": PlatformDescriptor(
@@ -135,8 +137,8 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_quick_replies=True,
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
-            supports_processing_typing=True,
-            supports_processing_reaction=True,
+            supports_typing_indicator=True,
+            supports_reaction_indicator=True,
         ),
     ),
     "telegram": PlatformDescriptor(
@@ -157,9 +159,9 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
             quick_reply_single_column=True,
-            supports_processing_typing=True,
-            supports_processing_reaction=True,
-            supports_processing_message_delete=True,
+            supports_typing_indicator=True,
+            supports_reaction_indicator=True,
+            supports_message_indicator_delete=True,
         ),
     ),
     "lark": PlatformDescriptor(
@@ -180,7 +182,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
             quick_reply_single_column=True,
-            supports_processing_reaction=True,
+            supports_reaction_indicator=True,
             preferred_processing_indicator="reaction",
         ),
     ),
@@ -200,9 +202,9 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_buttons=False,
             supports_quick_replies=False,
             supports_message_editing=False,
-            supports_processing_typing=True,
-            processing_typing_requires_clear=True,
-            supports_processing_reaction=False,
+            supports_typing_indicator=True,
+            typing_indicator_requires_clear=True,
+            supports_reaction_indicator=False,
             preferred_processing_indicator="typing",
             force_preferred_processing_indicator=True,
         ),

--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -26,6 +26,9 @@ class ActivePollInfo:
     # Ack reaction info for cleanup on restore
     ack_reaction_message_id: Optional[str] = None
     ack_reaction_emoji: Optional[str] = None
+    # Typing indicator info for cleanup on restore
+    typing_indicator_active: bool = False
+    context_token: str = ""
     # User identity for restoring question UI context
     user_id: str = ""
     platform: str = ""
@@ -44,6 +47,8 @@ class ActivePollInfo:
             "started_at": self.started_at,
             "ack_reaction_message_id": self.ack_reaction_message_id,
             "ack_reaction_emoji": self.ack_reaction_emoji,
+            "typing_indicator_active": self.typing_indicator_active,
+            "context_token": self.context_token,
             "user_id": self.user_id,
             "platform": self.platform,
         }
@@ -63,6 +68,8 @@ class ActivePollInfo:
             started_at=data.get("started_at", 0.0),
             ack_reaction_message_id=data.get("ack_reaction_message_id"),
             ack_reaction_emoji=data.get("ack_reaction_emoji"),
+            typing_indicator_active=bool(data.get("typing_indicator_active", False)),
+            context_token=data.get("context_token", ""),
             user_id=data.get("user_id", ""),
             platform=data.get("platform", ""),
         )

--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -29,6 +29,7 @@ class ActivePollInfo:
     # Typing indicator info for cleanup on restore
     typing_indicator_active: bool = False
     context_token: str = ""
+    processing_indicator: Dict[str, Any] = field(default_factory=dict)
     # User identity for restoring question UI context
     user_id: str = ""
     platform: str = ""
@@ -49,12 +50,25 @@ class ActivePollInfo:
             "ack_reaction_emoji": self.ack_reaction_emoji,
             "typing_indicator_active": self.typing_indicator_active,
             "context_token": self.context_token,
+            "processing_indicator": self.processing_indicator,
             "user_id": self.user_id,
             "platform": self.platform,
         }
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ActivePollInfo":
+        processing_indicator = data.get("processing_indicator") or {}
+        if not processing_indicator:
+            processing_indicator = {
+                "platform": data.get("platform", ""),
+                "user_id": data.get("user_id", ""),
+                "channel_id": data.get("channel_id", ""),
+                "thread_id": data.get("thread_id", ""),
+                "context_token": data.get("context_token", ""),
+                "ack_reaction_message_id": data.get("ack_reaction_message_id"),
+                "ack_reaction_emoji": data.get("ack_reaction_emoji"),
+                "typing_indicator_active": bool(data.get("typing_indicator_active", False)),
+            }
         return cls(
             opencode_session_id=data.get("opencode_session_id", ""),
             base_session_id=data.get("base_session_id", ""),
@@ -70,6 +84,7 @@ class ActivePollInfo:
             ack_reaction_emoji=data.get("ack_reaction_emoji"),
             typing_indicator_active=bool(data.get("typing_indicator_active", False)),
             context_token=data.get("context_token", ""),
+            processing_indicator=processing_indicator,
             user_id=data.get("user_id", ""),
             platform=data.get("platform", ""),
         )

--- a/core/controller.py
+++ b/core/controller.py
@@ -24,6 +24,7 @@ from core.handlers import (
 )
 from core.agent_auth_service import AgentAuthService
 from core.message_dispatcher import ConsolidatedMessageDispatcher
+from core.processing_indicator import ProcessingIndicatorService
 from core.scheduled_tasks import ScheduledTaskService
 from core.update_checker import UpdateChecker
 from core.watches import ManagedWatchService
@@ -105,6 +106,7 @@ class Controller:
         self.platform_settings_managers = self.settings_manager.managers
         self.sessions = self.settings_manager.sessions
         self.native_session_service = None
+        self.processing_indicator = ProcessingIndicatorService(self)
 
         # Migrate legacy per-channel language into global config
         self._migrate_language_from_settings()

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -1,6 +1,5 @@
 """Message routing and Agent communication handlers"""
 
-import asyncio
 import logging
 from typing import List, Optional, Tuple
 
@@ -30,72 +29,6 @@ class MessageHandler(BaseHandler):
         """Set reference to session handler"""
         self.session_handler = session_handler
 
-    def _get_target_context(self, context: MessageContext) -> MessageContext:
-        """Get target context for sending messages"""
-        # For Slack, use thread for replies if enabled
-        if self._get_im_client(context).should_use_thread_for_reply() and context.thread_id:
-            return MessageContext(
-                user_id=context.user_id,
-                channel_id=context.channel_id,
-                platform=context.platform,
-                thread_id=context.thread_id,
-                message_id=context.message_id,
-                platform_specific=context.platform_specific,
-            )
-        return context
-
-    def _get_context_platform(self, context: MessageContext) -> str:
-        return (
-            context.platform
-            or (context.platform_specific or {}).get("platform")
-            or getattr(self.config, "platform", "")
-        )
-
-    def _should_use_typing_ack(self, context: MessageContext) -> bool:
-        platform = self._get_context_platform(context)
-        if platform == "wechat":
-            return True
-        return getattr(self.config, "ack_mode", "typing") == "typing"
-
-    async def _typing_keepalive_loop(self, context: MessageContext) -> None:
-        im_client = self._get_im_client(context)
-        try:
-            while True:
-                await asyncio.sleep(5)
-                ok = await im_client.send_typing_indicator(context)
-                if not ok:
-                    logger.debug("Typing keepalive not applied for %s", context.user_id)
-        except asyncio.CancelledError:
-            raise
-
-    async def _start_processing_indicator(
-        self, context: MessageContext
-    ) -> Tuple[Optional[str], Optional[str], bool, Optional[asyncio.Task]]:
-        im_client = self._get_im_client(context)
-        if self._should_use_typing_ack(context):
-            try:
-                ok = await im_client.send_typing_indicator(context)
-                if ok:
-                    return None, None, True, asyncio.create_task(self._typing_keepalive_loop(context))
-                logger.info("Typing indicator not applied (platform returned False)")
-            except Exception as ack_err:
-                logger.debug(f"Failed to send typing ack: {ack_err}")
-            if self._get_context_platform(context) == "wechat":
-                return None, None, False, None
-
-        ack_reaction_message_id = None
-        ack_reaction_emoji = None
-        try:
-            if context.message_id:
-                ack_reaction_message_id = context.message_id
-                ack_reaction_emoji = ":eyes:"
-                ok = await im_client.add_reaction(context, ack_reaction_message_id, ack_reaction_emoji)
-                if not ok:
-                    logger.info("Ack reaction not applied (platform returned False)")
-        except Exception as ack_err:
-            logger.debug(f"Failed to add reaction ack: {ack_err}")
-        return ack_reaction_message_id, ack_reaction_emoji, False, None
-
     async def handle_user_message(self, context: MessageContext, message: str):
         """Process regular human-originated messages and route to configured agent."""
         await self._handle_turn(context, message, source=self.TURN_SOURCE_HUMAN)
@@ -120,10 +53,7 @@ class MessageHandler(BaseHandler):
 
     async def _handle_turn(self, context: MessageContext, message: str, *, source: str) -> Optional[str]:
         """Shared turn-processing pipeline used by both human and scheduled turns."""
-        ack_reaction_message_id = None
-        ack_reaction_emoji = None
-        typing_indicator_active = False
-        typing_indicator_task = None
+        processing_indicator = None
         try:
             is_human = source == self.TURN_SOURCE_HUMAN
             control_message = self._get_control_message(context, message) if is_human else message
@@ -292,24 +222,8 @@ class MessageHandler(BaseHandler):
                 base_session_id = f"{base_session_id}:{routing_agent}"
                 composite_key = f"{base_session_id}:{working_path}"
 
-            ack_message_id = None
             if is_human:
-                ack_mode = getattr(self.config, "ack_mode", "typing")
-                effective_ack_mode = "typing" if self._get_context_platform(context) == "wechat" else ack_mode
-                if effective_ack_mode == "message":
-                    ack_context = self._get_target_context(context)
-                    ack_text = self._get_ack_text(agent_name)
-                    try:
-                        ack_message_id = await self._get_im_client(ack_context).send_message(ack_context, ack_text)
-                    except Exception as ack_err:
-                        logger.debug(f"Failed to send ack message: {ack_err}")
-                else:
-                    (
-                        ack_reaction_message_id,
-                        ack_reaction_emoji,
-                        typing_indicator_active,
-                        typing_indicator_task,
-                    ) = await self._start_processing_indicator(context)
+                processing_indicator = await self.controller.processing_indicator.start(context, agent_name)
 
             if is_human and subagent_name and context.message_id:
                 try:
@@ -349,18 +263,15 @@ class MessageHandler(BaseHandler):
                 base_session_id=base_session_id,
                 composite_session_id=composite_key,
                 session_key=session_key,
-                ack_message_id=ack_message_id,
                 subagent_name=subagent_name,
                 subagent_key=matched_prefix,
                 subagent_model=subagent_model,
                 subagent_reasoning_effort=subagent_reasoning_effort,
-                # Reaction info — agent removes :eyes: on result/error
-                ack_reaction_message_id=ack_reaction_message_id,
-                ack_reaction_emoji=ack_reaction_emoji,
-                typing_indicator_active=typing_indicator_active,
-                typing_indicator_task=typing_indicator_task,
+                processing_indicator=processing_indicator,
                 files=processed_files,
             )
+            if processing_indicator is not None:
+                self.controller.processing_indicator.apply_to_request(request, processing_indicator)
             try:
                 await self.controller.agent_service.handle_message(agent_name, request)
             except KeyError:
@@ -382,22 +293,8 @@ class MessageHandler(BaseHandler):
                     # clears typing indicators, which do not have a reaction ID.
                     await self._remove_ack_reaction(context, request)  # type: ignore[possibly-undefined]
                 except NameError:
-                    # request not defined yet, try using local variables
-                    if (
-                        ack_reaction_message_id  # type: ignore[possibly-undefined]
-                        and ack_reaction_emoji  # type: ignore[possibly-undefined]
-                    ):
-                        await self._get_im_client(context).remove_reaction(
-                            context, ack_reaction_message_id, ack_reaction_emoji
-                        )
-                    if typing_indicator_task:  # type: ignore[possibly-undefined]
-                        typing_indicator_task.cancel()
-                        try:
-                            await typing_indicator_task
-                        except asyncio.CancelledError:
-                            pass
-                    if typing_indicator_active:  # type: ignore[possibly-undefined]
-                        await self._get_im_client(context).clear_typing_indicator(context)
+                    if processing_indicator is not None:
+                        await self.controller.processing_indicator.finish(processing_indicator)
             except Exception as cleanup_err:
                 logger.debug(f"Failed to clean up reaction on error: {cleanup_err}")
             await self._get_im_client(context).send_message(
@@ -681,56 +578,11 @@ class MessageHandler(BaseHandler):
 
     async def _delete_ack(self, channel_id: str, request: AgentRequest):
         """Delete acknowledgement message if it still exists."""
-        im_client = self._get_im_client(request.context)
-        if request.ack_message_id and hasattr(im_client, "delete_message"):
-            try:
-                await im_client.delete_message(channel_id, request.ack_message_id)
-            except Exception as err:
-                logger.debug(f"Failed to delete ack message: {err}")
-            finally:
-                request.ack_message_id = None
+        await self.controller.processing_indicator.delete_ack_message(request, channel_id=channel_id)
 
     async def _remove_ack_reaction(self, context: MessageContext, request: AgentRequest):
         """Remove acknowledgement reaction / typing indicator if it still exists."""
-        im_client = self._get_im_client(context)
-        typing_task = request.typing_indicator_task
-        if typing_task is not None:
-            typing_task.cancel()
-            try:
-                await typing_task
-            except asyncio.CancelledError:
-                pass
-            except Exception as err:
-                logger.debug(f"Failed to stop typing keepalive task: {err}")
-            finally:
-                request.typing_indicator_task = None
-
-        if request.typing_indicator_active:
-            try:
-                await im_client.clear_typing_indicator(context)
-            except Exception as err:
-                logger.debug(f"Failed to clear typing ack: {err}")
-            finally:
-                request.typing_indicator_active = False
-
-        if request.ack_reaction_message_id and request.ack_reaction_emoji:
-            try:
-                await im_client.remove_reaction(
-                    context,
-                    request.ack_reaction_message_id,
-                    request.ack_reaction_emoji,
-                )
-            except Exception as err:
-                logger.debug(f"Failed to remove reaction ack: {err}")
-            finally:
-                request.ack_reaction_message_id = None
-                request.ack_reaction_emoji = None
-
-    def _get_ack_text(self, agent_name: str) -> str:
-        """Unified acknowledgement text before agent processing."""
-        label = agent_name or self.controller.agent_service.default_agent
-        agent_label = label.capitalize() if label else ""
-        return f"📨 {self._t('message.ack', agent=agent_label)}"
+        await self.controller.processing_indicator.finish(request)
 
     async def _process_file_attachments(
         self, context: MessageContext, working_path: str

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -497,7 +497,7 @@ class MessageHandler(BaseHandler):
                     try:
                         quick_reply_echo = self._t("message.quickReplyNote", text=reply_text)
                         quick_reply_echo_id = await im_client.send_message(
-                            self._get_target_context(context),
+                            self.controller.processing_indicator.target_context(context),
                             quick_reply_echo,
                         )
                     except Exception as err:
@@ -507,7 +507,7 @@ class MessageHandler(BaseHandler):
                     if quick_reply_echo_id and getattr(self.config, "ack_mode", "typing") == "reaction":
                         try:
                             await im_client.add_reaction(
-                                self._get_target_context(context),
+                                self.controller.processing_indicator.target_context(context),
                                 quick_reply_echo_id,
                                 ":eyes:",
                             )

--- a/core/processing_indicator.py
+++ b/core/processing_indicator.py
@@ -107,11 +107,11 @@ class ProcessingIndicatorService:
         context: MessageContext,
     ) -> bool:
         if mode == "typing":
-            return capabilities.supports_processing_typing
+            return capabilities.supports_typing_indicator
         if mode == "reaction":
-            return capabilities.supports_processing_reaction and bool(context.message_id)
+            return capabilities.supports_reaction_indicator and bool(context.message_id)
         if mode == "message":
-            return capabilities.supports_processing_message
+            return capabilities.supports_message_indicator
         return False
 
     def _candidate_modes(self, capabilities: PlatformCapabilities) -> list[str]:
@@ -243,10 +243,10 @@ class ProcessingIndicatorService:
         return handle.context
 
     def _should_delete_ack_message(self, handle: ProcessingIndicatorHandle) -> bool:
-        return self._capabilities(handle.context).supports_processing_message_delete
+        return self._capabilities(handle.context).supports_message_indicator_delete
 
     def _should_clear_typing_indicator(self, handle: ProcessingIndicatorHandle) -> bool:
-        return self._capabilities(handle.context).processing_typing_requires_clear
+        return self._capabilities(handle.context).typing_indicator_requires_clear
 
     async def _delete_ack_message_for_handle(
         self,

--- a/core/processing_indicator.py
+++ b/core/processing_indicator.py
@@ -10,13 +10,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Optional
 
+from config.platform_registry import PlatformCapabilities, get_platform_descriptor
 from modules.im import MessageContext
 from vibe.i18n import t as i18n_t
 
 logger = logging.getLogger(__name__)
+
+_PROCESSING_INDICATOR_MODES = ("typing", "reaction", "message")
 
 
 @dataclass
@@ -94,14 +97,48 @@ class ProcessingIndicatorService:
             or getattr(self.config, "platform", "")
         )
 
-    def _should_use_typing_ack(self, context: MessageContext) -> bool:
-        if self._get_context_platform(context) == "wechat":
-            return True
-        return getattr(self.config, "ack_mode", "typing") == "typing"
+    def _capabilities(self, context: MessageContext) -> PlatformCapabilities:
+        return get_platform_descriptor(self._get_context_platform(context)).capabilities
+
+    def _mode_supported(
+        self,
+        capabilities: PlatformCapabilities,
+        mode: str,
+        context: MessageContext,
+    ) -> bool:
+        if mode == "typing":
+            return capabilities.supports_processing_typing
+        if mode == "reaction":
+            return capabilities.supports_processing_reaction and bool(context.message_id)
+        if mode == "message":
+            return capabilities.supports_processing_message
+        return False
+
+    def _candidate_modes(self, capabilities: PlatformCapabilities) -> list[str]:
+        preferred = capabilities.preferred_processing_indicator
+        configured = getattr(self.config, "ack_mode", "typing")
+        if capabilities.force_preferred_processing_indicator:
+            candidates = [preferred]
+        else:
+            candidates = [configured, preferred, "typing", "reaction", "message"]
+        return [
+            mode
+            for index, mode in enumerate(candidates)
+            if mode in _PROCESSING_INDICATOR_MODES and mode not in candidates[:index]
+        ]
+
+    def _processing_modes(self, context: MessageContext) -> list[str]:
+        capabilities = self._capabilities(context)
+        return [
+            mode
+            for mode in self._candidate_modes(capabilities)
+            if self._mode_supported(capabilities, mode, context)
+        ]
 
     def _get_target_context(self, context: MessageContext) -> MessageContext:
         im_client = self._get_im_client(context)
-        if im_client.should_use_thread_for_reply() and context.thread_id:
+        capabilities = self._capabilities(context)
+        if capabilities.supports_threads and im_client.should_use_thread_for_reply() and context.thread_id:
             return MessageContext(
                 user_id=context.user_id,
                 channel_id=context.channel_id,
@@ -134,49 +171,103 @@ class ProcessingIndicatorService:
         if not enabled:
             return handle
 
-        im_client = self._get_im_client(context)
-        ack_mode = getattr(self.config, "ack_mode", "typing")
-        effective_ack_mode = "typing" if self._get_context_platform(context) == "wechat" else ack_mode
-
-        if effective_ack_mode == "message":
-            ack_context = self._get_target_context(context)
-            try:
-                handle.ack_message_id = await self._get_im_client(ack_context).send_message(
-                    ack_context,
-                    self._get_ack_text(agent_name),
-                )
-                handle.ack_message_channel_id = ack_context.channel_id
-            except Exception as ack_err:
-                logger.debug("Failed to send ack message: %s", ack_err)
-            return handle
-
-        if self._should_use_typing_ack(context):
-            try:
-                ok = await im_client.send_typing_indicator(context)
-                if ok:
-                    handle.typing_indicator_active = True
-                    handle.typing_indicator_task = asyncio.create_task(self._typing_keepalive_loop(context))
-                    return handle
-                logger.info("Typing indicator not applied (platform returned False)")
-            except Exception as ack_err:
-                logger.debug("Failed to send typing ack: %s", ack_err)
-            if self._get_context_platform(context) == "wechat":
+        for mode in self._processing_modes(context):
+            if mode == "message" and await self._start_message_indicator(handle, agent_name):
+                return handle
+            if mode == "typing" and await self._start_typing_indicator(handle):
+                return handle
+            if mode == "reaction" and await self._start_reaction_indicator(handle):
                 return handle
 
+        return handle
+
+    async def _start_message_indicator(self, handle: ProcessingIndicatorHandle, agent_name: str) -> bool:
+        ack_context = self._get_target_context(handle.context)
         try:
-            if context.message_id:
-                handle.ack_reaction_message_id = context.message_id
-                handle.ack_reaction_emoji = ":eyes:"
-                ok = await im_client.add_reaction(
-                    context,
-                    handle.ack_reaction_message_id,
-                    handle.ack_reaction_emoji,
-                )
-                if not ok:
-                    logger.info("Ack reaction not applied (platform returned False)")
+            ack_message_id = await self._get_im_client(ack_context).send_message(
+                ack_context,
+                self._get_ack_text(agent_name),
+            )
+        except Exception as ack_err:
+            logger.debug("Failed to send ack message: %s", ack_err)
+            return False
+
+        if not ack_message_id:
+            logger.info("Ack message not applied (platform returned empty message id)")
+            return False
+
+        handle.ack_message_id = ack_message_id
+        handle.ack_message_channel_id = ack_context.channel_id
+        return True
+
+    async def _start_typing_indicator(self, handle: ProcessingIndicatorHandle) -> bool:
+        context = handle.context
+        im_client = self._get_im_client(context)
+        try:
+            ok = await im_client.send_typing_indicator(context)
+        except Exception as ack_err:
+            logger.debug("Failed to send typing ack: %s", ack_err)
+            return False
+
+        if not ok:
+            logger.info("Typing indicator not applied (platform returned False)")
+            return False
+
+        handle.typing_indicator_active = True
+        handle.typing_indicator_task = asyncio.create_task(self._typing_keepalive_loop(context))
+        return True
+
+    async def _start_reaction_indicator(self, handle: ProcessingIndicatorHandle) -> bool:
+        context = handle.context
+        if not context.message_id:
+            return False
+        im_client = self._get_im_client(context)
+        try:
+            ok = await im_client.add_reaction(context, context.message_id, ":eyes:")
         except Exception as ack_err:
             logger.debug("Failed to add reaction ack: %s", ack_err)
-        return handle
+            return False
+
+        if not ok:
+            logger.info("Ack reaction not applied (platform returned False)")
+            return False
+
+        handle.ack_reaction_message_id = context.message_id
+        handle.ack_reaction_emoji = ":eyes:"
+        return True
+
+    def _delete_context(self, handle: ProcessingIndicatorHandle, channel_id: Optional[str]) -> MessageContext:
+        target_channel_id = channel_id or handle.ack_message_channel_id
+        if target_channel_id and target_channel_id != handle.context.channel_id:
+            return replace(handle.context, channel_id=target_channel_id)
+        return handle.context
+
+    def _should_delete_ack_message(self, handle: ProcessingIndicatorHandle) -> bool:
+        return self._capabilities(handle.context).supports_processing_message_delete
+
+    def _should_clear_typing_indicator(self, handle: ProcessingIndicatorHandle) -> bool:
+        return self._capabilities(handle.context).processing_typing_requires_clear
+
+    async def _delete_ack_message_for_handle(
+        self,
+        handle: ProcessingIndicatorHandle,
+        *,
+        request: Optional[Any] = None,
+        channel_id: Optional[str] = None,
+    ) -> None:
+        ack_id = handle.ack_message_id
+        if not ack_id:
+            return
+        if self._should_delete_ack_message(handle):
+            im_client = self._get_im_client(handle.context)
+            if hasattr(im_client, "delete_message"):
+                try:
+                    await im_client.delete_message(self._delete_context(handle, channel_id), ack_id)
+                except Exception as err:
+                    logger.debug("Could not delete ack message: %s", err)
+        handle.ack_message_id = None
+        if request is not None:
+            request.ack_message_id = None
 
     def apply_to_request(self, request: Any, handle: ProcessingIndicatorHandle) -> None:
         request.processing_indicator = handle
@@ -223,29 +314,6 @@ class ProcessingIndicatorService:
         if getattr(request, "processing_indicator", None) is None:
             request.processing_indicator = handle
 
-    async def _delete_ack_message_for_handle(
-        self,
-        handle: ProcessingIndicatorHandle,
-        *,
-        request: Optional[Any] = None,
-        channel_id: Optional[str] = None,
-    ) -> None:
-        ack_id = handle.ack_message_id
-        if ack_id:
-            im_client = self._get_im_client(handle.context)
-            if hasattr(im_client, "delete_message"):
-                try:
-                    await im_client.delete_message(
-                        channel_id or handle.ack_message_channel_id or handle.context.channel_id,
-                        ack_id,
-                    )
-                except Exception as err:
-                    logger.debug("Could not delete ack message: %s", err)
-                finally:
-                    handle.ack_message_id = None
-                    if request is not None:
-                        request.ack_message_id = None
-
     async def finish(self, request_or_handle: Any) -> None:
         if isinstance(request_or_handle, ProcessingIndicatorHandle):
             handle = request_or_handle
@@ -270,15 +338,16 @@ class ProcessingIndicatorService:
                 if request is not None:
                     request.typing_indicator_task = None
 
-        if handle.typing_indicator_active:
+        if handle.typing_indicator_active and self._should_clear_typing_indicator(handle):
             try:
                 await self._get_im_client(handle.context).clear_typing_indicator(handle.context)
             except Exception as err:
                 logger.debug("Failed to clear typing indicator: %s", err)
-            finally:
-                handle.typing_indicator_active = False
-                if request is not None:
-                    request.typing_indicator_active = False
+
+        if handle.typing_indicator_active:
+            handle.typing_indicator_active = False
+            if request is not None:
+                request.typing_indicator_active = False
 
         if handle.ack_reaction_message_id and handle.ack_reaction_emoji:
             try:

--- a/core/processing_indicator.py
+++ b/core/processing_indicator.py
@@ -1,0 +1,300 @@
+"""Processing indicator lifecycle management.
+
+This module owns the short-lived UI state shown while a user turn is being
+processed: acknowledgement messages, acknowledgement reactions, and typing
+indicators.  Agent implementations should not know platform-specific cleanup
+details; they should only ask this service to delete or finish an indicator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from modules.im import MessageContext
+from vibe.i18n import t as i18n_t
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProcessingIndicatorHandle:
+    """Runtime handle for a processing indicator."""
+
+    context: MessageContext
+    ack_message_id: Optional[str] = None
+    ack_message_channel_id: Optional[str] = None
+    ack_reaction_message_id: Optional[str] = None
+    ack_reaction_emoji: Optional[str] = None
+    typing_indicator_active: bool = False
+    typing_indicator_task: Optional[asyncio.Task] = None
+
+    def to_snapshot(self) -> dict[str, Any]:
+        payload = self.context.platform_specific or {}
+        return {
+            "platform": self.context.platform or payload.get("platform") or "",
+            "user_id": self.context.user_id or "",
+            "channel_id": self.context.channel_id or "",
+            "thread_id": self.context.thread_id or "",
+            "message_id": self.context.message_id or "",
+            "context_token": str(payload.get("context_token") or ""),
+            "ack_message_id": self.ack_message_id,
+            "ack_message_channel_id": self.ack_message_channel_id,
+            "ack_reaction_message_id": self.ack_reaction_message_id,
+            "ack_reaction_emoji": self.ack_reaction_emoji,
+            "typing_indicator_active": self.typing_indicator_active,
+        }
+
+    @classmethod
+    def from_snapshot(cls, data: dict[str, Any]) -> "ProcessingIndicatorHandle":
+        platform = str(data.get("platform") or "")
+        context_token = str(data.get("context_token") or "")
+        platform_specific: dict[str, Any] = {}
+        if platform:
+            platform_specific["platform"] = platform
+        if context_token:
+            platform_specific["context_token"] = context_token
+        context = MessageContext(
+            user_id=str(data.get("user_id") or ""),
+            channel_id=str(data.get("channel_id") or ""),
+            platform=platform or None,
+            thread_id=data.get("thread_id") or None,
+            message_id=data.get("message_id") or None,
+            platform_specific=platform_specific or None,
+        )
+        return cls(
+            context=context,
+            ack_message_id=data.get("ack_message_id") or None,
+            ack_message_channel_id=data.get("ack_message_channel_id") or data.get("channel_id") or None,
+            ack_reaction_message_id=data.get("ack_reaction_message_id") or None,
+            ack_reaction_emoji=data.get("ack_reaction_emoji") or None,
+            typing_indicator_active=bool(data.get("typing_indicator_active", False)),
+        )
+
+
+class ProcessingIndicatorService:
+    """Start and finish processing indicators through one owner."""
+
+    def __init__(self, controller):
+        self.controller = controller
+        self.config = controller.config
+
+    def _get_im_client(self, context: MessageContext):
+        getter = getattr(self.controller, "get_im_client_for_context", None)
+        if callable(getter):
+            return getter(context)
+        return self.controller.im_client
+
+    def _get_context_platform(self, context: MessageContext) -> str:
+        return (
+            context.platform
+            or (context.platform_specific or {}).get("platform")
+            or getattr(self.config, "platform", "")
+        )
+
+    def _should_use_typing_ack(self, context: MessageContext) -> bool:
+        if self._get_context_platform(context) == "wechat":
+            return True
+        return getattr(self.config, "ack_mode", "typing") == "typing"
+
+    def _get_target_context(self, context: MessageContext) -> MessageContext:
+        im_client = self._get_im_client(context)
+        if im_client.should_use_thread_for_reply() and context.thread_id:
+            return MessageContext(
+                user_id=context.user_id,
+                channel_id=context.channel_id,
+                platform=context.platform,
+                thread_id=context.thread_id,
+                message_id=context.message_id,
+                platform_specific=context.platform_specific,
+            )
+        return context
+
+    def _get_ack_text(self, agent_name: str) -> str:
+        label = agent_name or self.controller.agent_service.default_agent
+        agent_label = label.capitalize() if label else ""
+        lang = self.controller._get_lang() if hasattr(self.controller, "_get_lang") else getattr(self.config, "language", "en")
+        return f"📨 {i18n_t('message.ack', lang, agent=agent_label)}"
+
+    async def _typing_keepalive_loop(self, context: MessageContext) -> None:
+        im_client = self._get_im_client(context)
+        try:
+            while True:
+                await asyncio.sleep(5)
+                ok = await im_client.send_typing_indicator(context)
+                if not ok:
+                    logger.debug("Typing keepalive not applied for %s", context.user_id)
+        except asyncio.CancelledError:
+            raise
+
+    async def start(self, context: MessageContext, agent_name: str, *, enabled: bool = True) -> ProcessingIndicatorHandle:
+        handle = ProcessingIndicatorHandle(context=context)
+        if not enabled:
+            return handle
+
+        im_client = self._get_im_client(context)
+        ack_mode = getattr(self.config, "ack_mode", "typing")
+        effective_ack_mode = "typing" if self._get_context_platform(context) == "wechat" else ack_mode
+
+        if effective_ack_mode == "message":
+            ack_context = self._get_target_context(context)
+            try:
+                handle.ack_message_id = await self._get_im_client(ack_context).send_message(
+                    ack_context,
+                    self._get_ack_text(agent_name),
+                )
+                handle.ack_message_channel_id = ack_context.channel_id
+            except Exception as ack_err:
+                logger.debug("Failed to send ack message: %s", ack_err)
+            return handle
+
+        if self._should_use_typing_ack(context):
+            try:
+                ok = await im_client.send_typing_indicator(context)
+                if ok:
+                    handle.typing_indicator_active = True
+                    handle.typing_indicator_task = asyncio.create_task(self._typing_keepalive_loop(context))
+                    return handle
+                logger.info("Typing indicator not applied (platform returned False)")
+            except Exception as ack_err:
+                logger.debug("Failed to send typing ack: %s", ack_err)
+            if self._get_context_platform(context) == "wechat":
+                return handle
+
+        try:
+            if context.message_id:
+                handle.ack_reaction_message_id = context.message_id
+                handle.ack_reaction_emoji = ":eyes:"
+                ok = await im_client.add_reaction(
+                    context,
+                    handle.ack_reaction_message_id,
+                    handle.ack_reaction_emoji,
+                )
+                if not ok:
+                    logger.info("Ack reaction not applied (platform returned False)")
+        except Exception as ack_err:
+            logger.debug("Failed to add reaction ack: %s", ack_err)
+        return handle
+
+    def apply_to_request(self, request: Any, handle: ProcessingIndicatorHandle) -> None:
+        request.processing_indicator = handle
+        request.ack_message_id = handle.ack_message_id
+        request.ack_reaction_message_id = handle.ack_reaction_message_id
+        request.ack_reaction_emoji = handle.ack_reaction_emoji
+        request.typing_indicator_active = handle.typing_indicator_active
+        request.typing_indicator_task = handle.typing_indicator_task
+
+    def handle_from_request(self, request: Any) -> ProcessingIndicatorHandle:
+        handle = getattr(request, "processing_indicator", None)
+        if isinstance(handle, ProcessingIndicatorHandle):
+            handle.ack_message_id = handle.ack_message_id or getattr(request, "ack_message_id", None)
+            handle.ack_reaction_message_id = handle.ack_reaction_message_id or getattr(
+                request,
+                "ack_reaction_message_id",
+                None,
+            )
+            handle.ack_reaction_emoji = handle.ack_reaction_emoji or getattr(request, "ack_reaction_emoji", None)
+            handle.typing_indicator_active = handle.typing_indicator_active or bool(
+                getattr(request, "typing_indicator_active", False)
+            )
+            handle.typing_indicator_task = handle.typing_indicator_task or getattr(request, "typing_indicator_task", None)
+            return handle
+        return ProcessingIndicatorHandle(
+            context=request.context,
+            ack_message_id=getattr(request, "ack_message_id", None),
+            ack_message_channel_id=getattr(request.context, "channel_id", None),
+            ack_reaction_message_id=getattr(request, "ack_reaction_message_id", None),
+            ack_reaction_emoji=getattr(request, "ack_reaction_emoji", None),
+            typing_indicator_active=bool(getattr(request, "typing_indicator_active", False)),
+            typing_indicator_task=getattr(request, "typing_indicator_task", None),
+        )
+
+    def handle_from_snapshot(self, data: dict[str, Any]) -> ProcessingIndicatorHandle:
+        return ProcessingIndicatorHandle.from_snapshot(data)
+
+    def snapshot_request(self, request: Any) -> dict[str, Any]:
+        return self.handle_from_request(request).to_snapshot()
+
+    async def delete_ack_message(self, request: Any, *, channel_id: Optional[str] = None) -> None:
+        handle = self.handle_from_request(request)
+        await self._delete_ack_message_for_handle(handle, request=request, channel_id=channel_id)
+        if getattr(request, "processing_indicator", None) is None:
+            request.processing_indicator = handle
+
+    async def _delete_ack_message_for_handle(
+        self,
+        handle: ProcessingIndicatorHandle,
+        *,
+        request: Optional[Any] = None,
+        channel_id: Optional[str] = None,
+    ) -> None:
+        ack_id = handle.ack_message_id
+        if ack_id:
+            im_client = self._get_im_client(handle.context)
+            if hasattr(im_client, "delete_message"):
+                try:
+                    await im_client.delete_message(
+                        channel_id or handle.ack_message_channel_id or handle.context.channel_id,
+                        ack_id,
+                    )
+                except Exception as err:
+                    logger.debug("Could not delete ack message: %s", err)
+                finally:
+                    handle.ack_message_id = None
+                    if request is not None:
+                        request.ack_message_id = None
+
+    async def finish(self, request_or_handle: Any) -> None:
+        if isinstance(request_or_handle, ProcessingIndicatorHandle):
+            handle = request_or_handle
+            request = None
+        else:
+            request = request_or_handle
+            handle = self.handle_from_request(request)
+
+        await self._delete_ack_message_for_handle(handle, request=request)
+
+        typing_task = handle.typing_indicator_task
+        if typing_task is not None:
+            typing_task.cancel()
+            try:
+                await typing_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug("Failed to stop typing keepalive task", exc_info=True)
+            finally:
+                handle.typing_indicator_task = None
+                if request is not None:
+                    request.typing_indicator_task = None
+
+        if handle.typing_indicator_active:
+            try:
+                await self._get_im_client(handle.context).clear_typing_indicator(handle.context)
+            except Exception as err:
+                logger.debug("Failed to clear typing indicator: %s", err)
+            finally:
+                handle.typing_indicator_active = False
+                if request is not None:
+                    request.typing_indicator_active = False
+
+        if handle.ack_reaction_message_id and handle.ack_reaction_emoji:
+            try:
+                await self._get_im_client(handle.context).remove_reaction(
+                    handle.context,
+                    handle.ack_reaction_message_id,
+                    handle.ack_reaction_emoji,
+                )
+            except Exception as err:
+                logger.debug("Failed to remove reaction ack: %s", err)
+            finally:
+                handle.ack_reaction_message_id = None
+                handle.ack_reaction_emoji = None
+                if request is not None:
+                    request.ack_reaction_message_id = None
+                    request.ack_reaction_emoji = None
+
+        if request is not None and getattr(request, "processing_indicator", None) is None:
+            request.processing_indicator = handle

--- a/core/processing_indicator.py
+++ b/core/processing_indicator.py
@@ -135,7 +135,9 @@ class ProcessingIndicatorService:
             if self._mode_supported(capabilities, mode, context)
         ]
 
-    def _get_target_context(self, context: MessageContext) -> MessageContext:
+    def target_context(self, context: MessageContext) -> MessageContext:
+        """Return the platform-appropriate context for immediate ACK-style replies."""
+
         im_client = self._get_im_client(context)
         capabilities = self._capabilities(context)
         if capabilities.supports_threads and im_client.should_use_thread_for_reply() and context.thread_id:
@@ -182,7 +184,7 @@ class ProcessingIndicatorService:
         return handle
 
     async def _start_message_indicator(self, handle: ProcessingIndicatorHandle, agent_name: str) -> bool:
-        ack_context = self._get_target_context(handle.context)
+        ack_context = self.target_context(handle.context)
         try:
             ack_message_id = await self._get_im_client(ack_context).send_message(
                 ack_context,

--- a/docs/plans/processing-indicator-lifecycle.md
+++ b/docs/plans/processing-indicator-lifecycle.md
@@ -18,14 +18,28 @@ conversation context token, and restored OpenCode polls did not own that state.
 `core.processing_indicator.ProcessingIndicatorService` is the lifecycle owner.
 
 - Start indicators through one service.
+- Select indicator strategy from platform registry capabilities, not platform
+  string checks.
 - Store a single handle on `AgentRequest`.
 - Keep legacy request fields in sync for compatibility while callers migrate.
 - Finish and ack-message deletion go through the same service for OpenCode,
   Codex, Claude, and handler-level errors.
 - Persist a serializable handle snapshot for restored OpenCode polls.
 
-## Follow-Up Boundary
+## Platform Capability Source
 
-This PR keeps the public request fields as a compatibility layer. A later cleanup
-can remove direct reads of `ack_reaction_message_id`, `typing_indicator_active`,
-and related fields once all tests and helper code use the handle directly.
+The registry owns ACK/typing differences:
+
+- which platforms can use typing, reaction, or message indicators
+- whether typing requires an explicit clear operation
+- whether message ACKs can be deleted
+- whether a platform has a preferred or forced indicator mode
+
+This keeps WeChat's explicit cancel requirement, Lark's reaction preference, and
+Telegram's message-delete support out of backend-specific code.
+
+## Compatibility Boundary
+
+This PR keeps the public request fields as a compatibility layer. They mirror the
+handle, but lifecycle ownership and platform policy live in
+`ProcessingIndicatorService` plus `config.platform_registry`.

--- a/docs/plans/processing-indicator-lifecycle.md
+++ b/docs/plans/processing-indicator-lifecycle.md
@@ -1,0 +1,31 @@
+# Processing Indicator Lifecycle
+
+## Problem
+
+Processing indicators were split across layers:
+
+- `MessageHandler` started ack messages, reactions, and typing indicators.
+- `AgentRequest` carried several loosely related mutable fields.
+- Each agent backend decided when to delete or clear those fields.
+- OpenCode persisted active poll state separately for restart recovery.
+
+That made cleanup depend on every backend remembering the same platform-specific
+details. WeChat exposed the flaw because clearing typing requires the original
+conversation context token, and restored OpenCode polls did not own that state.
+
+## Direction
+
+`core.processing_indicator.ProcessingIndicatorService` is the lifecycle owner.
+
+- Start indicators through one service.
+- Store a single handle on `AgentRequest`.
+- Keep legacy request fields in sync for compatibility while callers migrate.
+- Finish and ack-message deletion go through the same service for OpenCode,
+  Codex, Claude, and handler-level errors.
+- Persist a serializable handle snapshot for restored OpenCode polls.
+
+## Follow-Up Boundary
+
+This PR keeps the public request fields as a compatibility layer. A later cleanup
+can remove direct reads of `ack_reaction_message_id`, `typing_indicator_active`,
+and related fields once all tests and helper code use the handle directly.

--- a/docs/plans/processing-indicator-lifecycle.md
+++ b/docs/plans/processing-indicator-lifecycle.md
@@ -32,11 +32,14 @@ The registry owns ACK/typing differences:
 
 - which platforms can use typing, reaction, or message indicators
 - whether typing requires an explicit clear operation
+- whether typing support is best-effort rather than a stable platform path
 - whether message ACKs can be deleted
 - whether a platform has a preferred or forced indicator mode
 
 This keeps WeChat's explicit cancel requirement, Lark's reaction preference, and
-Telegram's message-delete support out of backend-specific code.
+Telegram's sendChatAction/message-delete support out of backend-specific code.
+Slack is marked as typing-capable but best-effort because it relies on legacy
+RTM availability.
 
 ## Compatibility Boundary
 

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import time
-import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -35,6 +34,7 @@ class AgentRequest:
     last_agent_message_parse_mode: Optional[str] = None
     started_at: float = field(default_factory=time.monotonic)
     # Reaction ack: emoji added to user's message, to be removed when result is sent
+    processing_indicator: Optional[Any] = None
     ack_reaction_message_id: Optional[str] = None
     ack_reaction_emoji: Optional[str] = None
     typing_indicator_active: bool = False
@@ -92,38 +92,7 @@ class BaseAgent(ABC):
         should NOT override it.  The guard (check-then-clear) is idempotent so
         calling it more than once is harmless.
         """
-        typing_task = request.typing_indicator_task
-        if typing_task is not None:
-            typing_task.cancel()
-            try:
-                await typing_task
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                logger.debug("Failed to stop typing keepalive task", exc_info=True)
-            finally:
-                request.typing_indicator_task = None
-
-        if request.typing_indicator_active:
-            try:
-                await self._get_im_client(request.context).clear_typing_indicator(request.context)
-            except Exception as err:
-                logger.debug(f"Failed to clear typing indicator: {err}")
-            finally:
-                request.typing_indicator_active = False
-
-        if request.ack_reaction_message_id and request.ack_reaction_emoji:
-            try:
-                await self._get_im_client(request.context).remove_reaction(
-                    request.context,
-                    request.ack_reaction_message_id,
-                    request.ack_reaction_emoji,
-                )
-            except Exception as err:
-                logger.debug(f"Failed to remove reaction ack: {err}")
-            finally:
-                request.ack_reaction_message_id = None
-                request.ack_reaction_emoji = None
+        await self.controller.processing_indicator.finish(request)
 
     async def emit_result_message(
         self,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -550,12 +550,16 @@ class ClaudeAgent(BaseAgent):
         # inside the loop.
 
     async def _delete_ack(self, context: MessageContext, request: AgentRequest):
+        service = getattr(self.controller, "processing_indicator", None)
+        if service is not None:
+            await service.delete_ack_message(request, channel_id=context.channel_id)
+            return
         ack_id = request.ack_message_id
         if ack_id and hasattr(self.im_client, "delete_message"):
             try:
                 await self.im_client.delete_message(context.channel_id, ack_id)
             except Exception as err:
-                logger.debug(f"Could not delete ack message: {err}")
+                logger.debug("Could not delete ack message: %s", err)
             finally:
                 request.ack_message_id = None
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -725,6 +725,10 @@ class CodexAgent(BaseAgent):
         return turn_id
 
     async def _delete_ack(self, request: AgentRequest) -> None:
+        service = getattr(self.controller, "processing_indicator", None)
+        if service is not None:
+            await service.delete_ack_message(request)
+            return
         ack_id = request.ack_message_id
         if ack_id and hasattr(self.im_client, "delete_message"):
             try:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -289,6 +289,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 ack_reaction_emoji=request.ack_reaction_emoji,
                 typing_indicator_active=request.typing_indicator_active,
                 context_token=str(platform_payload.get("context_token") or ""),
+                processing_indicator=self.controller.processing_indicator.snapshot_request(request),
                 user_id=request.context.user_id or "",
                 platform=request.context.platform or platform_payload.get("platform") or "",
             )
@@ -421,12 +422,16 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         return terminated
 
     async def _delete_ack(self, request: AgentRequest) -> None:
+        service = getattr(self.controller, "processing_indicator", None)
+        if service is not None:
+            await service.delete_ack_message(request)
+            return
         ack_id = request.ack_message_id
         if ack_id and hasattr(self.im_client, "delete_message"):
             try:
                 await self.im_client.delete_message(request.context.channel_id, ack_id)
             except Exception as err:
-                logger.debug(f"Could not delete ack message: {err}")
+                logger.debug("Could not delete ack message: %s", err)
             finally:
                 request.ack_message_id = None
 

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -275,6 +275,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             raw_settings_key = request.session_key
             if "::" in raw_settings_key:
                 raw_settings_key = raw_settings_key.split("::", 1)[1]
+            platform_payload = request.context.platform_specific or {}
 
             self.sessions.add_active_poll(
                 opencode_session_id=session_id,
@@ -286,8 +287,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 baseline_message_ids=list(baseline_message_ids),
                 ack_reaction_message_id=request.ack_reaction_message_id,
                 ack_reaction_emoji=request.ack_reaction_emoji,
+                typing_indicator_active=request.typing_indicator_active,
+                context_token=str(platform_payload.get("context_token") or ""),
                 user_id=request.context.user_id or "",
-                platform=request.context.platform or (request.context.platform_specific or {}).get("platform") or "",
+                platform=request.context.platform or platform_payload.get("platform") or "",
             )
 
             final_text, should_emit = await self._poll_loop.run_prompt_poll(
@@ -467,6 +470,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             session_still_active = has_in_progress or last_assistant_finish == "tool-calls"
             if not session_still_active:
                 logger.info(f"OpenCode session {session_id} has completed, removing from active polls")
+                await self._poll_loop.remove_restored_ack(poll_info)
                 stale_poll_ids.append(session_id)
                 continue
 

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -21,25 +21,25 @@ class OpenCodePollLoop:
         self._agent = agent
         self._question_handler = question_handler
 
+    def _build_restored_handle(self, poll_info):
+        snapshot = poll_info.processing_indicator or {
+            "platform": poll_info.platform,
+            "user_id": poll_info.user_id,
+            "channel_id": poll_info.channel_id,
+            "thread_id": poll_info.thread_id,
+            "context_token": getattr(poll_info, "context_token", ""),
+            "ack_reaction_message_id": poll_info.ack_reaction_message_id,
+            "ack_reaction_emoji": poll_info.ack_reaction_emoji,
+            "typing_indicator_active": bool(getattr(poll_info, "typing_indicator_active", False)),
+        }
+        return self._agent.controller.processing_indicator.handle_from_snapshot(snapshot)
+
     def _build_restored_context(self, poll_info):
-        from modules.im import MessageContext
-
-        platform_specific: dict[str, Any] = {}
-        if poll_info.platform:
-            platform_specific["platform"] = poll_info.platform
-        if getattr(poll_info, "context_token", ""):
-            platform_specific["context_token"] = poll_info.context_token
-
-        return MessageContext(
-            user_id=poll_info.user_id or "",
-            channel_id=poll_info.channel_id,
-            platform=poll_info.platform or None,
-            thread_id=poll_info.thread_id,
-            platform_specific=platform_specific or None,
-        )
+        return self._build_restored_handle(poll_info).context
 
     def _build_restored_ack_request(self, poll_info) -> AgentRequest:
-        context = self._build_restored_context(poll_info)
+        handle = self._build_restored_handle(poll_info)
+        context = handle.context
         session_key = f"{poll_info.platform}::{poll_info.settings_key}" if poll_info.platform else poll_info.settings_key
         return AgentRequest(
             context=context,
@@ -48,9 +48,11 @@ class OpenCodePollLoop:
             base_session_id=poll_info.base_session_id,
             composite_session_id=f"{poll_info.base_session_id}:{poll_info.working_path}",
             session_key=session_key,
-            ack_reaction_message_id=poll_info.ack_reaction_message_id,
-            ack_reaction_emoji=poll_info.ack_reaction_emoji,
-            typing_indicator_active=bool(getattr(poll_info, "typing_indicator_active", False)),
+            processing_indicator=handle,
+            ack_message_id=handle.ack_message_id,
+            ack_reaction_message_id=handle.ack_reaction_message_id,
+            ack_reaction_emoji=handle.ack_reaction_emoji,
+            typing_indicator_active=handle.typing_indicator_active,
         )
 
     async def remove_restored_ack(self, poll_info) -> None:

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -21,6 +21,41 @@ class OpenCodePollLoop:
         self._agent = agent
         self._question_handler = question_handler
 
+    def _build_restored_context(self, poll_info):
+        from modules.im import MessageContext
+
+        platform_specific: dict[str, Any] = {}
+        if poll_info.platform:
+            platform_specific["platform"] = poll_info.platform
+        if getattr(poll_info, "context_token", ""):
+            platform_specific["context_token"] = poll_info.context_token
+
+        return MessageContext(
+            user_id=poll_info.user_id or "",
+            channel_id=poll_info.channel_id,
+            platform=poll_info.platform or None,
+            thread_id=poll_info.thread_id,
+            platform_specific=platform_specific or None,
+        )
+
+    def _build_restored_ack_request(self, poll_info) -> AgentRequest:
+        context = self._build_restored_context(poll_info)
+        session_key = f"{poll_info.platform}::{poll_info.settings_key}" if poll_info.platform else poll_info.settings_key
+        return AgentRequest(
+            context=context,
+            message="",
+            working_path=poll_info.working_path,
+            base_session_id=poll_info.base_session_id,
+            composite_session_id=f"{poll_info.base_session_id}:{poll_info.working_path}",
+            session_key=session_key,
+            ack_reaction_message_id=poll_info.ack_reaction_message_id,
+            ack_reaction_emoji=poll_info.ack_reaction_emoji,
+            typing_indicator_active=bool(getattr(poll_info, "typing_indicator_active", False)),
+        )
+
+    async def remove_restored_ack(self, poll_info) -> None:
+        await self._agent._remove_ack_reaction(self._build_restored_ack_request(poll_info))
+
     def _fallback_extract_text(
         self,
         messages: list[Dict[str, Any]],
@@ -307,28 +342,8 @@ class OpenCodePollLoop:
     async def run_restored_poll_loop(self, poll_info) -> None:
         """Continue a poll loop that was interrupted by restart."""
 
-        from modules.im import MessageContext
-
         session_id = poll_info.opencode_session_id
-        context = MessageContext(
-            user_id=poll_info.user_id or "",
-            channel_id=poll_info.channel_id,
-            platform=poll_info.platform or None,
-            thread_id=poll_info.thread_id,
-            platform_specific={"platform": poll_info.platform} if poll_info.platform else None,
-        )
-
-        async def _remove_ack_reaction() -> None:
-            """Remove ack reaction from the original message."""
-            if poll_info.ack_reaction_message_id and poll_info.ack_reaction_emoji:
-                try:
-                    await self._agent.controller.get_im_client_for_context(context).remove_reaction(
-                        context,
-                        poll_info.ack_reaction_message_id,
-                        poll_info.ack_reaction_emoji,
-                    )
-                except Exception as e:
-                    logger.debug(f"Failed to remove ack reaction: {e}")
+        context = self._build_restored_context(poll_info)
 
         await self._agent.controller.emit_agent_message(
             context,
@@ -413,13 +428,7 @@ class OpenCodePollLoop:
                             from modules.agents.base import AgentRequest
 
                             restored_request = AgentRequest(
-                                context=MessageContext(
-                                    user_id=poll_info.user_id or "",
-                                    channel_id=poll_info.channel_id,
-                                    platform=poll_info.platform or None,
-                                    thread_id=poll_info.thread_id,
-                                    platform_specific={"platform": poll_info.platform} if poll_info.platform else None,
-                                ),
+                                context=context,
                                 message="",
                                 session_key=f"{poll_info.platform}::{poll_info.settings_key}"
                                 if poll_info.platform
@@ -451,7 +460,7 @@ class OpenCodePollLoop:
                                 break
                             # Answer failed or cancelled — exit gracefully
                             self._agent.sessions.remove_active_poll(session_id)
-                            await _remove_ack_reaction()
+                            await self.remove_restored_ack(poll_info)
                             return
 
                         seen_tool_calls.add(call_key)
@@ -516,7 +525,7 @@ class OpenCodePollLoop:
                                             message,
                                         )
                                     self._agent.sessions.remove_active_poll(session_id)
-                                    await _remove_ack_reaction()
+                                    await self.remove_restored_ack(poll_info)
                                     return
 
                             if last_info.get("finish") != "tool-calls":
@@ -557,14 +566,14 @@ class OpenCodePollLoop:
                 )
 
             # Clean up ack reaction after result is sent
-            await _remove_ack_reaction()
+            await self.remove_restored_ack(poll_info)
             # Clean up answer reaction after result is sent
             await self._question_handler.clear(poll_info.base_session_id, context)
             self._agent.sessions.remove_active_poll(session_id)
 
         except asyncio.CancelledError:
             logger.info(f"Restored OpenCode poll cancelled for {poll_info.base_session_id}")
-            await _remove_ack_reaction()
+            await self.remove_restored_ack(poll_info)
             await self._question_handler.clear(poll_info.base_session_id, context)
             self._agent.sessions.remove_active_poll(session_id)
             raise
@@ -580,7 +589,7 @@ class OpenCodePollLoop:
                 logger.warning(f"Failed to abort OpenCode session after error: {abort_err}")
 
             self._agent.sessions.remove_active_poll(session_id)
-            await _remove_ack_reaction()
+            await self.remove_restored_ack(poll_info)
 
             message = f"Restored OpenCode session failed: {error_text}"
             handled = await self._agent.controller.agent_auth_service.maybe_emit_auth_recovery_message(

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -334,6 +334,7 @@ class SessionsFacade:
         ack_reaction_emoji: Optional[str] = None,
         typing_indicator_active: bool = False,
         context_token: str = "",
+        processing_indicator: Optional[Dict[str, Any]] = None,
         user_id: str = "",
         platform: str = "",
     ) -> None:
@@ -352,6 +353,7 @@ class SessionsFacade:
             ack_reaction_emoji=ack_reaction_emoji,
             typing_indicator_active=typing_indicator_active,
             context_token=context_token,
+            processing_indicator=processing_indicator or {},
             user_id=user_id,
             platform=platform,
         )

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -332,6 +332,8 @@ class SessionsFacade:
         baseline_message_ids: List[str],
         ack_reaction_message_id: Optional[str] = None,
         ack_reaction_emoji: Optional[str] = None,
+        typing_indicator_active: bool = False,
+        context_token: str = "",
         user_id: str = "",
         platform: str = "",
     ) -> None:
@@ -348,6 +350,8 @@ class SessionsFacade:
             started_at=time.time(),
             ack_reaction_message_id=ack_reaction_message_id,
             ack_reaction_emoji=ack_reaction_emoji,
+            typing_indicator_active=typing_indicator_active,
+            context_token=context_token,
             user_id=user_id,
             platform=platform,
         )

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -483,6 +483,8 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         await handler.handle_callback_query(context, "quick_reply:继续")
 
         self.assertEqual(controller.im_client.removed_keyboards, [("chat1", "lark", "om_123")])
+        self.assertEqual(controller.im_client.sent_messages, [("chat1", "Reply: 继续")])
+        self.assertEqual(controller.im_client.reactions, [("chat1", "msg-1", ":eyes:")])
         handler.handle_user_message.assert_awaited_once()
         forwarded_context, forwarded_text = handler.handle_user_message.await_args.args
         self.assertEqual(forwarded_text, "继续")

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -331,6 +331,20 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.ack_reaction_emoji, ":eyes:")
         self.assertEqual(controller.im_client.reactions, [("tg-chat", "m1", ":eyes:")])
 
+    async def test_lark_typing_preference_uses_registry_reaction_capability(self):
+        controller = _StubController(platform="lark", ack_mode="typing", typing_result=True)
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(user_id="lark-user", channel_id="lark-chat", message_id="om_1", platform="lark")
+
+        await handler.handle_user_message(context, "hello")
+
+        _, request = controller.agent_service.requests[0]
+        self.assertFalse(request.typing_indicator_active)
+        self.assertEqual(controller.im_client.typing_calls, [])
+        self.assertEqual(request.ack_reaction_message_id, "om_1")
+        self.assertEqual(controller.im_client.reactions, [("lark-chat", "om_1", ":eyes:")])
+
     async def test_platform_specific_client_is_used_for_user_info(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
         handler = MessageHandler(controller)

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from modules.im import MessageContext
+from core.processing_indicator import ProcessingIndicatorService
 
 
 def _load_message_handler_class():
@@ -31,6 +32,7 @@ def _load_message_handler_class():
             subagent_key: str | None = None
             subagent_model: str | None = None
             subagent_reasoning_effort: str | None = None
+            processing_indicator: object | None = None
             ack_reaction_message_id: str | None = None
             ack_reaction_emoji: str | None = None
             typing_indicator_active: bool = False
@@ -172,6 +174,7 @@ class _StubController:
         self.settings_handler = type("Settings", (), {})()
         self.command_handler = type("Cmd", (), {"handle_start": staticmethod(lambda context, args: None)})()
         self.agent_auth_service = type("Auth", (), {})()
+        self.processing_indicator = ProcessingIndicatorService(self)
 
     def update_thread_message_id(self, context):
         return None

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -11,6 +11,7 @@ from modules.im.base import BaseIMClient, BaseIMConfig, MessageContext
 from modules.im.multi import MultiIMClient
 from modules.settings_manager import MultiSettingsManager
 from config.v2_sessions import ActivePollInfo
+from modules.agents.opencode.poll_loop import OpenCodePollLoop
 
 
 @dataclass
@@ -147,7 +148,7 @@ def test_multi_im_client_routes_scoped_identity_lookups():
     assert wechat.sent[-1] == ("dm", "wx-user", "hello")
 
 
-def test_active_poll_info_round_trips_platform():
+def test_active_poll_info_round_trips_restored_typing_context():
     poll = ActivePollInfo(
         opencode_session_id="ses-1",
         base_session_id="base-1",
@@ -156,12 +157,45 @@ def test_active_poll_info_round_trips_platform():
         settings_key="chan-1",
         working_path="/tmp/work",
         user_id="user-1",
-        platform="discord",
+        platform="wechat",
+        typing_indicator_active=True,
+        context_token="ctx-1",
     )
 
     restored = ActivePollInfo.from_dict(poll.to_dict())
 
-    assert restored.platform == "discord"
+    assert restored.platform == "wechat"
+    assert restored.typing_indicator_active is True
+    assert restored.context_token == "ctx-1"
+
+
+def test_opencode_restored_ack_preserves_wechat_typing_context():
+    captured = []
+
+    class _StubAgent:
+        async def _remove_ack_reaction(self, request):
+            captured.append(request)
+
+    poll = ActivePollInfo(
+        opencode_session_id="ses-1",
+        base_session_id="base-1",
+        channel_id="chan-1",
+        thread_id="thread-1",
+        settings_key="chan-1",
+        working_path="/tmp/work",
+        user_id="user-1",
+        platform="wechat",
+        typing_indicator_active=True,
+        context_token="ctx-1",
+    )
+    loop = OpenCodePollLoop(_StubAgent(), question_handler=None)
+
+    asyncio.run(loop.remove_restored_ack(poll))
+
+    request = captured[0]
+    assert request.typing_indicator_active is True
+    assert request.context.platform == "wechat"
+    assert request.context.platform_specific == {"platform": "wechat", "context_token": "ctx-1"}
 
 
 def test_multi_im_client_routes_download_by_file_info_platform():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -11,6 +11,7 @@ from modules.im.base import BaseIMClient, BaseIMConfig, MessageContext
 from modules.im.multi import MultiIMClient
 from modules.settings_manager import MultiSettingsManager
 from config.v2_sessions import ActivePollInfo
+from core.processing_indicator import ProcessingIndicatorService
 from modules.agents.opencode.poll_loop import OpenCodePollLoop
 
 
@@ -77,6 +78,10 @@ class _StubClient(BaseIMClient):
         from modules.im.base import FileDownloadResult
 
         return FileDownloadResult(True, target_path)
+
+    async def clear_typing_indicator(self, context):
+        self.sent.append(("clear_typing", context.platform, context.user_id, (context.platform_specific or {}).get("context_token")))
+        return True
 
     def format_markdown(self, text: str) -> str:
         return text
@@ -160,6 +165,14 @@ def test_active_poll_info_round_trips_restored_typing_context():
         platform="wechat",
         typing_indicator_active=True,
         context_token="ctx-1",
+        processing_indicator={
+            "platform": "wechat",
+            "user_id": "user-1",
+            "channel_id": "chan-1",
+            "thread_id": "thread-1",
+            "context_token": "ctx-1",
+            "typing_indicator_active": True,
+        },
     )
 
     restored = ActivePollInfo.from_dict(poll.to_dict())
@@ -167,14 +180,29 @@ def test_active_poll_info_round_trips_restored_typing_context():
     assert restored.platform == "wechat"
     assert restored.typing_indicator_active is True
     assert restored.context_token == "ctx-1"
+    assert restored.processing_indicator["context_token"] == "ctx-1"
 
 
 def test_opencode_restored_ack_preserves_wechat_typing_context():
     captured = []
+    wechat = _StubClient("wechat")
 
     class _StubAgent:
+        def __init__(self):
+            self.controller = type(
+                "Controller",
+                (),
+                {
+                    "config": type("Config", (), {"platform": "wechat", "ack_mode": "typing", "language": "en"})(),
+                    "im_client": wechat,
+                    "get_im_client_for_context": lambda self, context: wechat,
+                },
+            )()
+            self.controller.processing_indicator = ProcessingIndicatorService(self.controller)
+
         async def _remove_ack_reaction(self, request):
             captured.append(request)
+            await self.controller.processing_indicator.finish(request)
 
     poll = ActivePollInfo(
         opencode_session_id="ses-1",
@@ -187,15 +215,68 @@ def test_opencode_restored_ack_preserves_wechat_typing_context():
         platform="wechat",
         typing_indicator_active=True,
         context_token="ctx-1",
+        processing_indicator={
+            "platform": "wechat",
+            "user_id": "user-1",
+            "channel_id": "chan-1",
+            "thread_id": "thread-1",
+            "context_token": "ctx-1",
+            "typing_indicator_active": True,
+        },
     )
     loop = OpenCodePollLoop(_StubAgent(), question_handler=None)
 
     asyncio.run(loop.remove_restored_ack(poll))
 
     request = captured[0]
-    assert request.typing_indicator_active is True
+    assert request.typing_indicator_active is False
     assert request.context.platform == "wechat"
     assert request.context.platform_specific == {"platform": "wechat", "context_token": "ctx-1"}
+    assert wechat.sent == [("clear_typing", "wechat", "user-1", "ctx-1")]
+
+
+def test_processing_indicator_handle_is_source_of_truth_for_backend_cleanup():
+    wechat = _StubClient("wechat")
+
+    class _Controller:
+        def __init__(self):
+            self.config = type("Config", (), {"platform": "wechat", "ack_mode": "typing", "language": "en"})()
+            self.im_client = wechat
+            self.settings_manager = type("Settings", (), {})()
+            self.processing_indicator = ProcessingIndicatorService(self)
+
+        def get_im_client_for_context(self, context):
+            return wechat
+
+    controller = _Controller()
+    handle = controller.processing_indicator.handle_from_snapshot(
+        {
+            "platform": "wechat",
+            "user_id": "user-1",
+            "channel_id": "chan-1",
+            "context_token": "ctx-1",
+            "typing_indicator_active": True,
+        }
+    )
+    request = type(
+        "Request",
+        (),
+        {
+            "context": handle.context,
+            "ack_message_id": None,
+            "ack_reaction_message_id": None,
+            "ack_reaction_emoji": None,
+            "typing_indicator_active": False,
+            "typing_indicator_task": None,
+            "processing_indicator": handle,
+        },
+    )()
+
+    asyncio.run(controller.processing_indicator.finish(request))
+
+    assert request.typing_indicator_active is False
+    assert handle.typing_indicator_active is False
+    assert wechat.sent == [("clear_typing", "wechat", "user-1", "ctx-1")]
 
 
 def test_multi_im_client_routes_download_by_file_info_platform():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -83,6 +83,10 @@ class _StubClient(BaseIMClient):
         self.sent.append(("clear_typing", context.platform, context.user_id, (context.platform_specific or {}).get("context_token")))
         return True
 
+    async def delete_message(self, context, message_id):
+        self.sent.append(("delete", context.platform, context.channel_id, message_id))
+        return True
+
     def format_markdown(self, text: str) -> str:
         return text
 
@@ -277,6 +281,64 @@ def test_processing_indicator_handle_is_source_of_truth_for_backend_cleanup():
     assert request.typing_indicator_active is False
     assert handle.typing_indicator_active is False
     assert wechat.sent == [("clear_typing", "wechat", "user-1", "ctx-1")]
+
+
+def test_processing_indicator_clear_policy_comes_from_platform_registry():
+    slack = _StubClient("slack")
+
+    class _Controller:
+        def __init__(self):
+            self.config = type("Config", (), {"platform": "slack", "ack_mode": "typing", "language": "en"})()
+            self.im_client = slack
+
+        def get_im_client_for_context(self, context):
+            return slack
+
+    controller = _Controller()
+    service = ProcessingIndicatorService(controller)
+    handle = service.handle_from_snapshot(
+        {
+            "platform": "slack",
+            "user_id": "user-1",
+            "channel_id": "chan-1",
+            "typing_indicator_active": True,
+        }
+    )
+
+    asyncio.run(service.finish(handle))
+
+    assert handle.typing_indicator_active is False
+    assert slack.sent == []
+
+
+def test_processing_indicator_message_delete_policy_comes_from_platform_registry():
+    telegram = _StubClient("telegram")
+
+    class _Controller:
+        def __init__(self):
+            self.config = type("Config", (), {"platform": "telegram", "ack_mode": "message", "language": "en"})()
+            self.im_client = telegram
+
+        def get_im_client_for_context(self, context):
+            return telegram
+
+    service = ProcessingIndicatorService(_Controller())
+    handle = service.handle_from_snapshot(
+        {
+            "platform": "telegram",
+            "user_id": "user-1",
+            "channel_id": "chat-1",
+            "ack_message_id": "ack-1",
+            "ack_message_channel_id": "chat-1",
+        }
+    )
+    request = type("Request", (), {"context": handle.context, "ack_message_id": "ack-1", "processing_indicator": handle})()
+
+    asyncio.run(service.delete_ack_message(request))
+
+    assert request.ack_message_id is None
+    assert handle.ack_message_id is None
+    assert telegram.sent == [("delete", "telegram", "chat-1", "ack-1")]
 
 
 def test_multi_im_client_routes_download_by_file_info_platform():

--- a/tests/test_platform_registry.py
+++ b/tests/test_platform_registry.py
@@ -15,12 +15,16 @@ def test_platform_catalog_exposes_capability_flags() -> None:
     assert catalog["telegram"]["capabilities"]["supports_threads"] is False
     assert catalog["wechat"]["capabilities"]["supports_buttons"] is False
     assert catalog["wechat"]["capabilities"]["supports_channels"] is False
-    assert catalog["wechat"]["capabilities"]["supports_processing_typing"] is True
-    assert catalog["wechat"]["capabilities"]["processing_typing_requires_clear"] is True
+    assert catalog["slack"]["capabilities"]["supports_typing_indicator"] is True
+    assert catalog["slack"]["capabilities"]["typing_indicator_best_effort"] is True
+    assert catalog["telegram"]["capabilities"]["supports_typing_indicator"] is True
+    assert catalog["telegram"]["capabilities"]["typing_indicator_requires_clear"] is False
+    assert catalog["wechat"]["capabilities"]["supports_typing_indicator"] is True
+    assert catalog["wechat"]["capabilities"]["typing_indicator_requires_clear"] is True
     assert catalog["wechat"]["capabilities"]["force_preferred_processing_indicator"] is True
-    assert catalog["lark"]["capabilities"]["supports_processing_typing"] is False
+    assert catalog["lark"]["capabilities"]["supports_typing_indicator"] is False
     assert catalog["lark"]["capabilities"]["preferred_processing_indicator"] == "reaction"
-    assert catalog["telegram"]["capabilities"]["supports_processing_message_delete"] is True
+    assert catalog["telegram"]["capabilities"]["supports_message_indicator_delete"] is True
 
 
 def test_credential_readiness_comes_from_platform_descriptor() -> None:

--- a/tests/test_platform_registry.py
+++ b/tests/test_platform_registry.py
@@ -15,6 +15,12 @@ def test_platform_catalog_exposes_capability_flags() -> None:
     assert catalog["telegram"]["capabilities"]["supports_threads"] is False
     assert catalog["wechat"]["capabilities"]["supports_buttons"] is False
     assert catalog["wechat"]["capabilities"]["supports_channels"] is False
+    assert catalog["wechat"]["capabilities"]["supports_processing_typing"] is True
+    assert catalog["wechat"]["capabilities"]["processing_typing_requires_clear"] is True
+    assert catalog["wechat"]["capabilities"]["force_preferred_processing_indicator"] is True
+    assert catalog["lark"]["capabilities"]["supports_processing_typing"] is False
+    assert catalog["lark"]["capabilities"]["preferred_processing_indicator"] == "reaction"
+    assert catalog["telegram"]["capabilities"]["supports_processing_message_delete"] is True
 
 
 def test_credential_readiness_comes_from_platform_descriptor() -> None:

--- a/tests/test_v2_sessions.py
+++ b/tests/test_v2_sessions.py
@@ -136,6 +136,34 @@ def test_migrate_active_polls_extracts_platform_from_scoped_key(tmp_path, monkey
     assert poll["settings_key"] == "C789"
 
 
+def test_active_poll_persists_typing_cleanup_context(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    store = SessionsStore()
+    sessions = SessionsFacade(store)
+
+    sessions.add_active_poll(
+        opencode_session_id="oc-session-4",
+        base_session_id="base-4",
+        channel_id="wx-chat",
+        thread_id="",
+        settings_key="wx-chat",
+        working_path="/tmp/work",
+        baseline_message_ids=[],
+        typing_indicator_active=True,
+        context_token="ctx-4",
+        user_id="wx-user",
+        platform="wechat",
+    )
+
+    reloaded = SessionsStore()
+    reloaded.load()
+    poll = reloaded.get_active_poll("oc-session-4")
+
+    assert poll is not None
+    assert poll.typing_indicator_active is True
+    assert poll.context_token == "ctx-4"
+
+
 # --- session_mappings migration tests ---
 
 

--- a/tests/test_v2_sessions.py
+++ b/tests/test_v2_sessions.py
@@ -151,6 +151,13 @@ def test_active_poll_persists_typing_cleanup_context(tmp_path, monkeypatch):
         baseline_message_ids=[],
         typing_indicator_active=True,
         context_token="ctx-4",
+        processing_indicator={
+            "platform": "wechat",
+            "user_id": "wx-user",
+            "channel_id": "wx-chat",
+            "context_token": "ctx-4",
+            "typing_indicator_active": True,
+        },
         user_id="wx-user",
         platform="wechat",
     )
@@ -162,6 +169,7 @@ def test_active_poll_persists_typing_cleanup_context(tmp_path, monkeypatch):
     assert poll is not None
     assert poll.typing_indicator_active is True
     assert poll.context_token == "ctx-4"
+    assert poll.processing_indicator["context_token"] == "ctx-4"
 
 
 # --- session_mappings migration tests ---

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -8,11 +8,12 @@ export type PlatformCapabilities = {
   supports_message_editing?: boolean;
   markdown_upload_returns_message_id?: boolean;
   quick_reply_single_column?: boolean;
-  supports_processing_typing?: boolean;
-  processing_typing_requires_clear?: boolean;
-  supports_processing_reaction?: boolean;
-  supports_processing_message?: boolean;
-  supports_processing_message_delete?: boolean;
+  supports_typing_indicator?: boolean;
+  typing_indicator_requires_clear?: boolean;
+  typing_indicator_best_effort?: boolean;
+  supports_reaction_indicator?: boolean;
+  supports_message_indicator?: boolean;
+  supports_message_indicator_delete?: boolean;
   preferred_processing_indicator?: string;
   force_preferred_processing_indicator?: boolean;
 };
@@ -39,9 +40,10 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_buttons: true,
       supports_quick_replies: true,
       supports_message_editing: true,
-      supports_processing_typing: true,
-      supports_processing_reaction: true,
-      supports_processing_message: true,
+      supports_typing_indicator: true,
+      typing_indicator_best_effort: true,
+      supports_reaction_indicator: true,
+      supports_message_indicator: true,
       preferred_processing_indicator: 'typing',
     },
   },
@@ -58,9 +60,9 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_quick_replies: true,
       supports_message_editing: true,
       markdown_upload_returns_message_id: true,
-      supports_processing_typing: true,
-      supports_processing_reaction: true,
-      supports_processing_message: true,
+      supports_typing_indicator: true,
+      supports_reaction_indicator: true,
+      supports_message_indicator: true,
       preferred_processing_indicator: 'typing',
     },
   },
@@ -78,10 +80,10 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_message_editing: true,
       markdown_upload_returns_message_id: true,
       quick_reply_single_column: true,
-      supports_processing_typing: true,
-      supports_processing_reaction: true,
-      supports_processing_message: true,
-      supports_processing_message_delete: true,
+      supports_typing_indicator: true,
+      supports_reaction_indicator: true,
+      supports_message_indicator: true,
+      supports_message_indicator_delete: true,
       preferred_processing_indicator: 'typing',
     },
   },
@@ -99,8 +101,8 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_message_editing: true,
       markdown_upload_returns_message_id: true,
       quick_reply_single_column: true,
-      supports_processing_reaction: true,
-      supports_processing_message: true,
+      supports_reaction_indicator: true,
+      supports_message_indicator: true,
       preferred_processing_indicator: 'reaction',
     },
   },
@@ -116,10 +118,10 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_buttons: false,
       supports_quick_replies: false,
       supports_message_editing: false,
-      supports_processing_typing: true,
-      processing_typing_requires_clear: true,
-      supports_processing_reaction: false,
-      supports_processing_message: true,
+      supports_typing_indicator: true,
+      typing_indicator_requires_clear: true,
+      supports_reaction_indicator: false,
+      supports_message_indicator: true,
       preferred_processing_indicator: 'typing',
       force_preferred_processing_indicator: true,
     },

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -8,6 +8,13 @@ export type PlatformCapabilities = {
   supports_message_editing?: boolean;
   markdown_upload_returns_message_id?: boolean;
   quick_reply_single_column?: boolean;
+  supports_processing_typing?: boolean;
+  processing_typing_requires_clear?: boolean;
+  supports_processing_reaction?: boolean;
+  supports_processing_message?: boolean;
+  supports_processing_message_delete?: boolean;
+  preferred_processing_indicator?: string;
+  force_preferred_processing_indicator?: boolean;
 };
 
 export type PlatformDescriptor = {
@@ -32,6 +39,10 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_buttons: true,
       supports_quick_replies: true,
       supports_message_editing: true,
+      supports_processing_typing: true,
+      supports_processing_reaction: true,
+      supports_processing_message: true,
+      preferred_processing_indicator: 'typing',
     },
   },
   {
@@ -47,6 +58,10 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_quick_replies: true,
       supports_message_editing: true,
       markdown_upload_returns_message_id: true,
+      supports_processing_typing: true,
+      supports_processing_reaction: true,
+      supports_processing_message: true,
+      preferred_processing_indicator: 'typing',
     },
   },
   {
@@ -63,6 +78,11 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_message_editing: true,
       markdown_upload_returns_message_id: true,
       quick_reply_single_column: true,
+      supports_processing_typing: true,
+      supports_processing_reaction: true,
+      supports_processing_message: true,
+      supports_processing_message_delete: true,
+      preferred_processing_indicator: 'typing',
     },
   },
   {
@@ -79,6 +99,9 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_message_editing: true,
       markdown_upload_returns_message_id: true,
       quick_reply_single_column: true,
+      supports_processing_reaction: true,
+      supports_processing_message: true,
+      preferred_processing_indicator: 'reaction',
     },
   },
   {
@@ -93,6 +116,12 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_buttons: false,
       supports_quick_replies: false,
       supports_message_editing: false,
+      supports_processing_typing: true,
+      processing_typing_requires_clear: true,
+      supports_processing_reaction: false,
+      supports_processing_message: true,
+      preferred_processing_indicator: 'typing',
+      force_preferred_processing_indicator: true,
     },
   },
 ];


### PR DESCRIPTION
## What
- Introduce `ProcessingIndicatorService` as the single lifecycle owner for ack messages, ack reactions, and typing indicators.
- Drive processing indicator strategy from platform registry capabilities instead of backend-specific logic or platform string checks.
- Separate platform API facts from ACK policy: typing support, typing explicit-clear requirement, best-effort typing transport, reaction/message indicators, ACK message deletion, and preferred/forced indicator modes.
- Persist a serializable processing-indicator snapshot for restored active polls, including WeChat `context_token`.
- Keep legacy `AgentRequest` fields as a compatibility mirror while lifecycle ownership moves to the handle/service.

## Why
The original fix only covered OpenCode restored polls, but the regression WeChat user can be routed to Claude or Codex. The real issue was architectural: ACK/typing state and policy were split across handler locals, backend cleanup code, mutable request fields, and restored poll persistence.

This PR makes platform capability data the source of truth. Slack and Telegram are both marked typing-capable; Slack typing is marked best-effort because it relies on legacy RTM availability, while Telegram uses Bot API chat actions and auto-expires. WeChat is marked typing-capable with explicit cancel required. Lark is marked as reaction-preferred because the current adapter has no typing API path. All current backends and future backends use the same lifecycle path.

## Validation
- Ruff passed for changed Python files.
- Platform registry + WeChat/multi-platform/session/message-handler tests: 71 passed.
- Backend behavior tests for OpenCode, Codex, Claude, and silent-result cleanup: 63 passed.
- UI build passed.
- Full `pytest` collection still hits existing unrelated import/package issues under e2e/scenario/UI-server tests.

## Risk
Medium. This is intentionally broader than the original hotfix, but it removes duplicated lifecycle policy instead of adding another backend-specific patch. Legacy request fields remain as a compatibility layer to reduce migration risk.
