### PR TITLE
fix(storage): skip bad discovered chat imports

### DIFF
--- a/storage/importer.py
+++ b/storage/importer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import tempfile
 from dataclasses import dataclass, field
@@ -28,6 +29,7 @@ from storage.sessions_service import SESSIONS_LAST_ACTIVITY_KEY, SQLiteSessionsS
 from storage.settings_service import SQLiteSettingsService, upsert_scope
 
 JSON_IMPORT_MARKER = "json_import_completed_at"
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -77,13 +79,17 @@ def ensure_sqlite_state(
                 discovered_count = _import_discovered_chats(conn, parsed.discovered)
                 counts = _current_counts(conn)
                 counts["discovered_scopes"] = discovered_count
+                if parsed.discovered_skipped:
+                    counts["discovered_chats_skipped"] = 1
                 _validate_import(conn, counts)
                 _set_import_marker(conn)
                 return MigrationImportReport(
                     db_path=target_db,
                     imported=True,
                     backup_path=backup_path,
-                    counts=_current_counts(conn) | {"discovered_scopes": discovered_count},
+                    counts=_current_counts(conn)
+                    | {"discovered_scopes": discovered_count}
+                    | ({"discovered_chats_skipped": 1} if parsed.discovered_skipped else {}),
                 )
         finally:
             engine.dispose()
@@ -195,13 +201,19 @@ class _ParsedState:
     settings: SettingsState
     sessions: SessionState
     discovered: DiscoveredChatsStore
+    discovered_skipped: bool = False
 
 
 def _parse_json_state(state_dir: Path, *, primary_platform: str | None) -> _ParsedState:
     settings = _load_settings_from_copy(state_dir / "settings.json")
     sessions = _load_sessions_from_copy(state_dir / "sessions.json", primary_platform=primary_platform)
-    discovered = _load_discovered_chats_strict(state_dir / "discovered_chats.json")
-    return _ParsedState(settings=settings, sessions=sessions, discovered=discovered)
+    discovered, discovered_skipped = _load_discovered_chats_for_import(state_dir / "discovered_chats.json")
+    return _ParsedState(
+        settings=settings,
+        sessions=sessions,
+        discovered=discovered,
+        discovered_skipped=discovered_skipped,
+    )
 
 
 def _load_settings_from_copy(source: Path) -> SettingsState:
@@ -223,11 +235,19 @@ def _load_sessions_from_copy(source: Path, *, primary_platform: str | None) -> S
         return state
 
 
-def _load_discovered_chats_strict(source: Path) -> DiscoveredChatsStore:
-    if source.exists():
+def _load_discovered_chats_for_import(source: Path) -> tuple[DiscoveredChatsStore, bool]:
+    if not source.exists():
+        return DiscoveredChatsStore(source), False
+    try:
         payload = json.loads(source.read_text(encoding="utf-8"))
         _validate_discovered_chats_payload(payload)
-    return DiscoveredChatsStore(source)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Skipping discovered_chats.json during SQLite import; settings and sessions will still be migrated: %s",
+            exc,
+        )
+        return DiscoveredChatsStore(source.with_name(f".{source.name}.skipped-for-sqlite-import")), True
+    return DiscoveredChatsStore(source), False
 
 
 def _validate_discovered_chats_payload(payload: Any) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -271,7 +271,7 @@ def test_failed_json_import_does_not_mark_complete_and_can_retry(tmp_path: Path)
     assert report.counts["scope_settings"] == 4
 
 
-def test_invalid_discovered_chats_import_does_not_mark_complete_and_can_retry(tmp_path: Path) -> None:
+def test_invalid_discovered_chats_import_does_not_block_core_state_migration(tmp_path: Path) -> None:
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
@@ -279,23 +279,22 @@ def test_invalid_discovered_chats_import_does_not_mark_complete_and_can_retry(tm
     _write_current_sessions(state_dir / "sessions.json")
     (state_dir / "discovered_chats.json").write_text("{not-json", encoding="utf-8")
 
-    with pytest.raises(json.JSONDecodeError):
-        ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+    report = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
 
     with sqlite3.connect(db_path) as conn:
         marker = conn.execute(
             "select value_json from state_meta where key = 'json_import_completed_at'",
         ).fetchone()
-    assert marker is None
-
-    _write_discovered_chats(state_dir / "discovered_chats.json")
-    report = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
 
     assert report.imported is True
-    assert report.counts["discovered_scopes"] == 1
+    assert marker is not None
+    assert report.counts["scope_settings"] == 4
+    assert report.counts["agent_sessions"] == 1
+    assert report.counts["discovered_scopes"] == 0
+    assert report.counts["discovered_chats_skipped"] == 1
 
 
-def test_malformed_discovered_chats_structure_does_not_mark_complete(tmp_path: Path) -> None:
+def test_malformed_discovered_chats_structure_does_not_block_core_state_migration(tmp_path: Path) -> None:
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
@@ -306,20 +305,19 @@ def test_malformed_discovered_chats_structure_does_not_mark_complete(tmp_path: P
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="platform 'telegram'"):
-        ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+    report = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
 
     with sqlite3.connect(db_path) as conn:
         marker = conn.execute(
             "select value_json from state_meta where key = 'json_import_completed_at'",
         ).fetchone()
-    assert marker is None
-
-    _write_discovered_chats(state_dir / "discovered_chats.json")
-    report = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
 
     assert report.imported is True
-    assert report.counts["discovered_scopes"] == 1
+    assert marker is not None
+    assert report.counts["scope_settings"] == 4
+    assert report.counts["agent_sessions"] == 1
+    assert report.counts["discovered_scopes"] == 0
+    assert report.counts["discovered_chats_skipped"] == 1
 
 
 def test_data_version_probe_detects_external_write(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Treat malformed `discovered_chats.json` as optional observed metadata during SQLite import.
- Keep core `settings.json` and `sessions.json` migration strict while skipping bad discovered-chat data with a warning.
- Update migration tests so malformed discovered-chat payloads no longer block settings/session import completion.

## Validation

- `npm ci` in `ui/`
- `npm run build` in `ui/`
- `uv run pytest tests/test_sqlite_state_migration.py tests/test_sqlite_settings_store.py tests/test_sqlite_sessions_store.py tests/test_sqlite_state_startup.py`
- `uv run ruff check storage/importer.py tests/test_sqlite_state_migration.py`

## Risk

- If discovered chat data is malformed, historical Telegram chat suggestions may be skipped for that one import. The original JSON is still backed up and future Telegram messages can rediscover chats.
