### PR TITLE
fix(codex): prioritize GPT-5.5 in model list

### DIFF
--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -36,7 +36,8 @@ Follow this skill as an operations playbook for agents, not as end-user marketin
 8. Do not hand-edit `sessions.json` unless the user explicitly asks for low-level recovery work.
 9. Do not restart the service by default. Use `POST /doctor`, `GET /status`, and read-back checks first.
 10. Only start, stop, restart, or reload Vibe Remote when the user explicitly asks or when a change cannot take effect otherwise; explain why before doing it.
-11. Tell the user whether the change is global or scope-specific.
+11. If an agent must restart Vibe Remote from an active conversation, use `vibe restart --delay-seconds 60` so the current session can receive the reply before the restart lands.
+12. Tell the user whether the change is global or scope-specific.
 
 ## API First Workflow
 
@@ -459,6 +460,8 @@ WeChat QR login is special: when login is confirmed and a token is returned, the
 
 Avoid these for routine configuration. `POST /control` starts, stops, or restarts the service. `POST /ui/reload` restarts only the Web UI server to apply host or port changes. Use them only with explicit user intent or a concrete need.
 
+When the restart is initiated by an agent from an active conversation, use the CLI delayed form `vibe restart --delay-seconds 60` so the transport does not cut off the current reply.
+
 ## Scope and Precedence Rules
 
 ### Backend selection
@@ -783,6 +786,8 @@ Common cases:
 - startup failure: use `GET /status`, `POST /doctor`, then inspect logs
 
 Do not use `vibe restart`, `POST /control {"action":"restart"}`, or `POST /ui/reload` as a first response to config problems.
+
+If a restart is still required and you are replying through an active Vibe Remote conversation, use `vibe restart --delay-seconds 60` so the current reply can be delivered before the restart lands.
 
 ## Direct File Recovery Fallback
 

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -337,7 +337,8 @@ def test_codex_models_prefers_cli_cache_and_filters_hidden_models(monkeypatch, t
     result = api.codex_models()
 
     assert result["ok"] is True
-    assert result["models"][:3] == [
+    assert result["models"][:4] == [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.4-nano",
@@ -368,7 +369,7 @@ def test_codex_models_falls_back_when_cli_cache_missing(monkeypatch, tmp_path):
     result = api.codex_models()
 
     assert result["ok"] is True
-    assert result["models"][:3] == ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]
+    assert result["models"][:4] == ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]
     assert "custom-codex-model" in result["models"]
     assert "legacy-codex" in result["models"]
     assert "gpt-5.1-codex-max" in result["models"]

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1451,6 +1451,7 @@ def codex_models() -> dict:
         options.append(model)
 
     built_in_options: list[str] = [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.4-nano",


### PR DESCRIPTION
## Summary

- Add gpt-5.5 as the first built-in Codex model option so Vibe Remote shows it first.
- Keep Codex cache/config merge behavior unchanged; cache entries still append only when not already present.
- Document that active Vibe Remote conversation restarts should use vibe restart --delay-seconds 60 so the current reply can be delivered first.

## Evidence

- Unit: pytest -q tests/test_ui_api.py -k codex_models
- Contract: not applicable; no API shape changed, only returned ordering.
- Scenario: no catalog scenario ID applies.
- Residual manual checks: verified vibe.api.codex_models() returns gpt-5.5 before gpt-5.4.

## Risk

Low. The change only affects Codex model option ordering and skill documentation.
