### PR TITLE
feat(messages): include current time metadata

### DIFF
--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -65,6 +65,7 @@ class AppCompatConfig:
     codex: Optional[CodexCompatConfig] = None
     opencode: Optional[OpenCodeCompatConfig] = None
     show_duration: bool = False
+    include_time_info: bool = True
     include_user_info: bool = True
     reply_enhancements: bool = True
     default_backend: str = DEFAULT_AGENT_BACKEND
@@ -123,6 +124,7 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
         ack_mode=v2.ack_mode,
         language=v2.language,
         show_duration=v2.show_duration,
+        include_time_info=v2.include_time_info,
         include_user_info=v2.include_user_info,
         reply_enhancements=v2.reply_enhancements,
         default_backend=v2.agents.default_backend,

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -268,6 +268,7 @@ class V2Config:
     update: UpdateConfig = field(default_factory=UpdateConfig)
     ack_mode: str = "typing"
     show_duration: bool = False  # Show task duration in result messages
+    include_time_info: bool = True  # Prepend current local time to agent messages
     include_user_info: bool = True  # Prepend user identity to agent messages
     reply_enhancements: bool = True  # Enable quick-reply buttons
     language: str = "en"  # Global language setting (see vibe/i18n)
@@ -421,6 +422,10 @@ class V2Config:
         if not isinstance(include_user_info, bool):
             include_user_info = True
 
+        include_time_info = payload.get("include_time_info", True)
+        if not isinstance(include_time_info, bool):
+            include_time_info = True
+
         reply_enhancements = payload.get("reply_enhancements", True)
         if not isinstance(reply_enhancements, bool):
             reply_enhancements = True
@@ -446,6 +451,7 @@ class V2Config:
             update=update,
             ack_mode=ack_mode,
             show_duration=show_duration,
+            include_time_info=include_time_info,
             include_user_info=include_user_info,
             reply_enhancements=reply_enhancements,
             language=language,
@@ -493,6 +499,7 @@ class V2Config:
             "update": self.update.__dict__,
             "ack_mode": self.ack_mode,
             "show_duration": self.show_duration,
+            "include_time_info": self.include_time_info,
             "include_user_info": self.include_user_info,
             "reply_enhancements": self.reply_enhancements,
             "language": self.language,

--- a/core/controller.py
+++ b/core/controller.py
@@ -178,7 +178,7 @@ class Controller:
         """Hot-reload mutable message-processing settings from config.json.
 
         Called on every ``_t()`` invocation (guarded by mtime check).
-        Refreshes: language, show_duration, ack_mode, include_user_info,
+        Refreshes: language, show_duration, ack_mode, include_time_info, include_user_info,
         reply_enhancements, and mutable platform message filters.
         """
         try:
@@ -193,6 +193,7 @@ class Controller:
                 self.config.language = v2_config.language
                 self.config.show_duration = v2_config.show_duration
                 self.config.ack_mode = v2_config.ack_mode
+                self.config.include_time_info = v2_config.include_time_info
                 self.config.include_user_info = v2_config.include_user_info
                 self.config.reply_enhancements = v2_config.reply_enhancements
 

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -1,6 +1,7 @@
 """Message routing and Agent communication handlers"""
 
 import logging
+from datetime import datetime
 from typing import List, Optional, Tuple
 
 from modules.agents.base import AgentRequest
@@ -250,9 +251,7 @@ class MessageHandler(BaseHandler):
                 if processed_files:
                     logger.info(f"Processed {len(processed_files)} file attachments for message")
 
-            # Prepend user identity when include_user_info is enabled
-            if is_human and self.config.include_user_info:
-                message = await self._prepend_user_info(context, message)
+            message = await self._prepend_message_metadata(context, message, include_user_info=is_human)
 
             message = self._append_attachment_errors(message, attachment_errors)
 
@@ -312,6 +311,40 @@ class MessageHandler(BaseHandler):
 
     async def _prepend_user_info(self, context: MessageContext, message: str) -> str:
         """Prepend user identity as [username<user_id>] to the message."""
+        user_info_line = await self._build_user_info_line(context)
+        return f"{user_info_line}\n{message}"
+
+    async def _prepend_message_metadata(
+        self,
+        context: MessageContext,
+        message: str,
+        *,
+        include_user_info: bool,
+    ) -> str:
+        """Prepend configured per-turn metadata lines to the agent message."""
+        metadata_lines: list[str] = []
+        if getattr(self.config, "include_time_info", True):
+            metadata_lines.append(self._build_current_time_line())
+        if include_user_info and getattr(self.config, "include_user_info", True):
+            metadata_lines.append(await self._build_user_info_line(context))
+
+        if not metadata_lines:
+            return message
+        return "\n".join([*metadata_lines, message])
+
+    @staticmethod
+    def _build_current_time_line(now: datetime | None = None) -> str:
+        """Return the current local time with seconds and UTC offset."""
+        current = now or datetime.now().astimezone()
+        if current.tzinfo is None:
+            current = current.astimezone()
+        offset = current.strftime("%z")
+        if len(offset) == 5:
+            offset = f"{offset[:3]}:{offset[3:]}"
+        return f"[Current Time: {current.strftime('%Y-%m-%d %H:%M:%S')} UTC{offset}]"
+
+    async def _build_user_info_line(self, context: MessageContext) -> str:
+        """Return user identity as [username<user_id>]."""
         try:
             user_info = await self._get_im_client(context).get_user_info(context.user_id)
             raw_name = self._resolve_user_display_name(user_info, context.user_id)
@@ -320,7 +353,7 @@ class MessageHandler(BaseHandler):
             raw_name = context.user_id
         name = self._sanitize_identity(raw_name)
         uid = self._sanitize_identity(context.user_id)
-        return f"[{name}<{uid}>]\n{message}"
+        return f"[{name}<{uid}>]"
 
     @staticmethod
     def _get_control_message(context: MessageContext, message: str) -> str:

--- a/scripts/incus_tenant.py
+++ b/scripts/incus_tenant.py
@@ -183,6 +183,7 @@ def default_config(spec: TenantSpec) -> dict:
         "update": {},
         "ack_mode": "typing",
         "show_duration": False,
+        "include_time_info": True,
         "include_user_info": True,
         "reply_enhancements": True,
         "language": "en",

--- a/scripts/prepare_three_regression.py
+++ b/scripts/prepare_three_regression.py
@@ -220,6 +220,7 @@ def _build_config_payload() -> dict:
         },
         "ack_mode": "reaction",
         "show_duration": True,
+        "include_time_info": True,
         "include_user_info": True,
         "reply_enhancements": True,
         "language": _env("THREE_REGRESSION_LANGUAGE", "en"),

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -307,6 +307,7 @@ Important config payload shape:
   "ack_mode": "typing",
   "language": "en",
   "show_duration": false,
+  "include_time_info": true,
   "include_user_info": true,
   "reply_enhancements": true
 }

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -76,6 +76,7 @@ def _full_config_payload() -> dict:
         },
         "ack_mode": "reaction",
         "show_duration": True,
+        "include_time_info": True,
         "include_user_info": True,
         "reply_enhancements": True,
         "language": "en",
@@ -87,11 +88,13 @@ def test_save_config_merges_partial_payload(monkeypatch, tmp_path):
 
     original = api.save_config(_full_config_payload())
     assert original.show_duration is True
+    assert original.include_time_info is True
     assert original.update.auto_update is False
 
-    updated = api.save_config({"show_duration": False, "update": {"auto_update": True}})
+    updated = api.save_config({"show_duration": False, "include_time_info": False, "update": {"auto_update": True}})
 
     assert updated.show_duration is False
+    assert updated.include_time_info is False
     assert updated.update.auto_update is True
     assert updated.platform == "discord"
     assert updated.discord is not None
@@ -108,6 +111,17 @@ def test_save_config_defaults_show_duration_to_false_for_new_config(monkeypatch,
     created = api.save_config(payload)
 
     assert created.show_duration is False
+
+
+def test_save_config_defaults_include_time_info_to_true_for_new_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    payload = _full_config_payload()
+    payload.pop("include_time_info")
+
+    created = api.save_config(payload)
+
+    assert created.include_time_info is True
 
 
 def test_save_config_accepts_typing_ack_mode(monkeypatch, tmp_path):

--- a/tests/test_message_handler_auth_setup.py
+++ b/tests/test_message_handler_auth_setup.py
@@ -95,7 +95,13 @@ class _StubIMClient:
 
 class _StubController:
     def __init__(self):
-        self.config = types.SimpleNamespace(platform="slack", ack_mode="reaction", include_user_info=False, language="en")
+        self.config = types.SimpleNamespace(
+            platform="slack",
+            ack_mode="reaction",
+            include_time_info=False,
+            include_user_info=False,
+            language="en",
+        )
         self.im_client = _StubIMClient()
         self.settings_manager = _StubSettingsManager()
         self.session_manager = object()

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -163,7 +163,13 @@ class _StubController:
         self.config = type(
             "Config",
             (),
-            {"platform": platform, "ack_mode": ack_mode, "include_user_info": False, "language": "en"},
+            {
+                "platform": platform,
+                "ack_mode": ack_mode,
+                "include_time_info": False,
+                "include_user_info": False,
+                "language": "en",
+            },
         )()
         self.im_client = _StubIMClient(typing_result=typing_result)
         self.settings_manager = _StubSettingsManager()

--- a/tests/test_message_handler_user_info.py
+++ b/tests/test_message_handler_user_info.py
@@ -2,6 +2,7 @@ import importlib.util
 import sys
 import types
 import unittest
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -71,6 +72,13 @@ class _StubController:
 
 
 class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
+    def test_build_current_time_line_uses_readable_utc_offset(self):
+        line = MessageHandler._build_current_time_line(
+            datetime(2026, 5, 13, 11, 42, 8, tzinfo=timezone(timedelta(hours=8)))
+        )
+
+        self.assertEqual(line, "[Current Time: 2026-05-13 11:42:08 UTC+08:00]")
+
     async def test_prepend_user_info_prefers_real_name_over_name(self):
         handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
         context = MessageContext(user_id="U0E0FM3QT", channel_id="C1")
@@ -86,6 +94,28 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
         result = await handler._prepend_user_info(context, "hello")
 
         self.assertEqual(result, "[Alex Chen<U0E0FM3QT>]\nhello")
+
+    async def test_prepend_message_metadata_includes_time_above_user_info(self):
+        handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
+        handler.config.include_time_info = True
+        handler.config.include_user_info = True
+        handler._build_current_time_line = lambda: "[Current Time: 2026-05-13 11:42:08 UTC+08:00]"  # type: ignore[method-assign]
+        context = MessageContext(user_id="U0E0FM3QT", channel_id="C1")
+
+        result = await handler._prepend_message_metadata(context, "hello", include_user_info=True)
+
+        self.assertEqual(result, "[Current Time: 2026-05-13 11:42:08 UTC+08:00]\n[Alex<U0E0FM3QT>]\nhello")
+
+    async def test_prepend_message_metadata_can_include_time_without_user_info(self):
+        handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
+        handler.config.include_time_info = True
+        handler.config.include_user_info = True
+        handler._build_current_time_line = lambda: "[Current Time: 2026-05-13 11:42:08 UTC+08:00]"  # type: ignore[method-assign]
+        context = MessageContext(user_id="U0E0FM3QT", channel_id="C1")
+
+        result = await handler._prepend_message_metadata(context, "scheduled work", include_user_info=False)
+
+        self.assertEqual(result, "[Current Time: 2026-05-13 11:42:08 UTC+08:00]\nscheduled work")
 
 
 if __name__ == "__main__":

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -23,6 +23,7 @@ const SAVE_KEYS = [
   'platforms',
   'ack_mode',
   'show_duration',
+  'include_time_info',
   'include_user_info',
   'reply_enhancements',
   'slack',
@@ -104,6 +105,7 @@ export const SettingsMessagingPage: React.FC = () => {
     { value: 'reaction', label: t('dashboard.ackReaction'), disabled: !reactionSupported },
     { value: 'message', label: t('dashboard.ackMessage'), disabled: false },
   ];
+  const includeTimeInfoEnabled = config.include_time_info !== false;
 
   return (
     <SettingsPageShell
@@ -191,6 +193,19 @@ export const SettingsMessagingPage: React.FC = () => {
             <ToggleSwitch
               enabled={config.show_duration !== false}
               onClick={() => void persist({ ...config, show_duration: !config.show_duration })}
+            />
+          }
+        />
+
+        <SettingsRow
+          title={t('dashboard.includeTimeInfo')}
+          description={t('dashboard.includeTimeInfoHint')}
+          control={
+            <ToggleSwitch
+              enabled={includeTimeInfoEnabled}
+              onClick={() =>
+                void persist({ ...config, include_time_info: !includeTimeInfoEnabled })
+              }
             />
           }
         />

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -688,6 +688,8 @@
     "errorRetryLimitHint": "Auto-retry with 'continue' when LLM stream errors occur (0 = no retry)",
     "showDuration": "Show Duration",
     "showDurationHint": "Display task elapsed time in result messages",
+    "includeTimeInfo": "Include Current Time",
+    "includeTimeInfoHint": "Prepend the current local time, including seconds and UTC offset, to messages sent to agents",
     "includeUserInfo": "Include User Info",
     "includeUserInfoHint": "Prepend [username<user_id>] to messages sent to agents",
     "replyEnhancements": "Quick-reply Buttons",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -688,6 +688,8 @@
     "errorRetryLimitHint": "当 LLM 流式响应出错时，自动发送 'continue' 重试（0 = 不重试）",
     "showDuration": "显示耗时",
     "showDurationHint": "在结果消息中显示任务耗时",
+    "includeTimeInfo": "携带时间信息",
+    "includeTimeInfoHint": "在发给 Agent 的消息前添加当前本地时间（精确到秒，包含 UTC 时区偏移）",
     "includeUserInfo": "携带用户信息",
     "includeUserInfoHint": "在发给 Agent 的消息前添加 [用户名<用户ID>]",
     "replyEnhancements": "快捷回复按钮",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -356,6 +356,7 @@ def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dic
         "ack_mode": config.ack_mode,
         "language": config.language,
         "show_duration": config.show_duration,
+        "include_time_info": config.include_time_info,
         "include_user_info": config.include_user_info,
         "reply_enhancements": config.reply_enhancements,
     }


### PR DESCRIPTION
## Summary

Adds a global message setting for carrying the current local time into agent turns. When enabled, Vibe Remote prepends a Current Time metadata line with seconds and UTC offset before existing user identity metadata. The switch defaults on for new and existing configs.

The metadata injection is shared by the message handling path, so human messages, hooks, scheduled tasks, and watches can all benefit from the same timestamp context. User identity metadata remains limited to human messages.

## UI

Adds a Messaging settings toggle named Include Current Time / 携带时间信息. The existing include-user-info setting remains separate.

## Scenario IDs

N/A. This capability is not represented in the current scenario catalog; coverage was added at unit and config-contract level.

## Evidence

- Unit: message metadata formatting/order, scheduled-style metadata without user info, existing user-info behavior
- Contract/config: save-config merge/default behavior, config payload registry, controller hot reload
- UI build: Settings page type/build validation
- Residual manual checks: not run; behavior is covered by deterministic formatter/config tests

## Validation

- npm run build
- uv run pytest tests/test_message_handler_user_info.py tests/test_message_handler_typing.py tests/test_message_handler_auth_setup.py tests/test_api_save_config_merge.py
- uv run pytest tests/test_controller_config_reload.py tests/test_v2_config_platform_registry.py tests/test_discord_guild_settings.py
- uv run ruff check core/handlers/message_handler.py config/v2_config.py config/v2_compat.py core/controller.py vibe/api.py tests/test_message_handler_user_info.py tests/test_message_handler_typing.py tests/test_message_handler_auth_setup.py tests/test_api_save_config_merge.py scripts/prepare_three_regression.py scripts/incus_tenant.py
- git diff --check