### PR TITLE
fix(update): link release notifications

### DIFF
--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -13,6 +13,7 @@ import json
 import logging
 import tempfile
 import time
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, fields
 from pathlib import Path
@@ -39,6 +40,8 @@ MIN_CHECK_INTERVAL_MINUTES = 1
 # This gives admins time to read the notification and decide whether to update manually.
 NOTIFICATION_GRACE_PERIOD_MINUTES = 10
 
+GITHUB_RELEASE_TAG_BASE_URL = "https://github.com/cyhhao/vibe-remote/releases/tag"
+
 
 def _fetch_pypi_version_sync() -> Dict[str, Any]:
     """Synchronous PyPI version fetch (to be run in thread)."""
@@ -61,6 +64,22 @@ def _fetch_pypi_version_sync() -> Dict[str, Any]:
         result["error"] = str(e)
 
     return result
+
+
+def _github_release_url(version: str) -> str:
+    version_text = str(version).strip()
+    tag = version_text if version_text.startswith(("v", "gh-v")) else f"v{version_text}"
+    return f"{GITHUB_RELEASE_TAG_BASE_URL}/{urllib.parse.quote(tag, safe='')}"
+
+
+def _format_release_version_link(version: str, platform: str = "markdown") -> str:
+    version_text = str(version).strip()
+    url = _github_release_url(version_text)
+    if platform == "slack":
+        return f"<{url}|{version_text}>"
+    if platform == "plain":
+        return f"{version_text} ({url})"
+    return f"[{version_text}]({url})"
 
 
 @dataclass
@@ -456,14 +475,16 @@ class UpdateChecker:
             im_client, raw_user_id, user_platform = self._get_im_client_for_user(uid)
             try:
                 if user_platform == "slack":
-                    text = f"Vibe Remote update available: {current} → {latest}"
+                    release_url = _github_release_url(latest)
+                    latest_link = _format_release_version_link(latest, "slack")
+                    text = f"Vibe Remote update available: {current} → {latest} ({release_url})"
                     blocks = [
                         {
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
                                 "text": f":rocket: *Vibe Remote Update Available*\n\n"
-                                f"A new version is available: `{current}` → `{latest}`",
+                                f"A new version is available: `{current}` → {latest_link}",
                             },
                         },
                         {
@@ -505,11 +526,15 @@ class UpdateChecker:
         return InlineKeyboard(buttons=[[InlineButton(text="Update Now", callback_data=f"vibe_update_now:{latest}")]])
 
     def _format_update_notification_text(self, current: str, latest: str, platform: str) -> str:
+        latest_link = _format_release_version_link(
+            latest,
+            "plain" if platform in {"wechat", "unknown"} else "markdown",
+        )
         if platform == "discord":
-            return f"🚀 **Vibe Remote Update Available**\n\nUpdate from `{current}` → `{latest}`"
+            return f"🚀 **Vibe Remote Update Available**\n\nUpdate from `{current}` → {latest_link}"
         if platform in {"telegram", "lark"}:
-            return f"🚀 Vibe Remote Update Available\n\nUpdate from `{current}` → `{latest}`"
-        return f"🚀 Vibe Remote Update Available\n\nUpdate from {current} → {latest}"
+            return f"🚀 Vibe Remote Update Available\n\nUpdate from `{current}` → {latest_link}"
+        return f"🚀 Vibe Remote Update Available\n\nUpdate from {current} → {latest_link}"
 
     async def _send_slack_notification_legacy(self, current: str, latest: str) -> bool:
         """Legacy Slack notification: send to workspace owner when no admins configured."""
@@ -526,13 +551,15 @@ class UpdateChecker:
 
         try:
             im_client = self._get_im_client_for_platform("slack")
+            release_url = _github_release_url(latest)
+            latest_link = _format_release_version_link(latest, "slack")
             blocks = [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
                         "text": f":rocket: *Vibe Remote Update Available*\n\n"
-                        f"A new version is available: `{current}` → `{latest}`",
+                        f"A new version is available: `{current}` → {latest_link}",
                     },
                 },
                 {
@@ -550,7 +577,9 @@ class UpdateChecker:
             ]
 
             await im_client.web_client.chat_postMessage(
-                channel=dm_channel, text=f"Vibe Remote update available: {current} → {latest}", blocks=blocks
+                channel=dm_channel,
+                text=f"Vibe Remote update available: {current} → {latest} ({release_url})",
+                blocks=blocks,
             )
             logger.info(f"Sent update notification to workspace owner {owner_id}")
             return True
@@ -567,7 +596,7 @@ class UpdateChecker:
         try:
             from modules.im import InlineButton, InlineKeyboard, MessageContext
 
-            text = f"🚀 **Vibe Remote Update Available**\n\nUpdate from `{current}` → `{latest}`"
+            text = self._format_update_notification_text(current, latest, "discord")
             keyboard = InlineKeyboard(
                 buttons=[[InlineButton(text="Update Now", callback_data=f"vibe_update_now:{latest}")]]
             )

--- a/modules/im/wechat.py
+++ b/modules/im/wechat.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -82,6 +83,7 @@ _MAX_CONSECUTIVE_FAILURES = 3
 _DEDUP_SET_MAX = 1000
 _DEDUP_CLEAN_INTERVAL_SECONDS = 300
 _SESSION_EXPIRED_ERRCODE = -14
+_CONTEXT_TOKEN_CACHE_VERSION = 1
 
 # Regex patterns for stripping markdown
 _MD_BOLD = re.compile(r"\*\*(.+?)\*\*")
@@ -388,6 +390,7 @@ class WeChatBot(BaseIMClient):
 
         # Context tokens per user (needed for replies)
         self._context_tokens: Dict[str, str] = {}
+        self._context_token_observed_at: Dict[str, float] = {}
         self._typing_tickets: Dict[tuple[str, str], str] = {}
 
         # getUpdates cursor
@@ -949,7 +952,7 @@ class WeChatBot(BaseIMClient):
         For WeChat, every conversation is already a DM, so we just need a
         cached context_token for the user.
         """
-        context_token = self._context_tokens.get(user_id, "")
+        context_token = self._get_context_token_for_user(user_id)
         if not context_token:
             logger.warning(
                 "No context_token cached for user %s; cannot send DM",
@@ -1003,6 +1006,7 @@ class WeChatBot(BaseIMClient):
 
             # Load persisted sync buffer
             self._load_sync_buf()
+            self._load_context_tokens()
 
             # Check login status
             logged_in = await self._auth_manager.check_login_status(
@@ -1066,6 +1070,7 @@ class WeChatBot(BaseIMClient):
     def _mark_session_expired(self, errcode: Any) -> None:
         self._auth_manager.is_logged_in = False
         self._typing_tickets.clear()
+        self._clear_context_tokens()
         if not self._session_expired_logged:
             logger.error(
                 "WeChat session expired (errcode %s); re-authentication required via the Web UI QR login",
@@ -1228,7 +1233,7 @@ class WeChatBot(BaseIMClient):
 
         # Cache context_token for replies
         if context_token:
-            self._context_tokens[from_user] = context_token
+            self._remember_context_token(from_user, context_token)
 
         # Extract text from item_list
         text = self._extract_text(msg)
@@ -1502,6 +1507,94 @@ class WeChatBot(BaseIMClient):
     # Context token helpers
     # ------------------------------------------------------------------
 
+    def _get_context_token_cache_path(self) -> Path:
+        state_dir = get_state_dir()
+        state_dir.mkdir(parents=True, exist_ok=True)
+        return state_dir / "wechat_context_tokens.json"
+
+    def _load_context_tokens(self) -> None:
+        path = self._get_context_token_cache_path()
+        if not path.is_file():
+            return
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            raw_tokens = data.get("tokens") if isinstance(data, dict) else None
+            if not isinstance(raw_tokens, dict):
+                return
+
+            loaded_tokens: Dict[str, str] = {}
+            loaded_observed_at: Dict[str, float] = {}
+            for user_id, record in raw_tokens.items():
+                token = ""
+                observed_at = 0.0
+                if isinstance(record, dict):
+                    token = str(record.get("context_token") or "")
+                    try:
+                        observed_at = float(record.get("observed_at") or 0)
+                    except (TypeError, ValueError):
+                        observed_at = 0.0
+                elif isinstance(record, str):
+                    token = record
+                if not user_id or not token:
+                    continue
+                loaded_tokens[str(user_id)] = token
+                loaded_observed_at[str(user_id)] = observed_at
+
+            self._context_tokens.update(loaded_tokens)
+            self._context_token_observed_at.update(loaded_observed_at)
+            if loaded_tokens:
+                logger.info("Loaded persisted WeChat context tokens for %d user(s)", len(loaded_tokens))
+        except Exception as exc:
+            logger.warning("Failed to load WeChat context tokens: %s", exc)
+
+    def _save_context_tokens(self) -> None:
+        try:
+            path = self._get_context_token_cache_path()
+            payload = {
+                "version": _CONTEXT_TOKEN_CACHE_VERSION,
+                "tokens": {
+                    user_id: {
+                        "context_token": token,
+                        "observed_at": self._context_token_observed_at.get(user_id, 0),
+                    }
+                    for user_id, token in self._context_tokens.items()
+                    if token
+                },
+            }
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=path.parent,
+                suffix=".tmp",
+                delete=False,
+                encoding="utf-8",
+            ) as handle:
+                json.dump(payload, handle, ensure_ascii=False)
+                temp_path = Path(handle.name)
+            temp_path.replace(path)
+        except Exception as exc:
+            logger.warning("Failed to save WeChat context tokens: %s", exc)
+
+    def _remember_context_token(self, user_id: str, context_token: str) -> None:
+        if not user_id or not context_token:
+            return
+        self._context_tokens[user_id] = context_token
+        self._context_token_observed_at[user_id] = time.time()
+        self._save_context_tokens()
+
+    def _clear_context_tokens(self) -> None:
+        if not self._context_tokens and not self._context_token_observed_at:
+            return
+        self._context_tokens.clear()
+        self._context_token_observed_at.clear()
+        self._save_context_tokens()
+
+    def _get_context_token_for_user(self, user_id: str) -> str:
+        token = self._context_tokens.get(user_id, "")
+        if token:
+            return token
+        self._load_context_tokens()
+        return self._context_tokens.get(user_id, "")
+
     def _get_context_token(self, context: MessageContext) -> str:
         """Resolve the context_token for a given message context.
 
@@ -1511,7 +1604,7 @@ class WeChatBot(BaseIMClient):
         token = ps.get("context_token", "")
         if token:
             return token
-        return self._context_tokens.get(context.user_id, "")
+        return self._get_context_token_for_user(context.user_id)
 
     # ------------------------------------------------------------------
     # Reactions (unsupported)

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -15,6 +15,9 @@ from core import update_checker
 from core.update_checker import UpdateChecker
 
 
+RELEASE_URL_101 = "https://github.com/cyhhao/vibe-remote/releases/tag/v1.0.1"
+
+
 class _StubSettingsManager:
     def __init__(self, store):
         self._store = store
@@ -79,14 +82,28 @@ def test_update_notification_admin_dms_include_buttons_except_wechat(monkeypatch
     slack_kwargs = clients["slack"].dm_calls[0][2]
     assert slack_kwargs["blocks"][1]["elements"][0]["action_id"] == "vibe_update_now"
     assert slack_kwargs["blocks"][1]["elements"][0]["value"] == "1.0.1"
+    assert f"<{RELEASE_URL_101}|1.0.1>" in slack_kwargs["blocks"][0]["text"]["text"]
+    assert RELEASE_URL_101 in clients["slack"].dm_calls[0][1]
 
     for platform in ["discord", "telegram", "lark"]:
+        text = clients[platform].dm_calls[0][1]
+        assert f"[1.0.1]({RELEASE_URL_101})" in text
         kwargs = clients[platform].dm_calls[0][2]
         keyboard = kwargs["keyboard"]
         assert keyboard.buttons[0][0].text == "Update Now"
         assert keyboard.buttons[0][0].callback_data == "vibe_update_now:1.0.1"
 
+    assert f"1.0.1 ({RELEASE_URL_101})" in clients["wechat"].dm_calls[0][1]
     assert "keyboard" not in clients["wechat"].dm_calls[0][2]
+
+
+def test_update_notification_release_url_normalizes_github_tags():
+    assert update_checker._github_release_url("1.0.1") == RELEASE_URL_101
+    assert update_checker._github_release_url("v1.0.1") == RELEASE_URL_101
+    assert (
+        update_checker._github_release_url("gh-v2.2.8rc1")
+        == "https://github.com/cyhhao/vibe-remote/releases/tag/gh-v2.2.8rc1"
+    )
 
 
 def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, tmp_path):

--- a/tests/test_wechat_bot.py
+++ b/tests/test_wechat_bot.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import logging
 import unittest
 from unittest.mock import AsyncMock
 from pathlib import Path
@@ -221,6 +223,45 @@ class WeChatBotTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(args[0].user_id, "user-1")
         self.assertEqual(args[1], "hi")
 
+    async def test_process_inbound_message_persists_context_token(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict("os.environ", {"VIBE_REMOTE_HOME": tmpdir}):
+                bot = self._make_bot()
+                bot.check_authorization = lambda **kwargs: AuthResult(allowed=True, is_dm=True)
+                bot.dispatch_text_command = AsyncMock(return_value=False)
+                bot._process_media_items = AsyncMock(return_value=None)
+
+                msg = {
+                    "message_id": "mid-token-1",
+                    "from_user_id": "user-1",
+                    "context_token": "ctx-persisted",
+                    "item_list": [{"type": 1, "text_item": {"text": "hi"}}],
+                }
+
+                await bot._process_inbound_message(msg)
+
+                cache_path = Path(tmpdir) / "state" / "wechat_context_tokens.json"
+                data = json.loads(cache_path.read_text(encoding="utf-8"))
+                self.assertEqual(data["tokens"]["user-1"]["context_token"], "ctx-persisted")
+
+                restored = self._make_bot()
+                restored._load_context_tokens()
+                self.assertEqual(restored._get_context_token_for_user("user-1"), "ctx-persisted")
+
+    async def test_send_dm_reuses_persisted_context_token(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict("os.environ", {"VIBE_REMOTE_HOME": tmpdir}):
+                bot = self._make_bot()
+                bot._remember_context_token("user-1", "ctx-persisted")
+
+                restored = self._make_bot()
+                with patch("modules.im.wechat.wechat_api.send_message", new=AsyncMock(return_value={})) as mock_send:
+                    result = await restored.send_dm("user-1", "hello")
+
+        self.assertIsNotNone(result)
+        mock_send.assert_awaited_once()
+        self.assertEqual(mock_send.await_args.args[3], "ctx-persisted")  # type: ignore[union-attr]
+
     async def test_process_inbound_message_does_not_block_commands_behind_running_callback(self):
         bot = self._make_bot()
         bot.check_authorization = lambda **kwargs: AuthResult(allowed=True, is_dm=True)
@@ -403,18 +444,29 @@ class WeChatBotTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.startswith("wc-"))
 
     async def test_send_message_marks_session_expired_on_explicit_error(self):
-        bot = self._make_bot()
-        context = MessageContext(user_id="user-1", channel_id="user-1", platform_specific={"context_token": "ctx-1"})
-        bot._auth_manager.is_logged_in = True
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict("os.environ", {"VIBE_REMOTE_HOME": tmpdir}):
+                bot = self._make_bot()
+                context = MessageContext(
+                    user_id="user-1",
+                    channel_id="user-1",
+                    platform_specific={"context_token": "ctx-1"},
+                )
+                bot._auth_manager.is_logged_in = True
+                bot._remember_context_token("user-1", "ctx-1")
 
-        with patch(
-            "modules.im.wechat.wechat_api.send_message",
-            new=AsyncMock(return_value={"errcode": -14, "errmsg": "session timeout"}),
-        ):
-            with self.assertRaises(RuntimeError):
-                await bot.send_message(context, "hello")
+                with patch(
+                    "modules.im.wechat.wechat_api.send_message",
+                    new=AsyncMock(return_value={"errcode": -14, "errmsg": "session timeout"}),
+                ):
+                    with self.assertRaises(RuntimeError):
+                        await bot.send_message(context, "hello")
+
+                cache_path = Path(tmpdir) / "state" / "wechat_context_tokens.json"
+                data = json.loads(cache_path.read_text(encoding="utf-8"))
 
         self.assertFalse(bot._auth_manager.is_logged_in)
+        self.assertEqual(data["tokens"], {})
 
     async def test_upload_file_from_path_uses_cdn_workflow(self):
         bot = self._make_bot()


### PR DESCRIPTION
## What changed

- Link the latest version in update notifications to the matching GitHub Release page.
- Keep platform formatting native: Slack mrkdwn links, Markdown links for Discord/Telegram/Lark, and plain version-plus-URL text for WeChat.
- Persist WeChat context tokens so restart does not discard a still-usable reply token, and clear them when iLink reports session expiry.

## Why

Admins should be able to open the release details directly from update notifications. WeChat cannot guarantee proactive delivery without a recent context token, but persisting the latest token lets Vibe Remote reuse it while iLink still accepts it.

## Evidence layers

- Unit: updated update notification and WeChat adapter tests.
- Contract: not changed; no external payload schema changes beyond message text/link content.
- Scenario: no scenario catalog entry applies to this narrow notification rendering/cache behavior.
- Residual manual checks: real IM rendering is still best verified in regression, especially WeChat best-effort delivery.

## Validation

- ruff check modules/im/wechat.py tests/test_wechat_bot.py core/update_checker.py tests/test_update_checker_platforms.py
- python3 -m pytest tests/test_wechat_bot.py tests/test_update_checker_platforms.py

Note: uv run pytest in the isolated worktree could not initialize because ui/dist is absent and the package config force-includes it. The same tests passed through python3 -m pytest.
