### PR TITLE
feat(incus): add tenant scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ vibe stop && uv tool uninstall vibe-remote && rm -rf ~/.vibe_remote
 - **[Official Docs](https://docs.avibe.bot)** — Quickstart, platform guides, agent setup, troubleshooting, and AI-readable install instructions
 - **[CLI Reference](docs/CLI.md)** — Command-line usage and service lifecycle
 - **[Install via AI Agent](docs/INSTALL_FOR_AI.md)** — Give this to Claude Code, Codex, or OpenCode for guided setup
+- **[Incus Tenant Scaffold](docs/INCUS_TENANTS.md)** — Create isolated Vibe Remote tenants on one Incus host
 - **[Slack Setup Guide](docs/SLACK_SETUP.md)** — Detailed setup with screenshots
 - **[Discord Setup Guide](docs/DISCORD_SETUP.md)** — Detailed setup with screenshots
 - **[Telegram Setup Guide](docs/TELEGRAM_SETUP.md)** — BotFather setup, token validation, and chat discovery

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -363,6 +363,7 @@ vibe stop && uv tool uninstall vibe-remote && rm -rf ~/.vibe_remote
 - **[官方文档](https://docs.avibe.bot)** — Quickstart、平台配置、Agent 设置、排错和 AI 可读安装说明
 - **[CLI 参考手册](docs/CLI_ZH.md)** — 命令行使用和服务生命周期
 - **[让 AI Agent 帮你安装](docs/INSTALL_FOR_AI_ZH.md)** — 交给 Claude Code、Codex 或 OpenCode 的引导式安装说明
+- **[Incus 租户脚手架](docs/INCUS_TENANTS_ZH.md)** — 在一台 Incus 宿主机上创建隔离的 Vibe Remote 租户
 - **[Slack 配置指南](docs/SLACK_SETUP_ZH.md)** — 详细配置和截图
 - **[Discord 配置指南](docs/DISCORD_SETUP_ZH.md)** — 详细配置和截图
 - **[Telegram 配置指南](docs/TELEGRAM_SETUP_ZH.md)** — BotFather 初始化、令牌验证与会话发现

--- a/docs/INCUS_TENANTS.md
+++ b/docs/INCUS_TENANTS.md
@@ -1,0 +1,137 @@
+# Incus tenants for Vibe Remote
+
+This scaffold creates one Vibe Remote tenant per Incus project. It is meant for
+small hosted bot deployments and operator-run pilots before the full avibe.bot
+control plane exists.
+
+Use containers for trusted pilots. Use `--type vm` when the tenant is less
+trusted or needs a stronger isolation boundary.
+
+## Host setup
+
+Install Incus on the host, then run:
+
+```bash
+python3 scripts/incus_tenant.py init-host --minimal
+```
+
+`--minimal` runs `incus admin init --minimal`. Skip it if the host is already
+initialized. The script assumes the default storage pool is `default` and the
+managed bridge is `incusbr0`; override them per tenant if your host uses
+different names.
+
+Check the host without changing it:
+
+```bash
+python3 scripts/incus_tenant.py doctor
+```
+
+## Create a tenant
+
+```bash
+python3 scripts/incus_tenant.py create alice \
+  --cpus 2 \
+  --memory 4GiB \
+  --disk 30GiB \
+  --processes 4096 \
+  --backend codex \
+  --ui-host-port 15123
+```
+
+This creates:
+
+- Incus project: `vr-alice`
+- Instance: `vibe`
+- Linux user inside the instance: `vibe`
+- Work directory: `/home/vibe/work`
+- Vibe Remote Web UI inside the instance: port `5123`
+- Optional host Web UI proxy: `http://127.0.0.1:15123`
+
+Wait for first boot:
+
+```bash
+python3 scripts/incus_tenant.py wait-ready alice
+```
+
+Then open the Web UI URL printed by `create` and complete the normal Vibe
+Remote setup wizard for that tenant.
+
+## Operate tenants
+
+```bash
+python3 scripts/incus_tenant.py status alice
+python3 scripts/incus_tenant.py shell alice
+python3 scripts/incus_tenant.py exec alice -- pwd
+python3 scripts/incus_tenant.py stop alice
+python3 scripts/incus_tenant.py start alice
+python3 scripts/incus_tenant.py restart alice
+python3 scripts/incus_tenant.py list
+```
+
+Delete a tenant and all tenant data:
+
+```bash
+python3 scripts/incus_tenant.py delete alice
+```
+
+Use `--dry-run` on any command to print the Incus commands without running
+them.
+
+The Web UI proxy binds to `127.0.0.1` by default. To expose it on another host
+address, pass `--ui-host <address>` explicitly and protect it with a firewall or
+reverse proxy.
+
+## Resource model
+
+The scaffold sets limits on both the Incus project and the project `default`
+profile:
+
+- `limits.cpu`
+- `limits.memory`
+- `limits.processes`
+- root disk `size`
+- one instance per project
+
+Example with a larger tenant:
+
+```bash
+python3 scripts/incus_tenant.py create buildbot \
+  --cpus 8 \
+  --memory 16GiB \
+  --disk 120GiB \
+  --processes 16384 \
+  --ui-host-port 15124
+```
+
+Example with a VM tenant:
+
+```bash
+python3 scripts/incus_tenant.py create paid-01 \
+  --type vm \
+  --cpus 4 \
+  --memory 8GiB \
+  --disk 80GiB \
+  --ui-host-port 15125
+```
+
+## Install source
+
+By default, cloud-init installs the latest Vibe Remote via the public installer.
+To test a branch or fork:
+
+```bash
+python3 scripts/incus_tenant.py create branch-test \
+  --install-package-spec 'git+https://github.com/cyhhao/vibe-remote.git@master' \
+  --ui-host-port 15126
+```
+
+## Security boundary
+
+Tenants get root-like control inside their own Ubuntu environment, not on the
+host. Do not give tenants access to the host Incus socket, the `incus-admin`
+group, host Docker socket, host SSH keys, or host secret files.
+
+Container tenants share the host kernel. For arbitrary untrusted paid users,
+prefer `--type vm`, strict resource limits, egress policy, backup/restore
+procedures, and operational monitoring before calling the setup production
+SaaS-ready.

--- a/docs/INCUS_TENANTS_ZH.md
+++ b/docs/INCUS_TENANTS_ZH.md
@@ -1,0 +1,121 @@
+# 用 Incus 创建 Vibe Remote 租户
+
+这个脚手架用于在一台 Incus 宿主机上创建多个 Vibe Remote 租户。它适合小范围托管 Bot、内部试点，以及在完整 avibe.bot 控制面完成前先手动运营。
+
+可信试点用户可以先用 container。用户不够可信，或者需要更强隔离时，用 `--type vm`。
+
+## 初始化宿主机
+
+先在宿主机安装 Incus，然后运行：
+
+```bash
+python3 scripts/incus_tenant.py init-host --minimal
+```
+
+`--minimal` 会执行 `incus admin init --minimal`。如果宿主机已经初始化过，可以不加。脚本默认使用 storage pool `default` 和网络桥 `incusbr0`；如果你的宿主机名字不同，在创建租户时用参数覆盖。
+
+只检查、不修改宿主机：
+
+```bash
+python3 scripts/incus_tenant.py doctor
+```
+
+## 创建租户
+
+```bash
+python3 scripts/incus_tenant.py create alice \
+  --cpus 2 \
+  --memory 4GiB \
+  --disk 30GiB \
+  --processes 4096 \
+  --backend codex \
+  --ui-host-port 15123
+```
+
+它会创建：
+
+- Incus project：`vr-alice`
+- 实例名：`vibe`
+- 实例内 Linux 用户：`vibe`
+- 工作目录：`/home/vibe/work`
+- 实例内 Vibe Remote Web UI：`5123`
+- 可选宿主机 Web UI 代理：`http://127.0.0.1:15123`
+
+首次启动后等待 cloud-init 完成：
+
+```bash
+python3 scripts/incus_tenant.py wait-ready alice
+```
+
+然后打开 `create` 输出的 Web UI 地址，按正常 Vibe Remote 向导给这个租户配置 Slack、Discord、Telegram、Lark 或 WeChat。
+
+## 启停和运维
+
+```bash
+python3 scripts/incus_tenant.py status alice
+python3 scripts/incus_tenant.py shell alice
+python3 scripts/incus_tenant.py exec alice -- pwd
+python3 scripts/incus_tenant.py stop alice
+python3 scripts/incus_tenant.py start alice
+python3 scripts/incus_tenant.py restart alice
+python3 scripts/incus_tenant.py list
+```
+
+删除租户和所有租户数据：
+
+```bash
+python3 scripts/incus_tenant.py delete alice
+```
+
+任何命令都可以加 `--dry-run`，只打印将要执行的 Incus 命令，不真正执行。
+
+Web UI 代理默认只监听 `127.0.0.1`。如果要绑定到其他宿主机地址，需要显式传
+`--ui-host <address>`，并放在防火墙或反向代理后面。
+
+## 资源分配
+
+脚手架会同时在 Incus project 和该 project 的 `default` profile 上设置资源限制：
+
+- `limits.cpu`
+- `limits.memory`
+- `limits.processes`
+- 根磁盘 `size`
+- 每个 project 只允许一个实例
+
+更大的租户示例：
+
+```bash
+python3 scripts/incus_tenant.py create buildbot \
+  --cpus 8 \
+  --memory 16GiB \
+  --disk 120GiB \
+  --processes 16384 \
+  --ui-host-port 15124
+```
+
+VM 租户示例：
+
+```bash
+python3 scripts/incus_tenant.py create paid-01 \
+  --type vm \
+  --cpus 4 \
+  --memory 8GiB \
+  --disk 80GiB \
+  --ui-host-port 15125
+```
+
+## 安装来源
+
+默认情况下，cloud-init 会通过公开 installer 安装最新版 Vibe Remote。测试某个分支或 fork 时可以指定包来源：
+
+```bash
+python3 scripts/incus_tenant.py create branch-test \
+  --install-package-spec 'git+https://github.com/cyhhao/vibe-remote.git@master' \
+  --ui-host-port 15126
+```
+
+## 安全边界
+
+租户拥有的是自己 Ubuntu 环境里的权限，不是宿主机权限。不要把宿主机 Incus socket、`incus-admin` 组、宿主机 Docker socket、宿主机 SSH key 或宿主机 secret 文件暴露给租户。
+
+container 租户会共享宿主机内核。面向陌生付费用户时，优先使用 `--type vm`，并配合严格资源限制、网络出口策略、备份恢复和监控之后，再把它视为生产 SaaS 隔离方案。

--- a/docs/plans/incus-tenant-scaffold.md
+++ b/docs/plans/incus-tenant-scaffold.md
@@ -1,0 +1,38 @@
+# Incus tenant scaffold
+
+## Background
+
+Vibe Remote can become a small hosted bot environment by running one isolated
+tenant environment per user. Incus is a good first runtime because it supports
+system containers and VMs, projects, profiles, cloud-init, and per-instance
+resource limits.
+
+## Goal
+
+Add a repository-local scaffold that lets an operator create and manage multiple
+Vibe Remote tenants on one Incus host without building the full avibe.bot SaaS
+control plane yet.
+
+## Design
+
+- One Incus project per tenant: `vr-<tenant>`.
+- One tenant instance per project: `vibe`.
+- Per-tenant limits live on both the project and the default profile.
+- Cloud-init installs Vibe Remote for a non-root `vibe` user and creates a
+  systemd unit that starts/stops the local `vibe` runtime.
+- Optional host port proxy exposes the tenant Web UI for local setup.
+- The script stays standalone Python with no dependencies beyond the Incus CLI.
+
+## Scope
+
+- Add `scripts/incus_tenant.py`.
+- Add operator docs in English and Chinese.
+- Add focused tests for naming, cloud-init rendering, command planning, and CLI
+  parsing behavior.
+
+## Non-goals
+
+- No avibe.bot backend integration yet.
+- No automatic payment/provisioning flow.
+- No promise that containers are the final security boundary for arbitrary
+  untrusted paid users; the script supports VM mode for stricter isolation.

--- a/scripts/incus_tenant.py
+++ b/scripts/incus_tenant.py
@@ -1,0 +1,679 @@
+#!/usr/bin/env python3
+"""Manage local Incus tenants for Vibe Remote.
+
+This script intentionally uses only the Python standard library so it can run on
+a fresh Incus host before the Vibe Remote Python package is installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import ipaddress
+import json
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+PROJECT_PREFIX = "vr-"
+INSTANCE_NAME = "vibe"
+TENANT_USER = "vibe"
+TENANT_HOME = f"/home/{TENANT_USER}"
+TENANT_WORKDIR = f"{TENANT_HOME}/work"
+DEFAULT_IMAGE = "images:ubuntu/24.04/cloud"
+DEFAULT_STORAGE_POOL = "default"
+DEFAULT_NETWORK = "incusbr0"
+DEFAULT_UI_PORT = 5123
+TENANT_RE = re.compile(r"^[a-z][a-z0-9-]{1,38}[a-z0-9]$")
+
+
+class TenantError(RuntimeError):
+    """A user-correctable scaffold error."""
+
+
+@dataclass(frozen=True)
+class TenantSpec:
+    tenant: str
+    instance_type: str
+    image: str
+    cpus: str
+    memory: str
+    disk: str
+    processes: str
+    storage_pool: str
+    network: str
+    ui_port: int
+    ui_host: str
+    ui_host_port: int | None
+    backend: str
+    install_package_spec: str | None
+
+    @property
+    def project(self) -> str:
+        return project_name(self.tenant)
+
+
+class Runner:
+    def __init__(self, *, dry_run: bool = False) -> None:
+        self.dry_run = dry_run
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        check: bool = True,
+        capture: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        print("+ " + shlex.join(command))
+        if self.dry_run:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return subprocess.run(
+            list(command),
+            input=input_text,
+            text=True,
+            check=check,
+            capture_output=capture,
+        )
+
+    def exists(self, command: Sequence[str]) -> bool:
+        if self.dry_run:
+            return False
+        result = subprocess.run(list(command), text=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return result.returncode == 0
+
+
+def project_name(tenant: str) -> str:
+    validate_tenant(tenant)
+    return f"{PROJECT_PREFIX}{tenant}"
+
+
+def validate_tenant(tenant: str) -> None:
+    if not TENANT_RE.match(tenant):
+        raise TenantError(
+            "Tenant must be 3-40 chars, lowercase, and contain only letters, numbers, and single hyphens."
+        )
+
+
+def incus(*args: str, project: str | None = None) -> list[str]:
+    command = ["incus"]
+    if project:
+        command.extend(["--project", project])
+    command.extend(args)
+    return command
+
+
+def require_incus() -> None:
+    if shutil.which("incus") is None:
+        raise TenantError("The Incus CLI was not found. Install Incus and make sure `incus` is in PATH.")
+
+
+def unbracket_host(host: str) -> str:
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
+def is_ipv6_host(host: str) -> bool:
+    try:
+        return ipaddress.ip_address(unbracket_host(host)).version == 6
+    except ValueError:
+        return False
+
+
+def tcp_endpoint(host: str, port: int) -> str:
+    if is_ipv6_host(host):
+        return f"tcp:[{unbracket_host(host)}]:{port}"
+    return f"tcp:{host}:{port}"
+
+
+def ensure_host_port_available(host: str, port: int) -> None:
+    bind_host = unbracket_host(host)
+    family = socket.AF_INET6 if is_ipv6_host(host) else socket.AF_INET
+    with socket.socket(family, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((bind_host, port))
+        except OSError as exc:
+            if exc.errno in {errno.EACCES, errno.EPERM}:
+                print(
+                    f"Warning: cannot preflight privileged host port {host}:{port} as this user; "
+                    "continuing so the Incus daemon can validate the proxy device.",
+                    file=sys.stderr,
+                )
+                return
+            raise TenantError(f"Host port {host}:{port} is not available: {exc}") from exc
+
+
+def yaml_block(value: str, indent: int = 6) -> str:
+    prefix = " " * indent
+    return "\n".join(prefix + line if line else prefix for line in value.splitlines())
+
+
+def default_config(spec: TenantSpec) -> dict:
+    enabled = {spec.backend, "opencode", "claude", "codex"}
+    return {
+        "platform": "slack",
+        "platforms": {"enabled": ["slack"], "primary": "slack"},
+        "mode": "self_host",
+        "version": "v2",
+        "slack": {"bot_token": "", "app_token": "", "signing_secret": "", "require_mention": False},
+        "discord": None,
+        "telegram": None,
+        "lark": None,
+        "wechat": None,
+        "runtime": {"default_cwd": TENANT_WORKDIR, "log_level": "INFO"},
+        "agents": {
+            "default_backend": spec.backend,
+            "opencode": {"enabled": "opencode" in enabled, "cli_path": "opencode", "error_retry_limit": 1},
+            "claude": {"enabled": "claude" in enabled, "cli_path": "claude"},
+            "codex": {"enabled": "codex" in enabled, "cli_path": "codex"},
+        },
+        "gateway": None,
+        "ui": {"setup_host": "0.0.0.0", "setup_port": spec.ui_port, "open_browser": False},
+        "remote_access": {"provider": "vibe_cloud", "vibe_cloud": {}},
+        "update": {},
+        "ack_mode": "typing",
+        "show_duration": False,
+        "include_user_info": True,
+        "reply_enhancements": True,
+        "language": "en",
+    }
+
+
+def cloud_init_user_data(spec: TenantSpec) -> str:
+    config_json = json.dumps(default_config(spec), indent=2)
+    install_prefix = ""
+    if spec.install_package_spec:
+        install_prefix = f"export VIBE_INSTALL_PACKAGE_SPEC={shlex.quote(spec.install_package_spec)}; "
+    install_command = install_prefix + "curl -fsSL https://avibe.bot/install.sh | bash"
+    runcmd = [
+        ["mkdir", "-p", TENANT_WORKDIR, f"{TENANT_HOME}/.vibe_remote/config"],
+        ["chown", "-R", f"{TENANT_USER}:{TENANT_USER}", TENANT_WORKDIR, f"{TENANT_HOME}/.vibe_remote"],
+        ["su", "-", TENANT_USER, "-c", install_command],
+        ["systemctl", "daemon-reload"],
+        ["systemctl", "enable", "--now", "vibe-remote.service"],
+    ]
+    runcmd_yaml = "\n".join(f"  - {json.dumps(item)}" for item in runcmd)
+    service = textwrap.dedent(
+        f"""\
+        [Unit]
+        Description=Vibe Remote tenant service
+        Wants=network-online.target
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        User={TENANT_USER}
+        Group={TENANT_USER}
+        Environment=HOME={TENANT_HOME}
+        Environment=SSH_CONNECTION=incus-cloud-init
+        Environment=PATH={TENANT_HOME}/.local/bin:{TENANT_HOME}/.cargo/bin:/usr/local/bin:/usr/bin:/bin
+        ExecStart=/bin/bash -lc 'vibe'
+        ExecStop=/bin/bash -lc 'vibe stop'
+        RemainAfterExit=yes
+        TimeoutStartSec=300
+        TimeoutStopSec=60
+
+        [Install]
+        WantedBy=multi-user.target
+        """
+    ).rstrip()
+    tenant_info = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "tenant={spec.tenant}"
+        echo "project={spec.project}"
+        echo "instance={INSTANCE_NAME}"
+        echo "ui=http://127.0.0.1:{spec.ui_port}"
+        echo "workdir={TENANT_WORKDIR}"
+        """
+    ).rstrip()
+    lines = [
+        "#cloud-config",
+        "package_update: true",
+        "packages:",
+        "  - bash",
+        "  - ca-certificates",
+        "  - curl",
+        "  - git",
+        "  - build-essential",
+        "  - python3",
+        "  - python3-pip",
+        "  - python3-venv",
+        "  - sudo",
+        "users:",
+        "  - name: vibe",
+        "    groups: sudo",
+        "    shell: /bin/bash",
+        "    sudo: ALL=(ALL) NOPASSWD:ALL",
+        "    lock_passwd: true",
+        "write_files:",
+        f"  - path: {TENANT_HOME}/.vibe_remote/config/config.json",
+        f"    owner: {TENANT_USER}:{TENANT_USER}",
+        "    permissions: '0600'",
+        "    content: |",
+        yaml_block(config_json),
+        "  - path: /etc/systemd/system/vibe-remote.service",
+        "    owner: root:root",
+        "    permissions: '0644'",
+        "    content: |",
+        yaml_block(service),
+        "  - path: /usr/local/bin/vibe-tenant-info",
+        "    owner: root:root",
+        "    permissions: '0755'",
+        "    content: |",
+        yaml_block(tenant_info),
+        "runcmd:",
+        runcmd_yaml,
+        f'final_message: "Vibe Remote tenant {spec.tenant} is ready. Run vibe-tenant-info for details."',
+    ]
+    return "\n".join(lines)
+
+
+def profile_yaml(spec: TenantSpec) -> str:
+    return textwrap.dedent(
+        f"""\
+        config:
+          limits.cpu: "{spec.cpus}"
+          limits.memory: "{spec.memory}"
+          limits.processes: "{spec.processes}"
+        description: Vibe Remote tenant profile for {spec.tenant}
+        devices:
+          eth0:
+            name: eth0
+            network: {spec.network}
+            type: nic
+          root:
+            path: /
+            pool: {spec.storage_pool}
+            size: {spec.disk}
+            type: disk
+        name: default
+        """
+    )
+
+
+def project_create_config(spec: TenantSpec) -> list[str]:
+    instance_limit_key = "limits.virtual-machines" if spec.instance_type == "vm" else "limits.containers"
+    return [
+        "features.images=false",
+        "features.profiles=true",
+        "features.storage.volumes=true",
+        "restricted=true",
+        "restricted.devices.proxy=allow",
+        "limits.instances=1",
+        f"{instance_limit_key}=1",
+        f"limits.cpu={spec.cpus}",
+        f"limits.memory={spec.memory}",
+        f"limits.processes={spec.processes}",
+        f"limits.disk.pool.{spec.storage_pool}={spec.disk}",
+        f"user.vibe_remote.tenant={spec.tenant}",
+        f"user.vibe_remote.instance_type={spec.instance_type}",
+        f"user.vibe_remote.ui_host={spec.ui_host}",
+        f"user.vibe_remote.ui_host_port={spec.ui_host_port or ''}",
+    ]
+
+
+def maybe_require_incus(args: argparse.Namespace) -> None:
+    if not getattr(args, "dry_run", False):
+        require_incus()
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    runner = Runner(dry_run=args.dry_run)
+    checks = [
+        ("version", incus("version")),
+        ("daemon info", incus("info")),
+        ("storage pools", incus("storage", "list")),
+        ("networks", incus("network", "list")),
+        ("default profile", incus("profile", "show", "default")),
+    ]
+    failed: list[str] = []
+    for name, command in checks:
+        result = runner.run(command, check=False)
+        if result.returncode != 0:
+            failed.append(name)
+    if failed:
+        print("Failed checks: " + ", ".join(failed), file=sys.stderr)
+        return 1
+    return 0
+
+
+def cmd_init_host(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    runner = Runner(dry_run=args.dry_run)
+    if args.minimal:
+        runner.run(incus("admin", "init", "--minimal"))
+    return cmd_doctor(args)
+
+
+def create_project(runner: Runner, spec: TenantSpec) -> None:
+    command = incus("project", "create", spec.project)
+    for item in project_create_config(spec):
+        command.extend(["--config", item])
+    runner.run(command)
+
+
+def ensure_create_target_available(runner: Runner, spec: TenantSpec) -> None:
+    if runner.exists(incus("project", "show", spec.project)):
+        raise TenantError(
+            f"Tenant project {spec.project} already exists. Use status/delete, or add a dedicated update command."
+        )
+
+
+def configure_profile(runner: Runner, spec: TenantSpec) -> None:
+    runner.run(incus("profile", "edit", "default", project=spec.project), input_text=profile_yaml(spec))
+
+
+def proxy_device_args(spec: TenantSpec) -> list[str]:
+    args = [
+        "config",
+        "device",
+        "add",
+        INSTANCE_NAME,
+        "ui",
+        "proxy",
+        f"listen={tcp_endpoint(spec.ui_host, spec.ui_host_port)}",
+        f"connect=tcp:127.0.0.1:{spec.ui_port}",
+    ]
+    if spec.instance_type == "vm":
+        args.append("nat=true")
+    return args
+
+
+def create_instance(runner: Runner, spec: TenantSpec) -> None:
+    if runner.exists(incus("info", INSTANCE_NAME, project=spec.project)):
+        raise TenantError(f"Tenant instance already exists in project {spec.project}.")
+    command = incus(
+        "init",
+        spec.image,
+        INSTANCE_NAME,
+        "--profile",
+        "default",
+        "--config",
+        f"cloud-init.user-data={cloud_init_user_data(spec)}",
+        project=spec.project,
+    )
+    if spec.instance_type == "vm":
+        command.append("--vm")
+    runner.run(command)
+    if spec.ui_host_port:
+        runner.run(incus(*proxy_device_args(spec), project=spec.project))
+    runner.run(incus("start", INSTANCE_NAME, project=spec.project))
+
+
+def cmd_create(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    spec = TenantSpec(
+        tenant=args.tenant,
+        instance_type=args.type,
+        image=args.image,
+        cpus=args.cpus,
+        memory=args.memory,
+        disk=args.disk,
+        processes=args.processes,
+        storage_pool=args.storage_pool,
+        network=args.network,
+        ui_port=args.ui_port,
+        ui_host=args.ui_host,
+        ui_host_port=args.ui_host_port,
+        backend=args.backend,
+        install_package_spec=args.install_package_spec,
+    )
+    if spec.ui_host_port and not args.dry_run:
+        ensure_host_port_available(spec.ui_host, spec.ui_host_port)
+    runner = Runner(dry_run=args.dry_run)
+    ensure_create_target_available(runner, spec)
+    create_project(runner, spec)
+    configure_profile(runner, spec)
+    create_instance(runner, spec)
+    print("")
+    print(f"Tenant created: {spec.tenant}")
+    print(f"Project: {spec.project}")
+    print(f"Instance: {INSTANCE_NAME}")
+    print(f"Wait for setup: python3 scripts/incus_tenant.py wait-ready {spec.tenant}")
+    if spec.ui_host_port:
+        print(f"Web UI: http://{spec.ui_host}:{spec.ui_host_port}")
+    else:
+        print(f"Web UI: incus --project {spec.project} exec {INSTANCE_NAME} -- vibe remote")
+    return 0
+
+
+def cmd_wait_ready(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    project = project_name(args.tenant)
+    runner = Runner(dry_run=args.dry_run)
+    runner.run(incus("exec", INSTANCE_NAME, "--", "cloud-init", "status", "--wait", project=project))
+    runner.run(
+        incus("exec", INSTANCE_NAME, "--", "systemctl", "is-active", "--quiet", "vibe-remote.service", project=project)
+    )
+    runner.run(incus("exec", INSTANCE_NAME, "--", "systemctl", "status", "vibe-remote", "--no-pager", project=project), check=False)
+    return 0
+
+
+def cmd_lifecycle(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    project = project_name(args.tenant)
+    runner = Runner(dry_run=args.dry_run)
+    runner.run(incus(args.action, INSTANCE_NAME, project=project))
+    return 0
+
+
+def cmd_restart(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    project = project_name(args.tenant)
+    runner = Runner(dry_run=args.dry_run)
+    runner.run(incus("restart", INSTANCE_NAME, project=project))
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    project = project_name(args.tenant)
+    runner = Runner(dry_run=args.dry_run)
+    checks = [
+        ("instance list", incus("list", project=project)),
+        ("tenant info", incus("exec", INSTANCE_NAME, "--", "vibe-tenant-info", project=project)),
+        ("vibe status", incus("exec", INSTANCE_NAME, "--", *tenant_user_bash("vibe status"), project=project)),
+    ]
+    failed: list[str] = []
+    for name, command in checks:
+        result = runner.run(command, check=False)
+        if result.returncode != 0:
+            failed.append(name)
+    if failed:
+        print("Failed status checks: " + ", ".join(failed), file=sys.stderr)
+        return 1
+    return 0
+
+
+def tenant_user_bash(command: str, *args: str) -> list[str]:
+    return [
+        "sudo",
+        "-H",
+        "-u",
+        TENANT_USER,
+        "--",
+        "bash",
+        "-lc",
+        f"cd {shlex.quote(TENANT_WORKDIR)} && {command}",
+        "bash",
+        *args,
+    ]
+
+
+def cmd_shell(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    project = project_name(args.tenant)
+    runner = Runner(dry_run=args.dry_run)
+    runner.run(incus("exec", INSTANCE_NAME, "--", *tenant_user_bash("exec bash -l"), project=project))
+    return 0
+
+
+def cmd_exec(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command:
+        raise TenantError("Pass a command after `--`.")
+    project = project_name(args.tenant)
+    runner = Runner(dry_run=args.dry_run)
+    runner.run(
+        incus(
+            "exec",
+            INSTANCE_NAME,
+            "--",
+            *tenant_user_bash('exec "$@"', *command),
+            project=project,
+        )
+    )
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    runner = Runner(dry_run=args.dry_run)
+    result = runner.run(incus("project", "list"), check=False)
+    print("")
+    print(f"Vibe Remote tenant projects use the `{PROJECT_PREFIX}` prefix.")
+    if result.returncode != 0:
+        return result.returncode
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    maybe_require_incus(args)
+    project = project_name(args.tenant)
+    if not args.yes and not args.dry_run:
+        confirmation = input(f"Delete tenant {args.tenant} ({project}) and all its data? Type the tenant name: ")
+        if confirmation != args.tenant:
+            raise TenantError("Confirmation did not match; aborting.")
+    runner = Runner(dry_run=args.dry_run)
+    if args.dry_run:
+        runner.run(incus("delete", INSTANCE_NAME, "--force", project=project))
+        runner.run(incus("project", "delete", project))
+        return 0
+    if not runner.exists(incus("project", "show", project)):
+        raise TenantError(f"Tenant project {project} does not exist.")
+    if runner.exists(incus("info", INSTANCE_NAME, project=project)):
+        runner.run(incus("delete", INSTANCE_NAME, "--force", project=project))
+    else:
+        print(f"Tenant instance {INSTANCE_NAME} is already absent in project {project}.", file=sys.stderr)
+    runner.run(incus("project", "delete", project))
+    return 0
+
+
+def add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--dry-run", action="store_true", help="Print Incus commands without running them.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Create and operate Vibe Remote tenant instances on a local Incus host.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor = subparsers.add_parser("doctor", help="Check Incus host readiness.")
+    add_common(doctor)
+    doctor.set_defaults(func=cmd_doctor)
+
+    init_host = subparsers.add_parser("init-host", help="Optionally initialize Incus, then check readiness.")
+    init_host.add_argument("--minimal", action="store_true", help="Run `incus admin init --minimal` before checks.")
+    add_common(init_host)
+    init_host.set_defaults(func=cmd_init_host)
+
+    create = subparsers.add_parser("create", help="Create and start a new Vibe Remote tenant.")
+    create.add_argument("tenant", help="Tenant slug, for example alice or demo-01.")
+    create.add_argument("--type", choices=["container", "vm"], default="container", help="Incus instance type.")
+    create.add_argument("--image", default=DEFAULT_IMAGE, help=f"Incus image alias. Default: {DEFAULT_IMAGE}")
+    create.add_argument("--cpus", default="2", help="CPU limit, for example 2.")
+    create.add_argument("--memory", default="4GiB", help="Memory limit, for example 4GiB.")
+    create.add_argument("--disk", default="30GiB", help="Root disk limit, for example 30GiB.")
+    create.add_argument("--processes", default="4096", help="Process count limit.")
+    create.add_argument("--storage-pool", default=DEFAULT_STORAGE_POOL, help="Incus storage pool.")
+    create.add_argument("--network", default=DEFAULT_NETWORK, help="Incus managed bridge network.")
+    create.add_argument("--ui-port", type=int, default=DEFAULT_UI_PORT, help="Tenant Web UI port inside the instance.")
+    create.add_argument(
+        "--ui-host",
+        default="127.0.0.1",
+        help="Host address for the optional Web UI proxy. Use 0.0.0.0 only behind a firewall or reverse proxy.",
+    )
+    create.add_argument("--ui-host-port", type=int, help="Optional host port proxy for the tenant Web UI.")
+    create.add_argument("--backend", choices=["opencode", "claude", "codex"], default="opencode", help="Default agent backend.")
+    create.add_argument(
+        "--install-package-spec",
+        help="Optional package spec passed to the Vibe Remote installer, e.g. git+https://github.com/cyhhao/vibe-remote.git@master.",
+    )
+    add_common(create)
+    create.set_defaults(func=cmd_create)
+
+    wait_ready = subparsers.add_parser("wait-ready", help="Wait until cloud-init finishes inside the tenant.")
+    wait_ready.add_argument("tenant")
+    add_common(wait_ready)
+    wait_ready.set_defaults(func=cmd_wait_ready)
+
+    for name in ("start", "stop"):
+        lifecycle = subparsers.add_parser(name, help=f"{name.title()} a tenant instance.")
+        lifecycle.add_argument("tenant")
+        add_common(lifecycle)
+        lifecycle.set_defaults(func=cmd_lifecycle, action=name)
+
+    restart = subparsers.add_parser("restart", help="Restart a tenant instance.")
+    restart.add_argument("tenant")
+    add_common(restart)
+    restart.set_defaults(func=cmd_restart)
+
+    status = subparsers.add_parser("status", help="Show tenant instance and Vibe Remote status.")
+    status.add_argument("tenant")
+    add_common(status)
+    status.set_defaults(func=cmd_status)
+
+    shell = subparsers.add_parser("shell", help="Open a shell as the tenant user.")
+    shell.add_argument("tenant")
+    add_common(shell)
+    shell.set_defaults(func=cmd_shell)
+
+    exec_parser = subparsers.add_parser("exec", help="Run a command as the tenant user.")
+    exec_parser.add_argument("tenant")
+    exec_parser.add_argument("command", nargs=argparse.REMAINDER, help="Command after --.")
+    add_common(exec_parser)
+    exec_parser.set_defaults(func=cmd_exec)
+
+    list_parser = subparsers.add_parser("list", help="List Incus projects and highlight tenant prefix.")
+    add_common(list_parser)
+    list_parser.set_defaults(func=cmd_list)
+
+    delete = subparsers.add_parser("delete", help="Delete a tenant project and all data.")
+    delete.add_argument("tenant")
+    delete.add_argument("-y", "--yes", action="store_true", help="Skip confirmation.")
+    add_common(delete)
+    delete.set_defaults(func=cmd_delete)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args) or 0)
+    except TenantError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as exc:
+        print(f"error: command failed with exit code {exc.returncode}: {shlex.join(exc.cmd)}", file=sys.stderr)
+        return exc.returncode or 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_incus_tenant_scaffold.py
+++ b/tests/test_incus_tenant_scaffold.py
@@ -1,0 +1,338 @@
+import importlib.util
+import argparse
+import errno
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "incus_tenant.py"
+SPEC = importlib.util.spec_from_file_location("incus_tenant", SCRIPT_PATH)
+incus_tenant = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = incus_tenant
+SPEC.loader.exec_module(incus_tenant)
+
+
+def tenant_spec(**overrides):
+    payload = {
+        "tenant": "demo-01",
+        "instance_type": "container",
+        "image": incus_tenant.DEFAULT_IMAGE,
+        "cpus": "2",
+        "memory": "4GiB",
+        "disk": "30GiB",
+        "processes": "4096",
+        "storage_pool": "default",
+        "network": "incusbr0",
+        "ui_port": 5123,
+        "ui_host": "127.0.0.1",
+        "ui_host_port": 15123,
+        "backend": "codex",
+        "install_package_spec": None,
+    }
+    payload.update(overrides)
+    return incus_tenant.TenantSpec(**payload)
+
+
+def test_project_name_validates_slug():
+    assert incus_tenant.project_name("demo-01") == "vr-demo-01"
+    with pytest.raises(incus_tenant.TenantError):
+        incus_tenant.project_name("Demo")
+    with pytest.raises(incus_tenant.TenantError):
+        incus_tenant.project_name("a")
+
+
+def test_cloud_init_configures_vibe_user_service_and_ui():
+    data = incus_tenant.cloud_init_user_data(tenant_spec())
+
+    assert "#cloud-config" in data
+    assert "name: vibe" in data
+    assert "ExecStart=/bin/bash -lc 'vibe'" in data
+    assert '"setup_host": "0.0.0.0"' in data
+    assert '"setup_port": 5123' in data
+    assert '"default_backend": "codex"' in data
+    assert "https://avibe.bot/install.sh" in data
+
+
+def test_profile_yaml_sets_resources_and_devices():
+    data = incus_tenant.profile_yaml(tenant_spec(cpus="4", memory="8GiB", disk="80GiB"))
+
+    assert 'limits.cpu: "4"' in data
+    assert 'limits.memory: "8GiB"' in data
+    assert "size: 80GiB" in data
+    assert "network: incusbr0" in data
+    assert "pool: default" in data
+
+
+def test_project_create_config_uses_vm_limit_for_vm():
+    config = incus_tenant.project_create_config(tenant_spec(instance_type="vm"))
+
+    assert "limits.instances=1" in config
+    assert "limits.virtual-machines=1" in config
+    assert "limits.containers=1" not in config
+    assert "user.vibe_remote.ui_host=127.0.0.1" in config
+    assert "restricted=true" in config
+    assert "restricted.devices.proxy=allow" in config
+
+
+def test_parser_accepts_create_dry_run():
+    parser = incus_tenant.build_parser()
+    args = parser.parse_args(
+        [
+            "create",
+            "demo-01",
+            "--cpus",
+            "4",
+            "--memory",
+            "8GiB",
+            "--disk",
+            "80GiB",
+            "--backend",
+            "codex",
+            "--ui-host-port",
+            "15123",
+            "--dry-run",
+        ]
+    )
+
+    assert args.command == "create"
+    assert args.tenant == "demo-01"
+    assert args.cpus == "4"
+    assert args.ui_host == "127.0.0.1"
+    assert args.backend == "codex"
+    assert args.dry_run is True
+
+
+def test_exec_dry_run_strips_command_separator(capsys):
+    exit_code = incus_tenant.main(["exec", "--dry-run", "demo-01", "--", "pwd"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "--user 1000" not in output
+    assert "sudo -H -u vibe" in output
+    assert "exec \"$@\"' bash pwd" in output
+
+
+def test_shell_dry_run_uses_tenant_username(capsys):
+    exit_code = incus_tenant.main(["shell", "--dry-run", "demo-01"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "--user 1000" not in output
+    assert "sudo -H -u vibe" in output
+    assert "exec bash -l" in output
+
+
+def test_parser_keeps_exec_separator_for_handler():
+    parser = incus_tenant.build_parser()
+    args = parser.parse_args(["exec", "--dry-run", "demo-01", "--", "pwd"])
+
+    assert args.command == ["pwd"]
+    assert args.dry_run is True
+
+
+def test_create_dry_run_binds_proxy_to_loopback(capsys):
+    exit_code = incus_tenant.main(["create", "demo-01", "--ui-host-port", "15123", "--dry-run"])
+
+    assert exit_code == 0
+    assert "listen=tcp:127.0.0.1:15123" in capsys.readouterr().out
+
+
+def test_create_vm_ui_proxy_uses_nat_mode(capsys):
+    exit_code = incus_tenant.main(["create", "demo-01", "--type", "vm", "--ui-host-port", "15123", "--dry-run"])
+
+    assert exit_code == 0
+    assert "connect=tcp:127.0.0.1:5123 nat=true" in capsys.readouterr().out
+
+
+def test_create_formats_ipv6_ui_proxy_endpoint(capsys):
+    exit_code = incus_tenant.main(
+        ["create", "demo-01", "--ui-host", "::1", "--ui-host-port", "15123", "--dry-run"]
+    )
+
+    assert exit_code == 0
+    assert "listen=tcp:[::1]:15123" in capsys.readouterr().out
+
+
+def test_privileged_port_preflight_does_not_block_on_permission(monkeypatch, capsys):
+    class PermissionDeniedSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def setsockopt(self, *args):
+            return None
+
+        def bind(self, address):
+            raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: PermissionDeniedSocket())
+
+    incus_tenant.ensure_host_port_available("127.0.0.1", 80)
+    assert "cannot preflight privileged host port" in capsys.readouterr().err
+
+
+def test_port_preflight_still_rejects_busy_ports(monkeypatch):
+    class BusySocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def setsockopt(self, *args):
+            return None
+
+        def bind(self, address):
+            raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: BusySocket())
+
+    with pytest.raises(incus_tenant.TenantError):
+        incus_tenant.ensure_host_port_available("127.0.0.1", 15123)
+
+
+def test_port_preflight_uses_ipv6_socket(monkeypatch):
+    families = []
+    addresses = []
+
+    class IPv6Socket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+        def setsockopt(self, *args):
+            return None
+
+        def bind(self, address):
+            addresses.append(address)
+
+    def fake_socket(family, sock_type):
+        families.append((family, sock_type))
+        return IPv6Socket()
+
+    monkeypatch.setattr(socket, "socket", fake_socket)
+
+    incus_tenant.ensure_host_port_available("::1", 15123)
+
+    assert families == [(socket.AF_INET6, socket.SOCK_STREAM)]
+    assert addresses == [("::1", 15123)]
+
+
+def test_create_refuses_existing_project_before_writes():
+    class ExistingProjectRunner:
+        def __init__(self):
+            self.commands = []
+
+        def exists(self, command):
+            self.commands.append(command)
+            return command == ["incus", "project", "show", "vr-demo-01"]
+
+    runner = ExistingProjectRunner()
+
+    with pytest.raises(incus_tenant.TenantError):
+        incus_tenant.ensure_create_target_available(runner, tenant_spec())
+
+    assert runner.commands == [["incus", "project", "show", "vr-demo-01"]]
+
+
+def test_doctor_returns_nonzero_for_failed_readiness_check(monkeypatch):
+    class FailingRunner:
+        def __init__(self, *, dry_run=False):
+            self.dry_run = dry_run
+
+        def run(self, command, *, check=True, capture=False, input_text=None):
+            returncode = 1 if command == ["incus", "info"] else 0
+            return subprocess.CompletedProcess(command, returncode)
+
+    monkeypatch.setattr(incus_tenant, "Runner", FailingRunner)
+
+    assert incus_tenant.cmd_doctor(argparse.Namespace(dry_run=True)) == 1
+
+
+def test_status_returns_nonzero_for_failed_probe(monkeypatch):
+    class FailingStatusRunner:
+        def __init__(self, *, dry_run=False):
+            self.dry_run = dry_run
+
+        def run(self, command, *, check=True, capture=False, input_text=None):
+            returncode = 1 if "vibe-tenant-info" in command else 0
+            return subprocess.CompletedProcess(command, returncode)
+
+    monkeypatch.setattr(incus_tenant, "Runner", FailingStatusRunner)
+
+    assert incus_tenant.cmd_status(argparse.Namespace(tenant="demo-01", dry_run=True)) == 1
+
+
+def test_list_returns_incus_project_list_exit_code(monkeypatch):
+    class FailingListRunner:
+        def __init__(self, *, dry_run=False):
+            self.dry_run = dry_run
+
+        def run(self, command, *, check=True, capture=False, input_text=None):
+            assert command == ["incus", "project", "list"]
+            return subprocess.CompletedProcess(command, 7)
+
+    monkeypatch.setattr(incus_tenant, "Runner", FailingListRunner)
+
+    assert incus_tenant.cmd_list(argparse.Namespace(dry_run=True)) == 7
+
+
+def test_wait_ready_checks_tenant_service_active(monkeypatch):
+    commands = []
+
+    class RecordingRunner:
+        def __init__(self, *, dry_run=False):
+            self.dry_run = dry_run
+
+        def run(self, command, *, check=True, capture=False, input_text=None):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(incus_tenant, "Runner", RecordingRunner)
+
+    assert incus_tenant.cmd_wait_ready(argparse.Namespace(tenant="demo-01", dry_run=True)) == 0
+    assert [
+        "incus",
+        "--project",
+        "vr-demo-01",
+        "exec",
+        "vibe",
+        "--",
+        "systemctl",
+        "is-active",
+        "--quiet",
+        "vibe-remote.service",
+    ] in commands
+
+
+def test_delete_returns_error_when_project_missing(monkeypatch):
+    class MissingProjectRunner:
+        def __init__(self, *, dry_run=False):
+            self.dry_run = dry_run
+
+        def exists(self, command):
+            return False
+
+    monkeypatch.setattr(incus_tenant, "Runner", MissingProjectRunner)
+    monkeypatch.setattr(incus_tenant, "require_incus", lambda: None)
+
+    with pytest.raises(incus_tenant.TenantError):
+        incus_tenant.cmd_delete(argparse.Namespace(tenant="demo-01", yes=True, dry_run=False))
+
+
+def test_delete_dry_run_prints_cleanup_plan(capsys):
+    exit_code = incus_tenant.main(["delete", "--dry-run", "-y", "demo-01"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "incus --project vr-demo-01 delete vibe --force" in output
+    assert "incus project delete vr-demo-01" in output


### PR DESCRIPTION
## What changed

Adds a local Incus tenant scaffold for operator-managed Vibe Remote deployments on a single host.

- Adds `scripts/incus_tenant.py` for `init-host`, `doctor`, `create`, `wait-ready`, `status`, `shell`, `exec`, `start`, `stop`, `restart`, `list`, and `delete`.
- Creates one Incus project per tenant and one `vibe` instance per project with CPU, memory, disk, process, and instance-count limits.
- Uses cloud-init to install Vibe Remote, seed a tenant config, create `/home/vibe/work`, and manage the tenant runtime through systemd.
- Documents English and Chinese operator workflows, including container vs VM guidance and security boundaries.

## Safety notes

- The optional Web UI proxy binds to `127.0.0.1` by default; non-loopback exposure requires explicit `--ui-host`.
- `create` refuses an existing tenant project before any write, so a repeated create cannot mutate a running tenant by accident.
- `wait-ready` now fails if the tenant service is not active after cloud-init.
- This is a local/operator scaffold, not a complete production SaaS isolation layer.

## Scenario IDs

None. This is an ops scaffold outside the existing scenario catalogs.

## Evidence layers

- Unit: `pytest -q tests/test_incus_tenant_scaffold.py`
- Contract: not applicable; no API contract changed
- Scenario: not applicable; no cataloged user scenario changed
- Manual residual: `python3 scripts/incus_tenant.py create demo-01 --ui-host-port 15123 --backend codex --dry-run`; parsed generated cloud-init YAML with PyYAML
- Lint: `ruff check scripts/incus_tenant.py tests/test_incus_tenant_scaffold.py`
