### PR TITLE
fix(agents): refresh session id prompt on cached runtimes

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -434,16 +434,15 @@ class SessionHandler(BaseHandler):
             # Claude SDK model changes are control requests; only send one when
             # the effective model actually changes.
             current_model = explicit_model or self.config.claude.default_model
-            next_runtime_prompt = self._build_claude_system_prompt(
+            next_system_prompt = self._build_claude_system_prompt(
                 context=context,
                 session_key=session_key,
                 agent_name="claude",
                 session_anchor=base_session_id,
                 agent_system_prompt=None,
-                include_user_preferences=False,
             )
-            cached_runtime_prompt = self.claude_system_prompts.get(composite_key)
-            if cached_runtime_prompt != next_runtime_prompt:
+            cached_system_prompt = self.claude_system_prompts.get(composite_key)
+            if cached_system_prompt != next_system_prompt:
                 logger.info(
                     "Recreating cached Claude SDK client for %s because Vibe Remote system prompt changed",
                     composite_key,
@@ -545,14 +544,6 @@ class SessionHandler(BaseHandler):
             session_anchor=base_session_id,
             agent_system_prompt=agent_system_prompt,
         )
-        runtime_system_prompt = self._build_claude_system_prompt(
-            context,
-            session_key=session_key,
-            agent_name="claude",
-            session_anchor=base_session_id,
-            agent_system_prompt=agent_system_prompt,
-            include_user_preferences=False,
-        )
 
         # Create extra_args for CLI passthrough (fallback for model)
         extra_args: Dict[str, str | None] = {}
@@ -653,7 +644,7 @@ class SessionHandler(BaseHandler):
             raise
 
         self.claude_sessions[composite_key] = client
-        self.claude_system_prompts[composite_key] = runtime_system_prompt
+        self.claude_system_prompts[composite_key] = final_system_prompt
         setattr(client, "_vibe_current_model", effective_model)
         self.bind_claude_runtime_session(client, base_session_id, composite_key)
         self.touch_session_activity(composite_key)
@@ -669,7 +660,6 @@ class SessionHandler(BaseHandler):
         agent_name: str,
         session_anchor: str,
         agent_system_prompt: Optional[str],
-        include_user_preferences: bool = True,
     ) -> str | Dict[str, str]:
         base_prompt = agent_system_prompt or self.config.claude.system_prompt
         quick_replies_on = getattr(self.config, "reply_enhancements", True)
@@ -686,7 +676,6 @@ class SessionHandler(BaseHandler):
 
         system_prompt_injection = build_system_prompt_injection(
             include_quick_replies=quick_replies_on and platform != "wechat",
-            include_user_preferences=include_user_preferences,
             context=context,
             fallback_platform=platform,
         )

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -50,8 +50,10 @@ class SessionHandler(BaseHandler):
         self.stored_session_mappings = controller.stored_session_mappings
         self.session_last_activity = getattr(controller, "session_last_activity", {})
         self.active_sessions = getattr(controller, "claude_active_sessions", set())
+        self.claude_system_prompts = getattr(controller, "claude_system_prompts", {})
         controller.session_last_activity = self.session_last_activity
         controller.claude_active_sessions = self.active_sessions
+        controller.claude_system_prompts = self.claude_system_prompts
 
     def touch_session_activity(self, composite_key: str) -> None:
         if composite_key:
@@ -75,6 +77,7 @@ class SessionHandler(BaseHandler):
             return
         self.active_sessions.discard(composite_key)
         self.session_last_activity.pop(composite_key, None)
+        self.claude_system_prompts.pop(composite_key, None)
 
     def bind_claude_runtime_session(self, client: ClaudeSDKClient, base_session_id: str, composite_key: str) -> None:
         """Attach the resolved Claude runtime keys to the connected client."""
@@ -431,16 +434,31 @@ class SessionHandler(BaseHandler):
             # Claude SDK model changes are control requests; only send one when
             # the effective model actually changes.
             current_model = explicit_model or self.config.claude.default_model
-            try:
-                await self._set_claude_model_if_needed(client, current_model)
-            except Exception as e:
-                logger.warning(f"Failed to update model on cached Claude session: {e}")
-            logger.info(
-                f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
+            next_session_prompt = self._build_claude_system_prompt(
+                context=context,
+                session_key=session_key,
+                agent_name="claude",
+                session_anchor=base_session_id,
+                agent_system_prompt=None,
             )
-            self.bind_claude_runtime_session(client, base_session_id, composite_key)
-            self.touch_session_activity(composite_key)
-            return client
+            cached_session_prompt = self.claude_system_prompts.get(composite_key)
+            if cached_session_prompt != next_session_prompt:
+                logger.info(
+                    "Recreating cached Claude SDK client for %s because Vibe Remote system prompt changed",
+                    composite_key,
+                )
+                await self.cleanup_session(composite_key)
+            else:
+                try:
+                    await self._set_claude_model_if_needed(client, current_model)
+                except Exception as e:
+                    logger.warning(f"Failed to update model on cached Claude session: {e}")
+                logger.info(
+                    f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
+                )
+                self.bind_claude_runtime_session(client, base_session_id, composite_key)
+                self.touch_session_activity(composite_key)
+                return client
 
         if effective_agent:
             cached_base = f"{base_session_id}:{effective_agent}"
@@ -519,33 +537,13 @@ class SessionHandler(BaseHandler):
         # Always append Vibe Remote system prompt injection so transport
         # capabilities remain available; reply_enhancements only controls
         # quick-reply button instructions.
-        base_prompt = agent_system_prompt or self.config.claude.system_prompt
-        quick_replies_on = getattr(self.config, "reply_enhancements", True)
-
-        from core.system_prompt_injection import build_system_prompt_injection
-
-        platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
-        self.ensure_agent_session_id(
+        final_system_prompt = self._build_claude_system_prompt(
             context,
             session_key=session_key,
             agent_name="claude",
             session_anchor=base_session_id,
+            agent_system_prompt=agent_system_prompt,
         )
-
-        system_prompt_injection = build_system_prompt_injection(
-            include_quick_replies=quick_replies_on and platform != "wechat",
-            context=context,
-            fallback_platform=platform,
-        )
-
-        if base_prompt:
-            final_system_prompt = f"{base_prompt}\n\n{system_prompt_injection}"
-        else:
-            final_system_prompt = {
-                "type": "preset",
-                "preset": "claude_code",
-                "append": system_prompt_injection,
-            }
 
         # Create extra_args for CLI passthrough (fallback for model)
         extra_args: Dict[str, str | None] = {}
@@ -646,12 +644,49 @@ class SessionHandler(BaseHandler):
             raise
 
         self.claude_sessions[composite_key] = client
+        self.claude_system_prompts[composite_key] = final_system_prompt
         setattr(client, "_vibe_current_model", effective_model)
         self.bind_claude_runtime_session(client, base_session_id, composite_key)
         self.touch_session_activity(composite_key)
         logger.info(f"Created new Claude SDK client for {base_session_id} at {working_path}")
 
         return client
+
+    def _build_claude_system_prompt(
+        self,
+        context: MessageContext,
+        *,
+        session_key: str,
+        agent_name: str,
+        session_anchor: str,
+        agent_system_prompt: Optional[str],
+    ) -> str | Dict[str, str]:
+        base_prompt = agent_system_prompt or self.config.claude.system_prompt
+        quick_replies_on = getattr(self.config, "reply_enhancements", True)
+        platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
+
+        self.ensure_agent_session_id(
+            context,
+            session_key=session_key,
+            agent_name=agent_name,
+            session_anchor=session_anchor,
+        )
+
+        from core.system_prompt_injection import build_system_prompt_injection
+
+        system_prompt_injection = build_system_prompt_injection(
+            include_quick_replies=quick_replies_on and platform != "wechat",
+            context=context,
+            fallback_platform=platform,
+        )
+
+        if base_prompt:
+            return f"{base_prompt}\n\n{system_prompt_injection}"
+        return {
+            "type": "preset",
+            "preset": "claude_code",
+            "append": system_prompt_injection,
+        }
 
     async def _prepare_backend_for_resume(
         self,

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -434,15 +434,16 @@ class SessionHandler(BaseHandler):
             # Claude SDK model changes are control requests; only send one when
             # the effective model actually changes.
             current_model = explicit_model or self.config.claude.default_model
-            next_session_prompt = self._build_claude_system_prompt(
+            next_runtime_prompt = self._build_claude_system_prompt(
                 context=context,
                 session_key=session_key,
                 agent_name="claude",
                 session_anchor=base_session_id,
                 agent_system_prompt=None,
+                include_user_preferences=False,
             )
-            cached_session_prompt = self.claude_system_prompts.get(composite_key)
-            if cached_session_prompt != next_session_prompt:
+            cached_runtime_prompt = self.claude_system_prompts.get(composite_key)
+            if cached_runtime_prompt != next_runtime_prompt:
                 logger.info(
                     "Recreating cached Claude SDK client for %s because Vibe Remote system prompt changed",
                     composite_key,
@@ -544,6 +545,14 @@ class SessionHandler(BaseHandler):
             session_anchor=base_session_id,
             agent_system_prompt=agent_system_prompt,
         )
+        runtime_system_prompt = self._build_claude_system_prompt(
+            context,
+            session_key=session_key,
+            agent_name="claude",
+            session_anchor=base_session_id,
+            agent_system_prompt=agent_system_prompt,
+            include_user_preferences=False,
+        )
 
         # Create extra_args for CLI passthrough (fallback for model)
         extra_args: Dict[str, str | None] = {}
@@ -644,7 +653,7 @@ class SessionHandler(BaseHandler):
             raise
 
         self.claude_sessions[composite_key] = client
-        self.claude_system_prompts[composite_key] = final_system_prompt
+        self.claude_system_prompts[composite_key] = runtime_system_prompt
         setattr(client, "_vibe_current_model", effective_model)
         self.bind_claude_runtime_session(client, base_session_id, composite_key)
         self.touch_session_activity(composite_key)
@@ -660,6 +669,7 @@ class SessionHandler(BaseHandler):
         agent_name: str,
         session_anchor: str,
         agent_system_prompt: Optional[str],
+        include_user_preferences: bool = True,
     ) -> str | Dict[str, str]:
         base_prompt = agent_system_prompt or self.config.claude.system_prompt
         quick_replies_on = getattr(self.config, "reply_enhancements", True)
@@ -676,6 +686,7 @@ class SessionHandler(BaseHandler):
 
         system_prompt_injection = build_system_prompt_injection(
             include_quick_replies=quick_replies_on and platform != "wechat",
+            include_user_preferences=include_user_preferences,
             context=context,
             fallback_platform=platform,
         )

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -102,7 +102,8 @@ Use this file proactively when it is helpful, especially when it can help you un
 
 You do not need to read it for every simple request; but if consulting it could improve personalization, efficiency, or continuity, prefer checking it early.
 
-You may also update it when explicitly asked. Use the platform and user id from the current message metadata to choose the appropriate user section.
+You may also update it when explicitly asked.
+Use the current platform `{platform}` and the user id from the current message metadata to choose the appropriate user section: `{platform}/<user_id>`.
 Only record durable, factual, reusable information there.
 Keep entries short, deduplicated, and free of secrets unless the user explicitly asks.
 """
@@ -121,8 +122,13 @@ def _build_user_preferences_prompt(
     *,
     fallback_platform: Optional[str] = None,
 ) -> str:
+    platform = fallback_platform or "<platform>"
+    if context is not None:
+        platform_specific = context.platform_specific or {}
+        platform = context.platform or platform_specific.get("platform") or fallback_platform or "<platform>"
     return _USER_PREFERENCES_PROMPT.format(
         preferences_path=f"`{paths.get_user_preferences_path()}`",
+        platform=platform,
     )
 
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -102,7 +102,7 @@ Use this file proactively when it is helpful, especially when it can help you un
 
 You do not need to read it for every simple request; but if consulting it could improve personalization, efficiency, or continuity, prefer checking it early.
 
-You may also update it, usually in the current user's section: `{user_section}`.
+You may also update it when explicitly asked. Use the platform and user id from the current message metadata to choose the appropriate user section.
 Only record durable, factual, reusable information there.
 Keep entries short, deduplicated, and free of secrets unless the user explicitly asks.
 """
@@ -121,16 +121,8 @@ def _build_user_preferences_prompt(
     *,
     fallback_platform: Optional[str] = None,
 ) -> str:
-    platform = fallback_platform
-    user_id = "<user_id>"
-    if context is not None:
-        platform_specific = context.platform_specific or {}
-        platform = context.platform or platform_specific.get("platform") or fallback_platform
-        user_id = context.user_id or "<user_id>"
-    user_section = f"{platform or '<platform>'}/{user_id}"
     return _USER_PREFERENCES_PROMPT.format(
         preferences_path=f"`{paths.get_user_preferences_path()}`",
-        user_section=user_section,
     )
 
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -138,6 +138,7 @@ def build_system_prompt_injection(
     *,
     include_quick_replies: bool = True,
     include_codex_generated_images: bool = False,
+    include_user_preferences: bool = True,
     context: Optional[MessageContext] = None,
     fallback_platform: Optional[str] = None,
 ) -> str:
@@ -150,7 +151,8 @@ def build_system_prompt_injection(
         prompt += _QUICK_REPLIES_PROMPT
     if context is not None:
         prompt += _build_scheduled_tasks_prompt(context, fallback_platform=fallback_platform)
-    prompt += _build_user_preferences_prompt(context, fallback_platform=fallback_platform)
+    if include_user_preferences:
+        prompt += _build_user_preferences_prompt(context, fallback_platform=fallback_platform)
     return prompt
 
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -731,12 +731,17 @@ class CodexAgent(BaseAgent):
         if cached == (thread_id, developer_instructions):
             return
 
+        resume_params: Dict[str, Any] = {
+            "threadId": thread_id,
+            "developerInstructions": developer_instructions,
+        }
+        model_provider = await self._resolve_resume_model_provider_override(transport, request, thread_id)
+        if model_provider:
+            resume_params["modelProvider"] = model_provider
+
         await transport.send_request(
             "thread/resume",
-            {
-                "threadId": thread_id,
-                "developerInstructions": developer_instructions,
-            },
+            resume_params,
         )
         self._remember_thread_developer_instructions(
             request.base_session_id,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -46,6 +46,8 @@ class CodexAgent(BaseAgent):
 
         # base_session_id → asyncio.Lock (serialize turn lifecycle per session)
         self._session_locks: Dict[str, asyncio.Lock] = {}
+        # base_session_id → (thread_id, developer_instructions)
+        self._thread_developer_instructions: Dict[str, tuple[str, str]] = {}
 
     # ------------------------------------------------------------------
     # BaseAgent interface
@@ -123,6 +125,7 @@ class CodexAgent(BaseAgent):
                     if interrupted_request:
                         await self._remove_ack_reaction(interrupted_request)
 
+                await self._refresh_thread_developer_instructions_if_needed(transport, request, thread_id)
                 thread_id = await self._start_turn(transport, request, thread_id)
 
             except Exception as e:
@@ -152,6 +155,7 @@ class CodexAgent(BaseAgent):
                         e,
                     )
                     self._session_mgr.invalidate_thread(request.base_session_id)
+                    self._clear_thread_developer_instructions(request.base_session_id)
                     self._turn_registry.clear_session(request.base_session_id)
                     self.sessions.clear_agent_session_mapping(
                         request.session_key,
@@ -226,6 +230,7 @@ class CodexAgent(BaseAgent):
         for bid in to_clear:
             self._turn_registry.clear_session(bid)
             self._session_locks.pop(bid, None)
+            self._clear_thread_developer_instructions(bid)
 
         return count
 
@@ -246,6 +251,7 @@ class CodexAgent(BaseAgent):
         for base_session_id in self._session_mgr.all_base_sessions():
             self._session_mgr.invalidate_thread(base_session_id)
             self._turn_registry.clear_session(base_session_id)
+            self._clear_thread_developer_instructions(base_session_id)
 
         logger.info("Refreshed Codex auth state across %d transport(s)", len(transports))
 
@@ -282,6 +288,7 @@ class CodexAgent(BaseAgent):
         self._transport_last_activity.pop(working_path, None)
         self._session_mgr.invalidate_thread(base_session_id)
         self._turn_registry.clear_session(base_session_id)
+        self._clear_thread_developer_instructions(base_session_id)
         logger.info("Prepared Codex runtime for resumed session %s", base_session_id)
 
     async def shutdown_runtime(self) -> None:
@@ -309,6 +316,7 @@ class CodexAgent(BaseAgent):
                 self.sessions.clear_agent_session_mapping(session_key, self.name, base_session_id)
             self._session_mgr.clear(base_session_id)
             self._turn_registry.clear_session(base_session_id)
+            self._clear_thread_developer_instructions(base_session_id)
 
         self._session_locks.clear()
         logger.info("Stopped Codex runtime across %d transport(s)", len(transports))
@@ -368,6 +376,7 @@ class CodexAgent(BaseAgent):
                     self._session_mgr.invalidate_thread(base_session_id)
                     self._turn_registry.clear_session(base_session_id)
                     self._session_locks.pop(base_session_id, None)
+                    self._clear_thread_developer_instructions(base_session_id)
 
                 evicted += 1
 
@@ -415,9 +424,11 @@ class CodexAgent(BaseAgent):
                     if base_session_id == request.base_session_id:
                         continue
                     self._session_mgr.invalidate_thread(base_session_id)
+                    self._clear_thread_developer_instructions(base_session_id)
                     self._turn_registry.clear_session(base_session_id)
 
         self._session_mgr.invalidate_thread(request.base_session_id)
+        self._clear_thread_developer_instructions(request.base_session_id)
         self._turn_registry.clear_session(request.base_session_id)
 
     async def _get_or_create_transport(self, cwd: str) -> CodexTransport:
@@ -442,6 +453,7 @@ class CodexAgent(BaseAgent):
                 affected = self._session_mgr.sessions_for_cwd(cwd)
                 for bid in affected:
                     self._session_mgr.invalidate_thread(bid)
+                    self._clear_thread_developer_instructions(bid)
                     self._turn_registry.clear_session(bid)
                 if affected:
                     logger.info(
@@ -498,6 +510,7 @@ class CodexAgent(BaseAgent):
         self._session_mgr.set_thread_id(request.base_session_id, thread_id)
         # Also persist for resume support
         self.bind_agent_session_id(request, thread_id)
+        self._remember_thread_developer_instructions(request.base_session_id, thread_id, developer_instructions)
         return thread_id
 
     def _resolve_codex_agent_settings(
@@ -578,6 +591,11 @@ class CodexAgent(BaseAgent):
                         thread_id = thread_obj.get("id", "")
                 if thread_id:
                     self._session_mgr.set_thread_id(request.base_session_id, thread_id)
+                    self._remember_thread_developer_instructions(
+                        request.base_session_id,
+                        thread_id,
+                        resume_params.get("developerInstructions"),
+                    )
                     logger.info("Resumed Codex thread %s for session %s", thread_id, request.base_session_id)
                     return thread_id
             except Exception as e:
@@ -694,6 +712,54 @@ class CodexAgent(BaseAgent):
 
         return "\n\n".join(part for part in instruction_parts if part) or None
 
+    async def _refresh_thread_developer_instructions_if_needed(
+        self,
+        transport: CodexTransport,
+        request: AgentRequest,
+        thread_id: str,
+    ) -> None:
+        """Refresh thread-level instructions for already-cached Codex threads."""
+        self.ensure_agent_session_id(request)
+        developer_instructions = self._build_thread_developer_instructions(request)
+        if not developer_instructions:
+            return
+
+        if not hasattr(self, "_thread_developer_instructions"):
+            self._thread_developer_instructions = {}
+
+        cached = self._thread_developer_instructions.get(request.base_session_id)
+        if cached == (thread_id, developer_instructions):
+            return
+
+        await transport.send_request(
+            "thread/resume",
+            {
+                "threadId": thread_id,
+                "developerInstructions": developer_instructions,
+            },
+        )
+        self._remember_thread_developer_instructions(
+            request.base_session_id,
+            thread_id,
+            developer_instructions,
+        )
+
+    def _remember_thread_developer_instructions(
+        self,
+        base_session_id: str,
+        thread_id: str,
+        developer_instructions: Optional[str],
+    ) -> None:
+        if not developer_instructions:
+            return
+        if not hasattr(self, "_thread_developer_instructions"):
+            self._thread_developer_instructions = {}
+        self._thread_developer_instructions[base_session_id] = (thread_id, developer_instructions)
+
+    def _clear_thread_developer_instructions(self, base_session_id: str) -> None:
+        if hasattr(self, "_thread_developer_instructions"):
+            self._thread_developer_instructions.pop(base_session_id, None)
+
     async def _start_turn(
         self,
         transport: CodexTransport,
@@ -701,6 +767,7 @@ class CodexAgent(BaseAgent):
         thread_id: str,
     ) -> str:
         """Build input, configure overrides, and send turn/start to Codex."""
+        self.ensure_agent_session_id(request)
         input_items = self._build_input(request)
         _, effective_model, effective_effort, _ = self._resolve_codex_agent_settings(request)
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -335,7 +335,8 @@ def test_session_handler_reuses_cached_claude_client_when_system_prompt_is_uncha
     assert first_client.disconnects == 0
     assert len(captured["clients"]) == 1
     assert controller.claude_sessions[composite_key] is first_client
-    assert "Use the platform and user id from the current message metadata" in first_client.options.system_prompt["append"]
+    assert "Use the current platform `slack`" in first_client.options.system_prompt["append"]
+    assert "`slack/<user_id>`" in first_client.options.system_prompt["append"]
     assert "slack/U123" not in first_client.options.system_prompt["append"]
     assert "slack/U456" not in first_client.options.system_prompt["append"]
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -230,6 +230,54 @@ def test_session_handler_ensures_agent_session_id_before_prompt(
     assert "--session-key" not in prompt
 
 
+def test_session_handler_recreates_cached_claude_client_when_prompt_changes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {"clients": []}
+
+    class _PromptSessions(_Sessions):
+        current_id = "sesold"
+
+        @classmethod
+        def ensure_agent_session_id(cls, settings_key, agent_name, base_session_id):
+            assert settings_key == "test::C123"
+            assert agent_name == "claude"
+            assert base_session_id == "slack_C123"
+            return cls.current_id
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.options = options
+            self.disconnects = 0
+            captured["clients"].append(self)
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    controller.settings_manager.sessions = _PromptSessions()
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    composite_key = f"slack_C123:{tmp_path}"
+
+    first_client = _run_session(handler, context)
+    _PromptSessions.current_id = "sesnew"
+    second_client = _run_session(handler, context)
+
+    assert first_client is not second_client
+    assert first_client.disconnects == 1
+    assert controller.claude_sessions[composite_key] is second_client
+    assert len(captured["clients"]) == 2
+    assert "Current session id: `sesold`" in first_client.options.system_prompt["append"]
+    assert "Current session id: `sesnew`" in second_client.options.system_prompt["append"]
+
+
 def test_session_handler_forces_bypass_mode_and_auto_approves_claude_tool_permissions(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -284,7 +284,7 @@ def test_session_handler_recreates_cached_claude_client_when_prompt_changes(
     assert "Current session id: `sesnew`" in second_client.options.system_prompt["append"]
 
 
-def test_session_handler_reuses_cached_claude_client_when_only_speaker_changes(
+def test_session_handler_reuses_cached_claude_client_when_system_prompt_is_unchanged(
     monkeypatch, tmp_path: Path
 ) -> None:
     captured: dict[str, Any] = {"clients": []}

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -335,7 +335,8 @@ def test_session_handler_reuses_cached_claude_client_when_only_speaker_changes(
     assert first_client.disconnects == 0
     assert len(captured["clients"]) == 1
     assert controller.claude_sessions[composite_key] is first_client
-    assert "usually in the current user's section: `slack/U123`" in first_client.options.system_prompt["append"]
+    assert "Use the platform and user id from the current message metadata" in first_client.options.system_prompt["append"]
+    assert "slack/U123" not in first_client.options.system_prompt["append"]
     assert "slack/U456" not in first_client.options.system_prompt["append"]
 
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -205,6 +205,12 @@ def test_session_handler_ensures_agent_session_id_before_prompt(
             assert base_session_id == "slack_C123"
             return "sesk8m4q2p7x"
 
+        @staticmethod
+        def get_claude_session_id(settings_key, base_session_id):
+            assert settings_key == "test::C123"
+            assert base_session_id == "slack_C123"
+            return None
+
     class _StubClaudeSDKClient:
         def __init__(self, options):
             captured["options"] = options
@@ -276,6 +282,61 @@ def test_session_handler_recreates_cached_claude_client_when_prompt_changes(
     assert len(captured["clients"]) == 2
     assert "Current session id: `sesold`" in first_client.options.system_prompt["append"]
     assert "Current session id: `sesnew`" in second_client.options.system_prompt["append"]
+
+
+def test_session_handler_reuses_cached_claude_client_when_only_speaker_changes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {"clients": []}
+
+    class _PromptSessions(_Sessions):
+        @staticmethod
+        def ensure_agent_session_id(settings_key, agent_name, base_session_id):
+            assert settings_key == "slack::C123"
+            assert agent_name == "claude"
+            assert base_session_id == "slack_C123"
+            return "sesk8m4q2p7x"
+
+        @staticmethod
+        def get_claude_session_id(settings_key, base_session_id):
+            assert settings_key == "slack::C123"
+            assert base_session_id == "slack_C123"
+            return None
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.options = options
+            self.disconnects = 0
+            captured["clients"].append(self)
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+        async def set_model(self, model: str | None) -> None:
+            self.model = model
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    controller.settings_manager.sessions = _PromptSessions()
+    handler = SessionHandler(controller)
+    first_context = MessageContext(user_id="U123", channel_id="C123", platform="slack")
+    second_context = MessageContext(user_id="U456", channel_id="C123", platform="slack")
+    composite_key = f"slack_C123:{tmp_path}"
+
+    first_client = _run_session(handler, first_context)
+    second_client = _run_session(handler, second_context)
+
+    assert first_client is second_client
+    assert first_client.disconnects == 0
+    assert len(captured["clients"]) == 1
+    assert controller.claude_sessions[composite_key] is first_client
+    assert "usually in the current user's section: `slack/U123`" in first_client.options.system_prompt["append"]
+    assert "slack/U456" not in first_client.options.system_prompt["append"]
 
 
 def test_session_handler_forces_bypass_mode_and_auto_approves_claude_tool_permissions(

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1256,6 +1256,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
         agent.codex_config = SimpleNamespace(default_model=None)
         agent.sessions = SimpleNamespace(ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"))
+        agent._resolve_resume_model_provider_override = AsyncMock(return_value=None)
         agent._thread_developer_instructions = {}
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -1281,8 +1282,46 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         method, params = transport.send_request.await_args.args
         self.assertEqual(method, "thread/resume")
         self.assertEqual(params["threadId"], "thread-existing")
+        self.assertNotIn("modelProvider", params)
         self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
         self.assertIn("# Vibe Remote", params["developerInstructions"])
+
+    async def test_refresh_thread_developer_instructions_preserves_resume_model_provider_override(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"))
+        agent._resolve_resume_model_provider_override = AsyncMock(return_value="openai-managed")
+        agent._thread_developer_instructions = {}
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            session_key="slack::channel::C1::thread::171717.123",
+            base_session_id="session-1",
+            context=SimpleNamespace(
+                platform="slack",
+                platform_specific={"is_dm": False},
+                user_id="U1",
+                channel_id="C1",
+                thread_id="171717.123",
+            ),
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-existing"}}))
+
+        await agent._refresh_thread_developer_instructions_if_needed(transport, request, "thread-existing")
+
+        agent._resolve_resume_model_provider_override.assert_awaited_once_with(
+            transport,
+            request,
+            "thread-existing",
+        )
+        method, params = transport.send_request.await_args.args
+        self.assertEqual(method, "thread/resume")
+        self.assertEqual(params["threadId"], "thread-existing")
+        self.assertEqual(params["modelProvider"], "openai-managed")
+        self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
 
     async def test_start_turn_uses_sandbox_policy_object(self):
         agent = object.__new__(CodexAgent)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -568,6 +568,56 @@ class _HandleMessageTurnRegistry:
 
 
 class CodexAgentHandleMessageTests(unittest.IsolatedAsyncioTestCase):
+    async def test_handle_message_refreshes_cached_thread_instructions_before_turn(self):
+        agent = object.__new__(CodexAgent)
+        request = SimpleNamespace(
+            base_session_id="session-1",
+            working_path="/tmp/work",
+            context=object(),
+            session_key="settings-1",
+            ack_message_id=None,
+        )
+        events = []
+        transport = SimpleNamespace()
+        agent._session_locks = {}
+        agent._turn_registry = _HandleMessageTurnRegistry(active_turn=None)
+        agent._event_handler = SimpleNamespace(clear_pending=Mock())
+        agent._remove_ack_reaction = AsyncMock()
+        agent._delete_ack = AsyncMock()
+        agent.controller = SimpleNamespace(
+            emit_agent_message=AsyncMock(),
+            agent_auth_service=SimpleNamespace(maybe_emit_auth_recovery_message=AsyncMock(return_value=False)),
+        )
+        agent._get_or_create_transport = AsyncMock(return_value=transport)
+        agent._touch_transport_activity = Mock()
+        agent._session_mgr = SimpleNamespace(
+            set_session_key=Mock(),
+            set_cwd=Mock(),
+            get_thread_id=Mock(return_value="thread-cached"),
+        )
+
+        async def refresh(existing_transport, existing_request, thread_id):
+            events.append(("refresh", existing_transport, existing_request, thread_id))
+
+        async def start_turn(existing_transport, existing_request, thread_id):
+            events.append(("turn", existing_transport, existing_request, thread_id))
+            return thread_id
+
+        agent._refresh_thread_developer_instructions_if_needed = refresh
+        agent._start_or_resume_thread = AsyncMock()
+        agent._start_turn = start_turn
+
+        await agent.handle_message(request)
+
+        self.assertEqual(
+            events,
+            [
+                ("refresh", transport, request, "thread-cached"),
+                ("turn", transport, request, "thread-cached"),
+            ],
+        )
+        agent._start_or_resume_thread.assert_not_awaited()
+
     async def test_handle_message_does_not_hide_turn_before_interrupt_succeeds(self):
         agent = object.__new__(CodexAgent)
         request = SimpleNamespace(
@@ -1201,10 +1251,44 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(items, [{"type": "text", "text": "hello"}])
 
+    async def test_refresh_thread_developer_instructions_updates_cached_thread_once(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"))
+        agent._thread_developer_instructions = {}
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            session_key="slack::channel::C1::thread::171717.123",
+            base_session_id="session-1",
+            context=SimpleNamespace(
+                platform="slack",
+                platform_specific={"is_dm": False},
+                user_id="U1",
+                channel_id="C1",
+                thread_id="171717.123",
+            ),
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-existing"}}))
+
+        await agent._refresh_thread_developer_instructions_if_needed(transport, request, "thread-existing")
+        await agent._refresh_thread_developer_instructions_if_needed(transport, request, "thread-existing")
+
+        transport.send_request.assert_awaited_once()
+        method, params = transport.send_request.await_args.args
+        self.assertEqual(method, "thread/resume")
+        self.assertEqual(params["threadId"], "thread-existing")
+        self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
+        self.assertIn("# Vibe Remote", params["developerInstructions"])
+
     async def test_start_turn_uses_sandbox_policy_object(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(get_codex_overrides=Mock(return_value=(None, None, None)))
         agent.codex_config = SimpleNamespace(default_model=None)
+        agent.ensure_agent_session_id = Mock()
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
         agent._turn_registry = SimpleNamespace(
             begin_turn_start=Mock(),
@@ -1224,6 +1308,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         thread_id = await agent._start_turn(transport, request, "thread-1")
 
         self.assertEqual(thread_id, "thread-1")
+        agent.ensure_agent_session_id.assert_called_once_with(request)
         transport.send_request.assert_awaited_once_with(
             "turn/start",
             {
@@ -1244,6 +1329,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             get_codex_overrides=Mock(return_value=(None, "gpt-5.4", "high")),
         )
         agent.codex_config = SimpleNamespace(default_model="fallback-model")
+        agent.ensure_agent_session_id = Mock()
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
         agent._turn_registry = SimpleNamespace(
             begin_turn_start=Mock(),
@@ -1285,6 +1371,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             get_codex_overrides=Mock(return_value=(None, "gpt-5.5", "xhigh")),
         )
         agent.codex_config = SimpleNamespace(default_model="fallback-model")
+        agent.ensure_agent_session_id = Mock()
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
         agent._turn_registry = SimpleNamespace(
             begin_turn_start=Mock(),
@@ -1324,6 +1411,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             get_codex_overrides=Mock(return_value=("reviewer", None, None)),
         )
         agent.codex_config = SimpleNamespace(default_model="fallback-model")
+        agent.ensure_agent_session_id = Mock()
         agent._build_input = Mock(return_value=[{"type": "text", "text": "hello"}])
         agent._turn_registry = SimpleNamespace(
             begin_turn_start=Mock(),

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -90,7 +90,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("## 2. Quick-reply buttons", prompt)
         self.assertIn("## 4. User Context and Preferences", prompt)
         self.assertIn("`/tmp/user_preferences.md`", prompt)
-        self.assertIn("`<platform>/<user_id>`", prompt)
+        self.assertIn("Use the platform and user id from the current message metadata", prompt)
+        self.assertNotIn("<platform>/<user_id>", prompt)
 
     def test_prompt_can_include_codex_generated_image_instructions(self):
         with (
@@ -237,7 +238,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("From first principles, serving the user better means thinking proactively about how to make full use of the available context", prompt)
         self.assertIn("Use this file proactively when it is helpful", prompt)
         self.assertIn("You do not need to read it for every simple request; but if consulting it could improve personalization, efficiency, or continuity, prefer checking it early.", prompt)
-        self.assertIn("usually in the current user's section: `slack/U1`.", prompt)
+        self.assertIn("Use the platform and user id from the current message metadata", prompt)
+        self.assertNotIn("slack/U1", prompt)
         self.assertIn("Only record durable, factual, reusable information there.", prompt)
         self.assertIn("Keep entries short, deduplicated, and free of secrets unless the user explicitly asks.", prompt)
 
@@ -260,7 +262,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("do not guess a target", prompt)
         self.assertNotIn("Legacy session key:", prompt)
         self.assertNotIn("Channel-level session key:", prompt)
-        self.assertIn("usually in the current user's section: `slack/U1`.", prompt)
+        self.assertIn("Use the platform and user id from the current message metadata", prompt)
+        self.assertNotIn("slack/U1", prompt)
 
     def test_prompt_handles_missing_platform_specific(self):
         context = MessageContext(
@@ -277,7 +280,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
                 fallback_platform="slack",
             )
 
-        self.assertIn("usually in the current user's section: `slack/U1`.", prompt)
+        self.assertIn("Use the platform and user id from the current message metadata", prompt)
+        self.assertNotIn("slack/U1", prompt)
 
     def test_file_links_with_parentheses_are_preserved(self):
         enhanced = process_reply("![video](file:///Users/test/SaveTwitter.Net_GABV3XNWYAARAZz(gif).mp4)")

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -90,8 +90,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("## 2. Quick-reply buttons", prompt)
         self.assertIn("## 4. User Context and Preferences", prompt)
         self.assertIn("`/tmp/user_preferences.md`", prompt)
-        self.assertIn("Use the platform and user id from the current message metadata", prompt)
-        self.assertNotIn("<platform>/<user_id>", prompt)
+        self.assertIn("Use the current platform `<platform>`", prompt)
+        self.assertIn("`<platform>/<user_id>`", prompt)
 
     def test_prompt_can_include_codex_generated_image_instructions(self):
         with (
@@ -238,7 +238,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("From first principles, serving the user better means thinking proactively about how to make full use of the available context", prompt)
         self.assertIn("Use this file proactively when it is helpful", prompt)
         self.assertIn("You do not need to read it for every simple request; but if consulting it could improve personalization, efficiency, or continuity, prefer checking it early.", prompt)
-        self.assertIn("Use the platform and user id from the current message metadata", prompt)
+        self.assertIn("Use the current platform `slack`", prompt)
+        self.assertIn("`slack/<user_id>`", prompt)
         self.assertNotIn("slack/U1", prompt)
         self.assertIn("Only record durable, factual, reusable information there.", prompt)
         self.assertIn("Keep entries short, deduplicated, and free of secrets unless the user explicitly asks.", prompt)
@@ -262,7 +263,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("do not guess a target", prompt)
         self.assertNotIn("Legacy session key:", prompt)
         self.assertNotIn("Channel-level session key:", prompt)
-        self.assertIn("Use the platform and user id from the current message metadata", prompt)
+        self.assertIn("Use the current platform `slack`", prompt)
+        self.assertIn("`slack/<user_id>`", prompt)
         self.assertNotIn("slack/U1", prompt)
 
     def test_prompt_handles_missing_platform_specific(self):
@@ -280,7 +282,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
                 fallback_platform="slack",
             )
 
-        self.assertIn("Use the platform and user id from the current message metadata", prompt)
+        self.assertIn("Use the current platform `slack`", prompt)
+        self.assertIn("`slack/<user_id>`", prompt)
         self.assertNotIn("slack/U1", prompt)
 
     def test_file_links_with_parentheses_are_preserved(self):

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -107,6 +107,26 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("file:///Users/test/.codex/generated_images/thread-id/image-file.png", prompt)
         self.assertIn("Never emit variables, placeholder paths, or sandbox paths like `/mnt/data/...`", prompt)
 
+    def test_prompt_can_exclude_user_preferences(self):
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={"agent_session_id": "sesk8m4q2p7x"},
+        )
+
+        with patch.object(paths, "get_user_preferences_path", return_value=Path("/tmp/user_preferences.md")):
+            prompt = build_system_prompt_injection(
+                include_quick_replies=False,
+                include_user_preferences=False,
+                context=context,
+            )
+
+        self.assertIn("Current session id: `sesk8m4q2p7x`", prompt)
+        self.assertNotIn("## 4. User Context and Preferences", prompt)
+        self.assertNotIn("/tmp/user_preferences.md", prompt)
+        self.assertNotIn("slack/U1", prompt)
+
     def test_process_reply_strips_silent_blocks_before_enhancements(self):
         reply = process_reply(
             "Visible\n<silent>skip [secret](file:///tmp/secret.txt)\n---\n[Hidden]</silent>\nDone"


### PR DESCRIPTION
## Summary

Fixes cached agent sessions that can keep stale Vibe Remote system prompt instructions after Agent Session ID prompt injection changes. The original bug was observed on Codex, where live cached app-server threads skipped `thread/resume`; a follow-up audit found Claude has the same cached-runtime class of risk. OpenCode was checked and already sends the Vibe Remote system prompt on each `prompt_async` call.

## Changes

- Refresh Codex thread-level `developerInstructions` with `thread/resume` before `turn/start` when reusing an in-memory cached thread.
- Ensure the public Vibe Remote Agent Session ID exists before building refreshed developer instructions.
- Cache Codex refreshed instruction payloads per base session and clear them when thread/runtime state is invalidated.
- Recreate cached Claude SDK clients when the Vibe Remote system prompt differs from the prompt used to create the client, so resumed Claude sessions receive the current Agent Session ID instructions.
- Keep user turn input clean; the session ID is not injected into the user message/input stream.

## Evidence

- Unit: updated Codex agent tests for cached-thread refresh and session-id prompt contents.
- Unit: updated Claude session-handler tests for prompt-change recreation on cached SDK clients.
- Contract: no external API contract changes; uses existing Codex `thread/resume` `developerInstructions` and Claude SDK session creation/resume surfaces.
- Scenario: covers old/live Codex and Claude runtime sessions created before current Agent Session ID prompt injection.
- Manual checks: OpenCode path audited; it builds and sends `system` on every `prompt_async`, so it does not share the same cached-prompt failure mode.

## Validation

- `uv run pytest tests/test_claude_cli_path.py tests/test_claude_agent_sessions.py -q`
- `uv run pytest tests/test_codex_agent.py tests/test_reply_enhancer_platform.py tests/test_opencode_session_manager.py tests/test_claude_cli_path.py tests/test_claude_agent_sessions.py -q`
- `uv run ruff check modules/agents/codex/agent.py core/handlers/session_handler.py tests/test_codex_agent.py tests/test_claude_cli_path.py`
