### PR TITLE
feat(remote): report runtime status

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 
-from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from config import paths
+from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from vibe import remote_access
 from vibe import runtime
 
@@ -82,6 +84,7 @@ def test_pair_redeems_key_and_starts_connector(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(remote_access, "_json_request", fake_request)
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True, "running": True})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": True, "paired": True})
+    monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
 
     result = remote_access.pair("vrp_test", "https://backend.test")
     saved_payload = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
@@ -155,6 +158,112 @@ def test_pair_origin_service_uses_ipv6_loopback_for_ipv6_wildcard(monkeypatch, t
     assert remote_access.origin_service_for_pairing() == "http://[::1]:15130"
 
 
+def test_runtime_status_payload_reports_local_origin_and_tunnel_state(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.ui.setup_host = "100.97.103.112"
+    config.save()
+    monkeypatch.setattr(remote_access, "_local_ui_healthy", lambda cfg: True)
+    monkeypatch.setattr(remote_access, "_observed_cloudflared_origin_service", lambda: "http://100.97.103.112:5123")
+    monkeypatch.setattr(
+        remote_access,
+        "status",
+        lambda cfg=None: {
+            "ok": True,
+            "running": True,
+            "binary_found": True,
+        },
+    )
+
+    payload = remote_access.runtime_status_payload(config, event="heartbeat")
+
+    assert payload["event"] == "heartbeat"
+    assert payload["ui_healthy"] is True
+    assert payload["tunnel_running"] is True
+    assert payload["cloudflared_found"] is True
+    assert payload["expected_origin_service"] == "http://127.0.0.1:5123"
+    assert payload["observed_origin_service"] == "http://100.97.103.112:5123"
+
+
+def test_observed_cloudflared_origin_service_reads_only_log_tail(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    remote_access._cloudflared_stderr_path().parent.mkdir(parents=True, exist_ok=True)
+    remote_access._cloudflared_stderr_path().write_bytes(
+        b'originService=http://old.local:5123\n'
+        + (b"x" * (remote_access.STATUS_LOG_TAIL_BYTES + 1024))
+        + b'originService=http://new.local:5123\n'
+    )
+    monkeypatch.setattr(remote_access.Path, "read_text", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("full read")))
+
+    assert remote_access._observed_cloudflared_origin_service() == "http://new.local:5123"
+
+
+def test_report_runtime_status_posts_to_backend(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    cloud = config.remote_access.vibe_cloud
+    cloud.backend_url = "https://backend.test"
+    cloud.instance_secret = "instance-secret"
+    config.save()
+    monkeypatch.setattr(remote_access, "_local_ui_healthy", lambda cfg: True)
+    monkeypatch.setattr(remote_access, "_observed_cloudflared_origin_service", lambda: "http://127.0.0.1:5123")
+    monkeypatch.setattr(remote_access, "status", lambda cfg=None: {"ok": True, "running": False, "binary_found": True})
+    calls = []
+
+    def fake_request(url: str, payload: dict, timeout: float = 20.0):
+        calls.append((url, payload, timeout))
+        return {"ok": True}
+
+    monkeypatch.setattr(remote_access, "_json_request", fake_request)
+
+    result = remote_access.report_runtime_status(config, event="stop")
+
+    assert result["ok"] is True
+    assert calls == [
+        (
+            "https://backend.test/api/v1/instances/inst_123/runtime-status",
+            {
+                "instance_secret": "instance-secret",
+                "event": "stop",
+                "local_version": "dev",
+                "ui_healthy": True,
+                "tunnel_running": False,
+                "cloudflared_found": True,
+                "expected_origin_service": "http://127.0.0.1:5123",
+                "observed_origin_service": "http://127.0.0.1:5123",
+            },
+            5.0,
+        )
+    ]
+
+
+def test_report_runtime_status_posts_when_remote_access_is_disabled(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = False
+    cloud.backend_url = "https://backend.test"
+    cloud.instance_secret = "instance-secret"
+    config.save()
+    monkeypatch.setattr(remote_access, "_local_ui_healthy", lambda cfg: True)
+    monkeypatch.setattr(remote_access, "_observed_cloudflared_origin_service", lambda: None)
+    monkeypatch.setattr(remote_access, "status", lambda cfg=None: {"ok": True, "running": False, "binary_found": True})
+    calls = []
+
+    def fake_request(url: str, payload: dict, timeout: float = 20.0):
+        calls.append((url, payload, timeout))
+        return {"ok": True}
+
+    monkeypatch.setattr(remote_access, "_json_request", fake_request)
+
+    result = remote_access.report_runtime_status(config, event="stop")
+
+    assert result["ok"] is True
+    assert calls[0][0] == "https://backend.test/api/v1/instances/inst_123/runtime-status"
+    assert calls[0][1]["event"] == "stop"
+    assert calls[0][1]["tunnel_running"] is False
+
+
 def test_pair_persists_with_locked_incremental_config_save(monkeypatch) -> None:
     config = _config()
     save_payloads = []
@@ -178,6 +287,7 @@ def test_pair_persists_with_locked_incremental_config_save(monkeypatch) -> None:
     monkeypatch.setattr(remote_access.api, "save_config", lambda payload: save_payloads.append(payload) or config)
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True, "running": True})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": True, "paired": True})
+    monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
 
     result = remote_access.pair("vrp_test", "https://backend.test")
 
@@ -214,6 +324,7 @@ def test_pair_reports_success_when_connector_start_fails(monkeypatch, tmp_path) 
     )
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": False, "error": "cloudflared_spawn_failed"})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": False, "paired": True})
+    monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
 
     result = remote_access.pair("vrp_test", "https://backend.test")
     saved_payload = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
@@ -244,6 +355,128 @@ def test_pair_preserves_backend_error_response(monkeypatch) -> None:
     result = remote_access.pair("vrp_test", "https://backend.test")
 
     assert result == {"ok": False, "error": "invalid_pairing_key", "status": 400}
+
+
+def test_pair_queues_lifecycle_status_for_drain(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    reports = []
+
+    monkeypatch.setattr(
+        remote_access,
+        "_json_request",
+        lambda *args, **kwargs: {
+            "instance_id": "inst_123",
+            "client_id": "vr_client_123",
+            "issuer": "https://backend.test",
+            "authorization_endpoint": "https://backend.test/oauth/authorize",
+            "token_endpoint": "https://backend.test/oauth/token",
+            "jwks_uri": "https://backend.test/oauth/jwks.json",
+            "public_url": "https://alex.avibe.bot",
+            "redirect_uri": "https://alex.avibe.bot/auth/callback",
+            "tunnel_token": "tunnel-token",
+            "instance_secret": "instance-secret",
+        },
+    )
+    monkeypatch.setattr(remote_access.api, "save_config", lambda payload: config)
+    monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": False, "error": "cloudflared_spawn_failed"})
+    monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": False, "paired": True})
+    monkeypatch.setattr(
+        remote_access,
+        "report_runtime_status",
+        lambda cfg, event="heartbeat", last_error=None: reports.append((event, last_error)) or {"ok": True},
+    )
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+    remote_access.drain_runtime_status_reports(timeout_seconds=1.0)
+
+    assert result["ok"] is True
+    assert reports == [("pair", "cloudflared_spawn_failed")]
+
+
+def test_lifecycle_status_report_does_not_block_stop(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_report(*args, **kwargs):
+        started.set()
+        release.wait(timeout=5)
+        return {"ok": True}
+
+    monkeypatch.setattr(remote_access, "report_runtime_status", blocking_report)
+
+    before = time.monotonic()
+    result = remote_access.stop(_config())
+    elapsed = time.monotonic() - before
+
+    assert result["ok"] is True
+    assert elapsed < 0.5
+    assert started.wait(timeout=1)
+    assert remote_access._CONNECTOR_LOCK.acquire(blocking=False)
+    remote_access._CONNECTOR_LOCK.release()
+    release.set()
+    remote_access.drain_runtime_status_reports(timeout_seconds=1.0)
+
+
+def test_lifecycle_status_thread_start_failure_is_best_effort(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    with remote_access._STATUS_REPORT_LOCK:
+        remote_access._STATUS_REPORT_THREADS.clear()
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread limit reached")
+
+        def is_alive(self):
+            return False
+
+        def join(self, timeout=None):
+            return None
+
+    monkeypatch.setattr(remote_access.threading, "Thread", FailingThread)
+
+    result = remote_access.stop(_config())
+
+    assert result["ok"] is True
+    with remote_access._STATUS_REPORT_LOCK:
+        assert remote_access._STATUS_REPORT_THREADS == set()
+
+
+def test_status_heartbeat_can_retry_after_thread_start_failure(monkeypatch) -> None:
+    remote_access._STATUS_HEARTBEAT_STARTED = False
+    starts = []
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("thread limit reached")
+
+    class SuccessfulThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            starts.append(True)
+
+    monkeypatch.setattr(remote_access.threading, "Thread", FailingThread)
+
+    try:
+        remote_access.start_status_heartbeat(interval_seconds=1)
+        assert remote_access._STATUS_HEARTBEAT_STARTED is False
+
+        monkeypatch.setattr(remote_access.threading, "Thread", SuccessfulThread)
+        remote_access.start_status_heartbeat(interval_seconds=1)
+        assert remote_access._STATUS_HEARTBEAT_STARTED is True
+        assert starts == [True]
+    finally:
+        remote_access._STATUS_HEARTBEAT_STARTED = False
 
 
 def test_stop_ui_continues_when_remote_access_stop_fails(monkeypatch, tmp_path) -> None:
@@ -313,6 +546,7 @@ def test_stop_preserves_pid_file_when_process_stop_fails(monkeypatch, tmp_path) 
     monkeypatch.setattr(runtime, "stop_pid", lambda candidate, timeout=8: False)
 
     result = remote_access.stop()
+    remote_access.drain_runtime_status_reports(timeout_seconds=1.0)
 
     assert result["ok"] is False
     assert result["error"] == "cloudflared_stop_failed"
@@ -330,11 +564,18 @@ def test_stop_preserves_pid_file_when_stop_reports_success_but_process_survives(
     monkeypatch.setattr(runtime, "pid_alive", lambda candidate: candidate == pid)
     monkeypatch.setattr(runtime, "get_process_command", lambda candidate: "cloudflared tunnel run")
     monkeypatch.setattr(runtime, "stop_pid", lambda candidate, timeout=8: True)
+    reports = []
+    monkeypatch.setattr(
+        remote_access,
+        "report_runtime_status",
+        lambda config=None, event="heartbeat", last_error=None: reports.append((event, last_error)),
+    )
 
     result = remote_access.stop()
 
     assert result["ok"] is False
     assert result["error"] == "cloudflared_stop_failed"
+    assert reports == [("stop_failed", "cloudflared_stop_failed")]
     assert remote_access._pid_path().read_text(encoding="utf-8") == str(pid)
     assert remote_access._state_path().exists()
 

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import atexit
 import hashlib
 import hmac
 import ipaddress
@@ -9,6 +10,7 @@ import json
 import ntpath
 import os
 import platform
+import re
 import shlex
 import secrets
 import shutil
@@ -34,6 +36,14 @@ CLOUDFLARED_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/lates
 SESSION_COOKIE_NAME = "__Host-vibe_remote_session"
 SESSION_TTL_SECONDS = 12 * 60 * 60
 _CONNECTOR_LOCK = threading.RLock()
+_STATUS_HEARTBEAT_LOCK = threading.Lock()
+_STATUS_HEARTBEAT_STARTED = False
+_STATUS_REPORT_LOCK = threading.Lock()
+_STATUS_REPORT_THREADS: set[threading.Thread] = set()
+_STATUS_REPORT_ATEXIT_REGISTERED = False
+STATUS_HEARTBEAT_SECONDS = 5 * 60
+STATUS_LOG_TAIL_BYTES = 64 * 1024
+STATUS_REPORT_DRAIN_SECONDS = 1.0
 
 
 class BackendRequestError(Exception):
@@ -58,6 +68,10 @@ def _pid_path() -> Path:
 
 def _state_path() -> Path:
     return paths.get_runtime_dir() / "remote-access-cloudflared.json"
+
+
+def _cloudflared_stderr_path() -> Path:
+    return paths.get_runtime_dir() / "remote_access_cloudflared_stderr.log"
 
 
 def _asset_name() -> str:
@@ -231,6 +245,33 @@ def _read_state() -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _read_text_tail(path: Path, byte_limit: int) -> str | None:
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - byte_limit))
+            return handle.read(byte_limit).decode("utf-8", errors="replace")
+    except Exception:
+        return None
+
+
+def _observed_cloudflared_origin_service() -> str | None:
+    content = _read_text_tail(_cloudflared_stderr_path(), STATUS_LOG_TAIL_BYTES)
+    if content is None:
+        return None
+    patterns = (
+        r'originService=([^\s"]+)',
+        r'\\"service\\":\\"(http://[^"\\]+)\\"',
+        r'"service":"(http://[^"]+)"',
+    )
+    for pattern in patterns:
+        matches = re.findall(pattern, content)
+        if matches:
+            return str(matches[-1])
+    return None
+
+
 def _running_signature(pid: int | None) -> dict[str, str] | None:
     if not _is_cloudflared_pid(pid):
         return None
@@ -273,6 +314,121 @@ def status(config: V2Config | None = None) -> dict[str, Any]:
     }
 
 
+def _local_ui_healthy(config: V2Config) -> bool:
+    try:
+        response = requests.get(f"{origin_service_for_pairing(config)}/health", timeout=1.0)
+        return response.ok
+    except Exception:
+        return False
+
+
+def runtime_status_payload(config: V2Config | None = None, event: str = "heartbeat", last_error: str | None = None) -> dict[str, Any]:
+    config = config or V2Config.load()
+    current = status(config)
+    payload = {
+        "event": event,
+        "local_version": "dev",
+        "ui_healthy": _local_ui_healthy(config),
+        "tunnel_running": bool(current.get("running")),
+        "cloudflared_found": bool(current.get("binary_found")),
+        "expected_origin_service": origin_service_for_pairing(config),
+        "observed_origin_service": _observed_cloudflared_origin_service(),
+    }
+    error = last_error or current.get("error")
+    if error:
+        payload["last_error"] = str(error)
+    return payload
+
+
+def report_runtime_status(config: V2Config | None = None, event: str = "heartbeat", last_error: str | None = None) -> dict[str, Any]:
+    try:
+        config = config or V2Config.load()
+        cloud = config.remote_access.vibe_cloud
+        if not (cloud.instance_id and cloud.instance_secret and cloud.backend_url):
+            return {"ok": False, "error": "remote_status_not_configured"}
+        payload = {
+            "instance_secret": cloud.instance_secret,
+            **runtime_status_payload(config, event=event, last_error=last_error),
+        }
+        result = _json_request(
+            f"{cloud.backend_url.rstrip('/')}/api/v1/instances/{cloud.instance_id}/runtime-status",
+            payload,
+            timeout=5.0,
+        )
+        return {"ok": True, **result}
+    except Exception as exc:
+        return {"ok": False, "error": "remote_status_report_failed", "detail": str(exc)}
+
+
+def drain_runtime_status_reports(timeout_seconds: float = STATUS_REPORT_DRAIN_SECONDS) -> None:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while True:
+        with _STATUS_REPORT_LOCK:
+            threads = [thread for thread in _STATUS_REPORT_THREADS if thread.is_alive()]
+        if not threads:
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        for thread in threads:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            thread.join(remaining)
+
+
+def _register_status_report_thread(thread: threading.Thread) -> None:
+    global _STATUS_REPORT_ATEXIT_REGISTERED
+    with _STATUS_REPORT_LOCK:
+        _STATUS_REPORT_THREADS.add(thread)
+        if not _STATUS_REPORT_ATEXIT_REGISTERED:
+            atexit.register(drain_runtime_status_reports)
+            _STATUS_REPORT_ATEXIT_REGISTERED = True
+
+
+def _report_runtime_status_async(config: V2Config | None = None, event: str = "heartbeat", last_error: str | None = None) -> None:
+    holder: dict[str, threading.Thread] = {}
+
+    def worker() -> None:
+        try:
+            report_runtime_status(config, event=event, last_error=last_error)
+        finally:
+            thread = holder.get("thread")
+            if thread is not None:
+                with _STATUS_REPORT_LOCK:
+                    _STATUS_REPORT_THREADS.discard(thread)
+
+    try:
+        thread = threading.Thread(target=worker, name="vibe-remote-status-report", daemon=True)
+    except Exception:
+        return
+    holder["thread"] = thread
+    try:
+        _register_status_report_thread(thread)
+        thread.start()
+    except Exception:
+        with _STATUS_REPORT_LOCK:
+            _STATUS_REPORT_THREADS.discard(thread)
+
+
+def start_status_heartbeat(config: V2Config | None = None, interval_seconds: int = STATUS_HEARTBEAT_SECONDS) -> None:
+    global _STATUS_HEARTBEAT_STARTED
+    def loop() -> None:
+        while True:
+            report_runtime_status(None, event="heartbeat")
+            time.sleep(interval_seconds)
+
+    with _STATUS_HEARTBEAT_LOCK:
+        if _STATUS_HEARTBEAT_STARTED:
+            return
+        try:
+            thread = threading.Thread(target=loop, name="vibe-remote-status-heartbeat", daemon=True)
+            thread.start()
+        except Exception:
+            return
+        _STATUS_HEARTBEAT_STARTED = True
+
+
 def stop(config: V2Config | None = None) -> dict[str, Any]:
     try:
         config = config or V2Config.load()
@@ -282,7 +438,9 @@ def stop(config: V2Config | None = None) -> dict[str, Any]:
         pid = _read_pid()
         pid_state = _cloudflared_pid_state(pid)
         if pid is not None and pid_state == "unknown":
-            return {**status(config), "ok": False, "error": "cloudflared_process_unknown", "stopped": False}
+            result = {**status(config), "ok": False, "error": "cloudflared_process_unknown", "stopped": False}
+            _report_runtime_status_async(config, event="stop_failed", last_error="cloudflared_process_unknown")
+            return result
         if pid is not None and pid_state in {"dead", "other"}:
             _pid_path().unlink(missing_ok=True)
             _state_path().unlink(missing_ok=True)
@@ -291,12 +449,18 @@ def stop(config: V2Config | None = None) -> dict[str, Any]:
         if stopped:
             post_stop_state = _cloudflared_pid_state(pid)
             if post_stop_state in {"cloudflared", "unknown"}:
-                return {**status(config), "ok": False, "error": "cloudflared_stop_failed", "stopped": False}
+                result = {**status(config), "ok": False, "error": "cloudflared_stop_failed", "stopped": False}
+                _report_runtime_status_async(config, event="stop_failed", last_error="cloudflared_stop_failed")
+                return result
             _pid_path().unlink(missing_ok=True)
             _state_path().unlink(missing_ok=True)
         if pid is not None and not stopped and _is_cloudflared_pid(pid):
-            return {**status(config), "ok": False, "error": "cloudflared_stop_failed", "stopped": False}
-        return {**status(config), "ok": True, "stopped": stopped}
+            result = {**status(config), "ok": False, "error": "cloudflared_stop_failed", "stopped": False}
+            _report_runtime_status_async(config, event="stop_failed", last_error="cloudflared_stop_failed")
+            return result
+        result = {**status(config), "ok": True, "stopped": stopped}
+        _report_runtime_status_async(config, event="stop")
+        return result
 
 
 def rotate_session_secret(config: V2Config) -> None:
@@ -328,15 +492,18 @@ def start(config: V2Config | None = None) -> dict[str, Any]:
         if not binary:
             install_result = install_cloudflared()
             if install_result.get("ok") is False:
+                _report_runtime_status_async(config, event="start_failed", last_error=str(install_result.get("error") or "cloudflared_install_failed"))
                 return {**status(config), **install_result}
             binary = str(install_result["path"])
         current = status(config)
         if current.get("pid_state") == "unknown":
+            _report_runtime_status_async(config, event="start_failed", last_error="cloudflared_process_unknown")
             return {**current, "ok": False, "error": "cloudflared_process_unknown", "started": False}
         if current.get("running"):
             running_sig = _running_signature(current.get("pid"))
             desired_sig = _runtime_signature(config, binary)
             if running_sig == desired_sig:
+                _report_runtime_status_async(config, event="start")
                 return {**current, "ok": True, "started": False}
             stop_result = stop(config)
             if stop_result.get("ok") is False or stop_result.get("running"):
@@ -357,12 +524,16 @@ def start(config: V2Config | None = None) -> dict[str, Any]:
             )
             _write_state(pid, config, binary)
         except Exception as exc:
+            _report_runtime_status_async(config, event="start_failed", last_error="cloudflared_spawn_failed")
             return {**status(config), "ok": False, "error": "cloudflared_spawn_failed", "detail": str(exc)}
         time.sleep(0.2)
         current = status(config)
         if not current.get("running"):
+            _report_runtime_status_async(config, event="start_failed", last_error="cloudflared_exited")
             return {**current, "ok": False, "error": "cloudflared_exited"}
-        return {**current, "ok": True, "started": True, "pid": pid}
+        result = {**current, "ok": True, "started": True, "pid": pid}
+        _report_runtime_status_async(config, event="start")
+        return result
 
 
 def reconcile(config: V2Config | None = None) -> dict[str, Any]:
@@ -487,6 +658,7 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "Vibe Remote") -
         }
     )
     start_result = start(config)
+    _report_runtime_status_async(config, event="pair", last_error=start_result.get("error"))
     return {**status(config), "ok": True, "pairing": {"ok": True}, "start": start_result}
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1499,6 +1499,12 @@ def run_ui_server(host: str, port: int) -> None:
         config = None
     if config is not None:
         init_sentry(config, component="ui", enable_flask=True)
+        try:
+            from vibe import remote_access
+
+            remote_access.start_status_heartbeat(config)
+        except Exception:
+            logger.warning("Failed to start remote access status heartbeat", exc_info=True)
     print(f"UI Server running at http://{host}:{port}")
 
     # Use make_server directly for better compatibility with subprocess/multiprocessing


### PR DESCRIPTION
## Summary

- Report Vibe Cloud runtime status to avibe.bot on pair/start/stop events and via a low-frequency UI heartbeat.
- Include local UI health, tunnel running state, cloudflared availability, expected origin, observed Cloudflare origin, and last error.
- Keep reporting non-blocking so remote access lifecycle commands do not fail because the status endpoint is unavailable.

## Validation

- `npm ci && npm run build` in `ui/`
- `uv run pytest tests/test_remote_access_vibe_cloud.py`
- `uv run ruff check vibe/remote_access.py vibe/ui_server.py tests/test_remote_access_vibe_cloud.py`
- `git diff --check`

## Notes

- This pairs with cyhhao/vibe-remote-backend#2. Until the backend endpoint is deployed, report attempts fail softly and do not affect tunnel startup.
