### PR TITLE
docs: promote avibe.bot/install.sh as the canonical install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ AI works. You live.
 ## Install in 10 Seconds
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash && vibe
+curl -fsSL https://avibe.bot/install.sh | bash && vibe
 ```
 
 That's it. Browser opens -> Follow the wizard -> Done.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -53,7 +53,7 @@
 ## 10 秒安装
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash && vibe
+curl -fsSL https://avibe.bot/install.sh | bash && vibe
 ```
 
 完事。浏览器打开 -> 跟着向导走 -> 搞定。

--- a/docs/INSTALL_FOR_AI.md
+++ b/docs/INSTALL_FOR_AI.md
@@ -34,7 +34,7 @@ On Windows, prefer the WSL guide unless the user explicitly wants native PowerSh
 macOS / Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash
+curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
 Windows PowerShell:

--- a/docs/INSTALL_FOR_AI_ZH.md
+++ b/docs/INSTALL_FOR_AI_ZH.md
@@ -34,7 +34,7 @@ Windows 用户默认推荐 WSL：
 macOS / Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash
+curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
 Windows PowerShell：

--- a/docs/WINDOWS_WSL.md
+++ b/docs/WINDOWS_WSL.md
@@ -185,7 +185,7 @@ Now you are in the right place.
 In the `Ubuntu terminal`, run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash
+curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
 After installation finishes, still in the same Ubuntu terminal, run:

--- a/docs/WINDOWS_WSL_ZH.md
+++ b/docs/WINDOWS_WSL_ZH.md
@@ -187,7 +187,7 @@ cd ~/work
 就在 `Ubuntu 终端` 里执行：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash
+curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
 安装完成后，继续在同一个 Ubuntu 终端里执行：

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Vibe Remote Installation Script
-# Usage: curl -fsSL https://raw.githubusercontent.com/cyhhao/vibe-remote/master/install.sh | bash
+# Usage: curl -fsSL https://avibe.bot/install.sh | bash
 #
 # Prerequisites: None! uv will be installed automatically and manages Python for you.
 


### PR DESCRIPTION
## Summary
- 安装命令统一改用品牌化的短链：
  \`\`\`
  curl -fsSL https://avibe.bot/install.sh | bash
  \`\`\`
- 后端在 [vibe-remote-backend#12](https://github.com/cyhhao/vibe-remote-backend/pull/12) 加了 \`/install.sh\` 的 307 重定向，目标就是本仓库 master 的 \`install.sh\`，所以行为完全一致。

## Files
- \`README.md\` / \`README_ZH.md\`
- \`install.sh\`（顶部 \`# Usage\` 注释）
- \`docs/INSTALL_FOR_AI.md\` / \`_ZH.md\`
- \`docs/WINDOWS_WSL.md\` / \`_ZH.md\`

## Out of scope
- \`install.ps1\`（Windows PowerShell）保留 GitHub raw URL，等需要时再加 \`/install.ps1\` 重定向

## Test plan
- [ ] 等后端 PR 合并 + 部署后，\`curl -fsSL https://avibe.bot/install.sh | bash\` 能完整跑通安装