### PR TITLE
fix(codex): pin supports_websockets=false when custom base_url is set

### DIFF
--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -171,6 +171,61 @@ def test_apply_preserves_user_owned_model_provider(tmp_path: Path) -> None:
     assert parsed["model_providers"]["OpenAI"]["base_url"] == "https://relay.example/v1"
 
 
+def test_apply_api_key_with_base_url_pins_supports_websockets_off(tmp_path: Path) -> None:
+    """Custom relays don't speak Codex's WSS responses protocol.
+
+    Newer Codex versions otherwise dispatch the WebSocket transport via
+    the built-in OpenAI provider's default ``wss://api.openai.com/...``
+    URL — silently bypassing the configured relay and producing 401s.
+    """
+    home = tmp_path
+    (home / ".codex").mkdir()
+
+    codex_config.apply_codex_auth(
+        auth_mode="api_key",
+        api_key="sk-relay-key",
+        base_url="https://relay.example.com",
+        home=home,
+    )
+
+    parsed = tomllib.loads((home / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    managed = parsed["model_providers"][codex_config.MANAGED_PROVIDER_ID]
+    assert managed["base_url"] == "https://relay.example.com"
+    assert managed["supports_websockets"] is False
+
+
+def test_apply_api_key_without_base_url_strips_supports_websockets(tmp_path: Path) -> None:
+    """Clearing a previously-set relay must remove our WSS pin.
+
+    Otherwise a user who switches back to the official OpenAI endpoint
+    would stay on the HTTP path forever, losing the WSS transport that
+    works correctly against ``api.openai.com``.
+    """
+    home = tmp_path
+    codex_home = home / ".codex"
+    codex_home.mkdir()
+    seed = (
+        f'model_provider = "{codex_config.MANAGED_PROVIDER_ID}"\n'
+        "\n"
+        f"[model_providers.{codex_config.MANAGED_PROVIDER_ID}]\n"
+        'base_url = "https://relay.example.com"\n'
+        "supports_websockets = false\n"
+    )
+    (codex_home / "config.toml").write_text(seed, encoding="utf-8")
+
+    codex_config.apply_codex_auth(
+        auth_mode="api_key",
+        api_key="sk-no-relay",
+        base_url=None,
+        home=home,
+    )
+
+    parsed = tomllib.loads((codex_home / "config.toml").read_text(encoding="utf-8"))
+    managed = parsed["model_providers"][codex_config.MANAGED_PROVIDER_ID]
+    assert "base_url" not in managed
+    assert "supports_websockets" not in managed
+
+
 def test_round_trip_datetime_scalars() -> None:
     """``tomllib`` returns datetime/date/time for temporal TOML values; the
     emitter must round-trip them unquoted instead of crashing on the

--- a/vibe/codex_config.py
+++ b/vibe/codex_config.py
@@ -358,8 +358,24 @@ def apply_codex_auth(
         managed.setdefault("requires_openai_auth", True)
         if base_url:
             managed["base_url"] = base_url
+            # Custom relays almost never speak Codex's bespoke responses-
+            # over-WebSocket protocol — they reverse-proxy HTTPS to OpenAI
+            # but don't accept the WSS upgrade Codex expects on
+            # ``/responses``. Codex 0.130+ gates that transport on this
+            # field (``codex-rs/core/src/client.rs::responses_websocket_enabled``);
+            # pinning it to false routes turns through the HTTP responses
+            # path, which honors our ``base_url``. Leaving it absent lets
+            # newer Codex versions dispatch WSS via the built-in OpenAI
+            # provider's default (``wss://api.openai.com/v1/responses``),
+            # silently bypassing the user's relay and producing 401s on
+            # whatever account-bound key the relay handed out.
+            managed["supports_websockets"] = False
         else:
             managed.pop("base_url", None)
+            # No custom base_url → user is on the built-in OpenAI endpoint
+            # where WSS works the way Codex expects. Drop our override so
+            # Codex's own default-on behavior applies.
+            managed.pop("supports_websockets", None)
     else:  # oauth
         auth_data.pop("OPENAI_API_KEY", None)
         # Flip auth_mode back to chatgpt when OAuth tokens still exist


### PR DESCRIPTION
## Summary

Custom Codex relays (Cloudflare workers, nginx reverse proxies, OpenAI-compatible gateways like `ai-relay.chainbot.io`) reverse-proxy HTTPS to OpenAI's Responses API but do **not** implement Codex's bespoke responses-over-WebSocket protocol. Codex 0.130+ still ends up dispatching the WSS transport via the built-in OpenAI provider's default URL (`wss://api.openai.com/v1/responses`) when our managed provider section omits `supports_websockets` — silently bypassing the user's configured `base_url` and producing a 401 on whatever account-bound key the relay handed out.

This change makes the Settings → Codex → API key flow write `supports_websockets = false` whenever a custom `base_url` is present, and pops it when the user clears `base_url` back to the official OpenAI endpoint (where WSS works as designed).

### What was happening before

1. User configures `base_url = https://relay.example` + relay-issued API key via Web UI.
2. Vibe writes `[model_providers.openai-managed]` with `base_url` but no `supports_websockets`.
3. Codex's runtime resolves the WSS transport through the built-in `openai` provider (default `https://api.openai.com/v1`, `supports_websockets: true` baked in).
4. WSS request hits `wss://api.openai.com/v1/responses` with the relay-issued key.
5. OpenAI rejects: `401 Unauthorized: Incorrect API key provided: sk-…`.

The HTTP `/v1/responses` path (which honors `base_url`) worked all along — only the WSS path was leaking to the official endpoint. `responses_websocket_enabled()` in `codex-rs/core/src/client.rs` is gated solely on this field, so explicitly setting it to false short-circuits the WSS code path entirely.

## Affected capability

- **Custom Codex relay configuration via Web UI** — `Settings → Backends → Codex → API key + Base URL`. No scenario in `tests/scenarios/auth_setup/catalog.yaml` covers this toml-writing detail (the catalog tracks device-auth flows, not custom-relay config emission), so no scenario IDs apply.

## Evidence

- **Unit**: two new tests in `tests/test_codex_config.py` — one asserts `supports_websockets: false` is written when `base_url` is set, the other asserts it is popped when `base_url` clears. Full suite passes (21/21).
- **Contract**: n/a (no protocol surface change).
- **Scenario**: not applicable — see above.
- **Manual**: validated end-to-end on a real chainbot relay. `POST https://ai-relay.chainbot.io/v1/responses` with the user's key returns 200 + real gpt-5.5 content; the prior WSS-to-OpenAI request returned 401 `invalid_api_key`.

## Test plan
- [x] `ruff check vibe/codex_config.py tests/test_codex_config.py` — passes.
- [x] `uv run pytest tests/test_codex_config.py -x -q` — 21 passed.
- [ ] Manual: re-save Codex API key in Web UI with custom base_url, verify `~/.codex/config.toml` has `supports_websockets = false` under `[model_providers.openai-managed]`, send a turn and confirm Codex doesn't hit `api.openai.com`.
- [ ] Manual: clear base_url, re-save, verify the field is removed.