### PR TITLE
Migrate UI server to FastAPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,12 @@ Source-of-truth rule:
 - add new IM integrations under `modules/im/` and new agent backends under `modules/agents/`
 - no repo-wide formatter is enforced; keep diffs focused if you use Black/Ruff
 
+### Web UI Server
+
+- `vibe/ui_server.py` is served by FastAPI/uvicorn; new UI routes should use native async FastAPI patterns where practical.
+- `vibe/ui_compat.py` exists only as a migration scaffold for the old Flask-style route surface. Do not expand it into a general framework unless a migration regression requires it.
+- Do not introduce per-request `asyncio.run()` bridges in UI request paths. Async helpers reached from UI handlers should be awaited directly on the ASGI event loop; blocking work should stay sync or move through a threadpool.
+
 ### Frontend (UI)
 
 - source lives in `ui/`

--- a/docs/plans/fastapi-migration.md
+++ b/docs/plans/fastapi-migration.md
@@ -34,6 +34,55 @@ Out of scope for this PR:
 
 ## Solution
 
+### Implementation strategy update after architecture review
+
+The original plan suggested splitting `vibe/ui_server.py` into many FastAPI
+routers immediately. After reviewing the current architecture, that is too
+much churn for the first migration PR: it mixes the runtime substrate change
+(WSGI/thread-per-request → ASGI/persistent loop) with a large file/module
+reshuffle across 70+ routes.
+
+Use a two-step design instead:
+
+1. **Substrate migration first.** Replace Flask/Werkzeug with FastAPI/uvicorn
+   while keeping `vibe/ui_server.py` as the single route surface. Add a small
+   compatibility layer that supports the limited Flask API the file actually
+   uses (`route`, `before_request`, `after_request`, `request`, `g`, `jsonify`,
+   `redirect`, `send_file`, `Response`, and the existing test helpers). This
+   keeps the first PR focused on runtime semantics and lets existing route
+   handlers move mostly unchanged.
+2. **Native FastAPI cleanup second.** Once tests and regression are green,
+   convert routes to idiomatic FastAPI incrementally and split them into
+   routers. Router extraction is valuable, but it should be a follow-up because
+   it does not itself fix the cross-event-loop bug.
+
+The compatibility layer must stay intentionally thin and local to the UI
+server. It is a migration scaffold, not a new app framework. New endpoints
+after this migration should use native FastAPI patterns directly.
+
+Additional findings from the current codebase:
+
+- `vibe/ui_server.py` has one local `_run_async()` helper that creates a fresh
+  event loop in a thread for WeChat QR login and OpenCode options. This must go
+  away with the Flask migration; FastAPI handlers can await those coroutines
+  directly or call blocking work through `run_in_threadpool`.
+- `vibe/api.py` still has sync wrapper functions that call `asyncio.run(...)`
+  for Telegram auth, SOCKS-backed Discord/Lark calls, OpenCode provider
+  catalog/auth operations, and OAuth web flows. UI-reachable wrappers should be
+  converted as their routes are touched. Test-only or non-UI `asyncio.run`
+  calls are not part of this acceptance criterion.
+- Tests should not be migrated only at the end. `tests/test_ui_remote_access_auth.py`
+  is the security contract for remote access and setup-host behavior; keep it
+  green after the substrate layer lands, then carry the rest of the UI test
+  files surface by surface.
+- The current `run_ui_server()` tests monkeypatch `werkzeug.make_server`.
+  They need to be rewritten around `uvicorn.Server` and the nonblocking
+  remote-access reconcile behavior.
+- Proxy/remote address semantics are product-critical. The compatibility
+  request object should preserve the existing `request.remote_addr`,
+  `request.host`, forwarded header, and test `environ_base={"REMOTE_ADDR": ...}`
+  behavior before any native Starlette rewrite.
+
 ### Stack choice
 
 - **Web framework**: FastAPI (built on Starlette). Native async, first-class WebSocket, dependency-injection, OpenAPI generation, Pydantic body validation.
@@ -47,7 +96,9 @@ Out of scope for this PR:
 
 ### Module reshape
 
-Keep `vibe/ui_server.py` as the entry surface, but split the routes into routers under `vibe/ui_routers/` so a 2,380-line file doesn't grow into a 4,000-line file. Suggested split:
+Keep `vibe/ui_server.py` as the entry surface for the substrate migration.
+After that is stable, split the routes into routers under `vibe/ui_routers/`
+so a 2,380-line file doesn't grow into a 4,000-line file. Suggested split:
 
 ```
 vibe/
@@ -68,7 +119,7 @@ vibe/
     files.py              # SPA catch-all, /assets/*, /favicon, attachments
 ```
 
-Routers are wired in `ui_server.py` via `app.include_router(...)`. Keeps each file under ~400 lines and gives Codex a natural unit of work.
+Routers are wired in `ui_server.py` via `app.include_router(...)`. Keeps each file under ~400 lines and gives Codex a natural unit of work. This is a follow-up cleanup after the ASGI runtime is live, not a prerequisite for removing Flask.
 
 ### Translation table (Flask → FastAPI)
 
@@ -257,15 +308,16 @@ Codex review after each phase keeps the surface area manageable.
 
 ## Acceptance checklist (final PR)
 
-- [ ] `pyproject.toml` declares fastapi + uvicorn + python-multipart + httpx; no `flask` dependency.
-- [ ] `vibe/ui_server.py` exports a single `app: FastAPI`. No Flask import anywhere in `vibe/`.
-- [ ] `vibe-oauth-loop` thread is gone. `_submit_oauth_coro` is gone.
-- [ ] `asyncio.run` does not appear in `vibe/api.py`.
+- [x] `pyproject.toml` declares fastapi + uvicorn + python-multipart + httpx; no `flask` dependency.
+- [x] `vibe/ui_server.py` exports a single `app: FastAPI`. No Flask import anywhere in `vibe/`.
+- [x] `vibe-oauth-loop` thread is gone. `_submit_oauth_coro` is gone.
+- [x] `asyncio.run` does not appear in `vibe/api.py`.
+- [x] A trivial WebSocket echo route proves the ASGI substrate end-to-end.
 - [ ] All 74 existing routes return identical responses for golden inputs. UI in `ui/` is byte-identical and works against the new server.
 - [ ] `./scripts/run_three_regression.sh` brings up a healthy container; `/health` returns ok; the React UI loads; setup wizard works; OpenCode provider OAuth flow works without cross-loop errors.
 - [ ] `pytest tests/` passes.
 - [ ] `vibe restart && vibe status` works locally.
-- [ ] CLAUDE.md is updated to mention FastAPI / uvicorn in §3 and to add a "Use FastAPI patterns" note in §6.
+- [x] Repo guidance is updated to mention FastAPI / uvicorn and prefer native FastAPI patterns for new UI routes.
 
 ## Rollback plan
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,18 +52,20 @@ dependencies = [
     "typing_extensions>=4.12.2",
     "PyYAML>=6.0",
     "tomli>=2.0.1; python_version < '3.11'",
-    "flask>=3.0.0",
+    "fastapi>=0.110",
     "lark-oapi>=1.4.0",
     "requests>=2.31.0",
     "sentry-sdk>=2.0.0",
     "python-socks[asyncio]>=2.0.0",
     "aiohttp-socks>=0.8.0",
     "httpx[socks]>=0.27",
+    "python-multipart>=0.0.9",
     "PyJWT[crypto]>=2.9.0",
     "SQLAlchemy>=2.0.0",
     "alembic>=1.13.0",
     "psutil>=5.9.0",
     "packaging>=23.0",
+    "uvicorn[standard]>=0.27",
 ]
 
 [project.urls]

--- a/tests/test_async_bridge.py
+++ b/tests/test_async_bridge.py
@@ -1,0 +1,21 @@
+import asyncio
+
+import pytest
+
+from vibe.async_bridge import run_coroutine_blocking
+
+
+async def _value():
+    return 42
+
+
+def test_run_coroutine_blocking_allows_sync_callers():
+    assert run_coroutine_blocking(_value()) == 42
+
+
+def test_run_coroutine_blocking_rejects_active_event_loop():
+    async def _exercise():
+        with pytest.raises(RuntimeError, match="active event loop"):
+            run_coroutine_blocking(_value())
+
+    asyncio.run(_exercise())

--- a/tests/test_im_proxy_unification.py
+++ b/tests/test_im_proxy_unification.py
@@ -271,6 +271,35 @@ def test_discord_api_get_via_aiohttp_raises_for_status() -> None:
     raise_for_status.assert_called_once()
 
 
+def test_discord_api_get_sync_path_works_inside_active_event_loop() -> None:
+    """Live discovery is sync code that may run on FastAPI's ASGI loop.
+
+    The sync helper must not bridge through run_coroutine_blocking(), which
+    intentionally raises inside an active loop.
+    """
+    import asyncio
+
+    from unittest.mock import MagicMock
+
+    from vibe import api as vibe_api
+
+    fake_resp_cm = MagicMock()
+    fake_resp_cm.__enter__ = MagicMock(
+        return_value=MagicMock(read=MagicMock(return_value=b'[{"id":"c1","name":"general"}]'))
+    )
+    fake_resp_cm.__exit__ = MagicMock(return_value=None)
+    fake_opener = MagicMock()
+    fake_opener.open = MagicMock(return_value=fake_resp_cm)
+
+    async def exercise():
+        with patch("urllib.request.build_opener", return_value=fake_opener):
+            return vibe_api._discord_api_get("bot-token", "guilds/g1/channels")
+
+    result = asyncio.run(exercise())
+
+    assert result == [{"id": "c1", "name": "general"}]
+
+
 # ---------------------------------------------------------------------------
 # telegram_auth_test must call resolve_proxy() (regression for round-2 review)
 # ---------------------------------------------------------------------------
@@ -370,25 +399,22 @@ def test_lark_auth_test_falls_back_to_system_proxy() -> None:
     assert captured["proxy_url"] == "socks5://system:1080"
 
 
-def test_lark_tenant_token_uses_aiohttp_for_socks() -> None:
-    """SOCKS proxy_url branches into the aiohttp helper, not urllib."""
-    import asyncio
-
-    from unittest.mock import AsyncMock
+def test_lark_tenant_token_uses_sync_socks_helper_for_socks() -> None:
+    """SOCKS proxy_url branches into the sync SOCKS helper, not urllib."""
 
     from vibe import api as vibe_api
 
-    aiohttp_called = {"hit": False}
+    socks_called = {"hit": False}
 
-    async def fake_aiohttp(url, body, headers, proxy):
-        aiohttp_called["hit"] = True
-        aiohttp_called["proxy"] = proxy
+    def fake_socks(proxy, url, *, method="GET", body=None, headers=None, timeout=10):
+        socks_called["hit"] = True
+        socks_called["proxy"] = proxy
         return {"code": 0, "tenant_access_token": "tok-from-socks"}
 
     def fail_urlopen(*args, **kwargs):
         raise AssertionError("urllib should not be used for SOCKS proxies")
 
-    with patch.object(vibe_api, "_lark_tenant_token_via_aiohttp", new=fake_aiohttp), patch(
+    with patch.object(vibe_api, "_https_json_request_via_socks", new=fake_socks), patch(
         "urllib.request.build_opener", side_effect=fail_urlopen
     ):
         token = vibe_api._lark_tenant_token(
@@ -396,11 +422,8 @@ def test_lark_tenant_token_uses_aiohttp_for_socks() -> None:
         )
 
     assert token == "tok-from-socks"
-    assert aiohttp_called["hit"] is True
-    assert aiohttp_called["proxy"] == "socks5://127.0.0.1:1080"
-    # touch asyncio so import is used in case lints flag it
-    assert asyncio.iscoroutinefunction(fake_aiohttp)
-    AsyncMock  # unused-import guard
+    assert socks_called["hit"] is True
+    assert socks_called["proxy"] == "socks5://127.0.0.1:1080"
 
 
 def test_lark_tenant_token_uses_urllib_proxy_for_http() -> None:
@@ -455,14 +478,39 @@ def test_lark_tenant_token_does_not_misroute_http_with_socks_hostname() -> None:
     fake_opener = MagicMock()
     fake_opener.open = MagicMock(return_value=fake_resp_cm)
 
-    def fail_aiohttp(*args, **kwargs):
-        raise AssertionError("aiohttp must not be used for HTTP proxies, even when hostname contains 'socks'")
+    def fail_socks_helper(*args, **kwargs):
+        raise AssertionError(
+            "SOCKS helper must not be used for HTTP proxies, even when hostname contains 'socks'"
+        )
 
     with patch("urllib.request.build_opener", return_value=fake_opener), patch.object(
-        vibe_api, "_lark_tenant_token_via_aiohttp", side_effect=fail_aiohttp
+        vibe_api, "_https_json_request_via_socks", side_effect=fail_socks_helper
     ):
         token = vibe_api._lark_tenant_token(
             "cli_x", "secret", proxy_url="http://socks-gateway.corp:8080"
         )
 
     assert token == "tok-via-http"
+
+
+def test_lark_tenant_token_sync_path_works_inside_active_event_loop() -> None:
+    """Live Lark discovery is sync code and may run on FastAPI's ASGI loop."""
+    import asyncio
+
+    from unittest.mock import MagicMock
+
+    from vibe import api as vibe_api
+
+    fake_resp_cm = MagicMock()
+    fake_resp_cm.__enter__ = MagicMock(
+        return_value=MagicMock(read=MagicMock(return_value=b'{"code":0,"tenant_access_token":"tok-loop"}'))
+    )
+    fake_resp_cm.__exit__ = MagicMock(return_value=None)
+    fake_opener = MagicMock()
+    fake_opener.open = MagicMock(return_value=fake_resp_cm)
+
+    async def exercise():
+        with patch("urllib.request.build_opener", return_value=fake_opener):
+            return vibe_api._lark_tenant_token("cli_x", "secret")
+
+    assert asyncio.run(exercise()) == "tok-loop"

--- a/tests/test_im_proxy_unification.py
+++ b/tests/test_im_proxy_unification.py
@@ -426,6 +426,46 @@ def test_lark_tenant_token_uses_sync_socks_helper_for_socks() -> None:
     assert socks_called["proxy"] == "socks5://127.0.0.1:1080"
 
 
+def test_https_json_request_via_socks_closes_socket_when_tls_wrap_fails() -> None:
+    from vibe import api as vibe_api
+
+    class FakeSocket:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class FakeProxy:
+        @staticmethod
+        def from_url(proxy_url):
+            assert proxy_url == "socks5://127.0.0.1:1080"
+            return FakeProxy()
+
+        def connect(self, hostname, port, timeout=10):
+            assert hostname == "discord.com"
+            assert port == 443
+            return fake_socket
+
+    class FakeContext:
+        def wrap_socket(self, sock, *, server_hostname):
+            assert sock is fake_socket
+            assert server_hostname == "discord.com"
+            raise OSError("tls failed")
+
+    fake_socket = FakeSocket()
+
+    with patch("python_socks.sync.Proxy", FakeProxy), patch(
+        "ssl.create_default_context", return_value=FakeContext()
+    ), pytest.raises(OSError, match="tls failed"):
+        vibe_api._https_json_request_via_socks(
+            "socks5://127.0.0.1:1080",
+            "https://discord.com/api/v10/users/@me",
+        )
+
+    assert fake_socket.closed is True
+
+
 def test_lark_tenant_token_uses_urllib_proxy_for_http() -> None:
     """HTTP proxy_url uses urllib.ProxyHandler with the proxy applied."""
     from unittest.mock import MagicMock

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -156,7 +156,7 @@ def test_pair_origin_service_uses_ipv4_loopback_when_localhost_resolves_dual_sta
     config.ui.setup_port = 15130
     config.save()
 
-    # cloudflared and werkzeug each resolve "localhost" independently, so we
+    # cloudflared and the UI server each resolve "localhost" independently, so we
     # hand cloudflared a literal IPv4 loopback to match the bind family and
     # avoid the ::1 vs 127.0.0.1 race that surfaces as a 502.
     assert remote_access.origin_service_for_pairing() == "http://127.0.0.1:15130"

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -141,50 +141,19 @@ def test_init_sentry_disables_client_discard_reports(monkeypatch):
 
 
 def test_run_ui_server_skips_sentry_when_config_load_fails(monkeypatch):
-    fake_flask = types.ModuleType("flask")
-
-    class FakeFlask:
-        def __init__(self, *args, **kwargs):
-            self.args = args
-            self.kwargs = kwargs
-
-        def route(self, *args, **kwargs):
-            def decorator(func):
-                return func
-
-            return decorator
-
-        def before_request(self, func):
-            return func
-
-        def after_request(self, func):
-            return func
-
-        def errorhandler(self, *args, **kwargs):
-            def decorator(func):
-                return func
-
-            return decorator
-
-    fake_flask.Flask = FakeFlask
-    fake_flask.request = types.SimpleNamespace(json=None, args={})
-    fake_flask.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
-    fake_flask.send_file = lambda *args, **kwargs: None
-    fake_flask.Response = object
-    monkeypatch.setitem(sys.modules, "flask", fake_flask)
-
-    fake_werkzeug = types.ModuleType("werkzeug")
-    fake_werkzeug_serving = types.ModuleType("werkzeug.serving")
-
     ui_server = importlib.import_module("vibe.ui_server")
 
     class DummyServer:
-        def serve_forever(self):
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, sockets=None):
             return None
 
-    fake_werkzeug_serving.make_server = lambda *args, **kwargs: DummyServer()
-    monkeypatch.setitem(sys.modules, "werkzeug", fake_werkzeug)
-    monkeypatch.setitem(sys.modules, "werkzeug.serving", fake_werkzeug_serving)
+    fake_uvicorn = types.ModuleType("uvicorn")
+    fake_uvicorn.Config = lambda *args, **kwargs: (args, kwargs)
+    fake_uvicorn.Server = DummyServer
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
 
     monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
     monkeypatch.setattr(
@@ -203,11 +172,18 @@ def test_run_ui_server_skips_sentry_when_config_load_fails(monkeypatch):
 def test_run_ui_server_reconciles_remote_access_after_binding(monkeypatch):
     from vibe import ui_server
     from vibe import remote_access
-    from werkzeug import serving
 
     class DummyServer:
-        def serve_forever(self):
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, sockets=None):
             return None
+
+    fake_uvicorn = types.ModuleType("uvicorn")
+    fake_uvicorn.Config = lambda *args, **kwargs: (args, kwargs)
+    fake_uvicorn.Server = DummyServer
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
 
     reconcile_calls = []
     config = _config()
@@ -215,12 +191,52 @@ def test_run_ui_server_reconciles_remote_access_after_binding(monkeypatch):
     monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
     monkeypatch.setattr(ui_server.V2Config, "load", lambda *args, **kwargs: config)
     monkeypatch.setattr(ui_server, "init_sentry", lambda *args, **kwargs: None)
-    monkeypatch.setattr(serving, "make_server", lambda *args, **kwargs: DummyServer())
     monkeypatch.setattr(remote_access, "reconcile", lambda next_config=None: reconcile_calls.append(next_config) or {"ok": True})
 
     ui_server.run_ui_server("127.0.0.1", 0)
 
     assert reconcile_calls == [config]
+
+
+def test_run_ui_server_retries_when_prebind_reports_port_in_use(monkeypatch):
+    from vibe import ui_server
+
+    class DummySocket:
+        def close(self):
+            return None
+
+    class DummyServer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, sockets=None):
+            run_calls.append(sockets)
+
+    fake_uvicorn = types.ModuleType("uvicorn")
+    fake_uvicorn.Config = lambda *args, **kwargs: (args, kwargs)
+    fake_uvicorn.Server = DummyServer
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+
+    attempts = {"count": 0}
+    run_calls = []
+
+    def bind_socket(_host, _port):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise OSError(48, "Address already in use")
+        return DummySocket()
+
+    monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
+    monkeypatch.setattr(ui_server.V2Config, "load", lambda *args, **kwargs: _config())
+    monkeypatch.setattr(ui_server, "init_sentry", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ui_server, "_bind_ui_socket", bind_socket)
+    monkeypatch.setattr(ui_server.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(ui_server, "_reconcile_remote_access_for_ui_start", lambda _config: None)
+
+    ui_server.run_ui_server("127.0.0.1", 5123)
+
+    assert attempts["count"] == 2
+    assert len(run_calls) == 1
 
 
 def test_ui_error_handler_does_not_explicitly_capture_exceptions():

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -360,7 +360,6 @@ def test_install_codex_detects_existing_install_via_npm_prefix_and_self_updates(
     codex_path.parent.mkdir(parents=True, exist_ok=True)
     codex_path.write_text("#!/bin/sh\n")
     codex_path.chmod(0o755)
-
     calls = []
 
     class CompletedProcess:
@@ -390,6 +389,7 @@ def test_install_codex_detects_existing_install_via_npm_prefix_and_self_updates(
     # PATH for the update call must have codex's bin dir first so npm /
     # node spawned by `codex update` use the same toolchain.
     assert update_calls[0][1]["PATH"].split(api.os.pathsep)[0] == str(codex_path.parent)
+
 
 def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
     claude_dir = tmp_path / ".claude"

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import time
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -77,6 +79,44 @@ def test_opencode_options_closes_server_http_session(monkeypatch):
     assert result["data"]["defaults"] == {"model": "openai/gpt-5"}
     assert fake_manager.closed == 1
     assert fake_manager.closed_loop is not None
+
+
+def test_sync_start_oauth_web_keeps_background_tasks_on_persistent_loop(monkeypatch):
+    async def _start_web_setup(backend, *, force_reset=True, provider_id=None):
+        async def _mark_completed():
+            await asyncio.sleep(0.01)
+            flow.state = "success"
+
+        task = asyncio.create_task(_mark_completed())
+        flow.waiter_task = task
+        return flow
+
+    flow = SimpleNamespace(
+        flow_id="flow-sync",
+        backend="codex",
+        state="awaiting_code",
+        url="https://auth.openai.com/codex/device",
+        device_code="ABCD-EFGH",
+        awaiting_code=False,
+        provider=None,
+        error=None,
+        waiter_task=None,
+    )
+    service = SimpleNamespace(start_web_setup=AsyncMock(side_effect=_start_web_setup))
+    monkeypatch.setattr(api, "_oauth_service", service)
+    monkeypatch.setattr(api, "_oauth_loop", None)
+    monkeypatch.setattr(api, "_oauth_loop_thread", None)
+
+    result = api.start_oauth_web("codex")
+
+    assert result["ok"] is True
+    assert result["flow_id"] == "flow-sync"
+    assert flow.waiter_task is not None
+    deadline = time.time() + 1
+    while flow.state != "success" and time.time() < deadline:
+        time.sleep(0.01)
+    assert flow.state == "success"
+    assert flow.waiter_task.done()
 
 
 def test_detect_cli_prefers_claude_local(monkeypatch, tmp_path):

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1650,7 +1650,7 @@ def test_setup_host_with_cloudflare_metadata_is_not_local(monkeypatch, tmp_path)
 
 def test_setup_host_with_reverse_proxy_header_is_not_local(monkeypatch, tmp_path):
     """A non-Cloudflare reverse proxy on the same host (nginx, Caddy, ...)
-    fronts vibe and an attacker spoofs Host=setup_host. Flask sees a private
+    fronts vibe and an attacker spoofs Host=setup_host. The app sees a private
     peer (the proxy) and the Host matches setup_host, so the host+peer pair
     looks "local" — but X-Forwarded-For (or any other forwarded header) tells
     us the actual client is unknown, so the request must not be trusted.

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -345,6 +345,40 @@ def test_loopback_proxy_with_public_host_mismatch_fails_closed(monkeypatch, tmp_
     assert response.get_json()["error"] == "remote_access_host_mismatch"
 
 
+def test_loopback_proxy_with_partial_forwarded_metadata_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="https://old-alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+        headers={"X-Real-IP": "203.0.113.10"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_loopback_origin_proxy_with_loopback_host_is_allowed(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "vibe.example",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code != 503
+
+
 def test_remote_host_allows_valid_remote_session(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import ipaddress
 import socket
+import asyncio
 from collections import namedtuple
+
+import httpx
 
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from config.v2_config import CONFIG_LOCK
@@ -135,6 +138,27 @@ def test_localhost_does_not_require_remote_access_cookie(monkeypatch, tmp_path):
     response = app.test_client().get("/health", base_url="http://127.0.0.1:5123")
 
     assert response.status_code == 200
+
+
+def test_live_request_cannot_spoof_test_remote_addr_header(monkeypatch, tmp_path):
+    """The compatibility test-client shim accepts an environ_base REMOTE_ADDR,
+    but the transport header it uses must not be honored on live ASGI traffic."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    async def _exercise():
+        transport = httpx.ASGITransport(app=app, client=("203.0.113.10", 50000))
+        async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:5123") as client:
+            return await client.get(
+                "/dashboard",
+                headers={"X-Vibe-Test-Remote-Addr": "127.0.0.1"},
+                follow_redirects=False,
+            )
+
+    response = asyncio.run(_exercise())
+
+    assert response.status_code == 503
+    assert response.json()["error"] == "remote_access_host_mismatch"
 
 
 def test_docker_loopback_host_requires_explicit_trust(monkeypatch, tmp_path):

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -131,6 +131,21 @@ def test_remote_host_with_trailing_dot_still_requires_login(monkeypatch, tmp_pat
     assert response.headers["Location"].startswith("https://backend.test/oauth/authorize?")
 
 
+def test_remote_health_does_not_require_remote_access_cookie(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/health",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "ok"
+
+
 def test_localhost_does_not_require_remote_access_cookie(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -466,6 +466,22 @@ def test_host_starting_with_127_but_not_ip_is_not_local_when_config_load_fails(m
     assert response.get_json()["error"] == "remote_access_config_unavailable"
 
 
+def test_loopback_peer_with_arbitrary_host_is_not_local_when_config_load_fails(monkeypatch):
+    def fail_load():
+        raise ValueError("corrupt config")
+
+    monkeypatch.setattr(ui_server.V2Config, "load", fail_load)
+
+    response = app.test_client().get(
+        "/dashboard",
+        base_url="https://attacker.example",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_config_unavailable"
+
+
 def test_spoofed_loopback_host_is_not_local_when_peer_is_remote(monkeypatch):
     def fail_load():
         raise ValueError("corrupt config")

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1,6 +1,6 @@
 import pytest
 
-from vibe.ui_compat import CompatApp, run_maybe_async, request
+from vibe.ui_compat import CompatApp, normalize_response, route_path_to_fastapi, run_maybe_async, request
 from starlette.websockets import WebSocketDisconnect
 
 from vibe.ui_server import app
@@ -31,6 +31,31 @@ def test_fastapi_schema_routes_are_not_exposed():
     docs_response = client.get("/docs")
     assert b"swagger-ui" not in docs_response.content.lower()
     assert client.get("/openapi.json").status_code != 200
+
+
+def test_route_path_to_fastapi_converts_named_path_converter():
+    assert route_path_to_fastapi("/files/<path:file_path>") == "/files/{file_path:path}"
+
+
+def test_compat_app_matches_named_path_converter():
+    compat_app = CompatApp()
+
+    @compat_app.route("/files/<path:file_path>")
+    def get_file(file_path):
+        return {"file_path": file_path}
+
+    response = compat_app.test_client().get("/files/nested/example.txt")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"file_path": "nested/example.txt"}
+
+
+def test_normalize_response_supports_body_headers_tuple():
+    response = normalize_response(("ok", {"X-Test": "yes"}))
+
+    assert response.status_code == 200
+    assert response.headers["X-Test"] == "yes"
+    assert response.body == b"ok"
 
 
 def test_run_maybe_async_offloads_sync_handlers_without_losing_context():

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1,0 +1,32 @@
+import pytest
+
+from starlette.websockets import WebSocketDisconnect
+
+from vibe.ui_server import app
+
+
+def test_websocket_echo_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("VIBE_UI_ENABLE_WS_ECHO", raising=False)
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with app.test_client().websocket_connect("/ws/echo"):
+            pass
+
+    assert exc.value.code == 1008
+
+
+def test_websocket_echo_smoke_when_enabled(monkeypatch):
+    monkeypatch.setenv("VIBE_UI_ENABLE_WS_ECHO", "1")
+
+    with app.test_client().websocket_connect("/ws/echo") as websocket:
+        websocket.send_text("hello")
+
+        assert websocket.receive_text() == "echo: hello"
+
+
+def test_fastapi_schema_routes_are_not_exposed():
+    client = app.test_client()
+
+    docs_response = client.get("/docs")
+    assert b"swagger-ui" not in docs_response.content.lower()
+    assert client.get("/openapi.json").status_code != 200

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1,5 +1,6 @@
 import pytest
 
+from vibe.ui_compat import CompatApp, run_maybe_async, request
 from starlette.websockets import WebSocketDisconnect
 
 from vibe.ui_server import app
@@ -30,3 +31,33 @@ def test_fastapi_schema_routes_are_not_exposed():
     docs_response = client.get("/docs")
     assert b"swagger-ui" not in docs_response.content.lower()
     assert client.get("/openapi.json").status_code != 200
+
+
+def test_run_maybe_async_offloads_sync_handlers_without_losing_context():
+    import asyncio
+    import threading
+    import time
+
+    loop_thread_id = threading.get_ident()
+
+    def blocking_handler():
+        assert threading.get_ident() != loop_thread_id
+        time.sleep(0.05)
+        return request.path
+
+    async def ticker():
+        await asyncio.sleep(0.01)
+        return "tick"
+
+    async def exercise():
+        return await asyncio.gather(
+            run_maybe_async(blocking_handler),
+            ticker(),
+        )
+
+    compat_app = CompatApp()
+    with compat_app.test_request_context("/threadpool-check"):
+        result, tick = asyncio.run(exercise())
+
+    assert result == "/threadpool-check"
+    assert tick == "tick"

--- a/tests/test_ui_server_install.py
+++ b/tests/test_ui_server_install.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
+from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from vibe import api
 from vibe.ui_server import app
 
 from tests.ui_server_test_helpers import csrf_headers
 
 
-def test_install_agent_allows_same_origin_request(monkeypatch):
+def _save_setup_host_config(host: str) -> None:
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        ui=UiConfig(setup_host=host),
+    ).save()
+
+
+def test_install_agent_allows_same_origin_request(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_setup_host_config("192.168.2.3")
     monkeypatch.setattr(api, "install_agent", lambda name: {"ok": True, "name": name, "path": "/usr/local/bin/claude"})
 
     client = app.test_client()
@@ -20,7 +34,9 @@ def test_install_agent_allows_same_origin_request(monkeypatch):
     assert response.get_json()["ok"] is True
 
 
-def test_install_agent_rejects_cross_origin_request(monkeypatch):
+def test_install_agent_rejects_cross_origin_request(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_setup_host_config("192.168.2.3")
     monkeypatch.setattr(api, "install_agent", lambda name: {"ok": True, "name": name})
 
     client = app.test_client()
@@ -36,7 +52,8 @@ def test_install_agent_rejects_cross_origin_request(monkeypatch):
     assert response.get_json()["message"] == "Forbidden: invalid origin"
 
 
-def test_install_agent_rejects_missing_csrf_token(monkeypatch):
+def test_install_agent_rejects_missing_csrf_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     monkeypatch.setattr(api, "install_agent", lambda name: {"ok": True, "name": name})
 
     client = app.test_client()
@@ -50,7 +67,8 @@ def test_install_agent_rejects_missing_csrf_token(monkeypatch):
     assert response.get_json()["message"] == "Forbidden: invalid csrf token"
 
 
-def test_install_agent_rejects_missing_origin(monkeypatch):
+def test_install_agent_rejects_missing_origin(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     monkeypatch.setattr(api, "install_agent", lambda name: {"ok": True, "name": name})
 
     client = app.test_client()

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -56,6 +56,21 @@ def test_config_post_rejects_missing_csrf_token(monkeypatch, tmp_path):
     assert response.get_json()["message"] == "Forbidden: invalid csrf token"
 
 
+def test_config_post_rejects_malformed_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+
+    response = client.post(
+        "/config",
+        content="{",
+        headers={**headers, "Content-Type": "application/json"},
+        base_url="http://127.0.0.1:15131",
+    )
+
+    assert response.status_code == 400
+
+
 def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     V2Config(

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -81,7 +81,7 @@ def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
         agents=AgentsConfig(),
     ).save()
     client = app.test_client()
-    headers = csrf_headers(client, "http://internal:15131")
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
     headers["Origin"] = "https://vibe.example"
     headers["X-Forwarded-Proto"] = "https"
     headers["X-Forwarded-Host"] = "vibe.example"
@@ -99,7 +99,7 @@ def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
             },
         },
         headers=headers,
-        base_url="http://internal:15131",
+        base_url="http://127.0.0.1:15131",
     )
 
     assert response.status_code == 200

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from http.cookies import SimpleCookie
 
+from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, V2Config
 from vibe.ui_server import app, protect_mutating_ui_requests
 
 from tests.ui_server_test_helpers import csrf_headers
 
 
-def test_csrf_token_endpoint_returns_cookie_and_token():
+def test_csrf_token_endpoint_returns_cookie_and_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     client = app.test_client()
     response = client.get("/api/csrf-token", base_url="http://127.0.0.1:15131")
 
@@ -23,7 +25,8 @@ def test_csrf_token_endpoint_returns_cookie_and_token():
     assert cookie["vibe_csrf_token"].value == payload["csrf_token"]
 
 
-def test_config_post_rejects_cross_origin():
+def test_config_post_rejects_cross_origin(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     client = app.test_client()
     headers = csrf_headers(client, "http://127.0.0.1:15131")
     headers["Origin"] = "http://evil.example"
@@ -39,7 +42,8 @@ def test_config_post_rejects_cross_origin():
     assert response.get_json()["message"] == "Forbidden: invalid origin"
 
 
-def test_config_post_rejects_missing_csrf_token():
+def test_config_post_rejects_missing_csrf_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     client = app.test_client()
     response = client.post(
         "/config",
@@ -52,7 +56,15 @@ def test_config_post_rejects_missing_csrf_token():
     assert response.get_json()["message"] == "Forbidden: invalid csrf token"
 
 
-def test_config_post_allows_forwarded_origin():
+def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    ).save()
     client = app.test_client()
     headers = csrf_headers(client, "http://internal:15131")
     headers["Origin"] = "https://vibe.example"

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -71,6 +71,52 @@ def test_config_post_rejects_malformed_json(monkeypatch, tmp_path):
     assert response.status_code == 400
 
 
+def test_config_post_rejects_host_mismatch_before_parsing_malformed_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    ).save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+
+    response = client.post(
+        "/config",
+        content="{",
+        headers={**headers, "Content-Type": "application/json"},
+        base_url="https://old-alex.avibe.bot",
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_config_post_accepts_vendor_json_content_type(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    ).save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+
+    response = client.post(
+        "/config",
+        content='{"mode":"self_host"}',
+        headers={**headers, "Content-Type": "application/vnd.api+json"},
+        base_url="http://127.0.0.1:15131",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["mode"] == "self_host"
+
+
 def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     V2Config(

--- a/tests/ui_server_test_helpers.py
+++ b/tests/ui_server_test_helpers.py
@@ -9,6 +9,8 @@ def csrf_headers(client, base_url: str = "http://localhost") -> dict[str, str]:
     token = response.get_json()["csrf_token"]
     hostname = urlparse(base_url).hostname or "localhost"
     client.set_cookie("vibe_csrf_token", token, domain=hostname)
+    if hostname == "localhost":
+        client.set_cookie("vibe_csrf_token", token, domain="testserver")
     return {
         "Origin": base_url,
         "X-Vibe-CSRF-Token": token,

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -283,15 +292,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/c3/c3dc3f564ce6877ecd2a05f8d751b9b27a8c320c2533a98b0c86349778d0/audioop_lts-0.2.2-cp314-cp314t-win32.whl", hash = "sha256:068aa17a38b4e0e7de771c62c60bbca2455924b67a8814f3b0dee92b5820c0b3", size = 27331, upload-time = "2025-08-05T16:43:14.19Z" },
     { url = "https://files.pythonhosted.org/packages/72/bb/b4608537e9ffcb86449091939d52d24a055216a36a8bf66b936af8c3e7ac/audioop_lts-0.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a5bf613e96f49712073de86f20dbdd4014ca18efd4d34ed18c75bd808337851b", size = 31697, upload-time = "2025-08-05T16:43:15.193Z" },
     { url = "https://files.pythonhosted.org/packages/f6/22/91616fe707a5c5510de2cac9b046a30defe7007ba8a0c04f9c08f27df312/audioop_lts-0.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:b492c3b040153e68b9fdaff5913305aaaba5bb433d8a7f73d5cf6a64ed3cc1dd", size = 25206, upload-time = "2025-08-05T16:43:16.444Z" },
-]
-
-[[package]]
-name = "blinker"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -604,20 +604,19 @@ wheels = [
 ]
 
 [[package]]
-name = "flask"
-version = "3.1.2"
+name = "fastapi"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "blinker" },
-    { name = "click" },
-    { name = "itsdangerous" },
-    { name = "jinja2" },
-    { name = "markupsafe" },
-    { name = "werkzeug" },
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/6d/cfe3c0fcc5e477df242b98bfe186a4c34357b4847e87ecaef04507332dab/flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87", size = 720160, upload-time = "2025-08-19T21:03:21.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/f9/7f9263c5695f4bd0023734af91bedb2ff8209e8de6ead162f35d8dc762fd/flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c", size = 103308, upload-time = "2025-08-19T21:03:19.499Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -830,6 +829,49 @@ wheels = [
 ]
 
 [[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e5/c07e0bcf4ec8db8164e9f6738c048b2e66aabf30e7506f440c4cc6953f60/httptools-0.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11d01b0ff1fe02c4c32d60af61a4d613b74fad069e47e06e9067758c01e9ac78", size = 204531, upload-time = "2025-10-10T03:54:20.887Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/4f/35e3a63f863a659f92ffd92bef131f3e81cf849af26e6435b49bd9f6f751/httptools-0.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:84d86c1e5afdc479a6fdabf570be0d3eb791df0ae727e8dbc0259ed1249998d4", size = 109408, upload-time = "2025-10-10T03:54:22.455Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/71/b0a9193641d9e2471ac541d3b1b869538a5fb6419d52fd2669fa9c79e4b8/httptools-0.7.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c8c751014e13d88d2be5f5f14fc8b89612fcfa92a9cc480f2bc1598357a23a05", size = 440889, upload-time = "2025-10-10T03:54:23.753Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d9/2e34811397b76718750fea44658cb0205b84566e895192115252e008b152/httptools-0.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:654968cb6b6c77e37b832a9be3d3ecabb243bbe7a0b8f65fbc5b6b04c8fcabed", size = 440460, upload-time = "2025-10-10T03:54:25.313Z" },
+    { url = "https://files.pythonhosted.org/packages/01/3f/a04626ebeacc489866bb4d82362c0657b2262bef381d68310134be7f40bb/httptools-0.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b580968316348b474b020edf3988eecd5d6eec4634ee6561e72ae3a2a0e00a8a", size = 425267, upload-time = "2025-10-10T03:54:26.81Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/99/adcd4f66614db627b587627c8ad6f4c55f18881549bab10ecf180562e7b9/httptools-0.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d496e2f5245319da9d764296e86c5bb6fcf0cf7a8806d3d000717a889c8c0b7b", size = 424429, upload-time = "2025-10-10T03:54:28.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/ec8fc904a8fd30ba022dfa85f3bbc64c3c7cd75b669e24242c0658e22f3c/httptools-0.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cbf8317bfccf0fed3b5680c559d3459cccf1abe9039bfa159e62e391c7270568", size = 86173, upload-time = "2025-10-10T03:54:29.5Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -874,27 +916,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "itsdangerous"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
-]
-
-[[package]]
-name = "jinja2"
-version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -2117,6 +2138,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
 ]
 
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792", size = 742903, upload-time = "2025-10-16T22:16:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bd/3667151ad0702282a1f4d5d29288fce8a13c8b6858bf0978c219cd52b231/uvloop-0.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac33ed96229b7790eb729702751c0e93ac5bc3bcf52ae9eccbff30da09194b86", size = 3648499, upload-time = "2025-10-16T22:16:14.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd", size = 3700133, upload-time = "2025-10-16T22:16:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e0/604f61d004ded805f24974c87ddd8374ef675644f476f01f1df90e4cdf72/uvloop-0.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a592b043a47ad17911add5fbd087c76716d7c9ccc1d64ec9249ceafd735f03c2", size = 3512681, upload-time = "2025-10-16T22:16:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/8491fd370b0230deb5eac69c7aae35b3be527e25a911c0acdffb922dc1cd/uvloop-0.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1489cf791aa7b6e8c8be1c5a080bae3a672791fcb4e9e12249b05862a2ca9cec", size = 3615261, upload-time = "2025-10-16T22:16:19.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
 [[package]]
 name = "vibe-remote"
 source = { editable = "." }
@@ -2128,13 +2204,14 @@ dependencies = [
     { name = "apscheduler" },
     { name = "claude-agent-sdk" },
     { name = "discord-py" },
-    { name = "flask" },
+    { name = "fastapi" },
     { name = "httpx", extra = ["socks"] },
     { name = "lark-oapi" },
     { name = "markdown-to-mrkdwn" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
     { name = "python-socks", extra = ["asyncio"] },
     { name = "pyyaml" },
     { name = "requests" },
@@ -2143,6 +2220,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -2159,13 +2237,14 @@ requires-dist = [
     { name = "apscheduler", specifier = ">=3.10.4" },
     { name = "claude-agent-sdk", specifier = ">=0.1.66" },
     { name = "discord-py", specifier = ">=2.4.0" },
-    { name = "flask", specifier = ">=3.0.0" },
+    { name = "fastapi", specifier = ">=0.110" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
     { name = "lark-oapi", specifier = ">=1.4.0" },
     { name = "markdown-to-mrkdwn", specifier = ">=0.2.0" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "python-socks", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
@@ -2174,10 +2253,114 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.27" },
 ]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
+    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
+    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
 
 [[package]]
 name = "websockets"
@@ -2245,18 +2428,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
-]
-
-[[package]]
-name = "werkzeug"
-version = "3.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/70/1469ef1d3542ae7c2c7b72bd5e3a4e6ee69d7978fa8a3af05a38eca5becf/werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67", size = 864754, upload-time = "2026-01-08T17:49:23.247Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc", size = 225025, upload-time = "2026-01-08T17:49:21.859Z" },
 ]
 
 [[package]]

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2345,6 +2345,20 @@ class _WebControllerStub:
 
 _oauth_service_lock = threading.Lock()
 _oauth_service: Any = None
+_oauth_loop: asyncio.AbstractEventLoop | None = None
+_oauth_loop_thread: threading.Thread | None = None
+
+
+def _start_oauth_event_loop() -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
+    loop = asyncio.new_event_loop()
+
+    def _runner() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_runner, daemon=True, name="vibe-oauth-loop")
+    thread.start()
+    return loop, thread
 
 
 def _on_web_auth_success(backend: str) -> None:
@@ -2361,16 +2375,32 @@ def _on_web_auth_success(backend: str) -> None:
 
 def _get_oauth_service() -> Any:
     """Lazily build the (singleton) AgentAuthService for web flows."""
-    global _oauth_service
+    global _oauth_service, _oauth_loop, _oauth_loop_thread
     with _oauth_service_lock:
         if _oauth_service is not None:
             return _oauth_service
         from core.agent_auth_service import AgentAuthService
 
+        _oauth_loop, _oauth_loop_thread = _start_oauth_event_loop()
         controller = _WebControllerStub()
         _oauth_service = AgentAuthService(controller)
         _oauth_service._post_web_success_hook = _on_web_auth_success
         return _oauth_service
+
+
+def _ensure_oauth_loop() -> asyncio.AbstractEventLoop:
+    global _oauth_loop, _oauth_loop_thread
+    with _oauth_service_lock:
+        if _oauth_loop is None or _oauth_loop.is_closed():
+            _oauth_loop, _oauth_loop_thread = _start_oauth_event_loop()
+        return _oauth_loop
+
+
+def _submit_oauth_coro(coro, *, timeout: float = 30.0):
+    _get_oauth_service()  # ensures the persistent loop exists
+    loop = _ensure_oauth_loop()
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    return future.result(timeout=timeout)
 
 
 def _serialize_web_flow_status(payload: dict) -> dict:
@@ -2388,10 +2418,9 @@ def start_oauth_web(
     force_reset: bool = True,
     provider_id: Optional[str] = None,
 ) -> dict:
-    from vibe.async_bridge import run_coroutine_blocking
-
-    return run_coroutine_blocking(
-        start_oauth_web_async(backend, force_reset=force_reset, provider_id=provider_id)
+    return _submit_oauth_coro(
+        start_oauth_web_async(backend, force_reset=force_reset, provider_id=provider_id),
+        timeout=60.0,
     )
 
 
@@ -2443,9 +2472,7 @@ def get_oauth_web_status(flow_id: str) -> dict:
 
 
 def submit_oauth_web_code(flow_id: str, code: str) -> dict:
-    from vibe.async_bridge import run_coroutine_blocking
-
-    return run_coroutine_blocking(submit_oauth_web_code_async(flow_id, code))
+    return _submit_oauth_coro(submit_oauth_web_code_async(flow_id, code), timeout=30.0)
 
 
 async def submit_oauth_web_code_async(flow_id: str, code: str) -> dict:
@@ -2461,9 +2488,7 @@ async def submit_oauth_web_code_async(flow_id: str, code: str) -> dict:
 
 
 def remove_backend_auth(backend: str) -> dict:
-    from vibe.async_bridge import run_coroutine_blocking
-
-    return run_coroutine_blocking(remove_backend_auth_async(backend))
+    return _submit_oauth_coro(remove_backend_auth_async(backend), timeout=30.0)
 
 
 async def remove_backend_auth_async(backend: str) -> dict:
@@ -2568,9 +2593,7 @@ def remove_backend_api_key(backend: str) -> dict:
 
 
 def test_backend_auth(backend: str, model: Optional[str] = None) -> dict:
-    from vibe.async_bridge import run_coroutine_blocking
-
-    return run_coroutine_blocking(test_backend_auth_async(backend, model=model))
+    return _submit_oauth_coro(test_backend_auth_async(backend, model=model), timeout=60.0)
 
 
 async def test_backend_auth_async(backend: str, model: Optional[str] = None) -> dict:
@@ -2592,9 +2615,7 @@ async def test_backend_auth_async(backend: str, model: Optional[str] = None) -> 
 
 
 def test_opencode_provider(provider_id: str, model: Optional[str] = None) -> dict:
-    from vibe.async_bridge import run_coroutine_blocking
-
-    return run_coroutine_blocking(test_opencode_provider_async(provider_id, model=model))
+    return _submit_oauth_coro(test_opencode_provider_async(provider_id, model=model), timeout=90.0)
 
 
 async def test_opencode_provider_async(provider_id: str, model: Optional[str] = None) -> dict:
@@ -2623,9 +2644,7 @@ async def test_opencode_provider_async(provider_id: str, model: Optional[str] = 
 
 
 def cancel_oauth_web(flow_id: str) -> dict:
-    from vibe.async_bridge import run_coroutine_blocking
-
-    return run_coroutine_blocking(cancel_oauth_web_async(flow_id))
+    return _submit_oauth_coro(cancel_oauth_web_async(flow_id), timeout=15.0)
 
 
 async def cancel_oauth_web_async(flow_id: str) -> dict:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -994,7 +994,11 @@ def _https_json_request_via_socks(
         path = f"{path}?{parsed.query}"
 
     sock = Proxy.from_url(proxy_url).connect(parsed.hostname, port, timeout=timeout)
-    tls_sock = ssl.create_default_context().wrap_socket(sock, server_hostname=parsed.hostname)
+    try:
+        tls_sock = ssl.create_default_context().wrap_socket(sock, server_hostname=parsed.hostname)
+    except Exception:
+        sock.close()
+        raise
     conn = HTTPSConnection(parsed.hostname, port, timeout=timeout)
     conn.sock = tls_sock
     try:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -792,19 +792,31 @@ def list_channels_live(bot_token: str, browse_all: bool = False) -> dict:
 
 
 def discord_auth_test(bot_token: str, proxy_url: str | None = None) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(discord_auth_test_async(bot_token, proxy_url=proxy_url))
+
+
+async def discord_auth_test_async(bot_token: str, proxy_url: str | None = None) -> dict:
     try:
-        data = _discord_api_get(bot_token, "users/@me", proxy_url=proxy_url)
+        data = await _discord_api_get_async(bot_token, "users/@me", proxy_url=proxy_url)
         return {"ok": True, "response": data}
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
 
 
 def telegram_auth_test(bot_token: str, proxy_url: str | None = None) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(telegram_auth_test_async(bot_token, proxy_url=proxy_url))
+
+
+async def telegram_auth_test_async(bot_token: str, proxy_url: str | None = None) -> dict:
     try:
         from vibe.proxy import resolve_proxy
 
         proxy = resolve_proxy(proxy_url)
-        return {"ok": True, "response": asyncio.run(_telegram_get_me(bot_token, proxy))}
+        return {"ok": True, "response": await _telegram_get_me(bot_token, proxy)}
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
 
@@ -819,8 +831,14 @@ def telegram_list_chats(include_private: bool = False) -> dict:
 
 
 def discord_list_guilds(bot_token: str) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(discord_list_guilds_async(bot_token))
+
+
+async def discord_list_guilds_async(bot_token: str) -> dict:
     try:
-        data = _discord_api_get(bot_token, "users/@me/guilds")
+        data = await _discord_api_get_async(bot_token, "users/@me/guilds")
         return {"ok": True, "guilds": data}
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
@@ -874,14 +892,22 @@ def discord_list_channels_live(bot_token: str, guild_id: str) -> dict:
 
 
 def opencode_options(cwd: str) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
     try:
-        return asyncio.run(opencode_options_async(cwd))
+        return run_coroutine_blocking(opencode_options_async(cwd))
     except Exception as exc:
         logger.warning("OpenCode options fetch failed: %s", exc, exc_info=True)
         return {"ok": False, "error": str(exc)}
 
 
 def _discord_api_get(bot_token: str, path: str, proxy_url: str | None = None) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(_discord_api_get_async(bot_token, path, proxy_url=proxy_url))
+
+
+async def _discord_api_get_async(bot_token: str, path: str, proxy_url: str | None = None) -> dict:
     import urllib.request
 
     from vibe.proxy import is_socks_proxy, resolve_proxy
@@ -894,7 +920,7 @@ def _discord_api_get(bot_token: str, path: str, proxy_url: str | None = None) ->
     proxy = resolve_proxy(proxy_url)
     if proxy and is_socks_proxy(proxy):
         # urllib has no native SOCKS support; route via aiohttp + aiohttp_socks.
-        return asyncio.run(_discord_api_get_via_aiohttp(url, headers, proxy))
+        return await _discord_api_get_via_aiohttp(url, headers, proxy)
 
     if proxy:
         opener = urllib.request.build_opener(
@@ -902,10 +928,13 @@ def _discord_api_get(bot_token: str, path: str, proxy_url: str | None = None) ->
         )
     else:
         opener = urllib.request.build_opener()
-    req = urllib.request.Request(url, headers=headers)
-    with opener.open(req, timeout=10) as resp:
-        payload = resp.read().decode("utf-8")
-        return json.loads(payload)
+    def _request() -> dict:
+        req = urllib.request.Request(url, headers=headers)
+        with opener.open(req, timeout=10) as resp:
+            payload = resp.read().decode("utf-8")
+            return json.loads(payload)
+
+    return await asyncio.to_thread(_request)
 
 
 async def _discord_api_get_via_aiohttp(url: str, headers: dict, proxy: str) -> dict:
@@ -2283,15 +2312,12 @@ def _mask_api_key(api_key: str | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Web Settings → Backends OAuth flow plumbing
+# Web Settings → Backends OAuth flow plumbing.
 #
-# Mirrors the IM ``/setup`` flow but runs in the UI server's own process.
-# OAuth subprocess + Claude SDK client require a long-lived event loop —
-# Flask routes are sync, so we host one on a dedicated thread and bridge
-# every call with ``run_coroutine_threadsafe``. On success we drop a
-# ``restart-<backend>.cmd`` marker so the live controller refreshes its
-# in-process agent state (mirroring what ``_refresh_backend_runtime`` does
-# in-process for IM-driven flows).
+# FastAPI hosts these flows on the UI server's persistent ASGI event loop.
+# On success we drop a ``restart-<backend>.cmd`` marker so the live
+# controller refreshes its in-process agent state (mirroring what
+# ``_refresh_backend_runtime`` does in-process for IM-driven flows).
 # ---------------------------------------------------------------------------
 
 
@@ -2319,20 +2345,6 @@ class _WebControllerStub:
 
 _oauth_service_lock = threading.Lock()
 _oauth_service: Any = None
-_oauth_loop: Any = None
-_oauth_loop_thread: Any = None
-
-
-def _start_oauth_event_loop() -> Any:
-    loop = asyncio.new_event_loop()
-
-    def _runner() -> None:
-        asyncio.set_event_loop(loop)
-        loop.run_forever()
-
-    thread = threading.Thread(target=_runner, daemon=True, name="vibe-oauth-loop")
-    thread.start()
-    return loop, thread
 
 
 def _on_web_auth_success(backend: str) -> None:
@@ -2349,23 +2361,16 @@ def _on_web_auth_success(backend: str) -> None:
 
 def _get_oauth_service() -> Any:
     """Lazily build the (singleton) AgentAuthService for web flows."""
-    global _oauth_service, _oauth_loop, _oauth_loop_thread
+    global _oauth_service
     with _oauth_service_lock:
         if _oauth_service is not None:
             return _oauth_service
         from core.agent_auth_service import AgentAuthService
 
-        _oauth_loop, _oauth_loop_thread = _start_oauth_event_loop()
         controller = _WebControllerStub()
         _oauth_service = AgentAuthService(controller)
         _oauth_service._post_web_success_hook = _on_web_auth_success
         return _oauth_service
-
-
-def _submit_oauth_coro(coro, *, timeout: float = 30.0):
-    service = _get_oauth_service()  # ensures loop  # noqa: F841
-    future = asyncio.run_coroutine_threadsafe(coro, _oauth_loop)
-    return future.result(timeout=timeout)
 
 
 def _serialize_web_flow_status(payload: dict) -> dict:
@@ -2383,6 +2388,18 @@ def start_oauth_web(
     force_reset: bool = True,
     provider_id: Optional[str] = None,
 ) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(
+        start_oauth_web_async(backend, force_reset=force_reset, provider_id=provider_id)
+    )
+
+
+async def start_oauth_web_async(
+    backend: str,
+    force_reset: bool = True,
+    provider_id: Optional[str] = None,
+) -> dict:
     backend = (backend or "").strip().lower()
     if backend not in _WEB_OAUTH_BACKENDS:
         return {"ok": False, "error": "unsupported_backend"}
@@ -2390,13 +2407,10 @@ def start_oauth_web(
         return {"ok": False, "error": "opencode_provider_id_required"}
     service = _get_oauth_service()
     try:
-        flow = _submit_oauth_coro(
-            service.start_web_setup(
-                backend,
-                force_reset=force_reset,
-                provider_id=(provider_id.strip() if isinstance(provider_id, str) else None),
-            ),
-            timeout=60.0,
+        flow = await service.start_web_setup(
+            backend,
+            force_reset=force_reset,
+            provider_id=(provider_id.strip() if isinstance(provider_id, str) else None),
         )
     except Exception as exc:  # noqa: BLE001
         logger.error("Web OAuth start failed for %s: %s", backend, exc, exc_info=True)
@@ -2429,28 +2443,37 @@ def get_oauth_web_status(flow_id: str) -> dict:
 
 
 def submit_oauth_web_code(flow_id: str, code: str) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(submit_oauth_web_code_async(flow_id, code))
+
+
+async def submit_oauth_web_code_async(flow_id: str, code: str) -> dict:
     flow_id = (flow_id or "").strip()
     if not flow_id:
         return {"ok": False, "error": "missing_flow_id"}
     service = _get_oauth_service()
     try:
-        return _submit_oauth_coro(
-            service.submit_web_code(flow_id, code or ""),
-            timeout=30.0,
-        )
+        return await service.submit_web_code(flow_id, code or "")
     except Exception as exc:  # noqa: BLE001
         logger.error("Web OAuth code submit failed: %s", exc, exc_info=True)
         return {"ok": False, "error": "submit_failed", "detail": str(exc)}
 
 
 def remove_backend_auth(backend: str) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(remove_backend_auth_async(backend))
+
+
+async def remove_backend_auth_async(backend: str) -> dict:
     """Clear stored credentials for Claude or Codex (web Settings)."""
     backend = (backend or "").strip().lower()
     if backend not in _WEB_OAUTH_BACKENDS:
         return {"ok": False, "error": "unsupported_backend"}
     service = _get_oauth_service()
     try:
-        return _submit_oauth_coro(service.remove_web_auth(backend), timeout=30.0)
+        return await service.remove_web_auth(backend)
     except Exception as exc:  # noqa: BLE001
         logger.error("Web auth remove failed for %s: %s", backend, exc, exc_info=True)
         return {"ok": False, "error": "remove_failed", "detail": str(exc)}
@@ -2545,6 +2568,12 @@ def remove_backend_api_key(backend: str) -> dict:
 
 
 def test_backend_auth(backend: str, model: Optional[str] = None) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(test_backend_auth_async(backend, model=model))
+
+
+async def test_backend_auth_async(backend: str, model: Optional[str] = None) -> dict:
     """Send a single-token ``Hi`` probe through the backend CLI.
 
     ``model`` lets the caller override the CLI's configured default —
@@ -2556,16 +2585,19 @@ def test_backend_auth(backend: str, model: Optional[str] = None) -> dict:
         return {"ok": False, "error": "unsupported_backend"}
     service = _get_oauth_service()
     try:
-        return _submit_oauth_coro(
-            service.test_web_auth(backend, model=model),
-            timeout=60.0,
-        )
+        return await service.test_web_auth(backend, model=model)
     except Exception as exc:  # noqa: BLE001
         logger.error("Web auth test failed for %s: %s", backend, exc, exc_info=True)
         return {"ok": False, "error": "test_failed", "detail": str(exc)}
 
 
 def test_opencode_provider(provider_id: str, model: Optional[str] = None) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(test_opencode_provider_async(provider_id, model=model))
+
+
+async def test_opencode_provider_async(provider_id: str, model: Optional[str] = None) -> dict:
     """Probe a single OpenCode provider over the live ``opencode serve`` HTTP API.
 
     OpenCode users typically wire up multiple providers (OpenAI, Poe,
@@ -2579,10 +2611,7 @@ def test_opencode_provider(provider_id: str, model: Optional[str] = None) -> dic
         return {"ok": False, "error": "missing_provider"}
     service = _get_oauth_service()
     try:
-        return _submit_oauth_coro(
-            service.test_opencode_provider(provider_id, model=model),
-            timeout=90.0,
-        )
+        return await service.test_opencode_provider(provider_id, model=model)
     except Exception as exc:  # noqa: BLE001
         logger.error(
             "OpenCode provider test failed for %s: %s",
@@ -2594,12 +2623,18 @@ def test_opencode_provider(provider_id: str, model: Optional[str] = None) -> dic
 
 
 def cancel_oauth_web(flow_id: str) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(cancel_oauth_web_async(flow_id))
+
+
+async def cancel_oauth_web_async(flow_id: str) -> dict:
     flow_id = (flow_id or "").strip()
     if not flow_id:
         return {"ok": False, "error": "missing_flow_id"}
     service = _get_oauth_service()
     try:
-        return _submit_oauth_coro(service.cancel_web_flow(flow_id), timeout=15.0)
+        return await service.cancel_web_flow(flow_id)
     except Exception as exc:  # noqa: BLE001
         logger.error("Web OAuth cancel failed: %s", exc, exc_info=True)
         return {"ok": False, "error": "cancel_failed", "detail": str(exc)}
@@ -3303,9 +3338,15 @@ async def _get_opencode_providers_async() -> dict:
 
 
 def get_opencode_providers() -> dict:
-    """Sync wrapper for the OpenCode provider catalog."""
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(get_opencode_providers_async())
+
+
+async def get_opencode_providers_async() -> dict:
+    """Return the OpenCode provider catalog."""
     try:
-        return asyncio.run(_get_opencode_providers_async())
+        return await _get_opencode_providers_async()
     except Exception as exc:
         logger.warning("OpenCode providers fetch failed: %s", exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
@@ -3395,6 +3436,12 @@ async def _save_opencode_provider_auth_async(
 
 
 def save_opencode_provider_auth(provider_id: str, payload: dict) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(save_opencode_provider_auth_async(provider_id, payload))
+
+
+async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> dict:
     """Persist a single OpenCode provider's API key (and optional base URL).
 
     The api key is forwarded to OpenCode's own ``PUT /auth`` endpoint so
@@ -3458,9 +3505,7 @@ def save_opencode_provider_auth(provider_id: str, payload: dict) -> dict:
             return {"ok": False, "message": "base_url must be a string"}
 
     try:
-        result = asyncio.run(
-            _save_opencode_provider_auth_async(provider_id.strip(), api_key, base_url)
-        )
+        result = await _save_opencode_provider_auth_async(provider_id.strip(), api_key, base_url)
     except Exception as exc:
         logger.warning("OpenCode set-auth failed for %s: %s", provider_id, exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
@@ -3493,6 +3538,12 @@ async def _delete_opencode_provider_auth_async(provider_id: str) -> dict:
 
 
 def delete_opencode_provider_auth(provider_id: str) -> dict:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(delete_opencode_provider_auth_async(provider_id))
+
+
+async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
     """Drop a single provider's stored credentials.
 
     Same restart pattern as save: the daemon caches ``connected`` at
@@ -3512,7 +3563,7 @@ def delete_opencode_provider_auth(provider_id: str) -> dict:
         return {"ok": False, "message": "provider_id is required"}
     pid = provider_id.strip()
     try:
-        result = asyncio.run(_delete_opencode_provider_auth_async(pid))
+        result = await _delete_opencode_provider_auth_async(pid)
     except Exception as exc:
         logger.warning("OpenCode delete-auth failed for %s: %s", provider_id, exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
@@ -3680,6 +3731,19 @@ def _lark_tenant_token(
     domain: str = "feishu",
     proxy_url: str | None = None,
 ) -> Optional[str]:
+    from vibe.async_bridge import run_coroutine_blocking
+
+    return run_coroutine_blocking(
+        _lark_tenant_token_async(app_id, app_secret, domain, proxy_url=proxy_url)
+    )
+
+
+async def _lark_tenant_token_async(
+    app_id: str,
+    app_secret: str,
+    domain: str = "feishu",
+    proxy_url: str | None = None,
+) -> Optional[str]:
     """Get Lark tenant access token (internal helper, not exposed to frontend).
 
     ``proxy_url`` is honored when set: SOCKS schemes route through
@@ -3696,17 +3760,20 @@ def _lark_tenant_token(
     headers = {"Content-Type": "application/json"}
 
     if proxy_url and is_socks_proxy(proxy_url):
-        result = asyncio.run(_lark_tenant_token_via_aiohttp(url, body, headers, proxy_url))
+        result = await _lark_tenant_token_via_aiohttp(url, body, headers, proxy_url)
     else:
-        if proxy_url:
-            opener = urllib.request.build_opener(
-                urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
-            )
-        else:
-            opener = urllib.request.build_opener()
-        req = urllib.request.Request(url, data=body, headers=headers)
-        with opener.open(req, timeout=10) as resp:
-            result = json.loads(resp.read().decode())
+        def _request() -> dict:
+            if proxy_url:
+                opener = urllib.request.build_opener(
+                    urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
+                )
+            else:
+                opener = urllib.request.build_opener()
+            req = urllib.request.Request(url, data=body, headers=headers)
+            with opener.open(req, timeout=10) as resp:
+                return json.loads(resp.read().decode())
+
+        result = await asyncio.to_thread(_request)
 
     if result.get("code") == 0:
         return result.get("tenant_access_token")
@@ -3731,6 +3798,24 @@ def lark_auth_test(
     domain: str = "feishu",
     proxy_url: str | None = None,
 ) -> dict:
+    from vibe.proxy import resolve_proxy
+
+    proxy = resolve_proxy(proxy_url)
+    try:
+        token = _lark_tenant_token(app_id, app_secret, domain, proxy_url=proxy)
+        if not token:
+            return {"ok": False, "error": "Invalid credentials"}
+        return {"ok": True}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+async def lark_auth_test_async(
+    app_id: str,
+    app_secret: str,
+    domain: str = "feishu",
+    proxy_url: str | None = None,
+) -> dict:
     """Test Lark/Feishu app credentials. Only returns ok/error, never exposes token.
 
     ``proxy_url`` is honored for the auth call itself; the runtime SDK
@@ -3741,7 +3826,7 @@ def lark_auth_test(
 
     proxy = resolve_proxy(proxy_url)
     try:
-        token = _lark_tenant_token(app_id, app_secret, domain, proxy_url=proxy)
+        token = await _lark_tenant_token_async(app_id, app_secret, domain, proxy_url=proxy)
         if not token:
             return {"ok": False, "error": "Invalid credentials"}
         return {"ok": True}
@@ -4062,9 +4147,7 @@ def _stop_temp_ws_internal():
             _temp_ws_client._auto_reconnect = False
             from lark_oapi.ws.client import loop as ws_loop
 
-            import asyncio
-
-            asyncio.run_coroutine_threadsafe(_temp_ws_client._disconnect(), ws_loop)
+            ws_loop.call_soon_threadsafe(ws_loop.create_task, _temp_ws_client._disconnect())
         except Exception:
             pass
         _temp_ws_client = None

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -4,12 +4,15 @@ import logging
 import os
 import re
 import shutil
+import ssl
 import subprocess
 import sys
 import threading
 import time
+import urllib.parse
 import urllib.request
 import uuid
+from http.client import HTTPSConnection
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -902,9 +905,29 @@ def opencode_options(cwd: str) -> dict:
 
 
 def _discord_api_get(bot_token: str, path: str, proxy_url: str | None = None) -> dict:
-    from vibe.async_bridge import run_coroutine_blocking
+    import urllib.request
 
-    return run_coroutine_blocking(_discord_api_get_async(bot_token, path, proxy_url=proxy_url))
+    from vibe.proxy import is_socks_proxy, resolve_proxy
+
+    if not bot_token:
+        raise ValueError("bot_token is required")
+    url = f"https://discord.com/api/v10/{path.lstrip('/')}"
+    headers = {"Authorization": f"Bot {bot_token}", "User-Agent": "vibe-remote"}
+
+    proxy = resolve_proxy(proxy_url)
+    if proxy and is_socks_proxy(proxy):
+        return _https_json_request_via_socks(proxy, url, headers=headers)
+
+    if proxy:
+        opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler({"http": proxy, "https": proxy})
+        )
+    else:
+        opener = urllib.request.build_opener()
+    req = urllib.request.Request(url, headers=headers)
+    with opener.open(req, timeout=10) as resp:
+        payload = resp.read().decode("utf-8")
+        return json.loads(payload)
 
 
 async def _discord_api_get_async(bot_token: str, path: str, proxy_url: str | None = None) -> dict:
@@ -935,6 +958,40 @@ async def _discord_api_get_async(bot_token: str, path: str, proxy_url: str | Non
             return json.loads(payload)
 
     return await asyncio.to_thread(_request)
+
+
+def _https_json_request_via_socks(
+    proxy_url: str,
+    url: str,
+    *,
+    method: str = "GET",
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 10,
+) -> dict:
+    from python_socks.sync import Proxy
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise ValueError("Only HTTPS URLs are supported")
+    port = parsed.port or 443
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    sock = Proxy.from_url(proxy_url).connect(parsed.hostname, port, timeout=timeout)
+    tls_sock = ssl.create_default_context().wrap_socket(sock, server_hostname=parsed.hostname)
+    conn = HTTPSConnection(parsed.hostname, port, timeout=timeout)
+    conn.sock = tls_sock
+    try:
+        conn.request(method, path, body=body, headers=headers or {})
+        resp = conn.getresponse()
+        payload = resp.read().decode("utf-8")
+        if resp.status < 200 or resp.status >= 300:
+            raise urllib.error.HTTPError(url, resp.status, resp.reason, resp.headers, None)
+        return json.loads(payload)
+    finally:
+        conn.close()
 
 
 async def _discord_api_get_via_aiohttp(url: str, headers: dict, proxy: str) -> dict:
@@ -3750,11 +3807,36 @@ def _lark_tenant_token(
     domain: str = "feishu",
     proxy_url: str | None = None,
 ) -> Optional[str]:
-    from vibe.async_bridge import run_coroutine_blocking
+    import urllib.request
 
-    return run_coroutine_blocking(
-        _lark_tenant_token_async(app_id, app_secret, domain, proxy_url=proxy_url)
-    )
+    from vibe.proxy import is_socks_proxy
+
+    url = f"{_lark_api_base(domain)}/open-apis/auth/v3/tenant_access_token/internal"
+    body = json.dumps({"app_id": app_id, "app_secret": app_secret}).encode()
+    headers = {"Content-Type": "application/json"}
+
+    if proxy_url and is_socks_proxy(proxy_url):
+        result = _https_json_request_via_socks(
+            proxy_url,
+            url,
+            method="POST",
+            body=body,
+            headers=headers,
+        )
+    else:
+        if proxy_url:
+            opener = urllib.request.build_opener(
+                urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
+            )
+        else:
+            opener = urllib.request.build_opener()
+        req = urllib.request.Request(url, data=body, headers=headers)
+        with opener.open(req, timeout=10) as resp:
+            result = json.loads(resp.read().decode())
+
+    if result.get("code") == 0:
+        return result.get("tenant_access_token")
+    return None
 
 
 async def _lark_tenant_token_async(

--- a/vibe/async_bridge.py
+++ b/vibe/async_bridge.py
@@ -1,0 +1,28 @@
+"""Compatibility helpers for legacy sync call sites."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import TypeVar
+
+
+T = TypeVar("T")
+
+
+def run_coroutine_blocking(coro: Coroutine[object, object, T]) -> T:
+    """Run a coroutine from legacy synchronous code.
+
+    New UI request handlers should await directly on the ASGI event loop. This
+    helper exists for old tests and non-request callers that have not migrated
+    yet. When already inside an event loop, the coroutine is isolated in a short
+    helper must not be used from async UI handlers; those should call the
+    corresponding ``*_async`` function directly.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    coro.close()
+    raise RuntimeError("run_coroutine_blocking cannot be used from an active event loop")

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -600,7 +600,7 @@ def _origin_host_for_pairing(config: V2Config) -> str:
     host = (config.ui.setup_host or "").strip()
     if host.startswith("[") and host.endswith("]"):
         host = host[1:-1].strip()
-    # "localhost" is ambiguous: cloudflared and werkzeug resolve it
+    # "localhost" is ambiguous: cloudflared and the UI server resolve it
     # independently, so on a dual-stack host they can land on different
     # families (::1 vs 127.0.0.1) and surface as a 502. Hand cloudflared
     # a literal loopback IP whose family matches the wildcard

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -547,7 +547,7 @@ def resolve_localhost_family() -> str:
     ``effective_ui_bind_host`` and ``_origin_host_for_pairing`` so the
     bind family and the cloudflared origin family stay aligned: forcing
     IPv4 unconditionally would regress IPv6-only hosts, while leaving
-    resolution to werkzeug + cloudflared independently re-creates the
+    resolution to the UI server + cloudflared independently re-creates the
     ::1 vs 127.0.0.1 race that surfaces as 502.
     """
     try:

--- a/vibe/sentry_integration.py
+++ b/vibe/sentry_integration.py
@@ -413,7 +413,7 @@ def before_breadcrumb(crumb: dict[str, Any], hint: dict[str, Any]) -> dict[str, 
     return scrub_data(crumb)
 
 
-def init_sentry(config: V2Config, component: str, enable_flask: bool = False) -> bool:
+def init_sentry(config: V2Config, component: str, enable_fastapi: bool = False) -> bool:
     options = resolve_sentry_options()
     if not options:
         return False
@@ -431,13 +431,15 @@ def init_sentry(config: V2Config, component: str, enable_flask: bool = False) ->
             event_level=logging.ERROR,
         )
     ]
-    if enable_flask:
+    if enable_fastapi:
         try:
-            from sentry_sdk.integrations.flask import FlaskIntegration
+            from sentry_sdk.integrations.fastapi import FastApiIntegration
+            from sentry_sdk.integrations.starlette import StarletteIntegration
         except Exception as exc:
-            logger.warning("Flask Sentry integration unavailable: %s", exc)
+            logger.warning("FastAPI Sentry integration unavailable: %s", exc)
         else:
-            integrations.append(FlaskIntegration())
+            integrations.append(StarletteIntegration())
+            integrations.append(FastApiIntegration())
 
     from vibe import __version__
 

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, Request as FastAPIRequest
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response as StarletteResponse
 from fastapi.testclient import TestClient
 from starlette.concurrency import run_in_threadpool
+from starlette.exceptions import HTTPException
 from starlette.datastructures import Headers, QueryParams, URL
 
 
@@ -482,7 +483,7 @@ async def _read_json_payload(request: FastAPIRequest) -> Any:
     try:
         return json.loads(body)
     except json.JSONDecodeError:
-        return None
+        raise HTTPException(status_code=400, detail="Malformed JSON")
 
 
 def _build_scope(method: str, url: str, headers: dict[str, str]) -> dict[str, Any]:

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -160,7 +160,7 @@ def route_path_to_regex(path: str) -> re.Pattern[str]:
 
 
 def route_path_to_fastapi(path: str) -> str:
-    converted = path.replace("<path:path>", "{path:path}")
+    converted = re.sub(r"<path:([A-Za-z_][A-Za-z0-9_]*)>", r"{\1:path}", path)
     return re.sub(r"<([A-Za-z_][A-Za-z0-9_]*)>", r"{\1}", converted)
 
 
@@ -171,7 +171,10 @@ def normalize_response(value: Any) -> Response:
     if isinstance(value, tuple):
         body = value[0]
         if len(value) > 1:
-            status_code = int(value[1])
+            if isinstance(value[1], (dict, list, tuple)):
+                headers = dict(value[1])
+            else:
+                status_code = int(value[1])
         if len(value) > 2:
             headers = dict(value[2])
     if isinstance(body, StarletteResponse):

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -16,6 +16,8 @@ from fastapi.testclient import TestClient
 from starlette.datastructures import Headers, QueryParams, URL
 
 
+TEST_REMOTE_ADDR_HEADER = "x-vibe-test-remote-addr"
+
 _request_var: ContextVar["CompatRequest"] = ContextVar("ui_request")
 _g_var: ContextVar[Any] = ContextVar("ui_g")
 
@@ -272,7 +274,7 @@ class CompatTestClient:
             if not base_url and "Origin" in headers:
                 request_url = _join_base_url(headers["Origin"], url)
             remote_addr = environ_base.get("REMOTE_ADDR") or "127.0.0.1"
-            headers["X-Vibe-Test-Remote-Addr"] = str(remote_addr)
+            headers[TEST_REMOTE_ADDR_HEADER] = str(remote_addr)
             request_url = _normalize_test_url_for_starlette(request_url, headers)
             kwargs.setdefault("follow_redirects", False)
             response = self._client.request(method, request_url, headers=headers, **kwargs)
@@ -344,14 +346,7 @@ class CompatApp(FastAPI):
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         if scope.get("type") == "http":
             query = scope.get("query_string", b"").decode("latin-1")
-            remote_addr = next(
-                (
-                    value.decode("latin-1")
-                    for key, value in scope.get("headers", [])
-                    if key == b"x-vibe-test-remote-addr"
-                ),
-                None,
-            )
+            remote_addr = _test_remote_addr_from_scope(scope)
             if "&amp;" in query or remote_addr:
                 scope = dict(scope)
                 scope["query_string"] = query.replace("&amp;", "&").encode("latin-1")
@@ -410,7 +405,7 @@ class CompatApp(FastAPI):
         defaults: dict[str, Any],
     ) -> Response:
         json_payload = await _read_json_payload(starlette_request)
-        remote_addr = starlette_request.headers.get("x-vibe-test-remote-addr")
+        remote_addr = _test_remote_addr_from_scope(starlette_request.scope)
         if remote_addr:
             starlette_request.scope["vibe_remote_addr"] = remote_addr
         compat_request = CompatRequest(starlette_request, json_payload=json_payload)
@@ -446,6 +441,20 @@ class CompatApp(FastAPI):
 def _extract_path_args(route_regex: re.Pattern[str], path: str) -> dict[str, str]:
     match = route_regex.match(path)
     return match.groupdict() if match else {}
+
+
+def _test_remote_addr_from_scope(scope: Any) -> str | None:
+    client = scope.get("client")
+    if not isinstance(client, tuple) or client[:1] != ("testclient",):
+        return None
+    return next(
+        (
+            value.decode("latin-1")
+            for key, value in scope.get("headers", [])
+            if key == TEST_REMOTE_ADDR_HEADER.encode("latin-1")
+        ),
+        None,
+    )
 
 
 async def _read_json_payload(request: FastAPIRequest) -> Any:

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -269,6 +269,8 @@ class CompatTestClient:
             request_url = url
             if base_url:
                 request_url = _join_base_url(base_url, url)
+            elif not url.startswith(("http://", "https://")):
+                request_url = _join_base_url("http://127.0.0.1", url)
             headers = kwargs.pop("headers", None) or {}
             headers = dict(headers)
             if not base_url and "Origin" in headers:

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import inspect
 import json
 import re
@@ -13,6 +14,7 @@ from urllib.parse import urlsplit
 from fastapi import FastAPI, Request as FastAPIRequest
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response as StarletteResponse
 from fastapi.testclient import TestClient
+from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import Headers, QueryParams, URL
 
 
@@ -187,8 +189,19 @@ def normalize_response(value: Any) -> Response:
     )
 
 
+def _is_async_callable(obj: Any) -> bool:
+    while isinstance(obj, functools.partial):
+        obj = obj.func
+    return inspect.iscoroutinefunction(obj) or (
+        callable(obj) and inspect.iscoroutinefunction(obj.__call__)
+    )
+
+
 async def run_maybe_async(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-    result = func(*args, **kwargs)
+    if _is_async_callable(func):
+        result = await func(*args, **kwargs)
+    else:
+        result = await run_in_threadpool(func, *args, **kwargs)
     if inspect.isawaitable(result):
         return await result
     return result

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import contextlib
+import inspect
+import json
+import re
+import threading
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+from fastapi import FastAPI, Request as FastAPIRequest
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response as StarletteResponse
+from fastapi.testclient import TestClient
+from starlette.datastructures import Headers, QueryParams, URL
+
+
+_request_var: ContextVar["CompatRequest"] = ContextVar("ui_request")
+_g_var: ContextVar[Any] = ContextVar("ui_g")
+
+
+class _LocalProxy:
+    def __init__(self, getter: Callable[[], Any]) -> None:
+        object.__setattr__(self, "_getter", getter)
+
+    def _get_current_object(self) -> Any:
+        return object.__getattribute__(self, "_getter")()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._get_current_object(), name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        setattr(self._get_current_object(), name, value)
+
+    def __delattr__(self, name: str) -> None:
+        delattr(self._get_current_object(), name)
+
+
+class CompatRequest:
+    def __init__(self, request: FastAPIRequest, json_payload: Any = None) -> None:
+        self._request = request
+        self._json_payload = json_payload
+
+    @property
+    def method(self) -> str:
+        return self._request.method
+
+    @property
+    def path(self) -> str:
+        return self._request.url.path
+
+    @property
+    def args(self) -> QueryParams:
+        return self._request.query_params
+
+    @property
+    def headers(self) -> Headers:
+        return self._request.headers
+
+    @property
+    def cookies(self) -> dict[str, str]:
+        return self._request.cookies
+
+    @property
+    def json(self) -> Any:
+        return self._json_payload
+
+    @property
+    def host(self) -> str:
+        return self._request.headers.get("host", "")
+
+    @property
+    def host_url(self) -> str:
+        return str(URL(scope=self._request.scope).replace(path="/", query=""))
+
+    @property
+    def full_path(self) -> str:
+        query = self.query_string.decode("latin-1")
+        return f"{self.path}?{query}" if query else self.path
+
+    @property
+    def query_string(self) -> bytes:
+        return self._request.scope.get("query_string", b"")
+
+    @property
+    def remote_addr(self) -> str | None:
+        override = self._request.scope.get("vibe_remote_addr")
+        if override:
+            return str(override)
+        client = self._request.client
+        return client.host if client else None
+
+    @property
+    def is_secure(self) -> bool:
+        return self._request.url.scheme == "https"
+
+
+request = _LocalProxy(lambda: _request_var.get())
+g = _LocalProxy(lambda: _g_var.get())
+
+
+def jsonify(*args: Any, **kwargs: Any) -> JSONResponse:
+    if args and kwargs:
+        raise TypeError("jsonify() behavior with args and kwargs is unsupported")
+    if kwargs:
+        content = kwargs
+    elif len(args) == 1:
+        content = args[0]
+    else:
+        content = list(args)
+    return JSONResponse(content)
+
+
+def redirect(location: str, code: int = 302) -> RedirectResponse:
+    return RedirectResponse(location, status_code=code)
+
+
+class Response(StarletteResponse):
+    def __init__(
+        self,
+        content: Any = None,
+        status_code: int = 200,
+        *,
+        status: int | None = None,
+        headers: dict[str, str] | None = None,
+        media_type: str | None = None,
+        mimetype: str | None = None,
+        background: Any = None,
+    ) -> None:
+        super().__init__(
+            content="" if content is None else content,
+            status_code=status if status is not None else status_code,
+            headers=headers,
+            media_type=mimetype or media_type,
+            background=background,
+        )
+
+
+def send_file(path: str | Path, mimetype: str | None = None) -> FileResponse:
+    return FileResponse(path, media_type=mimetype)
+
+
+def route_path_to_regex(path: str) -> re.Pattern[str]:
+    parts: list[str] = []
+    index = 0
+    token_re = re.compile(r"<(?:(path):)?([A-Za-z_][A-Za-z0-9_]*)>")
+    for match in token_re.finditer(path):
+        parts.append(re.escape(path[index : match.start()]))
+        converter, name = match.groups()
+        parts.append(rf"(?P<{name}>.*)" if converter == "path" else rf"(?P<{name}>[^/]+)")
+        index = match.end()
+    parts.append(re.escape(path[index:]))
+    return re.compile(rf"^{''.join(parts)}$")
+
+
+def route_path_to_fastapi(path: str) -> str:
+    converted = path.replace("<path:path>", "{path:path}")
+    return re.sub(r"<([A-Za-z_][A-Za-z0-9_]*)>", r"{\1}", converted)
+
+
+def normalize_response(value: Any) -> Response:
+    status_code: int | None = None
+    headers: dict[str, str] | None = None
+    body = value
+    if isinstance(value, tuple):
+        body = value[0]
+        if len(value) > 1:
+            status_code = int(value[1])
+        if len(value) > 2:
+            headers = dict(value[2])
+    if isinstance(body, StarletteResponse):
+        if status_code is not None:
+            body.status_code = status_code
+        if headers:
+            for key, val in headers.items():
+                body.headers[key] = val
+        return body
+    if isinstance(body, (dict, list)):
+        return JSONResponse(body, status_code=status_code or 200, headers=headers)
+    return Response(
+        content="" if body is None else str(body),
+        status_code=status_code or 200,
+        headers=headers,
+    )
+
+
+async def run_maybe_async(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    result = func(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+class CompatHeaders:
+    def __init__(self, headers: Any) -> None:
+        self._headers = headers
+
+    def getlist(self, key: str) -> list[str]:
+        if hasattr(self._headers, "getlist"):
+            return list(self._headers.getlist(key))
+        if hasattr(self._headers, "get_list"):
+            return list(self._headers.get_list(key))
+        value = self._headers.get(key)
+        return [] if value is None else [value]
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._headers, name)
+
+    def __getitem__(self, key: str) -> str:
+        return self._headers[key]
+
+    def __iter__(self):
+        return iter(self._headers)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._headers
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._headers.get(key, default)
+
+
+class CompatTestResponse:
+    def __init__(self, response: Any) -> None:
+        self._response = response
+        self.headers = CompatHeaders(response.headers)
+
+    def get_json(self) -> Any:
+        return self._response.json()
+
+    @property
+    def is_json(self) -> bool:
+        return "application/json" in self.headers.get("content-type", "").lower()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._response, name)
+
+
+class CompatTestClient:
+    def __init__(self, app: "CompatApp") -> None:
+        self._client = TestClient(app)
+        self._lock = threading.Lock()
+
+    def set_cookie(
+        self,
+        key: str,
+        value: str,
+        *,
+        domain: str = "testserver",
+        path: str = "/",
+    ) -> None:
+        self._client.cookies.set(key, value, domain=domain, path=path)
+
+    def get(self, url: str, **kwargs: Any) -> CompatTestResponse:
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> CompatTestResponse:
+        return self.request("POST", url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> CompatTestResponse:
+        return self.request("DELETE", url, **kwargs)
+
+    def request(self, method: str, url: str, **kwargs: Any) -> CompatTestResponse:
+        with self._lock:
+            base_url = kwargs.pop("base_url", None)
+            environ_base = kwargs.pop("environ_base", None) or {}
+            request_url = url
+            if base_url:
+                request_url = _join_base_url(base_url, url)
+            headers = kwargs.pop("headers", None) or {}
+            headers = dict(headers)
+            if not base_url and "Origin" in headers:
+                request_url = _join_base_url(headers["Origin"], url)
+            remote_addr = environ_base.get("REMOTE_ADDR") or "127.0.0.1"
+            headers["X-Vibe-Test-Remote-Addr"] = str(remote_addr)
+            request_url = _normalize_test_url_for_starlette(request_url, headers)
+            kwargs.setdefault("follow_redirects", False)
+            response = self._client.request(method, request_url, headers=headers, **kwargs)
+            return CompatTestResponse(response)
+
+    def websocket_connect(self, url: str, **kwargs: Any) -> Any:
+        return self._client.websocket_connect(url, **kwargs)
+
+
+def _join_base_url(base_url: str, url: str) -> str:
+    if url.startswith(("http://", "https://")):
+        return url
+    base = base_url.rstrip("/")
+    suffix = url if url.startswith("/") else f"/{url}"
+    return f"{base}{suffix}"
+
+
+def _normalize_test_url_for_starlette(url: str, headers: dict[str, str]) -> str:
+    parsed = urlsplit(url)
+    if parsed.hostname and ":" in parsed.hostname:
+        headers.setdefault("Host", parsed.netloc)
+        query = f"?{parsed.query}" if parsed.query else ""
+        return f"{parsed.scheme}://testserver{parsed.path or '/'}{query}"
+    return url
+
+
+class CompatApp(FastAPI):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.pop("static_folder", None)
+        super().__init__(*args, **kwargs)
+        self._before_request_handlers: list[Callable[..., Any]] = []
+        self._after_request_handlers: list[Callable[..., Any]] = []
+        self._error_handlers: list[tuple[type[BaseException], Callable[..., Any]]] = []
+
+    def route(
+        self,
+        path: str,
+        methods: list[str] | tuple[str, ...] | None = None,
+        defaults: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        methods = tuple(methods or ("GET",))
+        fastapi_path = route_path_to_fastapi(path)
+        route_regex = route_path_to_regex(path)
+        defaults = dict(defaults or {})
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            async def endpoint(starlette_request: FastAPIRequest) -> Response:
+                return await self._dispatch_compat_route(
+                    starlette_request,
+                    func,
+                    route_regex,
+                    defaults,
+                )
+
+            endpoint.__name__ = f"{func.__name__}_compat_endpoint"
+            endpoint.__doc__ = func.__doc__
+            self.add_api_route(
+                fastapi_path,
+                endpoint,
+                methods=list(methods),
+                include_in_schema=kwargs.pop("include_in_schema", False),
+                response_model=None,
+            )
+            return func
+
+        return decorator
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") == "http":
+            query = scope.get("query_string", b"").decode("latin-1")
+            remote_addr = next(
+                (
+                    value.decode("latin-1")
+                    for key, value in scope.get("headers", [])
+                    if key == b"x-vibe-test-remote-addr"
+                ),
+                None,
+            )
+            if "&amp;" in query or remote_addr:
+                scope = dict(scope)
+                scope["query_string"] = query.replace("&amp;", "&").encode("latin-1")
+                if remote_addr:
+                    scope["vibe_remote_addr"] = remote_addr
+                scope["headers"] = [
+                    (key, value)
+                    for key, value in scope.get("headers", [])
+                    if key != b"x-vibe-test-remote-addr"
+                ]
+        await super().__call__(scope, receive, send)
+
+    def before_request(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        self._before_request_handlers.append(func)
+        return func
+
+    def after_request(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        self._after_request_handlers.append(func)
+        return func
+
+    def errorhandler(self, exc_class: type[BaseException]):
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self._error_handlers.append((exc_class, func))
+            return func
+
+        return decorator
+
+    def test_client(self) -> CompatTestClient:
+        return CompatTestClient(self)
+
+    @contextlib.contextmanager
+    def test_request_context(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        base_url: str = "http://testserver",
+        headers: dict[str, str] | None = None,
+        json: Any = None,
+    ):
+        scope = _build_scope(method, _join_base_url(base_url, path), headers or {})
+        compat_request = CompatRequest(FastAPIRequest(scope), json_payload=json)
+        token_request = _request_var.set(compat_request)
+        token_g = _g_var.set(type("CompatG", (), {})())
+        try:
+            yield compat_request
+        finally:
+            _g_var.reset(token_g)
+            _request_var.reset(token_request)
+
+    async def _dispatch_compat_route(
+        self,
+        starlette_request: FastAPIRequest,
+        func: Callable[..., Any],
+        route_regex: re.Pattern[str],
+        defaults: dict[str, Any],
+    ) -> Response:
+        json_payload = await _read_json_payload(starlette_request)
+        remote_addr = starlette_request.headers.get("x-vibe-test-remote-addr")
+        if remote_addr:
+            starlette_request.scope["vibe_remote_addr"] = remote_addr
+        compat_request = CompatRequest(starlette_request, json_payload=json_payload)
+        token_request = _request_var.set(compat_request)
+        token_g = _g_var.set(type("CompatG", (), {})())
+        try:
+            response: Response | None = None
+            try:
+                for before in self._before_request_handlers:
+                    result = await run_maybe_async(before)
+                    if result is not None:
+                        response = normalize_response(result)
+                        break
+                if response is None:
+                    route_args = defaults | _extract_path_args(route_regex, compat_request.path)
+                    response = normalize_response(await run_maybe_async(func, **route_args))
+            except Exception as exc:
+                response = await self._handle_compat_exception(exc)
+            for after in reversed(self._after_request_handlers):
+                response = normalize_response(await run_maybe_async(after, response))
+            return response
+        finally:
+            _g_var.reset(token_g)
+            _request_var.reset(token_request)
+
+    async def _handle_compat_exception(self, exc: Exception) -> Response:
+        for exc_class, handler in reversed(self._error_handlers):
+            if isinstance(exc, exc_class):
+                return normalize_response(await run_maybe_async(handler, exc))
+        raise exc
+
+
+def _extract_path_args(route_regex: re.Pattern[str], path: str) -> dict[str, str]:
+    match = route_regex.match(path)
+    return match.groupdict() if match else {}
+
+
+async def _read_json_payload(request: FastAPIRequest) -> Any:
+    content_type = request.headers.get("content-type", "")
+    if "application/json" not in content_type.lower():
+        return None
+    body = await request.body()
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return None
+
+
+def _build_scope(method: str, url: str, headers: dict[str, str]) -> dict[str, Any]:
+    parsed = urlsplit(url)
+    raw_headers = [(key.lower().encode("latin-1"), value.encode("latin-1")) for key, value in headers.items()]
+    if not any(key == b"host" for key, _ in raw_headers):
+        raw_headers.append((b"host", parsed.netloc.encode("latin-1")))
+    return {
+        "type": "http",
+        "method": method,
+        "scheme": parsed.scheme or "http",
+        "path": parsed.path or "/",
+        "raw_path": (parsed.path or "/").encode("ascii"),
+        "query_string": parsed.query.encode("ascii"),
+        "headers": raw_headers,
+        "server": (parsed.hostname or "testserver", parsed.port or (443 if parsed.scheme == "https" else 80)),
+        "client": ("testclient", 50000),
+    }

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -423,11 +423,10 @@ class CompatApp(FastAPI):
         route_regex: re.Pattern[str],
         defaults: dict[str, Any],
     ) -> Response:
-        json_payload = await _read_json_payload(starlette_request)
         remote_addr = _test_remote_addr_from_scope(starlette_request.scope)
         if remote_addr:
             starlette_request.scope["vibe_remote_addr"] = remote_addr
-        compat_request = CompatRequest(starlette_request, json_payload=json_payload)
+        compat_request = CompatRequest(starlette_request)
         token_request = _request_var.set(compat_request)
         token_g = _g_var.set(type("CompatG", (), {})())
         try:
@@ -439,6 +438,7 @@ class CompatApp(FastAPI):
                         response = normalize_response(result)
                         break
                 if response is None:
+                    compat_request._json_payload = await _read_json_payload(starlette_request)
                     route_args = defaults | _extract_path_args(route_regex, compat_request.path)
                     response = normalize_response(await run_maybe_async(func, **route_args))
             except Exception as exc:
@@ -478,7 +478,7 @@ def _test_remote_addr_from_scope(scope: Any) -> str | None:
 
 async def _read_json_payload(request: FastAPIRequest) -> Any:
     content_type = request.headers.get("content-type", "")
-    if "application/json" not in content_type.lower():
+    if not _is_json_content_type(content_type):
         return None
     body = await request.body()
     if not body:
@@ -487,6 +487,13 @@ async def _read_json_payload(request: FastAPIRequest) -> Any:
         return json.loads(body)
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Malformed JSON")
+
+
+def _is_json_content_type(content_type: str) -> bool:
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    return media_type == "application/json" or (
+        media_type.startswith("application/") and media_type.endswith("+json")
+    )
 
 
 def _build_scope(method: str, url: str, headers: dict[str, str]) -> dict[str, Any]:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -207,6 +207,23 @@ def _has_forwarded_metadata() -> bool:
     return _has_cloudflare_forwarded_metadata()
 
 
+def _is_loopback_origin_proxy_request() -> bool:
+    if not _is_loopback_peer() or not _is_loopback_host(request.host):
+        return False
+    if request.headers.get("Forwarded") or request.headers.get("X-Forwarded-For"):
+        return False
+    client_ip_headers = (
+        "X-Real-IP",
+        "X-Original-Forwarded-For",
+        "True-Client-IP",
+    )
+    if any(request.headers.get(header) for header in client_ip_headers):
+        return False
+    if _has_cloudflare_forwarded_metadata():
+        return False
+    return bool(request.headers.get("X-Forwarded-Host") or request.headers.get("X-Forwarded-Proto"))
+
+
 def _is_loopback_peer() -> bool:
     remote_addr = (request.remote_addr or "").strip()
     if remote_addr == "localhost":
@@ -908,14 +925,7 @@ def enforce_remote_access_cookie():
         return jsonify({"ok": False, "error": "remote_access_public_url_invalid"}), 503
     remote_request = _is_remote_access_request(config)
     if not remote_request:
-        if (
-            _has_forwarded_metadata()
-            and _is_loopback_peer()
-            and "X-Forwarded-For" not in request.headers
-            and "Forwarded" not in request.headers
-            and _normalized_host(request.host) not in {"127.0.0.1", "localhost", "::1"}
-            and not _is_setup_host_request(config)
-        ):
+        if _is_loopback_origin_proxy_request():
             return None
         if not local_request and not docker_probe_request:
             return jsonify({"ok": False, "error": "remote_access_host_mismatch"}), 503

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import hashlib
 import hmac
@@ -20,7 +19,9 @@ from typing import Any, Callable
 from urllib.parse import quote, unquote, urlparse, urlsplit, urlunsplit
 
 import psutil
-from flask import Flask, g, request, jsonify, redirect, send_file, Response
+from fastapi import WebSocket, WebSocketDisconnect
+
+from vibe.ui_compat import CompatApp, Response, g, jsonify, redirect, request, send_file
 
 from config import paths
 from config.v2_config import CONFIG_LOCK, V2Config
@@ -29,14 +30,10 @@ from vibe.sentry_integration import init_sentry
 
 logger = logging.getLogger(__name__)
 
-app = Flask(__name__, static_folder=None)
+app = CompatApp(title="Vibe Remote UI", docs_url=None, redoc_url=None, openapi_url=None)
 
 # Global server instance for graceful shutdown on reload
 _server = None
-
-# Disable Flask's default logging
-log = logging.getLogger("werkzeug")
-log.setLevel(logging.WARNING)
 
 STRUCTURED_LOG_PATTERN = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s+-\s+([\w.]+)\s+-\s+(\w+)\s+-\s+(.*)$")
 LEVEL_HINT_PATTERN = re.compile(r"\b(DEBUG|INFO|WARNING|ERROR|CRITICAL)\b")
@@ -54,30 +51,6 @@ LOG_SOURCES = (
     ("ui_stdout", "ui_stdout.log", lambda: paths.get_runtime_dir() / "ui_stdout.log"),
     ("ui_stderr", "ui_stderr.log", lambda: paths.get_runtime_dir() / "ui_stderr.log"),
 )
-
-
-def _run_async(coro, timeout: float = 10.0) -> dict:
-    """Run async coroutine in a separate thread with timeout."""
-    result: dict[str, Any] = {}
-    error: str | None = None
-    lock = threading.Event()
-
-    def _runner():
-        nonlocal result, error
-        try:
-            result = asyncio.run(coro)
-        except Exception as exc:
-            error = str(exc)
-        finally:
-            lock.set()
-
-    threading.Thread(target=_runner, daemon=True).start()
-    lock.wait(timeout=timeout)
-    if not lock.is_set():
-        return {"ok": False, "error": "Request timed out"}
-    if error:
-        return {"ok": False, "error": error}
-    return result
 
 
 def _is_continuation_line(line: str, previous_message: str | None = None) -> bool:
@@ -515,6 +488,16 @@ def _is_trusted_docker_loopback_probe() -> bool:
     return _is_trusted_docker_peer()
 
 
+def _has_docker_loopback_probe_shape() -> bool:
+    return (
+        request.method in {"GET", "HEAD"}
+        and request.path in {"/health", "/status"}
+        and not _has_forwarded_metadata()
+        and _is_loopback_host(request.host)
+        and not _is_loopback_peer()
+    )
+
+
 def _is_wildcard_setup_host(setup_host: str) -> bool:
     return setup_host in {"0.0.0.0", "::", "*"}
 
@@ -824,9 +807,16 @@ def _remote_auth_exempt_path() -> bool:
         or path == "/auth/callback"
         or path == "/auth/logout"
         or path == "/api/session"
+        or path == "/api/csrf-token"
         or path.startswith("/assets/")
         or path == "/favicon.ico"
     )
+
+
+def _remote_auth_exempt_before_host_validation() -> bool:
+    return request.path in {"/auth/callback", "/auth/logout", "/api/session", "/api/csrf-token"} or request.path.startswith(
+        "/assets/"
+    ) or request.path == "/favicon.ico"
 
 
 def _oauth_cookie_signature(secret: str, payload: str) -> str:
@@ -905,7 +895,11 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
 @app.before_request
 def enforce_remote_access_cookie():
     config = _load_remote_access_config()
+    if _remote_auth_exempt_before_host_validation():
+        return None
     local_request = _is_local_request(config)
+    if config is None and not _has_forwarded_metadata() and _is_loopback_peer():
+        local_request = True
     docker_probe_request = _is_trusted_docker_loopback_probe()
     if config is None:
         if local_request or docker_probe_request:
@@ -915,10 +909,17 @@ def enforce_remote_access_cookie():
         return jsonify({"ok": False, "error": "remote_access_public_url_invalid"}), 503
     remote_request = _is_remote_access_request(config)
     if not remote_request:
+        if (
+            _has_forwarded_metadata()
+            and _is_loopback_peer()
+            and "X-Forwarded-For" not in request.headers
+            and "Forwarded" not in request.headers
+            and _normalized_host(request.host) not in {"127.0.0.1", "localhost", "::1"}
+            and not _is_setup_host_request(config)
+        ):
+            return None
         if not local_request and not docker_probe_request:
             return jsonify({"ok": False, "error": "remote_access_host_mismatch"}), 503
-        return None
-    if _remote_auth_exempt_path():
         return None
     from vibe import remote_access
 
@@ -1072,11 +1073,11 @@ def _resolve_log_sources() -> list[dict[str, Any]]:
 @app.errorhandler(Exception)
 def handle_exception(e):
     """Global exception handler - ensures all errors return JSON."""
-    from werkzeug.exceptions import HTTPException
-
     # Preserve HTTP status codes for client errors (4xx)
-    if isinstance(e, HTTPException):
-        return jsonify({"error": e.description}), e.code
+    status_code = getattr(e, "status_code", None)
+    detail = getattr(e, "detail", None)
+    if isinstance(status_code, int) and 400 <= status_code < 500:
+        return jsonify({"error": detail or str(e)}), status_code
 
     # Log and return 500 for unexpected server errors
     logger.exception("Unhandled exception in UI server")
@@ -1115,6 +1116,31 @@ def status():
         payload["running"] = False
         payload["pid"] = None
     return jsonify(payload)
+
+
+@app.websocket("/ws/echo")
+async def websocket_echo(websocket: WebSocket):
+    if os.environ.get("VIBE_UI_ENABLE_WS_ECHO", "").lower() not in {"1", "true", "yes", "on"}:
+        await websocket.close(code=1008)
+        return
+
+    client_host = websocket.client.host if websocket.client else ""
+    if client_host != "testclient":
+        try:
+            client_address = ipaddress.ip_address(client_host)
+        except ValueError:
+            client_address = None
+        if client_address is None or not client_address.is_loopback:
+            await websocket.close(code=1008)
+            return
+
+    await websocket.accept()
+    try:
+        while True:
+            message = await websocket.receive_text()
+            await websocket.send_text(f"echo: {message}")
+    except WebSocketDisconnect:
+        return
 
 
 @app.route("/doctor", methods=["GET"])
@@ -1430,7 +1456,12 @@ def ui_reload():
         time.sleep(0.2)
         # Shutdown the old server to release the port
         if _server:
-            _server.shutdown()
+            if hasattr(_server, "should_exit"):
+                _server.should_exit = True
+            else:
+                shutdown = getattr(_server, "shutdown", None)
+                if callable(shutdown):
+                    shutdown()
 
     # Schedule restart after response is sent
     threading.Thread(target=_restart).start()
@@ -1472,11 +1503,11 @@ def slack_channels():
 
 
 @app.route("/discord/auth_test", methods=["POST"])
-def discord_auth_test():
+async def discord_auth_test():
     from vibe import api
 
     payload = request.json or {}
-    result = api.discord_auth_test(
+    result = await api.discord_auth_test_async(
         payload.get("bot_token", ""),
         proxy_url=payload.get("proxy_url"),
     )
@@ -1484,11 +1515,11 @@ def discord_auth_test():
 
 
 @app.route("/discord/guilds", methods=["POST"])
-def discord_guilds():
+async def discord_guilds():
     from vibe import api
 
     payload = request.json or {}
-    return jsonify(api.discord_list_guilds(payload.get("bot_token", "")))
+    return jsonify(await api.discord_list_guilds_async(payload.get("bot_token", "")))
 
 
 @app.route("/discord/channels", methods=["POST"])
@@ -1506,11 +1537,11 @@ def discord_channels():
 
 
 @app.route("/telegram/auth_test", methods=["POST"])
-def telegram_auth_test():
+async def telegram_auth_test():
     from vibe import api
 
     payload = request.json or {}
-    result = api.telegram_auth_test(
+    result = await api.telegram_auth_test_async(
         payload.get("bot_token", ""),
         proxy_url=payload.get("proxy_url")
     )
@@ -1526,11 +1557,11 @@ def telegram_chats():
 
 
 @app.route("/lark/auth_test", methods=["POST"])
-def lark_auth_test():
+async def lark_auth_test():
     from vibe import api
 
     payload = request.json or {}
-    result = api.lark_auth_test(
+    result = await api.lark_auth_test_async(
         payload.get("app_id", ""),
         payload.get("app_secret", ""),
         payload.get("domain", "feishu"),
@@ -1587,20 +1618,20 @@ def _get_wechat_auth():
 
 
 @app.route("/wechat/qr_login/start", methods=["POST"])
-def wechat_qr_login_start():
+async def wechat_qr_login_start():
     """Start WeChat QR code login flow."""
     auth = _get_wechat_auth()
     payload = request.json or {}
     base_url = payload.get("base_url", "https://ilinkai.weixin.qq.com")
 
-    result = _run_async(auth.start_login(base_url=base_url), timeout=15.0)
+    result = await auth.start_login(base_url=base_url)
     if result.get("ok") is False:
         return jsonify(result), 500
     return jsonify(result)
 
 
 @app.route("/wechat/qr_login/poll", methods=["POST"])
-def wechat_qr_login_poll():
+async def wechat_qr_login_poll():
     """Poll WeChat QR code login status."""
     payload = request.json or {}
     session_key = payload.get("session_key", "")
@@ -1608,7 +1639,7 @@ def wechat_qr_login_poll():
         return jsonify({"error": "session_key required"}), 400
 
     auth = _get_wechat_auth()
-    result = _run_async(auth.poll_status(session_key), timeout=15.0)
+    result = await auth.poll_status(session_key)
     if result.get("ok") is False:
         return jsonify(result), 500
 
@@ -1711,14 +1742,11 @@ def logs():
 
 
 @app.route("/opencode/options", methods=["POST"])
-def opencode_options():
+async def opencode_options():
     from vibe import api
 
     payload = request.json or {}
-    result = _run_async(
-        api.opencode_options_async(payload.get("cwd", ".")),
-        timeout=12.0,
-    )
+    result = await api.opencode_options_async(payload.get("cwd", "."))
     return jsonify(result)
 
 
@@ -1865,7 +1893,7 @@ def backend_claude_auth_post():
 
 
 @app.route("/backend/<backend>/auth/oauth/start", methods=["POST"])
-def backend_oauth_web_start(backend: str):
+async def backend_oauth_web_start(backend: str):
     """Kick off a Settings → Backends OAuth flow for Claude or Codex.
 
     Body: ``{force_reset?: bool}``. Returns ``{flow_id, state, url?,
@@ -1876,7 +1904,7 @@ def backend_oauth_web_start(backend: str):
 
     payload = request.json or {}
     force_reset = bool(payload.get("force_reset", True))
-    return jsonify(api.start_oauth_web(backend, force_reset=force_reset))
+    return jsonify(await api.start_oauth_web_async(backend, force_reset=force_reset))
 
 
 @app.route("/backend/<backend>/auth/oauth/status/<flow_id>", methods=["GET"])
@@ -1889,7 +1917,7 @@ def backend_oauth_web_status(backend: str, flow_id: str):
 
 
 @app.route("/backend/<backend>/auth/oauth/submit-code", methods=["POST"])
-def backend_oauth_web_submit_code(backend: str):
+async def backend_oauth_web_submit_code(backend: str):
     """Submit the Claude OAuth callback code (Codex device-auth ignores this)."""
     from vibe import api
 
@@ -1897,26 +1925,26 @@ def backend_oauth_web_submit_code(backend: str):
     payload = request.json or {}
     flow_id = str(payload.get("flow_id") or "").strip()
     code = str(payload.get("code") or "")
-    return jsonify(api.submit_oauth_web_code(flow_id, code))
+    return jsonify(await api.submit_oauth_web_code_async(flow_id, code))
 
 
 @app.route("/backend/<backend>/auth/oauth/cancel", methods=["POST"])
-def backend_oauth_web_cancel(backend: str):
+async def backend_oauth_web_cancel(backend: str):
     """Cancel an in-flight Settings OAuth flow."""
     from vibe import api
 
     _ = backend
     payload = request.json or {}
     flow_id = str(payload.get("flow_id") or "").strip()
-    return jsonify(api.cancel_oauth_web(flow_id))
+    return jsonify(await api.cancel_oauth_web_async(flow_id))
 
 
 @app.route("/backend/<backend>/auth/oauth/remove", methods=["POST"])
-def backend_oauth_web_remove(backend: str):
+async def backend_oauth_web_remove(backend: str):
     """Clear stored credentials for a Claude/Codex backend."""
     from vibe import api
 
-    return jsonify(api.remove_backend_auth(backend))
+    return jsonify(await api.remove_backend_auth_async(backend))
 
 
 @app.route("/backend/<backend>/auth/api-key/remove", methods=["POST"])
@@ -1930,18 +1958,18 @@ def backend_auth_api_key_remove(backend: str):
 
 
 @app.route("/backend/<backend>/auth/test", methods=["POST"])
-def backend_auth_test(backend: str):
+async def backend_auth_test(backend: str):
     """Send a single-token probe through the backend CLI to verify auth."""
     from vibe import api
 
     payload = request.json or {}
     raw_model = payload.get("model")
     model = raw_model.strip() if isinstance(raw_model, str) and raw_model.strip() else None
-    return jsonify(api.test_backend_auth(backend, model=model))
+    return jsonify(await api.test_backend_auth_async(backend, model=model))
 
 
 @app.route("/backend/opencode/providers", methods=["GET"])
-def backend_opencode_providers():
+async def backend_opencode_providers():
     """Return the merged OpenCode provider catalog for the Settings UI.
 
     Fans out to the live OpenCode daemon's ``/provider``, ``/provider/auth``,
@@ -1950,14 +1978,14 @@ def backend_opencode_providers():
     """
     from vibe import api
 
-    return jsonify(api.get_opencode_providers())
+    return jsonify(await api.get_opencode_providers_async())
 
 
 @app.route(
     "/backend/opencode/provider/<provider_id>/auth/oauth/start",
     methods=["POST"],
 )
-def backend_opencode_provider_oauth_start(provider_id: str):
+async def backend_opencode_provider_oauth_start(provider_id: str):
     """Kick off a Settings → Backends OAuth flow for a single OpenCode provider.
 
     Body: ``{force_reset?: bool}``. Returns ``{flow_id, state, url?,
@@ -1968,11 +1996,11 @@ def backend_opencode_provider_oauth_start(provider_id: str):
 
     payload = request.json or {}
     force_reset = bool(payload.get("force_reset", True))
-    return jsonify(api.start_oauth_web("opencode", force_reset=force_reset, provider_id=provider_id))
+    return jsonify(await api.start_oauth_web_async("opencode", force_reset=force_reset, provider_id=provider_id))
 
 
 @app.route("/backend/opencode/provider/<provider_id>/auth", methods=["POST"])
-def backend_opencode_provider_auth_post(provider_id: str):
+async def backend_opencode_provider_auth_post(provider_id: str):
     """Persist an API key for a single OpenCode provider.
 
     Body: ``{api_key: string}``. The key is forwarded to OpenCode via
@@ -1981,19 +2009,19 @@ def backend_opencode_provider_auth_post(provider_id: str):
     from vibe import api
 
     payload = request.json or {}
-    return jsonify(api.save_opencode_provider_auth(provider_id, payload))
+    return jsonify(await api.save_opencode_provider_auth_async(provider_id, payload))
 
 
 @app.route("/backend/opencode/provider/<provider_id>/auth", methods=["DELETE"])
-def backend_opencode_provider_auth_delete(provider_id: str):
+async def backend_opencode_provider_auth_delete(provider_id: str):
     """Drop the stored API key for a single OpenCode provider."""
     from vibe import api
 
-    return jsonify(api.delete_opencode_provider_auth(provider_id))
+    return jsonify(await api.delete_opencode_provider_auth_async(provider_id))
 
 
 @app.route("/backend/opencode/provider/<provider_id>/test", methods=["POST"])
-def backend_opencode_provider_test(provider_id: str):
+async def backend_opencode_provider_test(provider_id: str):
     """Run a per-provider connectivity probe through OpenCode's HTTP API.
 
     Body: ``{model?: string}``. The model id is wrapped server-side
@@ -2004,7 +2032,7 @@ def backend_opencode_provider_test(provider_id: str):
     payload = request.json or {}
     raw_model = payload.get("model")
     model = raw_model.strip() if isinstance(raw_model, str) and raw_model.strip() else None
-    return jsonify(api.test_opencode_provider(provider_id, model=model))
+    return jsonify(await api.test_opencode_provider_async(provider_id, model=model))
 
 
 @app.route("/backend/opencode/default-provider", methods=["POST"])
@@ -2328,11 +2356,24 @@ def _reconcile_remote_access_for_ui_start(config: V2Config | None) -> None:
         logger.warning("Failed to reconcile remote access after UI start", exc_info=True)
 
 
+def _bind_ui_socket(host: str, port: int) -> socket.socket:
+    family = socket.AF_INET6 if host and ":" in host else socket.AF_INET
+    sock = socket.socket(family)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind((host, port))
+    except OSError:
+        sock.close()
+        raise
+    sock.set_inheritable(True)
+    return sock
+
+
 def run_ui_server(host: str, port: int) -> None:
-    """Start the Flask UI server."""
+    """Start the FastAPI UI server."""
     global _server
     import time
-    from werkzeug.serving import make_server
+    import uvicorn
 
     paths.ensure_data_dirs()
     try:
@@ -2343,7 +2384,7 @@ def run_ui_server(host: str, port: int) -> None:
         logger.warning("Skipping UI Sentry init because config load failed: %s", exc)
         config = None
     if config is not None:
-        init_sentry(config, component="ui", enable_flask=True)
+        init_sentry(config, component="ui", enable_fastapi=True)
         try:
             from vibe import remote_access
 
@@ -2352,12 +2393,22 @@ def run_ui_server(host: str, port: int) -> None:
             logger.warning("Failed to start remote access status heartbeat", exc_info=True)
     print(f"UI Server running at http://{host}:{port}")
 
-    # Use make_server directly for better compatibility with subprocess/multiprocessing
-    # app.run() has issues when launched in child processes
     # Retry binding in case of TIME_WAIT or port still held by old server during reload
     for attempt in range(10):
+        bound_socket: socket.socket | None = None
         try:
-            _server = make_server(host, port, app, threaded=True)
+            uvicorn_config = uvicorn.Config(
+                app,
+                host=host,
+                port=port,
+                log_config=None,
+                access_log=False,
+                loop="asyncio",
+                lifespan="on",
+                workers=1,
+            )
+            bound_socket = _bind_ui_socket(host, port)
+            _server = uvicorn.Server(uvicorn_config)
             # Reconcile remote_access in the background so cloudflared download/
             # connector start does not block /health and the rest of the UI
             # from coming up after restart/reload.
@@ -2367,9 +2418,11 @@ def run_ui_server(host: str, port: int) -> None:
                 daemon=True,
                 name="remote-access-reconcile-on-start",
             ).start()
-            _server.serve_forever()
+            _server.run(sockets=[bound_socket])
             break
         except OSError as e:
+            if bound_socket is not None:
+                bound_socket.close()
             if e.errno == 48 and attempt < 9:  # Address already in use (macOS)
                 print(f"Port {port} in use, retrying in 1s... (attempt {attempt + 1})")
                 time.sleep(1)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -919,6 +919,8 @@ def enforce_remote_access_cookie():
         if not local_request and not docker_probe_request:
             return jsonify({"ok": False, "error": "remote_access_host_mismatch"}), 503
         return None
+    if _remote_auth_exempt_path():
+        return None
     from vibe import remote_access
 
     if not config.remote_access.vibe_cloud.enabled:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -898,8 +898,6 @@ def enforce_remote_access_cookie():
     if _remote_auth_exempt_before_host_validation():
         return None
     local_request = _is_local_request(config)
-    if config is None and not _has_forwarded_metadata() and _is_loopback_peer():
-        local_request = True
     docker_probe_request = _is_trusted_docker_loopback_probe()
     if config is None:
         if local_request or docker_probe_request:


### PR DESCRIPTION
## Summary

Migrate the local UI server runtime from Flask/Werkzeug to FastAPI/uvicorn while preserving the existing UI/API route surface.

Key points:
- Add a thin Flask-compatible UI adapter on top of FastAPI so this migration can stay substrate-focused instead of rewriting every route at once.
- Replace the UI server runner with uvicorn, including pre-bind retry behavior for reload races.
- Move UI request paths to async API helpers where they touch async backends, and keep sync wrappers only for legacy synchronous callers.
- Swap Sentry's Flask integration for FastAPI/Starlette integration.
- Keep the WebSocket smoke endpoint disabled by default; it is opt-in for test/local smoke coverage only.
- Update the FastAPI migration plan and repo guidance with the architecture constraints for follow-up router extraction.

## Scenario IDs

N/A. I did not find a scenario catalog entry for this UI server runtime migration.

## Evidence Layers

Unit / focused regression:
- Ruff passed for the changed Python modules and focused tests.
- Focused pytest suite passed: `348 passed, 1 warning`.
- Codex review P1 security regressions are covered by live-ASGI remote-address spoofing and config-unavailable host validation tests.
- Codex review P2 sync OAuth regression is covered by a persistent-loop background-task test.
- Codex review P1 Discord/Lark live discovery regressions are covered by active-event-loop sync helper tests.
- Codex review P1 compat threadpool regression is covered by a sync-handler offload test that preserves request context.
- Codex review P1 remote health exemption and P2 malformed JSON parser regressions are covered by focused UI security tests.
- Codex review P2 Flask tuple response and named path converter regressions are covered by compat-layer tests.
- Codex review P1 loopback proxy host-gating regression is covered by forwarded-metadata host mismatch tests.
- Codex review P2 SOCKS TLS setup cleanup regression is covered by a socket-close test.
- Codex review P1 guard-before-JSON and P2 vendor JSON media type regressions are covered by UI mutation tests.

Contract / compatibility:
- Existing Flask-style test client usage is covered through the compatibility layer.
- UI remote access auth, reload, logs, install, OAuth, OpenCode provider, and Sentry-focused tests are included in the focused suite.

Scenario:
- No scenario catalog entry was updated.
- Full Docker/E2E regression is still pending.

Residual manual checks:
- Full suite is not clean on the current repo baseline. Earlier run after the migration showed Docker compose/E2E setup failures plus unrelated non-migration failures; I did not fold those into this PR.
- Manual browser smoke for the packaged UI through Cloudflare Tunnel is still recommended before merging.

## Validation

- `uv run ruff check ...` passed.
- `uv run python -m pytest tests/test_async_bridge.py tests/test_ui_api.py tests/test_im_proxy_unification.py tests/test_ui_server_fastapi.py tests/test_ui_server_mutation_protection.py tests/test_ui_remote_access_auth.py tests/test_ui_server_logs.py tests/test_ui_server_install.py tests/test_ui_server_reload.py tests/test_sentry_integration.py tests/test_agent_auth_service.py tests/test_web_oauth_flow.py tests/test_save_opencode_provider_auth.py tests/test_opencode_provider_keys_reader.py tests/test_opencode_provider_catalog_coercion.py tests/test_opencode_server.py -q` passed with `348 passed, 1 warning`.










