### PR TITLE
fix(ui): use shared ToggleSwitch in VersionBadge auto-update

### DIFF
--- a/ui/src/components/VersionBadge.tsx
+++ b/ui/src/components/VersionBadge.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useApi, type VersionInfo, type UpgradeResult } from '../context/ApiContext';
 import { Download, X, RefreshCw, Check, AlertCircle } from 'lucide-react';
 import clsx from 'clsx';
+import { ToggleSwitch } from './settings/SettingsPrimitives';
 
 export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = false }) => {
   const { t } = useTranslation();
@@ -218,16 +219,12 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
                   <div className="text-sm text-foreground">{t('dashboard.autoUpdate')}</div>
                   <div className="text-xs text-muted">{t('dashboard.autoUpdateHint')}</div>
                 </div>
-                <label className="relative inline-flex cursor-pointer items-center">
-                  <input
-                    type="checkbox"
-                    checked={autoUpdate}
-                    onChange={(e) => handleAutoUpdateToggle(e.target.checked)}
-                    disabled={savingAutoUpdate}
-                    className="peer sr-only"
-                  />
-                  <div className="peer h-5 w-9 rounded-full bg-surface-3 transition-colors after:absolute after:left-[2px] after:top-0.5 after:size-4 after:rounded-full after:bg-foreground after:transition-all after:content-[''] peer-checked:bg-mint peer-checked:after:translate-x-4 peer-checked:after:bg-primary-foreground peer-focus:ring-2 peer-focus:ring-ring" />
-                </label>
+                <ToggleSwitch
+                  enabled={autoUpdate}
+                  onClick={() => handleAutoUpdateToggle(!autoUpdate)}
+                  disabled={savingAutoUpdate}
+                />
+
               </div>
             )}
           </div>


### PR DESCRIPTION
## Capability changed

UI toggle consistency: the auto-update toggle inside the VersionBadge popup was a hand-rolled `<input type=checkbox class=peer> + peer-checked div` that rendered with different colors and no mint glow, breaking visual consistency with every other toggle on the settings pages.

Reported by user: "这个开关样式怎么跟其他的开关不一样呀？难道组件不是复用的吗？" on `/settings/messaging` (the Auto Update toggle visible from the version popup at the bottom of the sidebar).

## Fix

Replace the ad-hoc peer-based switch with the shared `ToggleSwitch` from `settings/SettingsPrimitives` (the same component used on every settings page). Behavior preserved: same `autoUpdate` state, same `handleAutoUpdateToggle(!autoUpdate)` action, same `savingAutoUpdate` disabled state.

## Evidence layers

- **Unit/contract**: not applicable — pure visual refactor, no logic touched
- **Scenario**: not applicable — no toggle-styling scenario exists
- **Manual**: built `npm run build` clean; spot-checked the version popup in dark mode against the running rc6 vibe service. Confirmed:
  - on-state: mint fill with glow, knob on right (matches every other toggle)
  - off-state: border-strong fill, knob on left (matches design.pen `fcMl6`)
- **Reviewer subagent**: pending after PR open