### PR TITLE
fix(handler): route quick reply indicators through strategy

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -503,27 +503,19 @@ class MessageHandler(BaseHandler):
                     except Exception as err:
                         logger.debug(f"Failed to send quick-reply echo message: {err}")
 
-                    # Add ack reaction on the echo message before dispatching.
-                    if quick_reply_echo_id and getattr(self.config, "ack_mode", "typing") == "reaction":
-                        try:
-                            await im_client.add_reaction(
-                                self.controller.processing_indicator.target_context(context),
-                                quick_reply_echo_id,
-                                ":eyes:",
-                            )
-                        except Exception as err:
-                            logger.debug(f"Failed to add quick-reply ack reaction: {err}")
-
-                    # Dispatch as a normal user message (message_id=None to
-                    # bypass dedup — this is a synthetic message, not a real
-                    # platform message that could be replayed).
+                    # Dispatch as a normal user message with message_id=None to
+                    # bypass platform event dedup.  The echo message remains
+                    # available as the processing-indicator reaction target.
+                    reply_payload = dict(context.platform_specific or {})
+                    if quick_reply_echo_id:
+                        reply_payload["processing_indicator_message_id"] = quick_reply_echo_id
                     context_for_reply = MessageContext(
                         user_id=context.user_id,
                         channel_id=context.channel_id,
                         platform=context.platform or (context.platform_specific or {}).get("platform"),
                         thread_id=context.thread_id,
                         message_id=None,
-                        platform_specific=context.platform_specific,
+                        platform_specific=reply_payload or None,
                     )
                     await self.handle_user_message(context_for_reply, reply_text)
 

--- a/core/processing_indicator.py
+++ b/core/processing_indicator.py
@@ -109,10 +109,18 @@ class ProcessingIndicatorService:
         if mode == "typing":
             return capabilities.supports_typing_indicator
         if mode == "reaction":
-            return capabilities.supports_reaction_indicator and bool(context.message_id)
+            return capabilities.supports_reaction_indicator and bool(self._reaction_target_message_id(context))
         if mode == "message":
             return capabilities.supports_message_indicator
         return False
+
+    def _reaction_target_message_id(self, context: MessageContext) -> Optional[str]:
+        payload = context.platform_specific or {}
+        if isinstance(payload, dict):
+            target_id = payload.get("processing_indicator_message_id")
+            if target_id:
+                return str(target_id)
+        return context.message_id
 
     def _candidate_modes(self, capabilities: PlatformCapabilities) -> list[str]:
         preferred = capabilities.preferred_processing_indicator
@@ -221,11 +229,12 @@ class ProcessingIndicatorService:
 
     async def _start_reaction_indicator(self, handle: ProcessingIndicatorHandle) -> bool:
         context = handle.context
-        if not context.message_id:
+        message_id = self._reaction_target_message_id(context)
+        if not message_id:
             return False
         im_client = self._get_im_client(context)
         try:
-            ok = await im_client.add_reaction(context, context.message_id, ":eyes:")
+            ok = await im_client.add_reaction(context, message_id, ":eyes:")
         except Exception as ack_err:
             logger.debug("Failed to add reaction ack: %s", ack_err)
             return False
@@ -234,7 +243,7 @@ class ProcessingIndicatorService:
             logger.info("Ack reaction not applied (platform returned False)")
             return False
 
-        handle.ack_reaction_message_id = context.message_id
+        handle.ack_reaction_message_id = message_id
         handle.ack_reaction_emoji = ":eyes:"
         return True
 

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -484,11 +484,59 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(controller.im_client.removed_keyboards, [("chat1", "lark", "om_123")])
         self.assertEqual(controller.im_client.sent_messages, [("chat1", "Reply: 继续")])
-        self.assertEqual(controller.im_client.reactions, [("chat1", "msg-1", ":eyes:")])
+        self.assertEqual(controller.im_client.reactions, [])
         handler.handle_user_message.assert_awaited_once()
         forwarded_context, forwarded_text = handler.handle_user_message.await_args.args
         self.assertEqual(forwarded_text, "继续")
         self.assertEqual(forwarded_context.platform, "lark")
+        self.assertIsNone(forwarded_context.message_id)
+        self.assertEqual((forwarded_context.platform_specific or {}).get("processing_indicator_message_id"), "msg-1")
+
+    async def test_quick_reply_callback_reaction_uses_echo_as_indicator_target(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="u1",
+            channel_id="chat1",
+            message_id="prompt-msg",
+            platform="slack",
+            platform_specific={"platform": "slack", "is_dm": False},
+        )
+
+        await handler.handle_callback_query(context, "quick_reply:按钮 1")
+
+        self.assertEqual(controller.im_client.removed_keyboards, [("chat1", "slack", "prompt-msg")])
+        self.assertEqual(controller.im_client.sent_messages, [("chat1", "Reply: 按钮 1")])
+        self.assertEqual(controller.im_client.reactions, [("chat1", "msg-1", ":eyes:")])
+        _, request = controller.agent_service.requests[0]
+        self.assertIsNone(request.context.message_id)
+        self.assertEqual(request.ack_reaction_message_id, "msg-1")
+        self.assertIsNone(request.ack_message_id)
+        self.assertFalse(request.typing_indicator_active)
+
+    async def test_quick_reply_callback_typing_uses_global_indicator_strategy(self):
+        controller = _StubController(platform="telegram", ack_mode="typing", typing_result=True)
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="u1",
+            channel_id="chat1",
+            message_id="prompt-msg",
+            platform="telegram",
+            platform_specific={"platform": "telegram", "is_dm": False},
+        )
+
+        await handler.handle_callback_query(context, "quick_reply:按钮 2")
+
+        self.assertEqual(controller.im_client.sent_messages, [("chat1", "Reply: 按钮 2")])
+        self.assertEqual(controller.im_client.reactions, [])
+        self.assertEqual(controller.im_client.typing_calls, [("chat1", "u1")])
+        _, request = controller.agent_service.requests[0]
+        self.assertTrue(request.typing_indicator_active)
+        self.assertIsNone(request.ack_message_id)
+        self.assertIsNone(request.ack_reaction_message_id)
+        await handler._remove_ack_reaction(context, request)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
- Route quick-reply follow-up turns through the shared processing indicator strategy instead of hand-applying a reaction in the callback path.
- Keep the synthetic quick-reply turn dedup-safe with `message_id=None`, while passing the echo message id as the processing indicator reaction target.
- Add regression coverage for quick replies in reaction mode and typing mode.

## Why
Quick-reply callbacks echo the selected answer as a bot message, then dispatch a synthetic user turn. The synthetic turn previously had no `message_id`, so reaction-capable strategies could not find a target and fell back to an ACK message. This made quick replies ignore the global typing/reaction/message strategy.

## Validation
Evidence layers updated:
- unit: `python3 -m pytest tests/test_message_handler_typing.py -q`
- contract: `python3 -m pytest tests/test_message_handler_typing.py tests/test_platform_registry.py tests/test_multi_platform_runtime.py tests/test_v2_sessions.py -q`
- lint: `ruff check core/processing_indicator.py core/handlers/message_handler.py tests/test_message_handler_typing.py`
- scenario: no scenario catalog entry for quick-reply processing indicators yet
- residual manual checks: quick-reply buttons should be verified once in regression on the platforms with buttons

## Risk
- The synthetic quick-reply turn still does not use the echo id as `context.message_id`, so platform event dedup behavior stays unchanged.
- If sending the echo message fails, quick replies retain the previous fallback behavior and may use a message ACK when no reaction target exists.
