### PR TITLE
fix(remote-access): skip cookie renewal on rejected requests

### DIFF
--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -354,6 +354,36 @@ def test_remote_host_renews_cookie_past_half_ttl(monkeypatch, tmp_path):
     assert payload["exp"] > near_exp
 
 
+def test_remote_host_does_not_renew_cookie_on_rejected_post(monkeypatch, tmp_path):
+    """A near-expiry cookie must NOT be slid by a request that later fails
+    a guard like CSRF/origin. Otherwise repeated rejected mutations could
+    keep a stolen session alive indefinitely."""
+    import time as _time
+
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    near_exp = int(_time.time()) + (remote_access.SESSION_TTL_SECONDS // 2) - 60
+    cookie = _forged_session_cookie(config, near_exp)
+    client = app.test_client()
+    client.set_cookie(remote_access.SESSION_COOKIE_NAME, cookie, domain="alex.avibe.bot")
+
+    # POST /config without CSRF/origin headers — protect_mutating_ui_requests
+    # will reject this with 403 inside the same request lifecycle that already
+    # set g.remote_session_renew in enforce_remote_access_cookie.
+    response = client.post(
+        "/config",
+        json={"remote_access": {"vibe_cloud": {"enabled": False}}},
+        base_url="https://alex.avibe.bot",
+    )
+
+    assert response.status_code == 403
+    refreshed = next(
+        (h for h in response.headers.getlist("Set-Cookie") if h.startswith(f"{remote_access.SESSION_COOKIE_NAME}=")),
+        None,
+    )
+    assert refreshed is None
+
+
 def test_remote_host_fails_closed_when_config_load_fails(monkeypatch):
     def fail_load():
         raise ValueError("corrupt config")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -728,6 +728,15 @@ def renew_remote_access_cookie(response: Response) -> Response:
     renew = getattr(g, "remote_session_renew", None)
     if not renew:
         return response
+    # Only slide the session cookie when the request was actually accepted.
+    # The renew flag is set in the early `enforce_remote_access_cookie`
+    # before-request hook, but later guards (e.g. CSRF/origin checks in
+    # `protect_mutating_ui_requests`) may still reject the request. Refreshing
+    # the cookie on a rejected response would let repeated failed mutations
+    # keep a stolen session alive indefinitely without any successful
+    # authenticated action.
+    if response.status_code >= 400:
+        return response
     config = _load_remote_access_config()
     if config is None or not config.remote_access.vibe_cloud.session_secret:
         return response


### PR DESCRIPTION
## Summary

Follow-up to merged PR #256. Codex flagged a P2 in
`vibe/ui_server.py` after merge: the renew flag is set in
`enforce_remote_access_cookie` (early before-request) before later
guards run, so a near-expiry cookie is still slid even when the
request is rejected by `protect_mutating_ui_requests` (CSRF / origin).
Because `renew_remote_access_cookie` runs in `after_request`, repeated
failed mutations could keep a stolen cookie alive without any
successful authenticated action.

Changed capability: remote-access session cookie renewal. Behavior on
the success path is unchanged.

## What changes

- `vibe/ui_server.py`
  - `renew_remote_access_cookie` now early-returns when
    `response.status_code >= 400`. Successful responses (2xx and
    redirects) still slide the cookie as before.
- `tests/test_ui_remote_access_auth.py`
  - New: `test_remote_host_does_not_renew_cookie_on_rejected_post`
    forges a near-half-TTL cookie and sends a CSRF-less POST; asserts
    `status_code == 403` and no `Set-Cookie` for the session cookie.
  - Existing `test_remote_host_renews_cookie_past_half_ttl` continues
    to cover the renew-on-success case.

## Why this matters

Without this guard, an attacker holding a stolen cookie could keep
extending its lifetime by sending POSTs that fail CSRF/origin checks
indefinitely — they never need to make a successful authenticated
action. P2 because triggering it requires already having a valid
cookie, but the keep-alive primitive amplifies any single cookie
exfiltration into a long-lived foothold.

## Evidence layers

- Unit: 1 new test case in `test_ui_remote_access_auth.py`; full
  file passes (63 tests).
- Contract: `renew_remote_access_cookie` semantics now explicitly
  bounded to non-error responses; documented in code comment.
- Scenario: no scenario-catalog entry — this is a follow-up security
  fix to existing behavior.
- Manual: `uv run pytest tests/test_ui_remote_access_auth.py` (63
  passed) and `uv run ruff check vibe/ui_server.py
  tests/test_ui_remote_access_auth.py` clean.

## Test plan

- [x] `uv run pytest tests/test_ui_remote_access_auth.py -x -q` (63 passed)
- [x] `uv run ruff check vibe/ui_server.py tests/test_ui_remote_access_auth.py` clean
- [ ] After merge: confirm dashboard GET on a near-expiry cookie still
  reissues (manual sanity check).