### PR TITLE
fix(scheduled-tasks): supervise watch_store coroutine and respawn on death

### DIFF
--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -473,6 +473,7 @@ class ScheduledTaskService:
         self._reconcile_task: Optional[asyncio.Task] = None
         self._job_signatures: Dict[str, tuple[Any, ...]] = {}
         self._running = False
+        self._watch_store_restart_count = 0
         self.request_store.recover_processing()
 
     def validate_platform(self, platform: str) -> None:
@@ -484,11 +485,33 @@ class ScheduledTaskService:
             return
         self.scheduler.start()
         self._running = True
-        self._reconcile_task = asyncio.create_task(self._watch_store())
+        self._spawn_watch_store()
         try:
             self.reconcile_jobs()
         except Exception as exc:
             logger.error("Initial scheduled task reconcile failed: %s", exc, exc_info=True)
+
+    def _spawn_watch_store(self) -> None:
+        self._reconcile_task = asyncio.create_task(self._watch_store())
+        self._reconcile_task.add_done_callback(self._on_watch_store_done)
+
+    def _on_watch_store_done(self, task: "asyncio.Task[Any]") -> None:
+        # Only respawn if the service is still meant to be running. During
+        # stop() we deliberately cancel the task and clear _running first.
+        if not self._running:
+            return
+        if task.cancelled():
+            cause: Any = "CancelledError"
+        else:
+            cause = task.exception()
+        self._watch_store_restart_count += 1
+        logger.error(
+            "Scheduled task watch store exited unexpectedly "
+            "(restart_count=%d, cause=%r); respawning",
+            self._watch_store_restart_count,
+            cause,
+        )
+        self._spawn_watch_store()
 
     async def stop(self) -> None:
         self._running = False
@@ -507,11 +530,15 @@ class ScheduledTaskService:
                 if self.store.maybe_reload():
                     self.reconcile_jobs()
                 await self._drain_requests()
+                await asyncio.sleep(2)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 logger.error("Scheduled task store watch failed: %s", exc, exc_info=True)
-            await asyncio.sleep(2)
+                try:
+                    await asyncio.sleep(2)
+                except asyncio.CancelledError:
+                    raise
 
     def reconcile_jobs(self) -> None:
         desired_ids = set()

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -580,5 +580,97 @@ def test_start_keeps_watcher_alive_after_initial_reconcile_failure(tmp_path: Pat
             await service._reconcile_task
         except asyncio.CancelledError:
             pass
+        await service.stop()
+
+    asyncio.run(_exercise())
+
+
+def test_watch_store_respawns_after_unexpected_cancellation(tmp_path: Path) -> None:
+    """A spurious CancelledError must not silently kill the drain loop."""
+    store = ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    controller = SimpleNamespace(platform_settings_managers={})
+    service = ScheduledTaskService(controller=controller, store=store)
+    service.scheduler = _StubScheduler()
+
+    started = asyncio.Event()
+
+    async def _watch_store():
+        started.set()
+        await asyncio.Event().wait()
+
+    service._watch_store = _watch_store  # type: ignore[method-assign]
+
+    async def _exercise():
+        service.start()
+        first_task = service._reconcile_task
+        assert first_task is not None
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        started.clear()
+        first_task.cancel()
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if service._reconcile_task is not None and service._reconcile_task is not first_task:
+                break
+        assert service._reconcile_task is not None
+        assert service._reconcile_task is not first_task
+        assert service._watch_store_restart_count == 1
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await service.stop()
+
+    asyncio.run(_exercise())
+
+
+def test_watch_store_respawns_after_unexpected_exception(tmp_path: Path) -> None:
+    """If the watch coroutine crashes with a non-Cancelled exception it must respawn."""
+    store = ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    controller = SimpleNamespace(platform_settings_managers={})
+    service = ScheduledTaskService(controller=controller, store=store)
+    service.scheduler = _StubScheduler()
+
+    invocations: list[int] = []
+
+    async def _watch_store():
+        invocations.append(1)
+        if len(invocations) == 1:
+            raise RuntimeError("boom")
+        await asyncio.Event().wait()
+
+    service._watch_store = _watch_store  # type: ignore[method-assign]
+
+    async def _exercise():
+        service.start()
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if len(invocations) >= 2:
+                break
+        assert len(invocations) >= 2
+        assert service._watch_store_restart_count == 1
+        await service.stop()
+
+    asyncio.run(_exercise())
+
+
+def test_watch_store_does_not_respawn_after_stop(tmp_path: Path) -> None:
+    """stop() cancels the task and must not trigger a respawn."""
+    store = ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    controller = SimpleNamespace(platform_settings_managers={})
+    service = ScheduledTaskService(controller=controller, store=store)
+    service.scheduler = _StubScheduler()
+
+    async def _watch_store():
+        await asyncio.Event().wait()
+
+    service._watch_store = _watch_store  # type: ignore[method-assign]
+
+    async def _exercise():
+        service.start()
+        first_task = service._reconcile_task
+        assert first_task is not None
+        await service.stop()
+        assert service._reconcile_task is None
+        assert service._watch_store_restart_count == 0
+        assert first_task.cancelled() or first_task.done()
 
     asyncio.run(_exercise())


### PR DESCRIPTION
## Summary

The drain loop (`_watch_store` in `core/scheduled_tasks.py`) was created
via `asyncio.create_task` with no done-callback, so a single
`CancelledError` or unexpected exception would silently kill it for the
lifetime of the service. Once dead, `hook_send` requests pile up under
`~/.vibe_remote/state/task_requests/pending/` and never get delivered,
even though APScheduler keeps firing watches and the vibe service keeps
running.

Changed capability: scheduled-task drain-loop supervision. Behavior
under normal operation is unchanged.

## What changes

- `core/scheduled_tasks.py`
  - New `_spawn_watch_store()` helper plus `_on_watch_store_done()`
    callback. If `_running` is still `True` when the task completes,
    log the cause (cancellation or exception) and respawn it. A
    `_watch_store_restart_count` counter is exposed for observability.
  - The trailing `await asyncio.sleep(2)` is moved inside the try block
    in `_watch_store` so a cancellation that lands during the sleep is
    caught by the same except clauses instead of escaping the loop.
    The error path gets its own protected sleep so we do not busy-loop
    on persistent failures.
  - `stop()` semantics are preserved: it clears `_running` *before*
    cancelling the task, so the done-callback skips respawn.

- `tests/test_scheduled_tasks.py`
  - Existing
    `test_start_keeps_watcher_alive_after_initial_reconcile_failure`
    now also calls `service.stop()` at the end so the new
    auto-respawn does not leak a pending task across the run.
  - New: `test_watch_store_respawns_after_unexpected_cancellation`
    asserts a fresh task is created and the restart counter increments.
  - New: `test_watch_store_respawns_after_unexpected_exception` covers
    the non-Cancelled exception path.
  - New: `test_watch_store_does_not_respawn_after_stop` asserts
    `stop()` cancels the task without triggering respawn.

## Why this matters

Observed today: watches for PR #7 r1/r2/r3 and PR #256 fired and wrote
pending `hook_send` files at 08:31, 11:50, 13:18, 14:04 local on
2026-05-07, but the last successful drain was 02:18 the previous night.
The vibe service was still healthy (`vibe status` reported running,
APScheduler was still triggering jobs); the watch coroutine had simply
died and never been resurrected.

## Evidence layers

- Unit: 4 unit tests (1 updated, 3 new) cover the supervisor behavior:
  cancellation, exception, no-respawn-after-stop, and the existing
  initial-reconcile-failure case.
- Contract: existing contract on `start()` / `stop()` /
  `_watch_store()` is unchanged from the caller's point of view.
- Scenario: no scenario catalog entry; this is internal supervisor
  plumbing not directly user-visible.
- Manual: full file ran with `uv run pytest tests/test_scheduled_tasks.py`
  (27 passed) and `uv run ruff check` on the changed files.

## Test plan

- [x] `uv run pytest tests/test_scheduled_tasks.py -x -q` passes (27 passed)
- [x] `uv run ruff check core/scheduled_tasks.py tests/test_scheduled_tasks.py` clean
- [ ] After merge: confirm a watch can be cancelled mid-flight and a
  follow-up watch still drains (i.e. drain loop survives at least one
  cancellation event).