### PR TITLE
fix(im): use unicode emoji in notifications

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -11,6 +11,8 @@ from .base import BaseHandler
 
 logger = logging.getLogger(__name__)
 
+SUBAGENT_REACTION_EMOJI = "🤖"
+
 
 class MessageHandler(BaseHandler):
     """Handles message routing and Claude communication"""
@@ -227,7 +229,7 @@ class MessageHandler(BaseHandler):
 
             if is_human and subagent_name and context.message_id:
                 try:
-                    reaction = ":robot_face:"
+                    reaction = SUBAGENT_REACTION_EMOJI
                     await self._get_im_client(context).add_reaction(
                         context,
                         context.message_id,
@@ -235,8 +237,8 @@ class MessageHandler(BaseHandler):
                     )
                 except Exception as err:
                     logger.debug(f"Failed to add subagent reaction: {err}")
-                # Keep :eyes: alive — the agent will remove it on result/error
-                # via the normal ack_reaction lifecycle.  Previously :eyes: was
+                # Keep 👀 alive; the agent will remove it on result/error
+                # via the normal ack_reaction lifecycle. Previously 👀 was
                 # removed here immediately, leaving no processing indicator
                 # for the entire duration of the subagent run.
 

--- a/core/processing_indicator.py
+++ b/core/processing_indicator.py
@@ -20,6 +20,7 @@ from vibe.i18n import t as i18n_t
 logger = logging.getLogger(__name__)
 
 _PROCESSING_INDICATOR_MODES = ("typing", "reaction", "message")
+ACK_REACTION_EMOJI = "👀"
 
 
 @dataclass
@@ -234,7 +235,7 @@ class ProcessingIndicatorService:
             return False
         im_client = self._get_im_client(context)
         try:
-            ok = await im_client.add_reaction(context, message_id, ":eyes:")
+            ok = await im_client.add_reaction(context, message_id, ACK_REACTION_EMOJI)
         except Exception as ack_err:
             logger.debug("Failed to add reaction ack: %s", ack_err)
             return False
@@ -244,7 +245,7 @@ class ProcessingIndicatorService:
             return False
 
         handle.ack_reaction_message_id = message_id
-        handle.ack_reaction_emoji = ":eyes:"
+        handle.ack_reaction_emoji = ACK_REACTION_EMOJI
         return True
 
     def _delete_context(self, handle: ProcessingIndicatorHandle, channel_id: Optional[str]) -> MessageContext:

--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -483,7 +483,7 @@ class UpdateChecker:
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": f":rocket: *Vibe Remote Update Available*\n\n"
+                                "text": f"🚀 *Vibe Remote Update Available*\n\n"
                                 f"A new version is available: `{current}` → {latest_link}",
                             },
                         },
@@ -558,7 +558,7 @@ class UpdateChecker:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f":rocket: *Vibe Remote Update Available*\n\n"
+                        "text": f"🚀 *Vibe Remote Update Available*\n\n"
                         f"A new version is available: `{current}` → {latest_link}",
                     },
                 },
@@ -770,16 +770,13 @@ class UpdateChecker:
             if channel_id:
                 platform = data.get("platform") or _infer_channel_platform(channel_id)
             im_client = self._get_im_client_for_platform(platform)
-            if platform == "discord":
-                success_text = f"✅ Vibe Remote has been updated to `{target_version}`"
-            else:
-                success_text = f":white_check_mark: Vibe Remote has been updated to `{target_version}`"
+            success_text = f"✅ Vibe Remote has been updated to `{target_version}`"
             success_blocks = [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f":white_check_mark: *Vibe Remote Updated Successfully*\n\n"
+                        "text": f"✅ *Vibe Remote Updated Successfully*\n\n"
                         f"Now running version `{target_version}`",
                     },
                 }
@@ -854,7 +851,7 @@ async def handle_update_button_click(controller: "Controller", payload: Dict[str
                 blocks=[
                     {
                         "type": "section",
-                        "text": {"type": "mrkdwn", "text": ":warning: An upgrade is already in progress. Please wait."},
+                        "text": {"type": "mrkdwn", "text": "⚠️ An upgrade is already in progress. Please wait."},
                     }
                 ],
             )
@@ -873,7 +870,7 @@ async def handle_update_button_click(controller: "Controller", payload: Dict[str
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": ":hourglass_flowing_sand: *Updating Vibe Remote...*\n\nPlease wait, the service will restart shortly.",
+                        "text": "⏳ *Updating Vibe Remote...*\n\nPlease wait, the service will restart shortly.",
                     },
                 }
             ],
@@ -921,7 +918,7 @@ async def _do_update_from_button(controller: "Controller", channel_id: str, mess
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": ":x: *Upgrade Failed*\n\nPlease check the logs for details.",
+                                "text": "❌ *Upgrade Failed*\n\nPlease check the logs for details.",
                             },
                         }
                     ],
@@ -937,7 +934,7 @@ async def _do_update_from_button(controller: "Controller", channel_id: str, mess
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": ":white_check_mark: *Upgrade complete*\n\nPlease restart Vibe Remote to apply the update.",
+                                "text": "✅ *Upgrade complete*\n\nPlease restart Vibe Remote to apply the update.",
                             },
                         }
                     ],
@@ -951,7 +948,7 @@ async def _do_update_from_button(controller: "Controller", channel_id: str, mess
                 blocks=[
                     {
                         "type": "section",
-                        "text": {"type": "mrkdwn", "text": ":white_check_mark: Already running the latest version."},
+                        "text": {"type": "mrkdwn", "text": "✅ Already running the latest version."},
                     }
                 ],
             )

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -552,7 +552,7 @@ class ClaudeAgent(BaseAgent):
         # When the receiver ends normally (stream exhausted after a result),
         # new messages may have already queued their reactions via
         # handle_message().  Blindly clearing them here would remove the
-        # :eyes: for an in-flight request that hasn't produced a result yet.
+        # 👀 for an in-flight request that hasn't produced a result yet.
         # The except blocks above handle the cancel/error cases; the
         # normal-result case is handled by _remove_pending_reaction()
         # inside the loop.

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -1021,6 +1021,8 @@ class SlackBot(BaseIMClient):
             name = name[1:-1]
         if name in ["👀", "eyes", "eye"]:
             name = "eyes"
+        elif name in ["🤖", "robot_face", "robot"]:
+            name = "robot_face"
 
         if not name:
             return False
@@ -1067,6 +1069,8 @@ class SlackBot(BaseIMClient):
             name = name[1:-1]
         if name in ["👀", "eyes", "eye"]:
             name = "eyes"
+        elif name in ["🤖", "robot_face", "robot"]:
+            name = "robot_face"
 
         if not name:
             return False

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -248,8 +248,8 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         _, request = controller.agent_service.requests[0]
         self.assertFalse(request.typing_indicator_active)
         self.assertEqual(request.ack_reaction_message_id, "m1")
-        self.assertEqual(request.ack_reaction_emoji, ":eyes:")
-        self.assertEqual(controller.im_client.reactions, [("C1", "m1", ":eyes:")])
+        self.assertEqual(request.ack_reaction_emoji, "👀")
+        self.assertEqual(controller.im_client.reactions, [("C1", "m1", "👀")])
 
     async def test_reply_anchor_alias_keeps_original_anchor_mapping(self):
         controller = _StubController(platform="discord", ack_mode="reaction", typing_result=True)
@@ -328,8 +328,8 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         _, request = controller.agent_service.requests[0]
         self.assertFalse(request.typing_indicator_active)
         self.assertEqual(request.ack_reaction_message_id, "m1")
-        self.assertEqual(request.ack_reaction_emoji, ":eyes:")
-        self.assertEqual(controller.im_client.reactions, [("tg-chat", "m1", ":eyes:")])
+        self.assertEqual(request.ack_reaction_emoji, "👀")
+        self.assertEqual(controller.im_client.reactions, [("tg-chat", "m1", "👀")])
 
     async def test_lark_typing_preference_uses_registry_reaction_capability(self):
         controller = _StubController(platform="lark", ack_mode="typing", typing_result=True)
@@ -343,7 +343,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(request.typing_indicator_active)
         self.assertEqual(controller.im_client.typing_calls, [])
         self.assertEqual(request.ack_reaction_message_id, "om_1")
-        self.assertEqual(controller.im_client.reactions, [("lark-chat", "om_1", ":eyes:")])
+        self.assertEqual(controller.im_client.reactions, [("lark-chat", "om_1", "👀")])
 
     async def test_platform_specific_client_is_used_for_user_info(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
@@ -422,6 +422,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.subagent_name, "reviewer")
         self.assertEqual(request.subagent_key, "reviewer")
         self.assertEqual(request.message, "[Agent Identity] Slack bot mention: <@U_BOT>\ncheck this")
+        self.assertEqual(controller.im_client.reactions, [("C1", "m1", "👀"), ("C1", "m1", "🤖")])
 
     async def test_scheduled_turn_returns_error_string_after_notifying_im(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
@@ -508,7 +509,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(controller.im_client.removed_keyboards, [("chat1", "slack", "prompt-msg")])
         self.assertEqual(controller.im_client.sent_messages, [("chat1", "Reply: 按钮 1")])
-        self.assertEqual(controller.im_client.reactions, [("chat1", "msg-1", ":eyes:")])
+        self.assertEqual(controller.im_client.reactions, [("chat1", "msg-1", "👀")])
         _, request = controller.agent_service.requests[0]
         self.assertIsNone(request.context.message_id)
         self.assertEqual(request.ack_reaction_message_id, "msg-1")

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -125,6 +125,22 @@ class _ResponseLike:
 
 
 class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_add_reaction_maps_unicode_robot_to_slack_name(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        calls = []
+
+        class _WebClient:
+            async def reactions_add(self, **kwargs):
+                calls.append(kwargs)
+
+        slack.web_client = _WebClient()
+        context = MessageContext(user_id="U123", channel_id="C123")
+
+        ok = await slack.add_reaction(context, "1710000000.000010", "🤖")
+
+        self.assertTrue(ok)
+        self.assertEqual(calls[0]["name"], "robot_face")
+
     async def test_send_message_does_not_set_unfurl_params_by_default(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
         sent_payloads = []

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -38,10 +38,15 @@ class _FakeIMClient:
     def __init__(self, message_id="msg-1"):
         self.message_id = message_id
         self.dm_calls = []
+        self.edit_calls = []
 
     async def send_dm(self, user_id: str, text: str, **kwargs):
         self.dm_calls.append((user_id, text, kwargs))
         return self.message_id
+
+    async def edit_message(self, context, message_id: str, text: str, **kwargs):
+        self.edit_calls.append((context, message_id, text, kwargs))
+        return True
 
 
 def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
@@ -170,6 +175,24 @@ def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp
     assert data["platform"] == "telegram"
     assert data["channel_id"] == "123456"
     assert data["message_id"] == "42"
+
+
+def test_post_update_notification_uses_unicode_emoji_for_non_slack(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    store = SettingsStore.get_instance()
+    controller = _StubController(store)
+    telegram_client = _FakeIMClient()
+    controller.im_clients = {"telegram": telegram_client}
+    checker = UpdateChecker(controller, UpdateConfig())
+    checker._write_update_marker("1.0.1", channel_id="123456", message_id="42", platform="telegram")
+
+    asyncio.run(checker.check_and_send_post_update_notification())
+
+    assert telegram_client.edit_calls
+    _, _, text, _ = telegram_client.edit_calls[0]
+    assert text == "✅ Vibe Remote has been updated to `1.0.1`"
+    assert ":white_check_mark:" not in text
 
 
 def test_stop_returns_cancellable_task(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Replace Slack-style emoji aliases in update notifications with Unicode emoji for cross-IM rendering.
- Use Unicode reaction emoji at the shared processing/subagent call sites while preserving adapter compatibility for legacy aliases.
- Add regression coverage for non-Slack update completion text and Slack Unicode robot reaction mapping.

## Evidence Layers
- Unit: updated update checker, message handler typing, and Slack reaction tests.
- Contract: adapter compatibility preserved for existing `:eyes:` / `:robot_face:` inputs.
- Scenario: N/A; no scenario catalog entry for update-notification emoji rendering.
- Residual manual checks: not run; Docker IM regression is still the broader end-to-end check if needed.

## Validation
- `uv run pytest tests/test_update_checker_platforms.py tests/test_message_handler_typing.py tests/test_slack_dm_mentions.py::SlackDmMentionTests::test_add_reaction_maps_unicode_robot_to_slack_name`
- `uv run ruff check core/update_checker.py core/processing_indicator.py core/handlers/message_handler.py modules/im/slack.py modules/agents/claude_agent.py tests/test_update_checker_platforms.py tests/test_message_handler_typing.py tests/test_slack_dm_mentions.py`
