### PR TITLE
feat(ui): collapsible proxy URL field across IM platforms

### DIFF
--- a/ui/src/components/shared/ProxyUrlField.tsx
+++ b/ui/src/components/shared/ProxyUrlField.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { ChevronDown, SplitSquareVertical } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+
+interface ProxyUrlFieldProps {
+  value: string;
+  onChange: (next: string) => void;
+  /**
+   * i18n key for the label. Defaults to `common.proxyUrl`. Telegram passes
+   * `telegramConfig.proxyUrl` so its label can stay platform-flavored.
+   */
+  labelKey?: string;
+  /**
+   * i18n key for the long hint shown below the input when expanded. Defaults
+   * to `common.proxyUrlHint`. Telegram passes `telegramConfig.proxyUrlHint`
+   * and Lark passes `larkConfig.proxyUrlLarkLimitation` so the SDK warning
+   * stays where users see it.
+   */
+  hintKey?: string;
+}
+
+export function ProxyUrlField({
+  value,
+  onChange,
+  labelKey = 'common.proxyUrl',
+  hintKey = 'common.proxyUrlHint',
+}: ProxyUrlFieldProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(!!value);
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="flex w-full items-center justify-between gap-2 text-left text-[12px] font-medium text-foreground transition hover:text-cyan"
+      >
+        <span className="flex items-center gap-2">
+          <SplitSquareVertical size={14} className="text-cyan" />
+          {t(labelKey)}
+          <span className="text-[11px] font-normal text-muted">
+            {t('common.proxyUrlCollapsedHint')}
+          </span>
+        </span>
+        <ChevronDown
+          size={14}
+          className={clsx('text-muted transition-transform', expanded && 'rotate-180')}
+        />
+      </button>
+      {expanded && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="socks5://user:pass@host:port (optional)"
+            className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+          />
+          <p className="text-[11px] text-muted">{t(hintKey)}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/steps/DiscordConfig.tsx
+++ b/ui/src/components/steps/DiscordConfig.tsx
@@ -14,7 +14,6 @@ import {
   AlertTriangle,
   ArrowLeft,
   ArrowRight,
-  SplitSquareVertical,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
@@ -22,6 +21,7 @@ import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
+import { ProxyUrlField } from '../shared/ProxyUrlField';
 
 interface DiscordConfigProps {
   data: any;
@@ -353,20 +353,7 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                   <p className="text-[11px] text-muted">{t('discordConfig.botTokenHint')}</p>
                 </div>
 
-                <div className="space-y-2">
-                  <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
-                    <SplitSquareVertical size={14} className="text-cyan" />
-                    {t('common.proxyUrl')}
-                  </label>
-                  <input
-                    type="text"
-                    value={proxyUrl}
-                    onChange={(e) => setProxyUrl(e.target.value)}
-                    placeholder="socks5://user:pass@host:port (optional)"
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
-                  />
-                  <p className="text-[11px] text-muted">{t('common.proxyUrlHint')}</p>
-                </div>
+                <ProxyUrlField value={proxyUrl} onChange={setProxyUrl} />
 
                 <div className="flex flex-wrap items-center gap-3">
                   <button

--- a/ui/src/components/steps/LarkConfig.tsx
+++ b/ui/src/components/steps/LarkConfig.tsx
@@ -16,7 +16,6 @@ import {
   Radio,
   RefreshCw,
   Shield,
-  SplitSquareVertical,
   Wifi,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -25,6 +24,7 @@ import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
+import { ProxyUrlField } from '../shared/ProxyUrlField';
 
 const LARK_PERMISSIONS_JSON = `{
   "scopes": {
@@ -344,20 +344,11 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
                   <p className="text-[11px] text-muted">{t('larkConfig.appSecretHint')}</p>
                 </div>
 
-                <div className="space-y-2">
-                  <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
-                    <SplitSquareVertical size={14} className="text-cyan" />
-                    {t('common.proxyUrl')}
-                  </label>
-                  <input
-                    type="text"
-                    value={proxyUrl}
-                    onChange={(e) => setProxyUrl(e.target.value)}
-                    placeholder="socks5://user:pass@host:port (optional)"
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
-                  />
-                  <p className="text-[11px] text-muted">{t('larkConfig.proxyUrlLarkLimitation')}</p>
-                </div>
+                <ProxyUrlField
+                  value={proxyUrl}
+                  onChange={setProxyUrl}
+                  hintKey="larkConfig.proxyUrlLarkLimitation"
+                />
 
                 <div className="flex flex-wrap items-center gap-3">
                   <button

--- a/ui/src/components/steps/SlackConfig.tsx
+++ b/ui/src/components/steps/SlackConfig.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Lock, Shield, RefreshCw, Copy, ExternalLink, Check, ChevronDown, ChevronUp, Key, Hash, Plus, ArrowLeft, ArrowRight, SplitSquareVertical } from 'lucide-react';
+import { Lock, Shield, RefreshCw, Copy, ExternalLink, Check, ChevronDown, ChevronUp, Key, Hash, Plus, ArrowLeft, ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
+import { ProxyUrlField } from '../shared/ProxyUrlField';
 
 interface SlackConfigProps {
   data: any;
@@ -315,20 +316,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
             {expandedSteps[4] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('slackConfig.step4Description')}</p>
-                <div className="space-y-2">
-                  <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
-                    <SplitSquareVertical size={14} className="text-cyan" />
-                    {t('common.proxyUrl')}
-                  </label>
-                  <input
-                    type="text"
-                    value={proxyUrl}
-                    onChange={(e) => setProxyUrl(e.target.value)}
-                    placeholder="socks5://user:pass@host:port (optional)"
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
-                  />
-                  <p className="text-[11px] text-muted">{t('common.proxyUrlHint')}</p>
-                </div>
+                <ProxyUrlField value={proxyUrl} onChange={setProxyUrl} />
                 <div className="flex flex-wrap items-center gap-3">
                   <button
                     onClick={runAuthTest}

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -20,6 +20,7 @@ import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
+import { ProxyUrlField } from '../shared/ProxyUrlField';
 
 interface TelegramConfigProps {
   data: any;
@@ -261,20 +262,12 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                   <p className="text-[11px] text-muted">{t('telegramConfig.botTokenHint')}</p>
                 </div>
 
-                <div className="space-y-2">
-                  <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
-                    <SplitSquareVertical size={14} className="text-cyan" />
-                    {t('telegramConfig.proxyUrl')}
-                  </label>
-                  <input
-                    type="text"
-                    value={proxyUrl}
-                    onChange={(e) => setProxyUrl(e.target.value)}
-                    placeholder="socks5://user:pass@host:port (optional)"
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
-                  />
-                  <p className="text-[11px] text-muted">{t('telegramConfig.proxyUrlHint')}</p>
-                </div>
+                <ProxyUrlField
+                  value={proxyUrl}
+                  onChange={setProxyUrl}
+                  labelKey="telegramConfig.proxyUrl"
+                  hintKey="telegramConfig.proxyUrlHint"
+                />
 
                 <div className="flex flex-wrap items-center gap-3">
                   <button

--- a/ui/src/components/steps/WeChatConfig.tsx
+++ b/ui/src/components/steps/WeChatConfig.tsx
@@ -9,13 +9,13 @@ import {
   Loader2,
   RefreshCw,
   Smartphone,
-  SplitSquareVertical,
   Wifi,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
+import { ProxyUrlField } from '../shared/ProxyUrlField';
 
 interface WeChatConfigProps {
   data: Record<string, any>;
@@ -382,19 +382,8 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
           )}
 
           {/* Proxy (optional) — applies to outbound iLink/CDN traffic */}
-          <div className="rounded-xl border border-border bg-background px-5 py-4 space-y-2">
-            <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
-              <SplitSquareVertical size={14} className="text-cyan" />
-              {t('common.proxyUrl')}
-            </label>
-            <input
-              type="text"
-              value={proxyUrl}
-              onChange={(e) => setProxyUrl(e.target.value)}
-              placeholder="socks5://user:pass@host:port (optional)"
-              className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
-            />
-            <p className="text-[11px] text-muted">{t('common.proxyUrlHint')}</p>
+          <div className="rounded-xl border border-border bg-background px-5 py-4">
+            <ProxyUrlField value={proxyUrl} onChange={setProxyUrl} />
           </div>
         </div>
     </>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -48,7 +48,8 @@
     "themeToggleHint": "Click to change theme",
     "step": "Step",
     "proxyUrl": "Proxy URL (optional)",
-    "proxyUrlHint": "SOCKS5, SOCKS4, HTTP or HTTPS proxy. Leave empty to fall back to system SOCKS proxy detection or direct connection."
+    "proxyUrlHint": "SOCKS5, SOCKS4, HTTP or HTTPS proxy. Leave empty to fall back to system SOCKS proxy detection or direct connection.",
+    "proxyUrlCollapsedHint": "(blank → system proxy if set, else direct)"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -48,7 +48,8 @@
     "themeToggleHint": "点击切换主题",
     "step": "步骤",
     "proxyUrl": "代理地址（可选）",
-    "proxyUrlHint": "SOCKS5、SOCKS4、HTTP 或 HTTPS 代理。留空则回退到系统 SOCKS 代理探测，未配置时直连。"
+    "proxyUrlHint": "SOCKS5、SOCKS4、HTTP 或 HTTPS 代理。留空则回退到系统 SOCKS 代理探测，未配置时直连。",
+    "proxyUrlCollapsedHint": "（留空则尝试系统代理，否则直连）"
   },
   "nav": {
     "dashboard": "仪表盘",


### PR DESCRIPTION
## Summary
- Added shared `ProxyUrlField` component used by Slack / Discord / Telegram / Lark / WeChat config pages.
- Collapses the proxy input behind a single line by default, with a parenthetical hint ` (blank → system proxy if set, else direct)` / `（留空则尝试系统代理，否则直连）`.
- Auto-expands when the platform already has a proxy configured, so existing users still see their value on entry.
- Keeps Telegram and Lark platform-specific copy via `labelKey` / `hintKey` props (Telegram's own label, Lark's SDK limitation note).
- New i18n key `common.proxyUrlCollapsedHint` (en + zh). No backend or behavioral change — the underlying `vibe.proxy.resolve_proxy()` precedence is unchanged.

Why this layer: `core` rule "fix at the highest appropriate layer" — the inline block was duplicated 5×; one shared component keeps a future Mattermost/Lark-OS adapter from re-introducing the same UI by accident.

## Screenshots
- Slack EN collapsed — single line with greyed parenthetical
- Slack EN expanded — input + full hint copy
- Slack ZH collapsed — `代理地址（可选） （留空则尝试系统代理，否则直连）`

## Evidence layers
- **Unit**: n/a (pure UI refactor)
- **Contract**: n/a
- **Scenario**: n/a — no scenario catalog covers this surface
- **Manual**: `npm run build` passes; verified collapsed/expanded/Chinese states in dev server

## Test plan
- [ ] Verify each platform's config page renders the new component
- [ ] Verify pre-filled proxy auto-expands on entry
- [ ] Verify Telegram and Lark show their platform-specific hint copy when expanded
- [ ] Verify Chinese copy fits without wrapping in the collapsed header