### PR TITLE
Defensively parse link-wrapped quick replies

### DIFF
--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -9,7 +9,7 @@ Extracts special syntaxes from agent reply text:
    e.g. ``[screenshot](file:///tmp/shot.png)``
 
 3. **Quick-reply buttons** – A ``---`` separator followed by
-   ``[button text]`` or Slack-style ``<url|button text>`` tokens separated by ``|``
+   ``[button text]`` or link-formatted ``[button text](<url>)`` tokens separated by ``|``
    e.g. ``---\\n[👌好的] | [✅提交PR] | [先review一下]``
 """
 
@@ -66,15 +66,15 @@ _FILE_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\((file://(?:[^()]+|\([^)]*\))+)\)"
 
 # Matches the quick-reply button block at the end of the text.
 # A horizontal rule (``---``) on its own line, followed by bracket buttons or
-# Slack-style link buttons separated by ``|`` or full-width ``｜``.
+# link-formatted buttons separated by ``|`` or full-width ``｜``.
 _BUTTON_BLOCK_RE = re.compile(
     r"\n-{3,}\s*\n"  # --- separator line
-    r"((?:\s*(?:\[[^\]]+\]|<[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
+    r"((?:\s*(?:\[[^\]]+\](?:\(<[^)>\n]+>\)|\([^)>\n]+\))?|<[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
     r"\s*$",  # trailing whitespace / end of string
 )
 
-# Individual button tokens: [button text] or Slack-style <url|button text>.
-_BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\]|<[^|>\n]+\|([^>\n]+)>")
+# Individual button tokens: [button text], [button text](<url>), or Slack-style <url|button text>.
+_BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\](?:\(<[^)>\n]+>\)|\([^)>\n]+\))?|<[^|>\n]+\|([^>\n]+)>")
 
 # Silent output blocks are intentionally simple and model-facing.  They are
 # stripped before any reply enhancement parsing so hidden text cannot create

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -9,7 +9,7 @@ Extracts special syntaxes from agent reply text:
    e.g. ``[screenshot](file:///tmp/shot.png)``
 
 3. **Quick-reply buttons** – A ``---`` separator followed by
-   ``[button text]`` or link-formatted ``[button text](<url>)`` tokens separated by ``|``
+   ``[button text]`` tokens separated by ``|``
    e.g. ``---\\n[👌好的] | [✅提交PR] | [先review一下]``
 """
 
@@ -65,15 +65,17 @@ class EnhancedReply:
 _FILE_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\((file://(?:[^()]+|\([^)]*\))+)\)")
 
 # Matches the quick-reply button block at the end of the text.
-# A horizontal rule (``---``) on its own line, followed by bracket buttons or
-# link-formatted buttons separated by ``|`` or full-width ``｜``.
+# A horizontal rule (``---``) on its own line, followed by bracket buttons.
+# Accept link-formatted variants defensively because some agents accidentally
+# wrap a quick-reply label in a Markdown/Slack link.
 _BUTTON_BLOCK_RE = re.compile(
     r"\n-{3,}\s*\n"  # --- separator line
     r"((?:\s*(?:\[[^\]]+\](?:\(<https?://[^)>\n]+>\))?|<https?://[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
     r"\s*$",  # trailing whitespace / end of string
 )
 
-# Individual button tokens: [button text], [button text](<url>), or Slack-style <url|button text>.
+# Individual button tokens. Link variants are accepted for compatibility only;
+# the button label remains the quick-reply payload.
 _BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\](?:\(<https?://[^)>\n]+>\))?|<https?://[^|>\n]+\|([^>\n]+)>")
 
 # Silent output blocks are intentionally simple and model-facing.  They are

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -9,7 +9,7 @@ Extracts special syntaxes from agent reply text:
    e.g. ``[screenshot](file:///tmp/shot.png)``
 
 3. **Quick-reply buttons** – A ``---`` separator followed by
-   ``[button text]`` tokens separated by ``|``
+   ``[button text]`` or Slack-style ``<url|button text>`` tokens separated by ``|``
    e.g. ``---\\n[👌好的] | [✅提交PR] | [先review一下]``
 """
 
@@ -65,16 +65,16 @@ class EnhancedReply:
 _FILE_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\((file://(?:[^()]+|\([^)]*\))+)\)")
 
 # Matches the quick-reply button block at the end of the text.
-# A horizontal rule (``---``) on its own line, followed by one or more
-# ``[text]`` tokens separated by ``|`` or full-width ``｜``.
+# A horizontal rule (``---``) on its own line, followed by bracket buttons or
+# Slack-style link buttons separated by ``|`` or full-width ``｜``.
 _BUTTON_BLOCK_RE = re.compile(
     r"\n-{3,}\s*\n"  # --- separator line
-    r"((?:\s*\[[^\]]+\]\s*(?:[|｜]\s*)?)+)"  # [text] tokens
+    r"((?:\s*(?:\[[^\]]+\]|<[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
     r"\s*$",  # trailing whitespace / end of string
 )
 
-# Individual button token:  [button text]
-_BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\]")
+# Individual button tokens: [button text] or Slack-style <url|button text>.
+_BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\]|<[^|>\n]+\|([^>\n]+)>")
 
 # Silent output blocks are intentionally simple and model-facing.  They are
 # stripped before any reply enhancement parsing so hidden text cannot create
@@ -176,7 +176,8 @@ def _extract_buttons(text: str) -> Tuple[List[QuickReplyButton], str]:
 
     block = m.group(1)
     buttons: List[QuickReplyButton] = []
-    for label in _BUTTON_TOKEN_RE.findall(block):
+    for bracket_label, slack_label in _BUTTON_TOKEN_RE.findall(block):
+        label = bracket_label or slack_label
         label = label.strip()
         if label:
             buttons.append(QuickReplyButton(text=label))

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -69,12 +69,12 @@ _FILE_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\((file://(?:[^()]+|\([^)]*\))+)\)"
 # link-formatted buttons separated by ``|`` or full-width ``｜``.
 _BUTTON_BLOCK_RE = re.compile(
     r"\n-{3,}\s*\n"  # --- separator line
-    r"((?:\s*(?:\[[^\]]+\](?:\(<[^)>\n]+>\)|\([^)>\n]+\))?|<[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
+    r"((?:\s*(?:\[[^\]]+\](?:\(<https?://[^)>\n]+>\))?|<https?://[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
     r"\s*$",  # trailing whitespace / end of string
 )
 
 # Individual button tokens: [button text], [button text](<url>), or Slack-style <url|button text>.
-_BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\](?:\(<[^)>\n]+>\)|\([^)>\n]+\))?|<[^|>\n]+\|([^>\n]+)>")
+_BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\](?:\(<https?://[^)>\n]+>\))?|<https?://[^|>\n]+\|([^>\n]+)>")
 
 # Silent output blocks are intentionally simple and model-facing.  They are
 # stripped before any reply enhancement parsing so hidden text cannot create

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -126,6 +126,26 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([file.path for file in reply.files], ["/tmp/report.txt"])
         self.assertEqual(reply.buttons, [])
 
+    def test_process_reply_accepts_slack_link_style_quick_reply_button(self):
+        reply = process_reply(
+            "Done.\n\n---\n"
+            "<https://github.com/cyhhao/vibe-remote/pull/298|:eyes: 看 PR> | "
+            "[:rocket: 等评审完合并] | [:test_tube: 先回归测一遍]"
+        )
+
+        self.assertEqual(reply.text, "Done.")
+        self.assertEqual(
+            [button.text for button in reply.buttons],
+            [":eyes: 看 PR", ":rocket: 等评审完合并", ":test_tube: 先回归测一遍"],
+        )
+
+    def test_process_reply_ignores_bare_angle_link_as_quick_reply_button(self):
+        text = "Done.\n\n---\n<https://github.com/cyhhao/vibe-remote/pull/298>"
+        reply = process_reply(text)
+
+        self.assertEqual(reply.text, text)
+        self.assertEqual(reply.buttons, [])
+
     def test_prompt_includes_task_watch_and_hook_usage_with_thread_default_session_key(self):
         context = MessageContext(
             user_id="U1",
@@ -263,6 +283,28 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(controller.im_client.sent_button_messages), 1)
         keyboard = controller.im_client.sent_button_messages[0][3]
         self.assertEqual([[button.text for button in row] for row in keyboard.buttons], [["继续"], ["提交PR"]])
+
+    async def test_slack_link_style_quick_reply_dispatches_label_callbacks(self):
+        controller = _StubController("slack")
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="U1", channel_id="C1", platform="slack")
+
+        await dispatcher.emit_agent_message(
+            context,
+            "result",
+            "Done.\n---\n"
+            "<https://github.com/cyhhao/vibe-remote/pull/298|:eyes: 看 PR> | "
+            "[:rocket: 等评审完合并]",
+        )
+
+        self.assertEqual(len(controller.im_client.sent_button_messages), 1)
+        keyboard = controller.im_client.sent_button_messages[0][3]
+        buttons = keyboard.buttons[0]
+        self.assertEqual([button.text for button in buttons], [":eyes: 看 PR", ":rocket: 等评审完合并"])
+        self.assertEqual(
+            [button.callback_data for button in buttons],
+            ["quick_reply::eyes: 看 PR", "quick_reply::rocket: 等评审完合并"],
+        )
 
     async def test_lark_log_message_strips_file_links_before_sending(self):
         controller = _StubController("lark")

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -126,7 +126,20 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([file.path for file in reply.files], ["/tmp/report.txt"])
         self.assertEqual(reply.buttons, [])
 
-    def test_process_reply_accepts_slack_link_style_quick_reply_button(self):
+    def test_process_reply_accepts_markdown_link_style_quick_reply_button(self):
+        reply = process_reply(
+            "Done.\n\n---\n"
+            "[:eyes: 看 PR](<https://github.com/cyhhao/vibe-remote/pull/298>) | "
+            "[:rocket: 等评审完合并] | [:test_tube: 先回归测一遍]"
+        )
+
+        self.assertEqual(reply.text, "Done.")
+        self.assertEqual(
+            [button.text for button in reply.buttons],
+            [":eyes: 看 PR", ":rocket: 等评审完合并", ":test_tube: 先回归测一遍"],
+        )
+
+    def test_process_reply_accepts_slack_angle_link_style_quick_reply_button(self):
         reply = process_reply(
             "Done.\n\n---\n"
             "<https://github.com/cyhhao/vibe-remote/pull/298|:eyes: 看 PR> | "
@@ -284,7 +297,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         keyboard = controller.im_client.sent_button_messages[0][3]
         self.assertEqual([[button.text for button in row] for row in keyboard.buttons], [["继续"], ["提交PR"]])
 
-    async def test_slack_link_style_quick_reply_dispatches_label_callbacks(self):
+    async def test_markdown_link_style_quick_reply_dispatches_label_callbacks(self):
         controller = _StubController("slack")
         dispatcher = ConsolidatedMessageDispatcher(controller)
         context = MessageContext(user_id="U1", channel_id="C1", platform="slack")
@@ -293,7 +306,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             context,
             "result",
             "Done.\n---\n"
-            "<https://github.com/cyhhao/vibe-remote/pull/298|:eyes: 看 PR> | "
+            "[:eyes: 看 PR](<https://github.com/cyhhao/vibe-remote/pull/298>) | "
             "[:rocket: 等评审完合并]",
         )
 

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -159,6 +159,13 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(reply.text, text)
         self.assertEqual(reply.buttons, [])
 
+    def test_process_reply_preserves_plain_markdown_reference_link_block(self):
+        text = "Done.\n\n---\n[Release notes](https://example.com)"
+        reply = process_reply(text)
+
+        self.assertEqual(reply.text, text)
+        self.assertEqual(reply.buttons, [])
+
     def test_prompt_includes_task_watch_and_hook_usage_with_thread_default_session_key(self):
         context = MessageContext(
             user_id="U1",


### PR DESCRIPTION
## What

Keep the canonical quick-reply syntax as `[button text]`, while defensively accepting malformed quick-reply tokens where an agent wraps that label in a link, such as `[:eyes: 看 PR](<https://github.com/cyhhao/vibe-remote/pull/298>)`.

The parser also tolerates Slack angle-link style `<https://github.com/cyhhao/vibe-remote/pull/298|:eyes: 看 PR>` as a defensive compatibility case.

## Why

Claude Code can accidentally format one quick-reply option as a Markdown link with an angle-bracket URL. Previously the parser only accepted `[text]`, so that trailing quick-reply block could be missed instead of becoming interactive buttons.

This is intentionally compatibility behavior, not a prompt-facing recommendation for agents to emit link-formatted buttons.

## Behavior

Link-wrapped quick replies are still quick replies, not URL buttons. Clicking the button sends the visible label back to the agent, for example `:eyes: 看 PR`; it does not open the URL.

Plain Markdown reference links such as `[Release notes](https://example.com)` remain normal message content and are not parsed as quick replies.

## Evidence layers

- Unit: updated reply enhancer parsing coverage for angle-bracket Markdown-link quick replies, mixed bracket quick replies, Slack angle-link fallback, bare angle-link non-match coverage, and plain Markdown-link non-match coverage.
- Contract: updated dispatcher coverage to verify emitted inline buttons use the visible label and `quick_reply:<label>` callback data.
- Scenario: no scenario catalog applies to reply-enhancement parsing.
- Manual: not run; behavior is covered at parser and dispatcher boundaries.

## Validation

- `python3 -m pytest tests/test_reply_enhancer_platform.py`
- `python3 -m pytest tests/test_reply_enhancer_platform.py tests/test_message_dispatcher_result_fallback.py`
- `python3 -m ruff check core/reply_enhancer.py tests/test_reply_enhancer_platform.py`
- `git diff --check`

Note: `uv run ...` is blocked in this fresh worktree because editable package build requires `ui/dist`; the same checks were run with the already available Python tooling to avoid generating unrelated UI build output.
