### PR TITLE
fix(npm): prepare scoped cli publish

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -36,6 +36,6 @@ jobs:
         working-directory: npm/avibe
         run: npm test
 
-      - name: Publish avibe
+      - name: Publish @avibe/cli
         working-directory: npm/avibe
         run: npm publish --access public

--- a/docs/plans/distribution-growth.md
+++ b/docs/plans/distribution-growth.md
@@ -20,19 +20,19 @@ The canonical install path should remain the current one-line curl / PowerShell 
 - Linked the AI-agent installation guides from the docs section without interrupting the landing-page narrative.
 - Updated package metadata and installer banner copy so the project no longer presents as Slack-only.
 - Added an npm entrypoint package under `npm/avibe`:
-  - `npx avibe` and globally installed `avibe` / `vibe` bootstrap the existing Python `vibe-remote` package.
+  - `npx @avibe/cli` and globally installed `avibe` / `vibe` bootstrap the existing Python `vibe-remote` package.
   - The npm package does not ship a second runtime; it installs or locates the real `vibe` command and delegates to it.
   - The npm package skips its own `vibe` shim when resolving the real Python runtime to avoid recursion.
   - `avibe init` and `avibe start` map to the default `vibe` startup flow.
   - `avibe status`, `doctor`, `remote`, `upgrade`, `task`, `hook`, and other commands pass through to `vibe`.
   - CI now tests the wrapper and validates the packed npm contents.
-  - A manual GitHub Actions workflow can publish `avibe` to npm with provenance after npm trusted publishing is configured.
+  - A manual GitHub Actions workflow can publish `@avibe/cli` to npm with provenance after npm trusted publishing is configured.
 
 ## Next High-Leverage Work
 
-1. Publish the `avibe` npm package as a supplemental install entrypoint.
+1. Publish the `@avibe/cli` npm package as a supplemental install entrypoint.
    - Keep the main README / docs install path as the existing one-line curl / PowerShell installer.
-   - Document `npx avibe` and `npm install -g avibe && vibe` as optional Node-friendly alternatives after publish.
+   - Document `npx @avibe/cli` and `npm install -g @avibe/cli && vibe` as optional Node-friendly alternatives after publish.
    - Do not make npm the default public install copy unless the product distribution strategy changes explicitly.
 
 2. Add Homebrew distribution.

--- a/npm/avibe/README.md
+++ b/npm/avibe/README.md
@@ -9,13 +9,13 @@ points.
 ## Quick Start
 
 ```bash
-npx avibe
+npx @avibe/cli
 ```
 
 Or install the npm entrypoint globally:
 
 ```bash
-npm install -g avibe
+npm install -g @avibe/cli
 vibe
 ```
 

--- a/npm/avibe/bin/avibe.js
+++ b/npm/avibe/bin/avibe.js
@@ -21,9 +21,9 @@ function printHelp() {
 NPM entrypoint for Vibe Remote.
 
 Usage:
-  npx avibe              Install Vibe Remote if needed, then start the setup wizard
-  avibe                 Same as above after npm install -g avibe
-  vibe                  Same as above after npm install -g avibe
+  npx @avibe/cli        Install Vibe Remote if needed, then start the setup wizard
+  avibe                 Same as above after npm install -g @avibe/cli
+  vibe                  Same as above after npm install -g @avibe/cli
   avibe install         Install or refresh the underlying vibe-remote Python CLI
   avibe init            Start the setup wizard
   avibe start           Start Vibe Remote

--- a/npm/avibe/package.json
+++ b/npm/avibe/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "avibe",
-  "version": "0.1.0",
+  "name": "@avibe/cli",
+  "version": "2.2.14",
   "description": "NPM entrypoint for installing and running Vibe Remote",
   "license": "MIT",
   "author": "cyhhao",
@@ -14,8 +14,8 @@
     "url": "https://github.com/cyhhao/vibe-remote/issues"
   },
   "bin": {
-    "avibe": "./bin/avibe.js",
-    "vibe": "./bin/avibe.js"
+    "avibe": "bin/avibe.js",
+    "vibe": "bin/avibe.js"
   },
   "files": [
     "bin/",

--- a/npm/avibe/test/cli.test.js
+++ b/npm/avibe/test/cli.test.js
@@ -89,8 +89,8 @@ test("prints wrapper help without installing", () => {
   });
 
   assert.equal(result.status, 0);
-  assert.match(result.stdout, /npx avibe/);
-  assert.match(result.stdout, /npm install -g avibe/);
+  assert.match(result.stdout, /npx @avibe\/cli/);
+  assert.match(result.stdout, /npm install -g @avibe\/cli/);
 });
 
 test("delegates help and version when invoked through vibe", () => {


### PR DESCRIPTION
## What
- Switch the npm wrapper package to the publishable `@avibe/cli` scope.
- Align the first npm package version with the current product release: `2.2.14`.
- Keep the installed global commands as both `vibe` and `avibe`.
- Update npm README/help text, tests, and the publish workflow label.

## Why
The unscoped `avibe` package name is currently blocked by npm registry anti-typosquatting rules even though it is not taken. Since the `avibe` npm org exists and the current account owns it, `@avibe/cli` is the practical first package name.

## Validation
- `npm test` in `npm/avibe`
- `npm pack --dry-run` in `npm/avibe`
- `git diff --check`

## Release note
This PR does not publish to npm and does not create any git tag. It only prepares the package metadata for a future manual publish.
