### PR TITLE
docs(growth): add AI install guide and distribution plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Vibe Remote
 
-### Your AI agent army, commanded from Slack, Discord, Telegram, WeChat & Lark.
+### Run Claude Code, OpenCode, and Codex from Slack, Discord, Telegram, WeChat, and Lark.
 
-**No laptop. No IDE. Just vibes.**
+**Local-first. Web setup wizard. Real agent sessions from any chat app.**
 
 [![GitHub Stars](https://img.shields.io/github/stars/cyhhao/vibe-remote?color=ffcb47&labelColor=black&style=flat-square)](https://github.com/cyhhao/vibe-remote/stargazers)
 [![Python](https://img.shields.io/badge/python-3.9%2B-3776AB?labelColor=black&style=flat-square)](https://www.python.org/)
@@ -35,6 +35,21 @@
 ![Banner](assets/banner.jpg)
 
 </div>
+
+## Feature Snapshot
+
+| Capability | Status |
+| --- | --- |
+| Chat platforms | Slack, Discord, Telegram, WeChat, Lark / Feishu |
+| Agent backends | Claude Code, OpenCode, Codex |
+| Setup | One-command installer plus browser wizard |
+| Session model | Each thread or chat scope maps to an isolated agent session |
+| Resume | Reopen real Claude Code, OpenCode, and Codex sessions from the current project |
+| Remote access | `vibe remote` pairs the local Web UI with a secure avibe.bot tunnel |
+| Automation | Scheduled tasks with `vibe task`, one-shot async callbacks with `vibe hook` |
+| Security model | Local-first runtime; your code stays on your machine |
+
+Vibe Remote is not another agent framework. It is the remote control layer for the coding agents you already trust.
 
 ## The Pitch
 
@@ -77,6 +92,18 @@ If you are new to WSL, this guide explains:
 - where to run the Vibe Remote install command
 - how to launch Ubuntu and open the Web UI
 </details>
+
+---
+
+## Install & Configure via AI Agent
+
+The easiest path is to hand the setup to your coding agent:
+
+```text
+Follow https://raw.githubusercontent.com/cyhhao/vibe-remote/master/docs/INSTALL_FOR_AI.md to install and configure Vibe Remote for me.
+```
+
+The agent guide covers OS checks, installing `vibe`, choosing Claude Code / OpenCode / Codex, starting the Web UI, and walking through the chat-platform wizard.
 
 ---
 
@@ -332,6 +359,7 @@ vibe stop && uv tool uninstall vibe-remote && rm -rf ~/.vibe_remote
 ## Docs
 
 - **[CLI Reference](docs/CLI.md)** — Command-line usage and service lifecycle
+- **[Install via AI Agent](docs/INSTALL_FOR_AI.md)** — Give this to Claude Code, Codex, or OpenCode for guided setup
 - **[Slack Setup Guide](docs/SLACK_SETUP.md)** — Detailed setup with screenshots
 - **[Discord Setup Guide](docs/DISCORD_SETUP.md)** — Detailed setup with screenshots
 - **[Telegram Setup Guide](docs/TELEGRAM_SETUP.md)** — BotFather setup, token validation, and chat discovery

--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ If you are new to WSL, this guide explains:
 
 ---
 
+## What Ships Today
+
+Not an agent framework. Not a hosted coding VM. Vibe Remote is the remote-control layer for the coding agents already running on your machine.
+
+- **Chat apps become terminals:** Slack, Discord, Telegram, WeChat, and Lark / Feishu.
+- **Real coding agents, no middleman:** Claude Code, OpenCode, and Codex run as themselves.
+- **Thread = session:** Start five threads, run five isolated jobs, resume later.
+- **Web setup, not token archaeology:** Local wizard, dashboard, routing, and health checks.
+- **Remote UI when you need it:** `vibe remote` opens your local Web UI through a secure avibe.bot tunnel.
+- **Walk away without losing the loop:** Completion notifications, scheduled tasks, and async hooks keep work moving.
+
+---
+
 ## Why This Exists
 
 | Problem | Solution |

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Vibe Remote
 
-### Run Claude Code, OpenCode, and Codex from Slack, Discord, Telegram, WeChat, and Lark.
+### Your AI agent army, commanded from Slack, Discord, Telegram, WeChat & Lark.
 
-**Local-first. Web setup wizard. Real agent sessions from any chat app.**
+**No laptop. No IDE. Just vibes.**
 
 [![GitHub Stars](https://img.shields.io/github/stars/cyhhao/vibe-remote?color=ffcb47&labelColor=black&style=flat-square)](https://github.com/cyhhao/vibe-remote/stargazers)
 [![Python](https://img.shields.io/badge/python-3.9%2B-3776AB?labelColor=black&style=flat-square)](https://www.python.org/)
@@ -35,21 +35,6 @@
 ![Banner](assets/banner.jpg)
 
 </div>
-
-## Feature Snapshot
-
-| Capability | Status |
-| --- | --- |
-| Chat platforms | Slack, Discord, Telegram, WeChat, Lark / Feishu |
-| Agent backends | Claude Code, OpenCode, Codex |
-| Setup | One-command installer plus browser wizard |
-| Session model | Each thread or chat scope maps to an isolated agent session |
-| Resume | Reopen real Claude Code, OpenCode, and Codex sessions from the current project |
-| Remote access | `vibe remote` pairs the local Web UI with a secure avibe.bot tunnel |
-| Automation | Scheduled tasks with `vibe task`, one-shot async callbacks with `vibe hook` |
-| Security model | Local-first runtime; your code stays on your machine |
-
-Vibe Remote is not another agent framework. It is the remote control layer for the coding agents you already trust.
 
 ## The Pitch
 
@@ -92,18 +77,6 @@ If you are new to WSL, this guide explains:
 - where to run the Vibe Remote install command
 - how to launch Ubuntu and open the Web UI
 </details>
-
----
-
-## Install & Configure via AI Agent
-
-The easiest path is to hand the setup to your coding agent:
-
-```text
-Follow https://raw.githubusercontent.com/cyhhao/vibe-remote/master/docs/INSTALL_FOR_AI.md to install and configure Vibe Remote for me.
-```
-
-The agent guide covers OS checks, installing `vibe`, choosing Claude Code / OpenCode / Codex, starting the Web UI, and walking through the chat-platform wizard.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -4,9 +4,9 @@
 
 # Vibe Remote
 
-### 在 Slack、Discord、Telegram、微信、飞书里运行 Claude Code、OpenCode 和 Codex。
+### 你的 AI agent 军团，用 Slack、Discord、Telegram、微信或飞书指挥。
 
-**本地优先。Web 设置向导。真实 agent 会话，随时从聊天 App 接管。**
+**不用笔记本电脑。不用 IDE。只需 vibe。**
 
 [![GitHub Stars](https://img.shields.io/github/stars/cyhhao/vibe-remote?color=ffcb47&labelColor=black&style=flat-square)](https://github.com/cyhhao/vibe-remote/stargazers)
 [![Python](https://img.shields.io/badge/python-3.9%2B-3776AB?labelColor=black&style=flat-square)](https://www.python.org/)
@@ -35,21 +35,6 @@
 ![Banner](assets/banner.jpg)
 
 </div>
-
-## 功能速览
-
-| 能力 | 状态 |
-| --- | --- |
-| 聊天平台 | Slack、Discord、Telegram、微信、飞书 / Lark |
-| Agent 后端 | Claude Code、OpenCode、Codex |
-| 设置方式 | 一行安装命令 + 浏览器向导 |
-| 会话模型 | 每个 thread 或聊天范围都是独立 agent 会话 |
-| 会话恢复 | 从当前项目恢复真实 Claude Code、OpenCode、Codex 历史会话 |
-| 远程访问 | `vibe remote` 通过 avibe.bot 安全 tunnel 打开本地 Web UI |
-| 自动化 | `vibe task` 定时任务，`vibe hook` 一次性异步回调 |
-| 安全模型 | 本地优先运行，代码留在自己的机器上 |
-
-Vibe Remote 不是另一个 agent 框架，而是你已经信任的编码 agent 的远程控制层。
 
 ## 为什么
 
@@ -92,24 +77,6 @@ Windows 下默认推荐使用 WSL 方案，因为它的兼容性最好。
 - 在哪里执行 Vibe Remote 的安装命令
 - 如何启动 Ubuntu 并打开 Web UI
 </details>
-
----
-
-## 让 AI Agent 帮你安装配置
-
-最省事的方式，是把这段话交给你的编码 agent：
-
-```text
-Follow https://raw.githubusercontent.com/cyhhao/vibe-remote/master/docs/INSTALL_FOR_AI.md to install and configure Vibe Remote for me.
-```
-
-如果希望中文说明，可以使用：
-
-```text
-按照 https://raw.githubusercontent.com/cyhhao/vibe-remote/master/docs/INSTALL_FOR_AI_ZH.md 帮我安装并配置 Vibe Remote。
-```
-
-这份指南会引导 agent 检查系统、安装 `vibe`、选择 Claude Code / OpenCode / Codex、启动 Web UI，并通过向导完成聊天平台配置。
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -4,9 +4,9 @@
 
 # Vibe Remote
 
-### 你的 AI agent 军团，用 Slack、Discord、Telegram、微信或飞书指挥。
+### 在 Slack、Discord、Telegram、微信、飞书里运行 Claude Code、OpenCode 和 Codex。
 
-**不用笔记本电脑。不用 IDE。只需 vibe。**
+**本地优先。Web 设置向导。真实 agent 会话，随时从聊天 App 接管。**
 
 [![GitHub Stars](https://img.shields.io/github/stars/cyhhao/vibe-remote?color=ffcb47&labelColor=black&style=flat-square)](https://github.com/cyhhao/vibe-remote/stargazers)
 [![Python](https://img.shields.io/badge/python-3.9%2B-3776AB?labelColor=black&style=flat-square)](https://www.python.org/)
@@ -35,6 +35,21 @@
 ![Banner](assets/banner.jpg)
 
 </div>
+
+## 功能速览
+
+| 能力 | 状态 |
+| --- | --- |
+| 聊天平台 | Slack、Discord、Telegram、微信、飞书 / Lark |
+| Agent 后端 | Claude Code、OpenCode、Codex |
+| 设置方式 | 一行安装命令 + 浏览器向导 |
+| 会话模型 | 每个 thread 或聊天范围都是独立 agent 会话 |
+| 会话恢复 | 从当前项目恢复真实 Claude Code、OpenCode、Codex 历史会话 |
+| 远程访问 | `vibe remote` 通过 avibe.bot 安全 tunnel 打开本地 Web UI |
+| 自动化 | `vibe task` 定时任务，`vibe hook` 一次性异步回调 |
+| 安全模型 | 本地优先运行，代码留在自己的机器上 |
+
+Vibe Remote 不是另一个 agent 框架，而是你已经信任的编码 agent 的远程控制层。
 
 ## 为什么
 
@@ -77,6 +92,24 @@ Windows 下默认推荐使用 WSL 方案，因为它的兼容性最好。
 - 在哪里执行 Vibe Remote 的安装命令
 - 如何启动 Ubuntu 并打开 Web UI
 </details>
+
+---
+
+## 让 AI Agent 帮你安装配置
+
+最省事的方式，是把这段话交给你的编码 agent：
+
+```text
+Follow https://raw.githubusercontent.com/cyhhao/vibe-remote/master/docs/INSTALL_FOR_AI.md to install and configure Vibe Remote for me.
+```
+
+如果希望中文说明，可以使用：
+
+```text
+按照 https://raw.githubusercontent.com/cyhhao/vibe-remote/master/docs/INSTALL_FOR_AI_ZH.md 帮我安装并配置 Vibe Remote。
+```
+
+这份指南会引导 agent 检查系统、安装 `vibe`、选择 Claude Code / OpenCode / Codex、启动 Web UI，并通过向导完成聊天平台配置。
 
 ---
 
@@ -332,6 +365,7 @@ vibe stop && uv tool uninstall vibe-remote && rm -rf ~/.vibe_remote
 ## 文档
 
 - **[CLI 参考手册](docs/CLI_ZH.md)** — 命令行使用和服务生命周期
+- **[让 AI Agent 帮你安装](docs/INSTALL_FOR_AI_ZH.md)** — 交给 Claude Code、Codex 或 OpenCode 的引导式安装说明
 - **[Slack 配置指南](docs/SLACK_SETUP_ZH.md)** — 详细配置和截图
 - **[Discord 配置指南](docs/DISCORD_SETUP_ZH.md)** — 详细配置和截图
 - **[Telegram 配置指南](docs/TELEGRAM_SETUP_ZH.md)** — BotFather 初始化、令牌验证与会话发现

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -80,6 +80,19 @@ Windows 下默认推荐使用 WSL 方案，因为它的兼容性最好。
 
 ---
 
+## 现在就能做什么
+
+Vibe Remote 不是 agent 框架，也不是云端 coding VM。它是你本地编码 agent 的远程控制层。
+
+- **聊天 App 变终端：** Slack、Discord、Telegram、微信、飞书 / Lark。
+- **真实编码 Agent，不加中间层：** Claude Code、OpenCode、Codex 以原本的方式运行。
+- **Thread = 会话：** 开 5 个 thread，跑 5 个隔离任务，之后还能接着做。
+- **Web 向导，不是手搓 token：** 本地设置向导、仪表盘、路由、健康检查。
+- **需要远程 UI 时再打开：** `vibe remote` 通过 avibe.bot 安全 tunnel 访问本地 Web UI。
+- **人走开，循环不断：** 完成通知、定时任务、异步 hook 让任务继续推进。
+
+---
+
 ## 为什么要用
 
 | 问题 | 解决 |

--- a/docs/INSTALL_FOR_AI.md
+++ b/docs/INSTALL_FOR_AI.md
@@ -1,0 +1,169 @@
+# Vibe Remote Installation Guide for AI Agents
+
+This file is designed to be handed directly to Claude Code, Codex, OpenCode, or another local coding agent. Use it to install and configure Vibe Remote with the user.
+
+Vibe Remote connects local AI coding agents to chat platforms such as Slack, Discord, Telegram, WeChat, and Lark / Feishu. The code and agent processes stay on the user's machine.
+
+## Rules for the Assisting Agent
+
+- Ask the user before choosing a chat platform, agent backend, workspace, or credential value.
+- Do not guess secrets, bot tokens, app tokens, API keys, workspace IDs, or chat IDs.
+- Prefer the browser setup wizard launched by `vibe` over hand-editing config files.
+- Do not restart an already-running local `vibe` service unless the user confirms it is safe.
+- Keep setup local-first. Do not expose public webhooks unless the selected platform requires it.
+
+## Step 1: Check the Machine
+
+Run:
+
+```bash
+uname -a
+command -v vibe || true
+command -v uv || true
+command -v claude || true
+command -v opencode || true
+command -v codex || true
+```
+
+On Windows, prefer the WSL guide unless the user explicitly wants native PowerShell:
+
+- https://github.com/cyhhao/vibe-remote/blob/master/docs/WINDOWS_WSL.md
+
+## Step 2: Install Vibe Remote
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.ps1 | iex
+```
+
+Verify:
+
+```bash
+vibe version
+vibe doctor
+```
+
+If the installer cannot use PyPI, it falls back to GitHub. If `vibe` is installed but not on `PATH`, inspect the installer's final output and help the user add the reported bin directory to their shell profile.
+
+## Step 3: Install at Least One Coding Agent
+
+Ask the user which backend they want first. Recommended default: OpenCode for low-friction setup, Claude Code for deeper coding work, Codex for OpenAI workflows.
+
+OpenCode:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+Then configure permission behavior if the user accepts the tradeoff:
+
+```json
+{
+  "permission": "allow"
+}
+```
+
+Claude Code:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Codex:
+
+```bash
+npm install -g @openai/codex
+```
+
+Verify the selected agent:
+
+```bash
+opencode --version || true
+claude --version || true
+codex --version || true
+```
+
+## Step 4: Start the Setup Wizard
+
+Run:
+
+```bash
+vibe
+```
+
+This starts the local service and opens the Web UI setup wizard. If a browser does not open automatically, check the terminal output for the local URL.
+
+In the wizard, help the user choose:
+
+1. Chat platform: Slack, Discord, Telegram, WeChat, or Lark / Feishu.
+2. Agent backend: Claude Code, OpenCode, or Codex.
+3. Project working directory.
+4. Channel or chat scopes that should be enabled.
+
+Platform docs:
+
+- Slack: https://github.com/cyhhao/vibe-remote/blob/master/docs/SLACK_SETUP.md
+- Discord: https://github.com/cyhhao/vibe-remote/blob/master/docs/DISCORD_SETUP.md
+- Telegram: https://github.com/cyhhao/vibe-remote/blob/master/docs/TELEGRAM_SETUP.md
+- WeChat: use the in-app wizard.
+- Lark / Feishu: use the in-app wizard.
+
+## Step 5: Optional Remote Web UI
+
+If the user wants to open the local Web UI from a phone, tablet, or remote machine, run:
+
+```bash
+vibe remote
+```
+
+This guides the user through avibe.bot sign-in, pairing, and a secure tunnel. Use this for Web UI access, not for exposing the agent runtime directly.
+
+## Step 6: Smoke Test
+
+After setup, ask the user to send a short message in the enabled chat:
+
+```text
+Say hello and tell me which project directory you are running in.
+```
+
+Then verify:
+
+```bash
+vibe status
+```
+
+If messages do not arrive, run:
+
+```bash
+vibe doctor
+```
+
+Check platform-specific docs for missing permissions, disabled bot privacy settings, or unselected channels.
+
+## Common Fixes
+
+| Symptom | What to check |
+| --- | --- |
+| `vibe` command missing | Shell `PATH`, uv tool bin directory, installer output |
+| Agent not found | Install the selected agent CLI and verify it is on `PATH` |
+| Slack bot silent | App installed, Socket Mode token, bot token scopes, bot invited to channel |
+| Telegram group silent | Bot privacy mode, mention requirements, discovered chat list |
+| Discord silent | Bot token, guild/channel selection, gateway intents |
+| Web UI unreachable from phone | Use `vibe remote`; localhost only works on the same machine |
+
+## Uninstall
+
+Only run this if the user asks to remove Vibe Remote:
+
+```bash
+vibe stop
+uv tool uninstall vibe-remote
+rm -rf ~/.vibe_remote
+```

--- a/docs/INSTALL_FOR_AI_ZH.md
+++ b/docs/INSTALL_FOR_AI_ZH.md
@@ -1,0 +1,169 @@
+# 给 AI Agent 的 Vibe Remote 安装指南
+
+这份文档可以直接丢给 Claude Code、Codex、OpenCode 或其他本地编码 agent，让它帮用户安装和配置 Vibe Remote。
+
+Vibe Remote 会把本地 AI 编码 agent 接到 Slack、Discord、Telegram、微信、飞书 / Lark 等聊天平台。代码和 agent 进程都留在用户自己的机器上。
+
+## 协助安装时的规则
+
+- 选择聊天平台、agent 后端、工作区、凭证值之前，先问用户。
+- 不要猜 token、API key、workspace ID、chat ID 等敏感配置。
+- 优先使用运行 `vibe` 后打开的浏览器设置向导，不要手写配置文件。
+- 如果本机已经有 `vibe` 服务在运行，除非用户确认安全，否则不要重启。
+- 默认保持本地优先；除非平台本身要求，不要暴露公开 webhook。
+
+## 第 1 步：检查机器环境
+
+运行：
+
+```bash
+uname -a
+command -v vibe || true
+command -v uv || true
+command -v claude || true
+command -v opencode || true
+command -v codex || true
+```
+
+Windows 用户默认推荐 WSL：
+
+- https://github.com/cyhhao/vibe-remote/blob/master/docs/WINDOWS_WSL_ZH.md
+
+## 第 2 步：安装 Vibe Remote
+
+macOS / Linux：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash
+```
+
+Windows PowerShell：
+
+```powershell
+irm https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.ps1 | iex
+```
+
+验证：
+
+```bash
+vibe version
+vibe doctor
+```
+
+如果安装器无法使用 PyPI，会自动回退到 GitHub。如果已经安装但找不到 `vibe` 命令，查看安装器最后输出的 bin 目录，并帮用户把它加入 shell `PATH`。
+
+## 第 3 步：至少安装一个编码 Agent
+
+先问用户想用哪个后端。默认建议：OpenCode 上手最轻，Claude Code 适合复杂编码任务，Codex 适合 OpenAI 工作流。
+
+OpenCode：
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+如果用户接受权限取舍，可配置：
+
+```json
+{
+  "permission": "allow"
+}
+```
+
+Claude Code：
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Codex：
+
+```bash
+npm install -g @openai/codex
+```
+
+验证所选 agent：
+
+```bash
+opencode --version || true
+claude --version || true
+codex --version || true
+```
+
+## 第 4 步：启动设置向导
+
+运行：
+
+```bash
+vibe
+```
+
+这会启动本地服务并打开 Web UI 设置向导。如果浏览器没有自动打开，查看终端输出里的本地 URL。
+
+在向导里帮用户选择：
+
+1. 聊天平台：Slack、Discord、Telegram、微信、飞书 / Lark。
+2. Agent 后端：Claude Code、OpenCode、Codex。
+3. 项目工作目录。
+4. 需要启用的频道或聊天范围。
+
+平台文档：
+
+- Slack: https://github.com/cyhhao/vibe-remote/blob/master/docs/SLACK_SETUP_ZH.md
+- Discord: https://github.com/cyhhao/vibe-remote/blob/master/docs/DISCORD_SETUP_ZH.md
+- Telegram: https://github.com/cyhhao/vibe-remote/blob/master/docs/TELEGRAM_SETUP_ZH.md
+- 微信：使用应用内向导。
+- 飞书 / Lark：使用应用内向导。
+
+## 第 5 步：可选的远程 Web UI
+
+如果用户想从手机、平板或远端机器打开本机 Web UI，运行：
+
+```bash
+vibe remote
+```
+
+它会引导用户登录 avibe.bot、完成配对并启动安全 tunnel。这个能力用于访问 Web UI，不是把 agent runtime 直接暴露到公网。
+
+## 第 6 步：冒烟测试
+
+配置完成后，让用户在启用的聊天里发一条短消息：
+
+```text
+Say hello and tell me which project directory you are running in.
+```
+
+然后验证：
+
+```bash
+vibe status
+```
+
+如果消息没有到达，运行：
+
+```bash
+vibe doctor
+```
+
+再按平台文档检查权限、bot 隐私设置、频道选择等问题。
+
+## 常见问题
+
+| 现象 | 检查点 |
+| --- | --- |
+| 找不到 `vibe` 命令 | shell `PATH`、uv tool bin 目录、安装器输出 |
+| 找不到 agent | 安装所选 agent CLI，并确认它在 `PATH` 里 |
+| Slack 没反应 | App 是否安装、Socket Mode token、bot token scopes、bot 是否被邀请进频道 |
+| Telegram 群里没反应 | Bot privacy mode、是否需要 @、聊天是否已被发现 |
+| Discord 没反应 | Bot token、服务器/频道选择、gateway intents |
+| 手机打不开 Web UI | 使用 `vibe remote`；localhost 只适合同一台机器 |
+
+## 卸载
+
+只有用户明确要删除 Vibe Remote 时才运行：
+
+```bash
+vibe stop
+uv tool uninstall vibe-remote
+rm -rf ~/.vibe_remote
+```

--- a/docs/plans/distribution-growth.md
+++ b/docs/plans/distribution-growth.md
@@ -11,6 +11,7 @@ Make Vibe Remote easier to understand, easier to install, and easier for AI codi
 ## Completed in This Pass
 
 - Kept the README / README_ZH first-screen brand story intact instead of replacing it with a checklist-style positioning block.
+- Added a concise "What Ships Today" checklist after installation, where it supports scanning without weakening the hero narrative.
 - Added AI-agent installation guides in English and Chinese:
   - `docs/INSTALL_FOR_AI.md`
   - `docs/INSTALL_FOR_AI_ZH.md`

--- a/docs/plans/distribution-growth.md
+++ b/docs/plans/distribution-growth.md
@@ -10,11 +10,11 @@ Make Vibe Remote easier to understand, easier to install, and easier for AI codi
 
 ## Completed in This Pass
 
-- Tightened the README / README_ZH first-screen positioning around concrete supported platforms, supported agents, and product capabilities.
-- Added a feature snapshot table so GitHub visitors can decide quickly whether the project fits their workflow.
+- Kept the README / README_ZH first-screen brand story intact instead of replacing it with a checklist-style positioning block.
 - Added AI-agent installation guides in English and Chinese:
   - `docs/INSTALL_FOR_AI.md`
   - `docs/INSTALL_FOR_AI_ZH.md`
+- Linked the AI-agent installation guides from the docs section without interrupting the landing-page narrative.
 - Updated package metadata and installer banner copy so the project no longer presents as Slack-only.
 
 ## Next High-Leverage Work

--- a/docs/plans/distribution-growth.md
+++ b/docs/plans/distribution-growth.md
@@ -1,0 +1,46 @@
+# Distribution and Growth Plan
+
+## Background
+
+Vibe Remote already has a stronger product experience than a simple bridge: setup wizard, multi-platform routing, session resume, remote Web UI access, scheduled tasks, and async hooks. The public surface does not make those strengths obvious quickly enough, and the current distribution story still reads like a Python package rather than a developer CLI.
+
+## Goal
+
+Make Vibe Remote easier to understand, easier to install, and easier for AI coding agents to configure on behalf of users without overstating channels that are not shipped yet.
+
+## Completed in This Pass
+
+- Tightened the README / README_ZH first-screen positioning around concrete supported platforms, supported agents, and product capabilities.
+- Added a feature snapshot table so GitHub visitors can decide quickly whether the project fits their workflow.
+- Added AI-agent installation guides in English and Chinese:
+  - `docs/INSTALL_FOR_AI.md`
+  - `docs/INSTALL_FOR_AI_ZH.md`
+- Updated package metadata and installer banner copy so the project no longer presents as Slack-only.
+
+## Next High-Leverage Work
+
+1. Add a tiny npm wrapper package named `vibe-remote` or `vibe-remote-cli` that delegates to the existing installer.
+   - Purpose: capture `npm install -g ...` muscle memory in the AI coding community.
+   - Constraint: do not ship a second runtime; keep Python / uv as the source of truth until a binary packaging decision is made.
+
+2. Add Homebrew distribution.
+   - Short path: maintain a tap first.
+   - Long path: submit to `homebrew-core` after install stability and release artifacts are boring.
+
+3. Produce signed standalone binaries or app bundles.
+   - Candidate tools: PyInstaller, Briefcase, or a small Go/Rust bootstrapper that installs and manages the Python package.
+   - Decision criterion: startup reliability and update behavior matter more than removing every dependency.
+
+4. Expand China-first platform coverage only where it fits the architecture.
+   - Evaluate DingTalk, WeCom, QQ, and personal WeChat improvements through the shared IM abstraction.
+   - Do not fork product behavior per platform unless platform constraints force it.
+
+5. Add a comparison page that is fair and specific.
+   - Compare with cc-connect and OpenClaw on setup, UX depth, session continuity, remote UI, security model, and automation.
+   - Avoid attacking projects; explain which workflow each tool optimizes for.
+
+## Non-Goals
+
+- Do not claim npm, Homebrew, or standalone binary support until the release path is real.
+- Do not turn Vibe Remote into a broad agent framework just to match bridge-project feature checklists.
+- Do not add platform adapters by copying large platform-specific stacks into core.

--- a/install.ps1
+++ b/install.ps1
@@ -18,7 +18,7 @@ function Write-Banner {
    \ V /  | || |_) ||  __/ |  _ <|  __/| | | | | | (_) | |_|  __/
     \_/   |_||_.__/  \___| |_| \_\\___||_| |_| |_|\___/ \__|\___|
 "@ -ForegroundColor Blue
-    Write-Host "Local-first agent runtime for Slack" -ForegroundColor Green
+    Write-Host "Local-first AI coding agents in your chat apps" -ForegroundColor Green
     Write-Host ""
 }
 

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ print_banner() {
     \_/   |_||_.__/  \___| |_| \_\\___||_| |_| |_|\___/ \__|\___|
 EOF
     echo -e "${NC}"
-    echo -e "${GREEN}Local-first agent runtime for Slack${NC}"
+    echo -e "${GREEN}Local-first AI coding agents in your chat apps${NC}"
     echo ""
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,29 @@ build-backend = "hatchling.build"
 [project]
 name = "vibe-remote"
 dynamic = ["version"]
-description = "Local-first agent runtime for Slack - run AI coding agents from your chat"
+description = "Local-first agent runtime for Slack, Discord, Telegram, WeChat, and Lark"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
     { name = "cyhhao", email = "cyhhao@users.noreply.github.com" }
 ]
-keywords = ["slack", "ai", "agent", "claude", "opencode", "codex", "automation"]
+keywords = [
+    "slack",
+    "discord",
+    "telegram",
+    "wechat",
+    "lark",
+    "feishu",
+    "ai",
+    "agent",
+    "claude-code",
+    "opencode",
+    "codex",
+    "automation",
+    "chatops",
+    "vibe-coding",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",


### PR DESCRIPTION
## Summary
- keep the original README hero, slogan, banner, and pitch intact
- add a concise "What Ships Today" checklist after installation so scanners can see the real product surface without weakening the landing-page narrative
- add AI-agent install guides in English and Chinese for handing setup to Claude Code, Codex, or OpenCode
- update installer/package metadata copy so Vibe Remote no longer presents as Slack-only
- capture follow-up distribution work for npm wrapper, Homebrew, standalone binaries, and platform expansion

## Validation
- parsed pyproject.toml with Python tomllib
- ran git diff --check
- verified staged files do not include secret/local config patterns

## Risks / follow-ups
- this PR does not add new distribution channels; npm, Homebrew, and standalone binaries are planned follow-up work
- no runtime behavior changes
