### PR TITLE
fix(ui): default theme to system preference

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,36 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@600&display=swap" rel="stylesheet">
+    <script>
+      (function () {
+        var key = "vibe-remote-theme";
+        var validModes = ["system", "light", "dark"];
+        var mode = "system";
+
+        try {
+          var queryMode = new URLSearchParams(window.location.search).get("theme");
+          var storedMode = window.localStorage.getItem(key);
+
+          if (validModes.indexOf(queryMode) !== -1) {
+            mode = queryMode;
+          } else if (validModes.indexOf(storedMode) !== -1) {
+            mode = storedMode;
+          }
+        } catch (error) {
+          mode = "system";
+        }
+
+        var resolvedTheme = mode;
+        if (mode === "system") {
+          resolvedTheme =
+            window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+        }
+
+        document.documentElement.setAttribute("data-theme", resolvedTheme);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 
 export type ThemeMode = 'system' | 'light' | 'dark';
 type ResolvedTheme = 'light' | 'dark';
@@ -12,19 +12,28 @@ type ThemeContextValue = {
 
 const STORAGE_KEY = 'vibe-remote-theme';
 const VALID_MODES: ThemeMode[] = ['system', 'light', 'dark'];
+const DEFAULT_MODE: ThemeMode = 'system';
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function getSystemTheme(): ResolvedTheme {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: light)').matches
+  ) {
+    return 'light';
+  }
+
+  return 'dark';
+}
 
 function resolveTheme(mode: ThemeMode): ResolvedTheme {
   if (mode !== 'system') {
     return mode;
   }
 
-  if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: light)').matches) {
-    return 'light';
-  }
-
-  return 'dark';
+  return getSystemTheme();
 }
 
 function applyTheme(mode: ThemeMode) {
@@ -47,39 +56,48 @@ function readStoredTheme(): ThemeMode {
       return value as ThemeMode;
     }
   } catch {
-    // Ignore storage issues and fall back to the design's default dark canvas.
+    // Ignore storage issues and fall back to following the system preference.
   }
 
-  return 'dark';
+  return DEFAULT_MODE;
 }
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [mode, setModeState] = useState<ThemeMode>('dark');
-  const resolvedTheme = useMemo(() => resolveTheme(mode), [mode]);
+  const [mode, setModeState] = useState<ThemeMode>(() => readStoredTheme());
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() => resolveTheme(DEFAULT_MODE));
+  const resolvedTheme = mode === 'system' ? systemTheme : mode;
 
   useEffect(() => {
-    const nextMode = readStoredTheme();
-    setModeState(nextMode);
-    applyTheme(nextMode);
+    applyTheme(mode);
+  }, [mode, systemTheme]);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      return;
+    }
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: light)');
     const handleChange = () => {
-      if (readStoredTheme() === 'system') {
-        applyTheme('system');
-      }
+      setSystemTheme(resolveTheme(DEFAULT_MODE));
     };
 
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
   }, []);
 
   const setMode = (nextMode: ThemeMode) => {
     setModeState(nextMode);
+    setSystemTheme(resolveTheme(DEFAULT_MODE));
 
     try {
       // Persist all modes including "system" so the choice survives reloads;
-      // removing the key would let readStoredTheme() fall back to the dark
-      // default and silently drop system-follow behavior.
+      // removing the key would let readStoredTheme() fall back to the default
+      // mode and silently drop system-follow behavior.
       window.localStorage.setItem(STORAGE_KEY, nextMode);
     } catch {
       // Ignore storage issues.


### PR DESCRIPTION
## What changed

- Default the Web UI theme mode to `system` when the user has not saved a preference.
- Keep persisting explicit user choices for `system`, `light`, and `dark`.
- Set the initial `data-theme` before React loads so first paint follows the selected or system theme without a dark-theme flash.
- Add a `matchMedia` fallback for older browsers or embedded WebViews.

## Why

The theme toggle supported `system`, but the no-preference fallback was hard-coded to dark. That made first-time visits show dark mode even when the OS preference was light.

## Scenario coverage

No existing scenario catalog ID appears to cover Web UI theme preference behavior.

## Evidence layers

- Unit: focused Node validation for first visit, stored preferences, `?theme=` override, and missing `matchMedia` bootstrap behavior.
- Contract: not applicable; this is local browser preference behavior.
- Scenario: not updated; no matching catalog scenario exists.
- Residual manual checks: production UI build completed successfully.

## Validation

- `npm run build` passed.
- Focused bootstrap validation passed for default system light/dark, stored `system`, stored `dark`, query override, and missing `matchMedia`.
- `npm run lint` was run and is still blocked by pre-existing front-end lint debt across the repo; this branch did not introduce new broad lint cleanup.
