### PR TITLE
fix(ui): improve switch off-state contrast in dark mode

### DIFF
--- a/ui/src/components/settings/SettingsPrimitives.tsx
+++ b/ui/src/components/settings/SettingsPrimitives.tsx
@@ -102,6 +102,8 @@ export const CompactSelect: React.FC<React.SelectHTMLAttributes<HTMLSelectElemen
 
 // Mirrors design.pen FALFE / ylboi (mint switch on): cornerRadius 9999,
 // fill --mint, blur 8 #5BFFA055 glow, 38×22 with knob inset 3.
+// Off state mirrors fcMl6 (Switch/Unchecked): fill + stroke = --border-strong
+// (14% white dark / 14% black light) for sufficient contrast against bg-background.
 export const ToggleSwitch: React.FC<{ enabled: boolean; onClick: () => void; disabled?: boolean }> = ({
   enabled,
   onClick,
@@ -117,7 +119,7 @@ export const ToggleSwitch: React.FC<{ enabled: boolean; onClick: () => void; dis
       'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint/40 disabled:opacity-50',
       enabled
         ? 'border-mint/50 bg-mint shadow-[0_0_12px_-2px_rgba(91,255,160,0.6)]'
-        : 'border-border bg-surface-2'
+        : 'border-border-strong bg-border-strong'
     )}
   >
     <span

--- a/ui/src/components/steps/AgentDetection.tsx
+++ b/ui/src/components/steps/AgentDetection.tsx
@@ -236,7 +236,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                     'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint/40',
                     agent.enabled
                       ? 'border-mint/50 bg-mint shadow-[0_0_12px_-2px_rgba(91,255,160,0.6)]'
-                      : 'border-border bg-surface-2'
+                      : 'border-border-strong bg-border-strong'
                   )}
                 >
                   <span

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -1097,12 +1097,12 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               <span
                 className={clsx(
                   'relative inline-flex h-[18px] w-[30px] items-center rounded-full transition-colors',
-                  showInactive ? 'bg-mint' : 'bg-neutral-300'
+                  showInactive ? 'bg-mint' : 'bg-border-strong'
                 )}
               >
                 <span
                   className={clsx(
-                    'inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform',
+                    'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
                     showInactive ? 'translate-x-[14px]' : 'translate-x-0.5'
                   )}
                 />
@@ -1189,12 +1189,12 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                       }}
                       className={clsx(
                         'relative inline-flex h-[18px] w-8 shrink-0 cursor-pointer items-center rounded-full transition-colors',
-                        channelEnabled ? 'bg-mint' : 'bg-neutral-300'
+                        channelEnabled ? 'bg-mint' : 'bg-border-strong'
                       )}
                     >
                       <span
                         className={clsx(
-                          'inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform',
+                          'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
                           channelEnabled ? 'translate-x-[14px]' : 'translate-x-0.5'
                         )}
                       />
@@ -1381,12 +1381,12 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             }}
             className={clsx(
               'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-              (config as any)[platform]?.require_mention ? 'bg-accent' : 'bg-neutral-300'
+              (config as any)[platform]?.require_mention ? 'bg-accent' : 'bg-border-strong'
             )}
           >
             <span
               className={clsx(
-                'inline-block h-4 w-4 rounded-full bg-white transition-transform shadow-sm',
+                'inline-block h-4 w-4 rounded-full bg-background transition-transform shadow-sm',
                 (config as any)[platform]?.require_mention ? 'translate-x-6' : 'translate-x-1'
               )}
             />

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -376,7 +376,7 @@ const Switch: React.FC<{ checked: boolean; onChange: (next: boolean) => void }> 
       'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint/40',
       checked
         ? 'border-mint/50 bg-mint shadow-[0_0_12px_-2px_rgba(91,255,160,0.6)]'
-        : 'border-border bg-surface-2'
+        : 'border-border-strong bg-border-strong'
     )}
   >
     <span

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -706,12 +706,12 @@ export const UserList: React.FC = () => {
             <span
               className={clsx(
                 'relative inline-flex h-[18px] w-[30px] items-center rounded-full transition-colors',
-                showDisabled ? 'bg-mint' : 'bg-white/[0.08]'
+                showDisabled ? 'bg-mint' : 'bg-border-strong'
               )}
             >
               <span
                 className={clsx(
-                  'inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform',
+                  'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
                   showDisabled ? 'translate-x-[14px]' : 'translate-x-0.5'
                 )}
               />
@@ -781,12 +781,12 @@ export const UserList: React.FC = () => {
                       }}
                       className={clsx(
                         'relative inline-flex h-[18px] w-8 shrink-0 cursor-pointer items-center rounded-full transition-colors',
-                        userConfig.enabled ? 'bg-mint' : 'bg-neutral-300'
+                        userConfig.enabled ? 'bg-mint' : 'bg-border-strong'
                       )}
                     >
                       <span
                         className={clsx(
-                          'inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform',
+                          'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
                           userConfig.enabled ? 'translate-x-[14px]' : 'translate-x-0.5'
                         )}
                       />


### PR DESCRIPTION
## Summary
- Use the theme-aware `--border-strong` token (14% white dark / 14% black light) for the canonical `ToggleSwitch` off-state fill + border, replacing `border-border bg-surface-2` (~8% white) which sat too close to the page background in dark mode.
- Align 7 scattered inline switches (AgentDetection, Summary, ChannelList ×3, UserList ×2) with the same token. Most were using `bg-neutral-300` or `bg-white/[0.08]` — both bypass the theme: `neutral-300` doesn't adapt at all, `white/[0.08]` is invisible in light mode.
- Replace hardcoded `bg-white` knobs with `bg-background` so the knob always picks up the page surface (works in both themes).
- Mirrors `design.pen` `fcMl6` (Switch/Unchecked) which now references `$--border-strong` for both fill and stroke.

Reported via Page Feedback on `/settings/messaging`: the off switch was hard to distinguish from the page in dark mode.

## Affected sites
| File | What changed |
| --- | --- |
| `ui/src/components/settings/SettingsPrimitives.tsx` | `ToggleSwitch` (root primitive) off-state |
| `ui/src/components/steps/AgentDetection.tsx` | Backend enable/disable switch |
| `ui/src/components/steps/Summary.tsx` | Local `Switch` component |
| `ui/src/components/steps/ChannelList.tsx` | `showInactive`, `channelEnabled`, `require_mention` |
| `ui/src/components/steps/UserList.tsx` | `showDisabled`, `userConfig.enabled` |

## Test plan
- [ ] `npm run build` passes (verified locally — Tailwind compiles `bg-border-strong` and `border-border-strong` utilities)
- [ ] In dark mode, off-state switch reads as a clearly-darker pill against the panel
- [ ] In light mode, off-state switch reads as a light-gray pill against the panel
- [ ] Knob remains visible in both modes (now uses `bg-background`)
- [ ] On switches: glow + mint fill unchanged

## Related
- Token already exists in `ui/src/index.css`: `--border-strong: rgba(255, 255, 255, 0.14)` (dark) / `rgba(8, 8, 18, 0.14)` (light), exposed via `@theme inline` as `--color-border-strong`.
- Drift audit (separate follow-up) found wider hardcoded-palette usage in `RemoteAccess.tsx` and `directory-browser.tsx`; tracking that as future work, not in this PR.