### PR TITLE
fix(remote): parse latest tunnel origin log

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -348,6 +348,48 @@ def test_pair_reports_success_when_connector_start_fails(monkeypatch, tmp_path) 
     assert saved_payload["remote_access"]["vibe_cloud"]["tunnel_token"] == "tunnel-token"
 
 
+def test_pair_rejects_origin_update_failure_before_saving_config(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+
+    monkeypatch.setattr(
+        remote_access,
+        "_json_request",
+        lambda *args, **kwargs: {
+            "instance_id": "inst_123",
+            "client_id": "vr_client_123",
+            "issuer": "https://backend.test",
+            "authorization_endpoint": "https://backend.test/oauth/authorize",
+            "token_endpoint": "https://backend.test/oauth/token",
+            "jwks_uri": "https://backend.test/oauth/jwks.json",
+            "public_url": "https://alex.avibe.bot",
+            "redirect_uri": "https://alex.avibe.bot/auth/callback",
+            "tunnel_token": "tunnel-token",
+            "instance_secret": "instance-secret",
+            "tunnel_origin_update": {"ok": False, "error": "tunnel_origin_update_failed"},
+        },
+    )
+    monkeypatch.setattr(
+        remote_access.api,
+        "save_config",
+        lambda payload: (_ for _ in ()).throw(AssertionError("failed origin update must not persist pairing")),
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "start",
+        lambda next_config: (_ for _ in ()).throw(AssertionError("failed origin update must not start tunnel")),
+    )
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+    saved_payload = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
+
+    assert result["ok"] is False
+    assert result["error"] == "tunnel_origin_update_failed"
+    assert saved_payload["remote_access"]["vibe_cloud"]["enabled"] is False
+
+
 def test_pair_returns_structured_error_when_backend_request_fails(monkeypatch) -> None:
     monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("offline")))
 
@@ -786,3 +828,33 @@ def test_start_restarts_when_runtime_signature_changes(monkeypatch, tmp_path) ->
     assert result["pid"] == new_pid
     assert old_pid not in alive
     assert state["tunnel_token_sha256"] == "348e9df2a42bd6e3c6356ca9c95c5f1fe9a6b3e5cd25f4ae58df0f09049c3209"
+
+
+def test_start_clears_previous_cloudflared_logs_before_spawn(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.tunnel_token = "tunnel-token"
+    config.save()
+    binary = "/usr/local/bin/cloudflared"
+    new_pid = 222
+    remote_access._cloudflared_stdout_path().parent.mkdir(parents=True, exist_ok=True)
+    remote_access._cloudflared_stdout_path().write_text("old stdout", encoding="utf-8")
+    remote_access._cloudflared_stderr_path().write_text("originService=http://old.local:5123\n", encoding="utf-8")
+
+    monkeypatch.setattr(remote_access, "_resolve_binary", lambda cfg: binary)
+    monkeypatch.setattr(remote_access, "_version", lambda path: "cloudflared test")
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == new_pid)
+    monkeypatch.setattr(runtime, "get_process_command", lambda pid: f"{binary} tunnel run")
+
+    def spawn_background(args, pid_path, stdout_name, stderr_name, env=None):
+        assert not remote_access._cloudflared_stdout_path().exists()
+        assert not remote_access._cloudflared_stderr_path().exists()
+        pid_path.write_text(str(new_pid), encoding="utf-8")
+        return new_pid
+
+    monkeypatch.setattr(runtime, "spawn_background", spawn_background)
+
+    result = remote_access.start(config)
+
+    assert result["ok"] is True
+    assert result["started"] is True

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -198,6 +198,18 @@ def test_observed_cloudflared_origin_service_reads_only_log_tail(monkeypatch, tm
     assert remote_access._observed_cloudflared_origin_service() == "http://new.local:5123"
 
 
+def test_observed_cloudflared_origin_service_uses_latest_mixed_log_format(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    remote_access._cloudflared_stderr_path().parent.mkdir(parents=True, exist_ok=True)
+    remote_access._cloudflared_stderr_path().write_text(
+        'ERR originService=http://100.97.103.112:5123\n'
+        'INF Updated to new configuration config="{\\"ingress\\":[{\\"service\\":\\"http://127.0.0.1:5123\\"}]}"\n',
+        encoding="utf-8",
+    )
+
+    assert remote_access._observed_cloudflared_origin_service() == "http://127.0.0.1:5123"
+
+
 def test_report_runtime_status_posts_to_backend(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _config()

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -260,16 +260,15 @@ def _observed_cloudflared_origin_service() -> str | None:
     content = _read_text_tail(_cloudflared_stderr_path(), STATUS_LOG_TAIL_BYTES)
     if content is None:
         return None
-    patterns = (
-        r'originService=([^\s"]+)',
-        r'\\"service\\":\\"(http://[^"\\]+)\\"',
-        r'"service":"(http://[^"]+)"',
+    pattern = re.compile(
+        r'originService=([^\s"]+)'
+        r'|\\"service\\":\\"(http://[^"\\]+)\\"'
+        r'|(?<!\\)"service":"(http://[^"]+)"'
     )
-    for pattern in patterns:
-        matches = re.findall(pattern, content)
-        if matches:
-            return str(matches[-1])
-    return None
+    last_origin = None
+    for match in pattern.finditer(content):
+        last_origin = next((group for group in match.groups() if group), None)
+    return str(last_origin) if last_origin else None
 
 
 def _running_signature(pid: int | None) -> dict[str, str] | None:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -74,6 +74,18 @@ def _cloudflared_stderr_path() -> Path:
     return paths.get_runtime_dir() / "remote_access_cloudflared_stderr.log"
 
 
+def _cloudflared_stdout_path() -> Path:
+    return paths.get_runtime_dir() / "remote_access_cloudflared_stdout.log"
+
+
+def _clear_cloudflared_logs() -> None:
+    for path in (_cloudflared_stdout_path(), _cloudflared_stderr_path()):
+        try:
+            path.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+
 def _asset_name() -> str:
     system = platform.system().lower()
     machine = platform.machine().lower()
@@ -514,6 +526,7 @@ def start(config: V2Config | None = None) -> dict[str, Any]:
                 }
         env = {**os.environ, "TUNNEL_TOKEN": cloud.tunnel_token}
         try:
+            _clear_cloudflared_logs()
             pid = runtime.spawn_background(
                 [binary, "tunnel", "--no-autoupdate", "run"],
                 _pid_path(),
@@ -634,6 +647,13 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "Vibe Remote") -
     missing = [field for field in required if not result.get(field)]
     if missing:
         return {"ok": False, "error": "invalid_pairing_response", "missing": missing}
+    origin_update = result.get("tunnel_origin_update")
+    if isinstance(origin_update, dict) and origin_update.get("ok") is False:
+        return {
+            "ok": False,
+            "error": str(origin_update.get("error") or "tunnel_origin_update_failed"),
+            "pairing": {"ok": False, "origin_service": origin_service},
+        }
     config = api.save_config(
         {
             "remote_access": {


### PR DESCRIPTION
## What
- Parse observed cloudflared origin by chronological order across log formats.
- Prevent stale `originService=...` error lines from overriding a newer managed-config `service` entry.
- Clear cloudflared logs before spawning a new tunnel process so runtime status reflects the current run.
- Treat backend `tunnel_origin_update` failures as pairing failures before saving local remote-access config or starting the tunnel.

## Test
- npm ci && npm run build (ui)
- uv run pytest tests/test_remote_access_vibe_cloud.py -q
- uv run ruff check vibe/remote_access.py tests/test_remote_access_vibe_cloud.py

## Risk
- Narrows the success criteria for pairing: a backend-reported tunnel-origin update failure no longer creates a local paired state.
