### PR TITLE
fix(claude): disallow remote interactive tools

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -16,6 +16,7 @@ from .base import BaseHandler
 logger = logging.getLogger(__name__)
 
 CLAUDE_NO_CONVERSATION_RE = re.compile(r"No conversation found with session ID:\s*(\S+)")
+CLAUDE_REMOTE_DISALLOWED_TOOLS = ["AskUserQuestion", "EnterPlanMode", "ExitPlanMode"]
 
 
 class ClaudeSessionNotFoundError(RuntimeError):
@@ -564,9 +565,9 @@ class SessionHandler(BaseHandler):
             "resume": stored_claude_session_id if stored_claude_session_id else None,
             "extra_args": extra_args,
             "setting_sources": ["user", "project", "local"],  # Load all setting sources (user, project CLAUDE.md, local overrides)
-            # Disable AskUserQuestion tool - SDK cannot respond to it programmatically
-            # See: https://github.com/anthropics/claude-code/issues/10168
-            "disallowed_tools": ["AskUserQuestion"],
+            # Disable interactive-only Claude Code tools that remote IM sessions
+            # cannot answer programmatically.
+            "disallowed_tools": CLAUDE_REMOTE_DISALLOWED_TOOLS,
             "env": claude_env,  # Pass Anthropic/Claude env vars
             "stderr": _capture_claude_stderr,
         }

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -163,6 +163,29 @@ def test_session_handler_keeps_sdk_default_for_default_claude_binary(monkeypatch
     assert captured["options"].cli_path is None
 
 
+def test_session_handler_disallows_remote_unsafe_claude_tools(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    assert captured["connected"] is True
+    assert captured["options"].disallowed_tools == ["AskUserQuestion", "EnterPlanMode", "ExitPlanMode"]
+
+
 def test_session_handler_does_not_repeat_claude_model_control_request(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, Any] = {"clients": []}
 


### PR DESCRIPTION
## Summary
- disallow Claude Code interactive-only tools in remote IM sessions
- keep the disallowed tool list centralized for SessionHandler
- add coverage for the Claude SDK options passed by remote sessions

## Evidence
- Unit: `pytest tests/test_claude_cli_path.py`
- Lint: `ruff check core/handlers/session_handler.py tests/test_claude_cli_path.py`
- Contract: not applicable
- Scenario: no scenario catalog entry affected

## Risk
Low. This only blocks Claude tools that Vibe Remote cannot answer programmatically from IM.
