### PR TITLE
fix(ui): sidebar popup z-stacking and language listbox alignment

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -101,7 +101,7 @@ export const AppShell: React.FC = () => {
 
   return (
     <div className="min-h-screen min-h-[100dvh] bg-background text-foreground">
-      <aside className="fixed inset-y-0 left-0 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
+      <aside className="fixed inset-y-0 left-0 z-30 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
         <div className="flex h-full flex-col justify-between gap-6 px-4 py-5">
           {/* Top: Brand + Workspace label + Nav list */}
           <div className="flex flex-col gap-6">

--- a/ui/src/components/LanguageSwitcher.tsx
+++ b/ui/src/components/LanguageSwitcher.tsx
@@ -78,8 +78,8 @@ export const LanguageSwitcher: React.FC<{ openUpward?: boolean }> = ({ openUpwar
         <div
           role="listbox"
           className={clsx(
-            'absolute right-0 z-50 min-w-[10rem] rounded-lg border border-border bg-popover py-1 text-popover-foreground shadow-xl',
-            openUpward ? 'bottom-full mb-2' : 'top-full mt-2'
+            'absolute z-50 min-w-[10rem] rounded-lg border border-border bg-popover py-1 text-popover-foreground shadow-xl',
+            openUpward ? 'bottom-full left-0 mb-2' : 'top-full right-0 mt-2'
           )}
         >
           {languages.map((lang) => {


### PR DESCRIPTION
## Summary

Two user-reported UI bugs in the desktop sidebar (visible on `/groups`, but the sidebar appears on every page):

1. **Version popup z-stacking**: clicking the version badge opens a popup that was being painted behind the channel-row toggle switches in the main content.
2. **Language listbox alignment**: clicking the "中" language switcher rendered the listbox right-aligned, so it extended off the left edge of the viewport and was nearly invisible.

## Root cause

- The desktop `<aside>` is `position: fixed` without an explicit `z-index`. Its stacking context is z=auto, while `<main>`'s positioned descendants (toggle switches, etc.) paint later in tree order at the same level — so even z-50 popups inside the sidebar get covered.
- `LanguageSwitcher` used `right-0` unconditionally, which works for the mobile header (trigger on the right) but breaks for the desktop sidebar (trigger on the left).

## Changes

- `ui/src/components/AppShell.tsx`: add `z-30` to the desktop sidebar so its stacking context paints above main content's positioned descendants. Sits below the mobile-only header (z-40) and bottom nav (z-50), which never coexist with the desktop sidebar.
- `ui/src/components/LanguageSwitcher.tsx`: when `openUpward` is true (sidebar context, trigger on the left), use `left-0`; otherwise keep `right-0` for the mobile header.

## Evidence

- **Unit / contract / scenario**: not applicable — CSS-only stacking and alignment fix; no scenario catalog covers sidebar UI visuals (`tests/scenarios/` only tracks `auth_setup` and `message_delivery`).
- **Manual visual check**: reproduced both bugs at 1428x902 in Chrome against running `vibe` service, then re-verified after copying the rebuilt `ui/dist` over the served assets. Version popup correctly overlays the channel toggles, and the language listbox is fully visible above the trigger.

## Test plan

- [ ] On desktop, click the version badge in the sidebar status box — popup should sit above any group-row toggle switches it overlaps.
- [ ] On desktop, click the "中" language switcher — listbox should appear above the trigger and stay fully on-screen.
- [ ] On mobile, open the language switcher in the top-right header — listbox should still right-align so it stays inside the viewport.