### PR TITLE
fix(ui): bind UI to wildcard when tunnel is enabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "PyJWT[crypto]>=2.9.0",
     "SQLAlchemy>=2.0.0",
     "alembic>=1.13.0",
+    "psutil>=5.9.0",
 ]
 
 [project.urls]

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -118,14 +118,17 @@ def test_pair_origin_service_ignores_configured_ui_host(monkeypatch, tmp_path) -
     assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"
 
 
-def test_pair_origin_service_preserves_localhost(monkeypatch, tmp_path) -> None:
+def test_pair_origin_service_normalizes_localhost_to_loopback_ipv4(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _config()
     config.ui.setup_host = "localhost"
     config.ui.setup_port = 15130
     config.save()
 
-    assert remote_access.origin_service_for_pairing() == "http://localhost:15130"
+    # cloudflared and werkzeug each resolve "localhost" independently, so we
+    # hand cloudflared a literal IPv4 loopback to match the bind family and
+    # avoid the ::1 vs 127.0.0.1 race that surfaces as a 502.
+    assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"
 
 
 def test_pair_origin_service_preserves_ipv6_loopback(monkeypatch, tmp_path) -> None:
@@ -922,3 +925,13 @@ def test_effective_ui_bind_host_requested_host_yields_to_tunnel_override() -> No
     config.ui.setup_host = "127.0.0.1"
 
     assert runtime.effective_ui_bind_host(config, requested_host="100.97.103.112") == "0.0.0.0"
+
+
+def test_effective_ui_bind_host_overrides_to_ipv4_wildcard_when_setup_host_is_localhost() -> None:
+    # Pairs with _origin_host_for_pairing returning 127.0.0.1 for "localhost":
+    # the bind family must be IPv4 so cloudflared can reach the UI.
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "localhost"
+
+    assert runtime.effective_ui_bind_host(config) == "0.0.0.0"

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -118,8 +118,11 @@ def test_pair_origin_service_ignores_configured_ui_host(monkeypatch, tmp_path) -
     assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"
 
 
-def test_pair_origin_service_normalizes_localhost_to_loopback_ipv4(monkeypatch, tmp_path) -> None:
+def test_pair_origin_service_uses_ipv4_loopback_when_localhost_resolves_dual_stack(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setattr(runtime, "resolve_localhost_family", lambda: "inet")
     config = _config()
     config.ui.setup_host = "localhost"
     config.ui.setup_port = 15130
@@ -129,6 +132,22 @@ def test_pair_origin_service_normalizes_localhost_to_loopback_ipv4(monkeypatch, 
     # hand cloudflared a literal IPv4 loopback to match the bind family and
     # avoid the ::1 vs 127.0.0.1 race that surfaces as a 502.
     assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"
+
+
+def test_pair_origin_service_uses_ipv6_loopback_when_localhost_resolves_v6_only(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setattr(runtime, "resolve_localhost_family", lambda: "inet6")
+    config = _config()
+    config.ui.setup_host = "localhost"
+    config.ui.setup_port = 15130
+    config.save()
+
+    # On IPv6-only hosts where ``localhost`` only resolves to ::1, the
+    # cloudflared origin must follow into v6 so it can reach the v6
+    # wildcard bind. Otherwise the tunnel dials an unreachable v4 socket.
+    assert remote_access.origin_service_for_pairing() == "http://[::1]:15130"
 
 
 def test_pair_origin_service_preserves_ipv6_loopback(monkeypatch, tmp_path) -> None:
@@ -927,11 +946,61 @@ def test_effective_ui_bind_host_requested_host_yields_to_tunnel_override() -> No
     assert runtime.effective_ui_bind_host(config, requested_host="100.97.103.112") == "0.0.0.0"
 
 
-def test_effective_ui_bind_host_overrides_to_ipv4_wildcard_when_setup_host_is_localhost() -> None:
+def test_effective_ui_bind_host_overrides_to_ipv4_wildcard_when_localhost_resolves_dual_stack(
+    monkeypatch,
+) -> None:
     # Pairs with _origin_host_for_pairing returning 127.0.0.1 for "localhost":
     # the bind family must be IPv4 so cloudflared can reach the UI.
+    monkeypatch.setattr(runtime, "resolve_localhost_family", lambda: "inet")
     config = _config()
     assert config.remote_access.vibe_cloud.enabled is True
     config.ui.setup_host = "localhost"
 
     assert runtime.effective_ui_bind_host(config) == "0.0.0.0"
+
+
+def test_effective_ui_bind_host_overrides_to_ipv6_wildcard_when_localhost_resolves_v6_only(
+    monkeypatch,
+) -> None:
+    # On IPv6-only hosts where "localhost" only resolves to ::1, forcing
+    # IPv4 would unbind the UI from the only loopback the OS exposes;
+    # follow the same family the cloudflared origin will use.
+    monkeypatch.setattr(runtime, "resolve_localhost_family", lambda: "inet6")
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "localhost"
+
+    assert runtime.effective_ui_bind_host(config) == "::"
+
+
+def test_resolve_localhost_family_prefers_ipv4_when_both_resolve(monkeypatch) -> None:
+    import socket as _socket
+
+    def fake_getaddrinfo(host, port, *, type=None):  # noqa: A002 - shadowing matches stdlib
+        return [
+            (_socket.AF_INET6, _socket.SOCK_STREAM, 0, "", ("::1", 0, 0, 0)),
+            (_socket.AF_INET, _socket.SOCK_STREAM, 0, "", ("127.0.0.1", 0)),
+        ]
+
+    monkeypatch.setattr("vibe.runtime.socket.getaddrinfo", fake_getaddrinfo)
+    assert runtime.resolve_localhost_family() == "inet"
+
+
+def test_resolve_localhost_family_returns_inet6_when_only_v6_resolves(monkeypatch) -> None:
+    import socket as _socket
+
+    def fake_getaddrinfo(host, port, *, type=None):  # noqa: A002
+        return [(_socket.AF_INET6, _socket.SOCK_STREAM, 0, "", ("::1", 0, 0, 0))]
+
+    monkeypatch.setattr("vibe.runtime.socket.getaddrinfo", fake_getaddrinfo)
+    assert runtime.resolve_localhost_family() == "inet6"
+
+
+def test_resolve_localhost_family_falls_back_to_inet_on_resolution_failure(monkeypatch) -> None:
+    import socket as _socket
+
+    def fake_getaddrinfo(host, port, *, type=None):  # noqa: A002
+        raise _socket.gaierror("simulated")
+
+    monkeypatch.setattr("vibe.runtime.socket.getaddrinfo", fake_getaddrinfo)
+    assert runtime.resolve_localhost_family() == "inet"

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -858,3 +858,67 @@ def test_start_clears_previous_cloudflared_logs_before_spawn(monkeypatch, tmp_pa
 
     assert result["ok"] is True
     assert result["started"] is True
+
+
+def test_effective_ui_bind_host_uses_setup_host_when_tunnel_disabled() -> None:
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.ui.setup_host = "100.97.103.112"
+
+    assert runtime.effective_ui_bind_host(config) == "100.97.103.112"
+
+
+def test_effective_ui_bind_host_overrides_to_wildcard_when_tunnel_enabled() -> None:
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "100.97.103.112"
+
+    assert runtime.effective_ui_bind_host(config) == "0.0.0.0"
+
+
+def test_effective_ui_bind_host_preserves_loopback_when_tunnel_disabled() -> None:
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.ui.setup_host = "127.0.0.1"
+
+    assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
+
+
+def test_effective_ui_bind_host_falls_back_to_loopback_when_setup_host_blank() -> None:
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.ui.setup_host = ""
+
+    assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
+
+
+def test_effective_ui_bind_host_uses_v6_wildcard_for_ipv6_setup_host() -> None:
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "::"
+
+    assert runtime.effective_ui_bind_host(config) == "::"
+
+
+def test_effective_ui_bind_host_uses_v6_wildcard_for_bracketed_ipv6_loopback() -> None:
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "[::1]"
+
+    assert runtime.effective_ui_bind_host(config) == "::"
+
+
+def test_effective_ui_bind_host_prefers_requested_host_over_persisted_setup_host() -> None:
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.ui.setup_host = "127.0.0.1"
+
+    assert runtime.effective_ui_bind_host(config, requested_host="192.168.1.10") == "192.168.1.10"
+
+
+def test_effective_ui_bind_host_requested_host_yields_to_tunnel_override() -> None:
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "127.0.0.1"
+
+    assert runtime.effective_ui_bind_host(config, requested_host="100.97.103.112") == "0.0.0.0"

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -972,6 +972,70 @@ def test_setup_host_ipv6_with_64_prefix_excludes_peer_outside_64(monkeypatch, tm
     assert response.get_json()["error"] == "remote_access_host_mismatch"
 
 
+def _save_config_tunnel_off_with_setup_host(tmp_path, host: str) -> V2Config:
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.enabled = False
+    config.ui.setup_host = host
+    config.save()
+    return config
+
+
+def test_setup_host_tunnel_off_allows_routed_peer_outside_interface_subnet(monkeypatch, tmp_path):
+    """When the tunnel is off, the UI binds directly to setup_host and the
+    kernel already enforces interface filtering — a routed peer reaching
+    setup_host across a /16 corporate or campus net must have been routed
+    legitimately, so the application layer should not add a second-pass
+    subnet gate (regression noted in Codex review of #252)."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_tunnel_off_with_setup_host(tmp_path, "10.1.2.3")
+    _mock_interface(monkeypatch, "10.1.2.3", 24)
+
+    response = app.test_client().get(
+        "/health",
+        base_url="http://10.1.2.3:5123",
+        environ_base={"REMOTE_ADDR": "10.50.0.5"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_setup_host_tunnel_off_still_rejects_public_peer(monkeypatch, tmp_path):
+    """Tunnel-off relaxation of the subnet gate must not relax the
+    private-peer requirement: a public peer is still untrusted."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_tunnel_off_with_setup_host(tmp_path, "10.1.2.3")
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://10.1.2.3:5123",
+        environ_base={"REMOTE_ADDR": "8.8.8.8"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_setup_host_tunnel_on_still_enforces_subnet_gate(monkeypatch, tmp_path):
+    """Mirror of the tunnel-off test above: with the tunnel on, the
+    wildcard bind requires the application-layer subnet gate, so the same
+    cross-subnet peer that is allowed when the tunnel is off must be
+    rejected when the tunnel is on."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "10.1.2.3")
+    _mock_interface(monkeypatch, "10.1.2.3", 24)
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://10.1.2.3:5123",
+        environ_base={"REMOTE_ADDR": "10.50.0.5"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
 def test_setup_host_mismatched_host_header_is_not_local(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -735,6 +735,56 @@ def test_setup_host_with_public_peer_is_not_local(monkeypatch, tmp_path):
     assert response.get_json()["error"] == "remote_access_host_mismatch"
 
 
+def test_setup_host_lan_peer_with_tailscale_setup_is_not_local(monkeypatch, tmp_path):
+    """Wildcard-bind regression guard: a LAN peer cannot inherit setup-host
+    trust by spoofing the Host header to a Tailscale setup_host that lives
+    in a different private block."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "100.97.103.112")
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://100.97.103.112:5123",
+        environ_base={"REMOTE_ADDR": "192.168.1.5"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_setup_host_tailscale_peer_with_lan_setup_is_not_local(monkeypatch, tmp_path):
+    """Inverse of the LAN-vs-Tailscale check: a Tailscale peer cannot inherit
+    setup-host trust by spoofing the Host header to a LAN setup_host."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "192.168.2.3")
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://192.168.2.3:5123",
+        environ_base={"REMOTE_ADDR": "100.97.103.5"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_setup_host_tailscale_peer_with_tailscale_setup_is_local(monkeypatch, tmp_path):
+    """Same-block trust still works: a Tailscale peer can inherit setup-host
+    trust when setup_host is also in 100.64/10."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "100.97.103.112")
+
+    response = app.test_client().get(
+        "/health",
+        base_url="http://100.97.103.112:5123",
+        environ_base={"REMOTE_ADDR": "100.97.103.5"},
+    )
+
+    assert response.status_code == 200
+
+
 def test_setup_host_mismatched_host_header_is_not_local(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -785,6 +785,57 @@ def test_setup_host_tailscale_peer_with_tailscale_setup_is_local(monkeypatch, tm
     assert response.status_code == 200
 
 
+def test_setup_host_rfc1918_peer_in_different_24_is_not_local(monkeypatch, tmp_path):
+    """RFC1918 trust must not span the entire /8: a 10.50/16 peer cannot
+    inherit setup-host trust from a 10.1.2/24 setup_host even though both
+    are in 10.0.0.0/8. Pre-wildcard, the kernel only let in peers on the
+    same interface subnet — restoring that scoping at the application
+    layer means /24 around setup_host, not the whole /8."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "10.1.2.3")
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://10.1.2.3:5123",
+        environ_base={"REMOTE_ADDR": "10.50.0.5"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_setup_host_rfc1918_peer_in_same_24_is_local(monkeypatch, tmp_path):
+    """Same-/24 RFC1918 peer still inherits trust (typical home/office LAN)."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "10.1.2.3")
+
+    response = app.test_client().get(
+        "/health",
+        base_url="http://10.1.2.3:5123",
+        environ_base={"REMOTE_ADDR": "10.1.2.50"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_setup_host_192168_peer_in_different_24_is_not_local(monkeypatch, tmp_path):
+    """A peer on 192.168.2/24 cannot spoof Host=192.168.1.5 even though both
+    are in 192.168/16."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "192.168.1.5")
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://192.168.1.5:5123",
+        environ_base={"REMOTE_ADDR": "192.168.2.5"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
 def test_setup_host_mismatched_host_header_is_not_local(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import ipaddress
+import socket
+from collections import namedtuple
+
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from config.v2_config import CONFIG_LOCK
 from tests.ui_server_test_helpers import csrf_headers
@@ -7,6 +11,30 @@ from vibe import api
 from vibe import remote_access
 from vibe import ui_server
 from vibe.ui_server import app
+
+
+_FakeSnicaddr = namedtuple("snicaddr", ["family", "address", "netmask", "broadcast", "ptp"])
+
+
+def _mock_interface(monkeypatch, ip: str, prefix: int) -> None:
+    """Make ``psutil.net_if_addrs()`` report ``ip`` with the given prefix
+    length so ``_local_interface_network`` returns the expected subnet.
+    Tests that exercise the RFC1918/ULA trust path need this because the
+    real test runner does not have the synthetic addresses (192.168.2.3
+    etc.) configured on any interface."""
+    address = ipaddress.ip_address(ip)
+    if address.version == 4:
+        family = socket.AF_INET
+        netmask = str(ipaddress.IPv4Network(f"0.0.0.0/{prefix}").netmask)
+    else:
+        family = socket.AF_INET6
+        netmask = str(ipaddress.IPv6Network(f"::/{prefix}").netmask)
+    snic = _FakeSnicaddr(family=family, address=ip, netmask=netmask, broadcast=None, ptp=None)
+    monkeypatch.setattr("vibe.ui_server.psutil.net_if_addrs", lambda: {"en0": [snic]})
+
+
+def _mock_no_interfaces(monkeypatch) -> None:
+    monkeypatch.setattr("vibe.ui_server.psutil.net_if_addrs", lambda: {})
 
 
 def _save_config(tmp_path) -> V2Config:
@@ -697,6 +725,7 @@ def _save_config_with_setup_host(tmp_path, host: str) -> V2Config:
 def test_setup_host_lan_request_is_treated_as_local(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
+    _mock_interface(monkeypatch, "192.168.2.3", 24)
 
     response = app.test_client().get(
         "/health",
@@ -710,6 +739,7 @@ def test_setup_host_lan_request_is_treated_as_local(monkeypatch, tmp_path):
 def test_setup_host_request_from_self_is_treated_as_local(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
+    _mock_interface(monkeypatch, "192.168.2.3", 24)
 
     response = app.test_client().get(
         "/health",
@@ -785,14 +815,15 @@ def test_setup_host_tailscale_peer_with_tailscale_setup_is_local(monkeypatch, tm
     assert response.status_code == 200
 
 
-def test_setup_host_rfc1918_peer_in_different_24_is_not_local(monkeypatch, tmp_path):
+def test_setup_host_rfc1918_peer_outside_interface_subnet_is_not_local(monkeypatch, tmp_path):
     """RFC1918 trust must not span the entire /8: a 10.50/16 peer cannot
-    inherit setup-host trust from a 10.1.2/24 setup_host even though both
-    are in 10.0.0.0/8. Pre-wildcard, the kernel only let in peers on the
-    same interface subnet — restoring that scoping at the application
-    layer means /24 around setup_host, not the whole /8."""
+    inherit setup-host trust from a 10.1.2.3 setup_host configured with a
+    /24 mask. Pre-wildcard, the kernel only let in peers on the same
+    interface subnet — _local_interface_network restores that scoping
+    using the actual netmask."""
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "10.1.2.3")
+    _mock_interface(monkeypatch, "10.1.2.3", 24)
 
     response = app.test_client().get(
         "/dashboard",
@@ -805,10 +836,11 @@ def test_setup_host_rfc1918_peer_in_different_24_is_not_local(monkeypatch, tmp_p
     assert response.get_json()["error"] == "remote_access_host_mismatch"
 
 
-def test_setup_host_rfc1918_peer_in_same_24_is_local(monkeypatch, tmp_path):
-    """Same-/24 RFC1918 peer still inherits trust (typical home/office LAN)."""
+def test_setup_host_rfc1918_peer_in_same_interface_subnet_is_local(monkeypatch, tmp_path):
+    """Same-subnet RFC1918 peer still inherits trust (typical home/office LAN)."""
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "10.1.2.3")
+    _mock_interface(monkeypatch, "10.1.2.3", 24)
 
     response = app.test_client().get(
         "/health",
@@ -819,16 +851,120 @@ def test_setup_host_rfc1918_peer_in_same_24_is_local(monkeypatch, tmp_path):
     assert response.status_code == 200
 
 
-def test_setup_host_192168_peer_in_different_24_is_not_local(monkeypatch, tmp_path):
-    """A peer on 192.168.2/24 cannot spoof Host=192.168.1.5 even though both
-    are in 192.168/16."""
+def test_setup_host_192168_peer_outside_interface_subnet_is_not_local(monkeypatch, tmp_path):
+    """A peer on 192.168.2/24 cannot spoof Host=192.168.1.5 when the
+    interface mask is /24."""
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.1.5")
+    _mock_interface(monkeypatch, "192.168.1.5", 24)
 
     response = app.test_client().get(
         "/dashboard",
         base_url="http://192.168.1.5:5123",
         environ_base={"REMOTE_ADDR": "192.168.2.5"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_setup_host_with_16_prefix_includes_peer_in_same_16(monkeypatch, tmp_path):
+    """When the interface mask is /16, a peer on a different /24 within
+    the same /16 still inherits trust — fixed-/24 estimates were too
+    narrow for /16 LANs."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "192.168.1.5")
+    _mock_interface(monkeypatch, "192.168.1.5", 16)
+
+    response = app.test_client().get(
+        "/health",
+        base_url="http://192.168.1.5:5123",
+        environ_base={"REMOTE_ADDR": "192.168.7.20"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_setup_host_with_20_prefix_includes_peer_in_same_20(monkeypatch, tmp_path):
+    """/20 corporate networks (4096 addresses) are honored without
+    artificially narrowing to /24."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "10.1.16.5")
+    _mock_interface(monkeypatch, "10.1.16.5", 20)
+
+    response = app.test_client().get(
+        "/health",
+        base_url="http://10.1.16.5:5123",
+        environ_base={"REMOTE_ADDR": "10.1.31.250"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_setup_host_with_20_prefix_excludes_peer_outside_20(monkeypatch, tmp_path):
+    """/20 still excludes peers outside the /20 (peer in next /20 is not
+    on the same routed subnet)."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "10.1.16.5")
+    _mock_interface(monkeypatch, "10.1.16.5", 20)
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://10.1.16.5:5123",
+        environ_base={"REMOTE_ADDR": "10.1.32.5"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_setup_host_unknown_to_local_interfaces_is_not_local(monkeypatch, tmp_path):
+    """If setup_host is not configured on any local interface, deny trust
+    rather than guess a subnet — this preserves the kernel's pre-wildcard
+    "no matching interface, no traffic" semantics."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "192.168.99.99")
+    _mock_no_interfaces(monkeypatch)
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://192.168.99.99:5123",
+        environ_base={"REMOTE_ADDR": "192.168.99.50"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_setup_host_ipv6_with_56_prefix_includes_peer_in_same_56(monkeypatch, tmp_path):
+    """A non-/64 IPv6 LAN (e.g. /56 prefix delegated to the home network)
+    is honored without artificially narrowing to /64."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "fd00:0:0:1::5")
+    _mock_interface(monkeypatch, "fd00:0:0:1::5", 56)
+
+    response = app.test_client().get(
+        "/health",
+        base_url="http://[fd00:0:0:1::5]:5123",
+        environ_base={"REMOTE_ADDR": "fd00:0:0:7::20"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_setup_host_ipv6_with_64_prefix_excludes_peer_outside_64(monkeypatch, tmp_path):
+    """Default IPv6 LAN /64 still scopes peers correctly."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config_with_setup_host(tmp_path, "fd00::5")
+    _mock_interface(monkeypatch, "fd00::5", 64)
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://[fd00::5]:5123",
+        environ_base={"REMOTE_ADDR": "fd00:0:0:1::20"},
         follow_redirects=False,
     )
 

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import threading
+
+from config.v2_config import (
+    AgentsConfig,
+    PlatformsConfig,
+    RemoteAccessConfig,
+    RuntimeConfig,
+    SlackConfig,
+    UiConfig,
+    V2Config,
+)
+from vibe import runtime
+from vibe.ui_server import app
+
+from tests.ui_server_test_helpers import csrf_headers
+
+
+def _config_with_tunnel(enabled: bool, setup_host: str = "127.0.0.1") -> V2Config:
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack"], primary="slack"),
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        ui=UiConfig(setup_host=setup_host),
+        remote_access=RemoteAccessConfig(),
+    )
+    config.remote_access.vibe_cloud.enabled = enabled
+    return config
+
+
+class _NoopThread:
+    def __init__(self, target=None, args=(), kwargs=None, **_extra):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self) -> None:
+        # Skip the actual subprocess respawn; the unit test only asserts
+        # the bind host computed before the thread is started.
+        return None
+
+
+def test_ui_reload_overrides_bind_host_when_tunnel_enabled(monkeypatch):
+    captured_calls: list[dict] = []
+    original = runtime.effective_ui_bind_host
+
+    def _spy(config, requested_host=None):
+        captured_calls.append({"config": config, "requested_host": requested_host})
+        return original(config, requested_host=requested_host)
+
+    monkeypatch.setattr(runtime, "effective_ui_bind_host", _spy)
+    monkeypatch.setattr(V2Config, "load", classmethod(lambda cls: _config_with_tunnel(enabled=True)))
+    monkeypatch.setattr(threading, "Thread", _NoopThread)
+
+    client = app.test_client()
+    response = client.post(
+        "/ui/reload",
+        json={"host": "100.97.103.112", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    # Response echoes the user-facing host (what the browser should redirect to).
+    assert body["host"] == "100.97.103.112"
+    assert body["port"] == 5123
+
+    assert captured_calls, "effective_ui_bind_host was not invoked"
+    call = captured_calls[-1]
+    assert call["requested_host"] == "100.97.103.112"
+    assert call["config"].remote_access.vibe_cloud.enabled is True
+
+
+def test_ui_reload_uses_requested_host_when_tunnel_disabled(monkeypatch):
+    captured: dict = {}
+
+    original = runtime.effective_ui_bind_host
+
+    def _spy(config, requested_host=None):
+        captured["requested_host"] = requested_host
+        captured["enabled"] = config.remote_access.vibe_cloud.enabled
+        return original(config, requested_host=requested_host)
+
+    monkeypatch.setattr(runtime, "effective_ui_bind_host", _spy)
+    monkeypatch.setattr(V2Config, "load", classmethod(lambda cls: _config_with_tunnel(enabled=False)))
+    monkeypatch.setattr(threading, "Thread", _NoopThread)
+
+    client = app.test_client()
+    response = client.post(
+        "/ui/reload",
+        json={"host": "192.168.1.5", "port": 6000},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 200
+    assert captured["requested_host"] == "192.168.1.5"
+    assert captured["enabled"] is False

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -78,6 +78,22 @@ def test_ui_reload_overrides_bind_host_when_tunnel_enabled(monkeypatch):
     assert call["config"].remote_access.vibe_cloud.enabled is True
 
 
+def test_ui_reload_rejects_non_string_host(monkeypatch):
+    monkeypatch.setattr(V2Config, "load", classmethod(lambda cls: _config_with_tunnel(enabled=True)))
+    monkeypatch.setattr(threading, "Thread", _NoopThread)
+
+    client = app.test_client()
+    response = client.post(
+        "/ui/reload",
+        json={"host": 123, "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "invalid_host"}
+
+
 def test_ui_reload_uses_requested_host_when_tunnel_disabled(monkeypatch):
     captured: dict = {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -1314,6 +1314,34 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -2050,6 +2078,7 @@ dependencies = [
     { name = "httpx", extra = ["socks"] },
     { name = "lark-oapi" },
     { name = "markdown-to-mrkdwn" },
+    { name = "psutil" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-socks", extra = ["asyncio"] },
     { name = "pyyaml" },
@@ -2074,6 +2103,7 @@ requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
     { name = "lark-oapi", specifier = ">=1.4.0" },
     { name = "markdown-to-mrkdwn", specifier = ">=0.2.0" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
     { name = "python-socks", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1829,7 +1829,8 @@ def cmd_vibe():
         _write_status("starting")
 
     service_pid = runtime.start_service()
-    ui_pid = runtime.start_ui(config.ui.setup_host, config.ui.setup_port)
+    bind_host = runtime.effective_ui_bind_host(config)
+    ui_pid = runtime.start_ui(bind_host, config.ui.setup_port)
     runtime.write_status("running", "pid={}".format(service_pid), service_pid, ui_pid)
 
     ui_url = "http://{}:{}".format(config.ui.setup_host, config.ui.setup_port)

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -600,12 +600,14 @@ def _origin_host_for_pairing(config: V2Config) -> str:
     host = (config.ui.setup_host or "").strip()
     if host.startswith("[") and host.endswith("]"):
         host = host[1:-1].strip()
-    # cloudflared and werkzeug each resolve "localhost" independently; on a
-    # dual-stack host they can land on different families (e.g. ::1 vs
-    # 127.0.0.1) and surface as a 502. Hand cloudflared a literal IPv4
-    # loopback so the origin family always matches the bind family.
+    # "localhost" is ambiguous: cloudflared and werkzeug resolve it
+    # independently, so on a dual-stack host they can land on different
+    # families (::1 vs 127.0.0.1) and surface as a 502. Hand cloudflared
+    # a literal loopback IP whose family matches the wildcard
+    # ``effective_ui_bind_host`` chooses, so the two sides never disagree
+    # and IPv6-only hosts still work.
     if host.lower() == "localhost":
-        return "127.0.0.1"
+        return "[::1]" if runtime.resolve_localhost_family() == "inet6" else "127.0.0.1"
 
     try:
         address = ipaddress.ip_address(host)

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -600,8 +600,12 @@ def _origin_host_for_pairing(config: V2Config) -> str:
     host = (config.ui.setup_host or "").strip()
     if host.startswith("[") and host.endswith("]"):
         host = host[1:-1].strip()
+    # cloudflared and werkzeug each resolve "localhost" independently; on a
+    # dual-stack host they can land on different families (e.g. ::1 vs
+    # 127.0.0.1) and surface as a 502. Hand cloudflared a literal IPv4
+    # loopback so the origin family always matches the bind family.
     if host.lower() == "localhost":
-        return "localhost"
+        return "127.0.0.1"
 
     try:
         address = ipaddress.ip_address(host)

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -398,6 +398,38 @@ def start_service():
         )
 
 
+def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) -> str:
+    """Resolve the host the UI server should bind to.
+
+    When the Vibe Cloud tunnel is enabled, bind to a wildcard so the local
+    ``cloudflared`` origin (which dials ``127.0.0.1``/``[::1]``) can reach the
+    UI no matter which interface IP the user typed into ``ui.setup_host``
+    (loopback, Tailscale CGNAT, LAN). The host-trust middleware in
+    ``ui_server`` still rejects untrusted peers, so widening the bind does
+    not widen exposure.
+
+    Why: If the user binds to a Tailscale or LAN IP and then enables the
+    tunnel, ``cloudflared`` cannot reach the UI on its loopback origin and
+    every public request returns 502.
+
+    ``requested_host`` lets callers (e.g. the ``/ui/reload`` endpoint)
+    propagate the host from the inbound request without persisting it first;
+    when omitted we fall back to ``config.ui.setup_host``.
+    """
+    setup_host = (requested_host if requested_host is not None else config.ui.setup_host) or "127.0.0.1"
+    cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
+    if cloud is not None and cloud.enabled:
+        # Pick the wildcard family that matches the user's intent so an
+        # IPv6-only setup_host stays reachable on v6.
+        normalized = setup_host.strip()
+        if normalized.startswith("[") and normalized.endswith("]"):
+            normalized = normalized[1:-1]
+        if normalized in {"::", "::0"} or ":" in normalized:
+            return "::"
+        return "0.0.0.0"
+    return setup_host
+
+
 def start_ui(host, port):
     command = "from vibe.ui_server import run_ui_server; run_ui_server('{}', {})".format(host, port)
     return spawn_background(

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -3,6 +3,7 @@ import logging
 import os
 import signal
 import shlex
+import socket
 import subprocess
 import sys
 import threading
@@ -398,6 +399,29 @@ def start_service():
         )
 
 
+def resolve_localhost_family() -> str:
+    """Return the loopback family ``localhost`` actually maps to on this host.
+
+    ``"inet"`` when IPv4 loopback resolves (the common dual-stack case),
+    ``"inet6"`` only when ``localhost`` is exclusively IPv6. Used by
+    ``effective_ui_bind_host`` and ``_origin_host_for_pairing`` so the
+    bind family and the cloudflared origin family stay aligned: forcing
+    IPv4 unconditionally would regress IPv6-only hosts, while leaving
+    resolution to werkzeug + cloudflared independently re-creates the
+    ::1 vs 127.0.0.1 race that surfaces as 502.
+    """
+    try:
+        infos = socket.getaddrinfo("localhost", None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return "inet"
+    families = {info[0] for info in infos}
+    if socket.AF_INET in families:
+        return "inet"
+    if socket.AF_INET6 in families:
+        return "inet6"
+    return "inet"
+
+
 def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) -> str:
     """Resolve the host the UI server should bind to.
 
@@ -424,6 +448,12 @@ def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) 
         normalized = setup_host.strip()
         if normalized.startswith("[") and normalized.endswith("]"):
             normalized = normalized[1:-1]
+        # "localhost" is ambiguous on dual-stack hosts and may even be
+        # exclusively IPv6. Resolve once and pick the wildcard that
+        # matches the family _origin_host_for_pairing will hand
+        # cloudflared, so the two sides cannot disagree.
+        if normalized.lower() == "localhost":
+            return "::" if resolve_localhost_family() == "inet6" else "0.0.0.0"
         if normalized in {"::", "::0"} or ":" in normalized:
             return "::"
         return "0.0.0.0"

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -900,6 +900,8 @@ def ui_reload():
     port = payload.get("port")
     if not host or not port:
         return jsonify({"error": "host_and_port_required"}), 400
+    if not isinstance(host, str):
+        return jsonify({"error": "invalid_host"}), 400
     try:
         port = int(port)
     except (TypeError, ValueError):

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -258,6 +258,27 @@ def _is_loopback_host(value: str | None) -> bool:
 # setup-host peers when the request's Host header otherwise matches.
 _SHARED_ADDRESS_SPACE = ipaddress.ip_network("100.64.0.0/10")
 
+# Private/CGNAT/link-local blocks used to gate setup-host trust. Pre-tunnel
+# the UI bound only to ``ui.setup_host`` so the kernel filtered out peers
+# from other interfaces; the ``Host`` match + private-peer pair was scoped
+# by the network layer. The tunnel-on path widens the bind to a wildcard,
+# so an attacker on a different private subnet could otherwise reach the
+# socket and spoof ``Host: <setup_host>`` to inherit local trust. We
+# restore the network scoping at the application layer by requiring the
+# peer's IP to share setup_host's block. Order is most-specific first so
+# the tightest block that still contains setup_host wins.
+_PRIVATE_NETWORKS_V4 = (
+    ipaddress.IPv4Network("100.64.0.0/10"),
+    ipaddress.IPv4Network("169.254.0.0/16"),
+    ipaddress.IPv4Network("192.168.0.0/16"),
+    ipaddress.IPv4Network("172.16.0.0/12"),
+    ipaddress.IPv4Network("10.0.0.0/8"),
+)
+_PRIVATE_NETWORKS_V6 = (
+    ipaddress.IPv6Network("fc00::/7"),
+    ipaddress.IPv6Network("fe80::/10"),
+)
+
 
 def _is_private_address(address: ipaddress._BaseAddress) -> bool:
     if address.is_loopback or address.is_private or address.is_link_local:
@@ -278,6 +299,32 @@ def _is_private_peer() -> bool:
     mapped = getattr(address, "ipv4_mapped", None)
     if mapped is not None:
         return _is_private_address(mapped)
+    return False
+
+
+def _peer_shares_setup_host_network(setup_address: ipaddress._BaseAddress) -> bool:
+    """Require the peer to be in the same private/CGNAT block as setup_host.
+
+    Compensates for the wildcard bind in the tunnel-on path. Without this,
+    a 192.168/16 LAN peer could spoof ``Host=<tailscale_setup_host>`` on
+    a different interface and inherit setup-host trust.
+    """
+    remote_addr = (request.remote_addr or "").strip()
+    if not remote_addr or remote_addr == "localhost":
+        return False
+    try:
+        peer = ipaddress.ip_address(remote_addr)
+    except ValueError:
+        return False
+    if peer.version != setup_address.version:
+        mapped = getattr(peer, "ipv4_mapped", None)
+        if mapped is None or mapped.version != setup_address.version:
+            return False
+        peer = mapped
+    candidates = _PRIVATE_NETWORKS_V4 if setup_address.version == 4 else _PRIVATE_NETWORKS_V6
+    for net in candidates:
+        if setup_address in net:
+            return peer in net
     return False
 
 
@@ -357,7 +404,13 @@ def _is_setup_host_request(config: V2Config | None) -> bool:
     # the actual client, so refuse the setup-host trust path entirely.
     if _has_forwarded_metadata():
         return False
-    return _is_private_peer()
+    if not _is_private_peer():
+        return False
+    # See _peer_shares_setup_host_network: the tunnel-on path widens the
+    # UI bind, so we have to enforce setup_host's network scoping at the
+    # application layer instead of relying on the kernel to drop traffic
+    # from peers on other interfaces.
+    return _peer_shares_setup_host_network(setup_address)
 
 
 def _is_local_request(config: V2Config | None = None) -> bool:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -907,6 +907,15 @@ def ui_reload():
 
     status = runtime.read_status()
 
+    try:
+        current_config = V2Config.load()
+    except Exception:
+        current_config = None
+    if current_config is not None:
+        bind_host = runtime.effective_ui_bind_host(current_config, requested_host=host)
+    else:
+        bind_host = host
+
     def _restart():
         global _server
         import subprocess
@@ -915,7 +924,7 @@ def ui_reload():
         from config import paths as config_paths
 
         working_dir = get_working_dir()
-        command = f"from vibe.ui_server import run_ui_server; run_ui_server('{host}', {port})"
+        command = f"from vibe.ui_server import run_ui_server; run_ui_server('{bind_host}', {port})"
         stdout_path = config_paths.get_runtime_dir() / "ui_stdout.log"
         stderr_path = config_paths.get_runtime_dir() / "ui_stderr.log"
         stdout = stdout_path.open("ab")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -258,26 +258,28 @@ def _is_loopback_host(value: str | None) -> bool:
 # setup-host peers when the request's Host header otherwise matches.
 _SHARED_ADDRESS_SPACE = ipaddress.ip_network("100.64.0.0/10")
 
-# Private/CGNAT/link-local blocks used to gate setup-host trust. Pre-tunnel
-# the UI bound only to ``ui.setup_host`` so the kernel filtered out peers
-# from other interfaces; the ``Host`` match + private-peer pair was scoped
-# by the network layer. The tunnel-on path widens the bind to a wildcard,
-# so an attacker on a different private subnet could otherwise reach the
-# socket and spoof ``Host: <setup_host>`` to inherit local trust. We
-# restore the network scoping at the application layer by requiring the
-# peer's IP to share setup_host's block. Order is most-specific first so
-# the tightest block that still contains setup_host wins.
-_PRIVATE_NETWORKS_V4 = (
+# Networks that are scoped by the overlay/link itself rather than by the
+# kernel's interface routing, so peers anywhere in the block are trusted
+# in lieu of a tighter same-subnet check:
+#   * 100.64.0.0/10 — Tailscale CGNAT. Tailscale assigns each peer a /32 in
+#     this range and routes peers via its overlay; legitimate peers can be
+#     anywhere in the /10 even though they share the same logical network.
+#   * 169.254.0.0/16 / fe80::/10 — link-local. Confined to the same L2
+#     segment by the kernel.
+_OVERLAY_TRUST_NETWORKS_V4 = (
     ipaddress.IPv4Network("100.64.0.0/10"),
     ipaddress.IPv4Network("169.254.0.0/16"),
-    ipaddress.IPv4Network("192.168.0.0/16"),
-    ipaddress.IPv4Network("172.16.0.0/12"),
-    ipaddress.IPv4Network("10.0.0.0/8"),
 )
-_PRIVATE_NETWORKS_V6 = (
-    ipaddress.IPv6Network("fc00::/7"),
-    ipaddress.IPv6Network("fe80::/10"),
-)
+_OVERLAY_TRUST_NETWORKS_V6 = (ipaddress.IPv6Network("fe80::/10"),)
+# Subnet sizes used to approximate the kernel's pre-wildcard interface
+# filtering for RFC1918 / ULA setup hosts. The wildcard bind in the
+# tunnel-on path means we no longer get free interface scoping from the
+# kernel; we have to enforce "peer is on the same subnet as setup_host"
+# at the application layer. /24 and /64 cover typical home/office LANs
+# without granting trust across the whole /8 (10.0.0.0/8) or /7 (fc00::/7)
+# block, which would let a 10.50/16 peer spoof ``Host=10.20.x.y``.
+_DEFAULT_TRUST_PREFIX_V4 = 24
+_DEFAULT_TRUST_PREFIX_V6 = 64
 
 
 def _is_private_address(address: ipaddress._BaseAddress) -> bool:
@@ -302,12 +304,38 @@ def _is_private_peer() -> bool:
     return False
 
 
+def _setup_host_trust_network(setup_address: ipaddress._BaseAddress) -> ipaddress._BaseNetwork | None:
+    """Return the network setup-host trust should extend to.
+
+    Tailscale CGNAT and link-local ranges keep their natural block size
+    because the overlay or kernel link-local routing scopes them. RFC1918
+    and ULA setup hosts get a typical same-subnet prefix (/24 v4, /64 v6)
+    around setup_host so we don't extend trust across an entire 10.0.0.0/8
+    or fc00::/7 block — a 10.50/16 peer should not inherit trust from a
+    10.20/16 setup host.
+    """
+    if setup_address.version == 4:
+        for overlay in _OVERLAY_TRUST_NETWORKS_V4:
+            if setup_address in overlay:
+                return overlay
+        return ipaddress.ip_network(f"{setup_address}/{_DEFAULT_TRUST_PREFIX_V4}", strict=False)
+    if setup_address.version == 6:
+        for overlay in _OVERLAY_TRUST_NETWORKS_V6:
+            if setup_address in overlay:
+                return overlay
+        return ipaddress.ip_network(f"{setup_address}/{_DEFAULT_TRUST_PREFIX_V6}", strict=False)
+    return None
+
+
 def _peer_shares_setup_host_network(setup_address: ipaddress._BaseAddress) -> bool:
-    """Require the peer to be in the same private/CGNAT block as setup_host.
+    """Require the peer to share setup_host's interface-level subnet.
 
     Compensates for the wildcard bind in the tunnel-on path. Without this,
     a 192.168/16 LAN peer could spoof ``Host=<tailscale_setup_host>`` on
-    a different interface and inherit setup-host trust.
+    a different interface and inherit setup-host trust. Subnet size comes
+    from :func:`_setup_host_trust_network`, which keeps overlay networks
+    (Tailscale, link-local) broad and tightens RFC1918/ULA to /24 or /64
+    around setup_host.
     """
     remote_addr = (request.remote_addr or "").strip()
     if not remote_addr or remote_addr == "localhost":
@@ -321,11 +349,10 @@ def _peer_shares_setup_host_network(setup_address: ipaddress._BaseAddress) -> bo
         if mapped is None or mapped.version != setup_address.version:
             return False
         peer = mapped
-    candidates = _PRIVATE_NETWORKS_V4 if setup_address.version == 4 else _PRIVATE_NETWORKS_V6
-    for net in candidates:
-        if setup_address in net:
-            return peer in net
-    return False
+    network = _setup_host_trust_network(setup_address)
+    if network is None:
+        return False
+    return peer in network
 
 
 def _env_flag_enabled(name: str) -> bool:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -495,11 +495,24 @@ def _is_setup_host_request(config: V2Config | None) -> bool:
         return False
     if not _is_private_peer():
         return False
-    # See _peer_shares_setup_host_network: the tunnel-on path widens the
-    # UI bind, so we have to enforce setup_host's network scoping at the
-    # application layer instead of relying on the kernel to drop traffic
-    # from peers on other interfaces.
-    return _peer_shares_setup_host_network(setup_address)
+    # When the Vibe Cloud tunnel is on, the UI binds to a wildcard so the
+    # local cloudflared origin can reach setup_host regardless of which
+    # interface it lives on. Wildcard means the kernel no longer drops
+    # cross-interface traffic, so we have to re-enforce "peer shares the
+    # setup_host interface subnet" at the application layer to prevent a
+    # peer on a different interface from spoofing Host=<setup_host>. When
+    # the tunnel is off, the kernel binds to setup_host directly and that
+    # interface filtering is already in force; adding the subnet gate
+    # here would just block legitimate routed peers (e.g. a 10.50/16
+    # client reaching setup_host=10.1.2.3 across a routed corporate net).
+    if _is_tunnel_wildcard_bind(config):
+        return _peer_shares_setup_host_network(setup_address)
+    return True
+
+
+def _is_tunnel_wildcard_bind(config: V2Config) -> bool:
+    cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
+    return bool(cloud is not None and cloud.enabled)
 
 
 def _is_local_request(config: V2Config | None = None) -> bool:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -9,12 +9,14 @@ import mimetypes
 import os
 import re
 import secrets
+import socket
 import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, unquote, urlparse, urlsplit, urlunsplit
 
+import psutil
 from flask import Flask, request, jsonify, redirect, send_file, Response
 
 from config import paths
@@ -271,15 +273,6 @@ _OVERLAY_TRUST_NETWORKS_V4 = (
     ipaddress.IPv4Network("169.254.0.0/16"),
 )
 _OVERLAY_TRUST_NETWORKS_V6 = (ipaddress.IPv6Network("fe80::/10"),)
-# Subnet sizes used to approximate the kernel's pre-wildcard interface
-# filtering for RFC1918 / ULA setup hosts. The wildcard bind in the
-# tunnel-on path means we no longer get free interface scoping from the
-# kernel; we have to enforce "peer is on the same subnet as setup_host"
-# at the application layer. /24 and /64 cover typical home/office LANs
-# without granting trust across the whole /8 (10.0.0.0/8) or /7 (fc00::/7)
-# block, which would let a 10.50/16 peer spoof ``Host=10.20.x.y``.
-_DEFAULT_TRUST_PREFIX_V4 = 24
-_DEFAULT_TRUST_PREFIX_V6 = 64
 
 
 def _is_private_address(address: ipaddress._BaseAddress) -> bool:
@@ -304,27 +297,96 @@ def _is_private_peer() -> bool:
     return False
 
 
-def _setup_host_trust_network(setup_address: ipaddress._BaseAddress) -> ipaddress._BaseNetwork | None:
-    """Return the network setup-host trust should extend to.
+def _local_interface_network(setup_address: ipaddress._BaseAddress) -> ipaddress._BaseNetwork | None:
+    """Return the network ``setup_host`` is configured on locally.
 
-    Tailscale CGNAT and link-local ranges keep their natural block size
-    because the overlay or kernel link-local routing scopes them. RFC1918
-    and ULA setup hosts get a typical same-subnet prefix (/24 v4, /64 v6)
-    around setup_host so we don't extend trust across an entire 10.0.0.0/8
-    or fc00::/7 block — a 10.50/16 peer should not inherit trust from a
-    10.20/16 setup host.
+    Reads the interface's actual netmask via ``psutil.net_if_addrs`` so
+    the trust scope mirrors the kernel's pre-wildcard interface filtering
+    exactly — a /16 LAN, a /20 corporate network, and a non-/64 IPv6
+    network all get their real prefix instead of a fixed estimate.
+
+    Returns None when ``setup_host`` is not configured on any local
+    interface or psutil cannot enumerate them; the caller denies trust
+    in that case so we never widen the application-layer scope beyond
+    what the kernel would have permitted.
+    """
+    try:
+        interfaces = psutil.net_if_addrs()
+    except Exception:
+        return None
+    target_family = socket.AF_INET if setup_address.version == 4 else socket.AF_INET6
+    for addrs in interfaces.values():
+        for snic in addrs:
+            if snic.family != target_family:
+                continue
+            address_str = (snic.address or "").split("%", 1)[0]
+            try:
+                addr = ipaddress.ip_address(address_str)
+            except ValueError:
+                continue
+            if addr != setup_address:
+                continue
+            netmask = snic.netmask
+            if not netmask:
+                continue
+            prefix = _netmask_to_prefix(netmask, addr.version)
+            if prefix is None:
+                continue
+            try:
+                return ipaddress.ip_network(f"{addr}/{prefix}", strict=False)
+            except ValueError:
+                continue
+    return None
+
+
+def _netmask_to_prefix(netmask: str, version: int) -> int | None:
+    """Convert ``psutil``'s netmask string to a prefix length.
+
+    psutil returns IPv4 netmasks as dotted strings (``255.255.255.0``)
+    and IPv6 netmasks as hex strings (``ffff:ffff:ffff:ff00::``).
+    ``ipaddress.ip_network`` only accepts the dotted form for IPv4 and
+    requires an integer prefix for IPv6, so we normalize to a prefix
+    length here. Returns None for malformed or non-contiguous masks.
+    """
+    try:
+        if version == 4:
+            mask_int = int(ipaddress.IPv4Address(netmask))
+            width = 32
+        else:
+            mask_int = int(ipaddress.IPv6Address(netmask))
+            width = 128
+    except (ipaddress.AddressValueError, ValueError):
+        return None
+    if mask_int == 0:
+        return 0
+    inverted = (~mask_int) & ((1 << width) - 1)
+    if inverted & (inverted + 1):
+        # Non-contiguous mask — refuse rather than guess.
+        return None
+    prefix = width - inverted.bit_length()
+    return prefix
+
+
+def _setup_host_trust_network(setup_address: ipaddress._BaseAddress) -> ipaddress._BaseNetwork | None:
+    """Return the network setup-host trust should extend to, or None to deny.
+
+    Overlay networks (Tailscale CGNAT, link-local) trust the entire block
+    because the overlay routing or kernel link-local scoping handles peer
+    isolation; legitimate peers can be anywhere in the block. RFC1918 and
+    ULA setup hosts derive the network from the actual interface netmask
+    via :func:`_local_interface_network` so the application-layer scope
+    matches the kernel's pre-wildcard interface filtering. Returning None
+    means the scope cannot be determined and the caller must deny trust.
     """
     if setup_address.version == 4:
         for overlay in _OVERLAY_TRUST_NETWORKS_V4:
             if setup_address in overlay:
                 return overlay
-        return ipaddress.ip_network(f"{setup_address}/{_DEFAULT_TRUST_PREFIX_V4}", strict=False)
-    if setup_address.version == 6:
+    elif setup_address.version == 6:
         for overlay in _OVERLAY_TRUST_NETWORKS_V6:
             if setup_address in overlay:
                 return overlay
-        return ipaddress.ip_network(f"{setup_address}/{_DEFAULT_TRUST_PREFIX_V6}", strict=False)
-    return None
+    return _local_interface_network(setup_address)
 
 
 def _peer_shares_setup_host_network(setup_address: ipaddress._BaseAddress) -> bool:
@@ -334,8 +396,8 @@ def _peer_shares_setup_host_network(setup_address: ipaddress._BaseAddress) -> bo
     a 192.168/16 LAN peer could spoof ``Host=<tailscale_setup_host>`` on
     a different interface and inherit setup-host trust. Subnet size comes
     from :func:`_setup_host_trust_network`, which keeps overlay networks
-    (Tailscale, link-local) broad and tightens RFC1918/ULA to /24 or /64
-    around setup_host.
+    (Tailscale, link-local) broad and otherwise mirrors the actual
+    interface netmask via :func:`_local_interface_network`.
     """
     remote_addr = (request.remote_addr or "").strip()
     if not remote_addr or remote_addr == "localhost":


### PR DESCRIPTION
## Summary
- `cloudflared` always dials its origin at `127.0.0.1` (or `[::1]`), so when a user binds `ui.setup_host` to a Tailscale CGNAT or LAN IP and then enables the tunnel, the UI socket refused loopback connections and every public request returned 502.
- Introduce `runtime.effective_ui_bind_host(config, requested_host=...)`: bind to `0.0.0.0` (or `::` if the user picked an IPv6 host) whenever the tunnel is enabled, otherwise keep binding to whatever `setup_host` the user configured. Port always follows user setting.
- The user-facing browser URL still reads from `setup_host`; the bind override is invisible from the browser side.
- Wire the helper into both `cmd_vibe()` (initial start) and the `/ui/reload` endpoint (settings-driven restart).

## Why this is safe
The host-trust middleware in `vibe/ui_server.py` (`_is_local_request` / `_is_remote_access_request`) already rejects non-private peer IPs and rejects requests carrying proxy/forwarded headers, so widening the bind to a wildcard does not widen exposure.

## Notes for reviewers
- `/ui/reload` reads `V2Config` from disk to determine tunnel state. The frontend persists settings before invoking `/ui/reload`, so this is consistent with current behavior; if a future settings flow toggles the tunnel and reloads in a single transaction, we'd want to pass `tunnel_enabled` in the payload instead.
- The `f"...run_ui_server('{bind_host}', {port})"` command-string in `runtime.start_ui` and `/ui/reload` is unchanged. `bind_host` is now either a constant (`"0.0.0.0"`/`"::"`) or the same user-supplied host that already flowed through the same string. The pre-existing quoting concern on user-supplied host strings is not made worse by this PR but is worth a follow-up to switch to `repr()` / `shlex.quote`.

## Evidence
- **Unit**: `tests/test_remote_access_vibe_cloud.py` — 8 new `test_effective_ui_bind_host_*` cases (tunnel on/off, IPv4/IPv6 wildcard, blank setup_host, `requested_host` override).
- **Integration**: `tests/test_ui_server_reload.py` (new) — exercises `/ui/reload` to verify the bind host is overridden to the wildcard when the persisted config has the tunnel enabled, and that the user-facing host is preserved when the tunnel is disabled.
- **Manual**: regression env not yet re-run; the original 502 was reproduced on the local install before the patch (cloudflared connection refused on 127.0.0.1:5100 while UI bound to 100.97.103.112:5100).

## Test plan
- [x] `ruff check` on changed files
- [x] `pytest tests/test_remote_access_vibe_cloud.py tests/test_ui_server_reload.py` (51 passed)
- [ ] Once merged: rebuild local install, verify the tunnel reaches the UI regardless of `setup_host` (loopback / Tailscale / LAN)