### PR TITLE
docs: surface install script source next to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ AI works. You live.
 curl -fsSL https://avibe.bot/install.sh | bash && vibe
 ```
 
+Open source — view the [script on GitHub](https://github.com/cyhhao/vibe-remote/blob/master/install.sh). The short URL is a 307 redirect to that file.
+
 That's it. Browser opens -> Follow the wizard -> Done.
 
 Need to open the Web UI from another device or a remote server? Run:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -56,6 +56,8 @@
 curl -fsSL https://avibe.bot/install.sh | bash && vibe
 ```
 
+开源脚本，源码在 [GitHub](https://github.com/cyhhao/vibe-remote/blob/master/install.sh) 上；该短链只是到这个文件的 307 重定向。
+
 完事。浏览器打开 -> 跟着向导走 -> 搞定。
 
 如果你希望从另一台设备或远端服务器打开 Web UI，运行：

--- a/docs/INSTALL_FOR_AI.md
+++ b/docs/INSTALL_FOR_AI.md
@@ -37,6 +37,8 @@ macOS / Linux:
 curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
+Open source — view the [script on GitHub](https://github.com/cyhhao/vibe-remote/blob/master/install.sh). The short URL is a 307 redirect to that file.
+
 Windows PowerShell:
 
 ```powershell

--- a/docs/INSTALL_FOR_AI_ZH.md
+++ b/docs/INSTALL_FOR_AI_ZH.md
@@ -37,6 +37,8 @@ macOS / Linux：
 curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
+开源脚本，源码在 [GitHub](https://github.com/cyhhao/vibe-remote/blob/master/install.sh) 上；该短链只是到这个文件的 307 重定向。
+
 Windows PowerShell：
 
 ```powershell

--- a/docs/WINDOWS_WSL.md
+++ b/docs/WINDOWS_WSL.md
@@ -188,6 +188,8 @@ In the `Ubuntu terminal`, run:
 curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
+Open source — view the [script on GitHub](https://github.com/cyhhao/vibe-remote/blob/master/install.sh). The short URL is a 307 redirect to that file.
+
 After installation finishes, still in the same Ubuntu terminal, run:
 
 ```bash

--- a/docs/WINDOWS_WSL_ZH.md
+++ b/docs/WINDOWS_WSL_ZH.md
@@ -190,6 +190,8 @@ cd ~/work
 curl -fsSL https://avibe.bot/install.sh | bash
 ```
 
+开源脚本，源码在 [GitHub](https://github.com/cyhhao/vibe-remote/blob/master/install.sh) 上；该短链只是到这个文件的 307 重定向。
+
 安装完成后，继续在同一个 Ubuntu 终端里执行：
 
 ```bash


### PR DESCRIPTION
## Summary

Follow-up to #260, which promoted `https://avibe.bot/install.sh` as the canonical install URL. Switching from a github.com URL to a private-domain short URL creates a small trust gap — users can't tell at a glance that the script is open source.

This PR adds one transparency line under every place we promote the new install command:

> Open source — view the [script on GitHub](https://github.com/cyhhao/vibe-remote/blob/master/install.sh). The short URL is a 307 redirect to that file.

(and the matching Chinese version in `_ZH.md` files.)

Pattern matches what other major OSS installers do (uv, bun, deno, pnpm, rustup): short branded URL primary + source transparency adjacent.

Files touched:
- `README.md` / `README_ZH.md`
- `docs/INSTALL_FOR_AI.md` / `docs/INSTALL_FOR_AI_ZH.md`
- `docs/WINDOWS_WSL.md` / `docs/WINDOWS_WSL_ZH.md`

The matching changes for `docs.avibe.bot` already shipped to `avibe-docs` `main`, including a longer "Audit before running" section on the install page.

## Test plan

- [x] Each install command has the transparency line directly underneath
- [x] EN and ZH copies stay in 1:1 correspondence
- [x] GitHub link points to the actual `install.sh` source