### PR TITLE
fix(remote-access): send UI origin during pairing

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -65,6 +65,7 @@ def test_pair_redeems_key_and_starts_connector(monkeypatch, tmp_path) -> None:
     def fake_request(url: str, payload: dict, timeout: float = 20.0):
         assert url == "https://backend.test/api/v1/pairing/redeem"
         assert payload["pairing_key"] == "vrp_test"
+        assert payload["origin_service"] == "http://127.0.0.1:5123"
         return {
             "instance_id": "inst_123",
             "client_id": "vr_client_123",
@@ -91,6 +92,27 @@ def test_pair_redeems_key_and_starts_connector(monkeypatch, tmp_path) -> None:
     assert saved_payload["remote_access"]["vibe_cloud"]["enabled"] is True
     assert saved_payload["remote_access"]["vibe_cloud"]["tunnel_token"] == "tunnel-token"
     assert saved_payload["remote_access"]["vibe_cloud"]["session_secret"]
+
+
+def test_pair_origin_service_follows_effective_ui_port(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("VIBE_UI_PORT", "15130")
+    config = _config()
+    config.ui.setup_host = "0.0.0.0"
+    config.ui.setup_port = 5123
+    config.save()
+
+    assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"
+
+
+def test_pair_origin_service_uses_configured_ui_host(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.ui.setup_host = "192.168.2.3"
+    config.ui.setup_port = 15130
+    config.save()
+
+    assert remote_access.origin_service_for_pairing() == "http://192.168.2.3:15130"
 
 
 def test_pair_persists_with_locked_incremental_config_save(monkeypatch) -> None:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -401,15 +401,49 @@ def _json_request(url: str, payload: dict[str, Any], timeout: float = 20.0) -> d
         raise RuntimeError(str(exc)) from exc
 
 
+def _effective_ui_port(config: V2Config) -> int:
+    raw_port = os.environ.get("VIBE_UI_PORT") or config.ui.setup_port
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):
+        port = int(config.ui.setup_port)
+    if port < 1 or port > 65535:
+        return int(config.ui.setup_port)
+    return port
+
+
+def _origin_host_for_ui(config: V2Config) -> str:
+    host = (config.ui.setup_host or "127.0.0.1").strip()
+    if not host or host in {"0.0.0.0", "::", "[::]"}:
+        return "127.0.0.1"
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
+def origin_service_for_pairing(config: V2Config | None = None) -> str:
+    config = config or V2Config.load()
+    return f"http://{_origin_host_for_ui(config)}:{_effective_ui_port(config)}"
+
+
 def pair(pairing_key: str, backend_url: str, device_name: str = "Vibe Remote") -> dict[str, Any]:
     pairing_key = (pairing_key or "").strip()
     backend_url = (backend_url or "https://avibe.bot").strip().rstrip("/")
     if not pairing_key:
         return {"ok": False, "error": "missing_pairing_key"}
     try:
+        origin_service = origin_service_for_pairing()
+    except Exception:
+        origin_service = "http://127.0.0.1:5123"
+    try:
         result = _json_request(
             f"{backend_url}/api/v1/pairing/redeem",
-            {"pairing_key": pairing_key, "device_name": device_name, "local_version": "dev"},
+            {
+                "pairing_key": pairing_key,
+                "device_name": device_name,
+                "local_version": "dev",
+                "origin_service": origin_service,
+            },
         )
     except BackendRequestError as exc:
         return {"ok": False, **exc.payload, "status": exc.status}


### PR DESCRIPTION
## Summary
- Send the local UI origin service when redeeming a Vibe Cloud pairing key.
- Derive the origin from the effective UI port, including VIBE_UI_PORT in regression containers.
- Normalize wildcard UI bind hosts to 127.0.0.1 for tunnel origin use.

## Validation
- uv run pytest tests/test_remote_access_vibe_cloud.py
- uv run ruff check vibe/remote_access.py tests/test_remote_access_vibe_cloud.py
- npm ci && npm run build in ui/ to provide ui/dist for package build in the clean worktree

## Notes
- This pairs with the backend change pushed to main that updates Cloudflare tunnel ingress from the reported origin_service.
