### PR TITLE
docs(skill): refresh use-vibe-remote skill and CLI doc for v2.3

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -332,7 +332,8 @@ The web UI (`http://127.0.0.1:5123`) provides the same controls:
 | Path | Description |
 |------|-------------|
 | `~/.vibe_remote/config/config.json` | Main configuration |
-| `~/.vibe_remote/state/vibe.sqlite` | Primary persistent store (settings, users, sessions, discovered chats) |
+| `~/.vibe_remote/state/vibe.sqlite` | Primary persistent store (scope settings, agent sessions, auth codes, runtime records) |
+| `~/.vibe_remote/state/discovered_chats.json` | Discovered IM chats/channels surfaced by platform adapters |
 | `~/.vibe_remote/state/settings.json` | Legacy JSON snapshot of channel routing settings |
 | `~/.vibe_remote/state/scheduled_tasks.json` | Persisted scheduled task definitions |
 | `~/.vibe_remote/state/watches.json` | Persisted managed watch definitions |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -183,8 +183,14 @@ stdout and delivers it through the chosen session as a follow-up message.
 ```bash
 vibe watch add \
   --session-key 'slack::channel::C123' \
-  --command './scripts/run_tests.sh' \
-  --prefix 'Test run finished. Summarize the failures and propose next steps.'
+  --prefix 'Test run finished. Summarize the failures and propose next steps.' \
+  -- ./scripts/run_tests.sh
+
+# Alternative: pass the command through a shell with --shell
+vibe watch add \
+  --session-key 'slack::channel::C123' \
+  --prefix 'Build done. Summarize.' \
+  --shell 'make build && ./scripts/post_build.sh'
 
 vibe watch list --brief
 vibe watch show <watch-id>
@@ -193,12 +199,14 @@ vibe watch resume <watch-id>
 vibe watch remove <watch-id>
 ```
 
-Use `vibe watch add --help` for the full surface, including `--cwd`,
-`--timeout-seconds`, `--max-cycles`, `--post-to channel`, `--deliver-key`, and
-`--name`. Watches share `--session-key`, `--post-to`, and `--deliver-key`
-semantics with `vibe task` and `vibe hook send`. Prefer `vibe watch` over
-ad-hoc `nohup` jobs when the user wants a managed background task with a
-guaranteed follow-up message.
+The waiter command is passed positionally after `--` (or as a single shell
+string via `--shell`). Use `vibe watch add --help` for the full surface,
+including `--timeout` (per-cycle timeout in seconds), `--lifetime-timeout`
+(total wall-clock limit), `--forever`, `--retry-exit-code`, `--retry-delay`,
+`--post-to channel`, `--deliver-key`, and `--name`. Watches share
+`--session-key`, `--post-to`, and `--deliver-key` semantics with `vibe task`
+and `vibe hook send`. Prefer `vibe watch` over ad-hoc `nohup` jobs when the
+user wants a managed background task with a guaranteed follow-up message.
 
 ### `vibe version`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -5,6 +5,7 @@
 ```bash
 vibe              # Start Vibe Remote (opens web UI)
 vibe status       # Check service status
+vibe restart      # Restart all services (use --delay-seconds when agent-triggered)
 vibe remote       # Guided Vibe Cloud remote-access setup
 vibe screenshot   # Capture a local desktop screenshot
 vibe stop         # Stop all services
@@ -50,6 +51,20 @@ vibe stop
 - Stops the main service
 - Stops the web UI server
 - **Terminates OpenCode server** — Use this when you need to restart OpenCode
+
+### `vibe restart`
+
+Restart Vibe Remote (main service + Web UI). The OpenCode server is terminated as part of the restart.
+
+```bash
+vibe restart
+vibe restart --delay-seconds 60
+```
+
+**Behavior:**
+- Stops the main service and Web UI, then re-starts them
+- Terminates the OpenCode server
+- With `--delay-seconds N`, schedules the restart `N` seconds in the future so an active conversation can receive its reply before the restart lands. Prefer this form when an agent is triggering the restart from inside Slack, Discord, Telegram, Lark/Feishu, or WeChat.
 
 ### `vibe status`
 
@@ -157,6 +172,33 @@ vibe hook send --session-key 'slack::channel::C123::thread::171717.123' --post-t
 ```
 
 Use this when you want one delayed or background follow-up without persisting a task in `scheduled_tasks.json`.
+
+### `vibe watch`
+
+Create, inspect, pause, resume, or remove a managed background watch. A watch
+runs a long-lived waiter command (for example a build or a status poll) and,
+when the command finishes successfully, prepends `--prefix` to the captured
+stdout and delivers it through the chosen session as a follow-up message.
+
+```bash
+vibe watch add \
+  --session-key 'slack::channel::C123' \
+  --command './scripts/run_tests.sh' \
+  --prefix 'Test run finished. Summarize the failures and propose next steps.'
+
+vibe watch list --brief
+vibe watch show <watch-id>
+vibe watch pause <watch-id>
+vibe watch resume <watch-id>
+vibe watch remove <watch-id>
+```
+
+Use `vibe watch add --help` for the full surface, including `--cwd`,
+`--timeout-seconds`, `--max-cycles`, `--post-to channel`, `--deliver-key`, and
+`--name`. Watches share `--session-key`, `--post-to`, and `--deliver-key`
+semantics with `vibe task` and `vibe hook send`. Prefer `vibe watch` over
+ad-hoc `nohup` jobs when the user wants a managed background task with a
+guaranteed follow-up message.
 
 ### `vibe version`
 
@@ -282,10 +324,15 @@ The web UI (`http://127.0.0.1:5123`) provides the same controls:
 | Path | Description |
 |------|-------------|
 | `~/.vibe_remote/config/config.json` | Main configuration |
-| `~/.vibe_remote/state/settings.json` | Channel routing settings |
+| `~/.vibe_remote/state/vibe.sqlite` | Primary persistent store (settings, users, sessions, discovered chats) |
+| `~/.vibe_remote/state/settings.json` | Legacy JSON snapshot of channel routing settings |
 | `~/.vibe_remote/state/scheduled_tasks.json` | Persisted scheduled task definitions |
+| `~/.vibe_remote/state/watches.json` | Persisted managed watch definitions |
 | `~/.vibe_remote/state/task_requests/` | Queued task run and hook execution requests |
 | `~/.vibe_remote/state/user_preferences.md` | Shared long-term user preference notes |
+| `~/.vibe_remote/state/backups/` | Automatic state backups taken before migrations |
+| `~/.vibe_remote/runtime/remote-access-cloudflared.pid` | cloudflared tunnel PID for Vibe Cloud remote access |
+| `~/.vibe_remote/screenshots/` | Default output directory for `vibe screenshot` |
 | `~/.vibe_remote/logs/vibe_remote.log` | Application logs |
 | `~/.vibe_remote/logs/opencode_server.json` | OpenCode server PID file |
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -332,7 +332,7 @@ The web UI (`http://127.0.0.1:5123`) provides the same controls:
 | Path | Description |
 |------|-------------|
 | `~/.vibe_remote/config/config.json` | Main configuration |
-| `~/.vibe_remote/state/vibe.sqlite` | Primary persistent store (scope settings, agent sessions, auth codes, runtime records) |
+| `~/.vibe_remote/state/vibe.sqlite` | Internal database managed by Vibe Remote — opaque; manage state through the Web UI or `vibe` CLI, never read or write this file directly |
 | `~/.vibe_remote/state/discovered_chats.json` | Discovered IM chats/channels surfaced by platform adapters |
 | `~/.vibe_remote/state/settings.json` | Legacy JSON snapshot of channel routing settings |
 | `~/.vibe_remote/state/scheduled_tasks.json` | Persisted scheduled task definitions |

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -934,7 +934,7 @@ Service lifecycle:
 Updates:
 
 - `vibe check-update` — query the release feed and print whether an upgrade is available
-- `vibe upgrade` — reinstall Vibe Remote to the latest release (followed by a restart)
+- `vibe upgrade` — reinstall Vibe Remote to the latest release. The CLI does not restart the service for you; it prints "Please restart vibe..." and exits. Run `vibe restart` (or `vibe restart --delay-seconds 60` from inside an active conversation) yourself after the upgrade reports success. The Web UI's `POST /upgrade` endpoint is the path that performs an automatic restart.
 
 Remote access:
 
@@ -981,7 +981,7 @@ Common cases:
 - platform cannot reach API: inspect `proxy_url` on that platform's config block; check logs for proxy/TLS errors; for SOCKS proxies confirm `aiohttp_socks` is installed
 - remote URL is unreachable: `GET /remote-access/status` should show `tunnel_running: true`; if not, check `remote-access-cloudflared.pid`, `cloudflared_path`, and the latest doctor result
 - remote session expired: instruct the user to re-sign in at the public URL (24h TTL with sliding renewal); use `POST /auth/logout` to clear a stale session on the current device
-- upgrade did not apply: inspect the response from `POST /upgrade` and follow up with `vibe status`; a restart is part of the upgrade flow
+- upgrade did not apply: inspect the response from `POST /upgrade` (auto-restart on success) or `vibe upgrade` (does not auto-restart — run `vibe restart` manually), then verify with `vibe status` that the new PID is running
 - startup failure: use `GET /status`, `POST /doctor`, then inspect logs
 
 Do not use `vibe restart`, `POST /control {"action":"restart"}`, or `POST /ui/reload` as a first response to config problems.
@@ -1005,7 +1005,7 @@ Recovery rules:
 5. Start or restart only when needed to bring the API back.
 6. After recovery, return to the API workflow for further changes.
 
-`vibe.sqlite` is never a fallback target. Never open it with sqlite3 or any inspection tool. If the database itself is the problem, stop Vibe Remote, move the file aside under `~/.vibe_remote/state/`, and let Vibe Remote rebuild from `backups/` on next start. Escalate to the repo if the rebuild fails.
+`vibe.sqlite` is never a fallback target. Never open it with sqlite3 or any inspection tool, and do not move the file aside in the hope of triggering a rebuild — `~/.vibe_remote/state/backups/` only holds JSON snapshots captured at the original migration, and a fresh startup will re-import from the current live JSON files, which may be stale relative to recent runtime state. If the database itself is the problem, stop Vibe Remote, preserve `vibe.sqlite` and the JSON state files as-is, and escalate to the repo.
 
 ## Safety Boundaries
 

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -528,7 +528,7 @@ These endpoints drive the managed `avibe.bot` tunnel that exposes the local Web 
 - `GET /auth/callback`
   - OIDC redirect target used by avibe.bot during sign-in. Browser-driven; do not call directly from automation.
 - `GET /api/session`
-  - returns the active avibe.bot user identity and signed-in state (or 401 when not signed in)
+  - always returns `200` with an auth-state payload, never `401`. Three shapes: `{"remote": false}` when remote access is not configured for this request, `{"remote": true, "authenticated": false}` when remote access is on but the caller has no valid session cookie, and `{"remote": true, "authenticated": true, "email": "..."}` when signed in. Check `authenticated` to gate behavior; do not poll for HTTP status codes.
 - `POST /auth/logout`
   - clears the avibe.bot session cookie on this device. Does not stop the tunnel.
 
@@ -960,7 +960,7 @@ Watches:
 
 - `vibe watch add`, `vibe watch list [--brief]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
 
-For any subcommand, prefer `<command> --help` before composing a new invocation. `vibe task`, `vibe hook send`, and `vibe watch add` share the delivery flags documented above (`--session-key`, `--post-to`, `--deliver-key`, `--prompt`, `--prompt-file`, `--name`, `--timezone`).
+For any subcommand, prefer `<command> --help` before composing a new invocation. The delivery flags shared by all three commands are `--session-key`, `--post-to`, `--deliver-key`, and `--name`. The remaining surface differs: `vibe task add` and `vibe hook send` take `--prompt` / `--prompt-file`, only `vibe task add` takes `--cron` / `--at` / `--timezone`, and `vibe watch add` takes its own set (`--prefix`, `--shell` or a positional command after `--`, `--cwd`, `--timeout`, `--forever`, `--lifetime-timeout`, `--retry-exit-code`, `--retry-delay`). Do not copy task or hook flags into a watch invocation.
 
 ## Troubleshooting
 

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -179,7 +179,7 @@ Scheduled tasks and watches are managed through `vibe task` / `vibe watch` (or t
 - `GET /api/csrf-token`
   - issues the `vibe_csrf_token` cookie and returns the matching token value for `X-Vibe-CSRF-Token`
 - `GET /platforms`
-  - returns the catalog of supported IM platforms, current enabled list, and credential state
+  - returns the static catalog of supported IM platforms only (id, config_key, title/description i18n keys, credential field names, capabilities). It does not include enablement or credential-presence state — fetch `/config` to see which platforms are enabled and whether credentials are configured.
 
 ### Global config
 
@@ -497,7 +497,7 @@ WeChat QR login is special: when login is confirmed and a token is returned, the
 These endpoints drive the managed `avibe.bot` tunnel that exposes the local Web UI to other devices. They are paired with the `remote_access.vibe_cloud` block under `/config`.
 
 - `GET /remote-access/status`
-  - returns enabled state, public URL, tunnel status, last error, OIDC issuer, and whether `cloudflared` is running
+  - returns `enabled`, `paired`, `public_url`, `running` (tunnel up), `pid`, `pid_state`, plus `binary_found` / `binary_path` / `binary_version` for the resolved `cloudflared` executable. Use `running: true` to assert the tunnel is up.
 - `POST /remote-access/vibe-cloud/pair`
   - payload: `{"pairing_key": "vrp_..."}`
   - exchanges the one-time key for an OIDC client, tunnel token, and persists the full `remote_access.vibe_cloud` block; on success Vibe Remote launches the cloudflared tunnel
@@ -710,7 +710,7 @@ Goal: connect the local Web UI to `avibe.bot` so it is reachable from another de
 
 1. The user signs in at `https://avibe.bot`, creates a remote-access bot, and copies the one-time pairing key (format `vrp_...`).
 2. Call `POST /remote-access/vibe-cloud/pair` with `{"pairing_key": "vrp_..."}` from the local Web UI origin.
-3. Verify with `GET /remote-access/status` — `enabled: true`, `public_url` populated, `tunnel_running: true`.
+3. Verify with `GET /remote-access/status` — `enabled: true`, `paired: true`, `public_url` populated, `running: true`.
 4. Have the user open `public_url` and sign in with the same avibe.bot account.
 
 Alternatively, drive the same flow from the CLI:
@@ -961,7 +961,7 @@ Common cases:
 - wrong repository/cwd: inspect `custom_cwd` and `runtime.default_cwd`
 - DM access denied: inspect `/api/users?platform=<platform>` and bind-code state
 - platform cannot reach API: inspect `proxy_url` on that platform's config block; check logs for proxy/TLS errors; for SOCKS proxies confirm `aiohttp_socks` is installed
-- remote URL is unreachable: `GET /remote-access/status` should show `tunnel_running: true`; if not, run `POST /doctor` and check the configured `cloudflared_path`
+- remote URL is unreachable: `GET /remote-access/status` should show `running: true` and `binary_found: true`; if not, run `POST /doctor` and check the configured `cloudflared_path`
 - remote session expired: instruct the user to re-sign in at the public URL (24h TTL with sliding renewal); use `POST /auth/logout` to clear a stale session on the current device
 - upgrade did not apply: inspect the response from `POST /upgrade` (auto-restart on success) or `vibe upgrade` (does not auto-restart — run `vibe restart` manually), then verify with `vibe status` that the new PID is running
 - startup failure: use `GET /status`, `POST /doctor`, then inspect logs

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -36,7 +36,7 @@ Follow this skill as an operations playbook for agents, not as end-user marketin
 5. Use the smallest viable API call and verify by reading back the API response.
 6. For `POST /settings`, preserve every existing channel for that platform; the endpoint replaces the platform's channel map.
 7. For `POST /api/users`, merge each edited user with its current user payload first; missing user fields are not a patch.
-8. Make every persistent-state change through the Web UI API or the `vibe` CLI. Vibe Remote keeps internal state in an opaque SQLite database (`~/.vibe_remote/state/vibe.sqlite`) plus a few JSON files such as `discovered_chats.json`; do not treat the database as an operator surface. JSON files may be hand-edited only as a documented recovery fallback (see "Direct File Recovery Fallback").
+8. Make every persistent-state change through the Web UI API or the `vibe` CLI. Vibe Remote's internal storage is opaque — do not read, query, or hand-edit it.
 9. `POST /config` persists the new payload but does not restart running platform adapters by itself. When the change is platform credentials, `proxy_url`, or other transport-level settings, plan an explicit restart afterwards; prefer the delayed CLI form (`vibe restart --delay-seconds 60`) when triggering it from inside an active conversation. The only credential save that restarts on its own is the WeChat QR-login completion through `POST /wechat/qr_login/poll`.
 10. Do not restart the service by default. Use `POST /doctor`, `GET /status`, and read-back checks first.
 11. Only start, stop, restart, or reload Vibe Remote when the user explicitly asks or when a change cannot take effect otherwise; explain why before doing it.
@@ -150,32 +150,14 @@ python3 "$API_HELPER" GET '/settings?platform=slack'
 
 ## Runtime Layout
 
-Vibe Remote stores runtime data under `~/.vibe_remote/` by default. If `VIBE_REMOTE_HOME` is set, use that directory instead.
+Vibe Remote stores runtime data under `~/.vibe_remote/` by default (or `VIBE_REMOTE_HOME` if set). The only paths an agent normally needs:
 
-Important paths:
+- `~/.vibe_remote/config/config.json` — global config; mutate through `POST /config`, not by editing the file
+- `~/.vibe_remote/logs/vibe_remote.log` — main application log; read via `POST /logs`
+- `~/.vibe_remote/screenshots/` — default output directory for `vibe screenshot`
+- `~/.vibe_remote/state/user_preferences.md` — shared long-term preference file (safe to read and update)
 
-- `~/.vibe_remote/config/config.json`: global config persisted by `POST /config`
-- `~/.vibe_remote/state/vibe.sqlite`: internal database managed by Vibe Remote. Treat as opaque; never read, write, or query it directly — use the Web UI API or `vibe` CLI for any state change.
-- `~/.vibe_remote/state/migration.lock`: internal migration lock for the database above; never delete or modify
-- `~/.vibe_remote/state/backups/`: automatic state backups taken before migrations
-- `~/.vibe_remote/state/settings.json`: legacy JSON snapshot mirror for `/settings`, `/api/users`, and `/api/bind-codes`; read-only during normal operation
-- `~/.vibe_remote/state/scheduled_tasks.json`: persisted scheduled tasks created by `vibe task`
-- `~/.vibe_remote/state/watches.json`: persisted managed watches
-- `~/.vibe_remote/state/task_requests/`: queued task-run and hook-send requests plus completion receipts
-- `~/.vibe_remote/state/user_preferences.md`: shared long-term preference file
-- `~/.vibe_remote/state/discovered_chats.json`: cached chat discovery payloads used by the setup wizard
-- `~/.vibe_remote/state/sessions.json`: legacy JSON session snapshot; do not edit during normal config work
-- `~/.vibe_remote/logs/vibe_remote.log`: main application log
-- `~/.vibe_remote/runtime/status.json`: runtime status file
-- `~/.vibe_remote/runtime/doctor.json`: latest doctor result
-- `~/.vibe_remote/runtime/watch_runtime.json`: live watch runtime state, including active PIDs
-- `~/.vibe_remote/runtime/vibe.pid`: main service PID
-- `~/.vibe_remote/runtime/vibe-ui.pid`: Web UI server PID
-- `~/.vibe_remote/runtime/remote-access-cloudflared.pid`: cloudflared tunnel PID for Vibe Cloud remote access
-- `~/.vibe_remote/attachments/`: attachment staging area
-- `~/.vibe_remote/screenshots/`: default output directory for `vibe screenshot`
-
-Only edit the JSON files in this layout as a recovery fallback when the Web UI API is unavailable or the user explicitly asks for low-level repair. If you must edit one directly, back it up first, validate JSON, and explain why the API path was not usable. Never read or write `vibe.sqlite` — escalate database issues instead of touching the file (see the recovery section below for the supported path).
+Scheduled tasks and watches are managed through `vibe task` / `vibe watch` (or their API endpoints), not by editing their persistence files. Everything else under `state/` and `runtime/` is internal — treat it as opaque.
 
 ## API Endpoint Reference
 
@@ -979,7 +961,7 @@ Common cases:
 - wrong repository/cwd: inspect `custom_cwd` and `runtime.default_cwd`
 - DM access denied: inspect `/api/users?platform=<platform>` and bind-code state
 - platform cannot reach API: inspect `proxy_url` on that platform's config block; check logs for proxy/TLS errors; for SOCKS proxies confirm `aiohttp_socks` is installed
-- remote URL is unreachable: `GET /remote-access/status` should show `tunnel_running: true`; if not, check `remote-access-cloudflared.pid`, `cloudflared_path`, and the latest doctor result
+- remote URL is unreachable: `GET /remote-access/status` should show `tunnel_running: true`; if not, run `POST /doctor` and check the configured `cloudflared_path`
 - remote session expired: instruct the user to re-sign in at the public URL (24h TTL with sliding renewal); use `POST /auth/logout` to clear a stale session on the current device
 - upgrade did not apply: inspect the response from `POST /upgrade` (auto-restart on success) or `vibe upgrade` (does not auto-restart — run `vibe restart` manually), then verify with `vibe status` that the new PID is running
 - startup failure: use `GET /status`, `POST /doctor`, then inspect logs
@@ -988,25 +970,6 @@ Do not use `vibe restart`, `POST /control {"action":"restart"}`, or `POST /ui/re
 
 If a restart is still required and you are replying through an active Vibe Remote conversation, use `vibe restart --delay-seconds 60` so the current reply can be delivered before the restart lands.
 
-## Direct File Recovery Fallback
-
-Use file edits only when:
-
-- the Web UI API is down and cannot be recovered through normal service start
-- the config file is malformed and prevents the API from starting
-- the user explicitly asks for low-level file repair
-
-Recovery rules:
-
-1. Identify `VIBE_REMOTE_HOME` or default to `~/.vibe_remote`.
-2. Back up the target file before writing.
-3. Preserve unrelated keys and secrets.
-4. Validate JSON after editing.
-5. Start or restart only when needed to bring the API back.
-6. After recovery, return to the API workflow for further changes.
-
-`vibe.sqlite` is never a fallback target. Never open it with sqlite3 or any inspection tool, and do not move the file aside in the hope of triggering a rebuild — `~/.vibe_remote/state/backups/` only holds JSON snapshots captured at the original migration, and a fresh startup will re-import from the current live JSON files, which may be stale relative to recent runtime state. If the database itself is the problem, stop Vibe Remote, preserve `vibe.sqlite` and the JSON state files as-is, and escalate to the repo.
-
 ## Safety Boundaries
 
 Always follow these constraints:
@@ -1014,8 +977,7 @@ Always follow these constraints:
 - never delete unrelated platform scopes
 - never blank out tokens or secrets as part of an unrelated config task
 - never claim a backend feature exists if current Vibe Remote behavior does not support it
-- never read, query, or rewrite `vibe.sqlite` — it is an internal store, not an operator surface
-- never manually rewrite `sessions.json` for routine routing changes — use the Web UI API or `vibe` CLI instead
+- never read, query, or hand-edit Vibe Remote's internal state storage — go through the Web UI API or `vibe` CLI
 - never expose bind codes, pairing keys, tunnel tokens, instance secrets, or session secrets unless the user explicitly asks
 - never paste a credentialed `proxy_url` (`user:pass@host`) back into chat — mask the credentials portion when echoing the value
 - always say when a requested change actually belongs in OpenCode, Claude Code, or Codex config instead of Vibe Remote

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -37,7 +37,7 @@ Follow this skill as an operations playbook for agents, not as end-user marketin
 6. For `POST /settings`, preserve every existing channel for that platform; the endpoint replaces the platform's channel map.
 7. For `POST /api/users`, merge each edited user with its current user payload first; missing user fields are not a patch.
 8. The persistent state store is `~/.vibe_remote/state/vibe.sqlite`. Do not hand-edit it. Use the API for settings, users, sessions, and discovered chats.
-9. `POST /config` for a platform credential block will trigger an automatic service restart inside Vibe Remote so the new credentials can take effect. Tell the user before saving, and prefer the delayed CLI form (`vibe restart --delay-seconds 60`) when an explicit restart is still needed from inside an active conversation.
+9. `POST /config` persists the new payload but does not restart running platform adapters by itself. When the change is platform credentials, `proxy_url`, or other transport-level settings, plan an explicit restart afterwards; prefer the delayed CLI form (`vibe restart --delay-seconds 60`) when triggering it from inside an active conversation. The only credential save that restarts on its own is the WeChat QR-login completion through `POST /wechat/qr_login/poll`.
 10. Do not restart the service by default. Use `POST /doctor`, `GET /status`, and read-back checks first.
 11. Only start, stop, restart, or reload Vibe Remote when the user explicitly asks or when a change cannot take effect otherwise; explain why before doing it.
 12. If an agent must restart Vibe Remote from an active conversation, use `vibe restart --delay-seconds 60` so the current session can receive the reply before the restart lands.
@@ -206,7 +206,7 @@ Only use direct file editing as a recovery fallback when the Web UI API is unava
 - `POST /config`
   - accepts a partial object, deep-merges it with current config, validates it through `V2Config.from_payload`, then persists it
   - use for platform credentials, enabled platforms, primary platform, runtime defaults, agent defaults, UI config, remote-access provider settings, update policy, and global toggles
-  - saving a platform credential block schedules an automatic restart so the new credentials take effect
+  - the handler only persists and (for `remote_access`) reconciles the cloudflared tunnel; running platform adapters keep using their previous credentials and transport until a restart. Plan a `vibe restart --delay-seconds 60` after any credential, `proxy_url`, or transport-level change.
 
 Important config payload shape:
 
@@ -719,7 +719,7 @@ Notes:
 
 - `proxy_url` accepts `http://`, `https://`, `socks5://`, and `socks5h://` schemes; the SOCKS variants require `aiohttp_socks` (bundled).
 - Set the field to `null` (or omit it on a fresh save) to disable the proxy.
-- Saving a platform credential block schedules an automatic restart so the proxy can apply to live connections.
+- `POST /config` only persists the new value; running platform adapters keep their old transport until the service restarts. After saving, run `vibe restart --delay-seconds 60` (or `POST /control {"action":"restart"}` with the user's confirmation) so the proxy applies to live connections.
 - Do not paste credentialed proxy URLs (`user:pass@host`) into logs or chat replies; mask the credentials portion when reporting back.
 
 ### Pair Vibe Cloud remote access
@@ -774,7 +774,7 @@ Preferred CLI shape:
 - one-off task: `vibe task add --session-key '<key>' --at '<ISO-8601>' --prompt '...'`
 - immediate rerun: `vibe task run <id>`
 - one-shot async hook: `vibe hook send --session-key '<key>' --prompt '...'`
-- managed background watch: `vibe watch add --session-key '<key>' --command '<cmd>' --prefix '...'`
+- managed background watch: `vibe watch add --session-key '<key>' --prefix '...' -- <cmd>` (or `--shell '<cmd>'` to pass a single shell string)
 
 Delivery controls (apply to `vibe task add`, `vibe hook send`, and `vibe watch add`):
 
@@ -798,7 +798,7 @@ Session key format:
 Operational guidance:
 
 - use `vibe task list` before editing or deleting an existing task; use `vibe watch list` before touching a managed watch
-- if this is the first time using `vibe task add`, `vibe hook send`, or `vibe watch add`, read the matching `--help` output first — watches accept additional flags like `--command`, `--cwd`, `--timeout-seconds`, and `--max-cycles`
+- if this is the first time using `vibe task add`, `vibe hook send`, or `vibe watch add`, read the matching `--help` output first — watches accept additional flags like `--shell`, `--timeout` (per-cycle), `--lifetime-timeout` (overall), `--forever`, `--retry-exit-code`, and `--retry-delay`
 - use `vibe task update <id>` to keep the same task ID while changing name, schedule, prompt, or target
 - watches do not have an `update` subcommand; remove and re-add when you must change the waiter
 - use `vibe task list --brief` and `vibe watch list --brief` for scheduling-focused summaries

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: use-vibe-remote
 slug: use-vibe-remote
-description: Safely inspect and modify local Vibe Remote configuration, routing, runtime settings, watches, scheduled tasks, and operational state.
-version: 0.2.2
+description: Safely inspect and modify local Vibe Remote configuration, routing, runtime settings, watches, scheduled tasks, Vibe Cloud remote access, and operational state.
+version: 0.3.0
 ---
 
 # Use Vibe Remote
@@ -16,9 +16,12 @@ Typical requests include:
 - set a working directory for a channel or DM user
 - choose a backend model, subagent, or reasoning level
 - show or hide intermediate message types
+- configure an outbound proxy (`proxy_url`) for an IM platform that cannot reach its API directly
+- pair, start, stop, or inspect Vibe Cloud remote Web UI access
 - create, inspect, pause, resume, or remove a managed background watch with `vibe watch`
 - create, inspect, run, pause, resume, or remove a scheduled task with `vibe task`
 - queue a one-shot asynchronous hook with `vibe hook send`
+- check or apply Vibe Remote updates (`vibe check-update`, `vibe upgrade`)
 - inspect logs, run doctor, check service status, or explain where Vibe Remote stores state
 - decide whether a requested change belongs in Vibe Remote config or in the host backend's own config
 
@@ -33,11 +36,12 @@ Follow this skill as an operations playbook for agents, not as end-user marketin
 5. Use the smallest viable API call and verify by reading back the API response.
 6. For `POST /settings`, preserve every existing channel for that platform; the endpoint replaces the platform's channel map.
 7. For `POST /api/users`, merge each edited user with its current user payload first; missing user fields are not a patch.
-8. Do not hand-edit `sessions.json` unless the user explicitly asks for low-level recovery work.
-9. Do not restart the service by default. Use `POST /doctor`, `GET /status`, and read-back checks first.
-10. Only start, stop, restart, or reload Vibe Remote when the user explicitly asks or when a change cannot take effect otherwise; explain why before doing it.
-11. If an agent must restart Vibe Remote from an active conversation, use `vibe restart --delay-seconds 60` so the current session can receive the reply before the restart lands.
-12. Tell the user whether the change is global or scope-specific.
+8. The persistent state store is `~/.vibe_remote/state/vibe.sqlite`. Do not hand-edit it. Use the API for settings, users, sessions, and discovered chats.
+9. `POST /config` for a platform credential block will trigger an automatic service restart inside Vibe Remote so the new credentials can take effect. Tell the user before saving, and prefer the delayed CLI form (`vibe restart --delay-seconds 60`) when an explicit restart is still needed from inside an active conversation.
+10. Do not restart the service by default. Use `POST /doctor`, `GET /status`, and read-back checks first.
+11. Only start, stop, restart, or reload Vibe Remote when the user explicitly asks or when a change cannot take effect otherwise; explain why before doing it.
+12. If an agent must restart Vibe Remote from an active conversation, use `vibe restart --delay-seconds 60` so the current session can receive the reply before the restart lands.
+13. Tell the user whether the change is global or scope-specific.
 
 ## API First Workflow
 
@@ -45,12 +49,14 @@ Use this order when changing Vibe Remote configuration:
 
 1. Determine the Web UI base URL.
    - Default is `http://127.0.0.1:5123`.
-   - If the user has a custom UI host or port, use that exact origin.
+   - If the user has a custom UI host or port (from `ui.setup_host` / `ui.setup_port`), use that exact origin.
+   - When Vibe Cloud remote access is active, the public origin (e.g. `https://<slug>.avibe.bot`) also speaks the same API and requires OIDC session cookies — prefer the local origin from the host running Vibe Remote.
    - Check liveness with `GET /health` or `GET /status`.
 2. Decide whether the request belongs in:
-   - `POST /config` for global defaults, platform credentials, runtime config, agent defaults, UI config, or global display toggles
+   - `POST /config` for global defaults, platform credentials, runtime config, agent defaults, UI config, remote-access provider settings, update policy, or global display toggles
    - `POST /settings` for channel-level routing, working directory, visibility, enablement, and mention policy
    - `/api/users` and `/api/bind-codes` for DM user binding and user-scope settings
+   - `/remote-access/*` for Vibe Cloud pairing and tunnel control
    - host backend config instead of Vibe Remote when the request is OpenCode, Claude Code, or Codex native behavior
 3. Fetch the current state from the matching GET endpoint.
 4. Merge the requested change in memory.
@@ -86,6 +92,8 @@ curl -fsS -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
 ```
 
 For `DELETE`, use the same cookie jar, `Origin`, and CSRF header.
+
+When the Web UI is served through Vibe Cloud, the same calls require an authenticated OIDC session cookie issued by `/auth/callback`. Prefer hitting `127.0.0.1:5123` directly from the local machine for maintenance work.
 
 Do not log full request bodies when they contain tokens or secrets.
 
@@ -147,19 +155,27 @@ Vibe Remote stores runtime data under `~/.vibe_remote/` by default. If `VIBE_REM
 Important paths:
 
 - `~/.vibe_remote/config/config.json`: global config persisted by `POST /config`
-- `~/.vibe_remote/state/settings.json`: scope settings persisted by `/settings`, `/api/users`, and `/api/bind-codes`
+- `~/.vibe_remote/state/vibe.sqlite`: primary persistent store (settings, users, sessions, discovered chats). Treat as opaque; do not hand-edit.
+- `~/.vibe_remote/state/migration.lock`: SQLite migration lock; do not delete during normal operation
+- `~/.vibe_remote/state/backups/`: automatic state backups taken before migrations
+- `~/.vibe_remote/state/settings.json`: legacy JSON snapshot mirror for `/settings`, `/api/users`, and `/api/bind-codes`; read-only during normal operation
 - `~/.vibe_remote/state/scheduled_tasks.json`: persisted scheduled tasks created by `vibe task`
 - `~/.vibe_remote/state/watches.json`: persisted managed watches
 - `~/.vibe_remote/state/task_requests/`: queued task-run and hook-send requests plus completion receipts
 - `~/.vibe_remote/state/user_preferences.md`: shared long-term preference file
-- `~/.vibe_remote/state/sessions.json`: runtime session state; do not edit during normal config work
+- `~/.vibe_remote/state/discovered_chats.json`: cached chat discovery payloads used by the setup wizard
+- `~/.vibe_remote/state/sessions.json`: legacy JSON session snapshot; do not edit during normal config work
 - `~/.vibe_remote/logs/vibe_remote.log`: main application log
 - `~/.vibe_remote/runtime/status.json`: runtime status file
 - `~/.vibe_remote/runtime/doctor.json`: latest doctor result
 - `~/.vibe_remote/runtime/watch_runtime.json`: live watch runtime state, including active PIDs
+- `~/.vibe_remote/runtime/vibe.pid`: main service PID
+- `~/.vibe_remote/runtime/vibe-ui.pid`: Web UI server PID
+- `~/.vibe_remote/runtime/remote-access-cloudflared.pid`: cloudflared tunnel PID for Vibe Cloud remote access
 - `~/.vibe_remote/attachments/`: attachment staging area
+- `~/.vibe_remote/screenshots/`: default output directory for `vibe screenshot`
 
-Only use direct file editing as a recovery fallback when the Web UI API is unavailable or the user explicitly asks for low-level repair. If you must edit files directly, back up the file first, validate JSON, and explain why the API path was not usable.
+Only use direct file editing as a recovery fallback when the Web UI API is unavailable or the user explicitly asks for low-level repair. If you must edit files directly, back up the file first, validate JSON, and explain why the API path was not usable. The SQLite store (`vibe.sqlite`) is not safe to hand-edit during recovery — escalate instead.
 
 ## API Endpoint Reference
 
@@ -178,6 +194,10 @@ Only use direct file editing as a recovery fallback when the Web UI API is unava
   - `source` can be `service` or another source listed in the response; use `all` for aggregated logs
 - `GET /version`
   - returns current version and update metadata
+- `GET /api/csrf-token`
+  - issues the `vibe_csrf_token` cookie and returns the matching token value for `X-Vibe-CSRF-Token`
+- `GET /platforms`
+  - returns the catalog of supported IM platforms, current enabled list, and credential state
 
 ### Global config
 
@@ -185,7 +205,8 @@ Only use direct file editing as a recovery fallback when the Web UI API is unava
   - returns the current V2 config payload
 - `POST /config`
   - accepts a partial object, deep-merges it with current config, validates it through `V2Config.from_payload`, then persists it
-  - use for platform credentials, enabled platforms, primary platform, runtime defaults, agent defaults, UI config, update policy, and global toggles
+  - use for platform credentials, enabled platforms, primary platform, runtime defaults, agent defaults, UI config, remote-access provider settings, update policy, and global toggles
+  - saving a platform credential block schedules an automatic restart so the new credentials take effect
 
 Important config payload shape:
 
@@ -205,12 +226,18 @@ Important config payload shape:
     "team_id": "T...",
     "team_name": "...",
     "app_id": "A...",
-    "require_mention": false
+    "require_mention": false,
+    "disable_link_unfurl": false,
+    "proxy_url": null
   },
   "discord": {
     "bot_token": "...",
     "application_id": "...",
-    "require_mention": false
+    "require_mention": false,
+    "thread_auto_archive_minutes": 10080,
+    "guild_allowlist": null,
+    "guild_denylist": null,
+    "proxy_url": null
   },
   "telegram": {
     "bot_token": "123:abc",
@@ -220,20 +247,22 @@ Important config payload shape:
     "webhook_url": null,
     "webhook_secret_token": null,
     "allowed_chat_ids": null,
-    "allowed_user_ids": null
+    "allowed_user_ids": null,
+    "proxy_url": null
   },
   "lark": {
     "app_id": "...",
     "app_secret": "...",
     "require_mention": false,
-    "domain": "feishu"
+    "domain": "feishu",
+    "proxy_url": null
   },
   "wechat": {
     "bot_token": "...",
     "base_url": "https://ilinkai.weixin.qq.com",
     "cdn_base_url": "https://novac2c.cdn.weixin.qq.com/c2c",
-    "proxy_url": null,
-    "require_mention": false
+    "require_mention": false,
+    "proxy_url": null
   },
   "runtime": {
     "default_cwd": "/path/to/workdir",
@@ -262,6 +291,37 @@ Important config payload shape:
       "idle_timeout_seconds": 600
     }
   },
+  "ui": {
+    "setup_host": "127.0.0.1",
+    "setup_port": 5123,
+    "open_browser": true
+  },
+  "remote_access": {
+    "provider": "vibe_cloud",
+    "vibe_cloud": {
+      "enabled": false,
+      "backend_url": "https://avibe.bot",
+      "public_url": "",
+      "instance_id": "",
+      "client_id": "",
+      "issuer": "",
+      "authorization_endpoint": "",
+      "token_endpoint": "",
+      "jwks_uri": "",
+      "redirect_uri": "",
+      "tunnel_token": "",
+      "instance_secret": "",
+      "session_secret": "",
+      "cloudflared_path": "",
+      "dev_login_hint": ""
+    }
+  },
+  "update": {
+    "auto_update": true,
+    "check_interval_minutes": 60,
+    "idle_minutes": 30,
+    "notify_admins": true
+  },
   "ack_mode": "typing",
   "language": "en",
   "show_duration": false,
@@ -287,6 +347,18 @@ servers under `guilds`, next to channel settings:
 
 When switching the active platform, update `platforms.primary` and make sure `platforms.enabled` contains the new primary. Keep the legacy `platform` field aligned for readability, but `platforms.primary` is the real multi-platform source of truth.
 
+Per-platform fields worth knowing about:
+
+- every platform inherits `proxy_url` from the shared `BaseIMConfig`. Set it when the host machine cannot reach the upstream API directly. Accepts standard HTTP/HTTPS proxy URLs and `socks5://` / `socks5h://` URLs (SOCKS5 support uses `aiohttp_socks`).
+- `slack.disable_link_unfurl` suppresses link previews when posting messages.
+- `discord.thread_auto_archive_minutes` must be one of `60`, `1440`, `4320`, or `10080`.
+- `discord.guild_allowlist` / `guild_denylist` are legacy input lists; current runtime server access lives in `/settings` under `guilds`.
+- `telegram.forum_auto_topic` enables automatic topic creation in forum chats; `use_webhook` plus `webhook_url` / `webhook_secret_token` switches Telegram delivery to the webhook transport.
+- `telegram.allowed_chat_ids` / `allowed_user_ids` restrict which chats and users Telegram will respond to.
+- `wechat.cdn_base_url` controls the CDN host used for fetching WeChat media; the default `novac2c.cdn.weixin.qq.com` is the official c2c CDN.
+- `update.auto_update`, `check_interval_minutes`, and `idle_minutes` control unattended upgrades; `notify_admins` posts the upgrade announcement to bound admins.
+- `ui.setup_host`, `setup_port`, and `open_browser` configure the local Web UI server; changing host or port requires `POST /ui/reload`.
+
 Secret-bearing config fields that you should not print:
 
 - `slack.bot_token`
@@ -300,6 +372,11 @@ Secret-bearing config fields that you should not print:
 - `wechat.bot_token`
 - `gateway.workspace_token`
 - `gateway.client_secret`
+- `remote_access.vibe_cloud.tunnel_token`
+- `remote_access.vibe_cloud.instance_secret`
+- `remote_access.vibe_cloud.session_secret`
+- `remote_access.vibe_cloud.client_id`
+- any `proxy_url` value that embeds credentials such as `user:pass@host`
 
 ### Channel settings
 
@@ -433,6 +510,32 @@ DM caveat: current DM authorization checks whether the user is bound, not whethe
 
 WeChat QR login is special: when login is confirmed and a token is returned, the API auto-binds the WeChat user and schedules an internal service restart so the new token can take effect. Do not add an extra restart unless the user asks.
 
+### Remote access (Vibe Cloud)
+
+These endpoints drive the managed `avibe.bot` tunnel that exposes the local Web UI to other devices. They are paired with the `remote_access.vibe_cloud` block under `/config`.
+
+- `GET /remote-access/status`
+  - returns enabled state, public URL, tunnel status, last error, OIDC issuer, and whether `cloudflared` is running
+- `POST /remote-access/vibe-cloud/pair`
+  - payload: `{"pairing_key": "vrp_..."}`
+  - exchanges the one-time key for an OIDC client, tunnel token, and persists the full `remote_access.vibe_cloud` block; on success Vibe Remote launches the cloudflared tunnel
+- `POST /remote-access/start`
+  - payload: `{}`
+  - starts the cloudflared tunnel using the persisted pairing config
+- `POST /remote-access/stop`
+  - payload: `{}`
+  - stops the cloudflared tunnel; configuration is preserved so `start` can resume later
+- `GET /auth/callback`
+  - OIDC redirect target used by avibe.bot during sign-in. Browser-driven; do not call directly from automation.
+- `GET /api/session`
+  - returns the active avibe.bot user identity and signed-in state (or 401 when not signed in)
+- `POST /auth/logout`
+  - clears the avibe.bot session cookie on this device. Does not stop the tunnel.
+
+The session cookie is bound to the tunnel session and expires after roughly 24 hours; the server slides the TTL when activity reaches the half-life. Do not invent custom auth headers — rely on the existing cookie issued by `/auth/callback`.
+
+Treat `tunnel_token`, `instance_secret`, `session_secret`, and `client_id` from `remote_access.vibe_cloud` as opaque secrets.
+
 ### Backend and local helper endpoints
 
 - `GET /cli/detect?binary=<name-or-path>`
@@ -457,8 +560,11 @@ WeChat QR login is special: when login is confirmed and a token is returned, the
   - payload: `{"action": "start"}`, `{"action": "stop"}`, or `{"action": "restart"}`
 - `POST /ui/reload`
   - payload: `{"host": "127.0.0.1", "port": 5123}`
+- `POST /upgrade`
+  - payload: `{}`
+  - triggers an in-place upgrade to the latest released version using the same code path as `vibe upgrade`
 
-Avoid these for routine configuration. `POST /control` starts, stops, or restarts the service. `POST /ui/reload` restarts only the Web UI server to apply host or port changes. Use them only with explicit user intent or a concrete need.
+Avoid these for routine configuration. `POST /control` starts, stops, or restarts the service. `POST /ui/reload` restarts only the Web UI server to apply host or port changes. `POST /upgrade` reinstalls Vibe Remote and then restarts the service. Use them only with explicit user intent or a concrete need.
 
 When the restart is initiated by an agent from an active conversation, use the CLI delayed form `vibe restart --delay-seconds 60` so the transport does not cut off the current reply.
 
@@ -595,6 +701,48 @@ Use `POST /config` and keep `platforms.enabled` complete:
 
 Make sure the target platform config section exists and validates. Do not delete old platform config unless the user explicitly asks.
 
+### Configure an outbound proxy for an IM platform
+
+When the host cannot reach a platform API directly, set `proxy_url` on that platform's config block.
+
+Use `POST /config` with only the proxy field for the affected platform:
+
+```json
+{
+  "telegram": {
+    "proxy_url": "http://proxy.internal:3128"
+  }
+}
+```
+
+Notes:
+
+- `proxy_url` accepts `http://`, `https://`, `socks5://`, and `socks5h://` schemes; the SOCKS variants require `aiohttp_socks` (bundled).
+- Set the field to `null` (or omit it on a fresh save) to disable the proxy.
+- Saving a platform credential block schedules an automatic restart so the proxy can apply to live connections.
+- Do not paste credentialed proxy URLs (`user:pass@host`) into logs or chat replies; mask the credentials portion when reporting back.
+
+### Pair Vibe Cloud remote access
+
+Goal: connect the local Web UI to `avibe.bot` so it is reachable from another device.
+
+1. The user signs in at `https://avibe.bot`, creates a remote-access bot, and copies the one-time pairing key (format `vrp_...`).
+2. Call `POST /remote-access/vibe-cloud/pair` with `{"pairing_key": "vrp_..."}` from the local Web UI origin.
+3. Verify with `GET /remote-access/status` — `enabled: true`, `public_url` populated, `tunnel_running: true`.
+4. Have the user open `public_url` and sign in with the same avibe.bot account.
+
+Alternatively, drive the same flow from the CLI:
+
+```bash
+vibe remote                       # guided flow
+vibe remote pair vrp_abc123       # paste key directly
+vibe remote status --json         # inspect tunnel state
+vibe remote stop                  # stop tunnel; keep config
+vibe remote start                 # bring tunnel back up
+```
+
+Treat the pairing key, tunnel token, instance secret, and session secret as opaque. Never echo them in chat replies.
+
 ### Generate a DM bind code
 
 Use `POST /api/bind-codes`:
@@ -616,24 +764,25 @@ For an expiring code:
 
 Do not expose bind codes unless the user explicitly asks for them.
 
-## Scheduled Tasks
+## Scheduled Tasks and Watches
 
-Use scheduled tasks when the user wants Vibe Remote to inject a prompt later or repeatedly into an existing chat scope.
+Use scheduled tasks and watches when the user wants Vibe Remote to inject a prompt later or repeatedly into an existing chat scope, or wait on a background condition before sending a follow-up.
 
 Preferred CLI shape:
 
-- recurring: `vibe task add --session-key '<key>' --cron '<expr>' --prompt '...'`
-- one-off: `vibe task add --session-key '<key>' --at '<ISO-8601>' --prompt '...'`
+- recurring task: `vibe task add --session-key '<key>' --cron '<expr>' --prompt '...'`
+- one-off task: `vibe task add --session-key '<key>' --at '<ISO-8601>' --prompt '...'`
 - immediate rerun: `vibe task run <id>`
 - one-shot async hook: `vibe hook send --session-key '<key>' --prompt '...'`
+- managed background watch: `vibe watch add --session-key '<key>' --command '<cmd>' --prefix '...'`
 
-Delivery controls:
+Delivery controls (apply to `vibe task add`, `vibe hook send`, and `vibe watch add`):
 
 - `session_key` controls which session Vibe Remote continues using
 - when you want to keep the current session, keep using the current `session_key`
 - when you do not want to keep the current thread session and instead want to start or reuse the higher-level session, switch to the higher-level key
 - example: `slack::channel::C123::thread::171717.123` keeps the current thread session, while `slack::channel::C123` creates or reuses the channel-scoped session
-- use `--post-to channel` when the task or hook should keep the session chosen by `session_key` but publish to the parent channel
+- use `--post-to channel` when the task, hook, or watch should keep the session chosen by `session_key` but publish to the parent channel
 - use `--deliver-key '<key>'` only when delivery must go to a different explicit target than `session_key`
 - do not combine `--post-to` and `--deliver-key` in the same command
 - `vibe task add` stores the text from `--prompt` or `--prompt-file` and injects it each time the task runs
@@ -648,13 +797,15 @@ Session key format:
 
 Operational guidance:
 
-- use `vibe task list` before editing or deleting an existing task
-- if this is the first time using `vibe task add`, `vibe watch add`, or `vibe hook send`, read the matching `--help` output first
+- use `vibe task list` before editing or deleting an existing task; use `vibe watch list` before touching a managed watch
+- if this is the first time using `vibe task add`, `vibe hook send`, or `vibe watch add`, read the matching `--help` output first — watches accept additional flags like `--command`, `--cwd`, `--timeout-seconds`, and `--max-cycles`
 - use `vibe task update <id>` to keep the same task ID while changing name, schedule, prompt, or target
-- use `vibe task list --brief` for scheduling-focused summaries
+- watches do not have an `update` subcommand; remove and re-add when you must change the waiter
+- use `vibe task list --brief` and `vibe watch list --brief` for scheduling-focused summaries
 - `vibe task list` hides completed one-shot tasks by default; use `vibe task list --all` when you need full history
-- use `vibe task show <id>` to inspect stored fields and derived scheduling state such as `next_run_at`
-- treat `warnings` from task or hook commands as delivery-risk hints to fix proactively
+- use `vibe task show <id>` or `vibe watch show <id>` to inspect stored fields and derived runtime state (such as `next_run_at` or `pid`)
+- use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
+- treat `warnings` from task, hook, or watch commands as delivery-risk hints to fix proactively
 
 ## Backend Capability Matrix
 
@@ -767,6 +918,50 @@ Relevant docs:
 
 Inside Vibe Remote, Codex scope routing controls backend choice, subagent, model, and reasoning effort.
 
+## CLI Reference
+
+Use the CLI only when the Web UI API cannot cover the request, when the user explicitly asks for the command, or when restarting/upgrading from an active conversation.
+
+Service lifecycle:
+
+- `vibe` — start (or restart) Vibe Remote and open the local Web UI
+- `vibe status` — print service status, PID metadata, and last action
+- `vibe stop` — stop main service, Web UI, and any background helpers
+- `vibe restart` — stop and re-start the service. Pass `--delay-seconds N` when triggering from inside an active conversation so the current reply has time to deliver before the restart lands.
+- `vibe doctor` — run diagnostics and print the latest result
+- `vibe version` — print the installed version
+
+Updates:
+
+- `vibe check-update` — query the release feed and print whether an upgrade is available
+- `vibe upgrade` — reinstall Vibe Remote to the latest release (followed by a restart)
+
+Remote access:
+
+- `vibe remote` — guided Vibe Cloud pairing
+- `vibe remote pair <key>` — pair using an existing one-time key
+- `vibe remote status [--json]` — show tunnel + OIDC state
+- `vibe remote start` / `vibe remote stop` — manage the cloudflared tunnel after pairing
+
+Screenshots:
+
+- `vibe screenshot` — capture the local desktop to `~/.vibe_remote/screenshots/`
+- `vibe screenshot --output <path>` / `--json` — pick an explicit output path or get machine-readable output
+
+Scheduled tasks:
+
+- `vibe task add`, `vibe task update`, `vibe task list [--all|--brief]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
+
+Async hooks:
+
+- `vibe hook send` — one-shot prompt injection without persisting a task
+
+Watches:
+
+- `vibe watch add`, `vibe watch list [--brief]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
+
+For any subcommand, prefer `<command> --help` before composing a new invocation. `vibe task`, `vibe hook send`, and `vibe watch add` share the delivery flags documented above (`--session-key`, `--post-to`, `--deliver-key`, `--prompt`, `--prompt-file`, `--name`, `--timezone`).
+
 ## Troubleshooting
 
 Start with evidence:
@@ -783,6 +978,10 @@ Common cases:
 - channel does not respond: verify `/settings?platform=<platform>` contains the channel and `enabled` is true
 - wrong repository/cwd: inspect `custom_cwd` and `runtime.default_cwd`
 - DM access denied: inspect `/api/users?platform=<platform>` and bind-code state
+- platform cannot reach API: inspect `proxy_url` on that platform's config block; check logs for proxy/TLS errors; for SOCKS proxies confirm `aiohttp_socks` is installed
+- remote URL is unreachable: `GET /remote-access/status` should show `tunnel_running: true`; if not, check `remote-access-cloudflared.pid`, `cloudflared_path`, and the latest doctor result
+- remote session expired: instruct the user to re-sign in at the public URL (24h TTL with sliding renewal); use `POST /auth/logout` to clear a stale session on the current device
+- upgrade did not apply: inspect the response from `POST /upgrade` and follow up with `vibe status`; a restart is part of the upgrade flow
 - startup failure: use `GET /status`, `POST /doctor`, then inspect logs
 
 Do not use `vibe restart`, `POST /control {"action":"restart"}`, or `POST /ui/reload` as a first response to config problems.
@@ -806,6 +1005,8 @@ Recovery rules:
 5. Start or restart only when needed to bring the API back.
 6. After recovery, return to the API workflow for further changes.
 
+`vibe.sqlite` is not part of this fallback. If the database is the problem, copy aside the file under `~/.vibe_remote/state/` and let Vibe Remote rebuild from `backups/` rather than editing it directly. Escalate to the repo if the rebuild fails.
+
 ## Safety Boundaries
 
 Always follow these constraints:
@@ -813,8 +1014,9 @@ Always follow these constraints:
 - never delete unrelated platform scopes
 - never blank out tokens or secrets as part of an unrelated config task
 - never claim a backend feature exists if current Vibe Remote behavior does not support it
-- never manually rewrite `sessions.json` for routine routing changes
-- never expose bind codes unless the user explicitly asks
+- never manually rewrite `sessions.json` or `vibe.sqlite` for routine routing changes
+- never expose bind codes, pairing keys, tunnel tokens, instance secrets, or session secrets unless the user explicitly asks
+- never paste a credentialed `proxy_url` (`user:pass@host`) back into chat — mask the credentials portion when echoing the value
 - always say when a requested change actually belongs in OpenCode, Claude Code, or Codex config instead of Vibe Remote
 
 ## Escalation

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -36,7 +36,7 @@ Follow this skill as an operations playbook for agents, not as end-user marketin
 5. Use the smallest viable API call and verify by reading back the API response.
 6. For `POST /settings`, preserve every existing channel for that platform; the endpoint replaces the platform's channel map.
 7. For `POST /api/users`, merge each edited user with its current user payload first; missing user fields are not a patch.
-8. The persistent state store is `~/.vibe_remote/state/vibe.sqlite`. Do not hand-edit it. Use the API for settings, users, sessions, and discovered chats.
+8. The persistent state store is `~/.vibe_remote/state/vibe.sqlite` (scope settings, agent sessions, auth codes, runtime records). Discovered chats live separately in `~/.vibe_remote/state/discovered_chats.json`. Do not hand-edit either; use the API for settings, users, sessions, and chat discovery.
 9. `POST /config` persists the new payload but does not restart running platform adapters by itself. When the change is platform credentials, `proxy_url`, or other transport-level settings, plan an explicit restart afterwards; prefer the delayed CLI form (`vibe restart --delay-seconds 60`) when triggering it from inside an active conversation. The only credential save that restarts on its own is the WeChat QR-login completion through `POST /wechat/qr_login/poll`.
 10. Do not restart the service by default. Use `POST /doctor`, `GET /status`, and read-back checks first.
 11. Only start, stop, restart, or reload Vibe Remote when the user explicitly asks or when a change cannot take effect otherwise; explain why before doing it.
@@ -155,7 +155,7 @@ Vibe Remote stores runtime data under `~/.vibe_remote/` by default. If `VIBE_REM
 Important paths:
 
 - `~/.vibe_remote/config/config.json`: global config persisted by `POST /config`
-- `~/.vibe_remote/state/vibe.sqlite`: primary persistent store (settings, users, sessions, discovered chats). Treat as opaque; do not hand-edit.
+- `~/.vibe_remote/state/vibe.sqlite`: primary persistent store (scope settings, agent sessions, auth codes, runtime records). Treat as opaque; do not hand-edit.
 - `~/.vibe_remote/state/migration.lock`: SQLite migration lock; do not delete during normal operation
 - `~/.vibe_remote/state/backups/`: automatic state backups taken before migrations
 - `~/.vibe_remote/state/settings.json`: legacy JSON snapshot mirror for `/settings`, `/api/users`, and `/api/bind-codes`; read-only during normal operation

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -960,7 +960,7 @@ Watches:
 
 - `vibe watch add`, `vibe watch list [--brief]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
 
-For any subcommand, prefer `<command> --help` before composing a new invocation. The delivery flags shared by all three commands are `--session-key`, `--post-to`, `--deliver-key`, and `--name`. The remaining surface differs: `vibe task add` and `vibe hook send` take `--prompt` / `--prompt-file`, only `vibe task add` takes `--cron` / `--at` / `--timezone`, and `vibe watch add` takes its own set (`--prefix`, `--shell` or a positional command after `--`, `--cwd`, `--timeout`, `--forever`, `--lifetime-timeout`, `--retry-exit-code`, `--retry-delay`). Do not copy task or hook flags into a watch invocation.
+For any subcommand, prefer `<command> --help` before composing a new invocation. The delivery flags shared by all three commands are `--session-key`, `--post-to`, and `--deliver-key`. The remaining surface differs: `vibe task add` and `vibe hook send` take `--prompt` / `--prompt-file`; `vibe task add` and `vibe watch add` take `--name`; only `vibe task add` takes `--cron` / `--at` / `--timezone`; and `vibe watch add` takes its own set (`--prefix`, `--shell` or a positional command after `--`, `--cwd`, `--timeout`, `--forever`, `--lifetime-timeout`, `--retry-exit-code`, `--retry-delay`). Do not copy task or hook flags into a watch invocation, and do not pass `--name` to `vibe hook send`.
 
 ## Troubleshooting
 

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -331,7 +331,7 @@ When switching the active platform, update `platforms.primary` and make sure `pl
 
 Per-platform fields worth knowing about:
 
-- every platform inherits `proxy_url` from the shared `BaseIMConfig`. Set it when the host machine cannot reach the upstream API directly. Accepts standard HTTP/HTTPS proxy URLs and `socks5://` / `socks5h://` URLs (SOCKS5 support uses `aiohttp_socks`).
+- every platform inherits `proxy_url` from the shared `BaseIMConfig`. Set it when the host machine cannot reach the upstream API directly. Accepts standard HTTP/HTTPS proxy URLs and any `socks*://` URL (`socks4`, `socks4a`, `socks5`, `socks5h`). SOCKS variants route through `aiohttp_socks`.
 - `slack.disable_link_unfurl` suppresses link previews when posting messages.
 - `discord.thread_auto_archive_minutes` must be one of `60`, `1440`, `4320`, or `10080`.
 - `discord.guild_allowlist` / `guild_denylist` are legacy input lists; current runtime server access lives in `/settings` under `guilds`.
@@ -699,7 +699,7 @@ Use `POST /config` with only the proxy field for the affected platform:
 
 Notes:
 
-- `proxy_url` accepts `http://`, `https://`, `socks5://`, and `socks5h://` schemes; the SOCKS variants require `aiohttp_socks` (bundled).
+- `proxy_url` accepts `http://`, `https://`, and any `socks*://` scheme (`socks4`, `socks4a`, `socks5`, `socks5h`). The SOCKS variants route through `aiohttp_socks` (bundled).
 - Set the field to `null` (or omit it on a fresh save) to disable the proxy.
 - `POST /config` only persists the new value; running platform adapters keep their old transport until the service restarts. After saving, run `vibe restart --delay-seconds 60` (or `POST /control {"action":"restart"}` with the user's confirmation) so the proxy applies to live connections.
 - Do not paste credentialed proxy URLs (`user:pass@host`) into logs or chat replies; mask the credentials portion when reporting back.

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -36,7 +36,7 @@ Follow this skill as an operations playbook for agents, not as end-user marketin
 5. Use the smallest viable API call and verify by reading back the API response.
 6. For `POST /settings`, preserve every existing channel for that platform; the endpoint replaces the platform's channel map.
 7. For `POST /api/users`, merge each edited user with its current user payload first; missing user fields are not a patch.
-8. The persistent state store is `~/.vibe_remote/state/vibe.sqlite` (scope settings, agent sessions, auth codes, runtime records). Discovered chats live separately in `~/.vibe_remote/state/discovered_chats.json`. Do not hand-edit either; use the API for settings, users, sessions, and chat discovery.
+8. Make every persistent-state change through the Web UI API or the `vibe` CLI. Vibe Remote keeps internal state in an opaque SQLite database (`~/.vibe_remote/state/vibe.sqlite`) plus a few JSON files such as `discovered_chats.json`; do not treat the database as an operator surface. JSON files may be hand-edited only as a documented recovery fallback (see "Direct File Recovery Fallback").
 9. `POST /config` persists the new payload but does not restart running platform adapters by itself. When the change is platform credentials, `proxy_url`, or other transport-level settings, plan an explicit restart afterwards; prefer the delayed CLI form (`vibe restart --delay-seconds 60`) when triggering it from inside an active conversation. The only credential save that restarts on its own is the WeChat QR-login completion through `POST /wechat/qr_login/poll`.
 10. Do not restart the service by default. Use `POST /doctor`, `GET /status`, and read-back checks first.
 11. Only start, stop, restart, or reload Vibe Remote when the user explicitly asks or when a change cannot take effect otherwise; explain why before doing it.
@@ -155,8 +155,8 @@ Vibe Remote stores runtime data under `~/.vibe_remote/` by default. If `VIBE_REM
 Important paths:
 
 - `~/.vibe_remote/config/config.json`: global config persisted by `POST /config`
-- `~/.vibe_remote/state/vibe.sqlite`: primary persistent store (scope settings, agent sessions, auth codes, runtime records). Treat as opaque; do not hand-edit.
-- `~/.vibe_remote/state/migration.lock`: SQLite migration lock; do not delete during normal operation
+- `~/.vibe_remote/state/vibe.sqlite`: internal database managed by Vibe Remote. Treat as opaque; never read, write, or query it directly — use the Web UI API or `vibe` CLI for any state change.
+- `~/.vibe_remote/state/migration.lock`: internal migration lock for the database above; never delete or modify
 - `~/.vibe_remote/state/backups/`: automatic state backups taken before migrations
 - `~/.vibe_remote/state/settings.json`: legacy JSON snapshot mirror for `/settings`, `/api/users`, and `/api/bind-codes`; read-only during normal operation
 - `~/.vibe_remote/state/scheduled_tasks.json`: persisted scheduled tasks created by `vibe task`
@@ -175,7 +175,7 @@ Important paths:
 - `~/.vibe_remote/attachments/`: attachment staging area
 - `~/.vibe_remote/screenshots/`: default output directory for `vibe screenshot`
 
-Only use direct file editing as a recovery fallback when the Web UI API is unavailable or the user explicitly asks for low-level repair. If you must edit files directly, back up the file first, validate JSON, and explain why the API path was not usable. The SQLite store (`vibe.sqlite`) is not safe to hand-edit during recovery — escalate instead.
+Only edit the JSON files in this layout as a recovery fallback when the Web UI API is unavailable or the user explicitly asks for low-level repair. If you must edit one directly, back it up first, validate JSON, and explain why the API path was not usable. Never read or write `vibe.sqlite` — escalate database issues instead of touching the file (see the recovery section below for the supported path).
 
 ## API Endpoint Reference
 
@@ -1005,7 +1005,7 @@ Recovery rules:
 5. Start or restart only when needed to bring the API back.
 6. After recovery, return to the API workflow for further changes.
 
-`vibe.sqlite` is not part of this fallback. If the database is the problem, copy aside the file under `~/.vibe_remote/state/` and let Vibe Remote rebuild from `backups/` rather than editing it directly. Escalate to the repo if the rebuild fails.
+`vibe.sqlite` is never a fallback target. Never open it with sqlite3 or any inspection tool. If the database itself is the problem, stop Vibe Remote, move the file aside under `~/.vibe_remote/state/`, and let Vibe Remote rebuild from `backups/` on next start. Escalate to the repo if the rebuild fails.
 
 ## Safety Boundaries
 
@@ -1014,7 +1014,8 @@ Always follow these constraints:
 - never delete unrelated platform scopes
 - never blank out tokens or secrets as part of an unrelated config task
 - never claim a backend feature exists if current Vibe Remote behavior does not support it
-- never manually rewrite `sessions.json` or `vibe.sqlite` for routine routing changes
+- never read, query, or rewrite `vibe.sqlite` — it is an internal store, not an operator surface
+- never manually rewrite `sessions.json` for routine routing changes — use the Web UI API or `vibe` CLI instead
 - never expose bind codes, pairing keys, tunnel tokens, instance secrets, or session secrets unless the user explicitly asks
 - never paste a credentialed `proxy_url` (`user:pass@host`) back into chat — mask the credentials portion when echoing the value
 - always say when a requested change actually belongs in OpenCode, Claude Code, or Codex config instead of Vibe Remote


### PR DESCRIPTION
## Summary

- Bring `skills/use-vibe-remote/SKILL.md` from `0.2.2` → `0.3.0` so coding
  agents can drive the v2.3 surface (proxy_url, Vibe Cloud remote access,
  vibe.sqlite, vibe watch, vibe upgrade, automatic restart on credential
  save) without falling back to file edits.
- Align `docs/CLI.md` with the same v2.3 surface: standalone `vibe
  restart` (with `--delay-seconds`), full `vibe watch` section, and a
  refreshed file-locations table that lists `vibe.sqlite`,
  `watches.json`, `backups/`, the cloudflared PID, and the screenshots
  directory.

## Capability covered

- **Skill auditability** — the skill is the contract coding agents use
  to operate Vibe Remote. Out-of-date claims here either lead to wrong
  edits or to agents abandoning the API path. The refresh adds the
  endpoints and config blocks that landed in v2.3.

## Evidence

- **Unit** — none required; docs-only change.
- **Contract** — content cross-checked against `config/v2_config.py`
  (BaseIMConfig.proxy_url, SlackConfig.disable_link_unfurl,
  DiscordConfig.thread_auto_archive_minutes, TelegramConfig webhook +
  allowlist fields, VibeCloudRemoteAccessConfig, UpdateConfig, UiConfig)
  and against `vibe/ui_server.py` (`/platforms`, `/api/csrf-token`,
  `/remote-access/*`, `/auth/*`, `/api/session`, `/upgrade`).
- **Scenario** — no scenario catalog touched.
- **Residual manual checks** — none. A coding agent can verify the new
  recipes against a local v2.3 install (`POST /remote-access/vibe-cloud/pair`,
  `POST /config` with `proxy_url`).

## Test plan

- [ ] Open the skill in a Claude / OpenCode / Codex session and confirm
      it loads cleanly (no YAML / Markdown lint errors).
- [ ] Spot-check that the JSON config example validates through
      `V2Config.from_payload` by saving it via `POST /config` on a dev
      instance and reading it back.
- [ ] Drive one v2.3-only flow end-to-end via the skill recipes (proxy
      setup or Vibe Cloud pairing) on a dev instance.