### PR TITLE
fix(install): prefer native uv on Apple Silicon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -221,7 +221,7 @@ binary_architecture() {
         return 1
     fi
 
-    file "$path" 2>/dev/null || true
+    file -b "$path" 2>/dev/null || true
 }
 
 is_arm64_binary() {

--- a/install.sh
+++ b/install.sh
@@ -185,8 +185,37 @@ is_apple_silicon_macos() {
     [ "$(detect_os)" = "macos" ] && [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]
 }
 
+resolve_binary_path() {
+    local path="$1"
+    local dir=""
+    local target=""
+    local depth=0
+
+    if [ -z "$path" ]; then
+        return 1
+    fi
+
+    while [ -L "$path" ] && [ "$depth" -lt 20 ] && command_exists readlink; do
+        target="$(readlink "$path" 2>/dev/null || true)"
+        if [ -z "$target" ]; then
+            break
+        fi
+        case "$target" in
+            /*) path="$target" ;;
+            *)
+                dir="$(dirname "$path")"
+                path="$dir/$target"
+                ;;
+        esac
+        depth=$((depth + 1))
+    done
+
+    printf '%s\n' "$path"
+}
+
 binary_architecture() {
     local path="$1"
+    path="$(resolve_binary_path "$path" || true)"
 
     if [ -z "$path" ] || [ ! -e "$path" ] || ! command_exists file; then
         return 1

--- a/install.sh
+++ b/install.sh
@@ -181,6 +181,55 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+is_apple_silicon_macos() {
+    [ "$(detect_os)" = "macos" ] && [ "$(sysctl -n hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]
+}
+
+binary_architecture() {
+    local path="$1"
+
+    if [ -z "$path" ] || [ ! -e "$path" ] || ! command_exists file; then
+        return 1
+    fi
+
+    file "$path" 2>/dev/null || true
+}
+
+is_arm64_binary() {
+    local path="$1"
+    binary_architecture "$path" | grep -Eq '(^|[^[:alnum:]_])(arm64e?|aarch64)([^[:alnum:]_]|$)'
+}
+
+is_x86_64_binary() {
+    local path="$1"
+    binary_architecture "$path" | grep -Eq '(^|[^[:alnum:]_])x86_64([^[:alnum:]_]|$)'
+}
+
+uv_binary_is_acceptable() {
+    local uv_path="$1"
+
+    if [ -z "$uv_path" ]; then
+        return 1
+    fi
+
+    if is_apple_silicon_macos && is_x86_64_binary "$uv_path" && ! is_arm64_binary "$uv_path"; then
+        return 1
+    fi
+
+    return 0
+}
+
+uv_is_native_for_host() {
+    local uv_path
+
+    uv_path="$(command -v uv 2>/dev/null || true)"
+    if [ -z "$uv_path" ]; then
+        return 1
+    fi
+
+    uv_binary_is_acceptable "$uv_path"
+}
+
 uv_tool_install() {
     if [ -n "$VIBE_TOOL_BIN_DIR" ]; then
         UV_TOOL_BIN_DIR="$VIBE_TOOL_BIN_DIR" uv tool install "$@"
@@ -217,9 +266,17 @@ is_vibe_immediately_available() {
 
 # Install uv if not present
 install_uv() {
-    if command_exists uv; then
+    local existing_uv=""
+    existing_uv="$(command -v uv 2>/dev/null || true)"
+
+    if [ -n "$existing_uv" ] && uv_is_native_for_host; then
         success "uv is already installed"
         return 0
+    fi
+
+    if [ -n "$existing_uv" ] && is_apple_silicon_macos && is_x86_64_binary "$existing_uv" && ! is_arm64_binary "$existing_uv"; then
+        warn "Found x86_64 uv on Apple Silicon: $existing_uv"
+        info "Installing native arm64 uv for this Mac..."
     fi
     
     info "Installing uv (will also manage Python automatically)..."
@@ -241,16 +298,18 @@ install_uv() {
             ;;
     esac
     
-    if command_exists uv; then
+    if command_exists uv && uv_is_native_for_host; then
         success "uv installed successfully"
     else
         # Try to find it in common locations
-        if [ -f "$HOME/.local/bin/uv" ]; then
+        if [ -f "$HOME/.local/bin/uv" ] && uv_binary_is_acceptable "$HOME/.local/bin/uv"; then
             export PATH="$HOME/.local/bin:$PATH"
             success "uv installed successfully"
-        elif [ -f "$HOME/.cargo/bin/uv" ]; then
+        elif [ -f "$HOME/.cargo/bin/uv" ] && uv_binary_is_acceptable "$HOME/.cargo/bin/uv"; then
             export PATH="$HOME/.cargo/bin:$PATH"
             success "uv installed successfully"
+        elif [ -n "$existing_uv" ] && command_exists uv; then
+            error "uv is installed, but it does not match this Mac's native architecture. Please install native arm64 uv or remove the x86_64 uv from PATH."
         else
             error "Failed to install uv. Please install it manually: https://docs.astral.sh/uv/"
         fi

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -60,12 +60,18 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
 
 def _write_fake_file(path: Path, mapping: dict[Path, str]) -> None:
     cases = "\n".join(
-        f'        "{target}") echo "{target}: {description}" ;;' for target, description in mapping.items()
+        f'        "{target}") echo "${{prefix}}{description}" ;;' for target, description in mapping.items()
     )
     _write_executable(
         path,
         f"""\
         #!/usr/bin/env bash
+        prefix=""
+        if [ "${{1:-}}" = "-b" ]; then
+          shift
+        else
+          prefix="${{1:-}}: "
+        fi
         case "${{1:-}}" in
 {cases}
           *) echo "${{1:-}}: POSIX shell script text executable" ;;
@@ -429,6 +435,54 @@ def test_install_script_checks_uv_symlink_target_architecture_on_apple_silicon(t
         path_dir / "file",
         {
             uv_link: "symbolic link to Cellar/uv/bin/uv",
+            uv_target: "Mach-O 64-bit executable x86_64",
+            native_uv: "Mach-O 64-bit executable arm64",
+        },
+    )
+    _write_executable(
+        path_dir / "curl",
+        """\
+        #!/usr/bin/env bash
+        cat <<'EOF'
+        #!/usr/bin/env sh
+        mkdir -p "$HOME/.local/bin"
+        exit 0
+        EOF
+        """,
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    install_result = _install(env, cwd=tmp_path)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert "Found x86_64 uv on Apple Silicon" in install_result.stdout
+    assert uv_log.read_text(encoding="utf-8") == str(path_dir)
+
+
+def test_install_script_ignores_arch_tokens_in_uv_path_prefix(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_target_dir = tmp_path / "arm64-prefix" / "uv" / "bin"
+    uv_target_dir.mkdir(parents=True)
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    existing_uv = path_dir / "uv"
+    uv_target = uv_target_dir / "uv"
+    native_uv = home_dir / ".local" / "bin" / "uv"
+    native_uv.parent.mkdir(parents=True)
+    _write_fake_uv(uv_target, uv_log)
+    _write_fake_uv(native_uv, uv_log)
+    existing_uv.symlink_to(uv_target)
+    _write_fake_uname(path_dir / "uname")
+    _write_fake_sysctl(path_dir / "sysctl", arm64=True)
+    _write_fake_file(
+        path_dir / "file",
+        {
             uv_target: "Mach-O 64-bit executable x86_64",
             native_uv: "Mach-O 64-bit executable arm64",
         },

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -405,3 +405,52 @@ def test_install_script_accepts_universal_uv_with_arm64e_slice_on_apple_silicon(
     assert "Found x86_64 uv on Apple Silicon" not in install_result.stdout
     assert "uv is already installed" in install_result.stdout
     assert uv_log.read_text(encoding="utf-8") == str(path_dir)
+
+
+def test_install_script_checks_uv_symlink_target_architecture_on_apple_silicon(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    cellar_dir = tmp_path / "Cellar" / "uv" / "bin"
+    cellar_dir.mkdir(parents=True)
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    uv_link = path_dir / "uv"
+    uv_target = cellar_dir / "uv"
+    native_uv = home_dir / ".local" / "bin" / "uv"
+    native_uv.parent.mkdir(parents=True)
+    _write_fake_uv(uv_target, uv_log)
+    _write_fake_uv(native_uv, uv_log)
+    uv_link.symlink_to(uv_target)
+    _write_fake_uname(path_dir / "uname")
+    _write_fake_sysctl(path_dir / "sysctl", arm64=True)
+    _write_fake_file(
+        path_dir / "file",
+        {
+            uv_link: "symbolic link to Cellar/uv/bin/uv",
+            uv_target: "Mach-O 64-bit executable x86_64",
+            native_uv: "Mach-O 64-bit executable arm64",
+        },
+    )
+    _write_executable(
+        path_dir / "curl",
+        """\
+        #!/usr/bin/env bash
+        cat <<'EOF'
+        #!/usr/bin/env sh
+        mkdir -p "$HOME/.local/bin"
+        exit 0
+        EOF
+        """,
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    install_result = _install(env, cwd=tmp_path)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert "Found x86_64 uv on Apple Silicon" in install_result.stdout
+    assert uv_log.read_text(encoding="utf-8") == str(path_dir)

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -58,6 +58,53 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
     )
 
 
+def _write_fake_file(path: Path, mapping: dict[Path, str]) -> None:
+    cases = "\n".join(
+        f'        "{target}") echo "{target}: {description}" ;;' for target, description in mapping.items()
+    )
+    _write_executable(
+        path,
+        f"""\
+        #!/usr/bin/env bash
+        case "${{1:-}}" in
+{cases}
+          *) echo "${{1:-}}: POSIX shell script text executable" ;;
+        esac
+        """,
+    )
+
+
+def _write_fake_uname(path: Path, machine: str = "x86_64") -> None:
+    _write_executable(
+        path,
+        f"""\
+        #!/usr/bin/env bash
+        if [ "${{1:-}}" = "-s" ]; then
+          echo Darwin
+        elif [ "${{1:-}}" = "-m" ]; then
+          echo {machine}
+        else
+          echo Darwin
+        fi
+        """,
+    )
+
+
+def _write_fake_sysctl(path: Path, arm64: bool = True) -> None:
+    value = "1" if arm64 else "0"
+    _write_executable(
+        path,
+        f"""\
+        #!/usr/bin/env bash
+        if [ "${{1:-}}" = "-n" ] && [ "${{2:-}}" = "hw.optional.arm64" ]; then
+          echo {value}
+        else
+          exit 1
+        fi
+        """,
+    )
+
+
 def _install(env: dict[str, str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
     return _run(f'bash "{INSTALL_SCRIPT}"', cwd=cwd, env=env)
 
@@ -284,3 +331,77 @@ def test_install_script_requires_path_export_when_install_dir_not_on_original_pa
     assert 'export PATH="' in install_result.stdout
     assert str(home_dir / ".local" / "bin") in install_result.stdout
     assert version_result.returncode != 0
+
+
+def test_install_script_reinstalls_when_existing_uv_is_x86_on_apple_silicon(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    existing_uv = path_dir / "uv"
+    native_uv = home_dir / ".local" / "bin" / "uv"
+    native_uv.parent.mkdir(parents=True)
+    _write_fake_uv(existing_uv, uv_log)
+    _write_fake_uv(native_uv, uv_log)
+    _write_fake_uname(path_dir / "uname")
+    _write_fake_sysctl(path_dir / "sysctl", arm64=True)
+    _write_fake_file(
+        path_dir / "file",
+        {
+            existing_uv: "Mach-O 64-bit executable x86_64",
+            native_uv: "Mach-O 64-bit executable arm64",
+        },
+    )
+    _write_executable(
+        path_dir / "curl",
+        f"""\
+        #!/usr/bin/env bash
+        cat <<'EOF'
+        #!/usr/bin/env sh
+        mkdir -p "$HOME/.local/bin"
+        exit 0
+        EOF
+        """,
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    install_result = _install(env, cwd=tmp_path)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert "Found x86_64 uv on Apple Silicon" in install_result.stdout
+    assert uv_log.read_text(encoding="utf-8") == str(path_dir)
+
+
+def test_install_script_accepts_universal_uv_with_arm64e_slice_on_apple_silicon(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    uv_path = path_dir / "uv"
+    _write_fake_uv(uv_path, uv_log)
+    _write_fake_uname(path_dir / "uname")
+    _write_fake_sysctl(path_dir / "sysctl", arm64=True)
+    _write_fake_file(
+        path_dir / "file",
+        {
+            uv_path: "Mach-O universal binary with 2 architectures: [x86_64] [arm64e]",
+        },
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    install_result = _install(env, cwd=tmp_path)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert "Found x86_64 uv on Apple Silicon" not in install_result.stdout
+    assert "uv is already installed" in install_result.stdout
+    assert uv_log.read_text(encoding="utf-8") == str(path_dir)

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -267,7 +267,22 @@ def test_binary_architecture_follows_uv_symlink(tmp_path, monkeypatch):
     output = cli._binary_architecture(str(uv_link))
 
     assert output and "arm64" in output
-    assert calls == [["file", str(uv_target)]]
+    assert calls == [["file", "-b", str(uv_target)]]
+
+
+def test_binary_architecture_omits_path_prefix_before_token_parsing(tmp_path, monkeypatch):
+    uv_path = tmp_path / "arm64-prefix" / "uv"
+    uv_path.parent.mkdir(parents=True)
+    uv_path.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    def fake_run(command, **kwargs):
+        return SimpleNamespace(stdout="Mach-O 64-bit executable x86_64\n", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    output = cli._binary_architecture(str(uv_path))
+
+    assert cli._architecture_token(output) == "x86_64"
 
 
 def test_cmd_start_ensures_services_without_stopping(monkeypatch):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -186,6 +186,69 @@ def test_cmd_vibe_uses_restart_compatibility_default(monkeypatch):
     assert calls == [("restart", 0.0)]
 
 
+def test_runtime_architecture_items_warn_for_x86_uv_on_apple_silicon(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(cli, "_is_apple_silicon_host", lambda: True)
+    monkeypatch.setattr(cli.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(cli.shutil, "which", lambda binary: "/usr/local/bin/uv" if binary == "uv" else None)
+    monkeypatch.setattr(
+        cli,
+        "_binary_architecture",
+        lambda path: calls.append(path) or "/usr/local/bin/uv: Mach-O 64-bit executable x86_64",
+    )
+
+    items = cli._runtime_architecture_items()
+
+    assert calls == ["/usr/local/bin/uv"]
+    assert any(item["status"] == "warn" and "uv architecture: x86_64" in item["message"] for item in items)
+    assert any(item["status"] == "pass" and "Python runtime architecture: arm64" in item["message"] for item in items)
+
+
+def test_runtime_architecture_items_warn_for_x86_python_on_apple_silicon(monkeypatch):
+    monkeypatch.setattr(cli, "_is_apple_silicon_host", lambda: True)
+    monkeypatch.setattr(cli.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(cli.shutil, "which", lambda binary: None)
+
+    items = cli._runtime_architecture_items()
+
+    assert any(
+        item["status"] == "warn" and item.get("action") == "Reinstall Vibe Remote with native arm64 uv/Python"
+        for item in items
+    )
+
+
+def test_runtime_architecture_items_warn_for_unknown_uv_on_apple_silicon(monkeypatch):
+    monkeypatch.setattr(cli, "_is_apple_silicon_host", lambda: True)
+    monkeypatch.setattr(cli.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(cli.shutil, "which", lambda binary: "/usr/local/bin/uv" if binary == "uv" else None)
+    monkeypatch.setattr(cli, "_binary_architecture", lambda path: "/usr/local/bin/uv: POSIX shell script")
+
+    items = cli._runtime_architecture_items()
+
+    assert any(
+        item["status"] == "warn"
+        and "uv architecture: unknown" in item["message"]
+        and item.get("action") == "Check whether this uv wrapper launches native arm64 uv"
+        for item in items
+    )
+
+
+def test_runtime_architecture_items_pass_for_arm64e_universal_uv_on_apple_silicon(monkeypatch):
+    monkeypatch.setattr(cli, "_is_apple_silicon_host", lambda: True)
+    monkeypatch.setattr(cli.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(cli.shutil, "which", lambda binary: "/usr/local/bin/uv" if binary == "uv" else None)
+    monkeypatch.setattr(
+        cli,
+        "_binary_architecture",
+        lambda path: "Mach-O universal binary with 2 architectures: [x86_64] [arm64e]",
+    )
+
+    items = cli._runtime_architecture_items()
+
+    assert any(item["status"] == "pass" and "uv architecture: arm64" in item["message"] for item in items)
+
+
 def test_cmd_start_ensures_services_without_stopping(monkeypatch):
     calls = []
     config = SimpleNamespace(

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -249,6 +249,27 @@ def test_runtime_architecture_items_pass_for_arm64e_universal_uv_on_apple_silico
     assert any(item["status"] == "pass" and "uv architecture: arm64" in item["message"] for item in items)
 
 
+def test_binary_architecture_follows_uv_symlink(tmp_path, monkeypatch):
+    uv_target = tmp_path / "Cellar" / "uv" / "bin" / "uv"
+    uv_target.parent.mkdir(parents=True)
+    uv_target.write_text("#!/bin/sh\n", encoding="utf-8")
+    uv_link = tmp_path / "bin" / "uv"
+    uv_link.parent.mkdir()
+    uv_link.symlink_to(uv_target)
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return SimpleNamespace(stdout=f"{uv_target}: Mach-O 64-bit executable arm64\n", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    output = cli._binary_architecture(str(uv_link))
+
+    assert output and "arm64" in output
+    assert calls == [["file", str(uv_target)]]
+
+
 def test_cmd_start_ensures_services_without_stopping(monkeypatch):
     calls = []
     config = SimpleNamespace(

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -264,7 +264,7 @@ def _binary_architecture(path: str | None) -> str | None:
     resolved_path = str(Path(path).resolve())
     try:
         result = subprocess.run(
-            ["file", resolved_path],
+            ["file", "-b", resolved_path],
             capture_output=True,
             text=True,
             timeout=3,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import platform
 import shlex
 import shutil
 import signal
@@ -239,6 +240,95 @@ def _watch_examples_text() -> str:
           vibe watch pause 12ab34cd56ef
         """
     )
+
+
+def _is_apple_silicon_host() -> bool:
+    if platform.system().lower() != "darwin":
+        return False
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.optional.arm64"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except Exception:
+        return platform.machine().lower() in {"arm64", "aarch64"}
+    return (result.stdout or "").strip() == "1"
+
+
+def _binary_architecture(path: str | None) -> str | None:
+    if not path:
+        return None
+    try:
+        result = subprocess.run(
+            ["file", path],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except Exception:
+        return None
+    output = (result.stdout or result.stderr or "").strip()
+    return output or None
+
+
+def _architecture_token(text: str | None) -> str | None:
+    normalized = (text or "").lower()
+    if "arm64" in normalized or "arm64e" in normalized or "aarch64" in normalized:
+        return "arm64"
+    if "x86_64" in normalized or "x86-64" in normalized or "amd64" in normalized:
+        return "x86_64"
+    return None
+
+
+def _runtime_architecture_items() -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    is_apple_silicon = _is_apple_silicon_host()
+    host_arch = "Apple Silicon" if is_apple_silicon else platform.machine() or "unknown"
+    python_arch = platform.machine() or "unknown"
+    python_status = "warn" if is_apple_silicon and _architecture_token(python_arch) == "x86_64" else "pass"
+
+    python_item = {
+        "status": python_status,
+        "message": f"Python runtime architecture: {python_arch} ({sys.executable})",
+    }
+    if python_status == "warn":
+        python_item["action"] = "Reinstall Vibe Remote with native arm64 uv/Python"
+    items.append(python_item)
+
+    uv_path = shutil.which("uv")
+    if uv_path:
+        uv_arch_output = _binary_architecture(uv_path)
+        uv_arch = _architecture_token(uv_arch_output) or "unknown"
+        uv_status = "warn" if is_apple_silicon and uv_arch in {"x86_64", "unknown"} else "pass"
+        uv_item = {
+            "status": uv_status,
+            "message": f"uv architecture: {uv_arch} ({uv_path})",
+        }
+        if is_apple_silicon and uv_arch == "x86_64":
+            uv_item["action"] = "Install native arm64 uv, then reinstall Vibe Remote"
+        elif is_apple_silicon and uv_arch == "unknown":
+            uv_item["action"] = "Check whether this uv wrapper launches native arm64 uv"
+        items.append(uv_item)
+    else:
+        items.append(
+            {
+                "status": "warn",
+                "message": "uv command not found on PATH",
+                "action": "Install uv or add its bin directory to PATH",
+            }
+        )
+
+    items.append(
+        {
+            "status": "pass",
+            "message": f"Host architecture: {host_arch}",
+        }
+    )
+    return items
 
 
 def _remote_examples_text() -> str:
@@ -1793,6 +1883,12 @@ def _doctor():
             }
         )
         summary["pass"] += 1
+
+    for item in _runtime_architecture_items():
+        runtime_items.append(item)
+        status = item.get("status")
+        if status in summary:
+            summary[status] += 1
 
     groups.append({"name": "Runtime", "items": runtime_items})
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -261,9 +261,10 @@ def _is_apple_silicon_host() -> bool:
 def _binary_architecture(path: str | None) -> str | None:
     if not path:
         return None
+    resolved_path = str(Path(path).resolve())
     try:
         result = subprocess.run(
-            ["file", path],
+            ["file", resolved_path],
             capture_output=True,
             text=True,
             timeout=3,


### PR DESCRIPTION
## Summary
- Detect Apple Silicon hosts during install and avoid silently reusing a pure x86_64 `uv` binary.
- Accept native/universal `uv` binaries, including `arm64e` slices, so valid universal installs are not replaced.
- Add `vibe doctor` runtime architecture diagnostics for host, Python, and `uv`, with warnings for x86/unknown `uv` on Apple Silicon.

## Scenarios
- macOS Apple Silicon user has an existing x86_64-only `uv` on PATH.
- macOS Apple Silicon user has a universal `uv` with x86_64 + arm64e slices.
- `vibe doctor` is used to diagnose Vibe Remote Python/uv architecture mismatches.

## Evidence
- Unit: `PYTHONPATH=. python3 -m pytest tests/test_install_script.py tests/test_vibe_cli.py -q`
- Contract: N/A
- Scenario: install-script tests cover pure x86_64 uv, universal arm64e uv, and doctor warnings for x86/unknown uv.
- Manual: `bash -n install.sh`; `ruff check vibe/cli.py tests/test_install_script.py tests/test_vibe_cli.py`; local doctor architecture probe returned arm64 Python, arm64 uv, Apple Silicon host.

## Residual Risk
- No destructive migration of user-installed x86 uv is attempted; the installer only prefers/installs native uv for Vibe Remote installation. End-to-end smoke on a user machine with real x86-only uv remains useful before release.
