### PR TITLE
feat(remote-access): slide tunnel session cookie at half-TTL

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -47,6 +47,34 @@ def test_session_cookie_rejects_empty_session_secret() -> None:
     assert remote_access.validate_session_cookie(config, "payload.signature") is False
 
 
+def test_parse_session_cookie_returns_payload_for_fresh_token() -> None:
+    config = _config()
+    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+
+    payload = remote_access.parse_session_cookie(config, cookie)
+
+    assert payload is not None
+    assert payload["email"] == "alex@example.com"
+    assert payload["sub"] == "user-1"
+    assert payload["instance_id"] == "inst_123"
+
+
+def test_parse_session_cookie_rejects_tampered_signature() -> None:
+    config = _config()
+    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+
+    assert remote_access.parse_session_cookie(config, cookie + "x") is None
+
+
+def test_session_needs_renewal_only_after_half_ttl() -> None:
+    now = 1_700_000_000
+    fresh = {"exp": now + remote_access.SESSION_TTL_SECONDS}
+    half_minus_one = {"exp": now + remote_access.SESSION_TTL_SECONDS // 2 - 1}
+
+    assert remote_access.session_needs_renewal(fresh, now=now) is False
+    assert remote_access.session_needs_renewal(half_minus_one, now=now) is True
+
+
 def test_make_session_cookie_requires_session_secret() -> None:
     config = _config()
     config.remote_access.vibe_cloud.session_secret = ""

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -293,6 +293,67 @@ def test_remote_host_allows_valid_remote_session(monkeypatch, tmp_path):
     assert response.status_code != 302
 
 
+def _forged_session_cookie(config: V2Config, exp: int, *, email: str = "alex@example.com", subject: str = "user-1") -> str:
+    import json
+    import urllib.parse
+
+    cloud = config.remote_access.vibe_cloud
+    payload = {
+        "email": email,
+        "sub": subject,
+        "instance_id": cloud.instance_id,
+        "iat": exp - remote_access.SESSION_TTL_SECONDS,
+        "exp": exp,
+    }
+    payload_text = urllib.parse.quote(json.dumps(payload, separators=(",", ":")), safe="")
+    signature = remote_access._session_signature(cloud.session_secret, payload_text)
+    return f"{payload_text}.{signature}"
+
+
+def test_remote_host_does_not_renew_fresh_cookie(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        domain="alex.avibe.bot",
+    )
+
+    response = client.get("/dashboard", base_url="https://alex.avibe.bot", follow_redirects=False)
+
+    set_cookie_headers = response.headers.getlist("Set-Cookie")
+    assert not any(h.startswith(f"{remote_access.SESSION_COOKIE_NAME}=") for h in set_cookie_headers)
+
+
+def test_remote_host_renews_cookie_past_half_ttl(monkeypatch, tmp_path):
+    import time as _time
+
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    near_exp = int(_time.time()) + (remote_access.SESSION_TTL_SECONDS // 2) - 60
+    cookie = _forged_session_cookie(config, near_exp)
+    client = app.test_client()
+    client.set_cookie(remote_access.SESSION_COOKIE_NAME, cookie, domain="alex.avibe.bot")
+
+    response = client.get("/dashboard", base_url="https://alex.avibe.bot", follow_redirects=False)
+
+    refreshed = next(
+        (h for h in response.headers.getlist("Set-Cookie") if h.startswith(f"{remote_access.SESSION_COOKIE_NAME}=")),
+        None,
+    )
+    assert refreshed is not None
+    assert "HttpOnly" in refreshed
+    assert "Secure" in refreshed
+    new_value = refreshed.split(";", 1)[0].split("=", 1)[1]
+    assert new_value != cookie
+    payload = remote_access.parse_session_cookie(config, new_value)
+    assert payload is not None
+    assert payload["email"] == "alex@example.com"
+    assert payload["sub"] == "user-1"
+    assert payload["exp"] > near_exp
+
+
 def test_remote_host_fails_closed_when_config_load_fails(monkeypatch):
     def fail_load():
         raise ValueError("corrupt config")

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -34,7 +34,7 @@ from vibe import api, runtime
 
 CLOUDFLARED_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/latest/download"
 SESSION_COOKIE_NAME = "__Host-vibe_remote_session"
-SESSION_TTL_SECONDS = 12 * 60 * 60
+SESSION_TTL_SECONDS = 24 * 60 * 60
 _CONNECTOR_LOCK = threading.RLock()
 _STATUS_HEARTBEAT_LOCK = threading.Lock()
 _STATUS_HEARTBEAT_STARTED = False

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -708,21 +708,40 @@ def make_session_cookie(config: V2Config, email: str, subject: str) -> str:
     return f"{payload_text}.{signature}"
 
 
-def validate_session_cookie(config: V2Config, cookie_value: str | None) -> bool:
+def parse_session_cookie(config: V2Config, cookie_value: str | None) -> dict[str, Any] | None:
     if not cookie_value or "." not in cookie_value:
-        return False
+        return None
     cloud = config.remote_access.vibe_cloud
     if not cloud.session_secret:
-        return False
+        return None
     payload_text, signature = cookie_value.rsplit(".", 1)
     expected = _session_signature(cloud.session_secret, payload_text)
     if not hmac.compare_digest(signature, expected):
-        return False
+        return None
     try:
         payload = json.loads(urllib.parse.unquote(payload_text))
     except Exception:
-        return False
-    return payload.get("instance_id") == cloud.instance_id and int(payload.get("exp", 0)) > int(time.time())
+        return None
+    if payload.get("instance_id") != cloud.instance_id:
+        return None
+    if int(payload.get("exp", 0)) <= int(time.time()):
+        return None
+    return payload
+
+
+def validate_session_cookie(config: V2Config, cookie_value: str | None) -> bool:
+    return parse_session_cookie(config, cookie_value) is not None
+
+
+def session_needs_renewal(payload: dict[str, Any], now: int | None = None) -> bool:
+    """Return True when the session has spent more than half of SESSION_TTL_SECONDS.
+
+    Mirrors the avibe-bot-backend control-plane sliding-session policy
+    (middleware.ts): re-sign the cookie once the remaining lifetime drops
+    below half so users don't get bounced through OAuth on every visit.
+    """
+    current = now if now is not None else int(time.time())
+    return int(payload.get("exp", 0)) - current < SESSION_TTL_SECONDS // 2
 
 
 def authorization_url(config: V2Config, state: str, nonce: str, code_challenge: str) -> str:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -17,7 +17,7 @@ from typing import Any
 from urllib.parse import quote, unquote, urlparse, urlsplit, urlunsplit
 
 import psutil
-from flask import Flask, request, jsonify, redirect, send_file, Response
+from flask import Flask, g, request, jsonify, redirect, send_file, Response
 
 from config import paths
 from config.v2_config import CONFIG_LOCK, V2Config
@@ -686,7 +686,10 @@ def enforce_remote_access_cookie():
         return jsonify({"ok": False, "error": "remote_access_disabled"}), 503
     if not config.remote_access.vibe_cloud.session_secret:
         return jsonify({"ok": False, "error": "remote_access_session_secret_missing"}), 503
-    if remote_access.validate_session_cookie(config, request.cookies.get(remote_access.SESSION_COOKIE_NAME)):
+    payload = remote_access.parse_session_cookie(config, request.cookies.get(remote_access.SESSION_COOKIE_NAME))
+    if payload is not None:
+        if remote_access.session_needs_renewal(payload):
+            g.remote_session_renew = (str(payload.get("email", "")), str(payload.get("sub", "")))
         return None
     if request.method == "GET":
         return _redirect_to_vibe_cloud_login(config)
@@ -718,6 +721,29 @@ def protect_mutating_ui_requests():
 @app.after_request
 def add_csrf_cookie(response: Response) -> Response:
     return _ensure_csrf_cookie(response)
+
+
+@app.after_request
+def renew_remote_access_cookie(response: Response) -> Response:
+    renew = getattr(g, "remote_session_renew", None)
+    if not renew:
+        return response
+    config = _load_remote_access_config()
+    if config is None or not config.remote_access.vibe_cloud.session_secret:
+        return response
+    from vibe import remote_access
+
+    email, subject = renew
+    response.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_access.make_session_cookie(config, email, subject),
+        httponly=True,
+        secure=True,
+        samesite="Lax",
+        path="/",
+        max_age=remote_access.SESSION_TTL_SECONDS,
+    )
+    return response
 
 
 def _read_log_entries(log_path: Path, source_key: str, lines: int) -> tuple[list[dict[str, Any]], int]:


### PR DESCRIPTION
## Summary
- Tunnel cookie (`__Host-vibe_remote_session`) was a 12-hour fixed-expiry token. Once it expired, every request bounced the user through avibe.bot OAuth, even mid-session.
- Mirror the avibe-bot-backend control-plane policy: re-sign the cookie whenever its remaining lifetime drops below half of `SESSION_TTL_SECONDS`.
- Active users now stay signed in indefinitely; idle sessions still expire after the full 12 hours.

## Changes
- `vibe/remote_access.py`: add `parse_session_cookie` (returns the payload) and `session_needs_renewal` (now > exp − TTL/2). `validate_session_cookie` is preserved as a thin wrapper.
- `vibe/ui_server.py`: `before_request` hook flags `g.remote_session_renew` when renewal is due; new `after_request` hook re-issues the cookie with the same Host-only / HttpOnly / Secure / SameSite=Lax attributes.
- Tests: unit coverage for `parse_session_cookie` + `session_needs_renewal`, plus integration tests confirming fresh cookies are not refreshed and near-expiry cookies do receive a refreshed `Set-Cookie`.

## Test plan
- [x] `pytest tests/test_remote_access_vibe_cloud.py tests/test_ui_remote_access_auth.py` (120 passed)
- [x] `ruff check` on changed files
- [ ] Codex review pass