### PR TITLE
fix(ui): stop remounting wizard step rows on every render

### DIFF
--- a/ui/src/components/shared/WizardStep.tsx
+++ b/ui/src/components/shared/WizardStep.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import clsx from 'clsx';
+
+interface StepShellProps {
+  active: boolean;
+  children: React.ReactNode;
+}
+
+export const StepShell: React.FC<StepShellProps> = ({ active, children }) => (
+  <div
+    className={clsx(
+      'overflow-hidden rounded-xl border transition-colors',
+      active
+        ? 'border-mint/35 bg-surface-2 shadow-[0_8px_32px_-8px_rgba(91,255,160,0.078)]'
+        : 'border-border bg-background'
+    )}
+  >
+    {children}
+  </div>
+);
+
+interface StepHeaderProps {
+  step: number;
+  title: string;
+  icon: React.ReactNode;
+  completed?: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export const StepHeader: React.FC<StepHeaderProps> = ({
+  step,
+  title,
+  icon,
+  completed,
+  expanded,
+  onToggle,
+}) => (
+  <button
+    onClick={onToggle}
+    className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.02]"
+  >
+    <div className="flex items-center gap-3">
+      <span
+        className={clsx(
+          'flex size-7 items-center justify-center rounded-full text-[12px] font-bold transition-colors',
+          completed ? 'bg-mint text-[#080812]' : 'bg-cyan/15 text-cyan'
+        )}
+      >
+        {completed ? <Check size={14} /> : step}
+      </span>
+      <span className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
+        {icon}
+        {title}
+      </span>
+    </div>
+    {expanded ? <ChevronUp size={18} className="text-muted" /> : <ChevronDown size={18} className="text-muted" />}
+  </button>
+);

--- a/ui/src/components/steps/DiscordConfig.tsx
+++ b/ui/src/components/steps/DiscordConfig.tsx
@@ -8,8 +8,6 @@ import {
   Plus,
   ExternalLink,
   Settings,
-  ChevronDown,
-  ChevronUp,
   Copy,
   AlertTriangle,
   ArrowLeft,
@@ -22,6 +20,7 @@ import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
+import { StepHeader, StepShell } from '../shared/WizardStep';
 
 interface DiscordConfigProps {
   data: any;
@@ -141,47 +140,6 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
     showToast(t('common.copyFailed'), 'error');
   };
 
-  const StepHeader: React.FC<{ step: number; title: string; icon: React.ReactNode; completed?: boolean }> = ({
-    step,
-    title,
-    icon,
-    completed,
-  }) => (
-    <button
-      onClick={() => toggleStep(step)}
-      className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.02]"
-    >
-      <div className="flex items-center gap-3">
-        <span
-          className={clsx(
-            'flex size-7 items-center justify-center rounded-full text-[12px] font-bold transition-colors',
-            completed ? 'bg-mint text-[#080812]' : 'bg-cyan/15 text-cyan'
-          )}
-        >
-          {completed ? <Check size={14} /> : step}
-        </span>
-        <span className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
-          {icon}
-          {title}
-        </span>
-      </div>
-      {expandedSteps[step] ? <ChevronUp size={18} className="text-muted" /> : <ChevronDown size={18} className="text-muted" />}
-    </button>
-  );
-
-  const StepShell: React.FC<{ active: boolean; children: React.ReactNode }> = ({ active, children }) => (
-    <div
-      className={clsx(
-        'overflow-hidden rounded-xl border transition-colors',
-        active
-          ? 'border-mint/35 bg-surface-2 shadow-[0_8px_32px_-8px_rgba(91,255,160,0.078)]'
-          : 'border-border bg-background'
-      )}
-    >
-      {children}
-    </div>
-  );
-
   const completedCount = [
     !!clientId,
     Boolean(authResult?.ok || (data.discord?.bot_token && botToken === data.discord?.bot_token)),
@@ -214,7 +172,13 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
     <>
           {/* Step 1: Create application */}
           <StepShell active={expandedSteps[1]}>
-            <StepHeader step={1} title={t('discordConfig.step1Title')} icon={<Plus size={16} className="text-cyan" />} />
+            <StepHeader
+              step={1}
+              title={t('discordConfig.step1Title')}
+              icon={<Plus size={16} className="text-cyan" />}
+              expanded={expandedSteps[1]}
+              onToggle={() => toggleStep(1)}
+            />
             {expandedSteps[1] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('discordConfig.step1Description')}</p>
@@ -236,7 +200,13 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
 
           {/* Step 2: Configure bot */}
           <StepShell active={expandedSteps[2]}>
-            <StepHeader step={2} title={t('discordConfig.step2Title')} icon={<Settings size={16} className="text-cyan" />} />
+            <StepHeader
+              step={2}
+              title={t('discordConfig.step2Title')}
+              icon={<Settings size={16} className="text-cyan" />}
+              expanded={expandedSteps[2]}
+              onToggle={() => toggleStep(2)}
+            />
             {expandedSteps[2] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('discordConfig.step2Description')}</p>
@@ -253,7 +223,13 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
 
           {/* Step 3: Invite bot */}
           <StepShell active={expandedSteps[3]}>
-            <StepHeader step={3} title={t('discordConfig.step3Title')} icon={<ExternalLink size={16} className="text-cyan" />} />
+            <StepHeader
+              step={3}
+              title={t('discordConfig.step3Title')}
+              icon={<ExternalLink size={16} className="text-cyan" />}
+              expanded={expandedSteps[3]}
+              onToggle={() => toggleStep(3)}
+            />
             {expandedSteps[3] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('discordConfig.step3Description')}</p>
@@ -329,6 +305,8 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
               title={t('discordConfig.step4Title')}
               icon={<KeyRound size={16} className="text-cyan" />}
               completed={isValid}
+              expanded={expandedSteps[4]}
+              onToggle={() => toggleStep(4)}
             />
             {expandedSteps[4] && (
               <div className="space-y-4 border-t border-border px-5 py-4">

--- a/ui/src/components/steps/LarkConfig.tsx
+++ b/ui/src/components/steps/LarkConfig.tsx
@@ -5,8 +5,6 @@ import {
   ArrowRight,
   BookOpen,
   Check,
-  ChevronDown,
-  ChevronUp,
   Copy,
   ExternalLink,
   Globe,
@@ -25,6 +23,18 @@ import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
+import { StepHeader, StepShell } from '../shared/WizardStep';
+
+const LinkButton: React.FC<{ url: string; label: string }> = ({ url, label }) => (
+  <button
+    onClick={() => window.open(url, '_blank')}
+    disabled={!url}
+    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+  >
+    <ExternalLink size={14} strokeWidth={2.25} />
+    {label}
+  </button>
+);
 
 const LARK_PERMISSIONS_JSON = `{
   "scopes": {
@@ -175,58 +185,6 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
     showToast(t('common.copyFailed'), 'error');
   };
 
-  const LinkButton: React.FC<{ url: string; label: string }> = ({ url, label }) => (
-    <button
-      onClick={() => window.open(url, '_blank')}
-      disabled={!url}
-      className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
-    >
-      <ExternalLink size={14} strokeWidth={2.25} />
-      {label}
-    </button>
-  );
-
-  const StepHeader: React.FC<{ step: number; title: string; icon: React.ReactNode; completed?: boolean }> = ({
-    step,
-    title,
-    icon,
-    completed,
-  }) => (
-    <button
-      onClick={() => toggleStep(step)}
-      className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.02]"
-    >
-      <div className="flex items-center gap-3">
-        <span
-          className={clsx(
-            'flex size-7 items-center justify-center rounded-full text-[12px] font-bold transition-colors',
-            completed ? 'bg-mint text-[#080812]' : 'bg-cyan/15 text-cyan'
-          )}
-        >
-          {completed ? <Check size={14} /> : step}
-        </span>
-        <span className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
-          {icon}
-          {title}
-        </span>
-      </div>
-      {expandedSteps[step] ? <ChevronUp size={18} className="text-muted" /> : <ChevronDown size={18} className="text-muted" />}
-    </button>
-  );
-
-  const StepShell: React.FC<{ active: boolean; children: React.ReactNode }> = ({ active, children }) => (
-    <div
-      className={clsx(
-        'overflow-hidden rounded-xl border transition-colors',
-        active
-          ? 'border-mint/35 bg-surface-2 shadow-[0_8px_32px_-8px_rgba(91,255,160,0.078)]'
-          : 'border-border bg-background'
-      )}
-    >
-      {children}
-    </div>
-  );
-
   const completedCount = [
     Boolean(appId),
     isValid,
@@ -290,7 +248,13 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
         <div className="flex flex-col gap-3">
           {/* Step 1 — Create app */}
           <StepShell active={expandedSteps[1]}>
-            <StepHeader step={1} title={t('larkConfig.step1Title')} icon={<Plus size={16} className="text-cyan" />} />
+            <StepHeader
+              step={1}
+              title={t('larkConfig.step1Title')}
+              icon={<Plus size={16} className="text-cyan" />}
+              expanded={expandedSteps[1]}
+              onToggle={() => toggleStep(1)}
+            />
             {expandedSteps[1] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('larkConfig.step1Description')}</p>
@@ -311,6 +275,8 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
               title={t('larkConfig.step2Title')}
               icon={<KeyRound size={16} className="text-cyan" />}
               completed={isValid}
+              expanded={expandedSteps[2]}
+              onToggle={() => toggleStep(2)}
             />
             {expandedSteps[2] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
@@ -417,7 +383,13 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
 
           {/* Step 3 — Permissions */}
           <StepShell active={expandedSteps[3]}>
-            <StepHeader step={3} title={t('larkConfig.step3Title')} icon={<Shield size={16} className="text-cyan" />} />
+            <StepHeader
+              step={3}
+              title={t('larkConfig.step3Title')}
+              icon={<Shield size={16} className="text-cyan" />}
+              expanded={expandedSteps[3]}
+              onToggle={() => toggleStep(3)}
+            />
             {expandedSteps[3] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('larkConfig.step3Description')}</p>
@@ -462,7 +434,13 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
 
           {/* Step 4 — Events / callbacks / WS */}
           <StepShell active={expandedSteps[4]}>
-            <StepHeader step={4} title={t('larkConfig.step4Title')} icon={<Radio size={16} className="text-cyan" />} />
+            <StepHeader
+              step={4}
+              title={t('larkConfig.step4Title')}
+              icon={<Radio size={16} className="text-cyan" />}
+              expanded={expandedSteps[4]}
+              onToggle={() => toggleStep(4)}
+            />
             {expandedSteps[4] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('larkConfig.step4Description')}</p>
@@ -506,7 +484,13 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
 
           {/* Step 5 — Publish */}
           <StepShell active={expandedSteps[5]}>
-            <StepHeader step={5} title={t('larkConfig.step5Title')} icon={<BookOpen size={16} className="text-cyan" />} />
+            <StepHeader
+              step={5}
+              title={t('larkConfig.step5Title')}
+              icon={<BookOpen size={16} className="text-cyan" />}
+              expanded={expandedSteps[5]}
+              onToggle={() => toggleStep(5)}
+            />
             {expandedSteps[5] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('larkConfig.step5Description')}</p>

--- a/ui/src/components/steps/SlackConfig.tsx
+++ b/ui/src/components/steps/SlackConfig.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Lock, Shield, RefreshCw, Copy, ExternalLink, Check, ChevronDown, ChevronUp, Key, Hash, Plus, ArrowLeft, ArrowRight } from 'lucide-react';
+import { Lock, Shield, RefreshCw, Copy, ExternalLink, Check, ChevronDown, Key, Hash, Plus, ArrowLeft, ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
@@ -7,6 +7,7 @@ import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
+import { StepHeader, StepShell } from '../shared/WizardStep';
 
 interface SlackConfigProps {
   data: any;
@@ -111,47 +112,6 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
     setExpandedSteps((prev) => ({ ...prev, [step]: !prev[step] }));
   };
 
-  const StepHeader: React.FC<{ step: number; title: string; icon: React.ReactNode; completed?: boolean }> = ({
-    step,
-    title,
-    icon,
-    completed,
-  }) => (
-    <button
-      onClick={() => toggleStep(step)}
-      className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.02]"
-    >
-      <div className="flex items-center gap-3">
-        <span
-          className={clsx(
-            'flex size-7 items-center justify-center rounded-full text-[12px] font-bold transition-colors',
-            completed ? 'bg-mint text-[#080812]' : 'bg-cyan/15 text-cyan'
-          )}
-        >
-          {completed ? <Check size={14} /> : step}
-        </span>
-        <span className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
-          {icon}
-          {title}
-        </span>
-      </div>
-      {expandedSteps[step] ? <ChevronUp size={18} className="text-muted" /> : <ChevronDown size={18} className="text-muted" />}
-    </button>
-  );
-
-  const StepShell: React.FC<{ active: boolean; children: React.ReactNode }> = ({ active, children }) => (
-    <div
-      className={clsx(
-        'overflow-hidden rounded-xl border transition-colors',
-        active
-          ? 'border-mint/35 bg-surface-2 shadow-[0_8px_32px_-8px_rgba(91,255,160,0.078)]'
-          : 'border-border bg-background'
-      )}
-    >
-      {children}
-    </div>
-  );
-
   const completedCount = [
     !!manifest, // step 1 done as soon as manifest is available (best heuristic without backend signal)
     botToken.startsWith('xoxb-'),
@@ -179,7 +139,13 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
           {/* steps content */}
           {/* Step 1 */}
           <StepShell active={expandedSteps[1]}>
-            <StepHeader step={1} title={t('slackConfig.step1Title')} icon={<Plus size={16} className="text-cyan" />} />
+            <StepHeader
+              step={1}
+              title={t('slackConfig.step1Title')}
+              icon={<Plus size={16} className="text-cyan" />}
+              expanded={expandedSteps[1]}
+              onToggle={() => toggleStep(1)}
+            />
             {expandedSteps[1] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('slackConfig.step1Description')}</p>
@@ -234,6 +200,8 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
               title={t('slackConfig.step2Title')}
               icon={<Shield size={16} className="text-cyan" />}
               completed={botToken.startsWith('xoxb-')}
+              expanded={expandedSteps[2]}
+              onToggle={() => toggleStep(2)}
             />
             {expandedSteps[2] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
@@ -271,6 +239,8 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
               title={t('slackConfig.step3Title')}
               icon={<Lock size={16} className="text-cyan" />}
               completed={appToken.startsWith('xapp-')}
+              expanded={expandedSteps[3]}
+              onToggle={() => toggleStep(3)}
             />
             {expandedSteps[3] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
@@ -312,6 +282,8 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
               title={t('slackConfig.step4Title')}
               icon={<Hash size={16} className="text-cyan" />}
               completed={!!authResult?.ok}
+              expanded={expandedSteps[4]}
+              onToggle={() => toggleStep(4)}
             />
             {expandedSteps[4] && (
               <div className="space-y-4 border-t border-border px-5 py-4">

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -3,8 +3,6 @@ import {
   ArrowLeft,
   ArrowRight,
   Check,
-  ChevronDown,
-  ChevronUp,
   Copy,
   ExternalLink,
   KeyRound,
@@ -21,6 +19,7 @@ import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
+import { StepHeader, StepShell } from '../shared/WizardStep';
 
 interface TelegramConfigProps {
   data: any;
@@ -101,47 +100,6 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
     setExpandedSteps((prev) => ({ ...prev, [step]: !prev[step] }));
   };
 
-  const StepHeader: React.FC<{ step: number; title: string; icon: React.ReactNode; completed?: boolean }> = ({
-    step,
-    title,
-    icon,
-    completed,
-  }) => (
-    <button
-      onClick={() => toggleStep(step)}
-      className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.02]"
-    >
-      <div className="flex items-center gap-3">
-        <span
-          className={clsx(
-            'flex size-7 items-center justify-center rounded-full text-[12px] font-bold transition-colors',
-            completed ? 'bg-mint text-[#080812]' : 'bg-cyan/15 text-cyan'
-          )}
-        >
-          {completed ? <Check size={14} /> : step}
-        </span>
-        <span className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
-          {icon}
-          {title}
-        </span>
-      </div>
-      {expandedSteps[step] ? <ChevronUp size={18} className="text-muted" /> : <ChevronDown size={18} className="text-muted" />}
-    </button>
-  );
-
-  const StepShell: React.FC<{ active: boolean; children: React.ReactNode }> = ({ active, children }) => (
-    <div
-      className={clsx(
-        'overflow-hidden rounded-xl border transition-colors',
-        active
-          ? 'border-mint/35 bg-surface-2 shadow-[0_8px_32px_-8px_rgba(91,255,160,0.078)]'
-          : 'border-border bg-background'
-      )}
-    >
-      {children}
-    </div>
-  );
-
   const completedCount = [
     Boolean(botToken),
     isValid,
@@ -197,6 +155,8 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               step={1}
               title={t('telegramConfig.step1Title')}
               icon={<MessageSquare size={16} className="text-cyan" />}
+              expanded={expandedSteps[1]}
+              onToggle={() => toggleStep(1)}
             />
             {expandedSteps[1] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
@@ -237,6 +197,8 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               title={t('telegramConfig.step2Title')}
               icon={<KeyRound size={16} className="text-cyan" />}
               completed={isValid}
+              expanded={expandedSteps[2]}
+              onToggle={() => toggleStep(2)}
             />
             {expandedSteps[2] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
@@ -304,6 +266,8 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               step={3}
               title={t('telegramConfig.step3Title')}
               icon={<Shield size={16} className="text-cyan" />}
+              expanded={expandedSteps[3]}
+              onToggle={() => toggleStep(3)}
             />
             {expandedSteps[3] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
@@ -354,6 +318,8 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               step={4}
               title={t('telegramConfig.step4Title')}
               icon={<ExternalLink size={16} className="text-cyan" />}
+              expanded={expandedSteps[4]}
+              onToggle={() => toggleStep(4)}
             />
             {expandedSteps[4] && (
               <div className="space-y-4 border-t border-border px-5 py-4">
@@ -377,6 +343,8 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               step={5}
               title={t('telegramConfig.step5Title')}
               icon={<Settings2 size={16} className="text-cyan" />}
+              expanded={expandedSteps[5]}
+              onToggle={() => toggleStep(5)}
             />
             {expandedSteps[5] && (
               <div className="space-y-3 border-t border-border px-5 py-4">


### PR DESCRIPTION
## Summary

Fixes a bug reported on PR #254's new `ProxyUrlField`:
- Field auto-collapsed seconds after expanding it.
- Input lost focus on every keystroke.

## Root cause

Four platform configs (`SlackConfig`, `DiscordConfig`, `TelegramConfig`, `LarkConfig`) defined `StepHeader` and `StepShell` **inside** their parent component body. Every parent re-render produced new function references; React's reconciler treated them as different component types and unmounted/remounted the entire subtree.

Consequences for any child with internal state or an editable input:
- `ProxyUrlField`'s `useState(expanded)` reset → auto-collapse.
- `<input>` DOM node was destroyed and recreated → focus lost.

The bug existed before but went unnoticed because Slack/Discord/Lark/Telegram tokens are typically **pasted** (single value commit). The new collapsible proxy field, with internal state plus a typed input, exposed it.

## Fix

- Hoist `StepHeader` and `StepShell` to `ui/src/components/shared/WizardStep.tsx`.
- Pass `expanded` and `onToggle` as explicit props instead of relying on closure access to `expandedSteps` / `toggleStep`.
- Apply across all four platform configs.
- Also hoist `LinkButton` in `LarkConfig` (same anti-pattern, no functional bug today, but eliminates the trap).
- Net diff: ~150 added (mostly the new shared file + new prop wiring), ~190 removed (dedup).

## Test plan

- [ ] `npm run build` clean (verified locally).
- [ ] Manual: open any platform config wizard; expand the proxy field; confirm it stays expanded and the input keeps focus while typing.
- [ ] Manual: confirm step accordions still toggle correctly across all four platforms.