### PR TITLE
fix(codex): clarify generated image paths

### DIFF
--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -17,13 +18,17 @@ from modules.agents.codex.turn_state import CodexTurnRegistry
 
 logger = logging.getLogger(__name__)
 
-_CODEX_GENERATED_IMAGE_PROMPT = (
-    "If you generate an image with Codex, include it in the final reply with Markdown image syntax: "
-    "`![generated image](file:///$CODEX_HOME/generated_images/<thread-id>/<image-file>.png)` "
-    "or `![generated image](file:///$HOME/.codex/generated_images/<thread-id>/<image-file>.png)`. "
-    "Use only that local generated_images path, never sandbox paths like `/mnt/data/...`; "
-    "if you cannot determine the path, leave the final reply empty."
-)
+def _codex_generated_image_prompt() -> str:
+    codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex").expanduser().resolve()
+    example_uri = (codex_home / "generated_images" / "thread-id" / "image-file.png").as_uri()
+    return (
+        "If you generate an image with Codex, include it in the final reply with Markdown image syntax, "
+        f"using a real file URI under the local Codex generated_images directory, for example: "
+        f"`![generated image]({example_uri})`. "
+        "Replace the example thread id and filename with the actual generated image path. "
+        "Never emit variables, placeholder paths, or sandbox paths like `/mnt/data/...`; "
+        "if you cannot determine the real path, leave the final reply empty."
+    )
 
 
 class CodexAgent(BaseAgent):
@@ -653,7 +658,7 @@ class CodexAgent(BaseAgent):
         config = getattr(controller, "config", None)
         if not getattr(config, "reply_enhancements", True):
             return message
-        return f"{_CODEX_GENERATED_IMAGE_PROMPT}\n\n{message}"
+        return f"{_codex_generated_image_prompt()}\n\n{message}"
 
     # ------------------------------------------------------------------
     # Callback handlers (wired to transport)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -19,9 +19,10 @@ logger = logging.getLogger(__name__)
 
 _CODEX_GENERATED_IMAGE_PROMPT = (
     "If you generate an image with Codex, include it in the final reply with Markdown image syntax: "
-    "`![generated image](file:///absolute/path/to/image.png)`. "
-    "Use only a local absolute path readable by Vibe Remote, never sandbox paths like `/mnt/data/...`; "
-    "if no such path is available, leave the final reply empty."
+    "`![generated image](file:///$CODEX_HOME/generated_images/<thread-id>/<image-file>.png)` "
+    "or `![generated image](file:///$HOME/.codex/generated_images/<thread-id>/<image-file>.png)`. "
+    "Use only that local generated_images path, never sandbox paths like `/mnt/data/...`; "
+    "if you cannot determine the path, leave the final reply empty."
 )
 
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -19,7 +19,9 @@ logger = logging.getLogger(__name__)
 
 _CODEX_GENERATED_IMAGE_PROMPT = (
     "If you generate an image with Codex, include it in the final reply with Markdown image syntax: "
-    "`![generated image](file:///absolute/path/to/image.png)`"
+    "`![generated image](file:///absolute/path/to/image.png)`. "
+    "Use only a local absolute path readable by Vibe Remote, never sandbox paths like `/mnt/data/...`; "
+    "if no such path is available, leave the final reply empty."
 )
 
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -713,6 +713,9 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(items[0]["text"].startswith("If you generate an image with Codex"))
         self.assertIn("![generated image](file:///absolute/path/to/image.png)", items[0]["text"])
+        self.assertIn("local absolute path readable by Vibe Remote", items[0]["text"])
+        self.assertIn("never sandbox paths like `/mnt/data/...`", items[0]["text"])
+        self.assertIn("leave the final reply empty", items[0]["text"])
         self.assertTrue(items[0]["text"].endswith("hello"))
 
     async def test_start_turn_uses_sandbox_policy_object(self):

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -712,8 +712,9 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         items = agent._build_input(request)
 
         self.assertTrue(items[0]["text"].startswith("If you generate an image with Codex"))
-        self.assertIn("![generated image](file:///absolute/path/to/image.png)", items[0]["text"])
-        self.assertIn("local absolute path readable by Vibe Remote", items[0]["text"])
+        self.assertIn("$CODEX_HOME/generated_images/<thread-id>/<image-file>.png", items[0]["text"])
+        self.assertIn("$HOME/.codex/generated_images/<thread-id>/<image-file>.png", items[0]["text"])
+        self.assertIn("Use only that local generated_images path", items[0]["text"])
         self.assertIn("never sandbox paths like `/mnt/data/...`", items[0]["text"])
         self.assertIn("leave the final reply empty", items[0]["text"])
         self.assertTrue(items[0]["text"].endswith("hello"))

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import os
 import sys
 import types
 import unittest
@@ -709,13 +710,14 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent.controller = SimpleNamespace(config=SimpleNamespace(reply_enhancements=True))
         request = SimpleNamespace(message="hello", files=None)
 
-        items = agent._build_input(request)
+        with patch.dict(os.environ, {"CODEX_HOME": "/Users/test/.codex"}):
+            items = agent._build_input(request)
 
         self.assertTrue(items[0]["text"].startswith("If you generate an image with Codex"))
-        self.assertIn("$CODEX_HOME/generated_images/<thread-id>/<image-file>.png", items[0]["text"])
-        self.assertIn("$HOME/.codex/generated_images/<thread-id>/<image-file>.png", items[0]["text"])
-        self.assertIn("Use only that local generated_images path", items[0]["text"])
-        self.assertIn("never sandbox paths like `/mnt/data/...`", items[0]["text"])
+        self.assertIn("file:///Users/test/.codex/generated_images/thread-id/image-file.png", items[0]["text"])
+        self.assertIn("local Codex generated_images directory", items[0]["text"])
+        self.assertIn("Replace the example thread id and filename with the actual", items[0]["text"])
+        self.assertIn("Never emit variables, placeholder paths, or sandbox paths like `/mnt/data/...`", items[0]["text"])
         self.assertIn("leave the final reply empty", items[0]["text"])
         self.assertTrue(items[0]["text"].endswith("hello"))
 


### PR DESCRIPTION
## Summary
- Clarify the Codex generated-image instruction with the actual generated image directory pattern.
- Point Codex at `$CODEX_HOME/generated_images/<thread-id>/...` or `$HOME/.codex/generated_images/<thread-id>/...` instead of a placeholder path.
- Tell Codex not to use sandbox-only paths such as `/mnt/data/...`, and to leave the final reply empty if it cannot determine the generated image path so fallback delivery can attach the image.

## Validation
- `python3 -m pytest tests/test_codex_agent.py tests/test_codex_event_handler.py tests/test_reply_enhancer_platform.py -q`
- `python3 -m ruff check modules/agents/codex/agent.py tests/test_codex_agent.py`
