### PR TITLE
fix(codex): use shared routing overrides

### DIFF
--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -505,38 +505,14 @@ class CodexAgent(BaseAgent):
         self,
         request: AgentRequest,
     ) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
-        request_context = getattr(request, "context", None)
-        controller = getattr(self, "controller", None)
-        routing = None
-        settings_key = request.session_key
-        used_context_settings_manager = False
-
-        if request_context is not None and controller is not None and hasattr(controller, "_get_settings_key"):
-            settings_key = controller._get_settings_key(request_context)
-            manager_getter = getattr(controller, "get_settings_manager_for_context", None)
-            if callable(manager_getter):
-                try:
-                    context_settings_manager = manager_getter(request_context)
-                except Exception:
-                    context_settings_manager = None
-                if context_settings_manager is not None:
-                    used_context_settings_manager = True
-                    channel_settings = context_settings_manager.get_channel_settings(settings_key)
-                    routing = channel_settings.routing if channel_settings else None
-
-        if routing is None and not used_context_settings_manager:
-            channel_settings = self.settings_manager.get_channel_settings(settings_key)
-            routing = channel_settings.routing if channel_settings else None
-
+        routing_agent, routing_model, routing_effort = self._get_codex_overrides(request)
         request_subagent = getattr(request, "subagent_name", None)
         request_model = getattr(request, "subagent_model", None)
         request_effort = getattr(request, "subagent_reasoning_effort", None)
 
-        effective_agent = request_subagent or (getattr(routing, "codex_agent", None) if routing else None)
-        explicit_model = request_model or (getattr(routing, "codex_model", None) if routing else None)
-        explicit_effort = request_effort or (
-            getattr(routing, "codex_reasoning_effort", None) if routing else None
-        )
+        effective_agent = request_subagent or routing_agent
+        explicit_model = request_model or routing_model
+        explicit_effort = request_effort or routing_effort
 
         agent_definition: Optional[SubagentDefinition] = None
         if effective_agent:
@@ -552,6 +528,22 @@ class CodexAgent(BaseAgent):
         developer_instructions = agent_definition.developer_instructions if agent_definition else None
 
         return effective_agent, effective_model, effective_effort, developer_instructions
+
+    def _get_codex_overrides(
+        self,
+        request: AgentRequest,
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Resolve scope routing through the controller's shared routing API."""
+        controller = getattr(self, "controller", None)
+        request_context = getattr(request, "context", None)
+        getter = getattr(controller, "get_codex_overrides", None)
+        if request_context is None or not callable(getter):
+            return None, None, None
+        try:
+            return getter(request_context)
+        except Exception as exc:
+            logger.warning("Failed to resolve Codex routing overrides: %s", exc)
+            return None, None, None
 
     async def _start_or_resume_thread(
         self,

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -754,7 +754,6 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
     async def test_start_thread_requests_danger_full_access(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=False))
-        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(set_agent_session_mapping=Mock())
@@ -790,7 +789,6 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
     async def test_start_thread_includes_codex_agent_developer_instructions(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=False))
-        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(set_agent_session_mapping=Mock())
@@ -835,7 +833,6 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
     async def test_start_thread_adds_codex_generated_image_prompt_to_thread_instructions(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
-        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(set_agent_session_mapping=Mock())
@@ -868,7 +865,6 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
     async def test_resume_thread_refreshes_developer_instructions_without_appending(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
-        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
@@ -920,7 +916,6 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
     async def test_resume_thread_keeps_system_prompt_injection_when_quick_replies_are_disabled(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=False))
-        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
@@ -965,7 +960,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_start_turn_uses_sandbox_policy_object(self):
         agent = object.__new__(CodexAgent)
-        agent.settings_manager = SimpleNamespace(get_channel_settings=lambda session_key: None)
+        agent.controller = SimpleNamespace(get_codex_overrides=Mock(return_value=(None, None, None)))
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
         agent._turn_registry = SimpleNamespace(
@@ -995,22 +990,15 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
                 "sandboxPolicy": {"type": "dangerFullAccess"},
             },
         )
+        agent.controller.get_codex_overrides.assert_not_called()
 
-    async def test_start_turn_uses_context_specific_settings_manager_for_routing(self):
+    async def test_start_turn_uses_controller_codex_overrides(self):
         agent = object.__new__(CodexAgent)
         agent.settings_manager = SimpleNamespace(
-            get_channel_settings=lambda settings_key: SimpleNamespace(
-                routing=SimpleNamespace(codex_model="wrong-model", codex_reasoning_effort="low")
-            )
-        )
-        context_manager = SimpleNamespace(
-            get_channel_settings=lambda settings_key: SimpleNamespace(
-                routing=SimpleNamespace(codex_model="gpt-5.4", codex_reasoning_effort="high")
-            )
+            get_channel_settings=Mock(side_effect=AssertionError("Codex must use controller routing overrides"))
         )
         agent.controller = SimpleNamespace(
-            _get_settings_key=lambda context: "U123",
-            get_settings_manager_for_context=lambda context: context_manager,
+            get_codex_overrides=Mock(return_value=(None, "gpt-5.4", "high")),
         )
         agent.codex_config = SimpleNamespace(default_model="fallback-model")
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
@@ -1032,6 +1020,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
 
         await agent._start_turn(transport, request, "thread-1")
 
+        agent.controller.get_codex_overrides.assert_called_once_with(request.context)
         transport.send_request.assert_awaited_once_with(
             "turn/start",
             {
@@ -1044,17 +1033,13 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             },
         )
 
-    async def test_start_turn_does_not_fall_back_to_primary_platform_when_context_manager_has_no_settings(self):
+    async def test_start_turn_uses_codex_dm_user_effort_from_shared_overrides(self):
         agent = object.__new__(CodexAgent)
         agent.settings_manager = SimpleNamespace(
-            get_channel_settings=lambda settings_key: SimpleNamespace(
-                routing=SimpleNamespace(codex_model="wrong-model", codex_reasoning_effort="low")
-            )
+            get_channel_settings=Mock(side_effect=AssertionError("Codex must not read scope storage directly"))
         )
-        context_manager = SimpleNamespace(get_channel_settings=lambda settings_key: None)
         agent.controller = SimpleNamespace(
-            _get_settings_key=lambda context: "U123",
-            get_settings_manager_for_context=lambda context: context_manager,
+            get_codex_overrides=Mock(return_value=(None, "gpt-5.5", "xhigh")),
         )
         agent.codex_config = SimpleNamespace(default_model="fallback-model")
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
@@ -1077,6 +1062,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
 
         await agent._start_turn(transport, request, "thread-1")
 
+        agent.controller.get_codex_overrides.assert_called_once_with(request.context)
         transport.send_request.assert_awaited_once_with(
             "turn/start",
             {
@@ -1084,20 +1070,15 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
                 "input": [{"type": "text", "text": "hello"}],
                 "approvalPolicy": "never",
                 "sandboxPolicy": {"type": "dangerFullAccess"},
-                "model": "fallback-model",
+                "model": "gpt-5.5",
+                "effort": "xhigh",
             },
         )
 
     async def test_start_turn_uses_codex_agent_defaults_when_routing_selects_agent(self):
         agent = object.__new__(CodexAgent)
-        agent.settings_manager = SimpleNamespace(
-            get_channel_settings=lambda settings_key: SimpleNamespace(
-                routing=SimpleNamespace(
-                    codex_agent="reviewer",
-                    codex_model=None,
-                    codex_reasoning_effort=None,
-                )
-            )
+        agent.controller = SimpleNamespace(
+            get_codex_overrides=Mock(return_value=("reviewer", None, None)),
         )
         agent.codex_config = SimpleNamespace(default_model="fallback-model")
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
@@ -1110,6 +1091,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             session_key="channel-1",
             base_session_id="session-1",
             composite_session_id="slack:C1:T1",
+            context=SimpleNamespace(platform="slack", platform_specific={"is_dm": False}),
             working_path="/tmp/work",
             subagent_name=None,
             subagent_model=None,

--- a/tests/test_user_platform_scope.py
+++ b/tests/test_user_platform_scope.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from config.v2_settings import SettingsStore, UserSettings
+from config.v2_settings import RoutingSettings, SettingsStore, UserSettings
+from core.controller import Controller
+from modules.im import MessageContext
+from modules.settings_manager import SettingsManager
 from vibe import api
 
 
@@ -49,3 +52,42 @@ def test_toggle_admin_is_scoped_per_platform(monkeypatch, tmp_path):
     assert result["ok"] is True
     assert store.get_user("U1", platform="slack").is_admin is False
     assert store.get_user("U1", platform="wechat").is_admin is True
+
+
+def test_controller_codex_overrides_resolve_dm_user_scope(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    store = SettingsStore.get_instance()
+    store.set_users_for_platform(
+        "slack",
+        {
+            "U1": UserSettings(
+                display_name="Alex",
+                routing=RoutingSettings(
+                    agent_backend="codex",
+                    codex_model="gpt-5.5",
+                    codex_reasoning_effort="xhigh",
+                ),
+            )
+        },
+    )
+    store.save()
+
+    controller = Controller.__new__(Controller)
+    controller.primary_platform = "slack"
+    controller.platform_settings_managers = {
+        "slack": SettingsManager(platform="slack"),
+    }
+    context = MessageContext(
+        platform="slack",
+        user_id="U1",
+        channel_id="D1",
+        platform_specific={"is_dm": True},
+    )
+
+    assert Controller._get_settings_key(controller, context) == "U1"
+    assert Controller.get_codex_overrides(controller, context) == (
+        None,
+        "gpt-5.5",
+        "xhigh",
+    )


### PR DESCRIPTION
## What changed

- Route Codex model, agent, and reasoning-effort overrides through the controller's shared `get_codex_overrides(context)` API.
- Stop Codex from reading channel/user scope storage directly when building `turn/start` payloads.
- Add regression coverage for Slack DM user-scope Codex model and reasoning-effort settings.

## Why

Codex had a private settings lookup path that used channel settings directly. That bypassed bound DM user settings, so a Slack user-level Codex reasoning-effort override could be saved but still fall back at runtime. Group/channel settings worked because they lived in the channel scope Codex was accidentally reading.

This keeps routing ownership in the controller/settings layer and leaves Codex responsible only for backend-specific behavior such as subagent loading, defaults, and payload construction.

## Evidence

- Unit: `tests/test_codex_agent.py`, `tests/test_user_platform_scope.py`
- Contract: Codex now consumes `Controller.get_codex_overrides(context)` instead of scope storage internals
- Scenario: Slack DM bound user with Codex `gpt-5.5` and `xhigh` resolves into the Codex turn payload
- Manual residual: no live Slack regression run in this PR

## Validation

- `uv run pytest tests/test_codex_agent.py tests/test_user_platform_scope.py -q`
- `uv run ruff check modules/agents/codex/agent.py tests/test_codex_agent.py tests/test_user_platform_scope.py`
- reviewer subagent: no significant issues found
