### PR TITLE
fix(regression): stop idle cpu spin

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -814,6 +814,7 @@ class SessionHandler(BaseHandler):
         receiver_task = self.receiver_tasks.pop(composite_key, None)
         client = self.claude_sessions.pop(composite_key, None)
         cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
+        self.clear_session_tracking(composite_key)
 
         try:
             # Close the SDK client first so its receive stream can finish normally.
@@ -827,7 +828,6 @@ class SessionHandler(BaseHandler):
         finally:
             if not cleanup_from_receiver:
                 await self._stop_receiver_task(receiver_task, composite_key)
-            self.clear_session_tracking(composite_key)
 
     async def _disconnect_client(self, client, composite_key: str) -> None:
         try:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import time
+from contextlib import suppress
 from typing import Optional, Dict, Any, Tuple
 from uuid import uuid4
 from modules.im import MessageContext
@@ -811,29 +812,32 @@ class SessionHandler(BaseHandler):
 
     async def cleanup_session(self, composite_key: str):
         """Clean up a specific session by composite key"""
-        # Cancel receiver task if exists
-        if composite_key in self.receiver_tasks:
-            task = self.receiver_tasks[composite_key]
-            if not task.done():
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
-                except Exception:
-                    pass
-            del self.receiver_tasks[composite_key]
-            logger.info(f"Cancelled receiver task for session {composite_key}")
+        receiver_task = self.receiver_tasks.pop(composite_key, None)
+        client = self.claude_sessions.pop(composite_key, None)
 
-        # Cleanup Claude session
-        if composite_key in self.claude_sessions:
-            client = self.claude_sessions[composite_key]
+        # Close the SDK client first so its receive stream can finish normally.
+        # Cancelling the receiver first can leave the SDK's anyio cancel scope
+        # retrying cancellation on every event-loop tick.
+        if client is not None:
             try:
                 await client.disconnect()
             except Exception as e:
                 logger.error(f"Error disconnecting Claude session {composite_key}: {e}")
-            del self.claude_sessions[composite_key]
             logger.info(f"Cleaned up Claude session {composite_key}")
+
+        if receiver_task is not None:
+            if not receiver_task.done():
+                with suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
+            if not receiver_task.done():
+                receiver_task.cancel()
+                try:
+                    await receiver_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    pass
+            logger.info(f"Cancelled receiver task for session {composite_key}")
 
         self.clear_session_tracking(composite_key)
 

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import time
-from contextlib import suppress
 from typing import Optional, Dict, Any, Tuple
 from uuid import uuid4
 from modules.im import MessageContext
@@ -827,8 +826,14 @@ class SessionHandler(BaseHandler):
 
         if receiver_task is not None:
             if not receiver_task.done():
-                with suppress(asyncio.TimeoutError):
+                try:
                     await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
+                except asyncio.TimeoutError:
+                    pass
+                except asyncio.CancelledError:
+                    pass
+                except Exception as e:
+                    logger.warning("Claude receiver ended with error during cleanup: %s", e)
             if not receiver_task.done():
                 receiver_task.cancel()
                 try:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -811,44 +811,50 @@ class SessionHandler(BaseHandler):
 
     async def cleanup_session(self, composite_key: str):
         """Clean up a specific session by composite key"""
-        receiver_task = self.receiver_tasks.pop(composite_key, None)
+        receiver_task = self.receiver_tasks.get(composite_key)
         client = self.claude_sessions.pop(composite_key, None)
 
-        # Close the SDK client first so its receive stream can finish normally.
-        # Cancelling the receiver first can leave the SDK's anyio cancel scope
-        # retrying cancellation on every event-loop tick.
-        if client is not None:
-            try:
-                await client.disconnect()
-            except Exception as e:
-                logger.error(f"Error disconnecting Claude session {composite_key}: {e}")
-            logger.info(f"Cleaned up Claude session {composite_key}")
-
-        if receiver_task is not None:
-            receiver_result_retrieved = False
-            if not receiver_task.done():
+        try:
+            # Close the SDK client first so its receive stream can finish normally.
+            # Cancelling the receiver first can leave the SDK's anyio cancel scope
+            # retrying cancellation on every event-loop tick.
+            if client is not None:
                 try:
-                    await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
-                except asyncio.TimeoutError:
-                    pass
-                except asyncio.CancelledError:
-                    pass
+                    await client.disconnect()
                 except Exception as e:
-                    receiver_result_retrieved = True
-                    logger.warning("Claude receiver ended with error during cleanup: %s", e)
-            if receiver_task.done() and not receiver_result_retrieved:
-                self._drain_receiver_task_exception(receiver_task)
-            if not receiver_task.done():
-                receiver_task.cancel()
-                try:
-                    await receiver_task
-                except asyncio.CancelledError:
-                    pass
-                except Exception:
-                    pass
-            logger.info(f"Cancelled receiver task for session {composite_key}")
+                    logger.error(f"Error disconnecting Claude session {composite_key}: {e}")
+                logger.info(f"Cleaned up Claude session {composite_key}")
+        finally:
+            if self.receiver_tasks.get(composite_key) is receiver_task:
+                self.receiver_tasks.pop(composite_key, None)
+            await self._stop_receiver_task(receiver_task, composite_key)
+            self.clear_session_tracking(composite_key)
 
-        self.clear_session_tracking(composite_key)
+    async def _stop_receiver_task(self, receiver_task, composite_key: str) -> None:
+        if receiver_task is None:
+            return
+        receiver_result_retrieved = False
+        if not receiver_task.done():
+            try:
+                await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
+            except asyncio.TimeoutError:
+                pass
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                receiver_result_retrieved = True
+                logger.warning("Claude receiver ended with error during cleanup: %s", e)
+        if receiver_task.done() and not receiver_result_retrieved:
+            self._drain_receiver_task_exception(receiver_task)
+        if not receiver_task.done():
+            receiver_task.cancel()
+            try:
+                await receiver_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+        logger.info(f"Cancelled receiver task for session {composite_key}")
 
     @staticmethod
     def _drain_receiver_task_exception(receiver_task) -> None:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -809,24 +809,45 @@ class SessionHandler(BaseHandler):
                 f"❌ {self._t('error.resumeSubmitFailed', error=str(e))}",
             )
 
-    async def cleanup_session(self, composite_key: str):
+    async def cleanup_session(self, composite_key: str, *, current_receiver_task=None):
         """Clean up a specific session by composite key"""
         receiver_task = self.receiver_tasks.pop(composite_key, None)
         client = self.claude_sessions.pop(composite_key, None)
+        cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
 
         try:
             # Close the SDK client first so its receive stream can finish normally.
             # Cancelling the receiver first can leave the SDK's anyio cancel scope
             # retrying cancellation on every event-loop tick.
             if client is not None:
-                try:
-                    await client.disconnect()
-                except Exception as e:
-                    logger.error(f"Error disconnecting Claude session {composite_key}: {e}")
-                logger.info(f"Cleaned up Claude session {composite_key}")
+                if cleanup_from_receiver:
+                    self._disconnect_client_after_receiver(client, composite_key, receiver_task)
+                else:
+                    await self._disconnect_client(client, composite_key)
         finally:
-            await self._stop_receiver_task(receiver_task, composite_key)
+            if not cleanup_from_receiver:
+                await self._stop_receiver_task(receiver_task, composite_key)
             self.clear_session_tracking(composite_key)
+
+    async def _disconnect_client(self, client, composite_key: str) -> None:
+        try:
+            await client.disconnect()
+        except Exception as e:
+            logger.error(f"Error disconnecting Claude session {composite_key}: {e}")
+        logger.info(f"Cleaned up Claude session {composite_key}")
+
+    def _disconnect_client_after_receiver(self, client, composite_key: str, receiver_task) -> None:
+        async def _run() -> None:
+            if receiver_task is not None:
+                try:
+                    await receiver_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as e:
+                    logger.warning("Claude receiver ended with error before deferred disconnect: %s", e)
+            await self._disconnect_client(client, composite_key)
+
+        asyncio.create_task(_run())
 
     async def _stop_receiver_task(self, receiver_task, composite_key: str) -> None:
         if receiver_task is None:
@@ -926,7 +947,7 @@ class SessionHandler(BaseHandler):
             )
         elif "read() called while another coroutine" in error_msg:
             logger.error(f"Session {composite_key} has concurrent read error - cleaning up")
-            await self.cleanup_session(composite_key)
+            await self.cleanup_session(composite_key, current_receiver_task=asyncio.current_task())
 
             # Notify user and suggest retry
             await self._get_im_client(context).send_message(
@@ -935,7 +956,7 @@ class SessionHandler(BaseHandler):
             )
         elif "Session is broken" in error_msg or "Connection closed" in error_msg or "Connection lost" in error_msg:
             logger.error(f"Session {composite_key} is broken - cleaning up")
-            await self.cleanup_session(composite_key)
+            await self.cleanup_session(composite_key, current_receiver_task=asyncio.current_task())
 
             # Notify user
             await self._get_im_client(context).send_message(

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -825,6 +825,7 @@ class SessionHandler(BaseHandler):
             logger.info(f"Cleaned up Claude session {composite_key}")
 
         if receiver_task is not None:
+            receiver_result_retrieved = False
             if not receiver_task.done():
                 try:
                     await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
@@ -833,7 +834,10 @@ class SessionHandler(BaseHandler):
                 except asyncio.CancelledError:
                     pass
                 except Exception as e:
+                    receiver_result_retrieved = True
                     logger.warning("Claude receiver ended with error during cleanup: %s", e)
+            if receiver_task.done() and not receiver_result_retrieved:
+                self._drain_receiver_task_exception(receiver_task)
             if not receiver_task.done():
                 receiver_task.cancel()
                 try:
@@ -845,6 +849,18 @@ class SessionHandler(BaseHandler):
             logger.info(f"Cancelled receiver task for session {composite_key}")
 
         self.clear_session_tracking(composite_key)
+
+    @staticmethod
+    def _drain_receiver_task_exception(receiver_task) -> None:
+        try:
+            exc = receiver_task.exception()
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            logger.warning("Error reading Claude receiver cleanup result: %s", e)
+            return
+        if exc is not None:
+            logger.warning("Claude receiver ended with error during cleanup: %s", exc)
 
     async def evict_idle_sessions(self, idle_timeout: float) -> int:
         """Disconnect Claude sessions that have been idle beyond the timeout."""

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -811,7 +811,7 @@ class SessionHandler(BaseHandler):
 
     async def cleanup_session(self, composite_key: str):
         """Clean up a specific session by composite key"""
-        receiver_task = self.receiver_tasks.get(composite_key)
+        receiver_task = self.receiver_tasks.pop(composite_key, None)
         client = self.claude_sessions.pop(composite_key, None)
 
         try:
@@ -825,8 +825,6 @@ class SessionHandler(BaseHandler):
                     logger.error(f"Error disconnecting Claude session {composite_key}: {e}")
                 logger.info(f"Cleaned up Claude session {composite_key}")
         finally:
-            if self.receiver_tasks.get(composite_key) is receiver_task:
-                self.receiver_tasks.pop(composite_key, None)
             await self._stop_receiver_task(receiver_task, composite_key)
             self.clear_session_tracking(composite_key)
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -214,9 +214,25 @@ class ClaudeAgent(BaseAgent):
         except Exception as exc:  # noqa: BLE001
             logger.warning("Error disconnecting Claude session %s: %s", composite_key, exc)
 
-    async def _stop_receiver_task(self, receiver_task: asyncio.Task | None) -> None:
-        if receiver_task is None or receiver_task.done():
+    @staticmethod
+    def _drain_receiver_task_exception(receiver_task: asyncio.Task) -> None:
+        try:
+            exc = receiver_task.exception()
+        except asyncio.CancelledError:
             return
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Error reading Claude receiver cleanup result: %s", exc)
+            return
+        if exc is not None:
+            logger.warning("Claude receiver ended with error during cleanup: %s", exc)
+
+    async def _stop_receiver_task(self, receiver_task: asyncio.Task | None) -> None:
+        if receiver_task is None:
+            return
+        if receiver_task.done():
+            self._drain_receiver_task_exception(receiver_task)
+            return
+        receiver_result_retrieved = False
         try:
             await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
         except asyncio.TimeoutError:
@@ -224,8 +240,11 @@ class ClaudeAgent(BaseAgent):
         except asyncio.CancelledError:
             pass
         except Exception as exc:  # noqa: BLE001
+            receiver_result_retrieved = True
             logger.warning("Claude receiver ended with error during cleanup: %s", exc)
         if receiver_task.done():
+            if not receiver_result_retrieved:
+                self._drain_receiver_task_exception(receiver_task)
             return
         receiver_task.cancel()
         try:

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -149,20 +149,7 @@ class ClaudeAgent(BaseAgent):
                 sessions_to_clear.append(composite_id)
 
         for composite_id in sessions_to_clear:
-            client = self.claude_sessions.pop(composite_id, None)
-            if client is not None:
-                await self._disconnect_client(client, composite_id)
-
-            receiver_task = self.receiver_tasks.pop(composite_id, None)
-            await self._stop_receiver_task(receiver_task)
-
-            self._last_assistant_text.pop(composite_id, None)
-            self._pending_assistant_message.pop(composite_id, None)
-            self._pending_reactions.pop(composite_id, None)
-            self._pending_requests.pop(composite_id, None)
-            clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
-            if callable(clear_tracking):
-                clear_tracking(composite_id)
+            await self._cleanup_runtime_session(composite_id)
 
         # Legacy session manager cleanup (best-effort)
         await self.session_manager.clear_session(session_key)
@@ -174,19 +161,7 @@ class ClaudeAgent(BaseAgent):
         session_ids = set(self.claude_sessions.keys()) | set(self.receiver_tasks.keys())
 
         for composite_id in session_ids:
-            receiver_task = self.receiver_tasks.pop(composite_id, None)
-            client = self.claude_sessions.pop(composite_id, None)
-            if client is not None:
-                await self._disconnect_client(client, composite_id)
-            await self._stop_receiver_task(receiver_task)
-
-            self._last_assistant_text.pop(composite_id, None)
-            self._pending_assistant_message.pop(composite_id, None)
-            self._pending_reactions.pop(composite_id, None)
-            self._pending_requests.pop(composite_id, None)
-            clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
-            if callable(clear_tracking):
-                clear_tracking(composite_id)
+            await self._cleanup_runtime_session(composite_id)
 
         logger.info("Refreshed Claude auth state across %d runtime session(s)", len(session_ids))
 
@@ -263,25 +238,28 @@ class ClaudeAgent(BaseAgent):
     ) -> None:
         """Drop Claude runtime state without canceling the current receiver task."""
 
-        receiver_task = self.receiver_tasks.pop(composite_key, None)
+        receiver_task = self.receiver_tasks.get(composite_key)
         client = self.claude_sessions.pop(composite_key, None)
-        if client is not None:
-            # Closing the SDK client first lets the receiver consume the end of
-            # stream. Cancelling it first can leave an anyio cancellation retry
-            # handle spinning in the controller loop.
-            await self._disconnect_client(client, composite_key)
+        try:
+            if client is not None:
+                # Closing the SDK client first lets the receiver consume the end
+                # of stream. Cancelling it first can leave an anyio cancellation
+                # retry handle spinning in the controller loop.
+                await self._disconnect_client(client, composite_key)
+        finally:
+            if self.receiver_tasks.get(composite_key) is receiver_task:
+                self.receiver_tasks.pop(composite_key, None)
+            if receiver_task is not current_receiver_task:
+                await self._stop_receiver_task(receiver_task)
 
-        if receiver_task is not current_receiver_task:
-            await self._stop_receiver_task(receiver_task)
-
-        self._last_assistant_text.pop(composite_key, None)
-        self._pending_assistant_message.pop(composite_key, None)
-        if not preserve_pending_request_state:
-            self._pending_reactions.pop(composite_key, None)
-            self._pending_requests.pop(composite_key, None)
-        clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
-        if callable(clear_tracking):
-            clear_tracking(composite_key)
+            self._last_assistant_text.pop(composite_key, None)
+            self._pending_assistant_message.pop(composite_key, None)
+            if not preserve_pending_request_state:
+                self._pending_reactions.pop(composite_key, None)
+                self._pending_requests.pop(composite_key, None)
+            clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
+            if callable(clear_tracking):
+                clear_tracking(composite_key)
 
     async def handle_stop(self, request: AgentRequest) -> bool:
         composite_key = request.composite_session_id

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -238,7 +238,7 @@ class ClaudeAgent(BaseAgent):
     ) -> None:
         """Drop Claude runtime state without canceling the current receiver task."""
 
-        receiver_task = self.receiver_tasks.get(composite_key)
+        receiver_task = self.receiver_tasks.pop(composite_key, None)
         client = self.claude_sessions.pop(composite_key, None)
         try:
             if client is not None:
@@ -247,8 +247,6 @@ class ClaudeAgent(BaseAgent):
                 # retry handle spinning in the controller loop.
                 await self._disconnect_client(client, composite_key)
         finally:
-            if self.receiver_tasks.get(composite_key) is receiver_task:
-                self.receiver_tasks.pop(composite_key, None)
             if receiver_task is not current_receiver_task:
                 await self._stop_receiver_task(receiver_task)
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -189,6 +189,24 @@ class ClaudeAgent(BaseAgent):
         except Exception as exc:  # noqa: BLE001
             logger.warning("Error disconnecting Claude session %s: %s", composite_key, exc)
 
+    def _disconnect_client_after_receiver(
+        self,
+        client,
+        composite_key: str,
+        receiver_task: asyncio.Task | None,
+    ) -> None:
+        async def _run() -> None:
+            if receiver_task is not None:
+                try:
+                    await receiver_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Claude receiver ended with error before deferred disconnect: %s", exc)
+            await self._disconnect_client(client, composite_key)
+
+        asyncio.create_task(_run())
+
     @staticmethod
     def _drain_receiver_task_exception(receiver_task: asyncio.Task) -> None:
         try:
@@ -240,14 +258,18 @@ class ClaudeAgent(BaseAgent):
 
         receiver_task = self.receiver_tasks.pop(composite_key, None)
         client = self.claude_sessions.pop(composite_key, None)
+        cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
         try:
             if client is not None:
                 # Closing the SDK client first lets the receiver consume the end
                 # of stream. Cancelling it first can leave an anyio cancellation
                 # retry handle spinning in the controller loop.
-                await self._disconnect_client(client, composite_key)
+                if cleanup_from_receiver:
+                    self._disconnect_client_after_receiver(client, composite_key, receiver_task)
+                else:
+                    await self._disconnect_client(client, composite_key)
         finally:
-            if receiver_task is not current_receiver_task:
+            if not cleanup_from_receiver:
                 await self._stop_receiver_task(receiver_task)
 
             self._last_assistant_text.pop(composite_key, None)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-from contextlib import suppress
 from typing import Callable, Optional
 
 from core.agent_auth_service import classify_auth_error
@@ -218,8 +217,14 @@ class ClaudeAgent(BaseAgent):
     async def _stop_receiver_task(self, receiver_task: asyncio.Task | None) -> None:
         if receiver_task is None or receiver_task.done():
             return
-        with suppress(asyncio.TimeoutError):
+        try:
             await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
+        except asyncio.TimeoutError:
+            pass
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Claude receiver ended with error during cleanup: %s", exc)
         if receiver_task.done():
             return
         receiver_task.cancel()

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -259,6 +259,14 @@ class ClaudeAgent(BaseAgent):
         receiver_task = self.receiver_tasks.pop(composite_key, None)
         client = self.claude_sessions.pop(composite_key, None)
         cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
+        self._last_assistant_text.pop(composite_key, None)
+        self._pending_assistant_message.pop(composite_key, None)
+        if not preserve_pending_request_state:
+            self._pending_reactions.pop(composite_key, None)
+            self._pending_requests.pop(composite_key, None)
+        clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
+        if callable(clear_tracking):
+            clear_tracking(composite_key)
         try:
             if client is not None:
                 # Closing the SDK client first lets the receiver consume the end
@@ -271,15 +279,6 @@ class ClaudeAgent(BaseAgent):
         finally:
             if not cleanup_from_receiver:
                 await self._stop_receiver_task(receiver_task)
-
-            self._last_assistant_text.pop(composite_key, None)
-            self._pending_assistant_message.pop(composite_key, None)
-            if not preserve_pending_request_state:
-                self._pending_reactions.pop(composite_key, None)
-                self._pending_requests.pop(composite_key, None)
-            clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
-            if callable(clear_tracking):
-                clear_tracking(composite_key)
 
     async def handle_stop(self, request: AgentRequest) -> bool:
         composite_key = request.composite_session_id

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -388,7 +388,7 @@ class ClaudeAgent(BaseAgent):
                             await self._clear_pending_reactions(composite_key, context)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
-                            continue
+                            return
                         if assistant_text:
                             self._last_assistant_text[composite_key] = assistant_text
 
@@ -455,7 +455,7 @@ class ClaudeAgent(BaseAgent):
                             if callable(mark_session_idle):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
-                            continue
+                            return
                         if formatted_message and formatted_message.strip():
                             await self.controller.emit_agent_message(
                                 context,
@@ -487,7 +487,7 @@ class ClaudeAgent(BaseAgent):
                             await self._clear_pending_reactions(composite_key, context)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
-                            continue
+                            return
 
                         # NOTE: The pending assistant message is intentionally
                         # NOT emitted here.  ResultMessage.result already

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from contextlib import suppress
 from typing import Callable, Optional
 
 from core.agent_auth_service import classify_auth_error
@@ -149,31 +150,20 @@ class ClaudeAgent(BaseAgent):
                 sessions_to_clear.append(composite_id)
 
         for composite_id in sessions_to_clear:
-            try:
-                client = self.claude_sessions[composite_id]
-                if hasattr(client, "close"):
-                    await client.close()
-            except Exception as e:
-                logger.warning(f"Error closing Claude session {composite_id}: {e}")
-            finally:
-                self.claude_sessions.pop(composite_id, None)
-                receiver_task = self.receiver_tasks.pop(composite_id, None)
-                if receiver_task is not None:
-                    receiver_task.cancel()
-                    try:
-                        await receiver_task
-                    except asyncio.CancelledError:
-                        pass
-                    except Exception as task_err:
-                        logger.warning(f"Error stopping Claude receiver {composite_id}: {task_err}")
+            client = self.claude_sessions.pop(composite_id, None)
+            if client is not None:
+                await self._disconnect_client(client, composite_id)
 
-                self._last_assistant_text.pop(composite_id, None)
-                self._pending_assistant_message.pop(composite_id, None)
-                self._pending_reactions.pop(composite_id, None)
-                self._pending_requests.pop(composite_id, None)
-                clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
-                if callable(clear_tracking):
-                    clear_tracking(composite_id)
+            receiver_task = self.receiver_tasks.pop(composite_id, None)
+            await self._stop_receiver_task(receiver_task)
+
+            self._last_assistant_text.pop(composite_id, None)
+            self._pending_assistant_message.pop(composite_id, None)
+            self._pending_reactions.pop(composite_id, None)
+            self._pending_requests.pop(composite_id, None)
+            clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
+            if callable(clear_tracking):
+                clear_tracking(composite_id)
 
         # Legacy session manager cleanup (best-effort)
         await self.session_manager.clear_session(session_key)
@@ -186,24 +176,10 @@ class ClaudeAgent(BaseAgent):
 
         for composite_id in session_ids:
             receiver_task = self.receiver_tasks.pop(composite_id, None)
-            if receiver_task is not None and not receiver_task.done():
-                receiver_task.cancel()
-                try:
-                    await receiver_task
-                except asyncio.CancelledError:
-                    pass
-                except Exception as exc:
-                    logger.warning("Error stopping Claude receiver %s during auth refresh: %s", composite_id, exc)
-
             client = self.claude_sessions.pop(composite_id, None)
             if client is not None:
-                try:
-                    if hasattr(client, "disconnect"):
-                        await client.disconnect()
-                    elif hasattr(client, "close"):
-                        await client.close()
-                except Exception as exc:
-                    logger.warning("Error disconnecting Claude session %s during auth refresh: %s", composite_id, exc)
+                await self._disconnect_client(client, composite_id)
+            await self._stop_receiver_task(receiver_task)
 
             self._last_assistant_text.pop(composite_id, None)
             self._pending_assistant_message.pop(composite_id, None)
@@ -230,6 +206,30 @@ class ClaudeAgent(BaseAgent):
         await self._cleanup_runtime_session(composite_key)
         logger.info("Prepared Claude runtime for resumed session %s", composite_key)
 
+    async def _disconnect_client(self, client, composite_key: str) -> None:
+        try:
+            if hasattr(client, "disconnect"):
+                await client.disconnect()
+            elif hasattr(client, "close"):
+                await client.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Error disconnecting Claude session %s: %s", composite_key, exc)
+
+    async def _stop_receiver_task(self, receiver_task: asyncio.Task | None) -> None:
+        if receiver_task is None or receiver_task.done():
+            return
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(receiver_task), timeout=0.1)
+        if receiver_task.done():
+            return
+        receiver_task.cancel()
+        try:
+            await receiver_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Error stopping Claude receiver during cleanup: %s", exc)
+
     async def _cleanup_runtime_session(
         self,
         composite_key: str,
@@ -240,28 +240,15 @@ class ClaudeAgent(BaseAgent):
         """Drop Claude runtime state without canceling the current receiver task."""
 
         receiver_task = self.receiver_tasks.pop(composite_key, None)
-        if (
-            receiver_task is not None
-            and receiver_task is not current_receiver_task
-            and not receiver_task.done()
-        ):
-            receiver_task.cancel()
-            try:
-                await receiver_task
-            except asyncio.CancelledError:
-                pass
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("Error stopping Claude receiver %s during cleanup: %s", composite_key, exc)
-
         client = self.claude_sessions.pop(composite_key, None)
         if client is not None:
-            try:
-                if hasattr(client, "disconnect"):
-                    await client.disconnect()
-                elif hasattr(client, "close"):
-                    await client.close()
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("Error disconnecting Claude session %s during cleanup: %s", composite_key, exc)
+            # Closing the SDK client first lets the receiver consume the end of
+            # stream. Cancelling it first can leave an anyio cancellation retry
+            # handle spinning in the controller loop.
+            await self._disconnect_client(client, composite_key)
+
+        if receiver_task is not current_receiver_task:
+            await self._stop_receiver_task(receiver_task)
 
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)

--- a/modules/im/wechat_api.py
+++ b/modules/im/wechat_api.py
@@ -179,7 +179,7 @@ async def get_updates(
     headers = _build_headers(token=token, body_bytes=body_bytes)
 
     timeout = aiohttp.ClientTimeout(total=(timeout_ms + DEFAULT_LONG_POLL_TIMEOUT_GRACE_MS) / 1000.0)
-    logger.info(
+    logger.debug(
         "get_updates: POST %s token=%s timeout=%dms buf_len=%d",
         url,
         _redact_token(token),
@@ -191,7 +191,7 @@ async def get_updates(
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(url, data=body_bytes, headers=headers) as resp:
                 raw_text = await resp.text()
-                logger.info(
+                logger.debug(
                     "getUpdates: status=%d body_len=%d raw=%s",
                     resp.status,
                     len(raw_text) if raw_text else 0,

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -557,6 +557,55 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(composite_key, controller.claude_sessions)
         agent.emit_result_message.assert_not_awaited()
 
+    async def test_result_auth_error_exits_receiver_and_disconnects_client(self):
+        controller = _StubController()
+        controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)
+        controller._get_session_key = lambda context: "telegram::user::U1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent._clear_pending_reactions = AsyncMock()
+        context = SimpleNamespace()
+        composite_key = "session-1:/tmp/work"
+        disconnect_started = asyncio.Event()
+
+        ResultMessage = type("ResultMessage", (), {})
+        init_message = type(
+            "SystemMessage",
+            (),
+            {"subtype": "init", "data": {"session_id": "session-sdk"}},
+        )()
+        error_result = ResultMessage()
+        error_result.subtype = "error"
+        error_result.result = (
+            'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error",'
+            '"message":"Invalid bearer token"}}'
+        )
+        error_result.duration_ms = 0
+
+        class _Client:
+            async def disconnect(self):
+                disconnect_started.set()
+
+            def receive_messages(self):
+                async def _iterate():
+                    yield init_message
+                    yield error_result
+                    await asyncio.Future()
+
+                return _iterate()
+
+        client = _Client()
+        controller.claude_sessions[composite_key] = client
+        receiver_task = asyncio.create_task(agent._receive_messages(client, "session-1", "/tmp/work", context))
+        controller.receiver_tasks[composite_key] = receiver_task
+
+        await asyncio.wait_for(receiver_task, timeout=1)
+        await asyncio.wait_for(disconnect_started.wait(), timeout=1)
+
+        controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
+        self.assertNotIn(composite_key, controller.receiver_tasks)
+        self.assertNotIn(composite_key, controller.claude_sessions)
+
     async def test_assistant_auth_error_prefers_oauth_recovery_message(self):
         controller = _StubController()
         controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -308,6 +308,45 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(session_key, controller.claude_sessions)
         self.assertEqual(controller.session_manager.cleared, ["wechat-user"])
 
+    async def test_cleanup_runtime_session_cancels_receiver_when_disconnect_is_cancelled(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        session_key = "wechat_o9:/tmp/work"
+        disconnect_started = asyncio.Event()
+        receiver_cancelled = asyncio.Event()
+
+        class _SlowDisconnectClient(_StubClient):
+            async def disconnect(self):
+                self.disconnected = True
+                disconnect_started.set()
+                await asyncio.Future()
+
+        client = _SlowDisconnectClient()
+        controller.claude_sessions[session_key] = client
+
+        async def _receiver():
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                receiver_cancelled.set()
+                raise
+
+        receiver_task = asyncio.create_task(_receiver())
+        controller.receiver_tasks[session_key] = receiver_task
+        cleanup_task = asyncio.create_task(agent._cleanup_runtime_session(session_key))
+
+        await disconnect_started.wait()
+        self.assertIs(controller.receiver_tasks[session_key], receiver_task)
+
+        cleanup_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await cleanup_task
+
+        self.assertTrue(client.disconnected)
+        self.assertTrue(receiver_cancelled.is_set())
+        self.assertNotIn(session_key, controller.receiver_tasks)
+        self.assertNotIn(session_key, controller.claude_sessions)
+
     async def test_refresh_auth_state_disconnects_runtime_sessions(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -353,6 +353,8 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         session_key = "wechat_o9:/tmp/work"
         disconnect_started = asyncio.Event()
         old_receiver_cancelled = asyncio.Event()
+        clear_tracking_calls = []
+        controller.session_handler.clear_session_tracking = lambda key: clear_tracking_calls.append(key)
 
         class _SlowDisconnectClient(_StubClient):
             async def disconnect(self):
@@ -372,12 +374,28 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         old_receiver = asyncio.create_task(_old_receiver())
         new_receiver = asyncio.create_task(asyncio.sleep(3600))
+        old_request = SimpleNamespace(name="old")
+        agent._pending_requests[session_key] = [old_request]
+        agent._pending_reactions[session_key] = [("old", ":eyes:")]
+        agent._last_assistant_text[session_key] = "old text"
+        agent._pending_assistant_message[session_key] = "old assistant"
         controller.receiver_tasks[session_key] = old_receiver
         cleanup_task = asyncio.create_task(agent._cleanup_runtime_session(session_key))
 
         await disconnect_started.wait()
         self.assertNotIn(session_key, controller.receiver_tasks)
+        self.assertNotIn(session_key, agent._pending_requests)
+        self.assertNotIn(session_key, agent._pending_reactions)
+        self.assertNotIn(session_key, agent._last_assistant_text)
+        self.assertNotIn(session_key, agent._pending_assistant_message)
+        self.assertEqual(clear_tracking_calls, [session_key])
+
+        new_request = SimpleNamespace(name="new")
         controller.receiver_tasks[session_key] = new_receiver
+        agent._pending_requests[session_key] = [new_request]
+        agent._pending_reactions[session_key] = [("new", ":eyes:")]
+        agent._last_assistant_text[session_key] = "new text"
+        agent._pending_assistant_message[session_key] = "new assistant"
 
         cleanup_task.cancel()
         with self.assertRaises(asyncio.CancelledError):
@@ -385,6 +403,10 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(old_receiver_cancelled.is_set())
         self.assertIs(controller.receiver_tasks[session_key], new_receiver)
+        self.assertEqual(agent._pending_requests[session_key], [new_request])
+        self.assertEqual(agent._pending_reactions[session_key], [("new", ":eyes:")])
+        self.assertEqual(agent._last_assistant_text[session_key], "new text")
+        self.assertEqual(agent._pending_assistant_message[session_key], "new assistant")
         new_receiver.cancel()
         with self.assertRaises(asyncio.CancelledError):
             await new_receiver

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -278,6 +278,36 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(session_key, controller.claude_sessions)
         self.assertEqual(controller.session_manager.cleared, ["wechat-user"])
 
+    async def test_clear_sessions_drains_finished_receiver_task_failure(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        session_key = "wechat_o9:/tmp/work"
+        client = _StubClient()
+        controller.claude_sessions[session_key] = client
+
+        class _DoneReceiverTask:
+            drained = False
+
+            @staticmethod
+            def done():
+                return True
+
+            def exception(self):
+                self.drained = True
+                return RuntimeError("receiver already failed")
+
+        receiver_task = _DoneReceiverTask()
+        controller.receiver_tasks[session_key] = receiver_task
+
+        cleared = await agent.clear_sessions("wechat-user")
+
+        self.assertEqual(cleared, 1)
+        self.assertTrue(client.disconnected)
+        self.assertTrue(receiver_task.drained)
+        self.assertNotIn(session_key, controller.receiver_tasks)
+        self.assertNotIn(session_key, controller.claude_sessions)
+        self.assertEqual(controller.session_manager.cleared, ["wechat-user"])
+
     async def test_refresh_auth_state_disconnects_runtime_sessions(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -389,6 +389,42 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(asyncio.CancelledError):
             await new_receiver
 
+    async def test_cleanup_runtime_session_defers_disconnect_for_current_receiver(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        session_key = "wechat_o9:/tmp/work"
+        cleanup_returned = asyncio.Event()
+        disconnect_started = asyncio.Event()
+        release_disconnect = asyncio.Event()
+
+        class _SlowDisconnectClient(_StubClient):
+            async def disconnect(self):
+                self.disconnected = True
+                disconnect_started.set()
+                await release_disconnect.wait()
+
+        client = _SlowDisconnectClient()
+        controller.claude_sessions[session_key] = client
+
+        async def _receiver():
+            await agent._cleanup_runtime_session(
+                session_key,
+                current_receiver_task=asyncio.current_task(),
+            )
+            cleanup_returned.set()
+
+        receiver_task = asyncio.create_task(_receiver())
+        controller.receiver_tasks[session_key] = receiver_task
+
+        await cleanup_returned.wait()
+        self.assertNotIn(session_key, controller.receiver_tasks)
+        self.assertNotIn(session_key, controller.claude_sessions)
+
+        await disconnect_started.wait()
+        self.assertTrue(client.disconnected)
+        release_disconnect.set()
+        await asyncio.sleep(0)
+
     async def test_refresh_auth_state_disconnects_runtime_sessions(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -336,7 +336,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         cleanup_task = asyncio.create_task(agent._cleanup_runtime_session(session_key))
 
         await disconnect_started.wait()
-        self.assertIs(controller.receiver_tasks[session_key], receiver_task)
+        self.assertNotIn(session_key, controller.receiver_tasks)
 
         cleanup_task.cancel()
         with self.assertRaises(asyncio.CancelledError):
@@ -346,6 +346,48 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(receiver_cancelled.is_set())
         self.assertNotIn(session_key, controller.receiver_tasks)
         self.assertNotIn(session_key, controller.claude_sessions)
+
+    async def test_cleanup_runtime_session_preserves_new_receiver_during_disconnect(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        session_key = "wechat_o9:/tmp/work"
+        disconnect_started = asyncio.Event()
+        old_receiver_cancelled = asyncio.Event()
+
+        class _SlowDisconnectClient(_StubClient):
+            async def disconnect(self):
+                self.disconnected = True
+                disconnect_started.set()
+                await asyncio.Future()
+
+        client = _SlowDisconnectClient()
+        controller.claude_sessions[session_key] = client
+
+        async def _old_receiver():
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                old_receiver_cancelled.set()
+                raise
+
+        old_receiver = asyncio.create_task(_old_receiver())
+        new_receiver = asyncio.create_task(asyncio.sleep(3600))
+        controller.receiver_tasks[session_key] = old_receiver
+        cleanup_task = asyncio.create_task(agent._cleanup_runtime_session(session_key))
+
+        await disconnect_started.wait()
+        self.assertNotIn(session_key, controller.receiver_tasks)
+        controller.receiver_tasks[session_key] = new_receiver
+
+        cleanup_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await cleanup_task
+
+        self.assertTrue(old_receiver_cancelled.is_set())
+        self.assertIs(controller.receiver_tasks[session_key], new_receiver)
+        new_receiver.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await new_receiver
 
     async def test_refresh_auth_state_disconnects_runtime_sessions(self):
         controller = _StubController()

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -243,7 +243,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         cleared = await agent.clear_sessions("wechat-user")
 
         self.assertEqual(cleared, 1)
-        self.assertTrue(client.closed)
+        self.assertTrue(client.disconnected)
         self.assertTrue(task_cancelled.is_set())
         self.assertNotIn(session_key, controller.receiver_tasks)
         self.assertNotIn(session_key, controller.claude_sessions)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -249,6 +249,35 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(session_key, controller.claude_sessions)
         self.assertEqual(controller.session_manager.cleared, ["wechat-user"])
 
+    async def test_clear_sessions_swallows_receiver_task_failure(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        session_key = "wechat_o9:/tmp/work"
+        client = _StubClient()
+        controller.claude_sessions[session_key] = client
+        disconnected = asyncio.Event()
+
+        async def _disconnect():
+            client.disconnected = True
+            disconnected.set()
+
+        client.disconnect = _disconnect
+
+        async def _receiver():
+            await disconnected.wait()
+            raise RuntimeError("receiver failed")
+
+        controller.receiver_tasks[session_key] = asyncio.create_task(_receiver())
+        await asyncio.sleep(0)
+
+        cleared = await agent.clear_sessions("wechat-user")
+
+        self.assertEqual(cleared, 1)
+        self.assertTrue(client.disconnected)
+        self.assertNotIn(session_key, controller.receiver_tasks)
+        self.assertNotIn(session_key, controller.claude_sessions)
+        self.assertEqual(controller.session_manager.cleared, ["wechat-user"])
+
     async def test_refresh_auth_state_disconnects_runtime_sessions(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -680,7 +680,7 @@ def test_cleanup_session_cancels_receiver_when_disconnect_is_cancelled(monkeypat
         cleanup_task = asyncio.create_task(handler.cleanup_session(composite_key))
 
         await events["disconnect_started"].wait()
-        assert controller.receiver_tasks[composite_key] is receiver_task
+        assert composite_key not in controller.receiver_tasks
 
         cleanup_task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -692,6 +692,67 @@ def test_cleanup_session_cancels_receiver_when_disconnect_is_cancelled(monkeypat
     asyncio.run(_exercise_cleanup())
 
     assert composite_key not in controller.receiver_tasks
+    assert composite_key not in controller.claude_sessions
+
+
+def test_cleanup_session_preserves_new_receiver_during_disconnect(monkeypatch, tmp_path: Path) -> None:
+    events = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+            events["disconnect_started"].set()
+            await asyncio.Future()
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    composite_key = f"slack_C123:{tmp_path}"
+
+    async def _exercise_cleanup() -> None:
+        events["disconnect_started"] = asyncio.Event()
+        events["old_receiver_cancelled"] = asyncio.Event()
+        await handler.get_or_create_claude_session(context)
+
+        async def _old_receiver():
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                events["old_receiver_cancelled"].set()
+                raise
+
+        old_receiver = asyncio.create_task(_old_receiver())
+        new_receiver = asyncio.create_task(asyncio.sleep(3600))
+        controller.receiver_tasks[composite_key] = old_receiver
+        cleanup_task = asyncio.create_task(handler.cleanup_session(composite_key))
+
+        await events["disconnect_started"].wait()
+        assert composite_key not in controller.receiver_tasks
+        controller.receiver_tasks[composite_key] = new_receiver
+
+        cleanup_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cleanup_task
+
+        assert events["old_receiver_cancelled"].is_set()
+        assert controller.receiver_tasks[composite_key] is new_receiver
+        new_receiver.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await new_receiver
+
+    asyncio.run(_exercise_cleanup())
+
+    assert composite_key in controller.receiver_tasks
+    controller.receiver_tasks.pop(composite_key, None)
     assert composite_key not in controller.claude_sessions
 
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -556,6 +556,49 @@ def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path:
     assert composite_key not in controller.claude_sessions
 
 
+def test_cleanup_session_swallows_receiver_task_failure(monkeypatch, tmp_path: Path) -> None:
+    events = []
+    disconnected = asyncio.Event()
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            events.append("disconnect")
+            self.disconnects += 1
+            disconnected.set()
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    client = _run_session(handler, context)
+    composite_key = f"slack_C123:{tmp_path}"
+
+    async def _exercise_cleanup() -> None:
+        async def _receiver():
+            await disconnected.wait()
+            events.append("receiver-error")
+            raise RuntimeError("receiver failed")
+
+        controller.receiver_tasks[composite_key] = asyncio.create_task(_receiver())
+        await asyncio.sleep(0)
+        await handler.cleanup_session(composite_key)
+
+    asyncio.run(_exercise_cleanup())
+
+    assert client.disconnects == 1
+    assert events == ["disconnect", "receiver-error"]
+    assert composite_key not in controller.receiver_tasks
+    assert composite_key not in controller.claude_sessions
+
+
 def test_evict_idle_sessions_rechecks_active_state_before_cleanup(monkeypatch, tmp_path: Path) -> None:
     class _StubClaudeSDKClient:
         def __init__(self, options):

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -514,6 +514,8 @@ def test_session_handler_keeps_active_claude_session(monkeypatch, tmp_path: Path
 
 
 def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path: Path) -> None:
+    events = []
+
     class _StubClaudeSDKClient:
         def __init__(self, options):
             self.disconnects = 0
@@ -522,6 +524,7 @@ def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path:
             return None
 
         async def disconnect(self) -> None:
+            events.append("disconnect")
             self.disconnects += 1
 
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
@@ -535,7 +538,11 @@ def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path:
 
     async def _exercise_cleanup() -> None:
         async def _receiver():
-            await asyncio.Future()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                events.append("cancel")
+                raise
 
         controller.receiver_tasks[composite_key] = asyncio.create_task(_receiver())
         await asyncio.sleep(0)
@@ -544,6 +551,7 @@ def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path:
     asyncio.run(_exercise_cleanup())
 
     assert client.disconnects == 1
+    assert events == ["disconnect", "cancel"]
     assert composite_key not in controller.receiver_tasks
     assert composite_key not in controller.claude_sessions
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -733,11 +733,15 @@ def test_cleanup_session_preserves_new_receiver_during_disconnect(monkeypatch, t
         old_receiver = asyncio.create_task(_old_receiver())
         new_receiver = asyncio.create_task(asyncio.sleep(3600))
         controller.receiver_tasks[composite_key] = old_receiver
+        handler.mark_session_active(composite_key)
         cleanup_task = asyncio.create_task(handler.cleanup_session(composite_key))
 
         await events["disconnect_started"].wait()
         assert composite_key not in controller.receiver_tasks
+        assert composite_key not in handler.active_sessions
+        assert composite_key not in handler.session_last_activity
         controller.receiver_tasks[composite_key] = new_receiver
+        handler.mark_session_active(composite_key)
 
         cleanup_task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -745,6 +749,8 @@ def test_cleanup_session_preserves_new_receiver_during_disconnect(monkeypatch, t
 
         assert events["old_receiver_cancelled"].is_set()
         assert controller.receiver_tasks[composite_key] is new_receiver
+        assert composite_key in handler.active_sessions
+        assert composite_key in handler.session_last_activity
         new_receiver.cancel()
         with pytest.raises(asyncio.CancelledError):
             await new_receiver

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -599,6 +599,47 @@ def test_cleanup_session_swallows_receiver_task_failure(monkeypatch, tmp_path: P
     assert composite_key not in controller.claude_sessions
 
 
+def test_cleanup_session_drains_finished_receiver_task_failure(monkeypatch, tmp_path: Path) -> None:
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    class _DoneReceiverTask:
+        drained = False
+
+        @staticmethod
+        def done():
+            return True
+
+        def exception(self):
+            self.drained = True
+            return RuntimeError("receiver already failed")
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    client = _run_session(handler, context)
+    composite_key = f"slack_C123:{tmp_path}"
+    receiver_task = _DoneReceiverTask()
+    controller.receiver_tasks[composite_key] = receiver_task
+
+    asyncio.run(handler.cleanup_session(composite_key))
+
+    assert client.disconnects == 1
+    assert receiver_task.drained
+    assert composite_key not in controller.receiver_tasks
+    assert composite_key not in controller.claude_sessions
+
+
 def test_evict_idle_sessions_rechecks_active_state_before_cleanup(monkeypatch, tmp_path: Path) -> None:
     class _StubClaudeSDKClient:
         def __init__(self, options):

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -640,6 +640,61 @@ def test_cleanup_session_drains_finished_receiver_task_failure(monkeypatch, tmp_
     assert composite_key not in controller.claude_sessions
 
 
+def test_cleanup_session_cancels_receiver_when_disconnect_is_cancelled(monkeypatch, tmp_path: Path) -> None:
+    events = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+            events["disconnect_started"].set()
+            await asyncio.Future()
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    composite_key = f"slack_C123:{tmp_path}"
+
+    async def _exercise_cleanup() -> None:
+        events["disconnect_started"] = asyncio.Event()
+        events["receiver_cancelled"] = asyncio.Event()
+        client = await handler.get_or_create_claude_session(context)
+
+        async def _receiver():
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                events["receiver_cancelled"].set()
+                raise
+
+        receiver_task = asyncio.create_task(_receiver())
+        controller.receiver_tasks[composite_key] = receiver_task
+        cleanup_task = asyncio.create_task(handler.cleanup_session(composite_key))
+
+        await events["disconnect_started"].wait()
+        assert controller.receiver_tasks[composite_key] is receiver_task
+
+        cleanup_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cleanup_task
+
+        assert client.disconnects == 1
+        assert events["receiver_cancelled"].is_set()
+
+    asyncio.run(_exercise_cleanup())
+
+    assert composite_key not in controller.receiver_tasks
+    assert composite_key not in controller.claude_sessions
+
+
 def test_evict_idle_sessions_rechecks_active_state_before_cleanup(monkeypatch, tmp_path: Path) -> None:
     class _StubClaudeSDKClient:
         def __init__(self, options):

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -756,6 +756,60 @@ def test_cleanup_session_preserves_new_receiver_during_disconnect(monkeypatch, t
     assert composite_key not in controller.claude_sessions
 
 
+def test_cleanup_session_defers_disconnect_for_current_receiver(monkeypatch, tmp_path: Path) -> None:
+    events = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+            events["disconnect_started"].set()
+            await events["release_disconnect"].wait()
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    composite_key = f"slack_C123:{tmp_path}"
+
+    async def _exercise_cleanup() -> None:
+        events["cleanup_returned"] = asyncio.Event()
+        events["disconnect_started"] = asyncio.Event()
+        events["release_disconnect"] = asyncio.Event()
+        client = await handler.get_or_create_claude_session(context)
+
+        async def _receiver():
+            await handler.cleanup_session(
+                composite_key,
+                current_receiver_task=asyncio.current_task(),
+            )
+            events["cleanup_returned"].set()
+
+        receiver_task = asyncio.create_task(_receiver())
+        controller.receiver_tasks[composite_key] = receiver_task
+
+        await events["cleanup_returned"].wait()
+        assert composite_key not in controller.receiver_tasks
+        assert composite_key not in controller.claude_sessions
+
+        await events["disconnect_started"].wait()
+        assert client.disconnects == 1
+        events["release_disconnect"].set()
+        await asyncio.sleep(0)
+
+    asyncio.run(_exercise_cleanup())
+
+    assert composite_key not in controller.receiver_tasks
+    assert composite_key not in controller.claude_sessions
+
+
 def test_evict_idle_sessions_rechecks_active_state_before_cleanup(monkeypatch, tmp_path: Path) -> None:
     class _StubClaudeSDKClient:
         def __init__(self, options):

--- a/tests/test_wechat_bot.py
+++ b/tests/test_wechat_bot.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import unittest
 from unittest.mock import AsyncMock
 from pathlib import Path
@@ -93,6 +94,45 @@ class WeChatBotTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["get_updates_buf"], "buf-2")
         self.assertEqual(captured["timeout"], 40.0)
         self.assertTrue(captured["url"].endswith("/ilink/bot/getupdates"))
+
+    async def test_wechat_api_get_updates_poll_logs_are_debug(self):
+        class _Response:
+            ok = True
+            status = 200
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def text(self):
+                return '{"ret": 0, "msgs": [], "get_updates_buf": "buf-2"}'
+
+        class _Session:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def post(self, url, data=None, headers=None):
+                return _Response()
+
+        with patch("modules.im.wechat_api.aiohttp.ClientSession", side_effect=lambda timeout: _Session()):
+            with self.assertLogs("modules.im.wechat_api", level="DEBUG") as captured:
+                await wechat_api_module.get_updates(
+                    "https://wechat.example.com",
+                    "token",
+                    "buf-1",
+                    timeout_ms=35_000,
+                )
+
+        self.assertTrue(captured.records)
+        self.assertTrue(
+            all(record.levelno == logging.DEBUG for record in captured.records),
+            [record.getMessage() for record in captured.records],
+        )
 
     async def test_wechat_api_get_updates_returns_empty_response_on_timeout(self):
         class _TimeoutingRequest:


### PR DESCRIPTION
## What changed

- Fix Claude runtime cleanup so Vibe Remote disconnects the Claude SDK client before cancelling the receiver task. This prevents an anyio cancellation retry loop from spinning the controller event loop after idle cleanup or auth/session reset.
- Use the same cleanup order for Claude clear-sessions, auth refresh, resume binding, and generic session cleanup.
- Reduce WeChat long-poll empty request/response logs from INFO to DEBUG while keeping warnings and real message events visible.

## Why

The regression container was holding roughly one CPU core while idle. Process and Python profiler evidence pointed at Vibe Remote's main Python process, not opencode/codex/claude backend inference. The busy stack was in anyio cancellation delivery after Claude receiver cleanup.

## Evidence layers

- Unit: targeted Claude session cleanup and WeChat API logging tests updated.
- Contract: not changed; no public API or config shape changed.
- Scenario: no catalog scenario ID applies to runtime cleanup/log verbosity.
- Residual manual checks: Docker regression environment rebuilt with preserved state; idle CPU stayed low and WeChat empty long-poll INFO logs stopped in the new log window.

## Validation

- pytest -q tests/test_claude_agent_sessions.py tests/test_claude_cli_path.py tests/test_wechat_bot.py
- ruff check core/handlers/session_handler.py modules/agents/claude_agent.py modules/im/wechat_api.py tests/test_claude_agent_sessions.py tests/test_claude_cli_path.py tests/test_wechat_bot.py
- ./scripts/run_three_regression.sh
- Docker stats after rebuild: idle container around 2-5% CPU instead of ~100%+
