### PR TITLE
fix(codex): refresh developer instructions on resume

### DIFF
--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -424,36 +424,14 @@ class CodexAgent(BaseAgent):
         request: AgentRequest,
     ) -> str:
         """Create a new Codex thread and return its threadId."""
-        _, _, _, agent_instructions = self._resolve_codex_agent_settings(request)
-
         params: Dict[str, Any] = {
             "cwd": request.working_path,
             "approvalPolicy": "never",
             "sandbox": "danger-full-access",
         }
-        platform = (
-            request.context.platform
-            or (request.context.platform_specific or {}).get("platform")
-            or self.controller.config.platform
-        )
-
-        instruction_parts: list[str] = []
-        if agent_instructions:
-            instruction_parts.append(agent_instructions)
-
-        if getattr(self.controller.config, "reply_enhancements", True):
-            from core.reply_enhancer import build_reply_enhancements_prompt
-
-            instruction_parts.append(
-                build_reply_enhancements_prompt(
-                    include_quick_replies=platform != "wechat",
-                    context=request.context,
-                    fallback_platform=platform,
-                )
-            )
-
-        if instruction_parts:
-            params["developerInstructions"] = "\n\n".join(part for part in instruction_parts if part)
+        developer_instructions = self._build_thread_developer_instructions(request)
+        if developer_instructions:
+            params["developerInstructions"] = developer_instructions
 
         resp = await transport.send_request("thread/start", params)
         # thread/start returns Thread directly OR may nest under "thread"
@@ -541,9 +519,13 @@ class CodexAgent(BaseAgent):
         )
         if persisted:
             try:
+                resume_params: Dict[str, Any] = {"threadId": persisted}
+                developer_instructions = self._build_thread_developer_instructions(request)
+                if developer_instructions:
+                    resume_params["developerInstructions"] = developer_instructions
                 resp = await transport.send_request(
                     "thread/resume",
-                    {"threadId": persisted},
+                    resume_params,
                 )
                 # thread/resume returns Thread directly OR may nest under "thread"
                 thread_id = resp.get("id", "")
@@ -559,6 +541,37 @@ class CodexAgent(BaseAgent):
                 logger.warning("Failed to resume Codex thread %s: %s, starting new", persisted, e)
 
         return await self._start_thread(transport, request)
+
+    def _build_thread_developer_instructions(self, request: AgentRequest) -> Optional[str]:
+        """Build Codex thread-level developer instructions for start/resume.
+
+        Codex treats these as session configuration, not appended chat history.
+        Passing the current value on resume refreshes stale Vibe Remote targeting
+        instructions without growing the thread transcript.
+        """
+        _, _, _, agent_instructions = self._resolve_codex_agent_settings(request)
+        platform = (
+            request.context.platform
+            or (request.context.platform_specific or {}).get("platform")
+            or self.controller.config.platform
+        )
+
+        instruction_parts: list[str] = []
+        if agent_instructions:
+            instruction_parts.append(agent_instructions)
+
+        if getattr(self.controller.config, "reply_enhancements", True):
+            from core.reply_enhancer import build_reply_enhancements_prompt
+
+            instruction_parts.append(
+                build_reply_enhancements_prompt(
+                    include_quick_replies=platform != "wechat",
+                    context=request.context,
+                    fallback_platform=platform,
+                )
+            )
+
+        return "\n\n".join(part for part in instruction_parts if part) or None
 
     async def _start_turn(
         self,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -424,36 +424,14 @@ class CodexAgent(BaseAgent):
         request: AgentRequest,
     ) -> str:
         """Create a new Codex thread and return its threadId."""
-        _, _, _, agent_instructions = self._resolve_codex_agent_settings(request)
-
         params: Dict[str, Any] = {
             "cwd": request.working_path,
             "approvalPolicy": "never",
             "sandbox": "danger-full-access",
         }
-        platform = (
-            request.context.platform
-            or (request.context.platform_specific or {}).get("platform")
-            or self.controller.config.platform
-        )
-
-        instruction_parts: list[str] = []
-        if agent_instructions:
-            instruction_parts.append(agent_instructions)
-
-        if getattr(self.controller.config, "reply_enhancements", True):
-            from core.reply_enhancer import build_reply_enhancements_prompt
-
-            instruction_parts.append(
-                build_reply_enhancements_prompt(
-                    include_quick_replies=platform != "wechat",
-                    context=request.context,
-                    fallback_platform=platform,
-                )
-            )
-
-        if instruction_parts:
-            params["developerInstructions"] = "\n\n".join(part for part in instruction_parts if part)
+        developer_instructions = self._build_thread_developer_instructions(request)
+        if developer_instructions:
+            params["developerInstructions"] = developer_instructions
 
         resp = await transport.send_request("thread/start", params)
         # thread/start returns Thread directly OR may nest under "thread"
@@ -541,9 +519,13 @@ class CodexAgent(BaseAgent):
         )
         if persisted:
             try:
+                resume_params: Dict[str, Any] = {
+                    "threadId": persisted,
+                    "developerInstructions": self._build_thread_developer_instructions(request),
+                }
                 resp = await transport.send_request(
                     "thread/resume",
-                    {"threadId": persisted},
+                    resume_params,
                 )
                 # thread/resume returns Thread directly OR may nest under "thread"
                 thread_id = resp.get("id", "")
@@ -559,6 +541,37 @@ class CodexAgent(BaseAgent):
                 logger.warning("Failed to resume Codex thread %s: %s, starting new", persisted, e)
 
         return await self._start_thread(transport, request)
+
+    def _build_thread_developer_instructions(self, request: AgentRequest) -> Optional[str]:
+        """Build Codex thread-level developer instructions for start/resume.
+
+        Codex treats these as session configuration, not appended chat history.
+        Passing the current value on resume refreshes stale Vibe Remote targeting
+        instructions without growing the thread transcript.
+        """
+        _, _, _, agent_instructions = self._resolve_codex_agent_settings(request)
+        platform = (
+            request.context.platform
+            or (request.context.platform_specific or {}).get("platform")
+            or self.controller.config.platform
+        )
+
+        instruction_parts: list[str] = []
+        if agent_instructions:
+            instruction_parts.append(agent_instructions)
+
+        if getattr(self.controller.config, "reply_enhancements", True):
+            from core.reply_enhancer import build_reply_enhancements_prompt
+
+            instruction_parts.append(
+                build_reply_enhancements_prompt(
+                    include_quick_replies=platform != "wechat",
+                    context=request.context,
+                    fallback_platform=platform,
+                )
+            )
+
+        return "\n\n".join(part for part in instruction_parts if part) or None
 
     async def _start_turn(
         self,

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -705,6 +705,57 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         params = transport.send_request.await_args.args[1]
         self.assertNotIn("If you generate an image with Codex", params["developerInstructions"])
 
+    async def test_resume_thread_refreshes_developer_instructions_without_appending(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
+        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value="thread-existing"),
+        )
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="slack",
+                platform_specific={"is_dm": False},
+                user_id="U1",
+                channel_id="C1",
+                thread_id="171717.123",
+            ),
+            base_session_id="session-1",
+            session_key="slack::channel::C1::thread::171717.123",
+            subagent_name="reviewer",
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-existing"}}))
+
+        with patch.object(
+            _MODULE,
+            "load_codex_subagent",
+            return_value=SimpleNamespace(
+                developer_instructions="Focus on regressions.",
+                model=None,
+                reasoning_effort=None,
+            ),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-existing")
+        transport.send_request.assert_awaited_once()
+        method, params = transport.send_request.await_args.args
+        self.assertEqual(method, "thread/resume")
+        self.assertEqual(params["threadId"], "thread-existing")
+        developer_instructions = params["developerInstructions"]
+        self.assertEqual(developer_instructions.count("Focus on regressions."), 1)
+        self.assertEqual(developer_instructions.count("Default session key:"), 1)
+        self.assertIn(
+            "Default session key: `slack::channel::C1::thread::171717.123`",
+            developer_instructions,
+        )
+        self.assertIn("Channel-level session key: `slack::channel::C1`", developer_instructions)
+
     def test_build_input_adds_codex_generated_image_prompt_to_each_turn(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(reply_enhancements=True))

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -705,6 +705,91 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         params = transport.send_request.await_args.args[1]
         self.assertNotIn("If you generate an image with Codex", params["developerInstructions"])
 
+    async def test_resume_thread_refreshes_developer_instructions_without_appending(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
+        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value="thread-existing"),
+        )
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="slack",
+                platform_specific={"is_dm": False},
+                user_id="U1",
+                channel_id="C1",
+                thread_id="171717.123",
+            ),
+            base_session_id="session-1",
+            session_key="slack::channel::C1::thread::171717.123",
+            subagent_name="reviewer",
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-existing"}}))
+
+        with patch.object(
+            _MODULE,
+            "load_codex_subagent",
+            return_value=SimpleNamespace(
+                developer_instructions="Focus on regressions.",
+                model=None,
+                reasoning_effort=None,
+            ),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-existing")
+        transport.send_request.assert_awaited_once()
+        method, params = transport.send_request.await_args.args
+        self.assertEqual(method, "thread/resume")
+        self.assertEqual(params["threadId"], "thread-existing")
+        developer_instructions = params["developerInstructions"]
+        self.assertEqual(developer_instructions.count("Focus on regressions."), 1)
+        self.assertEqual(developer_instructions.count("Default session key:"), 1)
+        self.assertIn(
+            "Default session key: `slack::channel::C1::thread::171717.123`",
+            developer_instructions,
+        )
+        self.assertIn("Channel-level session key: `slack::channel::C1`", developer_instructions)
+
+    async def test_resume_thread_sends_explicit_null_when_developer_instructions_are_disabled(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=False))
+        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value="thread-existing"),
+        )
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="slack",
+                platform_specific={"is_dm": False},
+                user_id="U1",
+                channel_id="C1",
+                thread_id="171717.123",
+            ),
+            base_session_id="session-1",
+            session_key="slack::channel::C1::thread::171717.123",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-existing"}}))
+
+        thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-existing")
+        method, params = transport.send_request.await_args.args
+        self.assertEqual(method, "thread/resume")
+        self.assertIn("developerInstructions", params)
+        self.assertIsNone(params["developerInstructions"])
+
     def test_build_input_adds_codex_generated_image_prompt_to_each_turn(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(reply_enhancements=True))


### PR DESCRIPTION
## Summary

Refresh Codex thread-level developer instructions when resuming a persisted Codex thread.

## Why

Vibe Remote injects current session targeting, file delivery, quick replies, watches, hooks, and user preference guidance through Codex `developerInstructions`. Codex keeps these as session configuration rather than appending them to chat history, but a resumed thread should still receive the current Vibe Remote instructions instead of depending only on whatever was stored when the thread first started.

## Changes

- Share Codex developer-instruction construction between `thread/start` and `thread/resume`.
- Pass the current developer instructions on `thread/resume` when a persisted Codex thread id exists.
- Send an explicit `developerInstructions: null` on resume when current thread-level instructions are disabled, so the wire payload does not silently omit the field.
- Add regression coverage that verifies resume includes the current session key guidance exactly once, includes subagent developer instructions once, and sends explicit null when no current developer instructions exist.

## Validation

- `uv run pytest tests/test_codex_agent.py -q`
- `uv run pytest tests/test_reply_enhancer_platform.py tests/test_codex_agent.py -q`
- `uv run ruff check modules/agents/codex/agent.py tests/test_codex_agent.py`
- `npm run build` in `ui/` to satisfy package editable build assets

## Risk

Low. Codex app-server treats `developerInstructions` on non-running `thread/resume` as config input, not appended history. If the target thread is already running, Codex ignores this override and logs a warning, so the prompt does not grow.
