### PR TITLE
fix(ui): sweep bg/border-white/[0.0X] to foreground/[0.0X]

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -34,7 +34,7 @@ const ShellNavLink: React.FC<{ item: ShellNavItem }> = ({ item }) => {
         'group flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors',
         active
           ? 'border border-mint/30 bg-mint/[0.08] text-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]'
-          : 'border border-transparent text-muted hover:bg-white/[0.04] hover:text-foreground'
+          : 'border border-transparent text-muted hover:bg-foreground/[0.04] hover:text-foreground'
       )}
     >
       <Icon className={clsx('size-4', active ? 'text-mint' : 'text-muted group-hover:text-foreground')} />
@@ -135,7 +135,7 @@ export const AppShell: React.FC = () => {
                 'flex items-center gap-2.5 rounded-lg border px-3 py-2.5',
                 isRunning
                   ? 'border-mint/30 bg-mint/[0.08]'
-                  : 'border-border bg-white/[0.02]'
+                  : 'border-border bg-foreground/[0.02]'
               )}
             >
               <span

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -201,7 +201,7 @@ export const Dashboard: React.FC = () => {
               'flex size-[52px] shrink-0 items-center justify-center rounded-full border',
               isRunning
                 ? 'border-mint/35 bg-mint/[0.08] shadow-[0_0_24px_-6px_rgba(91,255,160,0.44)]'
-                : 'border-border bg-white/[0.04]'
+                : 'border-border bg-foreground/[0.04]'
             )}
           >
             <Zap
@@ -216,7 +216,7 @@ export const Dashboard: React.FC = () => {
                   'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.14em]',
                   isRunning
                     ? 'border-mint/30 bg-mint/[0.08] text-mint'
-                    : 'border-border bg-white/[0.04] text-muted'
+                    : 'border-border bg-foreground/[0.04] text-muted'
                 )}
               >
                 <span
@@ -283,7 +283,7 @@ export const Dashboard: React.FC = () => {
               type="button"
               onClick={() => void handleAction('stop')}
               disabled={loading}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2.5 text-[13px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2.5 text-[13px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Square className="size-3.5" strokeWidth={2.5} />
               {t('common.stop')}
@@ -297,7 +297,7 @@ export const Dashboard: React.FC = () => {
               'inline-flex items-center gap-1.5 rounded-lg px-4 py-2.5 text-[13px] font-bold transition disabled:cursor-not-allowed disabled:opacity-50',
               isRunning
                 ? 'bg-mint text-[#080812] shadow-[0_0_24px_-6px_rgba(91,255,160,0.44)] hover:brightness-105'
-                : 'border border-border bg-white/[0.04] text-foreground hover:border-border-strong'
+                : 'border border-border bg-foreground/[0.04] text-foreground hover:border-border-strong'
             )}
           >
             <RotateCw className="size-3.5" strokeWidth={2.5} />
@@ -348,7 +348,7 @@ export const Dashboard: React.FC = () => {
             </div>
             <Link
               to="/settings/platforms"
-              className="inline-flex items-center gap-1 rounded-lg border border-border bg-white/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong"
+              className="inline-flex items-center gap-1 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong"
             >
               {t('dashboard.manageAll')}
               <ArrowRight className="size-3.5" strokeWidth={2.25} />
@@ -378,7 +378,7 @@ export const Dashboard: React.FC = () => {
                       'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium',
                       platform.enabled
                         ? 'border-mint/30 bg-mint/[0.08] text-mint'
-                        : 'border-border bg-white/[0.04] text-muted'
+                        : 'border-border bg-foreground/[0.04] text-muted'
                     )}
                   >
                     {platform.enabled ? t('dashboard.connected') : t('dashboard.notConfigured')}

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -248,7 +248,7 @@ export const SettingsMessagingPage: React.FC = () => {
           control={
             <Link
               to="/groups"
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
             >
               {t('common.manageChannels')}
               <ArrowRight className="size-3.5" strokeWidth={2.25} />

--- a/ui/src/components/settings/SettingsPlaceholderPage.tsx
+++ b/ui/src/components/settings/SettingsPlaceholderPage.tsx
@@ -24,7 +24,7 @@ export const SettingsPlaceholderPage: React.FC<{
           <span className="text-[12px] text-muted">{t('settings.inProgressHint')}</span>
           <Link
             to="/setup"
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong"
           >
             {t('settings.openSetup')}
             <ArrowRight className="size-3.5" strokeWidth={2.25} />

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -165,7 +165,7 @@ export const SettingsPlatformsPage: React.FC = () => {
                 <div className="mt-1 flex flex-wrap items-center gap-1.5">
                   {enabledPlatforms.map((id) => {
                     const descriptor = platformCatalog.find((p) => p.id === id);
-                    const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-white/[0.04]', border: 'border-white/[0.10]' };
+                    const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
                     return (
                       <span
                         key={id}
@@ -197,7 +197,7 @@ export const SettingsPlatformsPage: React.FC = () => {
               {platformCatalog.map((platform) => {
                 const id = platform.id;
                 const active = draftEnabled.includes(id);
-                const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-white/[0.04]', border: 'border-white/[0.10]' };
+                const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
                 return (
                   <button
                     key={id}
@@ -207,7 +207,7 @@ export const SettingsPlatformsPage: React.FC = () => {
                       'flex flex-col items-center gap-2 rounded-xl px-3 py-3.5 transition-colors',
                       active
                         ? 'border-2 border-mint bg-mint/[0.16]'
-                        : 'border border-white/[0.08] bg-background hover:border-white/[0.16] hover:bg-white/[0.02]'
+                        : 'border border-foreground/[0.08] bg-background hover:border-foreground/[0.16] hover:bg-foreground/[0.02]'
                     )}
                   >
                     <span
@@ -237,7 +237,7 @@ export const SettingsPlatformsPage: React.FC = () => {
                 type="button"
                 onClick={closeAll}
                 disabled={savingEnabled}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
               >
                 {t('common.cancel')}
               </button>
@@ -259,7 +259,7 @@ export const SettingsPlatformsPage: React.FC = () => {
           const descriptor = platformCatalog.find((p) => p.id === id);
           const label = t(descriptor?.title_key || `platform.${id}.title`);
           const description = t(descriptor?.description_key || `platform.${id}.desc`);
-          const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-white/[0.04]', border: 'border-white/[0.10]' };
+          const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
           const configured = platformHasCredentials(config, id);
           return (
             <CollapseCard
@@ -335,7 +335,7 @@ const CollapseCard: React.FC<{
             'inline-flex shrink-0 items-center gap-1.5 rounded-lg border px-3 py-1.5 text-[12px] font-medium transition',
             expanded
               ? 'border-mint/35 bg-mint/[0.08] text-mint'
-              : 'border-border bg-white/[0.04] text-foreground hover:border-border-strong'
+              : 'border-border bg-foreground/[0.04] text-foreground hover:border-border-strong'
           )}
         >
           {expanded ? (

--- a/ui/src/components/settings/SettingsPrimitives.tsx
+++ b/ui/src/components/settings/SettingsPrimitives.tsx
@@ -80,7 +80,7 @@ export const CompactField: React.FC<React.InputHTMLAttributes<HTMLInputElement>>
 }) => (
   <input
     className={clsx(
-      'h-9 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40',
+      'h-9 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40',
       className
     )}
     {...props}
@@ -93,7 +93,7 @@ export const CompactSelect: React.FC<React.SelectHTMLAttributes<HTMLSelectElemen
 }) => (
   <select
     className={clsx(
-      'h-9 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40',
+      'h-9 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40',
       className
     )}
     {...props}

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -132,7 +132,7 @@ export const SettingsServicePage: React.FC = () => {
               'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.14em]',
               isRunning
                 ? 'border-mint/30 bg-mint/[0.08] text-mint'
-                : 'border-border bg-white/[0.04] text-muted'
+                : 'border-border bg-foreground/[0.04] text-muted'
             )}
           >
             <span
@@ -166,7 +166,7 @@ export const SettingsServicePage: React.FC = () => {
                   type="button"
                   onClick={() => void handleAction('stop')}
                   disabled={loading}
-                  className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+                  className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <Square className="size-3.5" strokeWidth={2.5} />
                   {t('common.stop')}
@@ -176,7 +176,7 @@ export const SettingsServicePage: React.FC = () => {
                 type="button"
                 onClick={() => void handleAction('restart')}
                 disabled={loading}
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RotateCw className="size-3.5" strokeWidth={2.5} />
                 {t('common.restart')}
@@ -225,7 +225,7 @@ export const SettingsServicePage: React.FC = () => {
                 type="button"
                 onClick={() => void handleUiSaveRestart()}
                 disabled={uiSaving}
-                className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RotateCw className={clsx('size-3.5', uiSaving && 'animate-spin')} strokeWidth={2.5} />
                 {uiSaving ? t('common.saving') : t('common.saveAndRestart')}
@@ -239,7 +239,7 @@ export const SettingsServicePage: React.FC = () => {
       <SettingsPanel>
         <div className="flex flex-col gap-3 px-5 py-4 md:flex-row md:items-center md:justify-between">
           <div className="text-[13px] font-medium text-foreground">{t('settings.logFileLabel')}</div>
-          <div className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/[0.04] px-3 py-2">
+          <div className="inline-flex items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-3 py-2">
             <FileText className="size-3.5 text-muted" />
             <span className="font-mono text-[11px] text-foreground">~/.vibe_remote/logs/vibe_remote.log</span>
           </div>

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -200,7 +200,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
               <div
                 role="radiogroup"
                 aria-label={t('channelList.requireMention') as string}
-                className="flex h-9 items-stretch gap-0.5 rounded-md border border-border bg-white/[0.03] p-0.5"
+                className="flex h-9 items-stretch gap-0.5 rounded-md border border-border bg-foreground/[0.03] p-0.5"
               >
                 {segs.map((seg) => {
                   const active = current === seg.id;
@@ -258,7 +258,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                   'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12px] font-medium transition-colors',
                   checked
                     ? 'border-mint/40 bg-mint/15 text-mint'
-                    : 'border-border bg-white/[0.02] text-muted hover:border-border-strong hover:text-foreground'
+                    : 'border-border bg-foreground/[0.02] text-muted hover:border-border-strong hover:text-foreground'
                 )}
               >
                 <span

--- a/ui/src/components/shared/WizardStep.tsx
+++ b/ui/src/components/shared/WizardStep.tsx
@@ -39,7 +39,7 @@ export const StepHeader: React.FC<StepHeaderProps> = ({
 }) => (
   <button
     onClick={onToggle}
-    className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-white/[0.02]"
+    className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left transition-colors hover:bg-foreground/[0.02]"
   >
     <div className="flex items-center gap-3">
       <span

--- a/ui/src/components/steps/AgentDetection.tsx
+++ b/ui/src/components/steps/AgentDetection.tsx
@@ -204,7 +204,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
         </label>
         <button
           onClick={detectAll}
-          className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
+          className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
         >
           <Search className="size-3.5" /> {t('common.detectAll')}
         </button>
@@ -266,7 +266,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                 <button
                   onClick={() => detect(name, agent.cli_path)}
                   disabled={checking}
-                  className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+                  className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {checking ? <RefreshCw className="size-3.5 animate-spin" /> : <Search className="size-3.5" />}
                   {t('common.detect')}
@@ -381,7 +381,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
               {t('agentDetection.subtitle')}
             </p>
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-3 py-1.5">
+          <div className="flex items-center gap-2 rounded-full border border-border bg-foreground/[0.04] px-3 py-1.5">
             <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-mint">
               {enabledCount} active
             </span>
@@ -395,7 +395,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
             <button
               type="button"
               onClick={onBack}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
             >
               <ArrowLeft size={14} strokeWidth={2.25} />
               {t('common.back')}

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -785,7 +785,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               <button
                 type="button"
                 onClick={onBack}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
               >
                 <ArrowLeft size={14} strokeWidth={2.25} />
                 {t('common.back')}
@@ -912,7 +912,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 type="button"
                 onClick={handleRescan}
                 disabled={isRescanLoading}
-                className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[13px] font-medium text-foreground transition-colors hover:border-border-strong disabled:opacity-50"
+                className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[13px] font-medium text-foreground transition-colors hover:border-border-strong disabled:opacity-50"
               >
                 <RefreshCw size={14} className={isRescanLoading ? 'animate-spin' : ''} />
                 {t('channelList.rescan')}
@@ -937,7 +937,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               <span
                 className={clsx(
                   'rounded-full px-1.5 py-0.5 font-mono text-[10px]',
-                  pageTab === 'all' ? 'bg-mint-soft text-mint' : 'bg-white/[0.06] text-muted'
+                  pageTab === 'all' ? 'bg-mint-soft text-mint' : 'bg-foreground/[0.06] text-muted'
                 )}
               >
                 {allTabCounts.active}
@@ -963,7 +963,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                   <span
                     className={clsx(
                       'rounded-full px-1.5 py-0.5 font-mono text-[10px]',
-                      active ? 'bg-mint-soft text-mint' : 'bg-white/[0.06] text-muted'
+                      active ? 'bg-mint-soft text-mint' : 'bg-foreground/[0.06] text-muted'
                     )}
                   >
                     {counts.active}
@@ -1048,7 +1048,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                   type="button"
                   onClick={() => loadChannels(true)}
                   disabled={loadingAll}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:border-cyan/40 disabled:opacity-50"
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:border-cyan/40 disabled:opacity-50"
                 >
                   <Globe size={13} className={loadingAll ? 'animate-spin' : ''} />
                   {loadingAll ? t('common.loading') : t('channelList.browseAll')}
@@ -1226,7 +1226,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                         'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium',
                         channelEnabled
                           ? 'border-mint/40 bg-mint-soft text-mint'
-                          : 'border-border bg-white/[0.04] text-muted'
+                          : 'border-border bg-foreground/[0.04] text-muted'
                       )}
                     >
                       <span
@@ -1342,7 +1342,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 'rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors',
                 platform === candidate
                   ? 'border-mint/50 bg-mint/[0.16] text-mint shadow-[0_0_20px_-4px_rgba(91,255,160,0.4)]'
-                  : 'border-border bg-white/[0.04] text-foreground hover:border-border-strong'
+                  : 'border-border bg-foreground/[0.04] text-foreground hover:border-border-strong'
               )}
             >
               {t(`platform.${candidate}.title`)}
@@ -1635,7 +1635,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/DiscordConfig.tsx
+++ b/ui/src/components/steps/DiscordConfig.tsx
@@ -447,7 +447,7 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
               {t('discordConfig.subtitle')}
             </p>
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-3 py-1.5">
+          <div className="flex items-center gap-2 rounded-full border border-border bg-foreground/[0.04] px-3 py-1.5">
             <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-mint">
               {completedCount} / 4
             </span>
@@ -457,7 +457,7 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                   key={i}
                   className={clsx(
                     'h-1 w-5 rounded-full',
-                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-white/[0.08]'
+                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-foreground/[0.08]'
                   )}
                 />
               ))}
@@ -471,7 +471,7 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/DoctorPanel.tsx
+++ b/ui/src/components/steps/DoctorPanel.tsx
@@ -113,7 +113,7 @@ export const DoctorPanel: React.FC<DoctorPanelProps> = ({
         <div className="flex flex-wrap items-center gap-2">
           <Link
             to={logsPath}
-            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
+            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
           >
             <FileText className="size-3.5" />
             {t('common.viewLogs')}
@@ -122,7 +122,7 @@ export const DoctorPanel: React.FC<DoctorPanelProps> = ({
             <button
               type="button"
               onClick={() => void copyReport()}
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
+              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
             >
               <Copy className="size-3.5" />
               {t('doctor.copyReport')}

--- a/ui/src/components/steps/LarkConfig.tsx
+++ b/ui/src/components/steps/LarkConfig.tsx
@@ -235,7 +235,7 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
                   'flex-1 rounded-lg border px-3 py-2 text-[12px] font-semibold transition',
                   domain === opt
                     ? 'border-mint/45 bg-mint/[0.08] text-mint shadow-[0_0_24px_-4px_rgba(91,255,160,0.4)]'
-                    : 'border-border bg-white/[0.04] text-muted hover:border-border-strong hover:text-foreground'
+                    : 'border-border bg-foreground/[0.04] text-muted hover:border-border-strong hover:text-foreground'
                 )}
               >
                 {opt === 'feishu' ? t('larkConfig.domainFeishu') : t('larkConfig.domainLark')}
@@ -420,7 +420,7 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
                   <ul className="mt-2 space-y-1.5 pl-1">
                     {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14].map((i) => (
                       <li key={i} className="flex items-start gap-2">
-                        <code className="shrink-0 rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[11px] text-foreground">
+                        <code className="shrink-0 rounded bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[11px] text-foreground">
                           {i}
                         </code>
                         {t(`larkConfig.step3Item${i}`)}
@@ -538,7 +538,7 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
               {t('larkConfig.subtitle')}
             </p>
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-3 py-1.5">
+          <div className="flex items-center gap-2 rounded-full border border-border bg-foreground/[0.04] px-3 py-1.5">
             <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-mint">
               {completedCount} / 5
             </span>
@@ -548,7 +548,7 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
                   key={i}
                   className={clsx(
                     'h-1 w-4 rounded-full',
-                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-white/[0.08]'
+                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-foreground/[0.08]'
                   )}
                 />
               ))}
@@ -562,7 +562,7 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/LogsPanel.tsx
+++ b/ui/src/components/steps/LogsPanel.tsx
@@ -16,7 +16,7 @@ import { useApi, type LogEntry, type LogSource } from '../../context/ApiContext'
 type LogLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'ALL';
 
 const LEVEL_PILL: Record<string, string> = {
-  DEBUG: 'border-border bg-white/[0.04] text-muted',
+  DEBUG: 'border-border bg-foreground/[0.04] text-muted',
   INFO: 'border-cyan/30 bg-cyan/[0.08] text-cyan',
   WARNING: 'border-gold/30 bg-gold/[0.08] text-gold',
   ERROR: 'border-danger/30 bg-danger/[0.08] text-danger',
@@ -158,7 +158,7 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
               'inline-flex h-9 items-center gap-1.5 rounded-lg border px-3 text-[12px] font-medium transition',
               autoRefresh
                 ? 'border-cyan/40 bg-cyan/[0.08] text-cyan'
-                : 'border-border bg-white/[0.04] text-foreground hover:border-border-strong'
+                : 'border-border bg-foreground/[0.04] text-foreground hover:border-border-strong'
             )}
           >
             {autoRefresh ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
@@ -184,7 +184,7 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
             placeholder={t('logs.searchPlaceholder')}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-9 w-full rounded-lg border border-border bg-white/[0.04] pl-9 pr-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+            className="h-9 w-full rounded-lg border border-border bg-foreground/[0.04] pl-9 pr-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40"
           />
         </div>
         <div className="flex items-center gap-2">
@@ -192,7 +192,7 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
           <select
             value={levelFilter}
             onChange={(e) => setLevelFilter(e.target.value as LogLevel)}
-            className="h-9 rounded-lg border border-border bg-white/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+            className="h-9 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40"
           >
             <option value="ALL">{t('logs.allLevels')}</option>
             <option value="ERROR">{t('logs.error')} ({levelCounts.ERROR})</option>
@@ -214,7 +214,7 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
                 'inline-flex h-7 items-center gap-1 rounded-full border px-3 text-[11px] font-medium transition-colors',
                 selectedSource === source.key
                   ? 'border-mint/35 bg-mint/[0.08] text-mint shadow-[0_0_12px_-4px_rgba(91,255,160,0.5)]'
-                  : 'border-border bg-white/[0.04] text-muted hover:border-border-strong hover:text-foreground'
+                  : 'border-border bg-foreground/[0.04] text-muted hover:border-border-strong hover:text-foreground'
               )}
             >
               {getSourceLabel(source.key)}
@@ -236,7 +236,7 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
               'inline-flex h-7 items-center gap-1 rounded-full border px-3 text-[11px] font-medium transition-colors',
               levelFilter === level
                 ? 'border-cyan/40 bg-cyan/[0.08] text-cyan'
-                : 'border-border bg-white/[0.04] text-muted hover:border-border-strong hover:text-foreground'
+                : 'border-border bg-foreground/[0.04] text-muted hover:border-border-strong hover:text-foreground'
             )}
           >
             {level === 'ALL' ? t('logs.all') : level}
@@ -248,7 +248,7 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-background">
-        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-white/[0.02] px-4 py-2.5">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-foreground/[0.02] px-4 py-2.5">
           <span className="font-mono text-[11px] font-medium text-muted">
             {t('logs.entriesCount', { filtered: filteredLogs.length, total: logs.length })}
             {logsTotal > logs.length && ` · ${t('logs.totalInFile', { total: logsTotal })}`}
@@ -293,7 +293,7 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
                   <div
                     key={i}
                     className={clsx(
-                      'px-4 py-2.5 transition-colors hover:bg-white/[0.02]',
+                      'px-4 py-2.5 transition-colors hover:bg-foreground/[0.02]',
                       log.level === 'ERROR' && 'bg-danger/[0.04]',
                       log.level === 'WARNING' && 'bg-gold/[0.04]'
                     )}

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -495,8 +495,8 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
             const option = platform.id;
             const active = selected.includes(option);
             const tileTint = PLATFORM_TILE_STYLES[option] || {
-              bg: 'bg-white/[0.04]',
-              border: 'border-white/[0.10]',
+              bg: 'bg-foreground/[0.04]',
+              border: 'border-foreground/[0.10]',
             };
             return (
               <button
@@ -507,7 +507,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
                   'flex flex-col items-center gap-2.5 rounded-xl px-4 py-5 transition-colors',
                   active
                     ? 'border-2 border-mint bg-mint/[0.16]'
-                    : 'border border-white/[0.08] bg-background hover:border-white/[0.16] hover:bg-white/[0.02]'
+                    : 'border border-foreground/[0.08] bg-background hover:border-foreground/[0.16] hover:bg-foreground/[0.02]'
                 )}
               >
                 <span
@@ -532,7 +532,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
           })}
         </div>
 
-        <div className="flex items-center gap-2 rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-2.5">
+        <div className="flex items-center gap-2 rounded-lg border border-foreground/[0.08] bg-foreground/[0.04] px-4 py-2.5">
           <Info className="size-3.5 shrink-0 text-cyan" />
           <span className="text-[12px] leading-[1.45] text-muted">
             {t('platform.selectedSummary', { count: selected.length })}
@@ -543,7 +543,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/SlackConfig.tsx
+++ b/ui/src/components/steps/SlackConfig.tsx
@@ -162,7 +162,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                     <button
                       onClick={copyManifest}
                       disabled={manifestLoading}
-                      className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
                     >
                       {copied ? <Check size={14} /> : <Copy size={14} />}
                       {copied ? t('slackConfig.copied') : t('slackConfig.copyManifest')}
@@ -225,7 +225,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                   />
                   <p className="text-[11px] text-muted">
                     {t('slackConfig.botTokenHint')}{' '}
-                    <code className="rounded bg-white/[0.06] px-1.5 py-0.5 text-foreground">xoxb-</code>
+                    <code className="rounded bg-foreground/[0.06] px-1.5 py-0.5 text-foreground">xoxb-</code>
                   </p>
                 </div>
               </div>
@@ -265,7 +265,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                   />
                   <p className="text-[11px] text-muted">
                     {t('slackConfig.appTokenHint')}{' '}
-                    <code className="rounded bg-white/[0.06] px-1.5 py-0.5 text-foreground">xapp-</code>
+                    <code className="rounded bg-foreground/[0.06] px-1.5 py-0.5 text-foreground">xapp-</code>
                   </p>
                 </div>
                 <div className="rounded-lg border border-gold/30 bg-gold/10 px-3 py-2 text-[12px] leading-[1.55] text-gold">
@@ -359,7 +359,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
               {t('slackConfig.selfHostDescription')}
             </p>
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-3 py-1.5">
+          <div className="flex items-center gap-2 rounded-full border border-border bg-foreground/[0.04] px-3 py-1.5">
             <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-mint">
               {completedCount} / 4
             </span>
@@ -369,7 +369,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                   key={i}
                   className={clsx(
                     'h-1 w-5 rounded-full',
-                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-white/[0.08]'
+                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-foreground/[0.08]'
                   )}
                 />
               ))}
@@ -383,7 +383,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -213,7 +213,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
               <code className="flex-1 select-all font-mono text-[13px] text-foreground">bind {bindCode}</code>
               <button
                 onClick={copyBindCode}
-                className="rounded-md p-1.5 text-muted transition hover:bg-white/[0.04] hover:text-foreground"
+                className="rounded-md p-1.5 text-muted transition hover:bg-foreground/[0.04] hover:text-foreground"
                 title="Copy"
                 aria-label={t('common.copy') as string}
               >
@@ -346,7 +346,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
             type="button"
             onClick={onBack}
             disabled={saving}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong disabled:opacity-50"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -177,7 +177,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                   </button>
                   <button
                     onClick={() => copyCommand('/newbot')}
-                    className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong"
+                    className="inline-flex items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong"
                   >
                     {copiedCommand === '/newbot' ? <Check size={14} className="text-mint" /> : <Copy size={14} />}
                     {copiedCommand === '/newbot' ? t('telegramConfig.copiedCommand') : t('telegramConfig.copyNewBotCommand')}
@@ -291,7 +291,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                         </div>
                         <button
                           onClick={() => copyCommand(item.command)}
-                          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition hover:border-border-strong"
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-2.5 py-1.5 text-[11px] font-medium text-foreground transition hover:border-border-strong"
                         >
                           {copiedCommand === item.command ? <Check size={12} className="text-mint" /> : <Copy size={12} />}
                           <code className="font-mono">
@@ -414,7 +414,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               {t('telegramConfig.subtitle')}
             </p>
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-3 py-1.5">
+          <div className="flex items-center gap-2 rounded-full border border-border bg-foreground/[0.04] px-3 py-1.5">
             <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-mint">
               {completedCount} / 5
             </span>
@@ -424,7 +424,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                   key={i}
                   className={clsx(
                     'h-1 w-4 rounded-full',
-                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-white/[0.08]'
+                    i < completedCount ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-foreground/[0.08]'
                   )}
                 />
               ))}
@@ -438,7 +438,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -212,7 +212,7 @@ const BindCodeCard: React.FC<BindCodeCardProps> = ({ refreshTrigger, onCodesChan
               <button
                 type="button"
                 onClick={() => setShowAllModal(true)}
-                className="rounded-md border border-border bg-white/[0.04] px-3.5 py-2 text-[12px] font-medium text-muted transition-colors hover:border-border-strong hover:text-foreground"
+                className="rounded-md border border-border bg-foreground/[0.04] px-3.5 py-2 text-[12px] font-medium text-muted transition-colors hover:border-border-strong hover:text-foreground"
               >
                 {moreCount > 0
                   ? t('bindCode.viewMore', { count: moreCount })
@@ -223,7 +223,7 @@ const BindCodeCard: React.FC<BindCodeCardProps> = ({ refreshTrigger, onCodesChan
               <button
                 type="button"
                 onClick={() => handleDelete(primary.code)}
-                className="rounded-md border border-border bg-white/[0.04] px-3.5 py-2 text-[12px] font-medium text-muted transition-colors hover:border-danger/40 hover:text-danger"
+                className="rounded-md border border-border bg-foreground/[0.04] px-3.5 py-2 text-[12px] font-medium text-muted transition-colors hover:border-danger/40 hover:text-danger"
               >
                 {t('bindCode.revoke')}
               </button>
@@ -319,9 +319,9 @@ const BindCodeCard: React.FC<BindCodeCardProps> = ({ refreshTrigger, onCodesChan
                           className={clsx(
                             'rounded-full border px-2 py-0.5 text-[10px] font-mono font-bold tracking-[0.12em]',
                             status === 'active' && 'border-mint/40 bg-mint-soft text-mint',
-                            status === 'used' && 'border-border bg-white/[0.04] text-muted',
+                            status === 'used' && 'border-border bg-foreground/[0.04] text-muted',
                             status === 'expired' && 'border-gold/40 bg-gold/10 text-gold',
-                            status === 'inactive' && 'border-border bg-white/[0.04] text-muted',
+                            status === 'inactive' && 'border-border bg-foreground/[0.04] text-muted',
                           )}
                         >
                           {t(`bindCode.${status}`)}
@@ -673,7 +673,7 @@ export const UserList: React.FC = () => {
             <button
               type="button"
               onClick={() => setRefreshTrigger((v) => v + 1)}
-              className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 text-[13px] font-medium text-foreground transition-colors hover:border-border-strong"
+              className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[13px] font-medium text-foreground transition-colors hover:border-border-strong"
               title={t('common.refresh', { defaultValue: 'Refresh' })}
             >
               <RefreshCw size={14} />
@@ -691,7 +691,7 @@ export const UserList: React.FC = () => {
         <div className="flex items-center justify-between px-1 py-2">
           <div className="flex items-center gap-2">
             <span className="text-[15px] font-semibold text-foreground">{t('userList.allUsers')}</span>
-            <span className="rounded-full bg-white/[0.08] px-1.5 py-0.5 font-mono text-[11px] font-bold text-muted">
+            <span className="rounded-full bg-foreground/[0.08] px-1.5 py-0.5 font-mono text-[11px] font-bold text-muted">
               {totalCount}
             </span>
           </div>
@@ -826,7 +826,7 @@ export const UserList: React.FC = () => {
 
                     {/* Admin badge — clickable; bot renders as static label */}
                     {isBot ? (
-                      <span className="inline-flex shrink-0 items-center rounded-full border border-border bg-white/[0.04] px-2 py-0.5 text-[11px] font-semibold text-muted">
+                      <span className="inline-flex shrink-0 items-center rounded-full border border-border bg-foreground/[0.04] px-2 py-0.5 text-[11px] font-semibold text-muted">
                         {t('userList.bot')}
                       </span>
                     ) : (
@@ -849,7 +849,7 @@ export const UserList: React.FC = () => {
                           'inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium transition-colors',
                           userConfig.is_admin
                             ? 'border-gold/40 bg-gold/10 font-bold text-gold hover:bg-gold/15'
-                            : 'border-border bg-white/[0.04] text-muted hover:border-border-strong hover:text-foreground'
+                            : 'border-border bg-foreground/[0.04] text-muted hover:border-border-strong hover:text-foreground'
                         )}
                       >
                         <Shield size={11} strokeWidth={2.4} />
@@ -884,7 +884,7 @@ export const UserList: React.FC = () => {
                           type="button"
                           onClick={() => handleRemoveUser(u.platform, u.userId)}
                           title={t('userList.removeUser')}
-                          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-white/[0.04] px-3 py-1.5 text-[12px] font-medium text-muted transition-colors hover:border-danger/40 hover:text-danger"
+                          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-muted transition-colors hover:border-danger/40 hover:text-danger"
                         >
                           <Trash2 size={12} />
                           {t('userList.removeUser')}

--- a/ui/src/components/steps/WeChatConfig.tsx
+++ b/ui/src/components/steps/WeChatConfig.tsx
@@ -233,7 +233,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
                           ? 'bg-mint text-[#080812]'
                           : isActive
                             ? 'bg-cyan/15 text-cyan'
-                            : 'bg-white/[0.06] text-muted'
+                            : 'bg-foreground/[0.06] text-muted'
                       )}
                     >
                       {isCompleted ? <Check size={14} /> : num}
@@ -281,7 +281,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
                     void startLogin();
                   }}
                   disabled={starting}
-                  className="inline-flex items-center gap-2 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
+                  className="inline-flex items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
                 >
                   <RefreshCw size={14} className={starting ? 'animate-spin' : ''} />
                   {t('wechatConfig.rebind')}
@@ -417,7 +417,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
               {t('wechatConfig.subtitle')}
             </p>
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-border bg-white/[0.04] px-3 py-1.5">
+          <div className="flex items-center gap-2 rounded-full border border-border bg-foreground/[0.04] px-3 py-1.5">
             <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-mint">
               {completedDots} / 3
             </span>
@@ -427,7 +427,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
                   key={i}
                   className={clsx(
                     'h-1 w-6 rounded-full',
-                    i < completedDots ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-white/[0.08]'
+                    i < completedDots ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-foreground/[0.08]'
                   )}
                 />
               ))}
@@ -441,7 +441,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}

--- a/ui/src/components/steps/Welcome.tsx
+++ b/ui/src/components/steps/Welcome.tsx
@@ -64,7 +64,7 @@ export const Welcome: React.FC<WelcomeProps> = ({ onNext }) => {
           {features.map(({ Icon, iconClass, title, body }) => (
             <div
               key={title}
-              className="flex flex-col gap-2 rounded-xl border border-white/[0.08] bg-background px-4 py-[18px]"
+              className="flex flex-col gap-2 rounded-xl border border-foreground/[0.08] bg-background px-4 py-[18px]"
             >
               <Icon className={`size-5 ${iconClass}`} strokeWidth={1.75} />
               <div className="text-[14px] font-semibold leading-tight text-foreground">{title}</div>

--- a/ui/src/components/visual/EmbeddedConfigShell.tsx
+++ b/ui/src/components/visual/EmbeddedConfigShell.tsx
@@ -37,7 +37,7 @@ export const EmbeddedConfigShell: React.FC<EmbeddedConfigShellProps> = ({
               key={i}
               className={clsx(
                 'h-1 w-4 rounded-full',
-                i < completed ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-white/[0.08]'
+                i < completed ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' : 'bg-foreground/[0.08]'
               )}
             />
           ))}
@@ -49,7 +49,7 @@ export const EmbeddedConfigShell: React.FC<EmbeddedConfigShellProps> = ({
           type="button"
           onClick={onCancel}
           disabled={applying}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-white/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
         >
           {t('common.cancel')}
         </button>

--- a/ui/src/components/visual/ProgressBar.tsx
+++ b/ui/src/components/visual/ProgressBar.tsx
@@ -32,7 +32,7 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
               'h-1 flex-1 rounded-full transition-all duration-300',
               filled
                 ? 'bg-mint shadow-[0_0_12px_rgba(91,255,160,0.45)]'
-                : 'bg-white/[0.06]'
+                : 'bg-foreground/[0.06]'
             )}
           />
         );


### PR DESCRIPTION
## Capability changed

UI ambient-surface theming: `bg-white/[0.0X]` and `border-white/[0.0X]` arbitrary-alpha classes were invisible in light mode (page background is also light), so subtle structural surfaces like sidebar hover, status pills, platform tiles, and card chrome only showed up in dark mode. Replacing the color base with the theme-adaptive `--foreground` token keeps the same alpha but renders correctly in both themes.

## Scope

- 92 swaps across 24 files in `ui/src/components/`
- regex: `(bg|border)-white(/\[0\.\d+\])` → `(bg|border)-foreground$2`
- hover/focus/responsive prefixes preserved
- alpha values preserved exactly (0.02–0.16)
- intentional exclusion: `WeChatConfig.tsx:309` keeps literal `bg-white` on the QR-code tile (solid white is required for QR scanner contrast)

## Evidence layers

- **Unit/contract**: not applicable — pure className refactor, no logic touched
- **Scenario**: no scenario catalog covers this; visual-only change
- **Manual**: built `npm run build` clean (906 kB bundle); spot-checked Dashboard + Settings/Platforms in light and dark mode against the running rc6 vibe service. Sidebar inactive items remain borderless (`border-transparent`); active item keeps its mint outline; platform tiles, status pills, and stat cards render with the intended subtle alpha in both themes
- **Reviewer subagent**: ran on the diff — verdict LGTM, 0 concerns, 0 alpha drift, 0 collateral edits

## Why this isn't `border-border` / `bg-secondary`

Those tokens collapse the design's graduated 4–6% alpha into a single 8% step, making borders too prominent on ambient surfaces (especially on inactive sidebar items). Using `foreground/[0.0X]` swaps just the color base while keeping the original alpha graduation intact.