### PR TITLE
fix(claude): auto-approve bypass tool permissions

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import time
+from pathlib import Path
 from typing import Optional, Dict, Any, Tuple
 from uuid import uuid4
 from modules.im import MessageContext
@@ -12,6 +13,7 @@ from modules.claude_sdk_compat import (
     CLAUDE_SDK_MAX_BUFFER_SIZE,
     ClaudeAgentOptions,
     ClaudeSDKClient,
+    PermissionResultAllow,
 )
 from modules.agents.native_sessions.base import build_resume_preview
 
@@ -21,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 CLAUDE_NO_CONVERSATION_RE = re.compile(r"No conversation found with session ID:\s*(\S+)")
 CLAUDE_REMOTE_DISALLOWED_TOOLS = ["AskUserQuestion", "EnterPlanMode", "ExitPlanMode"]
+CLAUDE_REMOTE_PERMISSION_MODE = "bypassPermissions"
 
 
 class ClaudeSessionNotFoundError(RuntimeError):
@@ -244,8 +247,11 @@ class SessionHandler(BaseHandler):
     def _should_force_claude_sandbox(self) -> bool:
         if os.environ.get("IS_SANDBOX"):
             return False
-        permission_mode = getattr(getattr(self.config, "claude", None), "permission_mode", None)
-        return permission_mode == "bypassPermissions" and self._running_as_root()
+        return self._running_as_root()
+
+    async def _allow_claude_bypass_tool(self, tool_name: str, tool_input: Dict[str, Any], context: Any):
+        logger.info("Auto-approving Claude tool permission request in Vibe Remote bypass mode: %s", tool_name)
+        return PermissionResultAllow()
 
     def _get_claude_cli_path_override(self) -> Optional[str]:
         cli_path = getattr(getattr(self.config, "claude", None), "cli_path", None)
@@ -563,7 +569,7 @@ class SessionHandler(BaseHandler):
             logger.info("Detected Claude bypassPermissions running as root; forcing IS_SANDBOX=1 for Claude subprocess")
 
         option_kwargs: Dict[str, Any] = {
-            "permission_mode": self.config.claude.permission_mode,
+            "permission_mode": CLAUDE_REMOTE_PERMISSION_MODE,
             "cwd": working_path,
             "system_prompt": final_system_prompt,
             "resume": stored_claude_session_id if stored_claude_session_id else None,
@@ -575,6 +581,7 @@ class SessionHandler(BaseHandler):
             "env": claude_env,  # Pass Anthropic/Claude env vars
             "stderr": _capture_claude_stderr,
             "max_buffer_size": CLAUDE_SDK_MAX_BUFFER_SIZE,
+            "can_use_tool": self._allow_claude_bypass_tool,
         }
         cli_path_override = self._get_claude_cli_path_override()
         if cli_path_override:

--- a/modules/claude_sdk_compat.py
+++ b/modules/claude_sdk_compat.py
@@ -20,6 +20,7 @@ try:
         AssistantMessage,
         ClaudeAgentOptions,
         ClaudeSDKClient as _ClaudeSDKClient,
+        PermissionResultAllow,
         ResultMessage,
         SystemMessage,
         TextBlock,
@@ -72,6 +73,12 @@ except ModuleNotFoundError:  # pragma: no cover - exercised only in minimal test
 
     class ClaudeSDKClient(_MissingClaudeSDK):
         pass
+
+    class PermissionResultAllow:
+        def __init__(self, behavior="allow", updated_input=None, updated_permissions=None):
+            self.behavior = behavior
+            self.updated_input = updated_input
+            self.updated_permissions = updated_permissions
 
     class SystemMessage:  # minimal placeholders for isinstance checks
         pass

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -188,6 +188,44 @@ def test_session_handler_disallows_remote_unsafe_claude_tools(monkeypatch, tmp_p
     assert captured["options"].disallowed_tools == ["AskUserQuestion", "EnterPlanMode", "ExitPlanMode"]
 
 
+def test_session_handler_forces_bypass_mode_and_auto_approves_claude_tool_permissions(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    controller.config.claude.permission_mode = "default"
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+    result = asyncio.run(captured["options"].can_use_tool("Bash", {"command": "git status"}, object()))
+
+    assert captured["connected"] is True
+    assert captured["options"].permission_mode == "bypassPermissions"
+    assert result.behavior == "allow"
+
+
+def test_session_handler_auto_approves_all_claude_tool_permission_requests(
+    monkeypatch, tmp_path: Path
+) -> None:
+    handler = SessionHandler(_Controller(tmp_path))
+
+    result = asyncio.run(handler._allow_claude_bypass_tool("Bash", {"command": "git status"}, object()))
+
+    assert result.behavior == "allow"
+
+
 def test_session_handler_does_not_repeat_claude_model_control_request(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, Any] = {"clients": []}
 

--- a/tests/test_claude_sdk_compat.py
+++ b/tests/test_claude_sdk_compat.py
@@ -1,11 +1,14 @@
 import asyncio
+import builtins
+import importlib.util
+from pathlib import Path
 
 import pytest
 
 import modules.claude_sdk_compat as compat
 
 
-pytestmark = pytest.mark.skipif(
+requires_claude_sdk = pytest.mark.skipif(
     not compat.CLAUDE_SDK_AVAILABLE,
     reason="claude_agent_sdk is not installed",
 )
@@ -26,6 +29,7 @@ async def _collect_messages(messages):
     return [message async for message in client.receive_messages()]
 
 
+@requires_claude_sdk
 def test_receive_messages_skips_rate_limit_event():
     messages = asyncio.run(
         _collect_messages(
@@ -41,7 +45,33 @@ def test_receive_messages_skips_rate_limit_event():
     assert messages[0].subtype == "init"
 
 
+@requires_claude_sdk
 def test_receive_messages_skips_unknown_types_returning_none():
     messages = asyncio.run(_collect_messages([{"type": "mystery_event"}]))
 
     assert messages == []
+
+
+def test_missing_sdk_permission_allow_fallback_is_non_throwing(monkeypatch):
+    original_import = builtins.__import__
+
+    def _block_claude_sdk(name, *args, **kwargs):
+        if name == "claude_agent_sdk" or name.startswith("claude_agent_sdk."):
+            raise ModuleNotFoundError("claude_agent_sdk")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_claude_sdk)
+    module_path = Path(__file__).resolve().parents[1] / "modules" / "claude_sdk_compat.py"
+    spec = importlib.util.spec_from_file_location("claude_sdk_compat_missing", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    spec.loader.exec_module(module)
+
+    result = module.PermissionResultAllow()
+
+    assert module.CLAUDE_SDK_AVAILABLE is False
+    assert result.behavior == "allow"
+    assert result.updated_input is None
+    assert result.updated_permissions is None


### PR DESCRIPTION
## What

Fixes #263.

Vibe Remote now treats Claude Code remote sessions as a fully headless bypass runtime:
- Always passes `permission_mode="bypassPermissions"` when creating Claude SDK sessions.
- Always attaches a `can_use_tool` callback that returns `PermissionResultAllow()` for every Claude tool permission request.
- Keeps remote-only interactive tools disabled (`AskUserQuestion`, `EnterPlanMode`, `ExitPlanMode`) because IM sessions cannot service those UI flows.

## Why

`bypassPermissions` covers ordinary file edits, but Claude Code can still ask for explicit permission for protected paths such as `.claude/agents/*.md` and `~/.claude/CLAUDE.md`. In an IM/headless runtime there is no permission UI to answer, so the session hangs.

The intended Vibe Remote product behavior is simpler: if the user is running Claude through Vibe Remote, the session is already a remote automation context and should bypass all Claude tool permission prompts. Vibe Remote should not try to replicate Claude Code's managed-settings policy parser or gate this behind an additional Vibe-specific env var.

## Validation

Evidence layers:
- Unit: `tests/test_claude_cli_path.py` verifies Claude sessions are forced to `bypassPermissions`, that the permission callback is attached, and that it allows generic tool permission requests. `tests/test_claude_sdk_compat.py` verifies the no-SDK `PermissionResultAllow` fallback is non-throwing.
- Contract: focused session option construction and SDK compatibility tests cover the SDK option/result surface.
- Scenario: no catalog scenario added; this is a Claude SDK permission callback edge case without an existing scenario ID.
- Manual: prior SDK probes confirmed `can_use_tool -> PermissionResultAllow()` unblocks `.claude/agents/*.md`, while ordinary files already work under `bypassPermissions`.

Checks run:
- `uv run --no-sync pytest tests/test_claude_cli_path.py tests/test_claude_sdk_compat.py -q`
- `uv run --no-sync ruff check core/handlers/session_handler.py modules/claude_sdk_compat.py tests/test_claude_cli_path.py tests/test_claude_sdk_compat.py`

## Risk

This deliberately bypasses Claude Code tool permission prompts for Vibe Remote Claude sessions. That matches the remote automation model, but deployments that need Claude Code's interactive or organization-managed permission gates should not route Claude through Vibe Remote with this backend behavior.
