### PR TITLE
fix(message): separate user identity prefix

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -320,7 +320,7 @@ class MessageHandler(BaseHandler):
             raw_name = context.user_id
         name = self._sanitize_identity(raw_name)
         uid = self._sanitize_identity(context.user_id)
-        return f"[{name}<{uid}>] {message}"
+        return f"[{name}<{uid}>]\n{message}"
 
     @staticmethod
     def _get_control_message(context: MessageContext, message: str) -> str:

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -359,7 +359,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
 
         result = await handler._prepend_user_info(context, "hello")
 
-        self.assertEqual(result, "[WeChat User<wx-user>] hello")
+        self.assertEqual(result, "[WeChat User<wx-user>]\nhello")
 
     async def test_control_text_handles_mentioned_inline_stop(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)

--- a/tests/test_message_handler_user_info.py
+++ b/tests/test_message_handler_user_info.py
@@ -14,8 +14,13 @@ from modules.im import MessageContext
 def _load_message_handler_class():
     with patch.dict(sys.modules, {}, clear=False):
         agents_module = types.ModuleType("modules.agents")
-        setattr(agents_module, "AgentRequest", type("AgentRequest", (), {}))
+        agents_module.__path__ = []
+        agent_request = type("AgentRequest", (), {})
+        setattr(agents_module, "AgentRequest", agent_request)
         sys.modules["modules.agents"] = agents_module
+        agents_base_module = types.ModuleType("modules.agents.base")
+        setattr(agents_base_module, "AgentRequest", agent_request)
+        sys.modules["modules.agents.base"] = agents_base_module
 
         core_pkg = types.ModuleType("core")
         core_pkg.__path__ = [str(ROOT / "core")]
@@ -72,7 +77,7 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
 
         result = await handler._prepend_user_info(context, "hello")
 
-        self.assertEqual(result, "[Alex<U0E0FM3QT>] hello")
+        self.assertEqual(result, "[Alex<U0E0FM3QT>]\nhello")
 
     async def test_prepend_user_info_uses_display_name_when_present(self):
         handler = MessageHandler(_StubController({"display_name": "Alex Chen", "real_name": "Alex", "name": "cyh"}))
@@ -80,7 +85,7 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
 
         result = await handler._prepend_user_info(context, "hello")
 
-        self.assertEqual(result, "[Alex Chen<U0E0FM3QT>] hello")
+        self.assertEqual(result, "[Alex Chen<U0E0FM3QT>]\nhello")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Separates the injected user identity prefix from the user message body with a newline.

Before:

```text
[Alex<U0E0FM3QT>] hello
```

After:

```text
[Alex<U0E0FM3QT>]
hello
```

## Why

The identity prefix is metadata for the agent, not part of the user's sentence. Keeping it on the same line makes the first token of the user message harder to distinguish from the identity wrapper.

## Capability and scenarios

Changed capability: user identity prefix injection for agent messages.

Scenario IDs: N/A. This path currently has focused unit coverage rather than a scenario catalog entry.

## Evidence layers

Unit: updated message handler user-info and typing tests.

Contract: existing attachment/message handler tests still pass, including the isolated message handler loader.

Scenario: not updated; no scenario catalog exists for this narrow formatting behavior.

Residual manual checks: no local Vibe service restart was performed.

## Validation

- `tests/test_message_handler_user_info.py`
- `tests/test_message_handler_typing.py`
- `tests/test_message_handler_attachments.py`
- Ruff on changed Python files
- `git diff --check`
