### PR TITLE
feat(incus): default tenants to vibey user

### DIFF
--- a/docs/INCUS_TENANTS.md
+++ b/docs/INCUS_TENANTS.md
@@ -42,8 +42,8 @@ This creates:
 
 - Incus project: `vr-alice`
 - Instance: `vibe`
-- Linux user inside the instance: `vibe`
-- Work directory: `/home/vibe/work`
+- Linux user inside the instance: `vibey`
+- Work directory: `/home/vibey/work`
 - Vibe Remote Web UI inside the instance: port `5123`
 - Optional host Web UI proxy: `http://127.0.0.1:15123`
 

--- a/docs/INCUS_TENANTS_ZH.md
+++ b/docs/INCUS_TENANTS_ZH.md
@@ -36,8 +36,8 @@ python3 scripts/incus_tenant.py create alice \
 
 - Incus project：`vr-alice`
 - 实例名：`vibe`
-- 实例内 Linux 用户：`vibe`
-- 工作目录：`/home/vibe/work`
+- 实例内 Linux 用户：`vibey`
+- 工作目录：`/home/vibey/work`
 - 实例内 Vibe Remote Web UI：`5123`
 - 可选宿主机 Web UI 代理：`http://127.0.0.1:15123`
 

--- a/docs/plans/incus-tenant-scaffold.md
+++ b/docs/plans/incus-tenant-scaffold.md
@@ -18,7 +18,7 @@ control plane yet.
 - One Incus project per tenant: `vr-<tenant>`.
 - One tenant instance per project: `vibe`.
 - Per-tenant limits live on both the project and the default profile.
-- Cloud-init installs Vibe Remote for a non-root `vibe` user and creates a
+- Cloud-init installs Vibe Remote for a non-root `vibey` user and creates a
   systemd unit that starts/stops the local `vibe` runtime.
 - Optional host port proxy exposes the tenant Web UI for local setup.
 - The script stays standalone Python with no dependencies beyond the Incus CLI.

--- a/scripts/incus_tenant.py
+++ b/scripts/incus_tenant.py
@@ -25,7 +25,7 @@ from typing import Sequence
 
 PROJECT_PREFIX = "vr-"
 INSTANCE_NAME = "vibe"
-TENANT_USER = "vibe"
+TENANT_USER = "vibey"
 TENANT_HOME = f"/home/{TENANT_USER}"
 TENANT_WORKDIR = f"{TENANT_HOME}/work"
 DEFAULT_IMAGE = "images:ubuntu/24.04/cloud"
@@ -252,7 +252,7 @@ def cloud_init_user_data(spec: TenantSpec) -> str:
         "  - python3-venv",
         "  - sudo",
         "users:",
-        "  - name: vibe",
+        f"  - name: {TENANT_USER}",
         "    groups: sudo",
         "    shell: /bin/bash",
         "    sudo: ALL=(ALL) NOPASSWD:ALL",

--- a/tests/test_incus_tenant_scaffold.py
+++ b/tests/test_incus_tenant_scaffold.py
@@ -50,7 +50,9 @@ def test_cloud_init_configures_vibe_user_service_and_ui():
     data = incus_tenant.cloud_init_user_data(tenant_spec())
 
     assert "#cloud-config" in data
-    assert "name: vibe" in data
+    assert "name: vibey" in data
+    assert "User=vibey" in data
+    assert '"default_cwd": "/home/vibey/work"' in data
     assert "ExecStart=/bin/bash -lc 'vibe'" in data
     assert '"setup_host": "0.0.0.0"' in data
     assert '"setup_port": 5123' in data
@@ -113,7 +115,7 @@ def test_exec_dry_run_strips_command_separator(capsys):
     assert exit_code == 0
     output = capsys.readouterr().out
     assert "--user 1000" not in output
-    assert "sudo -H -u vibe" in output
+    assert "sudo -H -u vibey" in output
     assert "exec \"$@\"' bash pwd" in output
 
 
@@ -123,7 +125,7 @@ def test_shell_dry_run_uses_tenant_username(capsys):
     assert exit_code == 0
     output = capsys.readouterr().out
     assert "--user 1000" not in output
-    assert "sudo -H -u vibe" in output
+    assert "sudo -H -u vibey" in output
     assert "exec bash -l" in output
 
 


### PR DESCRIPTION
## What changed

- Change the Incus tenant scaffold default Linux user from vibe to vibey.
- Keep the Incus instance name as vibe so existing tenant operations still target the Vibe Remote service instance.
- Update Incus operator docs and scaffold tests for the new home and workdir paths.

## Evidence

- Unit: pytest -q tests/test_incus_tenant_scaffold.py
- Lint: ruff check scripts/incus_tenant.py tests/test_incus_tenant_scaffold.py
- Syntax: python3 -m py_compile scripts/incus_tenant.py
- Contract/scenario: not applicable; this is an operator scaffold default and docs/test update.
- Manual residual check: searched the Incus scaffold docs/tests for stale default vibe user references.

## Risk

Existing Incus tenants created before this change keep their original Linux users. This changes only newly generated tenant cloud-init and docs.
