### PR TITLE
fix(update): add admin update buttons across platforms

### DIFF
--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -238,14 +238,19 @@ class UpdateChecker:
 
             # Notification flow — failure must not block auto-update
             if self.config.notify_admins and self.state.notified_version != latest:
+                delivered = False
                 try:
-                    await self._send_update_notification(current, latest)
-                    # Only record delivery time on success — grace period depends on this
-                    self.state.notified_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                    delivered = await self._send_update_notification(current, latest)
                 except Exception as e:
                     logger.error(f"Failed to send update notification: {e}", exc_info=True)
-                # Always mark version to prevent retry every cycle (even if send failed)
-                self.state.notified_version = latest
+                if delivered:
+                    self.state.notified_version = latest
+                    self.state.notified_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                else:
+                    logger.warning(
+                        "Update notification for %s was not delivered; skipping grace period",
+                        latest,
+                    )
                 self.state.save()
 
             # Auto-update flow — respect a grace period after successful notification
@@ -426,25 +431,27 @@ class UpdateChecker:
 
         return None
 
-    async def _send_update_notification(self, current: str, latest: str) -> None:
+    async def _send_update_notification(self, current: str, latest: str) -> bool:
         """Send update notification to admin users, with platform-specific fallbacks."""
         platform = getattr(self.controller.config, "platform", "slack")
         admin_ids = self._get_admin_user_ids()
 
         if admin_ids:
             # Send DM to each admin via the platform-agnostic send_dm method
-            await self._send_notification_to_admins(admin_ids, current, latest, platform)
+            return await self._send_notification_to_admins(admin_ids, current, latest, platform)
         else:
             # Legacy fallback: no admins configured
             if platform == "slack":
-                await self._send_slack_notification_legacy(current, latest)
+                return await self._send_slack_notification_legacy(current, latest)
             elif platform == "discord":
-                await self._send_discord_notification_fallback(current, latest)
+                return await self._send_discord_notification_fallback(current, latest)
             else:
                 logger.warning("Update notification skipped: no admins and unsupported platform %s", platform)
+                return False
 
-    async def _send_notification_to_admins(self, admin_ids: list, current: str, latest: str, platform: str) -> None:
+    async def _send_notification_to_admins(self, admin_ids: list, current: str, latest: str, platform: str) -> bool:
         """Send update notification DM to each admin user."""
+        delivered = False
         for uid in admin_ids:
             im_client, raw_user_id, user_platform = self._get_im_client_for_user(uid)
             try:
@@ -482,11 +489,13 @@ class UpdateChecker:
                     result = await im_client.send_dm(raw_user_id, text, **kwargs)
 
                 if result:
+                    delivered = True
                     logger.info(f"Sent update notification to admin {uid}")
                 else:
                     logger.warning(f"Failed to send update notification to admin {uid}: send_dm returned None")
             except Exception as e:
                 logger.error(f"Failed to send update notification to admin {uid}: {e}")
+        return delivered
 
     def _supports_admin_update_button(self, platform: str) -> bool:
         """Return whether admin update DMs should include an update button."""
@@ -502,18 +511,18 @@ class UpdateChecker:
             return f"🚀 Vibe Remote Update Available\n\nUpdate from `{current}` → `{latest}`"
         return f"🚀 Vibe Remote Update Available\n\nUpdate from {current} → {latest}"
 
-    async def _send_slack_notification_legacy(self, current: str, latest: str) -> None:
+    async def _send_slack_notification_legacy(self, current: str, latest: str) -> bool:
         """Legacy Slack notification: send to workspace owner when no admins configured."""
         owner_id = await self._get_workspace_owner_id()
         if not owner_id:
             logger.warning("Cannot send update notification: no admins and no workspace owner found")
-            return
+            return False
 
         # Open DM channel first (required for sending messages to users)
         dm_channel = await self._open_dm_channel(owner_id)
         if not dm_channel:
             logger.warning(f"Cannot send update notification: failed to open DM with {owner_id}")
-            return
+            return False
 
         try:
             im_client = self._get_im_client_for_platform("slack")
@@ -544,15 +553,17 @@ class UpdateChecker:
                 channel=dm_channel, text=f"Vibe Remote update available: {current} → {latest}", blocks=blocks
             )
             logger.info(f"Sent update notification to workspace owner {owner_id}")
+            return True
         except Exception as e:
             logger.error(f"Failed to send update notification: {e}")
+            return False
 
-    async def _send_discord_notification_fallback(self, current: str, latest: str) -> None:
+    async def _send_discord_notification_fallback(self, current: str, latest: str) -> bool:
         """Fallback Discord notification: send to first enabled channel when no admins configured."""
         channel_id = self._get_default_notification_channel_id()
         if not channel_id:
             logger.warning("Cannot send update notification: no admins and no enabled channel found")
-            return
+            return False
         try:
             from modules.im import InlineButton, InlineKeyboard, MessageContext
 
@@ -561,12 +572,14 @@ class UpdateChecker:
                 buttons=[[InlineButton(text="Update Now", callback_data=f"vibe_update_now:{latest}")]]
             )
             context = MessageContext(user_id="system", channel_id=channel_id, platform="discord")
-            await self.controller.get_im_client_for_context(context).send_message_with_buttons(
+            message_id = await self.controller.get_im_client_for_context(context).send_message_with_buttons(
                 context, text, keyboard, parse_mode="markdown"
             )
             logger.info("Sent update notification to Discord channel %s", channel_id)
+            return bool(message_id)
         except Exception as e:
             logger.error(f"Failed to send Discord update notification: {e}")
+            return False
 
     def _get_default_notification_channel_id(self) -> Optional[str]:
         if not hasattr(self.controller, "settings_manager"):

--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from config import paths
 from config.v2_config import UpdateConfig
 from config.v2_settings import _infer_channel_platform, _infer_user_platform, _split_scoped_key
-from modules.im import MessageContext
+from modules.im import InlineButton, InlineKeyboard, MessageContext
 from vibe.upgrade import has_newer_version, select_latest_update_version
 
 if TYPE_CHECKING:
@@ -473,12 +473,13 @@ class UpdateChecker:
                         },
                     ]
                     result = await im_client.send_dm(raw_user_id, text, blocks=blocks)
-                elif user_platform == "discord":
-                    text = f"🚀 **Vibe Remote Update Available**\n\nUpdate from `{current}` → `{latest}`"
-                    result = await im_client.send_dm(raw_user_id, text)
                 else:
-                    text = f"🚀 Vibe Remote Update Available\n\nUpdate from {current} → {latest}"
-                    result = await im_client.send_dm(raw_user_id, text)
+                    text = self._format_update_notification_text(current, latest, user_platform)
+                    kwargs: dict[str, Any] = {}
+                    if self._supports_admin_update_button(user_platform):
+                        kwargs["keyboard"] = self._build_update_keyboard(latest)
+                        kwargs["parse_mode"] = "markdown"
+                    result = await im_client.send_dm(raw_user_id, text, **kwargs)
 
                 if result:
                     logger.info(f"Sent update notification to admin {uid}")
@@ -486,6 +487,20 @@ class UpdateChecker:
                     logger.warning(f"Failed to send update notification to admin {uid}: send_dm returned None")
             except Exception as e:
                 logger.error(f"Failed to send update notification to admin {uid}: {e}")
+
+    def _supports_admin_update_button(self, platform: str) -> bool:
+        """Return whether admin update DMs should include an update button."""
+        return platform not in {"wechat", "unknown"}
+
+    def _build_update_keyboard(self, latest: str) -> InlineKeyboard:
+        return InlineKeyboard(buttons=[[InlineButton(text="Update Now", callback_data=f"vibe_update_now:{latest}")]])
+
+    def _format_update_notification_text(self, current: str, latest: str, platform: str) -> str:
+        if platform == "discord":
+            return f"🚀 **Vibe Remote Update Available**\n\nUpdate from `{current}` → `{latest}`"
+        if platform in {"telegram", "lark"}:
+            return f"🚀 Vibe Remote Update Available\n\nUpdate from `{current}` → `{latest}`"
+        return f"🚀 Vibe Remote Update Available\n\nUpdate from {current} → {latest}"
 
     async def _send_slack_notification_legacy(self, current: str, latest: str) -> None:
         """Legacy Slack notification: send to workspace owner when no admins configured."""
@@ -568,7 +583,7 @@ class UpdateChecker:
         return None
 
     async def handle_update_button_click(self, context: MessageContext, target_version: Optional[str] = None) -> None:
-        """Handle update button click for Discord (non-Slack)."""
+        """Handle update button click for non-Slack platforms."""
         im_client = self.controller.get_im_client_for_context(context)
         message_id = context.message_id
         if not message_id:
@@ -598,14 +613,24 @@ class UpdateChecker:
                 return
 
         await im_client.edit_message(context, message_id, text="Updating Vibe Remote...")
-        result = await self._perform_update(target_version, channel_id=context.channel_id, message_id=message_id)
+        platform = context.platform or (context.platform_specific or {}).get("platform")
+        result = await self._perform_update(
+            target_version,
+            channel_id=context.channel_id,
+            message_id=message_id,
+            platform=platform,
+        )
         if not result.get("ok"):
             await im_client.edit_message(context, message_id, text="Upgrade failed. Please check logs.")
         elif not result.get("restarting"):
             await im_client.edit_message(context, message_id, text="Upgrade complete. Please restart Vibe Remote.")
 
     async def _perform_update(
-        self, target_version: str, channel_id: Optional[str] = None, message_id: Optional[str] = None
+        self,
+        target_version: str,
+        channel_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+        platform: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Perform the actual update and restart. Returns do_upgrade result dict."""
         # Prevent concurrent upgrades
@@ -630,7 +655,12 @@ class UpdateChecker:
                 logger.info(f"Upgrade successful: {result['message']}")
                 if result.get("restarting"):
                     # Write marker only if restart is scheduled
-                    self._write_update_marker(target_version, channel_id=channel_id, message_id=message_id)
+                    self._write_update_marker(
+                        target_version,
+                        channel_id=channel_id,
+                        message_id=message_id,
+                        platform=platform,
+                    )
                 else:
                     logger.warning("Upgrade completed without restart; manual restart required")
                 return result
@@ -642,7 +672,11 @@ class UpdateChecker:
                 return result
 
     def _write_update_marker(
-        self, version: str, channel_id: Optional[str] = None, message_id: Optional[str] = None
+        self,
+        version: str,
+        channel_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+        platform: Optional[str] = None,
     ) -> None:
         """Write a marker file to trigger post-update notification."""
         try:
@@ -656,6 +690,8 @@ class UpdateChecker:
             if channel_id and message_id:
                 data["channel_id"] = channel_id
                 data["message_id"] = message_id
+            if platform:
+                data["platform"] = platform
 
             # Atomic write
             with tempfile.NamedTemporaryFile(
@@ -688,9 +724,9 @@ class UpdateChecker:
             # Use the target version from marker (more reliable than __version__ in edge cases)
             target_version = data.get("version", "unknown")
 
-            platform = getattr(self.controller.config, "platform", "slack")
+            platform = data.get("platform") or getattr(self.controller.config, "platform", "slack")
             if channel_id:
-                platform = _infer_channel_platform(channel_id)
+                platform = data.get("platform") or _infer_channel_platform(channel_id)
             im_client = self._get_im_client_for_platform(platform)
             if platform == "discord":
                 success_text = f"✅ Vibe Remote has been updated to `{target_version}`"
@@ -716,15 +752,13 @@ class UpdateChecker:
                     blocks=success_blocks,
                 )
                 logger.info("Updated original message with post-update notification")
-            elif channel_id and message_id and platform == "discord":
+            elif channel_id and message_id:
                 try:
-                    from modules.im import MessageContext
-
-                    context = MessageContext(user_id="system", channel_id=channel_id, platform="discord")
+                    context = MessageContext(user_id="system", channel_id=channel_id, platform=platform)
                     await im_client.edit_message(context, message_id, text=success_text)
-                    logger.info("Updated Discord message with post-update notification")
+                    logger.info("Updated %s message with post-update notification", platform)
                 except Exception as e:
-                    logger.error("Failed to edit Discord update message: %s", e)
+                    logger.error("Failed to edit %s update message: %s", platform, e)
             else:
                 # Fallback: send a new message to admins, or workspace owner
                 admin_ids = self._get_admin_user_ids()
@@ -829,7 +863,10 @@ async def _do_update_from_button(controller: "Controller", channel_id: str, mess
         if version_info.get("has_update"):
             # Perform the update
             result = await update_checker._perform_update(
-                version_info["latest"], channel_id=channel_id, message_id=message_id
+                version_info["latest"],
+                channel_id=channel_id,
+                message_id=message_id,
+                platform="slack",
             )
             if not result.get("ok"):
                 # Update failed, show error

--- a/modules/im/discord.py
+++ b/modules/im/discord.py
@@ -447,7 +447,17 @@ class DiscordBot(BaseIMClient):
                 if user is None:
                     return None
                 dm_channel = user.dm_channel or await user.create_dm()
-                message = await dm_channel.send(content=text)
+                keyboard = kwargs.get("keyboard")
+                view = None
+                if keyboard is not None:
+                    context = MessageContext(
+                        user_id=user_id,
+                        channel_id=str(dm_channel.id),
+                        platform="discord",
+                        platform_specific={"is_dm": True},
+                    )
+                    view = _DiscordButtonView(self, context, keyboard, owner_id=str(uid))
+                message = await dm_channel.send(content=text, view=view)
                 return str(message.id)
             except Exception as e:
                 logger.error("Failed to send DM to Discord user %s: %s", user_id, e)

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -318,7 +318,14 @@ class FeishuBot(BaseIMClient):
                 CreateMessageRequestBody,
             )
 
-            content = self._build_card_json(text)
+            button_rows: Optional[List[List[dict]]] = None
+            keyboard = kwargs.get("keyboard")
+            if keyboard is not None:
+                button_rows = [
+                    [{"text": button.text, "callback_data": button.callback_data} for button in row]
+                    for row in keyboard.buttons
+                ]
+            content = self._build_card_json(text, button_rows)
             body = (
                 CreateMessageRequestBody.builder().receive_id(user_id).msg_type("interactive").content(content).build()
             )
@@ -332,7 +339,12 @@ class FeishuBot(BaseIMClient):
                     response.msg,
                 )
                 return None
-            return response.data.message_id
+            message_id = response.data.message_id
+            self._remember_message_text(message_id, text)
+            chat_id = getattr(response.data, "chat_id", None) or getattr(response.data, "open_chat_id", None)
+            if chat_id:
+                self._dm_chat_ids.add(chat_id)
+            return message_id
         except Exception as e:
             logger.error("Failed to send DM to Feishu user %s: %s", user_id, e)
             return None

--- a/modules/im/telegram.py
+++ b/modules/im/telegram.py
@@ -884,8 +884,17 @@ class TelegramBot(BaseIMClient):
         return {"id": channel_id, "name": name, "type": chat.get("type")}
 
     async def send_dm(self, user_id: str, text: str, **kwargs) -> Optional[str]:
-        context = MessageContext(user_id=user_id, channel_id=user_id, platform="telegram", platform_specific={"is_dm": True})
-        return await self.send_message(context, text)
+        context = MessageContext(
+            user_id=user_id,
+            channel_id=user_id,
+            platform="telegram",
+            platform_specific={"is_dm": True},
+        )
+        keyboard = kwargs.get("keyboard")
+        parse_mode = kwargs.get("parse_mode")
+        if keyboard is not None:
+            return await self.send_message_with_buttons(context, text, keyboard, parse_mode=parse_mode)
+        return await self.send_message(context, text, parse_mode=parse_mode)
 
     def _normalize_reaction_emoji(self, emoji: str) -> Optional[str]:
         normalized = (emoji or "").strip()

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -72,8 +73,9 @@ def test_update_notification_admin_dms_include_buttons_except_wechat(monkeypatch
     controller.im_client = clients["slack"]
     checker = UpdateChecker(controller, UpdateConfig())
 
-    asyncio.run(checker._send_update_notification("1.0.0", "1.0.1"))
+    delivered = asyncio.run(checker._send_update_notification("1.0.0", "1.0.1"))
 
+    assert delivered is True
     slack_kwargs = clients["slack"].dm_calls[0][2]
     assert slack_kwargs["blocks"][1]["elements"][0]["action_id"] == "vibe_update_now"
     assert slack_kwargs["blocks"][1]["elements"][0]["value"] == "1.0.1"
@@ -85,6 +87,58 @@ def test_update_notification_admin_dms_include_buttons_except_wechat(monkeypatch
         assert keyboard.buttons[0][0].callback_data == "vibe_update_now:1.0.1"
 
     assert "keyboard" not in clients["wechat"].dm_calls[0][2]
+
+
+def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    store = SettingsStore.get_instance()
+    store.set_users_for_platform("discord", {"123456789012345678": UserSettings(display_name="Discord", is_admin=True)})
+    store.set_users_for_platform("telegram", {"123456": UserSettings(display_name="Telegram", is_admin=True)})
+    store.save()
+
+    controller = _StubController(store)
+    controller.im_clients = {
+        "discord": _FakeIMClient(message_id=None),
+        "telegram": _FakeIMClient(message_id=None),
+    }
+    checker = UpdateChecker(controller, UpdateConfig())
+
+    delivered = asyncio.run(checker._send_update_notification("1.0.0", "1.0.1"))
+
+    assert delivered is False
+
+
+def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    store = SettingsStore.get_instance()
+    store.set_users_for_platform("discord", {"123456789012345678": UserSettings(display_name="Discord", is_admin=True)})
+    store.save()
+
+    controller = _StubController(store)
+    controller.im_clients = {"discord": _FakeIMClient(message_id=None)}
+    checker = UpdateChecker(controller, UpdateConfig(check_interval_minutes=1, notify_admins=True, auto_update=True))
+    checker.state.last_activity_at = time.time() - 3600
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_pypi_version_sync",
+        lambda: {"current": "1.0.0", "latest": "1.0.1", "has_update": True, "error": None},
+    )
+    monkeypatch.setattr(checker, "_is_idle", lambda: True)
+    performed = []
+
+    async def fake_perform_update(target_version, **kwargs):
+        performed.append((target_version, kwargs))
+        return {"ok": True, "restarting": False, "message": "ok"}
+
+    monkeypatch.setattr(checker, "_perform_update", fake_perform_update)
+
+    asyncio.run(checker._do_check())
+
+    assert checker.state.notified_version is None
+    assert checker.state.notified_at is None
+    assert performed == [("1.0.1", {})]
 
 
 def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path):

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -26,6 +27,17 @@ class _StubController:
         self.settings_manager = _StubSettingsManager(store)
         self.config = type("Config", (), {"platform": "slack"})()
         self.im_client = object()
+        self.im_clients = {}
+
+
+class _FakeIMClient:
+    def __init__(self, message_id="msg-1"):
+        self.message_id = message_id
+        self.dm_calls = []
+
+    async def send_dm(self, user_id: str, text: str, **kwargs):
+        self.dm_calls.append((user_id, text, kwargs))
+        return self.message_id
 
 
 def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
@@ -41,6 +53,52 @@ def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
     admin_ids = checker._get_admin_user_ids()
 
     assert set(admin_ids) == {"slack::U1", "discord::D1"}
+
+
+def test_update_notification_admin_dms_include_buttons_except_wechat(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    store = SettingsStore.get_instance()
+    store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
+    store.set_users_for_platform("discord", {"123456789012345678": UserSettings(display_name="Discord", is_admin=True)})
+    store.set_users_for_platform("telegram", {"123456": UserSettings(display_name="Telegram", is_admin=True)})
+    store.set_users_for_platform("lark", {"ou_admin": UserSettings(display_name="Lark", is_admin=True)})
+    store.set_users_for_platform("wechat", {"wx_admin": UserSettings(display_name="WeChat", is_admin=True)})
+    store.save()
+
+    controller = _StubController(store)
+    clients = {platform: _FakeIMClient() for platform in ["slack", "discord", "telegram", "lark", "wechat"]}
+    controller.im_clients = clients
+    controller.im_client = clients["slack"]
+    checker = UpdateChecker(controller, UpdateConfig())
+
+    asyncio.run(checker._send_update_notification("1.0.0", "1.0.1"))
+
+    slack_kwargs = clients["slack"].dm_calls[0][2]
+    assert slack_kwargs["blocks"][1]["elements"][0]["action_id"] == "vibe_update_now"
+    assert slack_kwargs["blocks"][1]["elements"][0]["value"] == "1.0.1"
+
+    for platform in ["discord", "telegram", "lark"]:
+        kwargs = clients[platform].dm_calls[0][2]
+        keyboard = kwargs["keyboard"]
+        assert keyboard.buttons[0][0].text == "Update Now"
+        assert keyboard.buttons[0][0].callback_data == "vibe_update_now:1.0.1"
+
+    assert "keyboard" not in clients["wechat"].dm_calls[0][2]
+
+
+def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
+
+    checker._write_update_marker("1.0.1", channel_id="123456", message_id="42", platform="telegram")
+
+    marker = tmp_path / "state" / "pending_update_notification.json"
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data["platform"] == "telegram"
+    assert data["channel_id"] == "123456"
+    assert data["message_id"] == "42"
 
 
 def test_stop_returns_cancellable_task(monkeypatch, tmp_path):


### PR DESCRIPTION
## What
- Add the same `Update Now` admin DM action for Discord, Telegram, and Lark update notifications.
- Keep WeChat update admin notifications as plain text because the platform adapter does not support buttons.
- Preserve platform identity in post-restart update markers so non-Slack button flows can update the original IM message after restart.
- Only start the 10-minute manual-update grace period after at least one update notification is actually delivered.

## Why
Previously only Slack admin DMs included an actionable update button. Other platform admins received plain text even though the generic `vibe_update_now:<version>` callback path already existed.

Button delivery should also be best-effort: if every notification fails, that should not delay idle auto-update or mark the version as already notified.

## Validation
- `ruff check core/update_checker.py modules/im/discord.py modules/im/telegram.py modules/im/feishu.py tests/test_update_checker_platforms.py`
- `python3 -m pytest tests/test_update_checker_platforms.py -q`
- `python3 -m pytest tests/test_update_checker_platforms.py tests/test_upgrade_flow.py tests/test_api_save_config_merge.py tests/test_v2_compat_platforms.py tests/test_v2_config_platform_registry.py -q`
- `python3 -m pytest tests/test_auth_pipeline.py tests/test_im_base_auth.py tests/test_message_handler_typing.py tests/test_slack_dm_mentions.py -q`

## Risk
- Discord dynamic buttons still use the existing 15-minute view timeout, which matches the current non-Slack dynamic-button behavior and covers the 10-minute manual update window.
- No behavior change for Web UI updates or WeChat notifications.
