### PR TITLE
fix(runtime): make vibe start idempotent

### DIFF
--- a/core/process_diagnostics.py
+++ b/core/process_diagnostics.py
@@ -8,6 +8,9 @@ import subprocess
 from typing import Callable
 
 
+ProcessParts = list[str]
+
+
 def _run_ps(args: list[str]) -> str:
     try:
         result = subprocess.run(
@@ -56,22 +59,62 @@ def process_row(pid: int) -> str:
     return _run_ps(["-p", str(pid), "-o", "pid=,ppid=,pgid=,sess=,stat=,command="])
 
 
-def _process_table_rows(predicate: Callable[[list[str]], bool], *, limit: int) -> tuple[int, list[str]]:
+def _read_process_table() -> tuple[str | None, list[ProcessParts]]:
     output = _run_ps(["-axo", "pid=,ppid=,pgid=,sess=,stat=,command="])
     if output.startswith("<"):
-        return 0, [output]
+        return output, []
 
-    rows: list[str] = []
-    total = 0
+    rows: list[ProcessParts] = []
     for line in output.splitlines():
         parts = line.split(None, 5)
         if len(parts) < 6:
             continue
+        rows.append(parts)
+    return None, rows
+
+
+def _process_table_rows(predicate: Callable[[ProcessParts], bool], *, limit: int) -> tuple[int, list[str]]:
+    error, table = _read_process_table()
+    if error:
+        return 0, [error]
+
+    rows: list[str] = []
+    total = 0
+    for parts in table:
         if not predicate(parts):
             continue
         total += 1
         if len(rows) < limit:
-            rows.append(line.strip())
+            rows.append(" ".join(parts))
+    return total, rows
+
+
+def _descendant_rows(pid: int, *, limit: int) -> tuple[int, list[str]]:
+    error, table = _read_process_table()
+    if error:
+        return 0, [error]
+
+    children: dict[int, list[ProcessParts]] = {}
+    for parts in table:
+        try:
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        children.setdefault(ppid, []).append(parts)
+
+    rows: list[str] = []
+    total = 0
+    stack = list(reversed(children.get(pid, [])))
+    while stack:
+        parts = stack.pop()
+        total += 1
+        if len(rows) < limit:
+            rows.append(" ".join(parts))
+        try:
+            child_pid = int(parts[0])
+        except ValueError:
+            continue
+        stack.extend(reversed(children.get(child_pid, [])))
     return total, rows
 
 
@@ -88,6 +131,7 @@ def log_process_snapshot(
     *,
     pid: int | None = None,
     limit: int = 30,
+    related_terms: tuple[str, ...] = (),
 ) -> None:
     """Log a compact process snapshot around service lifecycle events."""
     if not logger.isEnabledFor(logging.INFO):
@@ -133,3 +177,24 @@ def log_process_snapshot(
         total,
         _format_rows(total, rows),
     )
+
+    total, rows = _descendant_rows(target_pid, limit=limit)
+    logger.info(
+        "Process snapshot (%s) descendants (%s): %s",
+        reason,
+        total,
+        _format_rows(total, rows),
+    )
+
+    normalized_terms = tuple(term.lower() for term in related_terms if term)
+    if normalized_terms:
+        total, rows = _process_table_rows(
+            lambda parts: any(term in parts[5].lower() for term in normalized_terms),
+            limit=limit,
+        )
+        logger.info(
+            "Process snapshot (%s) related processes (%s): %s",
+            reason,
+            total,
+            _format_rows(total, rows),
+        )

--- a/core/process_diagnostics.py
+++ b/core/process_diagnostics.py
@@ -1,0 +1,135 @@
+"""Lightweight process diagnostics for shutdown investigations."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from typing import Callable
+
+
+def _run_ps(args: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            ["ps", *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.5,
+        )
+    except Exception as exc:
+        return f"<ps failed: {exc}>"
+    output = (result.stdout or result.stderr or "").strip()
+    if not output:
+        return "<none>"
+    return output
+
+
+def process_identity(pid: int | None = None) -> dict[str, int | None]:
+    """Return best-effort POSIX process identity fields."""
+    target_pid = pid if pid is not None else os.getpid()
+    identity: dict[str, int | None] = {"pid": target_pid}
+
+    if target_pid == os.getpid():
+        identity["ppid"] = os.getppid()
+        identity["pgid"] = os.getpgrp() if hasattr(os, "getpgrp") else None
+        identity["sid"] = os.getsid(0) if hasattr(os, "getsid") else None
+        return identity
+
+    identity["ppid"] = None
+    try:
+        identity["pgid"] = os.getpgid(target_pid) if hasattr(os, "getpgid") else None
+    except ProcessLookupError:
+        identity["pgid"] = None
+    except Exception:
+        identity["pgid"] = None
+    try:
+        identity["sid"] = os.getsid(target_pid) if hasattr(os, "getsid") else None
+    except ProcessLookupError:
+        identity["sid"] = None
+    except Exception:
+        identity["sid"] = None
+    return identity
+
+
+def process_row(pid: int) -> str:
+    return _run_ps(["-p", str(pid), "-o", "pid=,ppid=,pgid=,sess=,stat=,command="])
+
+
+def _process_table_rows(predicate: Callable[[list[str]], bool], *, limit: int) -> tuple[int, list[str]]:
+    output = _run_ps(["-axo", "pid=,ppid=,pgid=,sess=,stat=,command="])
+    if output.startswith("<"):
+        return 0, [output]
+
+    rows: list[str] = []
+    total = 0
+    for line in output.splitlines():
+        parts = line.split(None, 5)
+        if len(parts) < 6:
+            continue
+        if not predicate(parts):
+            continue
+        total += 1
+        if len(rows) < limit:
+            rows.append(line.strip())
+    return total, rows
+
+
+def _format_rows(total: int, rows: list[str]) -> str:
+    if not rows:
+        return "<none>"
+    suffix = "" if total <= len(rows) else f" ... (+{total - len(rows)} more)"
+    return " | ".join(rows) + suffix
+
+
+def log_process_snapshot(
+    logger: logging.Logger,
+    reason: str,
+    *,
+    pid: int | None = None,
+    limit: int = 30,
+) -> None:
+    """Log a compact process snapshot around service lifecycle events."""
+    if not logger.isEnabledFor(logging.INFO):
+        return
+
+    target_pid = pid if pid is not None else os.getpid()
+    identity = process_identity(target_pid)
+    own_pid = os.getpid()
+    own_pgid = os.getpgrp() if hasattr(os, "getpgrp") else None
+    target_pgid = identity.get("pgid")
+
+    logger.info(
+        "Process snapshot (%s): pid=%s ppid=%s pgid=%s sid=%s service_pid=%s service_pgid=%s",
+        reason,
+        identity.get("pid"),
+        identity.get("ppid"),
+        target_pgid,
+        identity.get("sid"),
+        own_pid,
+        own_pgid,
+    )
+
+    parent_pid = identity.get("ppid")
+    if parent_pid:
+        logger.info("Process snapshot (%s) parent: %s", reason, process_row(parent_pid))
+
+    logger.info("Process snapshot (%s) target: %s", reason, process_row(target_pid))
+
+    if target_pgid is not None:
+        total, rows = _process_table_rows(lambda parts: parts[2] == str(target_pgid), limit=limit)
+        logger.info(
+            "Process snapshot (%s) pgid=%s members (%s): %s",
+            reason,
+            target_pgid,
+            total,
+            _format_rows(total, rows),
+        )
+
+    total, rows = _process_table_rows(lambda parts: parts[1] == str(target_pid), limit=limit)
+    logger.info(
+        "Process snapshot (%s) direct children (%s): %s",
+        reason,
+        total,
+        _format_rows(total, rows),
+    )

--- a/core/process_isolation.py
+++ b/core/process_isolation.py
@@ -39,6 +39,14 @@ def _safe_signal_process_group(pid: int, sig: int, logger: logging.Logger, label
         )
         return False
     try:
+        logger.info(
+            "Signaling %s process group pgid=%s pid=%s signal=%s service_pgid=%s",
+            label,
+            pgid,
+            pid,
+            sig,
+            own_pgid,
+        )
         os.killpg(pgid, sig)
         return True
     except ProcessLookupError:
@@ -55,6 +63,7 @@ def signal_process_tree(process: Any, sig: int, logger: logging.Logger, label: s
         return
 
     try:
+        logger.info("Signaling %s direct process pid=%s signal=%s", label, pid, sig)
         if sig == signal.SIGTERM:
             process.terminate()
         elif sig == KILL_SIGNAL:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,16 +28,16 @@ The command walks you through signing in at `https://avibe.bot`, creating a remo
 
 ### `vibe`
 
-Start or restart Vibe Remote. Opens the web UI in your browser.
+Start Vibe Remote if needed. Opens the web UI in your browser.
 
 ```bash
 vibe
 ```
 
 **Behavior:**
-- Restarts the main service if already running
+- Reuses the main service if it is already running
 - Opens the setup wizard at `http://127.0.0.1:5123`
-- **Preserves OpenCode server** — Running tasks are not interrupted
+- **Preserves running processes** — Use `vibe restart` when you need an explicit restart
 
 ### `vibe stop`
 

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -27,16 +27,16 @@ vibe remote
 
 ### `vibe`
 
-启动或重启 Vibe Remote。会在浏览器中打开 Web UI。
+按需启动 Vibe Remote。会在浏览器中打开 Web UI。
 
 ```bash
 vibe
 ```
 
 **行为：**
-- 如果已在运行，则重启主服务
+- 如果主服务已在运行，则复用现有进程
 - 打开设置向导 `http://127.0.0.1:5123`
-- **保留 OpenCode 服务器** — 正在执行的任务不会被中断
+- **保留已运行的进程** — 需要明确重启时请使用 `vibe restart`
 
 ### `vibe stop`
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -517,7 +517,7 @@ The `vibe` executable controls the local service and async automation features.
 
 | Command | Purpose |
 | --- | --- |
-| `vibe` | Start or restart the service and Web UI |
+| `vibe` | Start the service and Web UI if needed; reuse already-running processes |
 | `vibe stop` | Stop the service and UI; also terminates OpenCode server |
 | `vibe restart` | Stop then start again |
 | `vibe status` | Print runtime status JSON |
@@ -536,9 +536,9 @@ The `vibe` executable controls the local service and async automation features.
 vibe
 ```
 
-- starts or restarts the main service
+- starts the main service if it is not already running
 - opens the Web UI
-- preserves the running OpenCode server when possible
+- preserves already-running service, Web UI, and OpenCode processes; use `vibe restart` for an explicit restart
 
 ### `vibe stop`
 

--- a/docs/COMMANDS_ZH.md
+++ b/docs/COMMANDS_ZH.md
@@ -496,7 +496,7 @@ bind vr-a3x9k2
 
 | 命令 | 作用 |
 | --- | --- |
-| `vibe` | 启动或重启服务与 Web UI |
+| `vibe` | 按需启动服务与 Web UI；已运行时复用现有进程 |
 | `vibe stop` | 停止服务与 UI，同时终止 OpenCode server |
 | `vibe restart` | 停止后重新启动 |
 | `vibe status` | 输出运行状态 JSON |
@@ -515,9 +515,9 @@ bind vr-a3x9k2
 vibe
 ```
 
-- 启动或重启主服务
+- 如果主服务尚未运行，则启动主服务
 - 打开 Web UI
-- 尽量保留正在运行的 OpenCode server
+- 保留已运行的服务、Web UI 与 OpenCode server；需要明确重启时使用 `vibe restart`
 
 ### `vibe stop`
 

--- a/main.py
+++ b/main.py
@@ -69,6 +69,33 @@ def prepare_sqlite_state(config: V2Config):
     return ensure_sqlite_state(primary_platform=config.platform)
 
 
+def _log_shutdown_signal(logger: logging.Logger, signum: int) -> None:
+    try:
+        logger.info(
+            "Received signal %s pid=%s ppid=%s pgid=%s sid=%s",
+            signum,
+            os.getpid(),
+            os.getppid(),
+            os.getpgid(0),
+            os.getsid(0),
+        )
+    except Exception:
+        logger.info("Received signal %s", signum)
+
+
+def _log_shutdown_intent(logger: logging.Logger, signum: int) -> None:
+    if signum != signal.SIGTERM or not shutdown_intent_required():
+        return
+    intent = consume_shutdown_intent(os.getpid(), signum)
+    if intent is None:
+        logger.warning(
+            "No managed shutdown intent found for SIGTERM pid=%s; honoring signal",
+            os.getpid(),
+        )
+        return
+    logger.info("Accepted managed shutdown intent: %s", intent)
+
+
 def main():
     """Main entry point"""
     try:
@@ -85,7 +112,7 @@ def main():
         logger.info("Starting vibe-remote service...")
         logger.info(f"Working directory: {config.runtime.default_cwd}")
         logger.info(
-            "Shutdown intent guard enabled=%s env=%s",
+            "Shutdown intent diagnostics enabled=%s env=%s",
             shutdown_intent_required(),
             os.environ.get("VIBE_REQUIRE_SHUTDOWN_INTENT"),
         )
@@ -111,28 +138,8 @@ def main():
                 return
             shutdown_initiated = True
             try:
-                logger.info("Received signal %s", signum)
-                log_process_snapshot(
-                    logger,
-                    f"signal-{signum}",
-                    related_terms=(
-                        "codex app-server",
-                        "/codex ",
-                        " claude",
-                        "/vibe restart",
-                        ".local/bin/vibe restart",
-                    ),
-                )
-                if signum == signal.SIGTERM and shutdown_intent_required():
-                    intent = consume_shutdown_intent(os.getpid(), signum)
-                    if intent is None:
-                        logger.warning(
-                            "Ignoring unmanaged SIGTERM for pid=%s because no valid shutdown intent was present",
-                            os.getpid(),
-                        )
-                        shutdown_initiated = False
-                        return
-                    logger.info("Accepted managed shutdown intent: %s", intent)
+                _log_shutdown_signal(logger, signum)
+                _log_shutdown_intent(logger, signum)
                 logger.info("Shutting down after signal %s", signum)
             except Exception:
                 pass

--- a/main.py
+++ b/main.py
@@ -7,8 +7,10 @@ import asyncio
 from config.paths import ensure_data_dirs, get_logs_dir
 from config.v2_config import V2Config
 from core.controller import Controller
+from core.process_diagnostics import log_process_snapshot
 from storage.importer import ensure_sqlite_state
 from vibe.sentry_integration import init_sentry
+from vibe.runtime import consume_shutdown_intent, shutdown_intent_required
 
 
 def _build_logging_handlers(logs_dir: str) -> list[logging.Handler]:
@@ -82,6 +84,7 @@ def main():
         
         logger.info("Starting vibe-remote service...")
         logger.info(f"Working directory: {config.runtime.default_cwd}")
+        log_process_snapshot(logger, "service-start")
         report = prepare_sqlite_state(config)
         logger.info(
             "SQLite state ready: imported=%s db_path=%s backup_path=%s",
@@ -104,6 +107,17 @@ def main():
             shutdown_initiated = True
             try:
                 logger.info(f"Received signal {signum}, shutting down...")
+                log_process_snapshot(logger, f"signal-{signum}")
+                if signum == signal.SIGTERM and shutdown_intent_required():
+                    intent = consume_shutdown_intent(os.getpid(), signum)
+                    if intent is None:
+                        logger.warning(
+                            "Ignoring unmanaged SIGTERM for pid=%s because no valid shutdown intent was present",
+                            os.getpid(),
+                        )
+                        shutdown_initiated = False
+                        return
+                    logger.info("Accepted managed shutdown intent: %s", intent)
             except Exception:
                 pass
             try:

--- a/main.py
+++ b/main.py
@@ -84,6 +84,11 @@ def main():
         
         logger.info("Starting vibe-remote service...")
         logger.info(f"Working directory: {config.runtime.default_cwd}")
+        logger.info(
+            "Shutdown intent guard enabled=%s env=%s",
+            shutdown_intent_required(),
+            os.environ.get("VIBE_REQUIRE_SHUTDOWN_INTENT"),
+        )
         log_process_snapshot(logger, "service-start")
         report = prepare_sqlite_state(config)
         logger.info(
@@ -106,8 +111,18 @@ def main():
                 return
             shutdown_initiated = True
             try:
-                logger.info(f"Received signal {signum}, shutting down...")
-                log_process_snapshot(logger, f"signal-{signum}")
+                logger.info("Received signal %s", signum)
+                log_process_snapshot(
+                    logger,
+                    f"signal-{signum}",
+                    related_terms=(
+                        "codex app-server",
+                        "/codex ",
+                        " claude",
+                        "/vibe restart",
+                        ".local/bin/vibe restart",
+                    ),
+                )
                 if signum == signal.SIGTERM and shutdown_intent_required():
                     intent = consume_shutdown_intent(os.getpid(), signum)
                     if intent is None:
@@ -118,6 +133,7 @@ def main():
                         shutdown_initiated = False
                         return
                     logger.info("Accepted managed shutdown intent: %s", intent)
+                logger.info("Shutting down after signal %s", signum)
             except Exception:
                 pass
             try:

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -10,6 +10,7 @@ import signal
 from asyncio.subprocess import Process
 from typing import Any, Awaitable, Callable, Optional
 
+from core.process_diagnostics import log_process_snapshot, process_identity
 from core.process_isolation import KILL_SIGNAL, isolated_subprocess_kwargs, signal_process_tree
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,15 @@ class CodexTransport:
             limit=STREAM_BUFFER_LIMIT,
             **isolated_subprocess_kwargs(),
         )
-        logger.info("Codex app-server started (pid=%s)", self._process.pid)
+        identity = process_identity(self._process.pid)
+        logger.info(
+            "Codex app-server started (pid=%s pgid=%s sid=%s service_pgid=%s)",
+            self._process.pid,
+            identity.get("pgid"),
+            identity.get("sid"),
+            os.getpgrp() if hasattr(os, "getpgrp") else None,
+        )
+        log_process_snapshot(logger, "codex-app-server-start", pid=self._process.pid, limit=10)
 
         # Start background readers
         self._reader_task = asyncio.create_task(self._reader_loop())

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -339,7 +339,7 @@ class CodexTransport:
                 if not line:
                     break
                 decoded = line.decode(errors="ignore").rstrip()
-                logger.debug("Codex stderr: %s", decoded)
+                logger.info("Codex stderr: %s", decoded[:2000])
         except asyncio.CancelledError:
             return
         except Exception:

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -906,7 +906,7 @@ Use the CLI only when the Web UI API cannot cover the request, when the user exp
 
 Service lifecycle:
 
-- `vibe` — start (or restart) Vibe Remote and open the local Web UI
+- `vibe` — start Vibe Remote if needed and open the local Web UI; it does not stop an already-running service
 - `vibe status` — print service status, PID metadata, and last action
 - `vibe stop` — stop main service, Web UI, and any background helpers
 - `vibe restart` — stop and re-start the service. Pass `--delay-seconds N` when triggering from inside an active conversation so the current reply has time to deliver before the restart lands.

--- a/tests/test_cli_setup_status.py
+++ b/tests/test_cli_setup_status.py
@@ -20,8 +20,8 @@ def test_cmd_vibe_marks_setup_when_no_enabled_platform_has_credentials(capsys) -
     with (
         patch("vibe.cli.paths.ensure_data_dirs"),
         patch("vibe.cli._ensure_config", return_value=config),
-        patch("vibe.cli.runtime.stop_service"),
-        patch("vibe.cli.runtime.stop_ui"),
+        patch("vibe.cli.runtime.stop_service") as stop_service,
+        patch("vibe.cli.runtime.stop_ui") as stop_ui,
         patch("vibe.cli.runtime.start_service", return_value=101),
         patch("vibe.cli.runtime.start_ui", return_value=202),
         patch("vibe.cli.runtime.write_status"),
@@ -29,6 +29,8 @@ def test_cmd_vibe_marks_setup_when_no_enabled_platform_has_credentials(capsys) -
     ):
         cli.cmd_vibe()
 
+    stop_service.assert_not_called()
+    stop_ui.assert_not_called()
     write_status.assert_called_once_with("setup", "missing platform credentials")
     output = capsys.readouterr().out
     assert "Run: vibe remote" in output
@@ -41,8 +43,8 @@ def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured() -> None
     with (
         patch("vibe.cli.paths.ensure_data_dirs"),
         patch("vibe.cli._ensure_config", return_value=config),
-        patch("vibe.cli.runtime.stop_service"),
-        patch("vibe.cli.runtime.stop_ui"),
+        patch("vibe.cli.runtime.stop_service") as stop_service,
+        patch("vibe.cli.runtime.stop_ui") as stop_ui,
         patch("vibe.cli.runtime.start_service", return_value=101),
         patch("vibe.cli.runtime.start_ui", return_value=202),
         patch("vibe.cli.runtime.write_status"),
@@ -50,4 +52,6 @@ def test_cmd_vibe_marks_starting_when_non_slack_platform_is_configured() -> None
     ):
         cli.cmd_vibe()
 
+    stop_service.assert_not_called()
+    stop_ui.assert_not_called()
     write_status.assert_called_once_with("starting")

--- a/tests/test_process_diagnostics.py
+++ b/tests/test_process_diagnostics.py
@@ -1,0 +1,46 @@
+import logging
+
+from core import process_diagnostics
+
+
+def test_log_process_snapshot_includes_recursive_descendants_and_related(caplog, monkeypatch):
+    table = "\n".join(
+        [
+            "100 1 100 100 Ss /usr/bin/python main.py",
+            "200 100 200 200 Ss node codex --dangerously-bypass-approvals-and-sandbox app-server",
+            "201 200 200 200 S /vendor/codex app-server",
+            "300 1 300 300 S claude",
+        ]
+    )
+
+    def fake_run_ps(args):
+        if args[:2] == ["-p", "100"]:
+            return "100 1 100 100 Ss /usr/bin/python main.py"
+        if args[:2] == ["-p", "1"]:
+            return "1 0 1 1 Ss launchd"
+        if args[:2] == ["-axo", "pid=,ppid=,pgid=,sess=,stat=,command="]:
+            return table
+        return "<none>"
+
+    monkeypatch.setattr(process_diagnostics, "_run_ps", fake_run_ps)
+    monkeypatch.setattr(
+        process_diagnostics,
+        "process_identity",
+        lambda pid=None: {"pid": 100, "ppid": 1, "pgid": 100, "sid": 100},
+    )
+
+    logger = logging.getLogger("test.process_diagnostics")
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        process_diagnostics.log_process_snapshot(
+            logger,
+            "test",
+            pid=100,
+            related_terms=("codex app-server", "claude"),
+        )
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Process snapshot (test) descendants (2):" in messages
+    assert "200 100 200 200 Ss node codex" in messages
+    assert "201 200 200 200 S /vendor/codex app-server" in messages
+    assert "Process snapshot (test) related processes (2):" in messages
+    assert "300 1 300 300 S claude" in messages

--- a/tests/test_runtime_service_lock.py
+++ b/tests/test_runtime_service_lock.py
@@ -17,11 +17,34 @@ class RuntimeServiceLockTests(unittest.TestCase):
 
             with patch("vibe.runtime.paths.get_runtime_pid_path", return_value=pid_path):
                 with patch("vibe.runtime.pid_alive", return_value=True):
-                    with patch("vibe.runtime.spawn_background") as spawn_background:
-                        pid = runtime.start_service()
+                    with patch(
+                        "vibe.runtime.get_process_command",
+                        return_value=f"{sys.executable} {runtime.get_service_main_path()}",
+                    ):
+                        with patch("vibe.runtime.spawn_background") as spawn_background:
+                            pid = runtime.start_service()
 
             self.assertEqual(pid, 12345)
             spawn_background.assert_not_called()
+
+    def test_start_service_ignores_reused_unrelated_pid(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = Path(tmpdir) / "service.pid"
+            pid_path.write_text("12345", encoding="utf-8")
+
+            def fake_spawn(args, target_pid_path, stdout_name, stderr_name, env=None):
+                target_pid_path.write_text("67890", encoding="utf-8")
+                return 67890
+
+            with patch("vibe.runtime.paths.get_runtime_pid_path", return_value=pid_path):
+                with patch("vibe.runtime.pid_alive", return_value=True):
+                    with patch("vibe.runtime.get_process_command", return_value="/usr/bin/unrelated --work"):
+                        with patch("vibe.runtime.spawn_background", side_effect=fake_spawn) as spawn_background:
+                            pid = runtime.start_service()
+
+            self.assertEqual(pid, 67890)
+            spawn_background.assert_called_once()
+            self.assertEqual(pid_path.read_text(encoding="utf-8"), "67890")
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_service_lock.py
+++ b/tests/test_runtime_service_lock.py
@@ -46,6 +46,20 @@ class RuntimeServiceLockTests(unittest.TestCase):
             spawn_background.assert_called_once()
             self.assertEqual(pid_path.read_text(encoding="utf-8"), "67890")
 
+    def test_start_service_reuses_live_pid_when_command_is_unreadable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pid_path = Path(tmpdir) / "service.pid"
+            pid_path.write_text("12345", encoding="utf-8")
+
+            with patch("vibe.runtime.paths.get_runtime_pid_path", return_value=pid_path):
+                with patch("vibe.runtime.pid_alive", return_value=True):
+                    with patch("vibe.runtime.get_process_command", return_value=None):
+                        with patch("vibe.runtime.spawn_background") as spawn_background:
+                            pid = runtime.start_service()
+
+            self.assertEqual(pid, 12345)
+            spawn_background.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_service_logging_handlers.py
+++ b/tests/test_service_logging_handlers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import signal
 from pathlib import Path
 
 import main
@@ -52,3 +53,27 @@ def test_start_service_disables_stdout_logging_for_background_process(monkeypatc
     assert captured["stderr_name"] == "service_stderr.log"
     assert isinstance(captured["env"], dict)
     assert captured["env"]["VIBE_DISABLE_STDOUT_LOGGING"] == "1"
+
+
+def test_shutdown_intent_missing_is_logged_not_ignored(monkeypatch, caplog):
+    monkeypatch.setattr(main, "shutdown_intent_required", lambda: True)
+    monkeypatch.setattr(main, "consume_shutdown_intent", lambda pid, signum: None)
+
+    logger = logging.getLogger("test.shutdown")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        main._log_shutdown_intent(logger, signal.SIGTERM)
+
+    assert "honoring signal" in caplog.text
+
+
+def test_shutdown_signal_logging_is_lightweight(monkeypatch, caplog):
+    monkeypatch.setattr(main.os, "getpid", lambda: 123)
+    monkeypatch.setattr(main.os, "getppid", lambda: 1)
+    monkeypatch.setattr(main.os, "getpgid", lambda pid: 123)
+    monkeypatch.setattr(main.os, "getsid", lambda pid: 123)
+
+    logger = logging.getLogger("test.shutdown")
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        main._log_shutdown_signal(logger, signal.SIGTERM)
+
+    assert "Received signal 15 pid=123 ppid=1 pgid=123 sid=123" in caplog.text

--- a/tests/test_ui_server_logs.py
+++ b/tests/test_ui_server_logs.py
@@ -228,3 +228,22 @@ def test_status_endpoint_degrades_when_pid_probe_raises(monkeypatch, tmp_path):
     assert payload["running"] is False
     assert payload["pid"] is None
     assert payload["state"] == "stopped"
+
+
+def test_control_start_reuses_running_service_without_stop(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    runtime.write_status("running", detail="already running", service_pid=12345, ui_pid=67890)
+    calls = []
+
+    monkeypatch.setattr(runtime, "ensure_config", lambda: calls.append("ensure_config"))
+    monkeypatch.setattr(runtime, "stop_service", lambda: calls.append("stop_service"))
+    monkeypatch.setattr(runtime, "start_service", lambda: calls.append("start_service") or 12345)
+
+    client = app.test_client()
+    response = client.post("/control", json={"action": "start"}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert calls == ["ensure_config", "start_service"]
+    payload = response.get_json()
+    assert payload["status"]["service_pid"] == 12345

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -418,6 +418,16 @@ def test_start_ui_reuses_existing_live_pid(tmp_path, monkeypatch):
 
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
     monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: host == "127.0.0.1" and port == 5123)
+    monkeypatch.setattr(
+        runtime,
+        "get_process_command",
+        lambda pid: (
+            f"{sys.executable} -c "
+            "\"from vibe.ui_server import run_ui_server; run_ui_server('127.0.0.1', 5123)\""
+            if pid == 12345
+            else None
+        ),
+    )
 
     def fail_spawn(*_args, **_kwargs):
         raise AssertionError("start_ui should not spawn when an existing UI process is healthy")
@@ -425,6 +435,30 @@ def test_start_ui_reuses_existing_live_pid(tmp_path, monkeypatch):
     monkeypatch.setattr(runtime, "spawn_background", fail_spawn)
 
     assert runtime.start_ui("127.0.0.1", 5123) == 12345
+
+
+def test_start_ui_does_not_reuse_unrelated_pid_with_healthy_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: True)
+    monkeypatch.setattr(runtime, "get_process_command", lambda pid: "/usr/bin/unrelated --work" if pid == 12345 else None)
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port: True)
+
+    def fail_stop(pid, timeout=5):
+        raise AssertionError(f"unrelated pid should not be stopped: {pid}")
+
+    def fake_spawn(args, pid_path, stdout_name, stderr_name, env=None):
+        pid_path.write_text("67890", encoding="utf-8")
+        return 67890
+
+    monkeypatch.setattr(runtime, "stop_pid", fail_stop)
+    monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
+
+    assert runtime.start_ui("127.0.0.1", 5123) == 67890
+    assert paths.get_runtime_ui_pid_path().read_text(encoding="utf-8") == "67890"
 
 
 def test_start_ui_replaces_stale_live_pid_when_health_check_fails(tmp_path, monkeypatch):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -411,6 +411,21 @@ def test_stop_pid_writes_shutdown_intent_before_sigterm(monkeypatch):
     assert calls[1] == (12345, signal.SIGTERM)
 
 
+def test_start_ui_reuses_existing_live_pid(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+
+    def fail_spawn(*_args, **_kwargs):
+        raise AssertionError("start_ui should not spawn when an existing UI process is alive")
+
+    monkeypatch.setattr(runtime, "spawn_background", fail_spawn)
+
+    assert runtime.start_ui("127.0.0.1", 5123) == 12345
+
+
 def test_shutdown_intent_round_trip(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
     runtime.ensure_dirs()

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -368,6 +368,7 @@ def test_restart_parser_rejects_non_finite_delay_seconds(raw_value):
 def test_stop_pid_handles_process_lookup_race(monkeypatch):
     monkeypatch.setattr(runtime.os, "name", "posix", raising=False)
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(runtime, "write_shutdown_intent", lambda *args, **kwargs: None)
 
     def _kill(pid, sig):
         raise ProcessLookupError()
@@ -380,6 +381,7 @@ def test_stop_pid_handles_process_lookup_race(monkeypatch):
 def test_stop_pid_handles_permission_error(monkeypatch):
     monkeypatch.setattr(runtime.os, "name", "posix", raising=False)
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(runtime, "write_shutdown_intent", lambda *args, **kwargs: None)
 
     def _kill(pid, sig):
         raise PermissionError()
@@ -387,3 +389,54 @@ def test_stop_pid_handles_permission_error(monkeypatch):
     monkeypatch.setattr(runtime.os, "kill", _kill)
 
     assert runtime.stop_pid(12345) is False
+
+
+def test_stop_pid_writes_shutdown_intent_before_sigterm(monkeypatch):
+    monkeypatch.setattr(runtime.os, "name", "posix", raising=False)
+    alive_results = iter([True, False])
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: next(alive_results))
+    calls = []
+
+    def _kill(pid, sig):
+        calls.append((pid, sig))
+
+    monkeypatch.setattr(runtime.os, "kill", _kill)
+    monkeypatch.setattr(runtime.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(runtime, "write_shutdown_intent", lambda *args, **kwargs: calls.append(("intent", args, kwargs)))
+
+    assert runtime.stop_pid(12345) is True
+    assert calls[0][0] == "intent"
+    assert calls[0][1] == (12345,)
+    assert calls[0][2]["signum"] == signal.SIGTERM
+    assert calls[1] == (12345, signal.SIGTERM)
+
+
+def test_shutdown_intent_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    monkeypatch.setattr(runtime.time, "time", lambda: 1000.0)
+    monkeypatch.setattr(runtime, "get_process_command", lambda pid: f"cmd-{pid}")
+
+    runtime.write_shutdown_intent(12345, reason="test")
+    payload = runtime.consume_shutdown_intent(12345, signal.SIGTERM)
+
+    assert payload is not None
+    assert payload["target_pid"] == 12345
+    assert payload["sender_pid"] == os.getpid()
+    assert not runtime.get_shutdown_intent_path().exists()
+
+
+def test_shutdown_intent_rejects_stale_payload(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    monkeypatch.setattr(runtime.time, "time", lambda: 1000.0)
+    runtime.write_json(
+        runtime.get_shutdown_intent_path(),
+        {
+            "target_pid": 12345,
+            "signum": signal.SIGTERM,
+            "created_at": 900.0,
+        },
+    )
+
+    assert runtime.consume_shutdown_intent(12345, signal.SIGTERM) is None

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -435,6 +435,16 @@ def test_start_ui_replaces_stale_live_pid_when_health_check_fails(tmp_path, monk
 
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
     monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: False)
+    monkeypatch.setattr(
+        runtime,
+        "get_process_command",
+        lambda pid: (
+            f"{sys.executable} -c "
+            "\"from vibe.ui_server import run_ui_server; run_ui_server('127.0.0.1', 5123)\""
+            if pid == 12345
+            else None
+        ),
+    )
     monkeypatch.setattr(runtime, "stop_pid", lambda pid: stopped.append(pid) or True)
     monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port: True)
 
@@ -447,6 +457,30 @@ def test_start_ui_replaces_stale_live_pid_when_health_check_fails(tmp_path, monk
 
     assert runtime.start_ui("127.0.0.1", 5123) == 67890
     assert stopped == [12345]
+    assert paths.get_runtime_ui_pid_path().read_text(encoding="utf-8") == "67890"
+
+
+def test_start_ui_does_not_stop_unrelated_reused_pid(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: False)
+    monkeypatch.setattr(runtime, "get_process_command", lambda pid: "/usr/bin/unrelated --work" if pid == 12345 else None)
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port: True)
+
+    def fail_stop(pid, timeout=5):
+        raise AssertionError(f"unrelated pid should not be stopped: {pid}")
+
+    def fake_spawn(args, pid_path, stdout_name, stderr_name, env=None):
+        pid_path.write_text("67890", encoding="utf-8")
+        return 67890
+
+    monkeypatch.setattr(runtime, "stop_pid", fail_stop)
+    monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
+
+    assert runtime.start_ui("127.0.0.1", 5123) == 67890
     assert paths.get_runtime_ui_pid_path().read_text(encoding="utf-8") == "67890"
 
 

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -431,9 +431,12 @@ def test_start_ui_replaces_stale_live_pid_when_health_check_fails(tmp_path, monk
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
     runtime.ensure_dirs()
     paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+    stopped = []
 
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
     monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: False)
+    monkeypatch.setattr(runtime, "stop_pid", lambda pid: stopped.append(pid) or True)
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port: True)
 
     def fake_spawn(args, pid_path, stdout_name, stderr_name, env=None):
         assert args[-1] == "from vibe.ui_server import run_ui_server; run_ui_server('127.0.0.1', 5123)"
@@ -443,7 +446,20 @@ def test_start_ui_replaces_stale_live_pid_when_health_check_fails(tmp_path, monk
     monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
 
     assert runtime.start_ui("127.0.0.1", 5123) == 67890
+    assert stopped == [12345]
     assert paths.get_runtime_ui_pid_path().read_text(encoding="utf-8") == "67890"
+
+
+def test_start_ui_waits_for_replacement_health(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    waited = []
+
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port: waited.append((host, port)) or True)
+    monkeypatch.setattr(runtime, "spawn_background", lambda *args, **kwargs: 67890)
+
+    assert runtime.start_ui("127.0.0.1", 5123) == 67890
+    assert waited == [("127.0.0.1", 5123)]
 
 
 def test_ui_health_url_uses_loopback_for_wildcard_bind():

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -417,13 +417,38 @@ def test_start_ui_reuses_existing_live_pid(tmp_path, monkeypatch):
     paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
 
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: host == "127.0.0.1" and port == 5123)
 
     def fail_spawn(*_args, **_kwargs):
-        raise AssertionError("start_ui should not spawn when an existing UI process is alive")
+        raise AssertionError("start_ui should not spawn when an existing UI process is healthy")
 
     monkeypatch.setattr(runtime, "spawn_background", fail_spawn)
 
     assert runtime.start_ui("127.0.0.1", 5123) == 12345
+
+
+def test_start_ui_replaces_stale_live_pid_when_health_check_fails(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: False)
+
+    def fake_spawn(args, pid_path, stdout_name, stderr_name, env=None):
+        assert args[-1] == "from vibe.ui_server import run_ui_server; run_ui_server('127.0.0.1', 5123)"
+        pid_path.write_text("67890", encoding="utf-8")
+        return 67890
+
+    monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
+
+    assert runtime.start_ui("127.0.0.1", 5123) == 67890
+    assert paths.get_runtime_ui_pid_path().read_text(encoding="utf-8") == "67890"
+
+
+def test_ui_health_url_uses_loopback_for_wildcard_bind():
+    assert runtime._ui_health_url("0.0.0.0", 5100) == "http://127.0.0.1:5100/health"
+    assert runtime._ui_health_url("::", 5100) == "http://[::1]:5100/health"
 
 
 def test_shutdown_intent_round_trip(tmp_path, monkeypatch):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1813,10 +1813,6 @@ def cmd_vibe():
     paths.ensure_data_dirs()
     config = _ensure_config()
 
-    # Always restart both processes
-    runtime.stop_service()
-    runtime.stop_ui()
-
     has_configured_platform_credentials = getattr(config, "has_configured_platform_credentials", None)
     if callable(has_configured_platform_credentials):
         ready = bool(has_configured_platform_credentials())

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -432,6 +432,28 @@ def read_status():
     return read_json(paths.get_runtime_status_path()) or {}
 
 
+def _command_references_path(command: str | None, expected_path: Path) -> bool:
+    if not command:
+        return False
+    try:
+        args = shlex.split(command, posix=(os.name != "nt"))
+    except ValueError:
+        return False
+    expected_resolved = expected_path.resolve()
+    for arg in args:
+        cleaned_arg = arg.strip("\"'")
+        try:
+            if Path(cleaned_arg).resolve() == expected_resolved:
+                return True
+        except (OSError, RuntimeError):
+            continue
+    return False
+
+
+def _pid_matches_service(pid: int) -> bool:
+    return _command_references_path(get_process_command(pid), get_service_main_path())
+
+
 def render_status():
     status = read_status()
     pid_path = paths.get_runtime_pid_path()
@@ -451,7 +473,12 @@ def start_service():
             except Exception:
                 existing_pid = 0
             if existing_pid and pid_alive(existing_pid):
-                return existing_pid
+                if _pid_matches_service(existing_pid):
+                    return existing_pid
+                logger.warning(
+                    "Ignoring stale service pid file pid=%s because it does not match the Vibe service",
+                    existing_pid,
+                )
             pid_path.unlink(missing_ok=True)
 
         main_path = get_service_main_path()

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -450,8 +450,15 @@ def _command_references_path(command: str | None, expected_path: Path) -> bool:
     return False
 
 
-def _pid_matches_service(pid: int) -> bool:
-    return _command_references_path(get_process_command(pid), get_service_main_path())
+def _pid_mismatches_service(pid: int) -> bool:
+    command = get_process_command(pid)
+    if not command:
+        logger.warning(
+            "Reusing existing service pid=%s because its command line could not be inspected",
+            pid,
+        )
+        return False
+    return not _command_references_path(command, get_service_main_path())
 
 
 def render_status():
@@ -473,7 +480,7 @@ def start_service():
             except Exception:
                 existing_pid = 0
             if existing_pid and pid_alive(existing_pid):
-                if _pid_matches_service(existing_pid):
+                if not _pid_mismatches_service(existing_pid):
                     return existing_pid
                 logger.warning(
                     "Ignoring stale service pid file pid=%s because it does not match the Vibe service",

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -600,9 +600,9 @@ def start_ui(host, port):
             existing_pid = int(pid_path.read_text(encoding="utf-8").strip())
         except Exception:
             existing_pid = 0
-        if existing_pid and pid_alive(existing_pid) and ui_server_healthy(host, port):
-            return existing_pid
         if existing_pid and pid_alive(existing_pid):
+            if _pid_matches_ui_server(existing_pid) and ui_server_healthy(host, port):
+                return existing_pid
             if _pid_matches_ui_server(existing_pid):
                 logger.warning(
                     "Stopping stale UI process pid=%s because health check failed for %s",

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -489,6 +489,15 @@ def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
         return False
 
 
+def wait_for_ui_server(host: str, port: int, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if ui_server_healthy(host, port):
+            return True
+        time.sleep(0.1)
+    return ui_server_healthy(host, port)
+
+
 def resolve_localhost_family() -> str:
     """Return the loopback family ``localhost`` actually maps to on this host.
 
@@ -559,15 +568,25 @@ def start_ui(host, port):
             existing_pid = 0
         if existing_pid and pid_alive(existing_pid) and ui_server_healthy(host, port):
             return existing_pid
+        if existing_pid and pid_alive(existing_pid):
+            logger.warning(
+                "Stopping stale UI process pid=%s because health check failed for %s",
+                existing_pid,
+                _ui_health_url(host, port),
+            )
+            stop_pid(existing_pid)
         pid_path.unlink(missing_ok=True)
 
     command = "from vibe.ui_server import run_ui_server; run_ui_server('{}', {})".format(host, port)
-    return spawn_background(
+    pid = spawn_background(
         [sys.executable, "-c", command],
         pid_path,
         "ui_stdout.log",
         "ui_stderr.log",
     )
+    if not wait_for_ui_server(host, port):
+        logger.warning("Started UI pid=%s but health check did not pass for %s", pid, _ui_health_url(host, port))
+    return pid
 
 
 def stop_service():

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -155,6 +155,7 @@ def write_shutdown_intent(
     }
     try:
         write_json(get_shutdown_intent_path(), payload)
+        logger.info("Recorded managed shutdown intent: %s", payload)
     except OSError:
         logger.warning("Failed to write shutdown intent for pid=%s", target_pid, exc_info=True)
 
@@ -334,6 +335,11 @@ def stop_pid(pid: int, timeout: float = 5) -> bool:
 
     write_shutdown_intent(pid, signum=signal.SIGTERM, reason="stop_pid")
     try:
+        logger.info(
+            "Sending managed SIGTERM to pid=%s command=%s",
+            pid,
+            get_process_command(pid),
+        )
         os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
         return False
@@ -345,6 +351,7 @@ def stop_pid(pid: int, timeout: float = 5) -> bool:
             return True
         time.sleep(0.2)
     try:
+        logger.warning("Sending managed SIGKILL to pid=%s command=%s", pid, get_process_command(pid))
         os.kill(pid, signal.SIGKILL)
     except ProcessLookupError:
         return True

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -498,6 +498,13 @@ def wait_for_ui_server(host: str, port: int, timeout: float = 5.0) -> bool:
     return ui_server_healthy(host, port)
 
 
+def _pid_matches_ui_server(pid: int) -> bool:
+    command = get_process_command(pid)
+    if not command:
+        return False
+    return "vibe.ui_server" in command and "run_ui_server" in command
+
+
 def resolve_localhost_family() -> str:
     """Return the loopback family ``localhost`` actually maps to on this host.
 
@@ -569,12 +576,18 @@ def start_ui(host, port):
         if existing_pid and pid_alive(existing_pid) and ui_server_healthy(host, port):
             return existing_pid
         if existing_pid and pid_alive(existing_pid):
-            logger.warning(
-                "Stopping stale UI process pid=%s because health check failed for %s",
-                existing_pid,
-                _ui_health_url(host, port),
-            )
-            stop_pid(existing_pid)
+            if _pid_matches_ui_server(existing_pid):
+                logger.warning(
+                    "Stopping stale UI process pid=%s because health check failed for %s",
+                    existing_pid,
+                    _ui_health_url(host, port),
+                )
+                stop_pid(existing_pid)
+            else:
+                logger.warning(
+                    "Ignoring stale UI pid file pid=%s because it does not match the Vibe UI server",
+                    existing_pid,
+                )
         pid_path.unlink(missing_ok=True)
 
     command = "from vibe.ui_server import run_ui_server; run_ui_server('{}', {})".format(host, port)

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -528,10 +528,20 @@ def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) 
 
 
 def start_ui(host, port):
+    pid_path = paths.get_runtime_ui_pid_path()
+    if pid_path.exists():
+        try:
+            existing_pid = int(pid_path.read_text(encoding="utf-8").strip())
+        except Exception:
+            existing_pid = 0
+        if existing_pid and pid_alive(existing_pid):
+            return existing_pid
+        pid_path.unlink(missing_ok=True)
+
     command = "from vibe.ui_server import run_ui_server; run_ui_server('{}', {})".format(host, port)
     return spawn_background(
         [sys.executable, "-c", command],
-        paths.get_runtime_ui_pid_path(),
+        pid_path,
         "ui_stdout.log",
         "ui_stderr.log",
     )

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 from config import paths
@@ -466,6 +468,27 @@ def start_service():
         )
 
 
+def _ui_health_url(host: str, port: int) -> str:
+    health_host = (host or "127.0.0.1").strip()
+    if health_host in {"0.0.0.0", ""}:
+        health_host = "127.0.0.1"
+    elif health_host in {"::", "::0"}:
+        health_host = "[::1]"
+    elif health_host.startswith("[") and health_host.endswith("]"):
+        pass
+    elif ":" in health_host:
+        health_host = f"[{health_host}]"
+    return f"http://{health_host}:{port}/health"
+
+
+def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
+    try:
+        with urllib.request.urlopen(_ui_health_url(host, port), timeout=timeout) as response:
+            return response.status == 200
+    except (OSError, urllib.error.URLError, TimeoutError, ValueError):
+        return False
+
+
 def resolve_localhost_family() -> str:
     """Return the loopback family ``localhost`` actually maps to on this host.
 
@@ -534,7 +557,7 @@ def start_ui(host, port):
             existing_pid = int(pid_path.read_text(encoding="utf-8").strip())
         except Exception:
             existing_pid = 0
-        if existing_pid and pid_alive(existing_pid):
+        if existing_pid and pid_alive(existing_pid) and ui_server_healthy(host, port):
             return existing_pid
         pid_path.unlink(missing_ok=True)
 

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -23,6 +23,8 @@ from config.v2_config import (
 
 
 logger = logging.getLogger(__name__)
+SHUTDOWN_INTENT_TTL_SECONDS = 30
+SHUTDOWN_INTENT_ENV = "VIBE_REQUIRE_SHUTDOWN_INTENT"
 
 
 def get_package_root() -> Path:
@@ -127,6 +129,62 @@ def read_json(path):
         # Status files are best-effort: a partially written or corrupted
         # payload should not break write_status() or read_status().
         return None
+
+
+def get_shutdown_intent_path() -> Path:
+    return paths.get_runtime_dir() / "shutdown_intent.json"
+
+
+def write_shutdown_intent(
+    target_pid: int,
+    *,
+    signum: int = signal.SIGTERM,
+    reason: str = "managed-stop",
+) -> None:
+    """Record a short-lived intent before sending a managed shutdown signal."""
+    if not isinstance(target_pid, int) or target_pid <= 0:
+        return
+    payload = {
+        "target_pid": target_pid,
+        "signum": int(signum),
+        "reason": reason,
+        "created_at": time.time(),
+        "sender_pid": os.getpid(),
+        "sender_command": get_process_command(os.getpid()),
+        "target_command": get_process_command(target_pid),
+    }
+    try:
+        write_json(get_shutdown_intent_path(), payload)
+    except OSError:
+        logger.warning("Failed to write shutdown intent for pid=%s", target_pid, exc_info=True)
+
+
+def consume_shutdown_intent(target_pid: int, signum: int = signal.SIGTERM) -> dict | None:
+    """Return and remove a valid managed shutdown intent for this process."""
+    path = get_shutdown_intent_path()
+    payload = read_json(path)
+    if not isinstance(payload, dict):
+        return None
+    try:
+        age = time.time() - float(payload.get("created_at", 0))
+        matches = (
+            payload.get("target_pid") == target_pid
+            and int(payload.get("signum", 0)) == int(signum)
+            and 0 <= age <= SHUTDOWN_INTENT_TTL_SECONDS
+        )
+    except (TypeError, ValueError):
+        matches = False
+    if not matches:
+        return None
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        logger.debug("Failed to remove consumed shutdown intent", exc_info=True)
+    return payload
+
+
+def shutdown_intent_required() -> bool:
+    return os.environ.get(SHUTDOWN_INTENT_ENV, "").lower() in {"1", "true", "yes"}
 
 
 def _pid_alive_windows(pid: int) -> bool:
@@ -274,6 +332,7 @@ def stop_pid(pid: int, timeout: float = 5) -> bool:
     if os.name == "nt":
         return _terminate_process_windows(pid, timeout=timeout)
 
+    write_shutdown_intent(pid, signum=signal.SIGTERM, reason="stop_pid")
     try:
         os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
@@ -395,6 +454,7 @@ def start_service():
             env={
                 **os.environ,
                 "VIBE_DISABLE_STDOUT_LOGGING": "1",
+                SHUTDOWN_INTENT_ENV: "1",
             },
         )
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1209,7 +1209,6 @@ def control():
     status["last_action"] = action
     if action == "start":
         runtime.ensure_config()
-        runtime.stop_service()
         service_pid = runtime.start_service()
         runtime.write_status("running", "started", service_pid, status.get("ui_pid"))
     elif action == "stop":


### PR DESCRIPTION
## What

- Add shutdown/process diagnostics for service startup, managed shutdown intent, and Codex app-server process metadata.
- Make bare `vibe` an idempotent ensure-start command instead of an unconditional stop/start restart.
- Reuse an existing Web UI process only when its `/health` endpoint is reachable; stop a stale live UI pid before spawning a replacement and wait for replacement health.
- Make the Web UI `start` control action ensure the service is running without stopping an already-running service.
- Update CLI docs and the Vibe Remote skill text so `vibe` and `vibe restart` have distinct lifecycle semantics.

## Root cause

The repeated service exits were not an unmanaged external signal. A Codex/Claude shell command searched for text containing backticked `vibe` inside double quotes, so the shell performed command substitution and accidentally executed the bare `vibe` CLI.

Before this PR, bare `vibe` always stopped the main service and Web UI before starting them again. Because that command was running inside a conversation hosted by Vibe Remote itself, it could kill the process tree that was supposed to finish the restart. The old startup path also trusted pid files without proving the UI/service was actually reachable, which could leave status saying running while the Web UI or background service was not usable.

## Why this fix

`vibe restart` remains the explicit destructive lifecycle command. Bare `vibe` should be safe to run from installers, docs, copied shell snippets, and agent tool calls: it should start missing pieces and preserve running work.

Shutdown intent is now diagnostic rather than a SIGTERM gate: managed lifecycle commands still write intent metadata, but Docker/systemd/direct SIGTERM is honored normally. The SIGTERM handler also avoids expensive process snapshots so graceful cleanup is not delayed.

## Validation

- `ruff check vibe/cli.py vibe/runtime.py tests/test_cli_setup_status.py tests/test_vibe_cli.py`
- `pytest -q tests/test_cli_setup_status.py tests/test_vibe_cli.py tests/test_runtime_service_lock.py`
- `pytest -q tests/test_process_diagnostics.py tests/test_process_isolation.py tests/test_service_logging_handlers.py tests/test_codex_agent.py`
- `ruff check vibe/runtime.py vibe/ui_server.py tests/test_vibe_cli.py tests/test_ui_server_logs.py`
- `PYTHONPATH="$PWD:/Users/cyh/.local/share/uv/tools/vibe-remote/lib/python3.13/site-packages" pytest -q tests/test_vibe_cli.py tests/test_ui_server_logs.py tests/test_cli_setup_status.py tests/test_runtime_service_lock.py`
- `ruff check main.py vibe/runtime.py tests/test_vibe_cli.py tests/test_service_logging_handlers.py`
- `PYTHONPATH="$PWD:/Users/cyh/.local/share/uv/tools/vibe-remote/lib/python3.13/site-packages" pytest -q tests/test_vibe_cli.py tests/test_service_logging_handlers.py tests/test_runtime_service_lock.py tests/test_cli_setup_status.py tests/test_process_diagnostics.py tests/test_process_isolation.py`
- `ruff check vibe/runtime.py tests/test_vibe_cli.py`
- `PYTHONPATH="$PWD:/Users/cyh/.local/share/uv/tools/vibe-remote/lib/python3.13/site-packages" pytest -q tests/test_vibe_cli.py tests/test_runtime_service_lock.py tests/test_process_diagnostics.py tests/test_process_isolation.py`
- `ruff check vibe/runtime.py tests/test_runtime_service_lock.py tests/test_vibe_cli.py`
- `PYTHONPATH="$PWD:/Users/cyh/.local/share/uv/tools/vibe-remote/lib/python3.13/site-packages" pytest -q tests/test_runtime_service_lock.py tests/test_vibe_cli.py tests/test_cli_setup_status.py tests/test_process_diagnostics.py tests/test_process_isolation.py`
- `ruff check vibe/runtime.py tests/test_vibe_cli.py tests/test_runtime_service_lock.py`
- `PYTHONPATH="$PWD:/Users/cyh/.local/share/uv/tools/vibe-remote/lib/python3.13/site-packages" pytest -q tests/test_vibe_cli.py tests/test_runtime_service_lock.py tests/test_cli_setup_status.py tests/test_process_diagnostics.py tests/test_process_isolation.py`
- `ruff check vibe/runtime.py tests/test_runtime_service_lock.py tests/test_vibe_cli.py`
- `PYTHONPATH="$PWD:/Users/cyh/.local/share/uv/tools/vibe-remote/lib/python3.13/site-packages" pytest -q tests/test_runtime_service_lock.py tests/test_vibe_cli.py tests/test_cli_setup_status.py tests/test_process_diagnostics.py tests/test_process_isolation.py`

## Risk

The main behavior change is that bare `vibe` no longer forces a restart. Users or automation that truly need a restart should call `vibe restart`; the CLI docs now say that explicitly.
