### PR TITLE
refactor(ui): let css own system theme

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,7 @@ jobs:
         working-directory: ui
         run: |
           npm ci
+          npm run validate:theme
           npm run build
 
       - uses: actions/setup-python@v6
@@ -90,6 +91,7 @@ jobs:
         working-directory: ui
         run: |
           npm ci
+          npm run validate:theme
           npm run build
 
       - uses: actions/setup-python@v6

--- a/ui/index.html
+++ b/ui/index.html
@@ -11,31 +11,24 @@
     <script>
       (function () {
         var key = "vibe-remote-theme";
-        var validModes = ["system", "light", "dark"];
-        var mode = "system";
+        var mode = null;
 
         try {
           var queryMode = new URLSearchParams(window.location.search).get("theme");
           var storedMode = window.localStorage.getItem(key);
 
-          if (validModes.indexOf(queryMode) !== -1) {
+          if (queryMode === "light" || queryMode === "dark" || queryMode === "system") {
             mode = queryMode;
-          } else if (validModes.indexOf(storedMode) !== -1) {
+          } else if (storedMode === "light" || storedMode === "dark" || storedMode === "system") {
             mode = storedMode;
           }
         } catch (error) {
-          mode = "system";
+          mode = null;
         }
 
-        var resolvedTheme = mode;
-        if (mode === "system") {
-          resolvedTheme =
-            window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches
-              ? "light"
-              : "dark";
+        if (mode === "light" || mode === "dark") {
+          document.documentElement.setAttribute("data-theme", mode);
         }
-
-        document.documentElement.setAttribute("data-theme", resolvedTheme);
       })();
     </script>
   </head>

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "validate:theme": "node scripts/validate-theme.mjs"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -1,0 +1,164 @@
+import fs from 'node:fs';
+import vm from 'node:vm';
+import postcss from 'postcss';
+
+const html = fs.readFileSync('index.html', 'utf8');
+const css = fs.readFileSync('src/index.css', 'utf8');
+
+function extractThemeBootstrap() {
+  const match = html.match(/<script>\r?\n([\s\S]*?)\r?\n\s*<\/script>/);
+  if (!match) {
+    throw new Error('Theme bootstrap script was not found in index.html');
+  }
+  return match[1];
+}
+
+function runBootstrap({ search = '', stored = null }) {
+  const attrs = {};
+  const context = {
+    URLSearchParams,
+    window: {
+      location: { search },
+      localStorage: { getItem: () => stored },
+    },
+    document: {
+      documentElement: {
+        setAttribute: (name, value) => {
+          attrs[name] = value;
+        },
+      },
+    },
+  };
+
+  vm.runInNewContext(extractThemeBootstrap(), context);
+  return attrs['data-theme'] ?? null;
+}
+
+function assertEqual(name, actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`${name}: expected ${expected ?? 'system-css'}, got ${actual ?? 'system-css'}`);
+  }
+}
+
+function normalizeCssValue(value) {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function mediaApplies(rule, prefersLight) {
+  let node = rule.parent;
+  while (node) {
+    if (node.type === 'atrule' && node.name === 'media') {
+      if (node.params === '(prefers-color-scheme: light)' && !prefersLight) {
+        return false;
+      }
+    }
+    node = node.parent;
+  }
+
+  return true;
+}
+
+function selectorMatches(selector, themeAttr) {
+  switch (selector.trim()) {
+    case ':root':
+      return true;
+    case '[data-theme="dark"]':
+      return themeAttr === 'dark';
+    case '[data-theme="light"]':
+      return themeAttr === 'light';
+    case ':root:not([data-theme="dark"])':
+      return themeAttr !== 'dark';
+    default:
+      return false;
+  }
+}
+
+function selectorSpecificity(selector) {
+  const idCount = (selector.match(/#/g) ?? []).length;
+  const classLikeCount = (selector.match(/(\.|:|\[)/g) ?? []).length;
+  const elementCount = selector.replace(/#[\w-]+|[.][\w-]+|:[\w-]+(?:\([^)]*\))?|\[[^\]]+\]/g, '').trim()
+    ? 1
+    : 0;
+  return idCount * 100 + classLikeCount * 10 + elementCount;
+}
+
+function splitSelectors(selectorText) {
+  return selectorText.split(',').map((selector) => selector.trim());
+}
+
+function resolveThemeTokens({ prefersLight, themeAttr }) {
+  const root = postcss.parse(css);
+  const resolved = new Map();
+  let order = 0;
+
+  root.walkRules((rule) => {
+    if (!mediaApplies(rule, prefersLight)) {
+      return;
+    }
+
+    const matchingSpecificity = splitSelectors(rule.selector)
+      .filter((selector) => selectorMatches(selector, themeAttr))
+      .reduce((highest, selector) => Math.max(highest, selectorSpecificity(selector)), -1);
+
+    if (matchingSpecificity === -1) {
+      return;
+    }
+
+    rule.walkDecls((decl) => {
+      if (decl.prop !== 'color-scheme' && !decl.prop.startsWith('--')) {
+        return;
+      }
+
+      const previous = resolved.get(decl.prop);
+      if (!previous || matchingSpecificity > previous.specificity || (matchingSpecificity === previous.specificity && order > previous.order)) {
+        resolved.set(decl.prop, {
+          order,
+          specificity: matchingSpecificity,
+          value: normalizeCssValue(decl.value),
+        });
+      }
+    });
+
+    order += 1;
+  });
+
+  return new Map([...resolved.entries()].map(([key, entry]) => [key, entry.value]));
+}
+
+function assertTokenMapsEqual(name, actual, expected) {
+  const actualKeys = [...actual.keys()].sort();
+  const expectedKeys = [...expected.keys()].sort();
+  assertEqual(`${name} token count`, actualKeys.length, expectedKeys.length);
+
+  for (const key of expectedKeys) {
+    assertEqual(`${name} ${key}`, actual.get(key), expected.get(key));
+  }
+}
+
+const bootstrapCases = [
+  ['first visit leaves system to CSS', runBootstrap({}), null],
+  ['stored system leaves system to CSS', runBootstrap({ stored: 'system' }), null],
+  ['stored light restores explicit override', runBootstrap({ stored: 'light' }), 'light'],
+  ['stored dark restores explicit override', runBootstrap({ stored: 'dark' }), 'dark'],
+  ['query system clears stored dark override', runBootstrap({ search: '?theme=system', stored: 'dark' }), null],
+  ['query light wins over stored dark', runBootstrap({ search: '?theme=light', stored: 'dark' }), 'light'],
+  ['invalid stored value leaves system to CSS', runBootstrap({ stored: 'sepia' }), null],
+];
+
+for (const [name, actual, expected] of bootstrapCases) {
+  assertEqual(name, actual, expected);
+}
+
+const systemDark = resolveThemeTokens({ prefersLight: false, themeAttr: null });
+const systemLight = resolveThemeTokens({ prefersLight: true, themeAttr: null });
+const explicitDark = resolveThemeTokens({ prefersLight: true, themeAttr: 'dark' });
+const explicitLight = resolveThemeTokens({ prefersLight: false, themeAttr: 'light' });
+
+assertTokenMapsEqual('system light and explicit light cascade', systemLight, explicitLight);
+assertTokenMapsEqual('system dark and explicit dark cascade', systemDark, explicitDark);
+assertEqual('system light background', systemLight.get('--background'), '#f4f6fb');
+assertEqual('system dark background', systemDark.get('--background'), '#080812');
+assertEqual('system light color-scheme', systemLight.get('color-scheme'), 'light');
+assertEqual('system dark color-scheme', systemDark.get('color-scheme'), 'dark');
+
+console.log('Theme bootstrap and CSS token validation passed.');

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -41,7 +41,12 @@ function applyTheme(mode: ThemeMode) {
     return;
   }
 
-  document.documentElement.setAttribute('data-theme', resolveTheme(mode));
+  if (mode === 'system') {
+    document.documentElement.removeAttribute('data-theme');
+    return;
+  }
+
+  document.documentElement.setAttribute('data-theme', mode);
 }
 
 function readStoredTheme(): ThemeMode {
@@ -69,7 +74,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useEffect(() => {
     applyTheme(mode);
-  }, [mode, systemTheme]);
+  }, [mode]);
 
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -64,6 +64,8 @@
 
 :root,
 [data-theme="dark"] {
+  color-scheme: dark;
+
   --background: #080812;
   --foreground: #f5f1e8;
   --surface: #0e0e18;
@@ -132,7 +134,85 @@
   --bg-page: var(--gradient-console);
 }
 
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    color-scheme: light;
+
+    --background: #f4f6fb;
+    --foreground: #0a0a14;
+    --surface: #ffffff;
+    --surface-2: #ffffff;
+    --surface-3: #eef1f7;
+    --card: #ffffff;
+    --card-foreground: #0a0a14;
+    --popover: #ffffff;
+    --popover-foreground: #0a0a14;
+
+    --primary: #10b981;
+    --primary-foreground: #ffffff;
+    --secondary: #eef1f7;
+    --secondary-foreground: #0a0a14;
+    --muted: #5c6079;
+    --muted-soft: #eef1f7;
+    --accent: #0891b2;
+    --accent-foreground: #ffffff;
+    --destructive: #e11d48;
+    --destructive-foreground: #ffffff;
+
+    --border: rgba(8, 8, 18, 0.08);
+    --border-strong: rgba(8, 8, 18, 0.14);
+    --input: rgba(8, 8, 18, 0.12);
+    --ring: rgba(16, 185, 129, 0.5);
+
+    --mint: #10b981;
+    --mint-soft: rgba(16, 185, 129, 0.14);
+    --cyan: #0891b2;
+    --cyan-soft: rgba(8, 145, 178, 0.14);
+    --violet: #7c3aed;
+    --violet-soft: rgba(124, 58, 237, 0.14);
+    --gold: #d97706;
+    --gold-foreground: #ffffff;
+
+    /* Light-theme page gradients (softer alphas over light base). */
+    --gradient-console:
+      radial-gradient(50% 40% at 5% 5%, rgba(16, 185, 129, 0.10), rgba(16, 185, 129, 0) 100%),
+      radial-gradient(40% 50% at 95% 40%, rgba(8, 145, 178, 0.08), rgba(8, 145, 178, 0) 100%),
+      radial-gradient(60% 50% at 50% 100%, rgba(124, 58, 237, 0.06), rgba(124, 58, 237, 0) 100%),
+      #f4f6fb;
+    --gradient-settings:
+      radial-gradient(50% 40% at 5% 5%, rgba(16, 185, 129, 0.10), rgba(16, 185, 129, 0) 100%),
+      radial-gradient(50% 50% at 95% 50%, rgba(124, 58, 237, 0.08), rgba(124, 58, 237, 0) 100%),
+      #f4f6fb;
+    --gradient-wizard-welcome:
+      radial-gradient(70% 60% at 50% 30%, rgba(16, 185, 129, 0.12), rgba(16, 185, 129, 0) 100%),
+      radial-gradient(50% 50% at 85% 70%, rgba(8, 145, 178, 0.08), rgba(8, 145, 178, 0) 100%),
+      #f4f6fb;
+    --gradient-wizard-backends:
+      radial-gradient(60% 50% at 50% 20%, rgba(124, 58, 237, 0.10), rgba(124, 58, 237, 0) 100%),
+      #f4f6fb;
+    --gradient-wizard-platforms:
+      radial-gradient(60% 50% at 50% 20%, rgba(16, 185, 129, 0.12), rgba(16, 185, 129, 0) 100%),
+      radial-gradient(40% 40% at 85% 70%, rgba(8, 145, 178, 0.08), rgba(8, 145, 178, 0) 100%),
+      radial-gradient(40% 40% at 15% 70%, rgba(124, 58, 237, 0.08), rgba(124, 58, 237, 0) 100%),
+      #f4f6fb;
+    --gradient-wizard-slack:
+      radial-gradient(50% 50% at 30% 20%, rgba(224, 30, 90, 0.08), rgba(224, 30, 90, 0) 100%),
+      #f4f6fb;
+    --gradient-wizard-summary:
+      radial-gradient(60% 50% at 30% 30%, rgba(16, 185, 129, 0.12), rgba(16, 185, 129, 0) 100%),
+      #f4f6fb;
+
+    --bg-page: var(--gradient-console);
+
+    /* Light card glow — much softer than dark. */
+    --shadow-mint-card: 0 12px 24px -16px rgba(16, 185, 129, 0.20);
+    --shadow-mint-card-lg: 0 16px 32px -16px rgba(16, 185, 129, 0.22);
+  }
+}
+
 [data-theme="light"] {
+  color-scheme: light;
+
   --background: #f4f6fb;
   --foreground: #0a0a14;
   --surface: #ffffff;


### PR DESCRIPTION
## What changed

- Make `system` theme mode CSS-native: React removes `data-theme` for system, while explicit `light` and `dark` still set `data-theme` as overrides.
- Move first-paint bootstrap back to a smaller responsibility: restore only explicit `light` / `dark` choices before React loads.
- Add CSS `prefers-color-scheme: light` handling so no `data-theme` means follow the OS preference.
- Add `npm run validate:theme` and run it in CI before UI builds on Linux and Windows.

## Why

PR #291 fixed the default behavior, but the first-paint script and React provider both resolved `system` into a concrete `light` / `dark` DOM attribute. That worked, but it kept duplicated theme resolution logic in two places. This refactor makes `system` a real CSS state: absence of `data-theme` means the browser owns OS preference matching.

## Scenario coverage

No existing scenario catalog ID appears to cover Web UI theme preference behavior.

## Evidence layers

- Unit: `npm run validate:theme` covers bootstrap priority and CSS cascade equivalence for system/explicit light and dark.
- Contract: not applicable; this is local browser preference behavior.
- Scenario: not updated; no matching catalog scenario exists.
- Residual manual checks: production UI build completed successfully; reviewer subagent passed after CRLF and cascade validation fixes.

## Validation

- `npm run validate:theme` passed.
- CRLF bootstrap extraction check passed.
- `npm run build` passed.
- Targeted eslint on `scripts/validate-theme.mjs` and `ThemeContext.tsx` still hits the repo's existing `react-refresh/only-export-components` issue in `ThemeContext.tsx`; no new script lint error was reported.
