### PR TITLE
refactor(ui): consolidate hand-rolled buttons onto shared Button (pass 2)

### DIFF
--- a/ui/src/components/RemoteAccess.tsx
+++ b/ui/src/components/RemoteAccess.tsx
@@ -4,6 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useApi } from '../context/ApiContext';
 import { useToast } from '../context/ToastContext';
 import { CompactField } from './settings/SettingsPrimitives';
+import { Button } from './ui/button';
 
 const VIBE_CLOUD_URL = 'https://avibe.bot';
 
@@ -146,14 +147,16 @@ export const RemoteAccess: React.FC = () => {
             <li>{t('remoteAccess.flowStep3')}</li>
           </ol>
         </div>
-        <button
-          className="inline-flex h-8 shrink-0 items-center gap-2 whitespace-nowrap rounded-md border border-border bg-surface-3 px-3 text-[12px] text-foreground transition hover:border-border-strong"
+        <Button
+          variant="secondary"
+          size="xs"
+          className="shrink-0"
           onClick={refresh}
           type="button"
         >
           <RefreshCcw className="size-3.5" />
           {t('common.refresh')}
-        </button>
+        </Button>
       </div>
 
       <div className="grid border-b border-border md:grid-cols-3">
@@ -187,26 +190,29 @@ export const RemoteAccess: React.FC = () => {
             <span className="block text-[10px] text-muted">{t('remoteAccess.pairingKeyHelp')}</span>
           </label>
           <div className="flex gap-2">
-            <button
+            <Button
               type="button"
-              className="inline-flex h-8 items-center gap-2 rounded-md bg-primary px-3 text-[12px] font-semibold text-primary-foreground disabled:opacity-50"
+              variant="default"
+              size="xs"
+              className="font-semibold"
               disabled={pairing || !pairingKey.trim()}
               onClick={pair}
             >
               <Link2 className="size-3.5" />
               {pairing ? t('remoteAccess.pairing') : t('remoteAccess.pair')}
-            </button>
+            </Button>
             {paired && (
-              <button
+              <Button
                 type="button"
-                className="h-8 rounded-md border border-border px-3 text-[12px] text-foreground"
+                variant="secondary"
+                size="xs"
                 onClick={() => {
                   setReconfiguring(false);
                   setPairingKey('');
                 }}
               >
                 {t('common.cancel')}
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -231,19 +237,32 @@ export const RemoteAccess: React.FC = () => {
             )}
           </div>
           <div className="flex gap-2">
-            <button
+            <Button
               type="button"
-              className="h-8 rounded-md border border-border px-3 text-[12px] text-foreground"
+              variant="secondary"
+              size="xs"
               onClick={() => setReconfiguring(true)}
             >
               {t('remoteAccess.repair')}
-            </button>
-            <button className="h-8 rounded-md border border-border px-3 text-[12px] text-foreground disabled:opacity-50" disabled={!paired || running} onClick={start} type="button">
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="xs"
+              disabled={!paired || running}
+              onClick={start}
+            >
               {t('common.start')}
-            </button>
-            <button className="h-8 rounded-md border border-border px-3 text-[12px] text-foreground disabled:opacity-50" disabled={!paired || !running} onClick={stop} type="button">
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              size="xs"
+              disabled={!paired || !running}
+              onClick={stop}
+            >
               {t('common.stop')}
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -234,14 +234,15 @@ export const SettingsPlatformsPage: React.FC = () => {
             </div>
 
             <div className="flex items-center justify-end gap-2 border-t border-border pt-3">
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="xs"
                 onClick={closeAll}
                 disabled={savingEnabled}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
               >
                 {t('common.cancel')}
-              </button>
+              </Button>
               <Button
                 type="button"
                 variant="brand"

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -164,25 +164,27 @@ export const SettingsServicePage: React.FC = () => {
                 </Button>
               )}
               {isRunning && (
-                <button
+                <Button
                   type="button"
+                  variant="secondary"
+                  size="xs"
                   onClick={() => void handleAction('stop')}
                   disabled={loading}
-                  className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <Square className="size-3.5" strokeWidth={2.5} />
                   {t('common.stop')}
-                </button>
+                </Button>
               )}
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="xs"
                 onClick={() => void handleAction('restart')}
                 disabled={loading}
-                className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <RotateCw className="size-3.5" strokeWidth={2.5} />
                 {t('common.restart')}
-              </button>
+              </Button>
             </div>
           }
         />
@@ -223,15 +225,17 @@ export const SettingsServicePage: React.FC = () => {
                   }));
                 }}
               />
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="sm"
                 onClick={() => void handleUiSaveRestart()}
                 disabled={uiSaving}
-                className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+                className="text-[12px]"
               >
                 <RotateCw className={clsx('size-3.5', uiSaving && 'animate-spin')} strokeWidth={2.5} />
                 {uiSaving ? t('common.saving') : t('common.saveAndRestart')}
-              </button>
+              </Button>
             </div>
           }
         />

--- a/ui/src/components/steps/AgentDetection.tsx
+++ b/ui/src/components/steps/AgentDetection.tsx
@@ -204,12 +204,14 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
             <option value="codex">Codex</option>
           </CompactSelect>
         </label>
-        <button
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
           onClick={detectAll}
-          className="inline-flex h-9 items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
         >
           <Search className="size-3.5" /> {t('common.detectAll')}
-        </button>
+        </Button>
       </div>
 
       <div className="flex flex-col gap-3">
@@ -251,14 +253,16 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                   placeholder={t('agentDetection.cliPathPlaceholder', { name })}
                   className="flex-1 font-mono"
                 />
-                <button
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
                   onClick={() => detect(name, agent.cli_path)}
                   disabled={checking}
-                  className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {checking ? <RefreshCw className="size-3.5 animate-spin" /> : <Search className="size-3.5" />}
                   {t('common.detect')}
-                </button>
+                </Button>
               </div>
 
               {isMissing(agent) && (
@@ -378,14 +382,16 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
 
         <div className="flex items-center justify-between border-t border-border pt-4">
           {onBack ? (
-            <button
+            <Button
               type="button"
+              variant="secondary"
+              size="default"
               onClick={onBack}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+              className="font-semibold"
             >
               <ArrowLeft size={14} strokeWidth={2.25} />
               {t('common.back')}
-            </button>
+            </Button>
           ) : (
             <span />
           )}

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -783,14 +783,16 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               <p className="text-[12px] text-muted">{t('wechat.noChannels')}</p>
             </div>
             <div className="flex items-center justify-between border-t border-border pt-4">
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="default"
                 onClick={onBack}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+                className="font-semibold"
               >
                 <ArrowLeft size={14} strokeWidth={2.25} />
                 {t('common.back')}
-              </button>
+              </Button>
               <Button
                 type="button"
                 variant="brand"
@@ -820,13 +822,15 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             <MessageSquare size={32} />
           </div>
           <p className="text-muted mb-6">{t('wechat.noChannels')}</p>
-          <button
+          <Button
+            type="button"
+            variant="brand"
+            size="default"
             onClick={() => navigate('/users')}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-accent hover:bg-accent/90 text-white rounded-lg font-medium transition-colors shadow-sm"
           >
             <Users size={18} />
             {t('wechat.manageUserSettings')}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -906,15 +910,16 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 placeholder={t('channelList.filterPlaceholder')}
                 className="w-[240px]"
               />
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="sm"
                 onClick={handleRescan}
                 disabled={isRescanLoading}
-                className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[13px] font-medium text-foreground transition-colors hover:border-border-strong disabled:opacity-50"
               >
                 <RefreshCw size={14} className={isRescanLoading ? 'animate-spin' : ''} />
                 {t('channelList.rescan')}
-              </button>
+              </Button>
             </div>
           </div>
 
@@ -1042,15 +1047,17 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
           {pageTab !== 'all' && (
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-0.5">
               {!['lark', 'telegram'].includes(pageTab) && (
-                <button
+                <Button
                   type="button"
+                  variant="secondary"
+                  size="xs"
                   onClick={() => loadChannels(true)}
                   disabled={loadingAll}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:border-cyan/40 disabled:opacity-50"
+                  className="hover:border-cyan/40"
                 >
                   <Globe size={13} className={loadingAll ? 'animate-spin' : ''} />
                   {loadingAll ? t('common.loading') : t('channelList.browseAll')}
-                </button>
+                </Button>
               )}
               {browseAll && pageTab === platform && (
                 <span className="text-[11px] text-muted">{t('channelList.showingAll')}</span>
@@ -1367,21 +1374,27 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       <div className="mb-4 space-y-3 rounded-2xl border border-border bg-surface-2/40 p-4 shadow-[0_18px_40px_-30px_rgba(0,0,0,0.8)]">
         <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-            <button
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
               onClick={() => loadChannels(browseAll)}
-              className="flex items-center gap-2 rounded-lg border border-border bg-surface-3/60 px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:border-cyan/40 hover:bg-surface-2/70"
+              className="hover:border-cyan/40"
             >
               <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('channelList.refreshList')}
-            </button>
+            </Button>
             {!browseAll && !['lark', 'telegram'].includes(platform) && (
-              <button
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
                 onClick={() => loadChannels(true)}
                 disabled={loadingAll}
-                className="flex items-center gap-2 rounded-lg border border-border bg-surface-3/60 px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:border-cyan/40 hover:bg-surface-2/70 disabled:opacity-50"
+                className="hover:border-cyan/40"
               >
                 <Globe size={14} className={loadingAll ? 'animate-spin' : ''} />
                 {loadingAll ? t('common.loading') : t('channelList.browseAll')}
-              </button>
+              </Button>
             )}
             {browseAll && (
               <span className="text-xs text-muted">{t('channelList.showingAll')}</span>
@@ -1602,14 +1615,16 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
 
       {!isPage && (
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button
             type="button"
             variant="brand"

--- a/ui/src/components/steps/DiscordConfig.tsx
+++ b/ui/src/components/steps/DiscordConfig.tsx
@@ -468,14 +468,16 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
         <div className="flex flex-col gap-3">{stepShells}</div>
 
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button
             type="button"
             variant="brand"

--- a/ui/src/components/steps/DoctorPanel.tsx
+++ b/ui/src/components/steps/DoctorPanel.tsx
@@ -120,14 +120,15 @@ export const DoctorPanel: React.FC<DoctorPanelProps> = ({
             {t('common.viewLogs')}
           </Link>
           {results && (
-            <button
+            <Button
               type="button"
+              variant="secondary"
+              size="xs"
               onClick={() => void copyReport()}
-              className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
             >
               <Copy className="size-3.5" />
               {t('doctor.copyReport')}
-            </button>
+            </Button>
           )}
           <Button type="button" variant="brand" size="xs" onClick={runDoctor} disabled={loading}>
             <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} strokeWidth={2.5} />

--- a/ui/src/components/steps/LarkConfig.tsx
+++ b/ui/src/components/steps/LarkConfig.tsx
@@ -557,14 +557,16 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
         {bodyContent}
 
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button
             type="button"
             variant="brand"

--- a/ui/src/components/steps/ModeSelection.tsx
+++ b/ui/src/components/steps/ModeSelection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { Cloud, Server } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '../ui/button';
 
 interface ModeSelectionProps {
   data: any;
@@ -68,15 +69,17 @@ export const ModeSelection: React.FC<ModeSelectionProps> = ({ data, onNext, onBa
       </div>
 
       <div className="mt-auto flex justify-between">
-         <button onClick={onBack} className="px-6 py-2 text-muted hover:text-text font-medium">
-            {t('common.back')}
-         </button>
-        <button
+        <Button type="button" variant="ghost" size="default" onClick={onBack} className="font-medium">
+          {t('common.back')}
+        </Button>
+        <Button
+          type="button"
+          variant="brand-cyan"
+          size="lg"
           onClick={() => onNext({ mode: selected })}
-          className="px-8 py-3 bg-accent hover:bg-accent/90 text-white rounded-lg font-medium transition-colors shadow-sm"
         >
           {t('common.continue')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -541,14 +541,16 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
         </div>
 
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button
             type="button"
             variant="brand"

--- a/ui/src/components/steps/SlackConfig.tsx
+++ b/ui/src/components/steps/SlackConfig.tsx
@@ -161,14 +161,16 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                     {t('slackConfig.createSlackApp')}
                   </Button>
                   {manifest && (
-                    <button
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
                       onClick={copyManifest}
                       disabled={manifestLoading}
-                      className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
                     >
                       {copied ? <Check size={14} /> : <Copy size={14} />}
                       {copied ? t('slackConfig.copied') : t('slackConfig.copyManifest')}
-                    </button>
+                    </Button>
                   )}
                 </div>
                 {manifest && (
@@ -383,14 +385,16 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
         <div className="flex flex-col gap-3">{stepShells}</div>
 
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button
             type="button"
             variant="brand"

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -344,15 +344,17 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
         )}
 
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
             disabled={saving}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong disabled:opacity-50"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button type="button" variant="brand" size="lg" onClick={saveAll} disabled={saving}>
             {saving ? t('common.saving') : t('summary.finishAndStart')}
             {!saving && <ArrowRight size={16} strokeWidth={2.25} />}

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -174,13 +174,15 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                     <ExternalLink size={14} strokeWidth={2.25} />
                     {t('telegramConfig.openBotFather')}
                   </Button>
-                  <button
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
                     onClick={() => copyCommand('/newbot')}
-                    className="inline-flex items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-3 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong"
                   >
                     {copiedCommand === '/newbot' ? <Check size={14} className="text-mint" /> : <Copy size={14} />}
                     {copiedCommand === '/newbot' ? t('telegramConfig.copiedCommand') : t('telegramConfig.copyNewBotCommand')}
-                  </button>
+                  </Button>
                 </div>
                 <div className="rounded-lg border border-cyan/30 bg-cyan/[0.06] px-3 py-2 text-[12px] leading-[1.55] text-cyan">
                   <strong>{t('slackConfig.tip')}:</strong> {t('telegramConfig.step1Tip')}
@@ -431,14 +433,16 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
         <div className="flex flex-col gap-3">{stepShells}</div>
 
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button
             type="button"
             variant="brand"

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -210,24 +210,28 @@ const BindCodeCard: React.FC<BindCodeCardProps> = ({ refreshTrigger, onCodesChan
           )}
           <div className="flex flex-wrap items-center gap-2">
             {moreCount > 0 || otherCodes.length > 0 ? (
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="xs"
                 onClick={() => setShowAllModal(true)}
-                className="rounded-md border border-border bg-foreground/[0.04] px-3.5 py-2 text-[12px] font-medium text-muted transition-colors hover:border-border-strong hover:text-foreground"
+                className="text-muted hover:text-foreground"
               >
                 {moreCount > 0
                   ? t('bindCode.viewMore', { count: moreCount })
                   : t('bindCode.viewUnavailable', { count: otherCodes.length })}
-              </button>
+              </Button>
             ) : null}
             {primary && (
-              <button
+              <Button
                 type="button"
+                variant="secondary"
+                size="xs"
                 onClick={() => handleDelete(primary.code)}
-                className="rounded-md border border-border bg-foreground/[0.04] px-3.5 py-2 text-[12px] font-medium text-muted transition-colors hover:border-danger/40 hover:text-danger"
+                className="text-muted hover:border-danger/40 hover:text-danger"
               >
                 {t('bindCode.revoke')}
-              </button>
+              </Button>
             )}
             <Button type="button" variant="brand" size="xs" onClick={() => setShowFormModal(true)}>
               <Plus size={14} strokeWidth={2.4} />
@@ -664,14 +668,16 @@ export const UserList: React.FC = () => {
               placeholder={t('userList.filterPlaceholder')}
               className="w-[280px]"
             />
-            <button
+            <Button
               type="button"
+              variant="secondary"
+              size="sm"
               onClick={() => setRefreshTrigger((v) => v + 1)}
-              className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[13px] font-medium text-foreground transition-colors hover:border-border-strong"
               title={t('common.refresh', { defaultValue: 'Refresh' })}
+              className="px-3"
             >
               <RefreshCw size={14} />
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -849,15 +855,17 @@ export const UserList: React.FC = () => {
                       codexAgents={codexAgents}
                       codexModels={codexModels}
                       footerActions={
-                        <button
+                        <Button
                           type="button"
+                          variant="secondary"
+                          size="xs"
                           onClick={() => handleRemoveUser(u.platform, u.userId)}
                           title={t('userList.removeUser')}
-                          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-muted transition-colors hover:border-danger/40 hover:text-danger"
+                          className="text-muted hover:border-danger/40 hover:text-danger"
                         >
                           <Trash2 size={12} />
                           {t('userList.removeUser')}
-                        </button>
+                        </Button>
                       }
                     />
                   )}

--- a/ui/src/components/steps/WeChatConfig.tsx
+++ b/ui/src/components/steps/WeChatConfig.tsx
@@ -276,17 +276,19 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
                     {'•'.repeat(16)}
                   </div>
                 </div>
-                <button
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
                   onClick={() => {
                     autoStartedRef.current = true;
                     void startLogin();
                   }}
                   disabled={starting}
-                  className="inline-flex items-center gap-2 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[12px] font-medium text-foreground transition hover:border-border-strong disabled:opacity-50"
                 >
                   <RefreshCw size={14} className={starting ? 'animate-spin' : ''} />
                   {t('wechatConfig.rebind')}
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -435,14 +437,16 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
         {bodyContent}
 
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <button
+          <Button
             type="button"
+            variant="secondary"
+            size="default"
             onClick={onBack}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-4 py-2 text-[13px] font-semibold text-foreground transition hover:border-border-strong"
+            className="font-semibold"
           >
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
-          </button>
+          </Button>
           <Button
             type="button"
             variant="brand"


### PR DESCRIPTION
## Capability
**UI buttons — shared primitive consolidation**

Follow-up to #275. Sweeps the remaining hand-rolled `<button>` elements that escaped pass 1 onto the shared shadcn-style `<Button>` primitive (cva variants + Radix Slot).

## Why now
User-reported visual bug on `/users#ai` (viewport 326×580): the bind-code action buttons (撤销 / 更多) visually mismatched the brand "新建绑定码" sibling — different height, padding, and corner radius because they were hand-rolled `<button>` elements. The same root cause that produced the pass-1 "restart-in-light-mode" black-on-white bug is still latent in ~25 other buttons across the codebase — any hand-rolled `bg-foreground/[0.04]` + ad-hoc sizing can drift from the design system and from neighboring buttons.

## Scope (15 files)
- `UserList.tsx` — bind-code revoke / viewMore, toolbar refresh, footer remove
- Wizard Back footers — Slack / Telegram / WeChat / Lark / Discord / Platform / Channel (×2) / AgentDetection / Summary / ModeSelection (10 files)
- `AgentDetection.tsx` — detect-all + per-row detect
- `ChannelList.tsx` — manage-users CTA + rescan + browse-all (×2) + refresh
- `SettingsServicePage.tsx` — stop / restart / save-restart
- `SettingsPlatformsPage.tsx` — cancel
- `RemoteAccess.tsx` — full migration (6 buttons)
- `DoctorPanel.tsx` — copy report
- `TelegramConfig.tsx` / `SlackConfig.tsx` / `WeChatConfig.tsx` — copy / rebind helpers

## Faithful translation rules
- Color preserved via faithful variant mapping. `ModeSelection` Continue stays cyan via `variant="brand-cyan"` because `--accent` resolves to `#3fe0e5` (dark) / `#0891b2` (light) — both cyan. Mint `variant="brand"` would have shifted color.
- Size preserved against neighbor siblings: `xs` (h-8) for inline row actions, `sm` (h-9) for toolbar refresh / copy, `default` (h-10) for wizard footers, `lg` (h-12) only where the original was `lg`.
- Hover states preserved as `className` overrides: `hover:text-danger`, `hover:border-danger/40`, `hover:border-cyan/40`, etc.
- All `onClick` / `disabled` / `type="button"` / `aria-*` / `title` carried over.
- `AgentDetection.tsx` preserves the `onBack ? (<Button…>) : (<span />)` conditional.
- `Summary.tsx` Back uses `size="default"` (matches original h-9 `py-2`), not the sibling Finish's `size="lg"` — faithful preservation > synthesized symmetry.

## Evidence layers
- **Unit**: n/a — mechanical visual refactor, no logic touched.
- **Contract**: ✅ TypeScript build clean (`npm run build`, 2271 modules, no TS errors).
- **Scenario**: n/a — no scenario catalog for UI button visuals; existing wizard scenarios remain green (no flow changes).
- **Manual**: ✅ Reviewer subagent ran against the full diff, flagged 2 yellow items (Summary Back size, ModeSelection variant). Summary Back downsized to match original h-9. ModeSelection Continue kept at `brand-cyan` (verified via `--accent` color token — `brand-cyan` is the faithful color mapping for the original `bg-accent`). Mechanical token equivalence guarantees pixel-identical geometry against existing shared-Button-using siblings (e.g. revoke/viewMore now match `新建绑定码` since all three are `size="xs"`).
- **Residual**: Browser visual verification on the regression env was blocked by the OAuth wall on `test-app.avibe.bot`; relying on mechanical correctness. Worth a quick eyeball on Slack `/users#ai` after merge to confirm bind-code row alignment.

## Test plan
- [ ] Pull and rebuild regression container
- [ ] `/users#ai` page (326×580) — bind-code action row alignment matches brand button
- [ ] Wizard flow — Back/Continue button geometry consistent across Slack/Telegram/WeChat/Lark/Discord/Platform/Channel/AgentDetection
- [ ] Service Settings page — Stop / Restart / Save-restart buttons render correctly
- [ ] Light + dark mode parity (the pass-1 bug class)