### PR TITLE
fix(remote): pair tunnel to loopback origin

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -105,14 +105,54 @@ def test_pair_origin_service_follows_effective_ui_port(monkeypatch, tmp_path) ->
     assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"
 
 
-def test_pair_origin_service_uses_configured_ui_host(monkeypatch, tmp_path) -> None:
+def test_pair_origin_service_ignores_configured_ui_host(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _config()
     config.ui.setup_host = "192.168.2.3"
     config.ui.setup_port = 15130
     config.save()
 
-    assert remote_access.origin_service_for_pairing() == "http://192.168.2.3:15130"
+    assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"
+
+
+def test_pair_origin_service_preserves_localhost(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.ui.setup_host = "localhost"
+    config.ui.setup_port = 15130
+    config.save()
+
+    assert remote_access.origin_service_for_pairing() == "http://localhost:15130"
+
+
+def test_pair_origin_service_preserves_ipv6_loopback(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.ui.setup_host = "::1"
+    config.ui.setup_port = 15130
+    config.save()
+
+    assert remote_access.origin_service_for_pairing() == "http://[::1]:15130"
+
+
+def test_pair_origin_service_preserves_bracketed_ipv6_loopback(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.ui.setup_host = "[::1]"
+    config.ui.setup_port = 15130
+    config.save()
+
+    assert remote_access.origin_service_for_pairing() == "http://[::1]:15130"
+
+
+def test_pair_origin_service_uses_ipv6_loopback_for_ipv6_wildcard(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.ui.setup_host = "::"
+    config.ui.setup_port = 15130
+    config.save()
+
+    assert remote_access.origin_service_for_pairing() == "http://[::1]:15130"
 
 
 def test_pair_persists_with_locked_incremental_config_save(monkeypatch) -> None:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import ntpath
 import os
@@ -412,18 +413,28 @@ def _effective_ui_port(config: V2Config) -> int:
     return port
 
 
-def _origin_host_for_ui(config: V2Config) -> str:
-    host = (config.ui.setup_host or "127.0.0.1").strip()
-    if not host or host in {"0.0.0.0", "::", "[::]"}:
+def _origin_host_for_pairing(config: V2Config) -> str:
+    host = (config.ui.setup_host or "").strip()
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1].strip()
+    if host.lower() == "localhost":
+        return "localhost"
+
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
         return "127.0.0.1"
-    if ":" in host and not host.startswith("["):
-        return f"[{host}]"
-    return host
+
+    if address.is_loopback:
+        return f"[{address.compressed}]" if address.version == 6 else address.compressed
+    if address.is_unspecified and address.version == 6:
+        return "[::1]"
+    return "127.0.0.1"
 
 
 def origin_service_for_pairing(config: V2Config | None = None) -> str:
     config = config or V2Config.load()
-    return f"http://{_origin_host_for_ui(config)}:{_effective_ui_port(config)}"
+    return f"http://{_origin_host_for_pairing(config)}:{_effective_ui_port(config)}"
 
 
 def pair(pairing_key: str, backend_url: str, device_name: str = "Vibe Remote") -> dict[str, Any]:


### PR DESCRIPTION
## Summary

- Fix Vibe Cloud pairing so `origin_service` always points cloudflared at the local UI loopback origin.
- Keep the effective UI port behavior, including `VIBE_UI_PORT`, but stop using `ui.setup_host` as the tunnel origin host.
- Update coverage so LAN/Tailscale UI hosts are not sent to the backend as cloudflared origins.

## Validation

- `npm ci && npm run build` in `ui/`
- `uv run pytest tests/test_remote_access_vibe_cloud.py`
- `uv run ruff check vibe/remote_access.py tests/test_remote_access_vibe_cloud.py`
- `git diff --check`

## Context

During regression pairing, the backend returned a tunnel config with origin `http://100.97.103.112:5123`; cloudflared runs next to the UI server and could not connect to that host, causing remote access to return 502. The tunnel origin should be loopback, while `ui.setup_host` remains a display/browser access host.
