### PR TITLE
feat(ui): add sign-out flow for remote-access sessions

### DIFF
--- a/ui/src/components/AccountMenu.tsx
+++ b/ui/src/components/AccountMenu.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { LogOut } from 'lucide-react';
+import clsx from 'clsx';
+
+import { useApi } from '../context/ApiContext';
+
+const initialFor = (email: string): string => {
+  const local = email.split('@')[0] || email;
+  const cleaned = local.trim();
+  return cleaned ? cleaned[0]!.toUpperCase() : '?';
+};
+
+export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = false }) => {
+  const { t } = useTranslation();
+  const { getSession, signOut } = useApi();
+  const [email, setEmail] = useState<string | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSession()
+      .then((session) => {
+        if (cancelled) return;
+        if (session.remote && session.authenticated) {
+          setEmail(session.email);
+        } else {
+          setEmail(null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setEmail(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [getSession]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKey);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [isOpen]);
+
+  if (email === null) return null;
+
+  const handleSignOut = async () => {
+    if (signingOut) return;
+    setSigningOut(true);
+    // Always navigate to "/" — even on transient errors. The cookie may already
+    // be expired (in which case the request would 401), so leaving the user
+    // stuck in the dropdown would be worse than letting the OIDC redirect
+    // handle whatever state remains.
+    try {
+      await signOut();
+    } catch {
+      // swallow — we still reload below
+    }
+    window.location.assign('/');
+  };
+
+  const accountLabel = t('appShell.accountMenuLabel', { email });
+
+  return (
+    <div className="relative" ref={wrapRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        aria-label={accountLabel}
+        title={accountLabel}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-cyan/35 bg-cyan/[0.08] text-[11px] font-semibold text-cyan transition hover:bg-cyan/[0.16] hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        {initialFor(email)}
+      </button>
+
+      {isOpen && (
+        <div
+          role="menu"
+          className={clsx(
+            'absolute z-50 min-w-[14rem] rounded-lg border border-border bg-popover py-1 text-popover-foreground shadow-xl',
+            openUpward ? 'bottom-full right-0 mb-2' : 'top-full right-0 mt-2'
+          )}
+        >
+          <div className="px-3 pt-2 text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
+            {t('appShell.signedInAs')}
+          </div>
+          <div className="px-3 pb-2 pt-0.5 text-[13px] font-medium text-foreground break-all">
+            {email}
+          </div>
+          <div className="my-1 border-t border-border" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handleSignOut}
+            disabled={signingOut}
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-muted transition-colors hover:bg-surface-2 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <LogOut className="size-4" />
+            <span>{signingOut ? t('appShell.signingOut') : t('appShell.signOut')}</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { useApi } from '../context/ApiContext';
 import { useStatus } from '../context/StatusContext';
+import { AccountMenu } from './AccountMenu';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { ThemeToggle } from './ThemeToggle';
 import { VersionBadge } from './VersionBadge';
@@ -155,6 +156,7 @@ export const AppShell: React.FC = () => {
             <div className="flex items-center gap-2">
               <LanguageSwitcher openUpward />
               <ThemeToggle />
+              <AccountMenu openUpward />
             </div>
 
             {config?.runtime?.hostname && (
@@ -179,6 +181,7 @@ export const AppShell: React.FC = () => {
           <VersionBadge />
           <LanguageSwitcher />
           <ThemeToggle />
+          <AccountMenu />
         </div>
       </header>
 

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -48,7 +48,14 @@ export type ApiContextType = {
   pairVibeCloudRemoteAccess: (payload: { backend_url: string; pairing_key: string; device_name?: string }) => Promise<any>;
   startRemoteAccess: () => Promise<any>;
   stopRemoteAccess: () => Promise<any>;
+  getSession: () => Promise<SessionInfo>;
+  signOut: () => Promise<{ ok: boolean }>;
 };
+
+export type SessionInfo =
+  | { remote: false }
+  | { remote: true; authenticated: false }
+  | { remote: true; authenticated: true; email: string };
 
 export type LogEntry = {
   timestamp: string;
@@ -193,6 +200,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     pairVibeCloudRemoteAccess: (payload) => postJson('/remote-access/vibe-cloud/pair', payload),
     startRemoteAccess: () => postJson('/remote-access/start', {}),
     stopRemoteAccess: () => postJson('/remote-access/stop', {}),
+    getSession: () => getJson('/api/session'),
+    signOut: () => postJson('/auth/logout', {}),
   };
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -166,7 +166,11 @@
     "workspaceLabel": "Workspace",
     "navigationLabel": "Console",
     "statusLabel": "Service status",
-    "versionLabel": "Version"
+    "versionLabel": "Version",
+    "accountMenuLabel": "Account ({{email}})",
+    "signedInAs": "Signed in as",
+    "signOut": "Sign out",
+    "signingOut": "Signing out…"
   },
   "wizard": {
     "title": "Vibe Remote Setup"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -166,7 +166,11 @@
     "workspaceLabel": "工作区",
     "navigationLabel": "控制台",
     "statusLabel": "服务状态",
-    "versionLabel": "版本"
+    "versionLabel": "版本",
+    "accountMenuLabel": "账户（{{email}}）",
+    "signedInAs": "当前登录账户",
+    "signOut": "退出登录",
+    "signingOut": "正在退出…"
   },
   "wizard": {
     "title": "Vibe Remote 设置向导"

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -584,6 +584,8 @@ def _remote_auth_exempt_path() -> bool:
     return (
         path == "/health"
         or path == "/auth/callback"
+        or path == "/auth/logout"
+        or path == "/api/session"
         or path.startswith("/assets/")
         or path == "/favicon.ico"
     )
@@ -725,6 +727,9 @@ def add_csrf_cookie(response: Response) -> Response:
 
 @app.after_request
 def renew_remote_access_cookie(response: Response) -> Response:
+    # Logout handler explicitly clears the session cookie; never re-issue it.
+    if getattr(g, "remote_session_logout", False):
+        return response
     renew = getattr(g, "remote_session_renew", None)
     if not renew:
         return response
@@ -1078,6 +1083,53 @@ def remote_access_auth_callback():
         max_age=remote_access.SESSION_TTL_SECONDS,
     )
     response.delete_cookie(REMOTE_OAUTH_COOKIE_NAME, path="/", secure=True, samesite="Lax")
+    return response
+
+
+@app.route("/api/session", methods=["GET"])
+def api_session():
+    from vibe import remote_access
+
+    config = _load_remote_access_config()
+    if config is None or not _is_remote_access_request(config):
+        response = jsonify({"remote": False})
+    else:
+        payload = remote_access.parse_session_cookie(
+            config, request.cookies.get(remote_access.SESSION_COOKIE_NAME)
+        )
+        if payload is None:
+            response = jsonify({"remote": True, "authenticated": False})
+        else:
+            response = jsonify(
+                {
+                    "remote": True,
+                    "authenticated": True,
+                    "email": str(payload.get("email", "")),
+                }
+            )
+    # Identity payload must never be cached by intermediaries (Cloudflare etc.).
+    response.headers["Cache-Control"] = "no-store, private"
+    response.headers["Vary"] = "Cookie"
+    return response
+
+
+@app.route("/auth/logout", methods=["POST"])
+def remote_access_logout():
+    from vibe import remote_access
+
+    # Suppress the after-request renewal so we don't re-issue the cookie we're
+    # about to clear; flagged so future hook reorderings stay safe.
+    g.remote_session_renew = None
+    g.remote_session_logout = True
+    response = jsonify({"ok": True})
+    response.delete_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        path="/",
+        secure=True,
+        httponly=True,
+        samesite="Lax",
+    )
+    response.headers["Cache-Control"] = "no-store"
     return response
 
 


### PR DESCRIPTION
## Summary
- Adds an avatar dropdown in the AppShell (desktop sidebar bottom + mobile header) so users on remote-access sessions (Cloudflare Tunnel + avibe.bot OIDC) can drop the local session cookie and switch accounts without clearing browser cookies manually.
- Exposes a small read-only `GET /api/session` so the shell can render the email without leaking identity through caches.
- Adds `POST /auth/logout` that clears `__Host-vibe_remote_session` with the same attributes used at issuance.

## Capability
**Remote-access session lifecycle** — the user-facing piece previously missing was a graceful logout. Adjacent capabilities (OIDC redirect, signed-cookie session, sliding renewal) are unchanged.

## Affected Scenarios
No scenario catalog exists for this flow yet (`tests/scenarios/auth_setup/catalog.yaml` covers OIDC pairing only). Behavior verified manually against the existing test fixtures; a scenario entry can follow once the catalog is extended for in-session identity ops.

## Evidence Layers
- **Unit**: `ruff check vibe/ui_server.py` clean. `npm run build` (UI) clean. Existing pytest suites (`test_ui_remote_access_auth.py`, `test_ui_server_mutation_protection.py`) still pass except `test_config_post_allows_forwarded_origin`, which **fails identically on master** (unrelated to this change — about CSRF endpoint with a forwarded-origin base URL).
- **Contract**: New endpoints follow existing patterns (`/api/session` parallels other `/api/*` JSON endpoints; `/auth/logout` is symmetric with `/auth/login` and `/auth/callback`).
- **Scenario**: pending — see above.
- **Manual**: Cookie clear verified to use `__Host-` compatible attributes (`HttpOnly`, `Secure`, `SameSite=Lax`, `Path=/`, no `Domain`) matching the issuer at `vibe/ui_server.py` (`make_session_cookie` issuance points). Logout is reachable when the cookie has expired (added to `_remote_auth_exempt_path`); CSRF + Origin checks still enforced via `protect_mutating_ui_requests`. Renewal hook short-circuits on `g.remote_session_logout` so sliding renewal cannot race the clear.

## Security Notes
- `/api/session` returns `Cache-Control: no-store, private` and `Vary: Cookie` — no intermediary should cache the email.
- `/auth/logout` is auth-exempt by design (idempotent cookie clear, CSRF still required).
- AccountMenu renders only when `session.remote && session.authenticated`; nothing for local/dev sessions.
- Failed `signOut()` still navigates to `/` so the next request triggers the OIDC redirect (covers expired-cookie case where the request would 401).

## Test plan
- [ ] Pull branch, restart `vibe`, open the Web UI through `https://*.avibe.bot` after OIDC pairing.
- [ ] Verify the avatar appears (desktop sidebar bottom; mobile header) with the signed-in email.
- [ ] Click "Sign out", confirm the user lands on the avibe.bot login page.
- [ ] Sign back in, verify the cookie is re-issued and the dashboard renders.
- [ ] In a local (non-remote) preview, verify the avatar is **not** rendered.
- [ ] Manually expire the cookie (e.g. devtools → delete) and confirm sign-out still resolves into a redirect rather than a stuck 401 toast.