### PR TITLE
feat(distribution): add npm avibe entrypoint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,23 @@ jobs:
           pip install pre-commit
           pre-commit run --all-files
 
+  npm-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Test npm entrypoint
+        working-directory: npm/avibe
+        run: npm test
+
+      - name: Validate npm package contents
+        working-directory: npm/avibe
+        run: npm pack --dry-run
+
   install-upgrade-regression:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,0 +1,41 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to publish from"
+        required: true
+        default: "master"
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install npm with trusted publishing support
+        run: npm install -g npm@latest
+
+      - name: Test npm entrypoint
+        working-directory: npm/avibe
+        run: npm test
+
+      - name: Publish avibe
+        working-directory: npm/avibe
+        run: npm publish --access public

--- a/docs/plans/distribution-growth.md
+++ b/docs/plans/distribution-growth.md
@@ -8,6 +8,8 @@ Vibe Remote already has a stronger product experience than a simple bridge: setu
 
 Make Vibe Remote easier to understand, easier to install, and easier for AI coding agents to configure on behalf of users without overstating channels that are not shipped yet.
 
+The canonical install path should remain the current one-line curl / PowerShell installer because it is explicit, cross-runtime, and does not require users to already think in the Node ecosystem. npm should be an additional familiar entrypoint for Node-heavy developers, not the primary public installation story.
+
 ## Completed in This Pass
 
 - Kept the README / README_ZH first-screen brand story intact instead of replacing it with a checklist-style positioning block.
@@ -27,10 +29,10 @@ Make Vibe Remote easier to understand, easier to install, and easier for AI codi
 
 ## Next High-Leverage Work
 
-1. Publish the `avibe` npm package, then switch public install copy to npm-first.
-   - Preferred public command after publish: `npx avibe`.
-   - Global install path: `npm install -g avibe && avibe`.
-   - Keep the curl / PowerShell installers documented as fallback paths.
+1. Publish the `avibe` npm package as a supplemental install entrypoint.
+   - Keep the main README / docs install path as the existing one-line curl / PowerShell installer.
+   - Document `npx avibe` and `npm install -g avibe && avibe` as optional Node-friendly alternatives after publish.
+   - Do not make npm the default public install copy unless the product distribution strategy changes explicitly.
 
 2. Add Homebrew distribution.
    - Short path: maintain a tap first.

--- a/docs/plans/distribution-growth.md
+++ b/docs/plans/distribution-growth.md
@@ -17,12 +17,20 @@ Make Vibe Remote easier to understand, easier to install, and easier for AI codi
   - `docs/INSTALL_FOR_AI_ZH.md`
 - Linked the AI-agent installation guides from the docs section without interrupting the landing-page narrative.
 - Updated package metadata and installer banner copy so the project no longer presents as Slack-only.
+- Added an npm entrypoint package under `npm/avibe`:
+  - `npx avibe` and globally installed `avibe` bootstrap the existing Python `vibe-remote` package.
+  - The npm package does not ship a second runtime; it installs or locates the real `vibe` command and delegates to it.
+  - `avibe init` and `avibe start` map to the default `vibe` startup flow.
+  - `avibe status`, `doctor`, `remote`, `upgrade`, `task`, `hook`, and other commands pass through to `vibe`.
+  - CI now tests the wrapper and validates the packed npm contents.
+  - A manual GitHub Actions workflow can publish `avibe` to npm with provenance after npm trusted publishing is configured.
 
 ## Next High-Leverage Work
 
-1. Add a tiny npm wrapper package named `vibe-remote` or `vibe-remote-cli` that delegates to the existing installer.
-   - Purpose: capture `npm install -g ...` muscle memory in the AI coding community.
-   - Constraint: do not ship a second runtime; keep Python / uv as the source of truth until a binary packaging decision is made.
+1. Publish the `avibe` npm package, then switch public install copy to npm-first.
+   - Preferred public command after publish: `npx avibe`.
+   - Global install path: `npm install -g avibe && avibe`.
+   - Keep the curl / PowerShell installers documented as fallback paths.
 
 2. Add Homebrew distribution.
    - Short path: maintain a tap first.

--- a/docs/plans/distribution-growth.md
+++ b/docs/plans/distribution-growth.md
@@ -20,8 +20,9 @@ The canonical install path should remain the current one-line curl / PowerShell 
 - Linked the AI-agent installation guides from the docs section without interrupting the landing-page narrative.
 - Updated package metadata and installer banner copy so the project no longer presents as Slack-only.
 - Added an npm entrypoint package under `npm/avibe`:
-  - `npx avibe` and globally installed `avibe` bootstrap the existing Python `vibe-remote` package.
+  - `npx avibe` and globally installed `avibe` / `vibe` bootstrap the existing Python `vibe-remote` package.
   - The npm package does not ship a second runtime; it installs or locates the real `vibe` command and delegates to it.
+  - The npm package skips its own `vibe` shim when resolving the real Python runtime to avoid recursion.
   - `avibe init` and `avibe start` map to the default `vibe` startup flow.
   - `avibe status`, `doctor`, `remote`, `upgrade`, `task`, `hook`, and other commands pass through to `vibe`.
   - CI now tests the wrapper and validates the packed npm contents.
@@ -31,7 +32,7 @@ The canonical install path should remain the current one-line curl / PowerShell 
 
 1. Publish the `avibe` npm package as a supplemental install entrypoint.
    - Keep the main README / docs install path as the existing one-line curl / PowerShell installer.
-   - Document `npx avibe` and `npm install -g avibe && avibe` as optional Node-friendly alternatives after publish.
+   - Document `npx avibe` and `npm install -g avibe && vibe` as optional Node-friendly alternatives after publish.
    - Do not make npm the default public install copy unless the product distribution strategy changes explicitly.
 
 2. Add Homebrew distribution.

--- a/npm/avibe/README.md
+++ b/npm/avibe/README.md
@@ -1,0 +1,51 @@
+# avibe
+
+NPM entrypoint for [Vibe Remote](https://github.com/cyhhao/vibe-remote).
+
+Vibe Remote is still installed and upgraded as the Python package `vibe-remote`.
+This package is a thin bootstrapper for developers who expect npm-native entry
+points.
+
+## Quick Start
+
+```bash
+npx avibe
+```
+
+Or install the npm entrypoint globally:
+
+```bash
+npm install -g avibe
+avibe
+```
+
+The first run installs the underlying `vibe` command if needed, then starts the
+local Vibe Remote setup wizard.
+
+## Commands
+
+```bash
+avibe install   # install or refresh the underlying vibe-remote Python CLI
+avibe init      # start the setup wizard
+avibe start     # start Vibe Remote
+avibe status    # show runtime status
+avibe doctor    # diagnose local setup issues
+avibe remote    # configure remote Web UI access
+avibe upgrade   # upgrade the underlying vibe-remote Python package
+```
+
+After bootstrap, `avibe` delegates to the real `vibe` command.
+
+## Requirements
+
+- Node.js 16+
+- macOS / Linux: `curl` or `wget`
+- Windows: PowerShell
+
+The installer downloads `uv` automatically when it is missing. `uv` manages the
+Python runtime for `vibe-remote`.
+
+## Docs
+
+- <https://docs.avibe.bot>
+- <https://github.com/cyhhao/vibe-remote>

--- a/npm/avibe/README.md
+++ b/npm/avibe/README.md
@@ -16,15 +16,18 @@ Or install the npm entrypoint globally:
 
 ```bash
 npm install -g avibe
-avibe
+vibe
 ```
 
 The first run installs the underlying `vibe` command if needed, then starts the
-local Vibe Remote setup wizard.
+local Vibe Remote setup wizard. The global npm package exposes both `vibe` and
+`avibe`; `vibe` matches the rest of the Vibe Remote docs, while `avibe` remains
+available when you want to call the npm bootstrapper explicitly.
 
 ## Commands
 
 ```bash
+vibe            # start Vibe Remote after global npm install
 avibe install   # install or refresh the underlying vibe-remote Python CLI
 avibe init      # start the setup wizard
 avibe start     # start Vibe Remote
@@ -34,7 +37,7 @@ avibe remote    # configure remote Web UI access
 avibe upgrade   # upgrade the underlying vibe-remote Python package
 ```
 
-After bootstrap, `avibe` delegates to the real `vibe` command.
+After bootstrap, the npm entrypoint delegates to the real `vibe` command.
 
 ## Requirements
 

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -40,6 +40,11 @@ function printVersion() {
   console.log(`avibe ${packageJson.version}`);
 }
 
+function invokedAsVibe() {
+  const invokedName = path.basename(process.argv[1] || "").toLowerCase();
+  return invokedName === "vibe" || invokedName === "vibe.cmd" || invokedName === "vibe.bat" || invokedName === "vibe.exe";
+}
+
 function prependPathEntries(env, entries) {
   const delimiter = path.delimiter;
   const currentPath = env.PATH || env.Path || "";
@@ -319,13 +324,14 @@ function normalizeArgs(args) {
 function main() {
   const args = process.argv.slice(2);
   const command = args[0];
+  const shouldDelegateHelpAndVersion = invokedAsVibe();
 
-  if (command === "--help" || command === "-h" || command === "help") {
+  if (!shouldDelegateHelpAndVersion && (command === "--help" || command === "-h" || command === "help")) {
     printHelp();
     return;
   }
 
-  if (command === "--version" || command === "-v") {
+  if (!shouldDelegateHelpAndVersion && (command === "--version" || command === "-v")) {
     printVersion();
     return;
   }

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -41,8 +41,11 @@ function printVersion() {
 }
 
 function invokedAsVibe() {
-  const invokedName = path.basename(process.argv[1] || "").toLowerCase();
-  return invokedName === "vibe" || invokedName === "vibe.cmd" || invokedName === "vibe.bat" || invokedName === "vibe.exe";
+  const candidates = [process.env.AVIBE_ENTRYPOINT, process.argv0, process.argv[1]];
+  return candidates.some((candidate) => {
+    const invokedName = path.basename(candidate || "").toLowerCase();
+    return invokedName === "vibe" || invokedName === "vibe.cmd" || invokedName === "vibe.bat" || invokedName === "vibe.exe";
+  });
 }
 
 function prependPathEntries(env, entries) {

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const packageJson = require("../package.json");
+
+const INSTALL_SH_URL =
+  process.env.AVIBE_INSTALL_SH_URL ||
+  "https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh";
+const INSTALL_PS1_URL =
+  process.env.AVIBE_INSTALL_PS1_URL ||
+  "https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.ps1";
+
+function printHelp() {
+  console.log(`avibe ${packageJson.version}
+
+NPM entrypoint for Vibe Remote.
+
+Usage:
+  npx avibe              Install Vibe Remote if needed, then start the setup wizard
+  avibe                 Same as above after npm install -g avibe
+  avibe install         Install or refresh the underlying vibe-remote Python CLI
+  avibe init            Start the setup wizard
+  avibe start           Start Vibe Remote
+  avibe status          Show runtime status
+  avibe doctor          Diagnose local setup issues
+  avibe remote          Configure remote Web UI access
+  avibe upgrade         Upgrade the underlying vibe-remote Python package
+
+After bootstrap, avibe delegates to the real 'vibe' command.
+Docs: https://docs.avibe.bot`);
+}
+
+function printVersion() {
+  console.log(`avibe ${packageJson.version}`);
+}
+
+function prependPathEntries(env, entries) {
+  const delimiter = path.delimiter;
+  const currentPath = env.PATH || env.Path || "";
+  const existing = new Set(currentPath.split(delimiter).filter(Boolean));
+  const nextEntries = [];
+
+  for (const entry of entries) {
+    if (entry && !existing.has(entry)) {
+      nextEntries.push(entry);
+    }
+  }
+
+  return {
+    ...env,
+    PATH: [...nextEntries, currentPath].filter(Boolean).join(delimiter),
+  };
+}
+
+function candidateBinDirs() {
+  const home = os.homedir();
+  const dirs = [];
+
+  if (process.platform === "win32") {
+    const profile = process.env.USERPROFILE || home;
+    dirs.push(path.join(profile, ".local", "bin"));
+    dirs.push(path.join(profile, ".cargo", "bin"));
+  } else {
+    dirs.push(path.join(home, ".local", "bin"));
+    dirs.push(path.join(home, ".cargo", "bin"));
+  }
+
+  return dirs;
+}
+
+function executableNames(name) {
+  if (process.platform === "win32") {
+    return [`${name}.exe`, `${name}.cmd`, `${name}.bat`, name];
+  }
+  return [name];
+}
+
+function isExecutable(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolveFromPath(command, env = process.env) {
+  const pathValue = env.PATH || env.Path || "";
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) {
+      continue;
+    }
+    for (const executableName of executableNames(command)) {
+      const candidate = path.join(dir, executableName);
+      if (isExecutable(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function findVibeBinary() {
+  if (process.env.AVIBE_VIBE_BIN) {
+    return process.env.AVIBE_VIBE_BIN;
+  }
+
+  const envWithCommonBins = prependPathEntries(process.env, candidateBinDirs());
+  const fromPath = resolveFromPath("vibe", envWithCommonBins);
+  if (fromPath) {
+    return fromPath;
+  }
+
+  for (const dir of candidateBinDirs()) {
+    for (const executableName of executableNames("vibe")) {
+      const candidate = path.join(dir, executableName);
+      if (isExecutable(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function runCommand(command, args, options = {}) {
+  const result = childProcess.spawnSync(command, args, {
+    stdio: "inherit",
+    shell: options.shell || false,
+    env: options.env || prependPathEntries(process.env, candidateBinDirs()),
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === "number") {
+    return result.status;
+  }
+
+  return result.signal ? 1 : 0;
+}
+
+function hasCommand(command) {
+  return Boolean(resolveFromPath(command, prependPathEntries(process.env, candidateBinDirs())));
+}
+
+function installWithCustomCommand() {
+  if (!process.env.AVIBE_INSTALL_COMMAND) {
+    return false;
+  }
+
+  const status = runCommand(process.env.AVIBE_INSTALL_COMMAND, [], { shell: true });
+  if (status !== 0) {
+    process.exit(status);
+  }
+  return true;
+}
+
+function installOnWindows() {
+  const powershell = resolveFromPath("powershell", process.env) || resolveFromPath("pwsh", process.env);
+  if (!powershell) {
+    console.error("PowerShell is required to install Vibe Remote on Windows.");
+    console.error("Manual install: https://docs.avibe.bot/quickstart");
+    process.exit(1);
+  }
+
+  const script = `irm ${JSON.stringify(INSTALL_PS1_URL)} | iex`;
+  const status = runCommand(powershell, ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script]);
+  if (status !== 0) {
+    process.exit(status);
+  }
+}
+
+function installOnPosix() {
+  let fetchCommand;
+  if (hasCommand("curl")) {
+    fetchCommand = `curl -fsSL ${shellQuote(INSTALL_SH_URL)} | bash`;
+  } else if (hasCommand("wget")) {
+    fetchCommand = `wget -qO- ${shellQuote(INSTALL_SH_URL)} | bash`;
+  } else {
+    console.error("curl or wget is required to install Vibe Remote.");
+    console.error("Manual install: https://docs.avibe.bot/quickstart");
+    process.exit(1);
+  }
+
+  const status = runCommand(fetchCommand, [], { shell: true });
+  if (status !== 0) {
+    process.exit(status);
+  }
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function installVibe() {
+  console.log("Installing Vibe Remote...");
+
+  if (installWithCustomCommand()) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    installOnWindows();
+  } else {
+    installOnPosix();
+  }
+}
+
+function ensureVibeInstalled() {
+  const existing = findVibeBinary();
+  if (existing) {
+    return existing;
+  }
+
+  installVibe();
+
+  const installed = findVibeBinary();
+  if (installed) {
+    return installed;
+  }
+
+  console.error("Vibe Remote was installed, but the 'vibe' command was not found on PATH.");
+  console.error("Open a new terminal, or add the uv tool bin directory to PATH.");
+  console.error("Common paths:");
+  for (const dir of candidateBinDirs()) {
+    console.error(`  ${dir}`);
+  }
+  process.exit(1);
+}
+
+function normalizeArgs(args) {
+  if (args[0] === "init" || args[0] === "start") {
+    return args.slice(1);
+  }
+  return args;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (command === "--help" || command === "-h" || command === "help") {
+    printHelp();
+    return;
+  }
+
+  if (command === "--version" || command === "-v") {
+    printVersion();
+    return;
+  }
+
+  if (command === "install") {
+    installVibe();
+    const vibe = findVibeBinary();
+    if (vibe) {
+      console.log(`Vibe Remote is ready: ${vibe}`);
+    }
+    return;
+  }
+
+  const vibe = ensureVibeInstalled();
+  const status = runCommand(vibe, normalizeArgs(args));
+  process.exit(status);
+}
+
+main();

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -83,7 +83,14 @@ function executableNames(name) {
 function isExecutable(filePath) {
   try {
     const stat = fs.statSync(filePath);
-    return stat.isFile();
+    if (!stat.isFile()) {
+      return false;
+    }
+    if (process.platform === "win32") {
+      return true;
+    }
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
   } catch {
     return false;
   }

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -23,6 +23,7 @@ NPM entrypoint for Vibe Remote.
 Usage:
   npx avibe              Install Vibe Remote if needed, then start the setup wizard
   avibe                 Same as above after npm install -g avibe
+  vibe                  Same as above after npm install -g avibe
   avibe install         Install or refresh the underlying vibe-remote Python CLI
   avibe init            Start the setup wizard
   avibe start           Start Vibe Remote
@@ -96,6 +97,39 @@ function isExecutable(filePath) {
   }
 }
 
+function realpathOrNull(filePath) {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function isSelfWrapperCandidate(filePath) {
+  const currentScriptPath = realpathOrNull(__filename);
+  const candidatePath = realpathOrNull(filePath);
+
+  if (currentScriptPath && candidatePath && currentScriptPath === candidatePath) {
+    return true;
+  }
+
+  if (process.platform !== "win32") {
+    return false;
+  }
+
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension !== ".cmd" && extension !== ".bat") {
+    return false;
+  }
+
+  try {
+    const content = fs.readFileSync(filePath, "utf8").toLowerCase();
+    return content.includes("\\node_modules\\avibe\\bin\\avibe.js") || content.includes("/node_modules/avibe/bin/avibe.js");
+  } catch {
+    return false;
+  }
+}
+
 function resolveFromPath(command, env = process.env) {
   const pathValue = env.PATH || env.Path || "";
   for (const dir of pathValue.split(path.delimiter)) {
@@ -104,7 +138,7 @@ function resolveFromPath(command, env = process.env) {
     }
     for (const executableName of executableNames(command)) {
       const candidate = path.join(dir, executableName);
-      if (isExecutable(candidate)) {
+      if (isExecutable(candidate) && !isSelfWrapperCandidate(candidate)) {
         return candidate;
       }
     }

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -136,13 +136,20 @@ function findVibeBinary() {
 }
 
 function runCommand(command, args, options = {}) {
-  const useShell = options.shell || shouldRunThroughShell(command);
+  if (!options.shell && shouldRunThroughShell(command)) {
+    return runWindowsBatchCommand(command, args, options);
+  }
+
   const result = childProcess.spawnSync(command, args, {
     stdio: "inherit",
-    shell: useShell,
+    shell: options.shell || false,
     env: options.env || prependPathEntries(process.env, candidateBinDirs()),
   });
 
+  return normalizeSpawnResult(result);
+}
+
+function normalizeSpawnResult(result) {
   if (result.error) {
     throw result.error;
   }
@@ -152,6 +159,22 @@ function runCommand(command, args, options = {}) {
   }
 
   return result.signal ? 1 : 0;
+}
+
+function runWindowsBatchCommand(command, args, options = {}) {
+  const shellCommand = [quoteWindowsCmdArgument(command), ...args.map(quoteWindowsCmdArgument)].join(" ");
+  const result = childProcess.spawnSync(process.env.ComSpec || "cmd.exe", ["/d", "/s", "/c", shellCommand], {
+    stdio: "inherit",
+    env: options.env || prependPathEntries(process.env, candidateBinDirs()),
+  });
+
+  return normalizeSpawnResult(result);
+}
+
+function quoteWindowsCmdArgument(value) {
+  const rawValue = String(value);
+  const escapedValue = rawValue.replace(/"/g, '\\"');
+  return `"${escapedValue}"`;
 }
 
 function shouldRunThroughShell(command) {

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -168,7 +168,7 @@ function findVibeBinary() {
   for (const dir of candidateBinDirs()) {
     for (const executableName of executableNames("vibe")) {
       const candidate = path.join(dir, executableName);
-      if (isExecutable(candidate)) {
+      if (isExecutable(candidate) && !isSelfWrapperCandidate(candidate)) {
         return candidate;
       }
     }

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -129,9 +129,10 @@ function findVibeBinary() {
 }
 
 function runCommand(command, args, options = {}) {
+  const useShell = options.shell || shouldRunThroughShell(command);
   const result = childProcess.spawnSync(command, args, {
     stdio: "inherit",
-    shell: options.shell || false,
+    shell: useShell,
     env: options.env || prependPathEntries(process.env, candidateBinDirs()),
   });
 
@@ -144,6 +145,15 @@ function runCommand(command, args, options = {}) {
   }
 
   return result.signal ? 1 : 0;
+}
+
+function shouldRunThroughShell(command) {
+  if (process.platform !== "win32") {
+    return false;
+  }
+
+  const extension = path.extname(command).toLowerCase();
+  return extension === ".cmd" || extension === ".bat";
 }
 
 function hasCommand(command) {

--- a/npm/avibe/package.json
+++ b/npm/avibe/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "avibe",
+  "version": "0.1.0",
+  "description": "NPM entrypoint for installing and running Vibe Remote",
+  "license": "MIT",
+  "author": "cyhhao",
+  "homepage": "https://docs.avibe.bot",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cyhhao/vibe-remote.git",
+    "directory": "npm/avibe"
+  },
+  "bugs": {
+    "url": "https://github.com/cyhhao/vibe-remote/issues"
+  },
+  "bin": {
+    "avibe": "./bin/avibe.js"
+  },
+  "files": [
+    "bin/",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "avibe",
+    "vibe-remote",
+    "claude-code",
+    "codex",
+    "opencode",
+    "slack",
+    "discord",
+    "telegram",
+    "wechat",
+    "lark",
+    "ai-agent",
+    "chatops"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/npm/avibe/package.json
+++ b/npm/avibe/package.json
@@ -14,7 +14,8 @@
     "url": "https://github.com/cyhhao/vibe-remote/issues"
   },
   "bin": {
-    "avibe": "./bin/avibe.js"
+    "avibe": "./bin/avibe.js",
+    "vibe": "./bin/avibe.js"
   },
   "files": [
     "bin/",

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -32,6 +32,16 @@ function writeFakeVibe(bin, label) {
   return vibePath;
 }
 
+function writeSelfNpmVibeShim(bin) {
+  const shimPath = path.join(bin, process.platform === "win32" ? "vibe.cmd" : "vibe");
+  if (process.platform === "win32") {
+    fs.writeFileSync(shimPath, '@echo off\r\nnode "%~dp0\\node_modules\\avibe\\bin\\avibe.js" %*\r\n');
+  } else {
+    fs.symlinkSync(cliPath, shimPath);
+  }
+  return shimPath;
+}
+
 function runCli(args, envOverrides = {}) {
   const env = {
     ...process.env,
@@ -113,6 +123,25 @@ test("ignores non-executable vibe files on PATH", { skip: process.platform === "
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /working-vibe status/);
+});
+
+test("skips its own npm vibe shim before delegating", () => {
+  const temp = makeTempEnv();
+  const npmBin = path.join(temp.root, "npm-bin");
+  const runtimeBin = path.join(temp.root, "runtime-bin");
+  fs.mkdirSync(npmBin, { recursive: true });
+  fs.mkdirSync(runtimeBin, { recursive: true });
+  writeSelfNpmVibeShim(npmBin);
+  writeFakeVibe(runtimeBin, "runtime-vibe");
+
+  const result = runCli(["status"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: `${npmBin}${path.delimiter}${runtimeBin}`,
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /runtime-vibe status/);
 });
 
 test("installs vibe when missing, then delegates", () => {

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -42,13 +42,13 @@ function writeSelfNpmVibeShim(bin) {
   return shimPath;
 }
 
-function runCli(args, envOverrides = {}) {
+function runCli(args, envOverrides = {}, binPath = cliPath) {
   const env = {
     ...process.env,
     ...envOverrides,
   };
 
-  return childProcess.spawnSync(process.execPath, [cliPath, ...args], {
+  return childProcess.spawnSync(process.execPath, [binPath, ...args], {
     encoding: "utf8",
     env,
   });
@@ -90,6 +90,39 @@ test("prints wrapper help without installing", () => {
   assert.equal(result.status, 0);
   assert.match(result.stdout, /npx avibe/);
   assert.match(result.stdout, /npm install -g avibe/);
+});
+
+test("delegates help and version when invoked through vibe", () => {
+  const temp = makeTempEnv();
+  const runtimeBin = path.join(temp.root, "runtime-bin");
+  const npmBin = path.join(temp.root, "npm-bin");
+  fs.mkdirSync(runtimeBin, { recursive: true });
+  fs.mkdirSync(npmBin, { recursive: true });
+  writeFakeVibe(runtimeBin, "runtime-vibe");
+  const npmVibeShim = writeSelfNpmVibeShim(npmBin);
+
+  const help = runCli(["--help"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: `${npmBin}${path.delimiter}${runtimeBin}`,
+  }, npmVibeShim);
+  const version = runCli(["--version"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: `${npmBin}${path.delimiter}${runtimeBin}`,
+  }, npmVibeShim);
+  const commandHelp = runCli(["help", "remote"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: `${npmBin}${path.delimiter}${runtimeBin}`,
+  }, npmVibeShim);
+
+  assert.equal(help.status, 0);
+  assert.equal(version.status, 0);
+  assert.equal(commandHelp.status, 0);
+  assert.match(help.stdout, /runtime-vibe --help/);
+  assert.match(version.stdout, /runtime-vibe --version/);
+  assert.match(commandHelp.stdout, /runtime-vibe help remote/);
 });
 
 test("delegates commands to an existing vibe binary", () => {

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -1,0 +1,114 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const cliPath = path.join(__dirname, "..", "bin", "avibe.js");
+
+function makeTempEnv() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "avibe-cli-test-"));
+  const bin = path.join(root, "bin");
+  const home = path.join(root, "home");
+  fs.mkdirSync(bin, { recursive: true });
+  fs.mkdirSync(home, { recursive: true });
+
+  return { root, bin, home };
+}
+
+function writeFakeVibe(bin, label) {
+  const vibePath = path.join(bin, process.platform === "win32" ? "vibe.cmd" : "vibe");
+  if (process.platform === "win32") {
+    fs.writeFileSync(vibePath, `@echo off\necho ${label} %*\n`);
+  } else {
+    fs.writeFileSync(vibePath, `#!/bin/sh\necho ${label} "$@"\n`);
+    fs.chmodSync(vibePath, 0o755);
+  }
+  return vibePath;
+}
+
+function runCli(args, envOverrides = {}) {
+  const env = {
+    ...process.env,
+    ...envOverrides,
+  };
+
+  return childProcess.spawnSync(process.execPath, [cliPath, ...args], {
+    encoding: "utf8",
+    env,
+  });
+}
+
+test("prints wrapper help without installing", () => {
+  const temp = makeTempEnv();
+  const result = runCli(["--help"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: temp.bin,
+    AVIBE_INSTALL_COMMAND: "exit 42",
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /npx avibe/);
+  assert.match(result.stdout, /npm install -g avibe/);
+});
+
+test("delegates commands to an existing vibe binary", () => {
+  const temp = makeTempEnv();
+  writeFakeVibe(temp.bin, "existing-vibe");
+
+  const result = runCli(["status", "--json"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: temp.bin,
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /existing-vibe status --json/);
+});
+
+test("installs vibe when missing, then delegates", () => {
+  const temp = makeTempEnv();
+  const installCommand =
+    process.platform === "win32"
+      ? `echo @echo off> "${path.join(temp.bin, "vibe.cmd")}" && echo echo installed-vibe %*>> "${path.join(temp.bin, "vibe.cmd")}"`
+      : `/bin/mkdir -p "${temp.bin}" && /usr/bin/printf '#!/bin/sh\\necho installed-vibe "$@"\\n' > "${path.join(
+          temp.bin,
+          "vibe"
+        )}" && /bin/chmod +x "${path.join(temp.bin, "vibe")}"`;
+
+  const result = runCli(["doctor"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: temp.bin,
+    AVIBE_INSTALL_COMMAND: installCommand,
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Installing Vibe Remote/);
+  assert.match(result.stdout, /installed-vibe doctor/);
+});
+
+test("maps init and start to the default vibe command", () => {
+  const temp = makeTempEnv();
+  writeFakeVibe(temp.bin, "default-vibe");
+
+  const init = runCli(["init"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: temp.bin,
+  });
+  const start = runCli(["start"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: temp.bin,
+  });
+
+  assert.equal(init.status, 0);
+  assert.equal(start.status, 0);
+  assert.match(init.stdout, /default-vibe\s*$/m);
+  assert.match(start.stdout, /default-vibe\s*$/m);
+});

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -35,7 +35,7 @@ function writeFakeVibe(bin, label) {
 function writeSelfNpmVibeShim(bin) {
   const shimPath = path.join(bin, process.platform === "win32" ? "vibe.cmd" : "vibe");
   if (process.platform === "win32") {
-    fs.writeFileSync(shimPath, '@echo off\r\nnode "%~dp0\\node_modules\\avibe\\bin\\avibe.js" %*\r\n');
+    fs.writeFileSync(shimPath, `@echo off\r\nset AVIBE_ENTRYPOINT=vibe\r\nnode "${cliPath}" %*\r\n`);
   } else {
     fs.symlinkSync(cliPath, shimPath);
   }

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -62,7 +62,7 @@ function loadCliForUnitTest(overrides = {}) {
     module: { exports: {} },
     exports: {},
   };
-  vm.runInNewContext(`${source}\nmodule.exports = { shouldRunThroughShell };`, sandbox, {
+  vm.runInNewContext(`${source}\nmodule.exports = { quoteWindowsCmdArgument, shouldRunThroughShell };`, sandbox, {
     filename: cliPath,
   });
   return sandbox.module.exports;
@@ -164,4 +164,30 @@ test("runs Windows batch wrappers through a shell", { skip: process.platform !==
   assert.equal(shouldRunThroughShell("C:\\Users\\alex\\.local\\bin\\vibe.cmd"), true);
   assert.equal(shouldRunThroughShell("C:\\Users\\alex\\.local\\bin\\vibe.bat"), true);
   assert.equal(shouldRunThroughShell("C:\\Users\\alex\\.local\\bin\\vibe.exe"), false);
+});
+
+test("quotes Windows batch wrapper paths with spaces", { skip: process.platform !== "win32" }, () => {
+  const { quoteWindowsCmdArgument } = loadCliForUnitTest();
+
+  assert.equal(
+    quoteWindowsCmdArgument("C:\\Users\\Jane Doe\\.local\\bin\\vibe.cmd"),
+    '"C:\\Users\\Jane Doe\\.local\\bin\\vibe.cmd"'
+  );
+  assert.equal(quoteWindowsCmdArgument('C:\\bin\\vibe "dev".cmd'), '"C:\\bin\\vibe \\"dev\\".cmd"');
+});
+
+test("delegates to Windows batch wrappers in paths with spaces", { skip: process.platform !== "win32" }, () => {
+  const temp = makeTempEnv();
+  const spacedBin = path.join(temp.root, "space dir");
+  fs.mkdirSync(spacedBin, { recursive: true });
+  writeFakeVibe(spacedBin, "spaced-vibe");
+
+  const result = runCli(["status", "--json"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: spacedBin,
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /spaced-vibe status --json/);
 });

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -3,9 +3,11 @@
 const assert = require("node:assert/strict");
 const childProcess = require("node:child_process");
 const fs = require("node:fs");
+const Module = require("node:module");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
 
 const cliPath = path.join(__dirname, "..", "bin", "avibe.js");
 
@@ -40,6 +42,30 @@ function runCli(args, envOverrides = {}) {
     encoding: "utf8",
     env,
   });
+}
+
+function loadCliForUnitTest(overrides = {}) {
+  const source = fs.readFileSync(cliPath, "utf8").replace(/\nmain\(\);\s*$/, "\n");
+  const sandbox = {
+    console,
+    process: {
+      ...process,
+      argv: [process.execPath, cliPath],
+      env: { ...process.env, ...overrides.env },
+      exit(code) {
+        throw new Error(`process.exit(${code})`);
+      },
+    },
+    require: Module.createRequire(cliPath),
+    __dirname: path.dirname(cliPath),
+    __filename: cliPath,
+    module: { exports: {} },
+    exports: {},
+  };
+  vm.runInNewContext(`${source}\nmodule.exports = { shouldRunThroughShell };`, sandbox, {
+    filename: cliPath,
+  });
+  return sandbox.module.exports;
 }
 
 test("prints wrapper help without installing", () => {
@@ -111,4 +137,12 @@ test("maps init and start to the default vibe command", () => {
   assert.equal(start.status, 0);
   assert.match(init.stdout, /default-vibe\s*$/m);
   assert.match(start.stdout, /default-vibe\s*$/m);
+});
+
+test("runs Windows batch wrappers through a shell", { skip: process.platform !== "win32" }, () => {
+  const { shouldRunThroughShell } = loadCliForUnitTest();
+
+  assert.equal(shouldRunThroughShell("C:\\Users\\alex\\.local\\bin\\vibe.cmd"), true);
+  assert.equal(shouldRunThroughShell("C:\\Users\\alex\\.local\\bin\\vibe.bat"), true);
+  assert.equal(shouldRunThroughShell("C:\\Users\\alex\\.local\\bin\\vibe.exe"), false);
 });

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -51,6 +51,7 @@ function runCli(args, envOverrides = {}, binPath = cliPath) {
   return childProcess.spawnSync(process.execPath, [binPath, ...args], {
     encoding: "utf8",
     env,
+    timeout: 5000,
   });
 }
 
@@ -175,6 +176,33 @@ test("skips its own npm vibe shim before delegating", () => {
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /runtime-vibe status/);
+});
+
+test("skips its own npm vibe shim in fallback bin dirs before installing", () => {
+  const temp = makeTempEnv();
+  const fallbackBin = path.join(temp.home, ".local", "bin");
+  fs.mkdirSync(fallbackBin, { recursive: true });
+  writeSelfNpmVibeShim(fallbackBin);
+
+  const installCommand =
+    process.platform === "win32"
+      ? `echo @echo off> "${path.join(temp.bin, "vibe.cmd")}" && echo echo installed-vibe %*>> "${path.join(temp.bin, "vibe.cmd")}"`
+      : `/bin/mkdir -p "${temp.bin}" && /usr/bin/printf '#!/bin/sh\\necho installed-vibe "$@"\\n' > "${path.join(
+          temp.bin,
+          "vibe"
+        )}" && /bin/chmod +x "${path.join(temp.bin, "vibe")}"`;
+
+  const result = runCli(["doctor"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: temp.bin,
+    AVIBE_INSTALL_COMMAND: installCommand,
+  });
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Installing Vibe Remote/);
+  assert.match(result.stdout, /installed-vibe doctor/);
 });
 
 test("installs vibe when missing, then delegates", () => {

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -96,6 +96,25 @@ test("delegates commands to an existing vibe binary", () => {
   assert.match(result.stdout, /existing-vibe status --json/);
 });
 
+test("ignores non-executable vibe files on PATH", { skip: process.platform === "win32" }, () => {
+  const temp = makeTempEnv();
+  const staleBin = path.join(temp.root, "stale-bin");
+  const workingBin = path.join(temp.root, "working-bin");
+  fs.mkdirSync(staleBin, { recursive: true });
+  fs.mkdirSync(workingBin, { recursive: true });
+  fs.writeFileSync(path.join(staleBin, "vibe"), "not executable\n", { mode: 0o644 });
+  writeFakeVibe(workingBin, "working-vibe");
+
+  const result = runCli(["status"], {
+    HOME: temp.home,
+    USERPROFILE: temp.home,
+    PATH: `${staleBin}${path.delimiter}${workingBin}`,
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /working-vibe status/);
+});
+
 test("installs vibe when missing, then delegates", () => {
   const temp = makeTempEnv();
   const installCommand =


### PR DESCRIPTION
## Summary

- capability: add an npm `avibe` entrypoint that bootstraps the existing Python `vibe-remote` CLI
- user-visible change: after npm publish, Node-oriented users can run `npx avibe` or `npm install -g avibe && vibe` as an optional install path
- motivation: reduce first-run friction for developers who expect npm-native CLI installation without introducing a second runtime or replacing the canonical one-line installer

## Scenario Coverage

- scenario IDs: distribution:npm-entrypoint
- unit / contract coverage: Node CLI tests cover help output, existing `vibe` delegation, install-then-delegate flow, `init` / `start` aliases, stale non-executable PATH candidates, npm self-shim recursion prevention, and Windows batch shim handling
- scenario coverage: no scenario catalog entry exists for distribution packaging yet
- residual manual checks: npm package publish still requires npm trusted publishing configuration for the `avibe` package

## Validation

- commands run:
  - `npm test` in `npm/avibe`
  - `npm pack --dry-run` in `npm/avibe`
  - `git diff --check`
  - Ruby YAML parse for `.github/workflows/lint.yml` and `.github/workflows/publish_npm.yml`
  - `node bin/avibe.js --help`
- result: all passed locally; CI has also passed on pushed revisions so far

## Risks / Follow-ups

- risk: public README should not switch its primary install command to `npx avibe`; the current curl / PowerShell one-line installer remains the main path
- follow-up: configure npm trusted publishing for `avibe`, run the manual publish workflow, then document npm as a supplemental Node-friendly alternative after publish
