### PR TITLE
fix(remote): accept escaped oauth callback state

### DIFF
--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -617,6 +617,42 @@ def test_remote_callback_rejects_when_remote_access_is_disabled(monkeypatch, tmp
     assert exchange_calls == []
 
 
+def test_remote_callback_accepts_html_escaped_state_separator(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+    oauth_cookie = ui_server._make_oauth_cookie(
+        config.remote_access.vibe_cloud.session_secret,
+        {
+            "state": "state-1",
+            "nonce": "nonce-1",
+            "code_verifier": "verifier-1",
+            "next": "/dashboard",
+            "exp": int(ui_server.datetime.now().timestamp()) + 300,
+        },
+    )
+    exchange_calls = []
+    client.set_cookie(ui_server.REMOTE_OAUTH_COOKIE_NAME, oauth_cookie, domain="alex.avibe.bot")
+
+    def exchange(cfg, code, verifier):
+        exchange_calls.append((code, verifier))
+        return {
+            "claims": {
+                "email": "alex@example.com",
+                "sub": "user-1",
+                "nonce": "nonce-1",
+            }
+        }
+
+    monkeypatch.setattr(remote_access, "exchange_oauth_code", exchange)
+
+    response = client.get("/auth/callback?code=test-code&amp;state=state-1", base_url="https://alex.avibe.bot")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/dashboard"
+    assert exchange_calls == [("test-code", "verifier-1")]
+
+
 def test_remote_callback_sanitizes_protocol_relative_next(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -389,6 +389,10 @@ def _safe_remote_redirect_target(value: Any) -> str:
     return urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
 
 
+def _oauth_callback_arg(name: str) -> str | None:
+    return request.args.get(name) or request.args.get(f"amp;{name}")
+
+
 def _redirect_to_vibe_cloud_login(config: V2Config):
     from vibe import remote_access
 
@@ -773,10 +777,10 @@ def remote_access_auth_callback():
     if not cloud.enabled:
         return jsonify({"error": "remote_access_disabled"}), 400
     oauth_state = _read_oauth_cookie(cloud.session_secret, request.cookies.get(REMOTE_OAUTH_COOKIE_NAME))
-    if not oauth_state or oauth_state.get("state") != request.args.get("state"):
+    if not oauth_state or oauth_state.get("state") != _oauth_callback_arg("state"):
         return jsonify({"error": "invalid_oauth_state"}), 400
     try:
-        result = remote_access.exchange_oauth_code(config, request.args.get("code", ""), oauth_state["code_verifier"])
+        result = remote_access.exchange_oauth_code(config, _oauth_callback_arg("code") or "", oauth_state["code_verifier"])
         claims = result["claims"]
     except Exception as exc:
         return jsonify({"error": "oauth_exchange_failed", "detail": str(exc)}), 400


### PR DESCRIPTION
## What
- Accept OAuth callback parameters that arrive with an HTML-escaped separator, e.g. `?code=...&amp;state=...`.
- Apply the same fallback to the callback `code` parameter for consistency.
- Add regression coverage for the escaped callback URL shape.

## Why
A copied or relayed callback URL can preserve `&amp;` literally. Flask then exposes the parameter as `amp;state`, so the local Web UI rejects an otherwise valid callback as `invalid_oauth_state` even when the OAuth cookie is present.

## Test
- `npm run build` in `ui/`
- `uv run pytest tests/test_ui_remote_access_auth.py -q`
- `uv run ruff check vibe/ui_server.py tests/test_ui_remote_access_auth.py`

## Note
A callback opened in a different browser/session, or after starting a newer login attempt, can still correctly fail with `invalid_oauth_state` because the OAuth cookie is missing or stale.
