### PR TITLE
fix(sentry): limit default error volume

### DIFF
--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -339,6 +339,23 @@ def test_event_rate_state_enforces_cache_limit(monkeypatch):
     assert len(sentry_integration._EVENT_RATE_STATE) == 2
 
 
+def test_event_rate_state_evicts_oldest_entries(monkeypatch):
+    monkeypatch.setattr(sentry_integration, "_EVENT_RATE_CACHE_LIMIT", 2)
+    sentry_integration._EVENT_RATE_STATE.clear()
+    sentry_integration._EVENT_RATE_STATE.update(
+        {
+            "z-oldest": (1.0, 1),
+            "a-middle": (2.0, 1),
+            "m-newest": (3.0, 1),
+        }
+    )
+
+    sentry_integration._prune_event_rate_state(now=3.0, window_seconds=10.0)
+
+    assert "z-oldest" not in sentry_integration._EVENT_RATE_STATE
+    assert set(sentry_integration._EVENT_RATE_STATE) == {"a-middle", "m-newest"}
+
+
 def test_before_send_rate_state_is_thread_safe(monkeypatch):
     monkeypatch.setattr(sentry_integration, "_EVENT_RATE_CACHE_LIMIT", 8)
     sentry_integration._EVENT_RATE_STATE.clear()

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -4,6 +4,7 @@ import sys
 import types
 import importlib
 import ast
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -336,3 +337,21 @@ def test_event_rate_state_enforces_cache_limit(monkeypatch):
         assert sentry_integration.before_send(event, {}) is not None
 
     assert len(sentry_integration._EVENT_RATE_STATE) == 2
+
+
+def test_before_send_rate_state_is_thread_safe(monkeypatch):
+    monkeypatch.setattr(sentry_integration, "_EVENT_RATE_CACHE_LIMIT", 8)
+    sentry_integration._EVENT_RATE_STATE.clear()
+
+    def send_event(index: int) -> bool:
+        event = {
+            "logger": "core.message_dispatcher",
+            "logentry": {"formatted": f"concurrent application bug {index}"},
+        }
+        return sentry_integration.before_send(event, {}) is not None
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(send_event, range(64)))
+
+    assert all(results)
+    assert len(sentry_integration._EVENT_RATE_STATE) <= 8

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -322,3 +322,17 @@ def test_before_send_rate_limit_can_be_raised(monkeypatch):
     assert sentry_integration.before_send(dict(event), {}) is not None
     assert sentry_integration.before_send(dict(event), {}) is not None
     assert sentry_integration.before_send(dict(event), {}) is None
+
+
+def test_event_rate_state_enforces_cache_limit(monkeypatch):
+    monkeypatch.setattr(sentry_integration, "_EVENT_RATE_CACHE_LIMIT", 2)
+    sentry_integration._EVENT_RATE_STATE.clear()
+
+    for index in range(4):
+        event = {
+            "logger": "core.message_dispatcher",
+            "logentry": {"formatted": f"unique application bug {index}"},
+        }
+        assert sentry_integration.before_send(event, {}) is not None
+
+    assert len(sentry_integration._EVENT_RATE_STATE) == 2

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -114,6 +114,31 @@ def test_init_sentry_returns_false_when_sdk_init_raises(monkeypatch):
     assert sentry_integration.init_sentry(_config(), component="service") is False
 
 
+def test_init_sentry_disables_client_discard_reports(monkeypatch):
+    monkeypatch.setenv("VIBE_SENTRY_DSN", "https://env@example.ingest.sentry.io/2")
+    init_kwargs = {}
+
+    sentry_sdk = types.ModuleType("sentry_sdk")
+    sentry_sdk.init = lambda **kwargs: init_kwargs.update(kwargs)
+    sentry_sdk.set_tag = lambda *args, **kwargs: None
+    sentry_sdk.set_context = lambda *args, **kwargs: None
+
+    logging_integration_module = types.ModuleType("sentry_sdk.integrations.logging")
+
+    class FakeLoggingIntegration:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    logging_integration_module.LoggingIntegration = FakeLoggingIntegration
+
+    monkeypatch.setitem(sys.modules, "sentry_sdk", sentry_sdk)
+    monkeypatch.setitem(sys.modules, "sentry_sdk.integrations.logging", logging_integration_module)
+
+    assert sentry_integration.init_sentry(_config(), component="service") is True
+    assert init_kwargs["send_client_reports"] is False
+
+
 def test_run_ui_server_skips_sentry_when_config_load_fails(monkeypatch):
     fake_flask = types.ModuleType("flask")
 
@@ -127,6 +152,12 @@ def test_run_ui_server_skips_sentry_when_config_load_fails(monkeypatch):
                 return func
 
             return decorator
+
+        def before_request(self, func):
+            return func
+
+        def after_request(self, func):
+            return func
 
         def errorhandler(self, *args, **kwargs):
             def decorator(func):
@@ -201,3 +232,81 @@ def test_scrub_data_redacts_sensitive_values():
     assert scrubbed["request"]["data"]["bot_token"] == "[Filtered]"
     assert scrubbed["request"]["data"]["nested"][0]["client_secret"] == "[Filtered]"
     assert "[Filtered]" in scrubbed["message"]
+
+
+def test_before_send_throttles_repeated_noisy_slack_socket_events(monkeypatch):
+    monkeypatch.delenv("VIBE_SENTRY_NOISE_FILTERS", raising=False)
+    monkeypatch.delenv("VIBE_SENTRY_NOISE_TTL_SECONDS", raising=False)
+    sentry_integration._NOISY_EVENT_LAST_SEEN.clear()
+    sentry_integration._EVENT_RATE_STATE.clear()
+    event = {
+        "logger": "slack_sdk.socket_mode.aiohttp",
+        "logentry": {
+            "formatted": (
+                "Failed to retrieve WSS URL: The request to the Slack API failed. "
+                "(url: https://slack.com/api/apps.connections.open, status: 200)"
+            )
+        },
+    }
+
+    assert sentry_integration.before_send(dict(event), {}) is not None
+    assert sentry_integration.before_send(dict(event), {}) is None
+
+
+def test_before_send_throttles_repeated_normal_errors(monkeypatch):
+    monkeypatch.delenv("VIBE_SENTRY_NOISE_FILTERS", raising=False)
+    monkeypatch.delenv("VIBE_SENTRY_EVENT_RATE_LIMIT_PER_WINDOW", raising=False)
+    sentry_integration._NOISY_EVENT_LAST_SEEN.clear()
+    sentry_integration._EVENT_RATE_STATE.clear()
+    event = {
+        "logger": "core.message_dispatcher",
+        "logentry": {"formatted": "Failed to send result message: unexpected application bug"},
+    }
+
+    assert sentry_integration.before_send(dict(event), {}) is not None
+    assert sentry_integration.before_send(dict(event), {}) is None
+
+
+def test_before_send_allows_distinct_normal_errors(monkeypatch):
+    monkeypatch.delenv("VIBE_SENTRY_EVENT_RATE_LIMIT_PER_WINDOW", raising=False)
+    sentry_integration._NOISY_EVENT_LAST_SEEN.clear()
+    sentry_integration._EVENT_RATE_STATE.clear()
+    first_event = {
+        "logger": "core.message_dispatcher",
+        "logentry": {"formatted": "Failed to send result message: unexpected application bug"},
+    }
+    second_event = {
+        "logger": "core.message_dispatcher",
+        "logentry": {"formatted": "Failed to send result message: different application bug"},
+    }
+
+    assert sentry_integration.before_send(dict(first_event), {}) is not None
+    assert sentry_integration.before_send(dict(second_event), {}) is not None
+
+
+def test_before_send_noise_filter_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("VIBE_SENTRY_NOISE_FILTERS", "0")
+    monkeypatch.setenv("VIBE_SENTRY_EVENT_RATE_LIMIT_PER_WINDOW", "0")
+    sentry_integration._NOISY_EVENT_LAST_SEEN.clear()
+    sentry_integration._EVENT_RATE_STATE.clear()
+    event = {
+        "logger": "core.watches",
+        "logentry": {"formatted": "Managed watch reconcile failed: [Errno 28] No space left on device"},
+    }
+
+    assert sentry_integration.before_send(dict(event), {}) is not None
+    assert sentry_integration.before_send(dict(event), {}) is not None
+
+
+def test_before_send_rate_limit_can_be_raised(monkeypatch):
+    monkeypatch.setenv("VIBE_SENTRY_EVENT_RATE_LIMIT_PER_WINDOW", "2")
+    sentry_integration._NOISY_EVENT_LAST_SEEN.clear()
+    sentry_integration._EVENT_RATE_STATE.clear()
+    event = {
+        "logger": "core.message_dispatcher",
+        "logentry": {"formatted": "Failed to send result message: recurring application bug"},
+    }
+
+    assert sentry_integration.before_send(dict(event), {}) is not None
+    assert sentry_integration.before_send(dict(event), {}) is not None
+    assert sentry_integration.before_send(dict(event), {}) is None

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -284,6 +284,18 @@ def test_before_send_allows_distinct_normal_errors(monkeypatch):
     assert sentry_integration.before_send(dict(second_event), {}) is not None
 
 
+def test_before_send_allows_distinct_exception_values(monkeypatch):
+    monkeypatch.delenv("VIBE_SENTRY_EVENT_RATE_LIMIT_PER_WINDOW", raising=False)
+    sentry_integration._NOISY_EVENT_LAST_SEEN.clear()
+    sentry_integration._EVENT_RATE_STATE.clear()
+    first_event = {"exception": {"values": [{"type": "ValueError", "value": "invalid channel C123456789"}]}}
+    second_event = {"exception": {"values": [{"type": "ValueError", "value": "invalid channel C987654321"}]}}
+
+    assert sentry_integration.before_send(dict(first_event), {}) is not None
+    assert sentry_integration.before_send(dict(second_event), {}) is not None
+    assert sentry_integration.before_send(dict(first_event), {}) is None
+
+
 def test_before_send_noise_filter_can_be_disabled(monkeypatch):
     monkeypatch.setenv("VIBE_SENTRY_NOISE_FILTERS", "0")
     monkeypatch.setenv("VIBE_SENTRY_EVENT_RATE_LIMIT_PER_WINDOW", "0")

--- a/vibe/sentry_integration.py
+++ b/vibe/sentry_integration.py
@@ -6,6 +6,7 @@ import platform
 import re
 import socket
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -48,6 +49,7 @@ _ONE_DAY_SECONDS = 60 * 60 * 24
 _NOISY_EVENT_TTL_SECONDS = _ONE_DAY_SECONDS
 _NOISY_EVENT_CACHE_LIMIT = 128
 _NOISY_EVENT_LAST_SEEN: dict[str, float] = {}
+_SENTRY_EVENT_CACHE_LOCK = threading.RLock()
 _EVENT_RATE_WINDOW_SECONDS = _ONE_DAY_SECONDS * 2
 _EVENT_RATE_LIMIT_PER_WINDOW = 1
 _EVENT_RATE_CACHE_LIMIT = 2048
@@ -302,14 +304,15 @@ def _should_drop_noisy_event(event: dict[str, Any]) -> bool:
         return False
 
     now = time.monotonic()
-    last_seen = _NOISY_EVENT_LAST_SEEN.get(fingerprint)
-    _NOISY_EVENT_LAST_SEEN[fingerprint] = now
+    with _SENTRY_EVENT_CACHE_LOCK:
+        last_seen = _NOISY_EVENT_LAST_SEEN.get(fingerprint)
+        _NOISY_EVENT_LAST_SEEN[fingerprint] = now
 
-    if len(_NOISY_EVENT_LAST_SEEN) > _NOISY_EVENT_CACHE_LIMIT:
-        expired_before = now - ttl_seconds
-        for key, timestamp in list(_NOISY_EVENT_LAST_SEEN.items()):
-            if timestamp < expired_before:
-                _NOISY_EVENT_LAST_SEEN.pop(key, None)
+        if len(_NOISY_EVENT_LAST_SEEN) > _NOISY_EVENT_CACHE_LIMIT:
+            expired_before = now - ttl_seconds
+            for key, timestamp in list(_NOISY_EVENT_LAST_SEEN.items()):
+                if timestamp < expired_before:
+                    _NOISY_EVENT_LAST_SEEN.pop(key, None)
 
     return last_seen is not None and now - last_seen < ttl_seconds
 
@@ -361,7 +364,9 @@ def _prune_event_rate_state(now: float, window_seconds: float) -> None:
     overflow = len(_EVENT_RATE_STATE) - _EVENT_RATE_CACHE_LIMIT
     if overflow <= 0:
         return
-    oldest_keys = sorted(_EVENT_RATE_STATE, key=lambda key: _EVENT_RATE_STATE[key][0])[:overflow]
+    oldest_keys = [
+        key for key, _timestamp in sorted((key, value[0]) for key, value in _EVENT_RATE_STATE.items())[:overflow]
+    ]
     for key in oldest_keys:
         _EVENT_RATE_STATE.pop(key, None)
 
@@ -377,14 +382,15 @@ def _should_drop_repeated_event(event: dict[str, Any]) -> bool:
 
     now = time.monotonic()
     fingerprint = _event_rate_fingerprint(event)
-    window_started_at, count = _EVENT_RATE_STATE.get(fingerprint, (now, 0))
-    if now - window_started_at >= window_seconds:
-        window_started_at = now
-        count = 0
+    with _SENTRY_EVENT_CACHE_LOCK:
+        window_started_at, count = _EVENT_RATE_STATE.get(fingerprint, (now, 0))
+        if now - window_started_at >= window_seconds:
+            window_started_at = now
+            count = 0
 
-    count += 1
-    _EVENT_RATE_STATE[fingerprint] = (window_started_at, count)
-    _prune_event_rate_state(now, window_seconds)
+        count += 1
+        _EVENT_RATE_STATE[fingerprint] = (window_started_at, count)
+        _prune_event_rate_state(now, window_seconds)
     return count > limit
 
 

--- a/vibe/sentry_integration.py
+++ b/vibe/sentry_integration.py
@@ -248,6 +248,11 @@ def _exception_types(event: dict[str, Any]) -> set[str]:
     return {value.get("type") for value in values if isinstance(value, dict) and isinstance(value.get("type"), str)}
 
 
+def _exception_values(event: dict[str, Any]) -> list[str]:
+    values = ((event.get("exception") or {}).get("values") or []) if isinstance(event.get("exception"), dict) else []
+    return [value.get("value") for value in values if isinstance(value, dict) and isinstance(value.get("value"), str)]
+
+
 def _noisy_event_fingerprint(event: dict[str, Any]) -> Optional[str]:
     logger_name = str(event.get("logger") or "")
     text = _event_text(event)
@@ -320,9 +325,7 @@ def _event_rate_limit_per_window() -> int:
     )
 
 
-def _normalized_event_text(event: dict[str, Any]) -> str:
-    event_text = _event_text(event)
-    text = event_text.splitlines()[0] if event_text else ""
+def _normalize_fingerprint_text(text: str) -> str:
     text = re.sub(r"\b[0-9a-f]{16,}\b", "<hex>", text, flags=re.IGNORECASE)
     text = re.sub(r"\b[0-9a-f]{8}-[0-9a-f-]{27,}\b", "<uuid>", text, flags=re.IGNORECASE)
     text = re.sub(r"\bs_\d+\b", "s_<id>", text)
@@ -331,10 +334,21 @@ def _normalized_event_text(event: dict[str, Any]) -> str:
     return text[:240]
 
 
+def _normalized_event_text(event: dict[str, Any]) -> str:
+    event_text = _event_text(event)
+    text = event_text.splitlines()[0] if event_text else ""
+    return _normalize_fingerprint_text(text)
+
+
+def _normalized_exception_values(event: dict[str, Any]) -> str:
+    return "|".join(_normalize_fingerprint_text(value) for value in _exception_values(event))
+
+
 def _event_rate_fingerprint(event: dict[str, Any]) -> str:
     logger_name = str(event.get("logger") or "")
     exception_types = ",".join(sorted(_exception_types(event)))
-    return f"{logger_name}|{exception_types}|{_normalized_event_text(event)}"
+    exception_values = _normalized_exception_values(event)
+    return f"{logger_name}|{exception_types}|{exception_values}|{_normalized_event_text(event)}"
 
 
 def _prune_event_rate_state(now: float, window_seconds: float) -> None:

--- a/vibe/sentry_integration.py
+++ b/vibe/sentry_integration.py
@@ -358,6 +358,12 @@ def _prune_event_rate_state(now: float, window_seconds: float) -> None:
     for key, (window_started_at, _count) in list(_EVENT_RATE_STATE.items()):
         if window_started_at < expired_before:
             _EVENT_RATE_STATE.pop(key, None)
+    overflow = len(_EVENT_RATE_STATE) - _EVENT_RATE_CACHE_LIMIT
+    if overflow <= 0:
+        return
+    oldest_keys = sorted(_EVENT_RATE_STATE, key=lambda key: _EVENT_RATE_STATE[key][0])[:overflow]
+    for key in oldest_keys:
+        _EVENT_RATE_STATE.pop(key, None)
 
 
 def _should_drop_repeated_event(event: dict[str, Any]) -> bool:

--- a/vibe/sentry_integration.py
+++ b/vibe/sentry_integration.py
@@ -6,6 +6,7 @@ import platform
 import re
 import socket
 import sys
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -14,7 +15,7 @@ from config.v2_config import V2Config
 logger = logging.getLogger(__name__)
 
 # Fill this with the real project DSN to make Sentry default-on across deployments.
-DEFAULT_SENTRY_DSN = "https://389134cd3be10054d640f631d7eac382@o4511104395051008.ingest.us.sentry.io/4511104396820480"
+DEFAULT_SENTRY_DSN = "https://b97175a2d2325951f1861e8a4386f840@o4511104395051008.ingest.us.sentry.io/4511104396820480"
 DEFAULT_TRACES_SAMPLE_RATE = 0.0
 DEFAULT_PROFILES_SAMPLE_RATE = 0.0
 DEPLOYMENT_ENV_VAR = "VIBE_DEPLOYMENT_ENV"
@@ -43,6 +44,23 @@ _STRING_REPLACEMENTS = (
     (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]+\b"), _REDACTED),
     (re.compile(r"\bxapp-[A-Za-z0-9-]+\b"), _REDACTED),
 )
+_ONE_DAY_SECONDS = 60 * 60 * 24
+_NOISY_EVENT_TTL_SECONDS = _ONE_DAY_SECONDS
+_NOISY_EVENT_CACHE_LIMIT = 128
+_NOISY_EVENT_LAST_SEEN: dict[str, float] = {}
+_EVENT_RATE_WINDOW_SECONDS = _ONE_DAY_SECONDS * 2
+_EVENT_RATE_LIMIT_PER_WINDOW = 1
+_EVENT_RATE_CACHE_LIMIT = 2048
+_EVENT_RATE_STATE: dict[str, tuple[float, int]] = {}
+_NETWORK_EXCEPTION_TYPES = {
+    "ClientConnectorDNSError",
+    "ClientConnectorError",
+    "ClientOSError",
+    "ConnectionResetError",
+    "ConnectionTimeoutError",
+    "ServerDisconnectedError",
+    "TimeoutError",
+}
 
 
 def _redact_string(value: str) -> str:
@@ -86,6 +104,34 @@ def _safe_float(raw: Optional[str], fallback: float) -> float:
     if 0.0 <= value <= 1.0:
         return value
     logger.warning("Out-of-range Sentry sample rate %r, falling back to %s", raw, fallback)
+    return fallback
+
+
+def _safe_positive_float(raw: Optional[str], fallback: float) -> float:
+    if raw is None or raw == "":
+        return fallback
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid Sentry positive float %r, falling back to %s", raw, fallback)
+        return fallback
+    if value >= 0.0:
+        return value
+    logger.warning("Out-of-range Sentry positive float %r, falling back to %s", raw, fallback)
+    return fallback
+
+
+def _safe_nonnegative_int(raw: Optional[str], fallback: int) -> int:
+    if raw is None or raw == "":
+        return fallback
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid Sentry nonnegative integer %r, falling back to %s", raw, fallback)
+        return fallback
+    if value >= 0:
+        return value
+    logger.warning("Out-of-range Sentry nonnegative integer %r, falling back to %s", raw, fallback)
     return fallback
 
 
@@ -169,9 +215,167 @@ def build_sentry_contexts(config: V2Config, component: str, environment: str) ->
     }
 
 
-def before_send(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
+def _event_text(event: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key in ("message", "transaction"):
+        value = event.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+
+    logentry = event.get("logentry")
+    if isinstance(logentry, dict):
+        for key in ("formatted", "message"):
+            value = logentry.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+
+    for entry in event.get("entries") or []:
+        if not isinstance(entry, dict) or entry.get("type") != "message":
+            continue
+        data = entry.get("data")
+        if not isinstance(data, dict):
+            continue
+        for key in ("formatted", "message"):
+            value = data.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+
+    return "\n".join(parts)
+
+
+def _exception_types(event: dict[str, Any]) -> set[str]:
+    values = ((event.get("exception") or {}).get("values") or []) if isinstance(event.get("exception"), dict) else []
+    return {value.get("type") for value in values if isinstance(value, dict) and isinstance(value.get("type"), str)}
+
+
+def _noisy_event_fingerprint(event: dict[str, Any]) -> Optional[str]:
+    logger_name = str(event.get("logger") or "")
+    text = _event_text(event)
+    exception_types = _exception_types(event)
+
+    if logger_name.startswith("slack_sdk.socket_mode") and (
+        "apps.connections.open" in text
+        or "Failed to retrieve WSS URL" in text
+        or "Failed to check the current session" in text
+    ):
+        return "slack-socket-mode-reconnect"
+
+    if logger_name == "Lark" and (
+        "processor not found, type: im.message.reaction." in text
+        or "receive message loop exit, err: no close frame received or sent" in text
+    ):
+        return "lark-benign-ws-event"
+
+    if logger_name == "core.watches" and ("No space left on device" in text or "Errno 28" in text):
+        return "watch-runtime-disk-full"
+
+    if logger_name == "modules.im.wechat" and "Poll loop error" in text and exception_types & _NETWORK_EXCEPTION_TYPES:
+        return "wechat-poll-network"
+
+    return None
+
+
+def _noise_filters_enabled() -> bool:
+    raw = os.environ.get("VIBE_SENTRY_NOISE_FILTERS", "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _noise_filter_ttl_seconds() -> float:
+    return _safe_positive_float(os.environ.get("VIBE_SENTRY_NOISE_TTL_SECONDS"), _NOISY_EVENT_TTL_SECONDS)
+
+
+def _should_drop_noisy_event(event: dict[str, Any]) -> bool:
+    if not _noise_filters_enabled():
+        return False
+
+    fingerprint = _noisy_event_fingerprint(event)
+    if not fingerprint:
+        return False
+
+    ttl_seconds = _noise_filter_ttl_seconds()
+    if ttl_seconds <= 0:
+        return False
+
+    now = time.monotonic()
+    last_seen = _NOISY_EVENT_LAST_SEEN.get(fingerprint)
+    _NOISY_EVENT_LAST_SEEN[fingerprint] = now
+
+    if len(_NOISY_EVENT_LAST_SEEN) > _NOISY_EVENT_CACHE_LIMIT:
+        expired_before = now - ttl_seconds
+        for key, timestamp in list(_NOISY_EVENT_LAST_SEEN.items()):
+            if timestamp < expired_before:
+                _NOISY_EVENT_LAST_SEEN.pop(key, None)
+
+    return last_seen is not None and now - last_seen < ttl_seconds
+
+
+def _event_rate_window_seconds() -> float:
+    return _safe_positive_float(os.environ.get("VIBE_SENTRY_EVENT_RATE_WINDOW_SECONDS"), _EVENT_RATE_WINDOW_SECONDS)
+
+
+def _event_rate_limit_per_window() -> int:
+    return _safe_nonnegative_int(
+        os.environ.get("VIBE_SENTRY_EVENT_RATE_LIMIT_PER_WINDOW"),
+        _EVENT_RATE_LIMIT_PER_WINDOW,
+    )
+
+
+def _normalized_event_text(event: dict[str, Any]) -> str:
+    event_text = _event_text(event)
+    text = event_text.splitlines()[0] if event_text else ""
+    text = re.sub(r"\b[0-9a-f]{16,}\b", "<hex>", text, flags=re.IGNORECASE)
+    text = re.sub(r"\b[0-9a-f]{8}-[0-9a-f-]{27,}\b", "<uuid>", text, flags=re.IGNORECASE)
+    text = re.sub(r"\bs_\d+\b", "s_<id>", text)
+    text = re.sub(r"\b\d{6,}\b", "<num>", text)
+    text = re.sub(r"file://\S+", "file://<path>", text)
+    return text[:240]
+
+
+def _event_rate_fingerprint(event: dict[str, Any]) -> str:
+    logger_name = str(event.get("logger") or "")
+    exception_types = ",".join(sorted(_exception_types(event)))
+    return f"{logger_name}|{exception_types}|{_normalized_event_text(event)}"
+
+
+def _prune_event_rate_state(now: float, window_seconds: float) -> None:
+    if len(_EVENT_RATE_STATE) <= _EVENT_RATE_CACHE_LIMIT:
+        return
+    expired_before = now - window_seconds
+    for key, (window_started_at, _count) in list(_EVENT_RATE_STATE.items()):
+        if window_started_at < expired_before:
+            _EVENT_RATE_STATE.pop(key, None)
+
+
+def _should_drop_repeated_event(event: dict[str, Any]) -> bool:
+    limit = _event_rate_limit_per_window()
+    if limit <= 0:
+        return False
+
+    window_seconds = _event_rate_window_seconds()
+    if window_seconds <= 0:
+        return False
+
+    now = time.monotonic()
+    fingerprint = _event_rate_fingerprint(event)
+    window_started_at, count = _EVENT_RATE_STATE.get(fingerprint, (now, 0))
+    if now - window_started_at >= window_seconds:
+        window_started_at = now
+        count = 0
+
+    count += 1
+    _EVENT_RATE_STATE[fingerprint] = (window_started_at, count)
+    _prune_event_rate_state(now, window_seconds)
+    return count > limit
+
+
+def before_send(event: dict[str, Any], hint: dict[str, Any]) -> Optional[dict[str, Any]]:
     del hint
-    return scrub_data(event)
+    scrubbed = scrub_data(event)
+    if _should_drop_noisy_event(scrubbed):
+        return None
+    if _should_drop_repeated_event(scrubbed):
+        return None
+    return scrubbed
 
 
 def before_breadcrumb(crumb: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any]:
@@ -221,6 +425,7 @@ def init_sentry(config: V2Config, component: str, enable_flask: bool = False) ->
             sample_rate=1.0,
             traces_sample_rate=options["traces_sample_rate"],
             profiles_sample_rate=options["profiles_sample_rate"],
+            send_client_reports=False,
             send_default_pii=True,
             server_name=socket.gethostname(),
         )

--- a/vibe/sentry_integration.py
+++ b/vibe/sentry_integration.py
@@ -365,7 +365,11 @@ def _prune_event_rate_state(now: float, window_seconds: float) -> None:
     if overflow <= 0:
         return
     oldest_keys = [
-        key for key, _timestamp in sorted((key, value[0]) for key, value in _EVENT_RATE_STATE.items())[:overflow]
+        key
+        for key, _timestamp in sorted(
+            ((key, value[0]) for key, value in _EVENT_RATE_STATE.items()),
+            key=lambda item: item[1],
+        )[:overflow]
     ]
     for key in oldest_keys:
         _EVENT_RATE_STATE.pop(key, None)


### PR DESCRIPTION
## Summary
- rotate the default Sentry DSN to the new active client key
- disable SDK client discard reports so quota-limited clients stop inflating usage telemetry
- throttle known noisy Sentry events and repeated error fingerprints before send

## Evidence
- Unit: `pytest tests/test_sentry_integration.py`
- Lint: `ruff check vibe/sentry_integration.py tests/test_sentry_integration.py`
- Contract: not applicable
- Scenario: no scenario catalog entry affected

## Risk
Medium. This intentionally reduces repeated Sentry event volume; first occurrences of distinct errors still pass through, and limits are configurable by environment variables.
