### PR TITLE
Add screenshot, file sending, and Telegram bot menu

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -343,6 +343,10 @@ class Controller:
             "settings": self._dispatch_to_controller_loop(self.settings_handler.handle_settings),
             "stop": self._dispatch_to_controller_loop(self.command_handler.handle_stop),
             "bind": self._dispatch_to_controller_loop(self.command_handler.handle_bind),
+            "screenshot": self._dispatch_to_controller_loop(self.command_handler.handle_screenshot),
+            "window": self._dispatch_to_controller_loop(
+                lambda ctx, args="pick": self.command_handler.handle_screenshot(ctx, args or "pick")
+            ),
         }
 
         # Register callbacks with the IM client

--- a/core/handlers/command_handlers.py
+++ b/core/handlers/command_handlers.py
@@ -9,6 +9,7 @@ from modules.agents import get_agent_display_name
 from modules.agents.native_sessions.types import NativeResumeSession
 from modules.agents.base import AgentRequest
 from modules.im import MessageContext, InlineKeyboard, InlineButton
+from modules.tools.screenshot import capture_screenshot, capture_active_window, capture_window_by_title, capture_window_by_hwnd, list_windows, cleanup_old_screenshots, ScreenshotError
 
 from .base import BaseHandler
 
@@ -456,8 +457,12 @@ class CommandHandlers(BaseHandler):
                 InlineButton(text=f"⏮️ {self._t('button.resumeSession')}", callback_data="cmd_resume"),
                 InlineButton(text=f"🤖 {self._t('button.agentSettings')}", callback_data="cmd_routing"),
             ],
-            # Row 4: Features
-            [InlineButton(text=f"✨ {self._t('button.howItWorks')}", callback_data="info_how_it_works")],
+            # Row 4: Screenshot + Features
+            [
+                InlineButton(text="📸 Screenshot", callback_data="cmd_screenshot"),
+                InlineButton(text="🪟 Window", callback_data="cmd_screenshot_window"),
+                InlineButton(text=f"✨ {self._t('button.howItWorks')}", callback_data="info_how_it_works"),
+            ],
         ]
 
         keyboard = InlineKeyboard(buttons=buttons)
@@ -937,4 +942,90 @@ class CommandHandlers(BaseHandler):
             await im_client.send_message(
                 context,  # Use original context
                 f"❌ {self._t('error.stopFailed', error=str(e))}",
+            )
+
+    async def handle_screenshot(self, context: MessageContext, args: str = ""):
+        """Handle /screenshot command - capture a screenshot and send it to the user.
+
+        /screenshot         - capture full screen
+        /screenshot window  - capture active window
+        /screenshot pick    - show window picker (IM platforms with inline buttons)
+        /screenshot <title> - capture window matching title
+        """
+        try:
+            cleanup_old_screenshots()
+            args = args.strip()
+
+            # "pick" mode: show window list as inline buttons
+            if args.lower() == "pick":
+                im_client = self._get_im_client(context)
+                channel_context = self._get_channel_context(context)
+                windows = list_windows()
+                visible = [w for w in windows if w.get("title") and w.get("width", 0) > 0][:10]
+                if not visible:
+                    await im_client.send_message(channel_context, "No visible windows found.")
+                    return
+                rows = []
+                for w in visible:
+                    label = w["title"][:30]
+                    rows.append([InlineButton(text=f"🪟 {label}", callback_data=f"cmd_screenshot_hwnd:{w['hwnd']}")])
+                rows.append([
+                    InlineButton(text="🖥 Full Screen", callback_data="cmd_screenshot"),
+                    InlineButton(text="✖️ Cancel", callback_data="cmd_screenshot_cancel"),
+                ])
+                keyboard = InlineKeyboard(buttons=rows)
+                await im_client.send_message_with_buttons(
+                    channel_context, "📸 Select a window to capture:", keyboard
+                )
+                return
+
+            filepath = None
+            caption = ""
+
+            if not args:
+                filepath = capture_screenshot()
+                caption = "🖥 Full Screen"
+            elif args.lower() in ("window", "active", "w"):
+                filepath = capture_active_window()
+                caption = "🪟 Active Window"
+            elif args.startswith("hwnd:"):
+                hwnd = int(args.split(":", 1)[1])
+                filepath = capture_window_by_hwnd(hwnd)
+                caption = f"🪟 Window"
+            else:
+                filepath = capture_window_by_title(args)
+                caption = f"🪟 {args}"
+
+            im_client = self._get_im_client(context)
+            channel_context = self._get_channel_context(context)
+            if hasattr(im_client, "upload_image_from_path"):
+                await im_client.upload_image_from_path(
+                    channel_context,
+                    file_path=filepath,
+                    title=caption,
+                )
+            elif hasattr(im_client, "upload_file_from_path"):
+                await im_client.upload_file_from_path(
+                    channel_context,
+                    file_path=filepath,
+                    title=f"{caption}.png",
+                )
+            else:
+                await im_client.send_message(
+                    channel_context,
+                    f"📸 {caption}: {filepath}\n(File upload not supported on this platform)",
+                )
+            logger.info(f"Screenshot sent to user {context.user_id}: {filepath}")
+
+        except ScreenshotError as e:
+            logger.warning(f"Screenshot capture failed: {e}")
+            channel_context = self._get_channel_context(context)
+            await self._get_im_client(channel_context).send_message(
+                channel_context, f"❌ {e}"
+            )
+        except Exception as e:
+            logger.error(f"Error handling screenshot command: {e}", exc_info=True)
+            channel_context = self._get_channel_context(context)
+            await self._get_im_client(channel_context).send_message(
+                channel_context, f"❌ Screenshot failed: {e}"
             )

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -392,6 +392,27 @@ class MessageHandler(BaseHandler):
             elif callback_data == "cmd_routing":
                 await settings_handler.handle_routing(context)
 
+            elif callback_data == "cmd_screenshot":
+                await command_handlers.handle_screenshot(context)
+
+            elif callback_data == "cmd_screenshot_window":
+                await command_handlers.handle_screenshot(context, args="pick")
+
+            elif callback_data.startswith("cmd_screenshot_hwnd:"):
+                hwnd_str = callback_data.split(":", 1)[1]
+                try:
+                    hwnd = int(hwnd_str)
+                except ValueError:
+                    hwnd = 0
+                await command_handlers.handle_screenshot(context, args=f"hwnd:{hwnd}")
+
+            elif callback_data.startswith("cmd_screenshot_title:"):
+                title = callback_data.split(":", 1)[1]
+                await command_handlers.handle_screenshot(context, args=title)
+
+            elif callback_data == "cmd_screenshot_cancel":
+                pass
+
             elif callback_data.startswith("vibe_update_now"):
                 # Discord update button handler
                 target_version = None

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -222,6 +222,26 @@ Vibe Remote will automatically send the file as an attachment.
 ### Image syntax
 If you want it sent as an image attachment rather than a regular file, use Markdown image syntax:
 Example: ![Page screenshot](file:///tmp/screenshot.jpg)
+
+## 1b. Screenshots
+When the user asks you to take a screenshot or show them what's on screen, you MUST take the screenshot yourself using Bash — do NOT tell the user to use a /screenshot command.
+
+Use the vibe-screenshot CLI script (works from any working directory):
+
+- **Full screen**: `python {screenshot_cli_path}`
+- **Active (foreground) window**: `python {screenshot_cli_path} window`
+- **Window by title** (partial match): `python {screenshot_cli_path} title Chrome`
+- **Window by HWND** (most reliable): `python {screenshot_cli_path} hwnd 12345`
+- **List visible windows** (shows hwnd + title): `python {screenshot_cli_path} list`
+
+The command prints the saved file path. Use that path in the image syntax:
+![Screenshot](file:///THE_PRINTED_PATH)
+
+Tips:
+- After launching a program, wait a moment for its window to appear before capturing.
+- If you just launched a program and want to screenshot it, use `title <name>` or `window` after a short delay.
+- Prefer `hwnd` over `title` when the HWND is known — window titles can change dynamically (e.g. spinner animations).
+- If `title` doesn't find a match, use `list` to see what's available, then retry with the correct title or hwnd.
 """
 
 _QUICK_REPLIES_PROMPT = """\
@@ -331,6 +351,29 @@ def _build_user_preferences_prompt(
     )
 
 
+def _resolve_screenshot_cli_path() -> str:
+    """Resolve the path to vibe_screenshot_cli.py at runtime."""
+    try:
+        from vibe.runtime import get_project_root
+        cli_path = get_project_root() / "vibe_screenshot_cli.py"
+        if cli_path.is_file():
+            return str(cli_path).replace("\\", "/")
+    except Exception:
+        pass
+    # Fallback: search sys.path for the package
+    import importlib
+    try:
+        spec = importlib.util.find_spec("vibe")
+        if spec and spec.origin:
+            pkg_dir = os.path.dirname(spec.origin)
+            cli_path = os.path.join(os.path.dirname(pkg_dir), "vibe_screenshot_cli.py")
+            if os.path.isfile(cli_path):
+                return cli_path.replace("\\", "/")
+    except Exception:
+        pass
+    return "vibe_screenshot_cli.py"
+
+
 def build_reply_enhancements_prompt(
     *,
     include_quick_replies: bool = True,
@@ -339,7 +382,7 @@ def build_reply_enhancements_prompt(
 ) -> str:
     """Build the reply-enhancement prompt for the current platform/backend."""
 
-    prompt = _FILES_PROMPT
+    prompt = _FILES_PROMPT.format(screenshot_cli_path=_resolve_screenshot_cli_path())
     if include_quick_replies:
         prompt += _QUICK_REPLIES_PROMPT
     if context is not None:

--- a/modules/im/telegram.py
+++ b/modules/im/telegram.py
@@ -169,6 +169,7 @@ class TelegramBot(BaseIMClient):
         try:
             self._bot_user = (await telegram_api.get_me(self.config.bot_token)).get("result")
             logger.info("Telegram bot connected as @%s", self._bot_user.get("username") if self._bot_user else "unknown")
+            await self._register_bot_menu()
             if self._on_ready:
                 await self._on_ready()
 
@@ -236,6 +237,35 @@ class TelegramBot(BaseIMClient):
             return
         pending = tuple(tasks)
         await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _register_bot_menu(self) -> None:
+        """Register bot commands and menu button via Telegram Bot API."""
+        try:
+            commands = [
+                {"command": "start", "description": "显示主菜单"},
+                {"command": "new", "description": "开始新会话"},
+                {"command": "screenshot", "description": "截取全屏截图"},
+                {"command": "window", "description": "选择窗口截图"},
+                {"command": "cwd", "description": "查看当前工作目录"},
+                {"command": "setcwd", "description": "切换工作目录"},
+                {"command": "resume", "description": "恢复历史会话"},
+                {"command": "settings", "description": "打开设置"},
+                {"command": "routing", "description": "Agent/模型设置"},
+                {"command": "stop", "description": "停止当前任务"},
+            ]
+            await telegram_api.set_my_commands(self.config.bot_token, commands)
+            logger.info("Registered %d bot commands", len(commands))
+        except Exception as e:
+            logger.warning("Failed to register bot commands: %s", e)
+
+        try:
+            menu_button = {
+                "type": "commands",
+            }
+            await telegram_api.set_chat_menu_button(self.config.bot_token, menu_button=menu_button)
+            logger.info("Set chat menu button to commands")
+        except Exception as e:
+            logger.warning("Failed to set chat menu button: %s", e)
 
     async def _drain_background_tasks(self) -> None:
         await self._drain_task_set(self._update_tasks)
@@ -491,7 +521,7 @@ class TelegramBot(BaseIMClient):
         }
         callback_data = str(payload.get("data", ""))
         primary_action = self._resolve_callback_action(callback_data)
-        is_internal_callback = callback_data.startswith(("tg_cwd:", "tg_resume:", "tg_route:", "tg_question:", "tg_settings:"))
+        is_internal_callback = callback_data.startswith(("tg_cwd:", "tg_resume:", "tg_route:", "tg_question:", "tg_settings:", "tg_screenshot:"))
         if is_internal_callback:
             auth_result = self.check_authorization(
                 user_id=context.user_id,
@@ -545,6 +575,9 @@ class TelegramBot(BaseIMClient):
             return True
         if callback_data.startswith("tg_question:"):
             await self._handle_question_callback(context, callback_data)
+            return True
+        if callback_data.startswith("tg_screenshot:"):
+            await self._handle_screenshot_callback(context, callback_data)
             return True
         return False
 
@@ -716,6 +749,8 @@ class TelegramBot(BaseIMClient):
             "set_cwd",
             "bind",
             "stop",
+            "screenshot",
+            "window",
         }
         parsed_command = self.parse_text_command(stripped, allow_plain_bind=True)
         if parsed_command and parsed_command[0] in known_commands:
@@ -1791,6 +1826,66 @@ class TelegramBot(BaseIMClient):
             ]
         )
         return "\n".join(lines), InlineKeyboard(buttons=rows)
+
+    async def _handle_screenshot_callback(self, context: MessageContext, callback_data: str) -> None:
+        """Handle tg_screenshot:... callback actions."""
+        from modules.tools.screenshot import (
+            capture_screenshot, capture_active_window,
+            capture_window_by_title, capture_window_by_hwnd,
+            list_windows, cleanup_old_screenshots, ScreenshotError,
+        )
+        action = callback_data.split(":", 1)[1] if ":" in callback_data else "fullscreen"
+        try:
+            cleanup_old_screenshots()
+            filepath = None
+            caption = ""
+
+            if action == "fullscreen":
+                filepath = capture_screenshot()
+                caption = "🖥 Full Screen"
+            elif action == "window":
+                filepath = capture_active_window()
+                caption = "🪟 Active Window"
+            elif action.startswith("hwnd:"):
+                hwnd = int(action.split(":", 1)[1])
+                filepath = capture_window_by_hwnd(hwnd)
+                caption = "🪟 Window"
+            elif action.startswith("title:"):
+                title = action.split(":", 1)[1]
+                filepath = capture_window_by_title(title)
+                caption = f"🪟 {title}"
+            elif action == "pick":
+                windows = list_windows()
+                visible = [w for w in windows if w.get("title") and w.get("width", 0) > 0][:10]
+                if not visible:
+                    await self.send_message(context, "No visible windows found.")
+                    return
+                rows = []
+                for w in visible:
+                    label = w["title"][:30]
+                    rows.append([InlineButton(text=f"🪟 {label}", callback_data=f"tg_screenshot:hwnd:{w['hwnd']}")])
+                rows.append([
+                    InlineButton(text="🖥 Full Screen", callback_data="tg_screenshot:fullscreen"),
+                    InlineButton(text="✖️ Cancel", callback_data="tg_screenshot:cancel"),
+                ])
+                keyboard = InlineKeyboard(buttons=rows)
+                await self.send_message_with_buttons(context, "📸 Select a window to capture:", keyboard)
+                return
+            elif action == "cancel":
+                return
+
+            if filepath is None:
+                await self.send_message(context, "❌ Screenshot capture failed.")
+                return
+            await self.upload_image_from_path(context, file_path=filepath, title=caption)
+            logger.info("Screenshot sent via callback: %s", filepath)
+
+        except ScreenshotError as e:
+            logger.warning("Screenshot capture failed: %s", e)
+            await self.send_message(context, f"❌ {e}")
+        except Exception as e:
+            logger.error("Error handling screenshot callback: %s", e, exc_info=True)
+            await self.send_message(context, f"❌ Screenshot failed: {e}")
 
     async def _handle_settings_callback(self, context: MessageContext, callback_data: str) -> None:
         scope_key = self._interaction_scope_key(context)

--- a/modules/im/telegram_api.py
+++ b/modules/im/telegram_api.py
@@ -98,6 +98,24 @@ async def clear_message_reaction(bot_token: str, chat_id: str, message_id: str) 
     return await call_api(bot_token, "setMessageReaction", payload)
 
 
+async def set_my_commands(
+    bot_token: str,
+    commands: list[dict[str, str]],
+) -> dict[str, Any]:
+    return await call_api(bot_token, "setMyCommands", {"commands": commands})
+
+
+async def set_chat_menu_button(
+    bot_token: str,
+    *,
+    menu_button: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if menu_button is not None:
+        payload["menu_button"] = menu_button
+    return await call_api(bot_token, "setChatMenuButton", payload)
+
+
 async def send_multipart_file(
     bot_token: str,
     method: str,

--- a/modules/tools/screenshot.py
+++ b/modules/tools/screenshot.py
@@ -1,0 +1,584 @@
+import os
+import time
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SCREENSHOT_DIR = os.path.join(os.path.expanduser("~"), ".vibe_remote", "screenshots")
+
+
+class ScreenshotError(Exception):
+    """Raised when a screenshot capture fails with a specific reason."""
+
+
+def ensure_screenshot_dir():
+    os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+
+
+def _timestamp() -> str:
+    return time.strftime("%Y%m%d_%H%M%S")
+
+
+def _save_cropped_image(full_img, left: int, top: int, right: int, bottom: int, filepath: str) -> bool:
+    """Crop a region from a full-screen mss image and save as PNG.
+
+    Returns True on success, False on failure (e.g. empty crop, off-screen window).
+    """
+    import numpy as np
+
+    c_left = max(0, min(left, full_img.shape[1]))
+    c_top = max(0, min(top, full_img.shape[0]))
+    c_right = max(0, min(right, full_img.shape[1]))
+    c_bottom = max(0, min(bottom, full_img.shape[0]))
+
+    crop_w = c_right - c_left
+    crop_h = c_bottom - c_top
+    if crop_w <= 0 or crop_h <= 0:
+        logger.error(f"Empty crop region: {crop_w}x{crop_h} (window may be off-screen or minimized)")
+        return False
+
+    cropped = full_img[c_top:c_bottom, c_left:c_right]
+    # mss returns BGRA; reverse BGR -> RGB for correct colors
+    rgb_data = cropped[:, :, :3][:, :, ::-1]
+
+    try:
+        from PIL import Image as PILImage
+        img = PILImage.fromarray(rgb_data)
+        img.save(filepath, "PNG")
+        return True
+    except ImportError:
+        mss.tools.to_png(rgb_data.tobytes(), (crop_w, crop_h), output=filepath)
+        # Verify the file was created and is not a degenerate PNG
+        if os.path.getsize(filepath) < 100:
+            logger.error(f"Generated PNG is too small ({os.path.getsize(filepath)} bytes), likely invalid")
+            os.remove(filepath)
+            return False
+        return True
+
+
+def _is_window_on_screen(left: int, top: int, right: int, bottom: int) -> bool:
+    """Check if a window rect has any visible portion on the primary monitor."""
+    # Windows places minimized windows at (-32000, -32000) or similar off-screen coords
+    if left < -10000 or top < -10000:
+        return False
+    if right <= left or bottom <= top:
+        return False
+    return True
+
+
+def capture_screenshot(monitor: int = 1) -> str | None:
+    """Capture a full-screen screenshot. Returns file path or None on failure.
+
+    monitor=1 captures the primary display (mss.monitors[1]).
+    monitor=0 captures all monitors combined (mss.monitors[0]).
+    """
+    try:
+        import mss
+    except ImportError:
+        raise ScreenshotError("mss not installed. Run: pip install mss")
+
+    ensure_screenshot_dir()
+    filepath = os.path.join(SCREENSHOT_DIR, f"fullscreen_{_timestamp()}.png")
+
+    try:
+        with mss.MSS() as sct:
+            monitors = sct.monitors
+            if monitor >= len(monitors):
+                monitor = len(monitors) - 1
+            shot = sct.grab(monitors[monitor])
+            import numpy as np
+            full_img = np.array(shot)
+            if not _save_cropped_image(full_img, 0, 0, full_img.shape[1], full_img.shape[0], filepath):
+                raise ScreenshotError("Failed to save fullscreen screenshot")
+            logger.info(f"Fullscreen screenshot saved: {filepath}")
+            return filepath
+    except ScreenshotError:
+        raise
+    except Exception as e:
+        raise ScreenshotError(f"Fullscreen screenshot failed: {e}") from e
+
+
+def capture_active_window() -> str | None:
+    """Capture the currently focused application window. Returns file path or None."""
+    try:
+        import ctypes
+        import ctypes.wintypes
+    except ImportError:
+        return _capture_active_window_linux()
+
+    ensure_screenshot_dir()
+    filepath = os.path.join(SCREENSHOT_DIR, f"window_{_timestamp()}.png")
+
+    try:
+        user32 = ctypes.windll.user32
+
+        hwnd = user32.GetForegroundWindow()
+        if not hwnd:
+            raise ScreenshotError("No foreground window found")
+
+        rect = ctypes.wintypes.RECT()
+        user32.GetWindowRect(hwnd, ctypes.byref(rect))
+
+        title_len = user32.GetWindowTextLengthW(hwnd) + 1
+        title_buf = ctypes.create_unicode_buffer(title_len)
+        user32.GetWindowTextW(hwnd, title_buf, title_len)
+        window_title = title_buf.value
+
+        # Always convert logical coords to physical pixels
+        left, top, right, bottom = _logical_to_physical_rect(
+            rect.left, rect.top, rect.right, rect.bottom
+        )
+
+        if not _is_window_on_screen(left, top, right, bottom):
+            raise ScreenshotError(f"Window '{window_title}' is off-screen or minimized")
+
+        import mss
+        with mss.MSS() as sct:
+            full_shot = sct.grab(sct.monitors[1])
+
+            import numpy as np
+            full_img = np.array(full_shot)
+            if not _save_cropped_image(full_img, left, top, right, bottom, filepath):
+                raise ScreenshotError("Failed to save window screenshot")
+            logger.info(f"Window screenshot saved ({window_title}): {filepath}")
+            return filepath
+    except ScreenshotError:
+        raise
+    except Exception as e:
+        raise ScreenshotError(f"Window screenshot failed: {e}") from e
+
+
+def _get_linux_dpi_scale() -> tuple[float, float]:
+    """Get the DPI scaling factor on Linux using xrandr.
+
+    Returns (scale_x, scale_y). Falls back to (1.0, 1.0) if detection fails.
+    On most X11 desktops without fractional scaling, this returns (1.0, 1.0).
+    """
+    import subprocess
+    try:
+        result = subprocess.run(
+            ["xrandr", "--query"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            return 1.0, 1.0
+        for line in result.stdout.splitlines():
+            if " connected" not in line:
+                continue
+            # Look for --scale NxN in the current mode line or transform matrix
+            # xrandr reports: "eDP-1 connected primary 1920x1080+0+0 (normal left inverted right x-axis y-axis) ..."
+            # Scale can appear as transform or --scale; parse the geometry instead.
+            # Alternative: parse "current X x Y" from xrandr output header
+            break
+        # Parse the screen size line: "Screen 0: minimum ... current 1920 x 1080 ..."
+        for line in result.stdout.splitlines():
+            if line.startswith("Screen ") and "current" in line:
+                import re
+                m = re.search(r"current (\d+) x (\d+)", line)
+                if m:
+                    # Compare with the physical resolution from mss
+                    pass
+        return 1.0, 1.0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return 1.0, 1.0
+
+
+def _linux_logical_to_physical(left: int, top: int, right: int, bottom: int) -> tuple[int, int, int, int]:
+    """Convert logical-pixel window rect to physical pixels on Linux.
+
+    On X11 with HiDPI scaling (e.g. 200%), xdotool returns logical coordinates
+    while mss captures in physical pixels. This function uses mss monitor info
+    to detect the scale factor and convert.
+    """
+    try:
+        import mss
+        with mss.MSS() as sct:
+            # mss.monitors[0] is the full virtual screen area (logical or physical depending on setup)
+            # mss.monitors[1] is the primary monitor
+            if len(sct.monitors) < 2:
+                return left, top, right, bottom
+            primary = sct.monitors[1]
+            phys_w = primary["width"]
+            phys_h = primary["height"]
+
+        # Get logical resolution from xdpyinfo or xrandr
+        import subprocess
+        try:
+            result = subprocess.run(
+                ["xdpyinfo"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                import re
+                for line in result.stdout.splitlines():
+                    if "dimensions:" in line:
+                        m = re.search(r"dimensions:\s+(\d+)x(\d+)", line)
+                        if m:
+                            log_w, log_h = int(m.group(1)), int(m.group(2))
+                            scale_x = phys_w / log_w if log_w else 1.0
+                            scale_y = phys_h / log_h if log_h else 1.0
+                            if scale_x == 1.0 and scale_y == 1.0:
+                                return left, top, right, bottom
+                            return (
+                                int(left * scale_x), int(top * scale_y),
+                                int(right * scale_x), int(bottom * scale_y),
+                            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+        return left, top, right, bottom
+    except Exception:
+        return left, top, right, bottom
+
+
+def _capture_active_window_linux() -> str | None:
+    """Capture active window on Linux using xdotool + mss."""
+    if not _check_xdotool():
+        raise ScreenshotError("xdotool not installed. Install: sudo apt install xdotool")
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["xdotool", "getactivewindow", "getwindowgeometry"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            raise ScreenshotError("xdotool failed to get active window geometry")
+
+        # Parse output: Position: X,Y (WxH)
+        left = top = width = height = 0
+        for line in result.stdout.splitlines():
+            if "Position" in line:
+                parts = line.split()
+                pos = parts[1].split(",")
+                geom = parts[2].replace("(", "").replace(")", "").split("x")
+                left, top = int(pos[0]), int(pos[1])
+                width, height = int(geom[0]), int(geom[1])
+                break
+
+        # Convert logical coords to physical pixels for mss
+        left, top, right, bottom = _linux_logical_to_physical(
+            left, top, left + width, top + height,
+        )
+
+        import mss
+        ensure_screenshot_dir()
+        filepath = os.path.join(SCREENSHOT_DIR, f"window_{_timestamp()}.png")
+        with mss.MSS() as sct:
+            monitor = {"left": left, "top": top, "width": right - left, "height": bottom - top}
+            shot = sct.grab(monitor)
+            mss.tools.to_png(shot.rgb, shot.size, output=filepath)
+            return filepath
+    except ScreenshotError:
+        raise
+    except Exception as e:
+        raise ScreenshotError(f"Linux window screenshot failed: {e}") from e
+
+
+def _get_dpi_scale() -> tuple[float, float]:
+    """Get the DPI scaling factor (physical / logical) for the primary monitor.
+
+    Works regardless of whether the process has DPI awareness set.
+    """
+    try:
+        import ctypes
+        user32 = ctypes.windll.user32
+        gdi32 = ctypes.windll.gdi32
+        hdc = user32.GetDC(0)
+        logical_w = gdi32.GetDeviceCaps(hdc, 8)   # HORZRES
+        logical_h = gdi32.GetDeviceCaps(hdc, 10)  # VERTRES
+        phys_w = gdi32.GetDeviceCaps(hdc, 118)    # DESKTOPHORZRES
+        phys_h = gdi32.GetDeviceCaps(hdc, 117)    # DESKTOPVERTRES
+        user32.ReleaseDC(0, hdc)
+        scale_x = phys_w / logical_w if logical_w else 1.0
+        scale_y = phys_h / logical_h if logical_h else 1.0
+        return scale_x, scale_y
+    except Exception:
+        return 1.0, 1.0
+
+
+def _logical_to_physical_rect(left: int, top: int, right: int, bottom: int) -> tuple[int, int, int, int]:
+    """Convert logical-pixel window rect to physical pixels using DPI scale."""
+    scale_x, scale_y = _get_dpi_scale()
+    if scale_x == 1.0 and scale_y == 1.0:
+        return left, top, right, bottom
+    return int(left * scale_x), int(top * scale_y), int(right * scale_x), int(bottom * scale_y)
+
+
+def list_windows() -> list[dict]:
+    """List visible application windows with titles and positions.
+
+    Only returns windows that are on-screen (not minimized/hidden).
+    Returns coordinates in physical pixels (converted from logical via DPI scale).
+    """
+    try:
+        import ctypes
+        import ctypes.wintypes
+    except ImportError:
+        return _list_windows_linux()
+
+    windows = []
+    try:
+        user32 = ctypes.windll.user32
+        gdi32 = ctypes.windll.gdi32
+
+        WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
+
+        def _enum_cb(hwnd, lparam):
+            if not user32.IsWindowVisible(hwnd):
+                return True
+            title_len = user32.GetWindowTextLengthW(hwnd)
+            if title_len == 0:
+                return True
+            title_buf = ctypes.create_unicode_buffer(title_len + 1)
+            user32.GetWindowTextW(hwnd, title_buf, title_len + 1)
+            rect = ctypes.wintypes.RECT()
+            user32.GetWindowRect(hwnd, ctypes.byref(rect))
+            # Convert logical coords to physical pixels
+            p_left, p_top, p_right, p_bottom = _logical_to_physical_rect(
+                rect.left, rect.top, rect.right, rect.bottom
+            )
+            # Skip minimized/off-screen windows
+            if not _is_window_on_screen(p_left, p_top, p_right, p_bottom):
+                return True
+            windows.append({
+                "hwnd": hwnd,
+                "title": title_buf.value,
+                "left": p_left,
+                "top": p_top,
+                "width": p_right - p_left,
+                "height": p_bottom - p_top,
+            })
+            return True
+
+        user32.EnumWindows(WNDENUMPROC(_enum_cb), 0)
+    except Exception as e:
+        logger.error(f"Failed to list windows: {e}")
+    return windows
+
+
+def _check_xdotool() -> bool:
+    """Check if xdotool is available on Linux. Log a warning if not."""
+    import subprocess
+    try:
+        subprocess.run(["xdotool", "--version"], capture_output=True, timeout=2)
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        logger.warning("xdotool not installed. Window capture on Linux requires xdotool. Install: sudo apt install xdotool")
+        return False
+
+
+def _list_windows_linux() -> list[dict]:
+    if not _check_xdotool():
+        return []
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["xdotool", "search", "--name", ""],
+            capture_output=True, text=True, timeout=5,
+        )
+        windows = []
+        for wid in result.stdout.strip().splitlines():
+            wid = wid.strip()
+            if not wid:
+                continue
+            name_result = subprocess.run(
+                ["xdotool", "getwindowname", wid],
+                capture_output=True, text=True, timeout=2,
+            )
+            if name_result.returncode == 0 and name_result.stdout.strip():
+                windows.append({"hwnd": int(wid), "title": name_result.stdout.strip()})
+        return windows
+    except Exception:
+        return []
+
+
+def capture_window_by_hwnd(hwnd: int) -> str | None:
+    """Capture a specific window by its HWND (Windows) or window ID (Linux).
+
+    More reliable than title-based capture because window titles can change
+    dynamically (e.g. Claude Code spinner animation).
+    """
+    try:
+        import ctypes
+        import ctypes.wintypes
+    except ImportError:
+        return _capture_window_by_wid_linux(hwnd)
+
+    try:
+        user32 = ctypes.windll.user32
+
+        if not user32.IsWindow(hwnd) or not user32.IsWindowVisible(hwnd):
+            raise ScreenshotError(f"HWND {hwnd} is not a visible window")
+
+        rect = ctypes.wintypes.RECT()
+        user32.GetWindowRect(hwnd, ctypes.byref(rect))
+
+        title_len = user32.GetWindowTextLengthW(hwnd) + 1
+        title_buf = ctypes.create_unicode_buffer(title_len)
+        user32.GetWindowTextW(hwnd, title_buf, title_len)
+        window_title = title_buf.value
+
+        left, top, right, bottom = _logical_to_physical_rect(
+            rect.left, rect.top, rect.right, rect.bottom
+        )
+
+        if not _is_window_on_screen(left, top, right, bottom):
+            raise ScreenshotError(f"Window '{window_title}' (HWND {hwnd}) is off-screen or minimized")
+
+        ensure_screenshot_dir()
+        filepath = os.path.join(SCREENSHOT_DIR, f"window_{_timestamp()}.png")
+
+        import mss
+        with mss.MSS() as sct:
+            full_shot = sct.grab(sct.monitors[1])
+
+            import numpy as np
+            full_img = np.array(full_shot)
+            if not _save_cropped_image(full_img, left, top, right, bottom, filepath):
+                raise ScreenshotError("Failed to save window screenshot")
+            logger.info(f"Window screenshot saved ({window_title}): {filepath}")
+            return filepath
+    except ScreenshotError:
+        raise
+    except Exception as e:
+        raise ScreenshotError(f"Window-by-HWND screenshot failed: {e}") from e
+
+
+def capture_window_by_title(title: str) -> str | None:
+    """Capture a specific window by matching its title (partial match).
+
+    Prefer capture_window_by_hwnd() when the HWND is known, as window titles
+    can change dynamically (e.g. spinner animations).
+    """
+    try:
+        import ctypes
+        import ctypes.wintypes
+    except ImportError:
+        return _capture_window_by_title_linux(title)
+
+    try:
+        windows = list_windows()
+        matches = [w for w in windows if title.lower() in w["title"].lower()]
+        if not matches:
+            visible_titles = [w["title"] for w in windows[:10]]
+            raise ScreenshotError(f"No window matching '{title}' found. Visible windows: {visible_titles}")
+
+        # Use the first match's HWND for reliable capture
+        target = matches[0]
+        return capture_window_by_hwnd(target["hwnd"])
+    except ScreenshotError:
+        raise
+    except Exception as e:
+        raise ScreenshotError(f"Window-by-title screenshot failed: {e}") from e
+
+
+def _capture_window_by_wid_linux(wid: int) -> str | None:
+    """Capture a specific window by its window ID on Linux using xdotool + mss."""
+    if not _check_xdotool():
+        raise ScreenshotError("xdotool not installed. Install: sudo apt install xdotool")
+    try:
+        import subprocess
+        geom_result = subprocess.run(
+            ["xdotool", "getwindowgeometry", str(wid)],
+            capture_output=True, text=True, timeout=5,
+        )
+        if geom_result.returncode != 0:
+            raise ScreenshotError(f"Window ID {wid} not found")
+
+        left = top = width = height = 0
+        for line in geom_result.stdout.splitlines():
+            if "Position" in line:
+                parts = line.split()
+                pos = parts[1].split(",")
+                geom = parts[2].replace("(", "").replace(")", "").split("x")
+                left, top = int(pos[0]), int(pos[1])
+                width, height = int(geom[0]), int(geom[1])
+
+        if width <= 0 or height <= 0:
+            raise ScreenshotError(f"Invalid window dimensions for WID {wid}: {width}x{height}")
+
+        # Convert logical coords to physical pixels for mss
+        p_left, p_top, p_right, p_bottom = _linux_logical_to_physical(
+            left, top, left + width, top + height,
+        )
+        p_width = p_right - p_left
+        p_height = p_bottom - p_top
+
+        import mss
+        ensure_screenshot_dir()
+        filepath = os.path.join(SCREENSHOT_DIR, f"window_{_timestamp()}.png")
+        with mss.MSS() as sct:
+            monitor = {"left": p_left, "top": p_top, "width": p_width, "height": p_height}
+            shot = sct.grab(monitor)
+            mss.tools.to_png(shot.rgb, shot.size, output=filepath)
+            return filepath
+    except ScreenshotError:
+        raise
+    except Exception as e:
+        raise ScreenshotError(f"Linux window-by-WID screenshot failed: {e}") from e
+
+
+def _capture_window_by_title_linux(title: str) -> str | None:
+    if not _check_xdotool():
+        raise ScreenshotError("xdotool not installed. Install: sudo apt install xdotool")
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["xdotool", "search", "--name", title],
+            capture_output=True, text=True, timeout=5,
+        )
+        wid = result.stdout.strip().splitlines()[0]
+        geom_result = subprocess.run(
+            ["xdotool", "getwindowgeometry", wid],
+            capture_output=True, text=True, timeout=5,
+        )
+        left = top = width = height = 0
+        for line in geom_result.stdout.splitlines():
+            if "Position" in line:
+                parts = line.split()
+                pos = parts[1].split(",")
+                geom = parts[2].replace("(", "").replace(")", "").split("x")
+                left, top = int(pos[0]), int(pos[1])
+                width, height = int(geom[0]), int(geom[1])
+
+        # Convert logical coords to physical pixels for mss
+        p_left, p_top, p_right, p_bottom = _linux_logical_to_physical(
+            left, top, left + width, top + height,
+        )
+        p_width = p_right - p_left
+        p_height = p_bottom - p_top
+
+        import mss
+        ensure_screenshot_dir()
+        filepath = os.path.join(SCREENSHOT_DIR, f"window_{_timestamp()}.png")
+        with mss.MSS() as sct:
+            monitor = {"left": p_left, "top": p_top, "width": p_width, "height": p_height}
+            shot = sct.grab(monitor)
+            mss.tools.to_png(shot.rgb, shot.size, output=filepath)
+            return filepath
+    except ScreenshotError:
+        raise
+    except Exception as e:
+        raise ScreenshotError(f"Linux window-by-title screenshot failed: {e}") from e
+
+
+def list_screenshots() -> list[str]:
+    """List all saved screenshots, newest first."""
+    ensure_screenshot_dir()
+    files = sorted(
+        Path(SCREENSHOT_DIR).glob("*.png"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return [str(f) for f in files]
+
+
+def cleanup_old_screenshots(max_age_hours: int = 24):
+    """Remove screenshots older than max_age_hours."""
+    ensure_screenshot_dir()
+    cutoff = time.time() - max_age_hours * 3600
+    for f in Path(SCREENSHOT_DIR).glob("*.png"):
+        if f.stat().st_mtime < cutoff:
+            f.unlink()
+            logger.info(f"Cleaned up old screenshot: {f}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
     "sentry-sdk>=2.0.0",
     "python-socks[asyncio]>=2.0.0",
     "aiohttp-socks>=0.8.0",
+    "mss>=0.9.0",  # screen capture (Windows & Linux)
+    "pyxdg>=0.28; sys_platform == 'linux'",  # Linux: XDG base directory support
 ]
 
 [project.urls]

--- a/vibe_screenshot_cli.py
+++ b/vibe_screenshot_cli.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""CLI entry point for screenshot capture. Used by AI agents via Bash.
+
+Usage:
+    vibe-screenshot                  Capture full screen
+    vibe-screenshot fullscreen       Capture full screen
+    vibe-screenshot window           Capture active (foreground) window
+    vibe-screenshot title <title>    Capture window by title (partial match)
+    vibe-screenshot hwnd <hwnd>      Capture window by HWND/window ID
+    vibe-screenshot list             List visible windows (hwnd + title)
+
+Prints the saved file path on success, or an error message on failure.
+"""
+
+import sys
+import os
+
+# Ensure the vibe-remote package is importable regardless of CWD
+_vibe_remote_dir = os.path.dirname(os.path.abspath(__file__))
+if _vibe_remote_dir not in sys.path:
+    sys.path.insert(0, _vibe_remote_dir)
+
+from modules.tools.screenshot import (
+    capture_screenshot,
+    capture_active_window,
+    capture_window_by_title,
+    capture_window_by_hwnd,
+    list_windows,
+    ScreenshotError,
+)
+
+
+def main():
+    args = sys.argv[1:]
+
+    if not args or args[0] == "fullscreen":
+        path = capture_screenshot()
+    elif args[0] == "window":
+        path = capture_active_window()
+    elif args[0] == "title" and len(args) >= 2:
+        title = " ".join(args[1:])
+        path = capture_window_by_title(title)
+    elif args[0] == "hwnd" and len(args) >= 2:
+        hwnd = int(args[1])
+        path = capture_window_by_hwnd(hwnd)
+    elif args[0] == "list":
+        windows = list_windows()
+        for w in windows:
+            title = w.get("title", "")
+            if title:
+                try:
+                    print(f"{w['hwnd']}\t{title}")
+                except UnicodeEncodeError:
+                    safe_title = title.encode("utf-8", errors="replace").decode("utf-8", errors="replace")
+                    sys.stdout.buffer.write(f"{w['hwnd']}\t{safe_title}\n".encode("utf-8", errors="replace"))
+        return
+    else:
+        print(f"Unknown command: {args}", file=sys.stderr)
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+
+    if path:
+        print(path)
+    else:
+        print("Screenshot capture failed", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ScreenshotError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Three new capabilities for Vibe Remote:

### 1. Remote screenshot
Users can capture their desktop from Telegram — fullscreen, active window, by title/hwnd, or via a window picker with inline buttons. The screenshot module handles Windows and Linux DPI scaling correctly, converting logical coordinates to physical pixels before capture.

Agents can also take screenshots themselves via the `vibe_screenshot_cli.py` CLI and send them using the `file://` image syntax.

### 2. File and image sending
Agents can now send files and images back to the user in their reply text:
- `[File](file:///path/to/file.pdf)` → sent as a document attachment
- `![Screenshot](file:///path/to/shot.png)` → sent as an image attachment

The reply enhancer parses these, strips the markup, and the IM client uploads the files.

### 3. Telegram bot command menu
Registering bot commands via `setMyCommands` and setting the chat menu button via `setChatMenuButton`. Now typing `/` shows a command list, and the M button appears next to the input field.

### New files
- `modules/tools/screenshot.py` — cross-platform screenshot module (Windows + Linux, DPI-aware)
- `vibe_screenshot_cli.py` — CLI entry point for agent use via Bash
- `modules/tools/__init__.py` — package init

### Dependencies
- `mss>=0.9.0` — screen capture library
- `pyxdg>=0.28` (Linux only) — XDG directory support

## Test plan

- [x] Full screen screenshot works on Windows with high DPI
- [x] Window capture by title and hwnd works correctly
- [x] Window picker shows visible windows as inline buttons
- [x] Agent can take screenshots via CLI and send with file:// syntax
- [x] File links in agent replies are uploaded as attachments
- [x] Image links are uploaded as photos
- [x] Bot command menu appears when typing / in Telegram
- [x] M menu button appears next to input field

🤖 Generated with [Claude Code](https://claude.com/claude-code)