### PR TITLE
refactor(ui): consolidate primitives — inputs, selects, toggles, and brand buttons

### DIFF
--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -20,6 +20,7 @@ import clsx from 'clsx';
 import { useApi, type LogEntry } from '@/context/ApiContext';
 import { useStatus } from '@/context/StatusContext';
 import { PlatformIcon } from '@/components/visual';
+import { Button } from '@/components/ui/button';
 import { getEnabledPlatforms, getPlatformCatalog, platformSupportsChannels } from '@/lib/platforms';
 
 function relativeFromIso(value?: string | null) {
@@ -268,41 +269,39 @@ export const Dashboard: React.FC = () => {
 
         <div className="flex flex-wrap items-center gap-2">
           {!isRunning && (
-            <button
+            <Button
               type="button"
+              variant="brand"
+              size="sm"
               onClick={() => void handleAction('start')}
               disabled={loading}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-mint px-4 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-6px_rgba(91,255,160,0.44)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Play className="size-3.5" strokeWidth={2.5} />
               {t('common.start')}
-            </button>
+            </Button>
           )}
           {isRunning && (
-            <button
+            <Button
               type="button"
+              variant="secondary"
+              size="sm"
               onClick={() => void handleAction('stop')}
               disabled={loading}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2.5 text-[13px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Square className="size-3.5" strokeWidth={2.5} />
               {t('common.stop')}
-            </button>
+            </Button>
           )}
-          <button
+          <Button
             type="button"
+            variant={isRunning ? 'brand' : 'secondary'}
+            size="sm"
             onClick={() => void handleAction('restart')}
             disabled={loading}
-            className={clsx(
-              'inline-flex items-center gap-1.5 rounded-lg px-4 py-2.5 text-[13px] font-bold transition disabled:cursor-not-allowed disabled:opacity-50',
-              isRunning
-                ? 'bg-mint text-[#080812] shadow-[0_0_24px_-6px_rgba(91,255,160,0.44)] hover:brightness-105'
-                : 'border border-border bg-foreground/[0.04] text-foreground hover:border-border-strong'
-            )}
           >
             <RotateCw className="size-3.5" strokeWidth={2.5} />
             {t('common.restart')}
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/ui/src/components/RemoteAccess.tsx
+++ b/ui/src/components/RemoteAccess.tsx
@@ -3,6 +3,7 @@ import { CheckCircle2, ExternalLink, Link2, RefreshCcw } from 'lucide-react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useApi } from '../context/ApiContext';
 import { useToast } from '../context/ToastContext';
+import { CompactField } from './settings/SettingsPrimitives';
 
 const VIBE_CLOUD_URL = 'https://avibe.bot';
 
@@ -177,8 +178,8 @@ export const RemoteAccess: React.FC = () => {
         <div className="grid gap-3 px-4 py-3 md:grid-cols-[1fr_auto] md:items-end">
           <label className="space-y-1.5">
             <span className="text-[12px] font-medium text-foreground">{t('remoteAccess.pairingKey')}</span>
-            <input
-              className="h-8 w-full rounded-md border border-input bg-surface-3 px-3 font-mono text-[12px] text-foreground outline-none focus:border-ring focus:ring-2 focus:ring-ring/30"
+            <CompactField
+              className="w-full font-mono"
               value={pairingKey}
               onChange={(event) => setPairingKey(event.target.value)}
               placeholder="vrp_xxxxxxxxxxxxxxxxx"

--- a/ui/src/components/VersionBadge.tsx
+++ b/ui/src/components/VersionBadge.tsx
@@ -4,6 +4,7 @@ import { useApi, type VersionInfo, type UpgradeResult } from '../context/ApiCont
 import { Download, X, RefreshCw, Check, AlertCircle } from 'lucide-react';
 import clsx from 'clsx';
 import { ToggleSwitch } from './settings/SettingsPrimitives';
+import { Button } from './ui/button';
 
 export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = false }) => {
   const { t } = useTranslation();
@@ -232,14 +233,10 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
           {/* Actions */}
           {hasUpdate && !restarting && (
             <div className="flex justify-end border-t border-border px-4 py-3">
-              <button
-                onClick={handleUpgrade}
-                disabled={upgrading}
-                className="inline-flex items-center gap-1.5 rounded-md bg-mint px-3 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-mint/90 disabled:opacity-50"
-              >
+              <Button variant="brand" size="xs" onClick={handleUpgrade} disabled={upgrading}>
                 <Download size={14} className={upgrading ? 'animate-bounce' : ''} />
                 {upgrading ? t('dashboard.upgrading') : t('dashboard.upgradeNow')}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -14,6 +14,7 @@ import { TelegramConfig } from '@/components/steps/TelegramConfig';
 import { LarkConfig } from '@/components/steps/LarkConfig';
 import { WeChatConfig } from '@/components/steps/WeChatConfig';
 import { SettingsPageShell } from './SettingsPageShell';
+import { Button } from '@/components/ui/button';
 
 const PLATFORM_TILE_STYLES: Record<string, { bg: string; border: string }> = {
   slack: { bg: 'bg-[#4A154B26]', border: 'border-[#4A154B66]' },
@@ -241,15 +242,16 @@ export const SettingsPlatformsPage: React.FC = () => {
               >
                 {t('common.cancel')}
               </button>
-              <button
+              <Button
                 type="button"
+                variant="brand"
+                size="xs"
                 onClick={() => void applyEnabled()}
                 disabled={!draftEnabled.length || savingEnabled}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-mint px-3.5 py-1.5 text-[12px] font-bold text-[#080812] shadow-[0_0_24px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none"
               >
                 {savingEnabled ? <RefreshCw size={12} className="animate-spin" /> : <Check size={12} />}
                 {t('platform.apply')}
-              </button>
+              </Button>
             </div>
           </div>
         </CollapseCard>

--- a/ui/src/components/settings/SettingsPrimitives.tsx
+++ b/ui/src/components/settings/SettingsPrimitives.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
+import { Search } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 type SettingsPanelProps = {
   title?: React.ReactNode;
@@ -98,6 +100,36 @@ export const CompactSelect: React.FC<React.SelectHTMLAttributes<HTMLSelectElemen
     )}
     {...props}
   />
+);
+
+type SearchFieldProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
+  icon?: LucideIcon;
+  containerClassName?: string;
+};
+
+// Search input with leading icon. Distinct from CompactField on purpose:
+// list pages use a slightly larger 13px shell on bg-surface with a mint
+// focus border (not the cyan focus ring used in dense settings forms).
+export const SearchField: React.FC<SearchFieldProps> = ({
+  icon: Icon = Search,
+  className,
+  containerClassName,
+  ...props
+}) => (
+  <div className={clsx('relative', containerClassName)}>
+    <Icon
+      size={14}
+      className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+    />
+    <input
+      type="search"
+      className={clsx(
+        'h-9 rounded-lg border border-border bg-surface pl-9 pr-3 text-[13px] text-foreground placeholder:text-muted focus:border-mint/50 focus:outline-none',
+        className
+      )}
+      {...props}
+    />
+  </div>
 );
 
 // Mirrors design.pen FALFE / ylboi (mint switch on): cornerRadius 9999,

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -9,6 +9,7 @@ import { apiFetch } from '@/lib/apiFetch';
 import { RemoteAccess } from '@/components/RemoteAccess';
 import { SettingsPageShell } from './SettingsPageShell';
 import { CompactField, SettingsPanel, SettingsRow } from './SettingsPrimitives';
+import { Button } from '@/components/ui/button';
 
 // Mirrors design.pen mHUcm (VR/CM/Service): two cards.
 // svcSec1: header [16, 20] + value rows [12, 20] with bottom borders.
@@ -151,15 +152,16 @@ export const SettingsServicePage: React.FC = () => {
           control={
             <div className="flex flex-wrap gap-2">
               {!isRunning && (
-                <button
+                <Button
                   type="button"
+                  variant="brand"
+                  size="xs"
                   onClick={() => void handleAction('start')}
                   disabled={loading}
-                  className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-mint px-3 text-[12px] font-bold text-[#080812] shadow-[0_0_18px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <Play className="size-3.5" strokeWidth={2.5} />
                   {t('common.start')}
-                </button>
+                </Button>
               )}
               {isRunning && (
                 <button

--- a/ui/src/components/shared/ProxyUrlField.tsx
+++ b/ui/src/components/shared/ProxyUrlField.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ChevronDown, SplitSquareVertical } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
+import { CompactField } from '../settings/SettingsPrimitives';
 
 interface ProxyUrlFieldProps {
   value: string;
@@ -51,12 +52,12 @@ export function ProxyUrlField({
       </button>
       {expanded && (
         <div className="space-y-2">
-          <input
+          <CompactField
             type="text"
             value={value}
             onChange={(e) => onChange(e.target.value)}
             placeholder="socks5://user:pass@host:port (optional)"
-            className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+            className="w-full font-mono placeholder:text-muted/55"
           />
           <p className="text-[11px] text-muted">{t(hintKey)}</p>
         </div>

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { Combobox } from '../ui/combobox';
 import { BackendIcon } from '../visual';
+import { CompactSelect } from '../settings/SettingsPrimitives';
 
 // Mirrors design.pen `asPXu` (VR/RoutingConfig). Shared between groups (channels)
 // and users — same form, same fields, same styles. The only difference is whether
@@ -140,7 +141,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
               placeholder={globalConfig?.runtime?.default_cwd || t('channelList.useGlobalDefault')}
               value={value.custom_cwd}
               onCommit={(v) => onChange({ custom_cwd: v })}
-              className="flex-1 rounded-lg border border-border bg-surface px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted/50 focus:border-cyan focus:outline-none"
+              className="h-9 flex-1 rounded-lg border border-border bg-foreground/[0.04] px-3 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/50 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
             />
             <button
               type="button"
@@ -160,15 +161,15 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
             <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2">
               <BackendIcon backend={effectiveBackend} variant="glyph" size={14} />
             </span>
-            <select
+            <CompactSelect
               value={effectiveBackend}
               onChange={(e) => onChange({ routing: { ...value.routing, agent_backend: e.target.value } })}
-              className="w-full rounded-lg border border-border bg-surface py-2 pl-9 pr-3 text-sm text-foreground focus:border-cyan focus:outline-none"
+              className="w-full pl-9 pr-3"
             >
               <option value="opencode">OpenCode</option>
               <option value="claude">ClaudeCode</option>
               <option value="codex">Codex</option>
-            </select>
+            </CompactSelect>
           </div>
         </div>
 
@@ -281,20 +282,20 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
           <div className="grid grid-cols-1 gap-3 rounded-xl border border-border bg-surface/80 p-3 md:grid-cols-3">
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.agent')}</label>
-              <select
+              <CompactSelect
                 value={value.routing.opencode_agent || ''}
                 onChange={(e) => onChange({ routing: { ...value.routing, opencode_agent: e.target.value || null } })}
-                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-foreground"
+                className="w-full"
               >
                 <option value="">{t('common.default')}</option>
                 {(opencodeOptions?.agents || []).map((a: any) => (
                   <option key={a.name} value={a.name}>{a.name}</option>
                 ))}
-              </select>
+              </CompactSelect>
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.model')}</label>
-              <select
+              <CompactSelect
                 value={value.routing.opencode_model || ''}
                 onChange={(e) => onChange({
                   routing: {
@@ -303,7 +304,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                     opencode_reasoning_effort: null,
                   },
                 })}
-                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-foreground"
+                className="w-full"
               >
                 <option value="">{t('common.default')}</option>
                 {(opencodeOptions?.models?.providers || []).flatMap((provider: any) => {
@@ -320,23 +321,23 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                     <option key={`${pid}:${mid}`} value={`${pid}/${mid}`}>{pLabel}/{mid}</option>
                   ));
                 })}
-              </select>
+              </CompactSelect>
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.reasoningEffort')}</label>
-              <select
+              <CompactSelect
                 value={value.routing.opencode_reasoning_effort || ''}
                 onChange={(e) => onChange({
                   routing: { ...value.routing, opencode_reasoning_effort: e.target.value || null },
                 })}
                 disabled={!getOpenCodeReasoningOptions(value.routing.opencode_model || '').length}
-                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-foreground disabled:opacity-50"
+                className="w-full disabled:opacity-50"
               >
                 <option value="">{t('common.default')}</option>
                 {getOpenCodeReasoningOptions(value.routing.opencode_model || '').map((opt) => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
                 ))}
-              </select>
+              </CompactSelect>
             </div>
           </div>
         </div>
@@ -348,14 +349,14 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
           <div className="grid grid-cols-1 gap-3 rounded-xl border border-border bg-surface/80 p-3 md:grid-cols-3">
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.agent')}</label>
-              <select
+              <CompactSelect
                 value={value.routing.claude_agent || ''}
                 onChange={(e) => onChange({ routing: { ...value.routing, claude_agent: e.target.value || null } })}
-                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-foreground"
+                className="w-full"
               >
                 <option value="">{t('common.default')}</option>
                 {claudeAgents.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
-              </select>
+              </CompactSelect>
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.model')}</label>
@@ -376,12 +377,12 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.reasoningEffort')}</label>
-              <select
+              <CompactSelect
                 value={value.routing.claude_reasoning_effort || ''}
                 onChange={(e) => onChange({
                   routing: { ...value.routing, claude_reasoning_effort: e.target.value || null },
                 })}
-                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-foreground"
+                className="w-full"
               >
                 <option value="">{t('common.default')}</option>
                 {getClaudeReasoning(value.routing.claude_model || '')
@@ -391,7 +392,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                       {getReasoningLabel(option.value, option.label)}
                     </option>
                   ))}
-              </select>
+              </CompactSelect>
             </div>
           </div>
         </div>
@@ -403,14 +404,14 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
           <div className="grid grid-cols-1 gap-3 rounded-xl border border-border bg-surface/80 p-3 md:grid-cols-3">
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.agent')}</label>
-              <select
+              <CompactSelect
                 value={value.routing.codex_agent || ''}
                 onChange={(e) => onChange({ routing: { ...value.routing, codex_agent: e.target.value || null } })}
-                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-foreground"
+                className="w-full"
               >
                 <option value="">{t('common.default')}</option>
                 {codexAgents.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
-              </select>
+              </CompactSelect>
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.model')}</label>
@@ -427,19 +428,19 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
             </div>
             <div className="space-y-1">
               <label className="text-xs text-muted">{t('channelList.reasoningEffort')}</label>
-              <select
+              <CompactSelect
                 value={value.routing.codex_reasoning_effort || ''}
                 onChange={(e) => onChange({
                   routing: { ...value.routing, codex_reasoning_effort: e.target.value || null },
                 })}
-                className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-foreground"
+                className="w-full"
               >
                 <option value="">{t('common.default')}</option>
                 <option value="low">{t('channelList.reasoningLow')}</option>
                 <option value="medium">{t('channelList.reasoningMedium')}</option>
                 <option value="high">{t('channelList.reasoningHigh')}</option>
                 <option value="xhigh">{t('channelList.reasoningXHigh')}</option>
-              </select>
+              </CompactSelect>
             </div>
           </div>
         </div>

--- a/ui/src/components/shared/WizardStep.tsx
+++ b/ui/src/components/shared/WizardStep.tsx
@@ -45,7 +45,7 @@ export const StepHeader: React.FC<StepHeaderProps> = ({
       <span
         className={clsx(
           'flex size-7 items-center justify-center rounded-full text-[12px] font-bold transition-colors',
-          completed ? 'bg-mint text-[#080812]' : 'bg-cyan/15 text-cyan'
+          completed ? 'bg-mint text-primary-foreground' : 'bg-cyan/15 text-cyan'
         )}
       >
         {completed ? <Check size={14} /> : step}

--- a/ui/src/components/steps/AgentDetection.tsx
+++ b/ui/src/components/steps/AgentDetection.tsx
@@ -16,6 +16,7 @@ import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import { BackendIcon, EyebrowBadge, WizardCard } from '../visual';
 import type { BackendId } from '../visual';
+import { CompactField, CompactSelect, ToggleSwitch } from '../settings/SettingsPrimitives';
 
 interface AgentDetectionProps {
   data: any;
@@ -192,15 +193,15 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
           <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">
             {t('agentDetection.defaultBackend')}
           </span>
-          <select
+          <CompactSelect
             value={defaultBackend}
             onChange={(e) => setDefaultBackend(e.target.value)}
-            className="mt-1 h-9 w-full rounded-lg border border-border bg-surface-2 px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40 md:max-w-[260px]"
+            className="mt-1 w-full md:max-w-[260px]"
           >
             <option value="opencode">OpenCode {t('agentDetection.recommended')}</option>
             <option value="claude">Claude Code</option>
             <option value="codex">Codex</option>
-          </select>
+          </CompactSelect>
         </label>
         <button
           onClick={detectAll}
@@ -228,30 +229,16 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
               </div>
               <div className="flex items-center gap-3">
                 <StatusBadge status={agent.status || 'unknown'} loading={checking} />
-                <button
-                  role="switch"
-                  aria-checked={agent.enabled}
+                <ToggleSwitch
+                  enabled={agent.enabled}
                   onClick={() => toggle(name, !agent.enabled)}
-                  className={clsx(
-                    'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint/40',
-                    agent.enabled
-                      ? 'border-mint/50 bg-mint shadow-[0_0_12px_-2px_rgba(91,255,160,0.6)]'
-                      : 'border-border-strong bg-border-strong'
-                  )}
-                >
-                  <span
-                    className={clsx(
-                      'inline-block size-3.5 rounded-full bg-background shadow transition-transform',
-                      agent.enabled ? 'translate-x-[18px]' : 'translate-x-1'
-                    )}
-                  />
-                </button>
+                />
               </div>
             </div>
 
             <div className="space-y-3 px-5 py-3.5">
               <div className="flex gap-2">
-                <input
+                <CompactField
                   type="text"
                   value={agent.cli_path}
                   onChange={(e) =>
@@ -261,7 +248,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                     }))
                   }
                   placeholder={t('agentDetection.cliPathPlaceholder', { name })}
-                  className="h-9 flex-1 rounded-lg border border-border bg-surface-2 px-3 font-mono text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                  className="flex-1 font-mono"
                 />
                 <button
                   onClick={() => detect(name, agent.cli_path)}

--- a/ui/src/components/steps/AgentDetection.tsx
+++ b/ui/src/components/steps/AgentDetection.tsx
@@ -17,6 +17,7 @@ import { useApi } from '../../context/ApiContext';
 import { BackendIcon, EyebrowBadge, WizardCard } from '../visual';
 import type { BackendId } from '../visual';
 import { CompactField, CompactSelect, ToggleSwitch } from '../settings/SettingsPrimitives';
+import { Button } from '../ui/button';
 
 interface AgentDetectionProps {
   data: any;
@@ -264,10 +265,11 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                 <div className="space-y-2 rounded-lg border border-cyan/30 bg-cyan/[0.06] px-3 py-2.5">
                   <p className="text-[11px] text-cyan">{t('agentDetection.installHint')}</p>
                   <div className="flex flex-wrap items-center gap-3">
-                    <button
+                    <Button
+                      variant="brand-cyan"
+                      size="xs"
                       onClick={() => installAgent(name)}
                       disabled={isAnyInstalling}
-                      className="inline-flex h-8 items-center gap-2 rounded-lg bg-cyan px-3 text-[12px] font-bold text-[#080812] shadow-[0_0_18px_-4px_rgba(63,224,229,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {installingAgents[name] ? (
                         <RefreshCw className="size-3.5 animate-spin" />
@@ -275,7 +277,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                         <Download className="size-3.5" />
                       )}
                       {installingAgents[name] ? t('agentDetection.installing') : t('agentDetection.installAgent')}
-                    </button>
+                    </Button>
                     {installResults[name]?.message && (
                       <span
                         className={clsx(
@@ -310,10 +312,11 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                 <div className="rounded-lg border border-gold/30 bg-gold/10 px-3 py-2.5">
                   <p className="mb-2 text-[11px] text-gold">{t('agentDetection.permissionHint')}</p>
                   <div className="flex flex-wrap items-center gap-3">
-                    <button
+                    <Button
+                      variant="brand-gold"
+                      size="xs"
                       onClick={setupPermission}
                       disabled={permissionState === 'loading'}
-                      className="inline-flex h-8 items-center gap-2 rounded-lg bg-gold px-3 text-[12px] font-bold text-[#080812] shadow-[0_0_18px_-4px_rgba(255,200,87,0.55)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {permissionState === 'loading' ? (
                         <RefreshCw className="size-3.5 animate-spin" />
@@ -321,7 +324,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                         <Settings className="size-3.5" />
                       )}
                       {t('agentDetection.setupPermission')}
-                    </button>
+                    </Button>
                     {permissionState === 'success' && (
                       <span className="text-[11px] text-mint">{permissionMessage}</span>
                     )}
@@ -343,13 +346,9 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
       <div className="flex flex-col gap-4">
         {Inner}
         <div className="flex justify-end">
-          <button
-            onClick={() => void handlePrimaryAction()}
-            disabled={!canContinue}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
-          >
+          <Button variant="brand" size="default" onClick={() => void handlePrimaryAction()} disabled={!canContinue}>
             {t('common.save')}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -390,15 +389,16 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
           ) : (
             <span />
           )}
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() => void handlePrimaryAction()}
             disabled={!canContinue}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -1157,6 +1157,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                     tabIndex={0}
                     onClick={() => setExpandedChannelId(expanded ? null : rowKey)}
                     onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
                       if (e.key === ' ' || e.key === 'Enter') {
                         e.preventDefault();
                         setExpandedChannelId(expanded ? null : rowKey);

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -24,6 +24,7 @@ import { getEnabledPlatforms, platformSupportsChannels } from '../../lib/platfor
 import { EyebrowBadge, PlatformIcon, WizardCard } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
 import { CompactSelect, SearchField, ToggleSwitch } from '../settings/SettingsPrimitives';
+import { Button } from '../ui/button';
 
 const PLATFORM_BRAND_COLORS: Record<string, string> = {
   slack: '#4A154B',
@@ -790,14 +791,15 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 <ArrowLeft size={14} strokeWidth={2.25} />
                 {t('common.back')}
               </button>
-              <button
+              <Button
                 type="button"
+                variant="brand"
+                size="default"
                 onClick={() => onNext && onNext({})}
-                className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105"
               >
                 {t('common.continue')}
                 <ArrowRight size={14} strokeWidth={2.25} />
-              </button>
+              </Button>
             </div>
           </WizardCard>
         </div>
@@ -1608,8 +1610,10 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() => {
               const discordGuildAllowlist = selectedGuildIds;
               if (isWizardMultiPlatform) {
@@ -1633,11 +1637,10 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 });
               }
             }}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       )}
     </Wrapper>

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -1084,13 +1084,13 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                     discovered: summary.total,
                   })}
             </div>
-            <div className="inline-flex items-center gap-2">
+            <label className="inline-flex cursor-pointer items-center gap-2">
               <span className="text-[12px] text-muted">{t('channelList.showInactive')}</span>
               <ToggleSwitch
                 enabled={showInactive}
                 onClick={() => setShowInactive(!showInactive)}
               />
-            </div>
+            </label>
           </div>
 
           {/* Channel rows — design.pen JrNBe / M8FRiG / KywfU */}

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -11,7 +11,6 @@ import {
   HelpCircle,
   MessageSquare,
   RefreshCw,
-  Search,
   Square,
   Users,
 } from 'lucide-react';
@@ -24,7 +23,7 @@ import clsx from 'clsx';
 import { getEnabledPlatforms, platformSupportsChannels } from '../../lib/platforms';
 import { EyebrowBadge, PlatformIcon, WizardCard } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
-import { CompactSelect, ToggleSwitch } from '../settings/SettingsPrimitives';
+import { CompactSelect, SearchField, ToggleSwitch } from '../settings/SettingsPrimitives';
 
 const PLATFORM_BRAND_COLORS: Record<string, string> = {
   slack: '#4A154B',
@@ -899,16 +898,12 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               <p className="text-[14px] leading-[1.55] text-muted">{t('channelList.subtitle')}</p>
             </div>
             <div className="flex items-center gap-2">
-              <div className="relative">
-                <Search size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
-                <input
-                  type="search"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder={t('channelList.filterPlaceholder')}
-                  className="h-9 w-[240px] rounded-lg border border-border bg-surface pl-9 pr-3 text-[13px] text-foreground placeholder:text-muted focus:border-mint/50 focus:outline-none"
-                />
-              </div>
+              <SearchField
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder={t('channelList.filterPlaceholder')}
+                className="w-[240px]"
+              />
               <button
                 type="button"
                 onClick={handleRescan}

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -24,6 +24,7 @@ import clsx from 'clsx';
 import { getEnabledPlatforms, platformSupportsChannels } from '../../lib/platforms';
 import { EyebrowBadge, PlatformIcon, WizardCard } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
+import { CompactSelect, ToggleSwitch } from '../settings/SettingsPrimitives';
 
 const PLATFORM_BRAND_COLORS: Record<string, string> = {
   slack: '#4A154B',
@@ -979,16 +980,16 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               <div className="grid gap-3 md:grid-cols-[minmax(220px,280px)_1fr]">
                 <div className="space-y-1">
                   <label className="font-medium text-foreground">{t('channelList.guildBrowse')}</label>
-                  <select
+                  <CompactSelect
                     value={selectedGuild}
                     onChange={(e) => updateSelectedGuild(e.target.value)}
-                    className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground focus:border-cyan focus:outline-none"
+                    className="w-full"
                   >
                     <option value="">{t('channelList.guildPlaceholder')}</option>
                     {knownDiscordGuilds.map((g) => (
                       <option key={g.id} value={g.id}>{g.name}</option>
                     ))}
-                  </select>
+                  </CompactSelect>
                 </div>
                 <div className="space-y-2">
                   <div className="flex flex-wrap items-center justify-between gap-2">
@@ -1086,28 +1087,13 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                     discovered: summary.total,
                   })}
             </div>
-            <label className="inline-flex cursor-pointer items-center gap-2">
+            <div className="inline-flex items-center gap-2">
               <span className="text-[12px] text-muted">{t('channelList.showInactive')}</span>
-              <input
-                type="checkbox"
-                checked={showInactive}
-                onChange={(e) => setShowInactive(e.target.checked)}
-                className="sr-only"
+              <ToggleSwitch
+                enabled={showInactive}
+                onClick={() => setShowInactive(!showInactive)}
               />
-              <span
-                className={clsx(
-                  'relative inline-flex h-[18px] w-[30px] items-center rounded-full transition-colors',
-                  showInactive ? 'bg-mint' : 'bg-border-strong'
-                )}
-              >
-                <span
-                  className={clsx(
-                    'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
-                    showInactive ? 'translate-x-[14px]' : 'translate-x-0.5'
-                  )}
-                />
-              </span>
-            </label>
+            </div>
           </div>
 
           {/* Channel rows — design.pen JrNBe / M8FRiG / KywfU */}
@@ -1166,37 +1152,23 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                   )}
                 >
                   {/* Top row */}
-                  <button
-                    type="button"
+                  <div
+                    role="button"
+                    tabIndex={0}
                     onClick={() => setExpandedChannelId(expanded ? null : rowKey)}
-                    className="flex w-full items-center gap-3.5 px-5 py-3.5 text-left"
+                    onKeyDown={(e) => {
+                      if (e.key === ' ' || e.key === 'Enter') {
+                        e.preventDefault();
+                        setExpandedChannelId(expanded ? null : rowKey);
+                      }
+                    }}
+                    className="flex w-full cursor-pointer items-center gap-3.5 px-5 py-3.5 text-left"
                   >
                     {/* Toggle */}
-                    <span
-                      role="switch"
-                      aria-checked={channelEnabled}
-                      tabIndex={0}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        updateRow({ enabled: !channelEnabled });
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === ' ' || e.key === 'Enter') {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          updateRow({ enabled: !channelEnabled });
-                        }
-                      }}
-                      className={clsx(
-                        'relative inline-flex h-[18px] w-8 shrink-0 cursor-pointer items-center rounded-full transition-colors',
-                        channelEnabled ? 'bg-mint' : 'bg-border-strong'
-                      )}
-                    >
-                      <span
-                        className={clsx(
-                          'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
-                          channelEnabled ? 'translate-x-[14px]' : 'translate-x-0.5'
-                        )}
+                    <span onClick={(e) => e.stopPropagation()}>
+                      <ToggleSwitch
+                        enabled={channelEnabled}
+                        onClick={() => updateRow({ enabled: !channelEnabled })}
                       />
                     </span>
 
@@ -1244,7 +1216,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                     ) : (
                       <ChevronDown size={18} className="shrink-0 text-muted" />
                     )}
-                  </button>
+                  </div>
 
                   {/* Expanded body — design.pen asPXu (VR/RoutingConfig) — shared with /users */}
                   {expanded && (
@@ -1442,16 +1414,16 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             <div className="grid gap-3 md:grid-cols-[minmax(220px,280px)_1fr]">
               <div className="space-y-1">
                 <label className="font-medium text-foreground">{t('channelList.guildBrowse')}</label>
-                <select
+                <CompactSelect
                   value={selectedGuild}
                   onChange={(e) => updateSelectedGuild(e.target.value)}
-                   className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-foreground focus:outline-none focus:border-cyan"
+                  className="w-full"
                 >
                   <option value="">{t('channelList.guildPlaceholder')}</option>
                   {knownDiscordGuilds.map((g) => (
                     <option key={g.id} value={g.id}>{g.name}</option>
                   ))}
-                </select>
+                </CompactSelect>
               </div>
               <div className="space-y-2">
                 <div className="flex flex-wrap items-center justify-between gap-2">

--- a/ui/src/components/steps/DiscordConfig.tsx
+++ b/ui/src/components/steps/DiscordConfig.tsx
@@ -21,6 +21,7 @@ import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
+import { Button } from '../ui/button';
 
 interface DiscordConfigProps {
   data: any;
@@ -187,13 +188,10 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                   <li>{t('discordConfig.step1Item2')}</li>
                   <li>{t('discordConfig.step1Item3')}</li>
                 </ol>
-                <button
-                  onClick={openDiscordDeveloperPortal}
-                  className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105"
-                >
+                <Button variant="brand" size="sm" onClick={openDiscordDeveloperPortal}>
                   <ExternalLink size={14} strokeWidth={2.25} />
                   {t('discordConfig.openDeveloperPortal')}
-                </button>
+                </Button>
               </div>
             )}
           </StepShell>
@@ -274,14 +272,15 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                     className="w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-[11px] text-foreground"
                   />
                 </div>
-                <button
+                <Button
+                  variant="brand"
+                  size="sm"
                   onClick={() => inviteUrl && window.open(inviteUrl, '_blank')}
                   disabled={!inviteUrl}
-                  className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <ExternalLink size={14} strokeWidth={2.25} />
                   {t('discordConfig.openInviteUrl')}
-                </button>
+                </Button>
 
                 <div className="space-y-2 rounded-lg border border-gold/30 bg-gold/10 px-3 py-2.5">
                   <div className="flex items-center gap-2 text-[12px] font-semibold text-gold">
@@ -334,14 +333,15 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                 <ProxyUrlField value={proxyUrl} onChange={setProxyUrl} />
 
                 <div className="flex flex-wrap items-center gap-3">
-                  <button
+                  <Button
+                    variant="brand"
+                    size="sm"
                     onClick={runAuthTest}
                     disabled={!botToken || checking}
-                    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {checking ? <RefreshCw size={14} className="animate-spin" /> : <Shield size={14} strokeWidth={2.25} />}
                     {t('discordConfig.validateToken')}
-                  </button>
+                  </Button>
                   {authResult && (
                     <span
                       className={clsx(
@@ -476,15 +476,16 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() => onNext(buildSubmitData())}
             disabled={!isValid}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/DoctorPanel.tsx
+++ b/ui/src/components/steps/DoctorPanel.tsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
+import { Button } from '../ui/button';
 
 interface DoctorPanelProps {
   isPage?: boolean;
@@ -128,15 +129,10 @@ export const DoctorPanel: React.FC<DoctorPanelProps> = ({
               {t('doctor.copyReport')}
             </button>
           )}
-          <button
-            type="button"
-            onClick={runDoctor}
-            disabled={loading}
-            className="inline-flex h-8 items-center gap-1.5 rounded-lg bg-mint px-3 text-[12px] font-bold text-[#080812] shadow-[0_0_18px_-4px_rgba(91,255,160,0.55)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
-          >
+          <Button type="button" variant="brand" size="xs" onClick={runDoctor} disabled={loading}>
             <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} strokeWidth={2.5} />
             {t('doctor.runChecks')}
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/ui/src/components/steps/LarkConfig.tsx
+++ b/ui/src/components/steps/LarkConfig.tsx
@@ -24,16 +24,13 @@ import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
+import { Button } from '../ui/button';
 
 const LinkButton: React.FC<{ url: string; label: string }> = ({ url, label }) => (
-  <button
-    onClick={() => window.open(url, '_blank')}
-    disabled={!url}
-    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
-  >
+  <Button variant="brand" size="sm" onClick={() => window.open(url, '_blank')} disabled={!url}>
     <ExternalLink size={14} strokeWidth={2.25} />
     {label}
-  </button>
+  </Button>
 );
 
 const LARK_PERMISSIONS_JSON = `{
@@ -317,14 +314,15 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
                 />
 
                 <div className="flex flex-wrap items-center gap-3">
-                  <button
+                  <Button
+                    variant="brand"
+                    size="sm"
                     onClick={runAuthTest}
                     disabled={!appId || !appSecret || checking}
-                    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {checking ? <RefreshCw size={14} className="animate-spin" /> : <Shield size={14} strokeWidth={2.25} />}
                     {t('larkConfig.validateCredentials')}
-                  </button>
+                  </Button>
                   {authResult && (
                     <span
                       className={clsx(
@@ -567,18 +565,19 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() => {
               api.larkTempWsStop().catch(() => {});
               onNext(buildSubmitData());
             }}
             disabled={!isValid}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/LogsPanel.tsx
+++ b/ui/src/components/steps/LogsPanel.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
 import { useApi, type LogEntry, type LogSource } from '../../context/ApiContext';
+import { Button } from '../ui/button';
 
 type LogLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'ALL';
 
@@ -164,15 +165,17 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
             {autoRefresh ? <Pause className="size-3.5" /> : <Play className="size-3.5" />}
             {autoRefresh ? t('logs.autoRefreshOn') : t('logs.autoRefresh')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="xs"
+            className="h-9"
             onClick={() => void loadLogs(selectedSource)}
             disabled={loading}
-            className="inline-flex h-9 items-center gap-1.5 rounded-lg bg-mint px-3 text-[12px] font-bold text-[#080812] shadow-[0_0_18px_-4px_rgba(91,255,160,0.55)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} strokeWidth={2.5} />
             {t('common.refresh')}
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -6,6 +6,7 @@ import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { getEnabledPlatforms, getPlatformCatalog, getPrimaryPlatform } from '../../lib/platforms';
 import { EyebrowBadge, PlatformIcon, WizardCard } from '../visual';
+import { Button } from '../ui/button';
 
 // Per-platform brand-tinted tile container colors (matches design.pen wT*L
 // frames: Slack purple-soft, Discord indigo-soft, etc.).
@@ -548,15 +549,16 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() => void handleContinue()}
             disabled={!selected.length}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/SlackConfig.tsx
+++ b/ui/src/components/steps/SlackConfig.tsx
@@ -8,6 +8,7 @@ import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
+import { Button } from '../ui/button';
 
 interface SlackConfigProps {
   data: any;
@@ -150,14 +151,15 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
               <div className="space-y-4 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('slackConfig.step1Description')}</p>
                 <div className="flex flex-wrap items-center gap-3">
-                  <button
+                  <Button
+                    variant="brand"
+                    size="sm"
                     onClick={openSlackCreateApp}
                     disabled={!manifestCompact || manifestLoading}
-                    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     <ExternalLink size={14} strokeWidth={2.25} />
                     {t('slackConfig.createSlackApp')}
-                  </button>
+                  </Button>
                   {manifest && (
                     <button
                       onClick={copyManifest}
@@ -290,14 +292,15 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                 <p className="text-[13px] leading-[1.55] text-muted">{t('slackConfig.step4Description')}</p>
                 <ProxyUrlField value={proxyUrl} onChange={setProxyUrl} />
                 <div className="flex flex-wrap items-center gap-3">
-                  <button
+                  <Button
+                    variant="brand"
+                    size="sm"
                     onClick={runAuthTest}
                     disabled={!botToken || !appToken || checking}
-                    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {checking ? <RefreshCw size={14} className="animate-spin" /> : <Shield size={14} strokeWidth={2.25} />}
                     {t('slackConfig.validateTokens')}
-                  </button>
+                  </Button>
                   {authResult && (
                     <span
                       className={clsx(
@@ -388,17 +391,18 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() =>
               onNext({ slack: { ...data.slack, bot_token: botToken, app_token: appToken, proxy_url: proxyUrl || undefined }, mode: 'self_host' })
             }
             disabled={!isValid}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -19,6 +19,7 @@ import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { getEnabledPlatforms, getPrimaryPlatform } from '../../lib/platforms';
 import { EyebrowBadge, WizardCard } from '../visual';
+import { ToggleSwitch } from '../settings/SettingsPrimitives';
 
 interface SummaryProps {
   data: any;
@@ -286,10 +287,13 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
                   className="flex items-center justify-between rounded-lg border border-border bg-surface-2 px-3 py-2"
                 >
                   <span className="text-[12px] font-medium text-foreground">{titleCase(platform)}</span>
-                  <Switch
-                    checked={!!requireMentionByPlatform[platform]}
-                    onChange={(value) =>
-                      setRequireMentionByPlatform((current) => ({ ...current, [platform]: value }))
+                  <ToggleSwitch
+                    enabled={!!requireMentionByPlatform[platform]}
+                    onClick={() =>
+                      setRequireMentionByPlatform((current) => ({
+                        ...current,
+                        [platform]: !current[platform],
+                      }))
                     }
                   />
                 </div>
@@ -304,7 +308,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
             <h3 className="text-[13px] font-semibold text-foreground">{t('summary.autoUpdate')}</h3>
             <p className="mt-0.5 text-[11px] text-muted">{t('summary.autoUpdateHint')}</p>
           </div>
-          <Switch checked={autoUpdate} onChange={setAutoUpdate} />
+          <ToggleSwitch enabled={autoUpdate} onClick={() => setAutoUpdate((v: boolean) => !v)} />
         </div>
 
         {/* Quick start tips */}
@@ -365,28 +369,6 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
     </div>
   );
 };
-
-const Switch: React.FC<{ checked: boolean; onChange: (next: boolean) => void }> = ({ checked, onChange }) => (
-  <button
-    type="button"
-    role="switch"
-    aria-checked={checked}
-    onClick={() => onChange(!checked)}
-    className={clsx(
-      'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors focus:outline-none focus:ring-2 focus:ring-mint/40',
-      checked
-        ? 'border-mint/50 bg-mint shadow-[0_0_12px_-2px_rgba(91,255,160,0.6)]'
-        : 'border-border-strong bg-border-strong'
-    )}
-  >
-    <span
-      className={clsx(
-        'inline-block size-3.5 rounded-full bg-background shadow transition-transform',
-        checked ? 'translate-x-[18px]' : 'translate-x-1'
-      )}
-    />
-  </button>
-);
 
 const Tip: React.FC<{
   icon: React.ReactNode;

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -20,6 +20,7 @@ import { copyTextToClipboard } from '../../lib/utils';
 import { getEnabledPlatforms, getPrimaryPlatform } from '../../lib/platforms';
 import { EyebrowBadge, WizardCard } from '../visual';
 import { ToggleSwitch } from '../settings/SettingsPrimitives';
+import { Button } from '../ui/button';
 
 interface SummaryProps {
   data: any;
@@ -225,13 +226,10 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
               <p className="mt-2 text-[11px] text-mint">{t('summary.bindCodeCopied')}</p>
             )}
           </div>
-          <button
-            onClick={() => navigate('/dashboard')}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-7 py-3 text-[14px] font-bold text-[#080812] shadow-[0_0_48px_-8px_rgba(91,255,160,0.7)] transition hover:brightness-105"
-          >
+          <Button variant="brand" size="lg" onClick={() => navigate('/dashboard')}>
             {t('summary.goToDashboard')}
             <ArrowRight size={16} strokeWidth={2.25} />
-          </button>
+          </Button>
         </WizardCard>
       </div>
     );
@@ -355,15 +353,10 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
-            type="button"
-            onClick={saveAll}
-            disabled={saving}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-7 py-3 text-[14px] font-bold text-[#080812] shadow-[0_0_48px_-8px_rgba(91,255,160,0.7)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none"
-          >
+          <Button type="button" variant="brand" size="lg" onClick={saveAll} disabled={saving}>
             {saving ? t('common.saving') : t('summary.finishAndStart')}
             {!saving && <ArrowRight size={16} strokeWidth={2.25} />}
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -20,6 +20,7 @@ import { copyTextToClipboard } from '../../lib/utils';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
+import { ToggleSwitch } from '../settings/SettingsPrimitives';
 
 interface TelegramConfigProps {
   data: any;
@@ -350,22 +351,20 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               <div className="space-y-3 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('telegramConfig.step5Description')}</p>
 
-                <label className="flex items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
+                <div className="flex items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
                   <div>
                     <div className="text-[12px] font-semibold text-foreground">
                       {t('telegramConfig.requireMention')}
                     </div>
                     <p className="mt-0.5 text-[11px] text-muted">{t('telegramConfig.requireMentionHint')}</p>
                   </div>
-                  <input
-                    type="checkbox"
-                    checked={requireMention}
-                    onChange={(e) => setRequireMention(e.target.checked)}
-                    className="mt-1 size-4 accent-mint"
+                  <ToggleSwitch
+                    enabled={requireMention}
+                    onClick={() => setRequireMention(!requireMention)}
                   />
-                </label>
+                </div>
 
-                <label className="flex items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
+                <div className="flex items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
                   <div className="pr-4">
                     <div className="flex items-center gap-2 text-[12px] font-semibold text-foreground">
                       <SplitSquareVertical size={14} className="text-cyan" />
@@ -373,13 +372,11 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                     </div>
                     <p className="mt-0.5 text-[11px] text-muted">{t('telegramConfig.forumAutoTopicHint')}</p>
                   </div>
-                  <input
-                    type="checkbox"
-                    checked={forumAutoTopic}
-                    onChange={(e) => setForumAutoTopic(e.target.checked)}
-                    className="mt-1 size-4 accent-mint"
+                  <ToggleSwitch
+                    enabled={forumAutoTopic}
+                    onClick={() => setForumAutoTopic(!forumAutoTopic)}
                   />
-                </label>
+                </div>
               </div>
             )}
           </StepShell>

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -350,7 +350,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
               <div className="space-y-3 border-t border-border px-5 py-4">
                 <p className="text-[13px] leading-[1.55] text-muted">{t('telegramConfig.step5Description')}</p>
 
-                <div className="flex items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
+                <label className="flex cursor-pointer items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
                   <div>
                     <div className="text-[12px] font-semibold text-foreground">
                       {t('telegramConfig.requireMention')}
@@ -361,9 +361,9 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                     enabled={requireMention}
                     onClick={() => setRequireMention(!requireMention)}
                   />
-                </div>
+                </label>
 
-                <div className="flex items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
+                <label className="flex cursor-pointer items-start justify-between gap-4 rounded-lg border border-border bg-background px-3 py-2.5">
                   <div className="pr-4">
                     <div className="flex items-center gap-2 text-[12px] font-semibold text-foreground">
                       <SplitSquareVertical size={14} className="text-cyan" />
@@ -375,7 +375,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                     enabled={forumAutoTopic}
                     onClick={() => setForumAutoTopic(!forumAutoTopic)}
                   />
-                </div>
+                </label>
               </div>
             )}
           </StepShell>

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -21,6 +21,7 @@ import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
 import { ToggleSwitch } from '../settings/SettingsPrimitives';
+import { Button } from '../ui/button';
 
 interface TelegramConfigProps {
   data: any;
@@ -169,13 +170,10 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                   <li>{t('telegramConfig.step1Item4')}</li>
                 </ol>
                 <div className="flex flex-wrap gap-2">
-                  <button
-                    onClick={openBotFather}
-                    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105"
-                  >
+                  <Button variant="brand" size="sm" onClick={openBotFather}>
                     <ExternalLink size={14} strokeWidth={2.25} />
                     {t('telegramConfig.openBotFather')}
-                  </button>
+                  </Button>
                   <button
                     onClick={() => copyCommand('/newbot')}
                     className="inline-flex items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong"
@@ -233,14 +231,15 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                 />
 
                 <div className="flex flex-wrap items-center gap-3">
-                  <button
+                  <Button
+                    variant="brand"
+                    size="sm"
                     onClick={runAuthTest}
                     disabled={!botToken || checking}
-                    className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {checking ? <RefreshCw size={14} className="animate-spin" /> : <Shield size={14} strokeWidth={2.25} />}
                     {t('telegramConfig.validateToken')}
-                  </button>
+                  </Button>
                   {authResult && (
                     <span
                       className={clsx(
@@ -440,15 +439,16 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() => onNext(buildSubmitData())}
             disabled={!isValid}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -8,7 +8,6 @@ import {
   KeyRound,
   Plus,
   RefreshCw,
-  Search,
   Shield,
   Trash2,
   X,
@@ -22,7 +21,7 @@ import { DirectoryBrowser } from '../ui/directory-browser';
 import { copyTextToClipboard } from '../../lib/utils';
 import { PlatformIcon } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
-import { ToggleSwitch } from '../settings/SettingsPrimitives';
+import { SearchField, ToggleSwitch } from '../settings/SettingsPrimitives';
 
 interface UserConfig {
   display_name: string;
@@ -661,16 +660,12 @@ export const UserList: React.FC = () => {
             <p className="text-[14px] leading-[1.55] text-muted">{t('userList.subtitle')}</p>
           </div>
           <div className="flex items-center gap-2">
-            <div className="relative">
-              <Search size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
-              <input
-                type="search"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder={t('userList.filterPlaceholder')}
-                className="h-9 w-[280px] rounded-lg border border-border bg-surface pl-9 pr-3 text-[13px] text-foreground placeholder:text-muted focus:border-mint/50 focus:outline-none"
-              />
-            </div>
+            <SearchField
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder={t('userList.filterPlaceholder')}
+              className="w-[280px]"
+            />
             <button
               type="button"
               onClick={() => setRefreshTrigger((v) => v + 1)}

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -22,6 +22,7 @@ import { DirectoryBrowser } from '../ui/directory-browser';
 import { copyTextToClipboard } from '../../lib/utils';
 import { PlatformIcon } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
+import { ToggleSwitch } from '../settings/SettingsPrimitives';
 
 interface UserConfig {
   display_name: string;
@@ -695,28 +696,13 @@ export const UserList: React.FC = () => {
               {totalCount}
             </span>
           </div>
-          <label className="flex cursor-pointer items-center gap-1.5 text-[12px] text-muted">
+          <div className="flex items-center gap-1.5 text-[12px] text-muted">
             <span>{t('userList.showDisabled')}</span>
-            <input
-              type="checkbox"
-              checked={showDisabled}
-              onChange={(e) => setShowDisabled(e.target.checked)}
-              className="sr-only"
+            <ToggleSwitch
+              enabled={showDisabled}
+              onClick={() => setShowDisabled(!showDisabled)}
             />
-            <span
-              className={clsx(
-                'relative inline-flex h-[18px] w-[30px] items-center rounded-full transition-colors',
-                showDisabled ? 'bg-mint' : 'bg-border-strong'
-              )}
-            >
-              <span
-                className={clsx(
-                  'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
-                  showDisabled ? 'translate-x-[14px]' : 'translate-x-0.5'
-                )}
-              />
-            </span>
-          </label>
+          </div>
         </div>
 
         {/* User cards — design.pen asPXu (VR/RoutingConfig) shared with /groups */}
@@ -761,34 +747,23 @@ export const UserList: React.FC = () => {
                   )}
                 >
                   {/* Master row — matches /groups layout */}
-                  <button
-                    type="button"
+                  <div
+                    role="button"
+                    tabIndex={0}
                     onClick={() => setExpandedKey(expanded ? null : u.key)}
-                    className="flex w-full items-center gap-3.5 px-5 py-3.5 text-left"
+                    onKeyDown={(e) => {
+                      if (e.key === ' ' || e.key === 'Enter') {
+                        e.preventDefault();
+                        setExpandedKey(expanded ? null : u.key);
+                      }
+                    }}
+                    className="flex w-full cursor-pointer items-center gap-3.5 px-5 py-3.5 text-left"
                   >
                     {/* Enabled toggle */}
-                    <span
-                      role="switch"
-                      aria-checked={userConfig.enabled}
-                      tabIndex={0}
-                      onClick={(e) => { e.stopPropagation(); toggleEnabled(); }}
-                      onKeyDown={(e) => {
-                        if (e.key === ' ' || e.key === 'Enter') {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          toggleEnabled();
-                        }
-                      }}
-                      className={clsx(
-                        'relative inline-flex h-[18px] w-8 shrink-0 cursor-pointer items-center rounded-full transition-colors',
-                        userConfig.enabled ? 'bg-mint' : 'bg-border-strong'
-                      )}
-                    >
-                      <span
-                        className={clsx(
-                          'inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform',
-                          userConfig.enabled ? 'translate-x-[14px]' : 'translate-x-0.5'
-                        )}
+                    <span onClick={(e) => e.stopPropagation()}>
+                      <ToggleSwitch
+                        enabled={userConfig.enabled}
+                        onClick={toggleEnabled}
                       />
                     </span>
 
@@ -863,7 +838,7 @@ export const UserList: React.FC = () => {
                     ) : (
                       <ChevronDown size={18} className="shrink-0 text-muted" />
                     )}
-                  </button>
+                  </div>
 
                   {/* Expanded body — design.pen asPXu (VR/RoutingConfig) shared with /groups, no @mention toggle */}
                   {expanded && (

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -752,6 +752,7 @@ export const UserList: React.FC = () => {
                     tabIndex={0}
                     onClick={() => setExpandedKey(expanded ? null : u.key)}
                     onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
                       if (e.key === ' ' || e.key === 'Enter') {
                         e.preventDefault();
                         setExpandedKey(expanded ? null : u.key);

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -689,13 +689,13 @@ export const UserList: React.FC = () => {
               {totalCount}
             </span>
           </div>
-          <div className="flex items-center gap-1.5 text-[12px] text-muted">
+          <label className="flex cursor-pointer items-center gap-1.5 text-[12px] text-muted">
             <span>{t('userList.showDisabled')}</span>
             <ToggleSwitch
               enabled={showDisabled}
               onClick={() => setShowDisabled(!showDisabled)}
             />
-          </div>
+          </label>
         </div>
 
         {/* User cards — design.pen asPXu (VR/RoutingConfig) shared with /groups */}

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -22,6 +22,7 @@ import { copyTextToClipboard } from '../../lib/utils';
 import { PlatformIcon } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
 import { SearchField, ToggleSwitch } from '../settings/SettingsPrimitives';
+import { Button } from '../ui/button';
 
 interface UserConfig {
   display_name: string;
@@ -228,14 +229,10 @@ const BindCodeCard: React.FC<BindCodeCardProps> = ({ refreshTrigger, onCodesChan
                 {t('bindCode.revoke')}
               </button>
             )}
-            <button
-              type="button"
-              onClick={() => setShowFormModal(true)}
-              className="inline-flex items-center gap-1.5 rounded-md bg-mint px-3.5 py-2 text-[12px] font-bold text-background shadow-[0_0_16px_rgba(91,255,160,0.35)] transition hover:brightness-110"
-            >
+            <Button type="button" variant="brand" size="xs" onClick={() => setShowFormModal(true)}>
               <Plus size={14} strokeWidth={2.4} />
               {primary ? t('bindCode.newCode') : t('bindCode.createCode')}
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -290,14 +287,15 @@ const BindCodeCard: React.FC<BindCodeCardProps> = ({ refreshTrigger, onCodesChan
                 />
               </div>
             )}
-            <button
+            <Button
               type="button"
+              variant="brand"
+              size="xs"
               onClick={handleCreate}
               disabled={loading || (newType === 'expiring' && !newExpiry)}
-              className="rounded-md bg-mint px-4 py-1.5 text-[12px] font-bold text-background shadow-[0_0_16px_rgba(91,255,160,0.35)] transition hover:brightness-110 disabled:opacity-50"
             >
               {t('bindCode.generate')}
-            </button>
+            </Button>
           </div>
         </Modal>
       )}

--- a/ui/src/components/steps/WeChatConfig.tsx
+++ b/ui/src/components/steps/WeChatConfig.tsx
@@ -16,6 +16,7 @@ import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
+import { Button } from '../ui/button';
 
 interface WeChatConfigProps {
   data: Record<string, any>;
@@ -230,7 +231,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
                       className={clsx(
                         'flex size-7 items-center justify-center rounded-full text-[12px] font-bold transition-colors',
                         isCompleted
-                          ? 'bg-mint text-[#080812]'
+                          ? 'bg-mint text-primary-foreground'
                           : isActive
                             ? 'bg-cyan/15 text-cyan'
                             : 'bg-foreground/[0.06] text-muted'
@@ -369,14 +370,10 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
                   <h3 className="text-[14px] font-semibold text-foreground">{t('wechatConfig.errorTitle')}</h3>
                   <p className="mt-1 text-[12px] text-danger">{message}</p>
                 </div>
-                <button
-                  onClick={startLogin}
-                  disabled={starting}
-                  className="inline-flex items-center gap-2 rounded-lg bg-mint px-4 py-2 text-[13px] font-bold text-[#080812] shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
-                >
+                <Button variant="brand" size="sm" onClick={startLogin} disabled={starting}>
                   <RefreshCw size={14} strokeWidth={2.25} />
                   {t('wechatConfig.retry')}
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -446,15 +443,16 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size="default"
             onClick={() => onNext(buildSubmitData())}
             disabled={!canProceed}
-            className="inline-flex items-center gap-2 rounded-lg bg-mint px-5 py-2.5 text-[13px] font-bold text-[#080812] shadow-[0_0_32px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />
-          </button>
+          </Button>
         </div>
       </WizardCard>
     </div>

--- a/ui/src/components/steps/Welcome.tsx
+++ b/ui/src/components/steps/Welcome.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ArrowRight, HardDrive, PlugZap, Radio, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { WizardCard } from '../visual';
+import { Button } from '../ui/button';
 
 interface WelcomeProps {
   onNext: (data: any) => void;
@@ -74,14 +75,10 @@ export const Welcome: React.FC<WelcomeProps> = ({ onNext }) => {
         </div>
 
         {/* welStart (a95QY) — large mint pill */}
-        <button
-          type="button"
-          onClick={() => onNext({})}
-          className="group inline-flex items-center gap-2 rounded-xl bg-mint px-8 py-[14px] text-[15px] font-bold leading-tight text-[#080812] shadow-[0_0_48px_-8px_rgba(91,255,160,0.44)] transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mint/60"
-        >
+        <Button type="button" variant="brand" size="hero" onClick={() => onNext({})} className="group">
           {t('welcome.getStarted')}
           <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" strokeWidth={2.25} />
-        </button>
+        </Button>
       </WizardCard>
     </div>
   );

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -5,29 +5,43 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-lg font-medium transition disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&_svg]:shrink-0',
   {
     variants: {
       variant: {
         // Mint primary — flat, no glow shadow (design.pen Button/Default).
-        default: 'bg-primary text-primary-foreground hover:brightness-110',
-        secondary: 'border border-border bg-secondary text-secondary-foreground hover:border-border-strong',
+        default: 'gap-1.5 bg-primary text-primary-foreground hover:brightness-110',
+        // Brand CTA — bright bg + brand-color glow shadow + bold text + brighten on hover.
+        // Foreground tokens flip in light mode (--primary/--accent/--gold-foreground).
+        brand:
+          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] hover:brightness-105 disabled:shadow-none',
+        'brand-cyan':
+          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_24px_-4px_rgba(63,224,229,0.6)] hover:brightness-105 disabled:shadow-none',
+        'brand-gold':
+          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_24px_-4px_rgba(255,200,87,0.55)] hover:brightness-105 disabled:shadow-none',
+        secondary: 'gap-1.5 border border-border bg-secondary text-secondary-foreground hover:border-border-strong',
         // Outline — bg matches page surface so it sits cleanly on glow gradients.
         outline:
-          'border border-border bg-background text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.05)] hover:bg-surface-2',
+          'gap-1.5 border border-border bg-background text-foreground shadow-[0_1px_2px_rgba(0,0,0,0.05)] hover:bg-surface-2',
         // Cyan outline — for "Read Vibe Remote" / docs style CTAs.
         'outline-cyan':
-          'border border-cyan/40 bg-cyan/[0.06] text-cyan hover:bg-cyan/[0.10]',
-        ghost: 'text-foreground hover:bg-surface-2',
-        destructive: 'bg-destructive text-destructive-foreground hover:opacity-90',
+          'gap-1.5 border border-cyan/40 bg-cyan/[0.06] text-cyan hover:bg-cyan/[0.10]',
+        ghost: 'gap-1.5 text-foreground hover:bg-surface-2',
+        destructive: 'gap-1.5 bg-destructive text-destructive-foreground hover:opacity-90',
         link: 'text-primary underline-offset-4 hover:underline',
-        accent: 'border border-cyan/40 bg-cyan-soft text-cyan hover:bg-cyan/15',
+        accent: 'gap-1.5 border border-cyan/40 bg-cyan-soft text-cyan hover:bg-cyan/15',
       },
       size: {
-        // Default = design's Large/Default: padding [8, 24].
-        default: 'h-10 px-6 py-2',
-        sm: 'h-8 rounded-md px-4 text-xs',
-        lg: 'h-11 rounded-md px-6 text-sm',
+        // h-8 toolbar buttons (LogsPanel/DoctorPanel/SettingsServicePage/AgentDetection toolbar).
+        xs: 'h-8 px-3 text-[12px] [&_svg]:size-3.5',
+        // h-9 config-inline CTAs (Slack/Discord/Telegram/...).
+        sm: 'h-9 px-4 text-[13px] [&_svg]:size-3.5',
+        // h-10 wizard "下一步" — most common.
+        default: 'h-10 px-5 text-[13px] [&_svg]:size-3.5',
+        // h-12 prominent CTAs (Summary main step CTA).
+        lg: 'h-12 px-7 text-[14px] [&_svg]:size-4',
+        // Welcome-only hero CTA.
+        hero: 'h-[52px] rounded-xl px-8 text-[15px] [&_svg]:size-4',
         icon: 'h-9 w-9',
       },
     },

--- a/ui/src/components/visual/EmbeddedConfigShell.tsx
+++ b/ui/src/components/visual/EmbeddedConfigShell.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { Check, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button';
 
 interface EmbeddedConfigShellProps {
   total: number;
@@ -45,23 +46,19 @@ export const EmbeddedConfigShell: React.FC<EmbeddedConfigShellProps> = ({
       </div>
       <div className="flex flex-col gap-3">{children}</div>
       <div className="flex items-center justify-end gap-2 border-t border-border pt-3">
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={applying}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
-        >
+        <Button type="button" variant="secondary" size="xs" onClick={onCancel} disabled={applying}>
           {t('common.cancel')}
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
+          variant="brand"
+          size="xs"
           onClick={onApply}
           disabled={!canApply || applying}
-          className="inline-flex items-center gap-1.5 rounded-lg bg-mint px-3.5 py-1.5 text-[12px] font-bold text-[#080812] shadow-[0_0_24px_-6px_rgba(91,255,160,0.6)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none"
         >
           {applying ? <RefreshCw size={12} className="animate-spin" /> : <Check size={12} />}
           {t('platform.apply')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -32,6 +32,7 @@
   --color-violet: var(--violet);
   --color-violet-soft: var(--violet-soft);
   --color-gold: var(--gold);
+  --color-gold-foreground: var(--gold-foreground);
 
   /* Compatibility aliases for current UI during migration. */
   --color-bg: var(--background);
@@ -96,6 +97,7 @@
   --violet: #7c5bff;
   --violet-soft: rgba(124, 91, 255, 0.16);
   --gold: #ffc857;
+  --gold-foreground: #080812;
 
   /* Page-family gradients (mirror design.pen 1:1). Layers ordered top-most first. */
   --gradient-console:
@@ -164,6 +166,7 @@
   --violet: #7c3aed;
   --violet-soft: rgba(124, 58, 237, 0.14);
   --gold: #d97706;
+  --gold-foreground: #ffffff;
 
   /* Light-theme page gradients (softer alphas over light base). */
   --gradient-console:


### PR DESCRIPTION
## Summary

Follow-up to #274. The VersionBadge fix exposed many other one-off shells across the wizard and settings pages — local toggles, native checkboxes, raw `<select>` and `<input>` elements that drifted in tone, focus ring, and sizing, plus ~30 hand-rolled `bg-mint ... text-[#080812]` brand buttons. This PR routes everything through shared primitives (`SettingsPrimitives` for fields and toggles, the shadcn `Button` cva for brand buttons) so every surface inherits the same look automatically.

## Changes

### Toggles → `ToggleSwitch`
- `Summary`: dropped a local 21-line `Switch` copy that had drifted from the shared one
- `AgentDetection`: inline `<button role="switch">` per detected agent
- `TelegramConfig`: two native `<input type="checkbox">` fields (mention + accept-empty)
- `UserList` / `ChannelList`: showDisabled / showInactive header toggles, plus the per-row enable toggle
- Row click container changed from `<button>` to `<div role="button" tabIndex={0}>` (HTML disallows nesting buttons), with `onKeyDown` for Space/Enter and a `stopPropagation` wrapper around the inner toggle so row clicks still expand/collapse

### Selects → `CompactSelect`
- `ChannelList`: Discord guild pickers (page mode + wizard mode)
- `AgentDetection`: default backend selector
- `RoutingConfigPanel`: backend, OpenCode agent/model/reasoning, Claude agent/reasoning, Codex agent/reasoning (8 selects total)

### Inputs → `CompactField`
- `AgentDetection`: per-agent CLI path
- `RoutingConfigPanel`: cwd input
- `RemoteAccess`: pairing key
- `ProxyUrlField`: proxy URL

### Brand buttons → shared `Button` cva (a024cb3)
The hardcoded `text-[#080812]` foreground was the **root cause** of the dashboard restart button rendering as black-on-emerald in light mode. Switching to `text-primary-foreground` lets the token flip to white in light mode automatically.

- extend `buttonVariants` cva with `brand`, `brand-cyan`, `brand-gold`
- add `xs` and `hero` size variants alongside existing sm/default/lg
- add `--gold-foreground` token for `brand-gold` text
- migrate all wizard steps, dashboard, version-upgrade, settings, channel/user lists, doctor/logs panels, embedded config shell (~30 sites)
- fix `WizardStep` step indicator hardcoded `text-[#080812]` → token

## Net effect

Combined diff: ~283 insertions / ~359 deletions across 28 files — net minus ~76 lines from removing duplicated shell markup, a local `Switch` clone, and repeated brand button class chains.

## Test plan

- [x] `npm run build` clean
- [x] `/settings/messaging` — all toggles render uniformly mint+glow
- [x] `/users` collapsed — row toggles unified
- [x] `/users` expanded — RoutingConfigPanel inputs/selects all use `bg-foreground/[0.04]`
- [x] `/groups` — header `显示未启用` toggle and per-row toggles render uniformly
- [x] `/dashboard` — light mode "启动" button shows white text on emerald (root-cause fix verified visually); dark mode "启动" mint with dark text
- [x] Welcome / Summary hero buttons render correctly in both modes
- [ ] Manual sanity in the wizard flow (Summary, TelegramConfig, AgentDetection) on next session