### PR TITLE
fix(ui): align account menu dropdown to left in sidebar

### DIFF
--- a/ui/src/components/AccountMenu.tsx
+++ b/ui/src/components/AccountMenu.tsx
@@ -95,7 +95,7 @@ export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = f
           role="menu"
           className={clsx(
             'absolute z-50 min-w-[14rem] rounded-lg border border-border bg-popover py-1 text-popover-foreground shadow-xl',
-            openUpward ? 'bottom-full right-0 mb-2' : 'top-full right-0 mt-2'
+            openUpward ? 'bottom-full left-0 mb-2' : 'top-full right-0 mt-2'
           )}
         >
           <div className="px-3 pt-2 text-[10px] font-bold uppercase tracking-[0.18em] text-muted">


### PR DESCRIPTION
## Summary
- The desktop sidebar AccountMenu (openUpward=true) used `right-0` alignment, which expanded the dropdown leftward from a trigger sitting near the right edge of a 240px-wide sidebar — pushing the popup off the left side of the viewport.
- Switch the openUpward branch to `left-0` so the popup expands into the main content area instead. Matches the alignment used by sibling sidebar widgets (LanguageSwitcher, VersionBadge).
- Mobile header path (`top-full right-0`) is unchanged because that trigger sits at the right edge of the header.

## Reported by
Page Feedback on `/dashboard` at 1673×1363: \"在 PC 端，这个弹窗延伸到屏幕最左侧出去了…应该是左端对齐，而不是右端\".

## Test plan
- [x] `npm run build` in `ui/` (no type/build errors)
- [ ] Manually verify the AccountMenu opens to the right of the trigger in the desktop sidebar at ≥md viewports
- [ ] Verify the mobile header AccountMenu still opens leftward (right-aligned) below the trigger