### PR TITLE
fix: unify backend runtime refresh

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -15,6 +15,7 @@ from config.platform_registry import (
     supported_platform_ids,
     supported_platform_set,
 )
+from modules.agents.catalog import DEFAULT_AGENT_BACKEND, supported_agent_backend_set
 from modules.im.base import BaseIMConfig
 from vibe.i18n import normalize_language
 
@@ -22,7 +23,6 @@ logger = logging.getLogger(__name__)
 
 CONFIG_LOCK = threading.RLock()
 
-DEFAULT_AGENT_BACKEND = "opencode"
 DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 600
 DEFAULT_OPENCODE_ERROR_RETRY_LIMIT = 1
 
@@ -401,8 +401,10 @@ class V2Config:
         codex = CodexConfig(**_filter_dataclass_fields(CodexConfig, codex_payload))
 
         default_backend = agents_payload.get("default_backend", DEFAULT_AGENT_BACKEND)
-        if default_backend not in {"opencode", "claude", "codex"}:
-            raise ValueError("Config 'agents.default_backend' must be 'opencode', 'claude', or 'codex'")
+        supported_backends = supported_agent_backend_set()
+        if default_backend not in supported_backends:
+            allowed = "', '".join(sorted(supported_backends))
+            raise ValueError(f"Config 'agents.default_backend' must be one of '{allowed}'")
 
         agents = AgentsConfig(
             default_backend=default_backend,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -20,6 +20,7 @@ from modules.claude_sdk_compat import (
     ClaudeAgentOptions,
     ClaudeSDKClient,
 )
+from modules.agents.catalog import WEB_OAUTH_BACKENDS
 from modules.im import InlineButton, InlineKeyboard, MessageContext
 from vibe.i18n import t as i18n_t
 from vibe.opencode_config import remove_opencode_provider_api_key
@@ -1324,13 +1325,33 @@ class AgentAuthService:
         if hasattr(server, "restart_for_auth_refresh"):
             await server.restart_for_auth_refresh()
 
+    def _load_backend_runtime_config(self, backend: str):
+        from config.v2_compat import to_app_config
+        from config.v2_config import V2Config
+
+        return getattr(to_app_config(V2Config.load()), backend, None)
+
     async def _refresh_backend_runtime(self, backend: str) -> None:
+        agent_service = getattr(self.controller, "agent_service", None)
+        refresh_runtime_config = getattr(agent_service, "refresh_runtime_config", None)
+        runtime_config = None
+        if callable(refresh_runtime_config):
+            runtime_config = self._load_backend_runtime_config(backend)
+            if runtime_config is not None and await refresh_runtime_config(backend, runtime_config):
+                return
+
+        agent = getattr(agent_service, "agents", {}).get(backend) if agent_service else None
+        refresh_config = getattr(agent, "refresh_runtime_config", None)
+        if callable(refresh_config):
+            if runtime_config is None:
+                runtime_config = self._load_backend_runtime_config(backend)
+            if runtime_config is None:
+                return
+            await refresh_config(runtime_config)
+            return
         if backend == "opencode":
             await self._refresh_opencode_server()
             return
-
-        agent_service = getattr(self.controller, "agent_service", None)
-        agent = getattr(agent_service, "agents", {}).get(backend) if agent_service else None
         refresh = getattr(agent, "refresh_auth_state", None)
         if callable(refresh):
             await refresh()
@@ -1477,7 +1498,7 @@ class AgentAuthService:
     # and read by a polling endpoint.
     # ------------------------------------------------------------------
 
-    WEB_BACKENDS = {"claude", "codex", "opencode"}
+    WEB_BACKENDS = WEB_OAUTH_BACKENDS
 
     # OpenCode OAuth providers route through the daemon's HTTP API rather
     # than a CLI subprocess. The Settings UI hands us the provider_id and

--- a/core/runtime_commands.py
+++ b/core/runtime_commands.py
@@ -23,13 +23,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Callable, Optional
 
 from config import paths
+from modules.agents.catalog import supports_runtime_refresh
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from core.controller import Controller
 
 logger = logging.getLogger(__name__)
 
-_SUPPORTED_BACKENDS = {"opencode", "codex"}
 # The optional ``.<reqid>`` suffix lets each restart get its own marker
 # (and ``.err`` companion). The UI server's ``_request_controller_restart``
 # always sends a reqid; we still accept the bare ``restart-<backend>.cmd``
@@ -120,7 +120,7 @@ class RuntimeCommandWatcher:
                 marker.unlink(missing_ok=True)
                 continue
             backend = match.group("backend")
-            if backend not in _SUPPORTED_BACKENDS:
+            if not supports_runtime_refresh(backend):
                 logger.debug("Ignoring unsupported backend marker: %s", backend)
                 marker.unlink(missing_ok=True)
                 continue

--- a/modules/agents/__init__.py
+++ b/modules/agents/__init__.py
@@ -1,26 +1,15 @@
 from typing import Optional
 
 from .base import BaseAgent, AgentRequest, AgentMessage
+from .catalog import display_name_for_backend
 from .service import AgentService
 
 
 def get_agent_display_name(agent_name: Optional[str], fallback: Optional[str] = None) -> str:
-    normalized_map = {
-        "claude": "Claude",
-        "codex": "Codex",
-        "opencode": "OpenCode",
-    }
-
     candidate = (agent_name or fallback or "Agent").strip()
     if not candidate:
         candidate = "Agent"
-
-    normalized = candidate.lower()
-    friendly = normalized_map.get(normalized)
-    if friendly:
-        return friendly
-
-    return candidate.replace("_", " ").title()
+    return display_name_for_backend(candidate.lower())
 
 
 __all__ = [

--- a/modules/agents/catalog.py
+++ b/modules/agents/catalog.py
@@ -1,0 +1,165 @@
+"""Shared agent backend capability catalog."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Final
+
+
+@dataclass(frozen=True)
+class AgentBackendCapabilities:
+    supports_runtime_refresh: bool = True
+    supports_web_oauth: bool = True
+    supports_install: bool = True
+
+
+@dataclass(frozen=True)
+class AgentBackendDescriptor:
+    id: str
+    display_name: str
+    config_key: str
+    default_cli: str
+    default_enabled: bool
+    latest_probe: tuple[str, str] | None
+    capabilities: AgentBackendCapabilities
+
+    @property
+    def description_key(self) -> str:
+        return f"settings.backends.{self.id}Description"
+
+    @property
+    def settings_route(self) -> str:
+        return f"/settings/backends/{self.id}"
+
+    def to_public_dict(self) -> dict:
+        payload = asdict(self)
+        payload["description_key"] = self.description_key
+        payload["settings_route"] = self.settings_route
+        return payload
+
+
+AGENT_BACKEND_REGISTRY: Final[dict[str, AgentBackendDescriptor]] = {
+    "opencode": AgentBackendDescriptor(
+        id="opencode",
+        display_name="OpenCode",
+        config_key="opencode",
+        default_cli="opencode",
+        default_enabled=True,
+        latest_probe=("github", "sst/opencode"),
+        capabilities=AgentBackendCapabilities(),
+    ),
+    "claude": AgentBackendDescriptor(
+        id="claude",
+        display_name="Claude Code",
+        config_key="claude",
+        default_cli="claude",
+        default_enabled=True,
+        latest_probe=("npm", "@anthropic-ai/claude-code"),
+        capabilities=AgentBackendCapabilities(),
+    ),
+    "codex": AgentBackendDescriptor(
+        id="codex",
+        display_name="Codex",
+        config_key="codex",
+        default_cli="codex",
+        default_enabled=False,
+        latest_probe=("npm", "@openai/codex"),
+        capabilities=AgentBackendCapabilities(),
+    ),
+}
+
+AGENT_BACKENDS: Final[tuple[str, ...]] = tuple(AGENT_BACKEND_REGISTRY)
+DEFAULT_AGENT_BACKEND: Final[str] = "opencode"
+RUNTIME_REFRESH_BACKENDS: Final[frozenset[str]] = frozenset(
+    descriptor.id
+    for descriptor in AGENT_BACKEND_REGISTRY.values()
+    if descriptor.capabilities.supports_runtime_refresh
+)
+WEB_OAUTH_BACKENDS: Final[frozenset[str]] = frozenset(
+    descriptor.id
+    for descriptor in AGENT_BACKEND_REGISTRY.values()
+    if descriptor.capabilities.supports_web_oauth
+)
+
+_RUNTIME_REFRESH_SUCCESS_MESSAGES: Final[dict[str, str]] = {
+    "opencode": "OpenCode server refreshed; it will respawn on next request.",
+    "claude": "Claude runtime refreshed; sessions will reconnect on next request.",
+    "codex": "Codex runtime refreshed; transports will respawn on next request.",
+}
+
+
+def agent_backend_descriptors() -> list[AgentBackendDescriptor]:
+    """Return backend descriptors in stable UI/routing order."""
+    return list(AGENT_BACKEND_REGISTRY.values())
+
+
+def get_agent_backend_descriptor(name: str) -> AgentBackendDescriptor:
+    """Return the descriptor for *name* or raise ``ValueError``."""
+    try:
+        return AGENT_BACKEND_REGISTRY[name]
+    except KeyError as err:
+        raise ValueError(f"Unsupported agent backend: {name}") from err
+
+
+def is_agent_backend(name: str) -> bool:
+    """Return whether *name* is a known agent backend."""
+    return name in AGENT_BACKEND_REGISTRY
+
+
+def supported_agent_backend_set() -> set[str]:
+    """Return the set of known agent backend ids."""
+    return set(AGENT_BACKEND_REGISTRY)
+
+
+def agent_backend_catalog_payload() -> list[dict]:
+    """Return a JSON-safe public backend catalog."""
+    return [descriptor.to_public_dict() for descriptor in agent_backend_descriptors()]
+
+
+def default_cli_for_backend(name: str) -> str:
+    """Return the default CLI command for *name*."""
+    return get_agent_backend_descriptor(name).default_cli
+
+
+def default_enabled_for_backend(name: str) -> bool:
+    """Return whether *name* is enabled by default."""
+    return get_agent_backend_descriptor(name).default_enabled
+
+
+def display_name_for_backend(name: str) -> str:
+    """Return the user-facing display name for *name*."""
+    if name in AGENT_BACKEND_REGISTRY:
+        return AGENT_BACKEND_REGISTRY[name].display_name
+    return name.replace("_", " ").title()
+
+
+def latest_probe_for_backend(name: str) -> tuple[str, str] | None:
+    """Return latest-version probe metadata for *name*, when available."""
+    if name not in AGENT_BACKEND_REGISTRY:
+        return None
+    return AGENT_BACKEND_REGISTRY[name].latest_probe
+
+
+def supports_runtime_refresh(name: str) -> bool:
+    """Return whether *name* supports runtime config refresh."""
+    return name in RUNTIME_REFRESH_BACKENDS
+
+
+def supports_web_oauth(name: str) -> bool:
+    """Return whether *name* supports Web Settings OAuth setup."""
+    return name in WEB_OAUTH_BACKENDS
+
+
+def supports_install(name: str) -> bool:
+    """Return whether *name* supports managed CLI install/upgrade."""
+    if name not in AGENT_BACKEND_REGISTRY:
+        return False
+    return AGENT_BACKEND_REGISTRY[name].capabilities.supports_install
+
+
+def runtime_refresh_success_message(name: str) -> str:
+    """Return the success message for a refreshed backend runtime."""
+    return _RUNTIME_REFRESH_SUCCESS_MESSAGES.get(
+        name,
+        f"{name} runtime refreshed; next request will use current settings.",
+    )

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -165,6 +165,15 @@ class ClaudeAgent(BaseAgent):
 
         logger.info("Refreshed Claude auth state across %d runtime session(s)", len(session_ids))
 
+    async def refresh_runtime_config(self, claude_config) -> None:
+        """Reload persisted runtime config before reconnecting Claude sessions."""
+        self.config.claude = claude_config
+        self.controller.config.claude = claude_config
+        session_handler = getattr(self, "session_handler", None)
+        if session_handler is not None:
+            session_handler.config = self.controller.config
+        await self.refresh_auth_state()
+
     async def prepare_resume_binding(
         self,
         *,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -249,6 +249,12 @@ class CodexAgent(BaseAgent):
 
         logger.info("Refreshed Codex auth state across %d transport(s)", len(transports))
 
+    async def refresh_runtime_config(self, codex_config: Any) -> None:
+        """Reload persisted runtime config before respawning app-server transports."""
+        self.codex_config = codex_config
+        self.controller.config.codex = codex_config
+        await self.refresh_auth_state()
+
     async def prepare_resume_binding(
         self,
         *,

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -57,6 +57,11 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         self.opencode_config = opencode_config
         self.controller.config.opencode = opencode_config
         if previous_server is not None:
+            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
+            if callable(detach):
+                await detach()
+            elif hasattr(previous_server, "restart_for_auth_refresh"):
+                await previous_server.restart_for_auth_refresh()
             reload_config = getattr(previous_server, "reload_runtime_config", None)
             if callable(reload_config):
                 await reload_config(
@@ -64,11 +69,6 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     port=opencode_config.port,
                     request_timeout_seconds=opencode_config.request_timeout_seconds,
                 )
-            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
-            if callable(detach):
-                await detach()
-            elif hasattr(previous_server, "restart_for_auth_refresh"):
-                await previous_server.restart_for_auth_refresh()
 
     async def handle_message(self, request: AgentRequest) -> None:
         lock = self._session_manager.get_session_lock(request.base_session_id)

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -51,6 +51,25 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
     async def _get_server(self) -> OpenCodeServerManager:
         return await self._client_manager.get_server()
 
+    async def refresh_runtime_config(self, opencode_config) -> None:
+        """Reload persisted runtime config before restarting the shared server."""
+        previous_server = await self._client_manager.reset_config(opencode_config)
+        self.opencode_config = opencode_config
+        self.controller.config.opencode = opencode_config
+        if previous_server is not None:
+            reload_config = getattr(previous_server, "reload_runtime_config", None)
+            if callable(reload_config):
+                await reload_config(
+                    binary=opencode_config.binary,
+                    port=opencode_config.port,
+                    request_timeout_seconds=opencode_config.request_timeout_seconds,
+                )
+            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
+            if callable(detach):
+                await detach()
+            elif hasattr(previous_server, "restart_for_auth_refresh"):
+                await previous_server.restart_for_auth_refresh()
+
     async def handle_message(self, request: AgentRequest) -> None:
         lock = self._session_manager.get_session_lock(request.base_session_id)
         open_modal_task: Optional[asyncio.Task] = None

--- a/modules/agents/opencode/client_manager.py
+++ b/modules/agents/opencode/client_manager.py
@@ -25,3 +25,10 @@ class OpenCodeClientManager:
                     request_timeout_seconds=self._config.request_timeout_seconds,
                 )
             return self._server_manager
+
+    async def reset_config(self, opencode_config) -> Optional[OpenCodeServerManager]:
+        async with self._lock:
+            previous = self._server_manager
+            self._config = opencode_config
+            self._server_manager = None
+            return previous

--- a/modules/agents/opencode/client_manager.py
+++ b/modules/agents/opencode/client_manager.py
@@ -30,5 +30,4 @@ class OpenCodeClientManager:
         async with self._lock:
             previous = self._server_manager
             self._config = opencode_config
-            self._server_manager = None
             return previous

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -65,6 +65,7 @@ class OpenCodeServerManager:
         self._active_requests = 0
         self._active_run_sessions: set[str] = set()
         self._auth_refresh_pending = False
+        self._auth_refresh_pending_port: Optional[int] = None
 
     def _get_lock(self) -> asyncio.Lock:
         """Get or create an asyncio.Lock bound to the current event loop."""
@@ -145,25 +146,30 @@ class OpenCodeServerManager:
     async def _restart_for_auth_refresh_locked(self) -> None:
         await self._close_http_session_locked()
 
+        cleanup_port = self._auth_refresh_pending_port or self.port
         targets: list[int] = []
         info = self._read_pid_file()
         pid = info.get("pid") if isinstance(info, dict) else None
         if isinstance(pid, int) and self._pid_exists(pid):
             cmd = self._get_pid_command(pid)
-            if cmd and self._is_opencode_serve_cmd(cmd, self.port):
+            if cmd and self._is_opencode_serve_cmd(cmd, cleanup_port):
                 targets.append(pid)
-            elif isinstance(info, dict) and info.get("port") == self.port and self._pid_owns_listening_port(pid, self.port):
+            elif (
+                isinstance(info, dict)
+                and info.get("port") == cleanup_port
+                and self._pid_owns_listening_port(pid, cleanup_port)
+            ):
                 logger.info(
                     "Trusting OpenCode pid file for pid=%s because it still owns port %s",
                     pid,
-                    self.port,
+                    cleanup_port,
                 )
                 targets.append(pid)
 
         if not targets:
-            for candidate in self._find_opencode_serve_pids(self.port):
+            for candidate in self._find_opencode_serve_pids(cleanup_port):
                 cmd = self._get_pid_command(candidate)
-                if cmd and self._is_opencode_serve_cmd(cmd, self.port):
+                if cmd and self._is_opencode_serve_cmd(cmd, cleanup_port):
                     targets.append(candidate)
 
         for target_pid in dict.fromkeys(targets):
@@ -174,12 +180,14 @@ class OpenCodeServerManager:
         self._process_loop = None
         self._base_url = None
         self._auth_refresh_pending = False
+        self._auth_refresh_pending_port = None
 
     async def detach_after_deferred_refresh(self) -> None:
         """Drop cached client state when a refresh must wait for active runs."""
         async with self._get_lock():
             if self._active_requests > 0 or self._has_active_run_sessions():
                 self._auth_refresh_pending = True
+                self._auth_refresh_pending_port = self.port
                 logger.info(
                     "Deferring OpenCode runtime detach until %s active request(s) and %s active run(s) finish",
                     self._active_requests,

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -66,6 +66,7 @@ class OpenCodeServerManager:
         self._active_run_sessions: set[str] = set()
         self._auth_refresh_pending = False
         self._auth_refresh_pending_port: Optional[int] = None
+        self._pending_runtime_config: Optional[tuple[str, int, int]] = None
 
     def _get_lock(self) -> asyncio.Lock:
         """Get or create an asyncio.Lock bound to the current event loop."""
@@ -181,6 +182,7 @@ class OpenCodeServerManager:
         self._base_url = None
         self._auth_refresh_pending = False
         self._auth_refresh_pending_port = None
+        self._apply_pending_runtime_config_locked()
 
     async def detach_after_deferred_refresh(self) -> None:
         """Drop cached client state when a refresh must wait for active runs."""
@@ -204,9 +206,21 @@ class OpenCodeServerManager:
         request_timeout_seconds: int,
     ) -> None:
         async with self._get_lock():
-            self.binary = binary
-            self.port = port
-            self.request_timeout_seconds = request_timeout_seconds
+            if self._auth_refresh_pending:
+                self._pending_runtime_config = (binary, port, request_timeout_seconds)
+                return
+            self._set_runtime_config(binary, port, request_timeout_seconds)
+
+    def _set_runtime_config(self, binary: str, port: int, request_timeout_seconds: int) -> None:
+        self.binary = binary
+        self.port = port
+        self.request_timeout_seconds = request_timeout_seconds
+
+    def _apply_pending_runtime_config_locked(self) -> None:
+        if self._pending_runtime_config is None:
+            return
+        self._set_runtime_config(*self._pending_runtime_config)
+        self._pending_runtime_config = None
 
     def _has_active_run_sessions(self) -> bool:
         return bool(self._active_run_sessions)

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -175,6 +175,31 @@ class OpenCodeServerManager:
         self._base_url = None
         self._auth_refresh_pending = False
 
+    async def detach_after_deferred_refresh(self) -> None:
+        """Drop cached client state when a refresh must wait for active runs."""
+        async with self._get_lock():
+            if self._active_requests > 0 or self._has_active_run_sessions():
+                self._auth_refresh_pending = True
+                logger.info(
+                    "Deferring OpenCode runtime detach until %s active request(s) and %s active run(s) finish",
+                    self._active_requests,
+                    len(self._active_run_sessions),
+                )
+                return
+            await self._restart_for_auth_refresh_locked()
+
+    async def reload_runtime_config(
+        self,
+        *,
+        binary: str,
+        port: int,
+        request_timeout_seconds: int,
+    ) -> None:
+        async with self._get_lock():
+            self.binary = binary
+            self.port = port
+            self.request_timeout_seconds = request_timeout_seconds
+
     def _has_active_run_sessions(self) -> bool:
         return bool(self._active_run_sessions)
 

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from .base import AgentRequest, BaseAgent
 
@@ -39,3 +39,20 @@ class AgentService:
     async def handle_stop(self, agent_name: str, request: AgentRequest) -> bool:
         agent = self.get(agent_name)
         return await agent.handle_stop(request)
+
+    async def refresh_runtime_config(self, agent_name: str, runtime_config: Any) -> bool:
+        """Refresh a backend's live runtime state from the latest config.
+
+        Backend adapters own their cached transports/sessions, so the service
+        centralizes dispatch while adapters decide how to apply the new
+        runtime config. Returns ``False`` when the backend is not registered or
+        does not expose the refresh contract.
+        """
+        agent = self.agents.get(agent_name)
+        if agent is None:
+            return False
+        refresh = getattr(agent, "refresh_runtime_config", None)
+        if not callable(refresh):
+            return False
+        await refresh(runtime_config)
+        return True

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -984,9 +984,17 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             port=4100,
             request_timeout_seconds=15,
         )
+        calls: list[str] = []
+
+        async def _detach() -> None:
+            calls.append("detach")
+
+        async def _reload_runtime_config(**kwargs) -> None:
+            calls.append("reload")
+
         previous_server = SimpleNamespace(
-            reload_runtime_config=AsyncMock(),
-            detach_after_deferred_refresh=AsyncMock(),
+            reload_runtime_config=AsyncMock(side_effect=_reload_runtime_config),
+            detach_after_deferred_refresh=AsyncMock(side_effect=_detach),
         )
         agent = OpenCodeAgent.__new__(OpenCodeAgent)
         agent.opencode_config = old_config
@@ -998,12 +1006,13 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIs(agent.opencode_config, new_config)
         self.assertIs(agent.controller.config.opencode, new_config)
         agent._client_manager.reset_config.assert_awaited_once_with(new_config)
+        previous_server.detach_after_deferred_refresh.assert_awaited_once()
         previous_server.reload_runtime_config.assert_awaited_once_with(
             binary="/new/opencode",
             port=4100,
             request_timeout_seconds=15,
         )
-        previous_server.detach_after_deferred_refresh.assert_awaited_once()
+        self.assertEqual(calls, ["detach", "reload"])
 
     async def test_refresh_claude_runtime_reloads_v2_cli_path(self):
         from config.v2_config import AgentsConfig, ClaudeConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1,10 +1,12 @@
 import asyncio
 import os
 import sys
+import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -17,6 +19,19 @@ from core.agent_auth_service import (
 )
 from modules.claude_sdk_compat import CLAUDE_SDK_MAX_BUFFER_SIZE
 from modules.im import MessageContext
+
+
+@contextmanager
+def _temporary_vibe_home(tmp_path: Path):
+    previous_home = os.environ.get("VIBE_REMOTE_HOME")
+    os.environ["VIBE_REMOTE_HOME"] = str(tmp_path)
+    try:
+        yield
+    finally:
+        if previous_home is None:
+            os.environ.pop("VIBE_REMOTE_HOME", None)
+        else:
+            os.environ["VIBE_REMOTE_HOME"] = previous_home
 
 
 class _StubIMClient:
@@ -878,6 +893,194 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         controller.agent_service.agents["codex"].refresh_auth_state.assert_awaited_once()
         controller.agent_service.agents["claude"].refresh_auth_state.assert_awaited_once()
         service._refresh_opencode_server.assert_awaited_once()
+
+    async def test_refresh_backend_runtime_prefers_runtime_config_reload(self):
+        controller = _StubController()
+        agent = SimpleNamespace(
+            refresh_runtime_config=AsyncMock(),
+            refresh_auth_state=AsyncMock(),
+        )
+        controller.agent_service.agents["codex"] = agent
+        service = AgentAuthService(controller)
+        runtime_config = object()
+        service._load_backend_runtime_config = Mock(return_value=runtime_config)
+
+        await service._refresh_backend_runtime("codex")
+
+        service._load_backend_runtime_config.assert_called_once_with("codex")
+        agent.refresh_runtime_config.assert_awaited_once_with(runtime_config)
+        agent.refresh_auth_state.assert_not_awaited()
+
+    async def test_refresh_opencode_runtime_reloads_v2_cli_path(self):
+        from config.v2_config import AgentsConfig, OpenCodeConfig, RuntimeConfig, SlackConfig, V2Config
+        from config.v2_compat import OpenCodeCompatConfig
+
+        controller = _StubController()
+        previous_server = SimpleNamespace(
+            reload_runtime_config=AsyncMock(),
+            detach_after_deferred_refresh=AsyncMock(),
+        )
+
+        class _FakeOpenCodeAgent:
+            def __init__(self) -> None:
+                self.refreshed = None
+
+            async def _get_server(self):
+                return previous_server
+
+            async def refresh_runtime_config(self, opencode_config):
+                self.refreshed = opencode_config
+                controller.config.opencode = opencode_config
+                await previous_server.reload_runtime_config(
+                    binary=opencode_config.binary,
+                    port=opencode_config.port,
+                    request_timeout_seconds=opencode_config.request_timeout_seconds,
+                )
+                await previous_server.detach_after_deferred_refresh()
+
+        agent = _FakeOpenCodeAgent()
+        controller.agent_service.agents["opencode"] = agent
+        service = AgentAuthService(controller)
+
+        with tempfile.TemporaryDirectory() as home:
+            with _temporary_vibe_home(Path(home)):
+                V2Config(
+                    mode="self_host",
+                    version="v2",
+                    slack=SlackConfig(),
+                    runtime=RuntimeConfig(default_cwd="/tmp/work"),
+                    agents=AgentsConfig(
+                        opencode=OpenCodeConfig(
+                            enabled=True,
+                            cli_path="/opt/opencode/bin/opencode",
+                        )
+                    ),
+                ).save()
+
+                await service._refresh_backend_runtime("opencode")
+
+        self.assertIsInstance(agent.refreshed, OpenCodeCompatConfig)
+        self.assertEqual(agent.refreshed.binary, "/opt/opencode/bin/opencode")
+        previous_server.reload_runtime_config.assert_awaited_once_with(
+            binary="/opt/opencode/bin/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        previous_server.detach_after_deferred_refresh.assert_awaited_once()
+
+    async def test_opencode_agent_refresh_runtime_config_updates_cached_server(self):
+        from config.v2_compat import OpenCodeCompatConfig
+        from modules.agents.opencode.agent import OpenCodeAgent
+
+        old_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/old/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        new_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
+        previous_server = SimpleNamespace(
+            reload_runtime_config=AsyncMock(),
+            detach_after_deferred_refresh=AsyncMock(),
+        )
+        agent = OpenCodeAgent.__new__(OpenCodeAgent)
+        agent.opencode_config = old_config
+        agent.controller = SimpleNamespace(config=SimpleNamespace(opencode=old_config))
+        agent._client_manager = SimpleNamespace(reset_config=AsyncMock(return_value=previous_server))
+
+        await agent.refresh_runtime_config(new_config)
+
+        self.assertIs(agent.opencode_config, new_config)
+        self.assertIs(agent.controller.config.opencode, new_config)
+        agent._client_manager.reset_config.assert_awaited_once_with(new_config)
+        previous_server.reload_runtime_config.assert_awaited_once_with(
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
+        previous_server.detach_after_deferred_refresh.assert_awaited_once()
+
+    async def test_refresh_claude_runtime_reloads_v2_cli_path(self):
+        from config.v2_config import AgentsConfig, ClaudeConfig, RuntimeConfig, SlackConfig, V2Config
+        from config.v2_compat import ClaudeCompatConfig
+
+        controller = _StubController()
+        agent = SimpleNamespace(refresh_runtime_config=AsyncMock())
+        controller.agent_service.agents["claude"] = agent
+        service = AgentAuthService(controller)
+
+        with tempfile.TemporaryDirectory() as home:
+            with _temporary_vibe_home(Path(home)):
+                V2Config(
+                    mode="self_host",
+                    version="v2",
+                    slack=SlackConfig(),
+                    runtime=RuntimeConfig(default_cwd="/tmp/work"),
+                    agents=AgentsConfig(
+                        claude=ClaudeConfig(
+                            enabled=True,
+                            cli_path="/opt/claude/bin/claude",
+                        )
+                    ),
+                ).save()
+
+                await service._refresh_backend_runtime("claude")
+
+        runtime_config = agent.refresh_runtime_config.await_args.args[0]
+        self.assertIsInstance(runtime_config, ClaudeCompatConfig)
+        self.assertEqual(runtime_config.cli_path, "/opt/claude/bin/claude")
+
+    async def test_codex_runtime_config_reload_updates_binary_before_refresh(self):
+        from config.v2_compat import CodexCompatConfig
+        from modules.agents.codex.agent import CodexAgent
+
+        old_config = CodexCompatConfig(enabled=True, binary="/old/codex", extra_args=[])
+        new_config = CodexCompatConfig(enabled=True, binary="/new/codex", extra_args=[])
+        agent = CodexAgent.__new__(CodexAgent)
+        agent.codex_config = old_config
+        agent.controller = SimpleNamespace(config=SimpleNamespace(codex=old_config))
+        agent.refresh_auth_state = AsyncMock()
+
+        await agent.refresh_runtime_config(new_config)
+
+        self.assertIs(agent.codex_config, new_config)
+        self.assertIs(agent.controller.config.codex, new_config)
+        agent.refresh_auth_state.assert_awaited_once()
+
+    async def test_claude_runtime_config_reload_updates_cli_path_before_refresh(self):
+        from config.v2_compat import ClaudeCompatConfig
+        from modules.agents.claude_agent import ClaudeAgent
+
+        old_config = ClaudeCompatConfig(
+            enabled=True,
+            permission_mode="bypassPermissions",
+            cwd="/tmp/work",
+            cli_path="/old/claude",
+        )
+        new_config = ClaudeCompatConfig(
+            enabled=True,
+            permission_mode="bypassPermissions",
+            cwd="/tmp/work",
+            cli_path="/new/claude",
+        )
+        session_handler = SimpleNamespace(config=None)
+        agent = ClaudeAgent.__new__(ClaudeAgent)
+        agent.config = SimpleNamespace(claude=old_config)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(claude=old_config))
+        agent.session_handler = session_handler
+        agent.refresh_auth_state = AsyncMock()
+
+        await agent.refresh_runtime_config(new_config)
+
+        self.assertIs(agent.config.claude, new_config)
+        self.assertIs(agent.controller.config.claude, new_config)
+        self.assertIs(session_handler.config, agent.controller.config)
+        agent.refresh_auth_state.assert_awaited_once()
 
     async def test_create_claude_control_client_sets_large_sdk_buffer(self):
         controller = _StubController()

--- a/tests/test_agent_backend_catalog.py
+++ b/tests/test_agent_backend_catalog.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from modules.agents.catalog import (
+    AGENT_BACKENDS,
+    DEFAULT_AGENT_BACKEND,
+    agent_backend_catalog_payload,
+    default_cli_for_backend,
+    default_enabled_for_backend,
+    display_name_for_backend,
+    is_agent_backend,
+    latest_probe_for_backend,
+    runtime_refresh_success_message,
+    supports_install,
+    supports_runtime_refresh,
+    supports_web_oauth,
+)
+from vibe import api
+
+
+def test_agent_catalog_is_backend_management_source_of_truth() -> None:
+    assert AGENT_BACKENDS == ("opencode", "claude", "codex")
+    assert DEFAULT_AGENT_BACKEND == "opencode"
+
+    for backend in AGENT_BACKENDS:
+        assert is_agent_backend(backend)
+        assert supports_runtime_refresh(backend)
+        assert supports_web_oauth(backend)
+        assert supports_install(backend)
+        assert default_cli_for_backend(backend)
+        assert latest_probe_for_backend(backend) is not None
+        assert backend.lower() in runtime_refresh_success_message(backend).lower()
+
+    assert display_name_for_backend("opencode") == "OpenCode"
+    assert display_name_for_backend("claude") == "Claude Code"
+    assert default_enabled_for_backend("codex") is False
+    assert not is_agent_backend("unknown")
+    assert not supports_runtime_refresh("unknown")
+    assert not supports_web_oauth("unknown")
+    assert not supports_install("unknown")
+
+
+def test_agent_backend_catalog_payload_exposes_public_metadata() -> None:
+    payload = agent_backend_catalog_payload()
+
+    assert [item["id"] for item in payload] == list(AGENT_BACKENDS)
+    assert payload[0]["settings_route"] == "/settings/backends/opencode"
+    assert payload[0]["capabilities"]["supports_runtime_refresh"] is True
+
+
+def test_api_exposes_agent_backend_catalog() -> None:
+    payload = api.get_agent_backend_catalog()
+
+    assert [item["id"] for item in payload["backends"]] == list(AGENT_BACKENDS)

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from modules.agents.service import AgentService
+
+
+def test_agent_service_dispatches_runtime_config_refresh() -> None:
+    service = AgentService(controller=SimpleNamespace())
+    runtime_config = object()
+    agent = SimpleNamespace(name="codex", refresh_runtime_config=AsyncMock())
+    service.register(agent)
+
+    handled = asyncio.run(service.refresh_runtime_config("codex", runtime_config))
+
+    assert handled is True
+    agent.refresh_runtime_config.assert_awaited_once_with(runtime_config)
+
+
+def test_agent_service_reports_missing_runtime_refresh_contract() -> None:
+    service = AgentService(controller=SimpleNamespace())
+    service.register(SimpleNamespace(name="codex"))
+
+    assert asyncio.run(service.refresh_runtime_config("codex", object())) is False
+    assert asyncio.run(service.refresh_runtime_config("claude", object())) is False

--- a/tests/test_api_runtime_refresh.py
+++ b/tests/test_api_runtime_refresh.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vibe import api
+
+
+def test_restart_backend_reports_claude_failure_when_controller_unacknowledged(monkeypatch) -> None:
+    monkeypatch.setattr(api, "_request_controller_restart", lambda name: (False, None))
+
+    result = api.restart_backend("claude")
+
+    assert result["ok"] is False
+    assert "not acknowledged" in result["message"]

--- a/tests/test_opencode_client_manager.py
+++ b/tests/test_opencode_client_manager.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agents.opencode import client_manager as client_manager_module
+from modules.agents.opencode.client_manager import OpenCodeClientManager
+
+
+def test_reset_config_keeps_existing_server_manager_until_refresh_completes(monkeypatch) -> None:
+    old_config = SimpleNamespace(binary="/old/opencode", port=4096, request_timeout_seconds=60)
+    new_config = SimpleNamespace(binary="/new/opencode", port=4100, request_timeout_seconds=15)
+    existing_server = SimpleNamespace()
+    created = []
+
+    async def _get_instance(**kwargs):
+        created.append(kwargs)
+        return existing_server
+
+    monkeypatch.setattr(client_manager_module.OpenCodeServerManager, "get_instance", _get_instance)
+
+    async def _run():
+        manager = OpenCodeClientManager(old_config)
+        first = await manager.get_server()
+        previous = await manager.reset_config(new_config)
+        second = await manager.get_server()
+        return first, previous, second
+
+    first, previous, second = asyncio.run(_run())
+    assert first is existing_server
+    assert previous is existing_server
+    assert second is existing_server
+    assert created == [
+        {
+            "binary": "/old/opencode",
+            "port": 4096,
+            "request_timeout_seconds": 60,
+        }
+    ]

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -269,6 +269,28 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(manager.port, 4100)
         self.assertEqual(manager.request_timeout_seconds, 15)
 
+    async def test_pending_detach_uses_original_port_after_runtime_reload(self):
+        manager = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
+        terminated = []
+        manager._active_run_sessions.add("sess-1")
+        manager._read_pid_file = lambda: {"pid": 654, "port": 4096}  # type: ignore[method-assign]
+        manager._pid_exists = lambda pid: pid == 654  # type: ignore[method-assign]
+        manager._get_pid_command = lambda pid: "opencode serve --port=4096"  # type: ignore[method-assign]
+        manager._terminate_pid = lambda pid, reason: terminated.append((pid, reason)) or _async_none()  # type: ignore[method-assign]
+
+        await manager.detach_after_deferred_refresh()
+        await manager.reload_runtime_config(
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
+        manager._active_run_sessions.clear()
+        await manager._restart_for_auth_refresh_locked()
+
+        self.assertEqual(terminated, [(654, "auth refresh")])
+        self.assertFalse(manager._auth_refresh_pending)
+        self.assertIsNone(manager._auth_refresh_pending_port)
+
     async def test_close_http_session_skips_session_owned_by_another_loop(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -256,6 +256,19 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(manager._active_requests, 0)
         self.assertTrue(manager._auth_refresh_pending)
 
+    async def test_reload_runtime_config_updates_singleton_binary(self):
+        manager = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
+
+        await manager.reload_runtime_config(
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
+
+        self.assertEqual(manager.binary, "/new/opencode")
+        self.assertEqual(manager.port, 4100)
+        self.assertEqual(manager.request_timeout_seconds, 15)
+
     async def test_close_http_session_skips_session_owned_by_another_loop(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -269,7 +269,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(manager.port, 4100)
         self.assertEqual(manager.request_timeout_seconds, 15)
 
-    async def test_pending_detach_uses_original_port_after_runtime_reload(self):
+    async def test_pending_detach_defers_runtime_reload_until_old_port_cleanup(self):
         manager = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
         terminated = []
         manager._active_run_sessions.add("sess-1")
@@ -284,12 +284,21 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             port=4100,
             request_timeout_seconds=15,
         )
+
+        self.assertEqual(manager.binary, "/old/opencode")
+        self.assertEqual(manager.port, 4096)
+        self.assertEqual(manager.request_timeout_seconds, 60)
+
         manager._active_run_sessions.clear()
         await manager._restart_for_auth_refresh_locked()
 
         self.assertEqual(terminated, [(654, "auth refresh")])
         self.assertFalse(manager._auth_refresh_pending)
         self.assertIsNone(manager._auth_refresh_pending_port)
+        self.assertEqual(manager.binary, "/new/opencode")
+        self.assertEqual(manager.port, 4100)
+        self.assertEqual(manager.request_timeout_seconds, 15)
+        self.assertIsNone(manager._pending_runtime_config)
 
     async def test_close_http_session_skips_session_owned_by_another_loop(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)

--- a/tests/test_runtime_commands.py
+++ b/tests/test_runtime_commands.py
@@ -71,6 +71,24 @@ def test_handle_restart_missing_handler_writes_err_sentinel(tmp_path: Path) -> N
     assert "refresh handler unavailable" in err.read_text()
 
 
+def test_sweep_accepts_claude_restart_marker(tmp_path: Path) -> None:
+    calls = []
+
+    async def handler(name: str) -> None:
+        calls.append(name)
+
+    auth_service = SimpleNamespace(_refresh_backend_runtime=handler)
+    controller = SimpleNamespace(agent_auth_service=auth_service)
+    watcher = RuntimeCommandWatcher(controller, directory=tmp_path)  # type: ignore[arg-type]
+    marker = tmp_path / "restart-claude.cmd"
+    marker.write_text("{}", encoding="utf-8")
+
+    asyncio.run(watcher._sweep_once())
+
+    assert calls == ["claude"]
+    assert not marker.exists()
+
+
 def test_handle_restart_err_message_truncated(tmp_path: Path) -> None:
     """Pathological multi-MB exception messages must not blow up the disk."""
 

--- a/tests/test_v2_config_platform_registry.py
+++ b/tests/test_v2_config_platform_registry.py
@@ -80,6 +80,11 @@ def test_config_payload_includes_platform_catalog_and_setup_state() -> None:
         "lark",
         "wechat",
     ]
+    assert [backend["id"] for backend in payload["agent_backend_catalog"]] == [
+        "opencode",
+        "claude",
+        "codex",
+    ]
     assert payload["setup_state"]["configured_platforms"] == ["slack", "discord", "telegram", "lark", "wechat"]
     assert payload["setup_state"]["needs_setup"] is False
 

--- a/ui/src/components/settings/SettingsBackendsPage.tsx
+++ b/ui/src/components/settings/SettingsBackendsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Bot, ChevronRight, Settings2, Sparkles, Terminal } from 'lucide-react';
+import { ChevronRight, Settings2 } from 'lucide-react';
 import clsx from 'clsx';
 
 import { Button } from '../ui/button';
@@ -11,6 +11,7 @@ import { BackendLifecycleChip } from './BackendLifecycleChip';
 import { SettingsPageShell } from './SettingsPageShell';
 import { useApi } from '@/context/ApiContext';
 import { useToast } from '@/context/ToastContext';
+import { AGENT_BACKENDS, DEFAULT_AGENT_STATE, DEFAULT_BACKEND_ID } from '@/lib/agentBackends';
 
 // Mirrors design.pen qVHh4 (VR/CM/Backends): top bar with default-backend
 // picker, then three horizontal cards (OpenCode/Claude/Codex). Each card
@@ -27,49 +28,7 @@ type AgentState = {
   status: CliStatus;
 };
 
-type BackendMeta = {
-  id: string;
-  label: string;
-  Icon: React.ComponentType<{ size?: number; className?: string }>;
-  // Tile background ($--violet-soft / $--cyan-soft / $--gold) and inner icon color.
-  // Codex matches design.pen's solid gold tile so the brand pop survives in light mode.
-  tileCls: string;
-  iconCls: string;
-  routeKey?: 'opencode' | 'claude' | 'codex';
-};
-
-const BACKENDS: BackendMeta[] = [
-  {
-    id: 'opencode',
-    label: 'OpenCode',
-    Icon: Terminal,
-    tileCls: 'bg-violet-soft',
-    iconCls: 'text-violet',
-    routeKey: 'opencode',
-  },
-  {
-    id: 'claude',
-    label: 'Claude Code',
-    Icon: Sparkles,
-    tileCls: 'bg-cyan-soft',
-    iconCls: 'text-cyan',
-    routeKey: 'claude',
-  },
-  {
-    id: 'codex',
-    label: 'Codex',
-    Icon: Bot,
-    tileCls: 'bg-gold',
-    iconCls: 'text-gold-foreground',
-    routeKey: 'codex',
-  },
-];
-
-const DEFAULT_AGENTS: Record<string, AgentState> = {
-  opencode: { enabled: true, cli_path: 'opencode', status: 'unknown' },
-  claude: { enabled: true, cli_path: 'claude', status: 'unknown' },
-  codex: { enabled: false, cli_path: 'codex', status: 'unknown' },
-};
+const DEFAULT_AGENTS = DEFAULT_AGENT_STATE as Record<string, AgentState>;
 
 const normalizeAgents = (source: any): Record<string, AgentState> => {
   const raw = source?.agents || {};
@@ -95,7 +54,7 @@ export const SettingsBackendsPage: React.FC = () => {
 
   const [loaded, setLoaded] = useState(false);
   const [agents, setAgents] = useState<Record<string, AgentState>>(DEFAULT_AGENTS);
-  const [defaultBackend, setDefaultBackend] = useState<string>('opencode');
+  const [defaultBackend, setDefaultBackend] = useState<string>(DEFAULT_BACKEND_ID);
 
   useEffect(() => {
     let cancelled = false;
@@ -105,7 +64,7 @@ export const SettingsBackendsPage: React.FC = () => {
         if (cancelled) return;
         setAgents(normalizeAgents(config));
         setDefaultBackend(
-          config?.default_backend || config?.agents?.default_backend || 'opencode'
+          config?.default_backend || config?.agents?.default_backend || DEFAULT_BACKEND_ID
         );
         setLoaded(true);
       })
@@ -227,7 +186,7 @@ export const SettingsBackendsPage: React.FC = () => {
                 className="min-w-[180px]"
                 aria-label={t('settings.backends.defaultLabel') as string}
               >
-                {BACKENDS.map((b) => (
+                {AGENT_BACKENDS.map((b) => (
                   <option key={b.id} value={b.id}>
                     {b.label}
                   </option>
@@ -236,11 +195,11 @@ export const SettingsBackendsPage: React.FC = () => {
             </label>
           </div>
 
-          {BACKENDS.map((meta) => {
+          {AGENT_BACKENDS.map((meta) => {
             const agent = agents[meta.id];
             const Icon = meta.Icon;
             const isDefault = defaultBackend === meta.id;
-            const route = meta.routeKey ? `/settings/backends/${meta.routeKey}` : null;
+            const route = meta.settingsRoute;
 
             return (
               <div

--- a/ui/src/components/settings/shared/useBackendRuntime.ts
+++ b/ui/src/components/settings/shared/useBackendRuntime.ts
@@ -193,6 +193,10 @@ export function useBackendRuntime({
         config?.agents?.default_backend ||
         fallbackDefaultBackend;
       await api.saveConfig({ agents: { ...nextAgents, default_backend: defaultBackend } });
+      const restart = await api.restartBackend(backend);
+      if (!restart?.ok) {
+        throw new Error(restart?.message || t('common.saveFailed'));
+      }
       setSavedCliPath(cliPath);
       showToast(t('common.saved'), 'success');
     } catch (e: any) {

--- a/ui/src/components/steps/AgentDetection.tsx
+++ b/ui/src/components/steps/AgentDetection.tsx
@@ -19,14 +19,7 @@ import type { BackendId } from '../visual';
 import { BackendLifecycleChip } from '../settings/BackendLifecycleChip';
 import { CompactField, CompactSelect, ToggleSwitch } from '../settings/SettingsPrimitives';
 import { Button } from '../ui/button';
-
-// Backends that expose a dedicated provider settings page. The link is
-// rendered only when the wizard is hosted inside Settings (``isPage``) —
-// hiding it during initial setup keeps the wizard linear and avoids
-// landing the user on a half-configured Codex with no app-server yet.
-const PROVIDER_PAGE_ROUTES: Record<string, string> = {
-  codex: '/settings/backends/codex',
-};
+import { AGENT_BACKENDS, DEFAULT_AGENT_STATE, DEFAULT_BACKEND_ID, getBackendUiMeta } from '@/lib/agentBackends';
 
 interface AgentDetectionProps {
   data: any;
@@ -44,17 +37,7 @@ type AgentState = {
 
 type PermissionState = 'idle' | 'loading' | 'success' | 'error';
 
-const DEFAULT_AGENTS: Record<string, AgentState> = {
-  opencode: { enabled: true, cli_path: 'opencode', status: 'unknown' },
-  claude: { enabled: true, cli_path: 'claude', status: 'unknown' },
-  codex: { enabled: false, cli_path: 'codex', status: 'unknown' },
-};
-
-const AGENT_LABEL: Record<string, string> = {
-  opencode: 'OpenCode',
-  claude: 'Claude Code',
-  codex: 'Codex',
-};
+const DEFAULT_AGENTS = DEFAULT_AGENT_STATE as Record<string, AgentState>;
 
 const normalizeAgents = (source: any): Record<string, AgentState> => {
   const raw = source?.agents || {};
@@ -81,7 +64,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
   const api = useApi();
   const [checking, setChecking] = useState(false);
   const [defaultBackend, setDefaultBackend] = useState<string>(
-    data.default_backend || data.agents?.default_backend || 'opencode'
+    data.default_backend || data.agents?.default_backend || DEFAULT_BACKEND_ID
   );
   const [agents, setAgents] = useState<Record<string, AgentState>>(normalizeAgents(data));
   const [permissionState, setPermissionState] = useState<PermissionState>('idle');
@@ -208,9 +191,12 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
             onChange={(e) => setDefaultBackend(e.target.value)}
             className="mt-1 w-full md:max-w-[260px]"
           >
-            <option value="opencode">OpenCode {t('agentDetection.recommended')}</option>
-            <option value="claude">Claude Code</option>
-            <option value="codex">Codex</option>
+            {AGENT_BACKENDS.map((backend) => (
+              <option key={backend.id} value={backend.id}>
+                {backend.label}
+                {backend.id === DEFAULT_BACKEND_ID ? ` ${t('agentDetection.recommended')}` : ''}
+              </option>
+            ))}
           </CompactSelect>
         </label>
         <Button
@@ -224,18 +210,20 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
       </div>
 
       <div className="flex flex-col gap-3">
-        {Object.entries(agents).map(([name, agent]) => (
-          <div
-            key={name}
-            className="overflow-hidden rounded-xl border border-border bg-background transition-colors hover:border-border-strong"
-          >
+        {Object.entries(agents).map(([name, agent]) => {
+          const meta = getBackendUiMeta(name);
+          return (
+            <div
+              key={name}
+              className="overflow-hidden rounded-xl border border-border bg-background transition-colors hover:border-border-strong"
+            >
             <div className="flex items-center justify-between gap-3 border-b border-border px-5 py-3.5">
               <div className="flex min-w-0 items-center gap-3">
                 <div className="flex size-9 items-center justify-center rounded-lg border border-border bg-surface-2">
                   <BackendIcon backend={name as BackendId} size={18} />
                 </div>
                 <div className="min-w-0">
-                  <h3 className="text-[13px] font-semibold text-foreground">{AGENT_LABEL[name] || name}</h3>
+                  <h3 className="text-[13px] font-semibold text-foreground">{meta.label}</h3>
                   <div className="mt-0.5 text-[11px] text-muted">{t('agentDetection.cliPath')}</div>
                 </div>
               </div>
@@ -366,10 +354,10 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                 </div>
               )}
 
-              {isPage && PROVIDER_PAGE_ROUTES[name] && (
+              {isPage && meta.settingsRoute && (
                 <div className="flex justify-end">
                   <Button asChild variant="ghost" size="sm">
-                    <Link to={PROVIDER_PAGE_ROUTES[name]}>
+                    <Link to={meta.settingsRoute}>
                       <Settings className="size-3.5" />
                       {t('settings.backends.openProviderPage')}
                       <ExternalLink className="size-3.5" />
@@ -378,8 +366,9 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
                 </div>
               )}
             </div>
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </div>
     </>
   );
@@ -449,4 +438,3 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
     </div>
   );
 };
-

--- a/ui/src/components/visual/BackendIcon.tsx
+++ b/ui/src/components/visual/BackendIcon.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Bot, Code2, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { getBackendUiMeta, type BackendId } from '@/lib/agentBackends';
 
-export type BackendId = 'opencode' | 'claude' | 'codex' | string;
+export type { BackendId } from '@/lib/agentBackends';
 
 interface BackendIconProps extends React.HTMLAttributes<HTMLSpanElement> {
   backend: BackendId;
@@ -14,41 +14,6 @@ interface BackendIconProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: 'block' | 'glyph';
 }
 
-interface BackendMeta {
-  label: string;
-  blockCls: string;
-  glyphCls: string;
-  Icon: React.ComponentType<{ size?: number; className?: string }>;
-}
-
-const BACKEND_META: Record<string, BackendMeta> = {
-  opencode: {
-    label: 'OP',
-    blockCls: 'border-mint/40 bg-mint/[0.10] text-mint',
-    glyphCls: 'text-mint',
-    Icon: Code2,
-  },
-  claude: {
-    label: 'CL',
-    blockCls: 'border-[rgba(217,119,87,0.4)] bg-[rgba(217,119,87,0.10)] text-[#e8a87c]',
-    glyphCls: 'text-cyan',
-    Icon: Sparkles,
-  },
-  codex: {
-    label: 'CO',
-    blockCls: 'border-violet/40 bg-violet/[0.10] text-violet',
-    glyphCls: 'text-violet',
-    Icon: Bot,
-  },
-};
-
-const FALLBACK_META: BackendMeta = {
-  label: '',
-  blockCls: 'border-border bg-surface-2 text-foreground',
-  glyphCls: 'text-muted',
-  Icon: Bot,
-};
-
 export const BackendIcon: React.FC<BackendIconProps> = ({
   backend,
   size = 40,
@@ -56,9 +21,7 @@ export const BackendIcon: React.FC<BackendIconProps> = ({
   className,
   ...props
 }) => {
-  const meta =
-    BACKEND_META[backend] ||
-    ({ ...FALLBACK_META, label: backend.slice(0, 2).toUpperCase() } as BackendMeta);
+  const meta = getBackendUiMeta(backend);
 
   if (variant === 'glyph') {
     const Icon = meta.Icon;
@@ -83,7 +46,7 @@ export const BackendIcon: React.FC<BackendIconProps> = ({
       style={{ width: size, height: size }}
       {...props}
     >
-      {meta.label}
+      {meta.initials}
     </span>
   );
 };

--- a/ui/src/lib/agentBackends.ts
+++ b/ui/src/lib/agentBackends.ts
@@ -1,0 +1,95 @@
+import type React from 'react';
+import { Bot, Sparkles, Terminal } from 'lucide-react';
+
+export type BackendId = 'opencode' | 'claude' | 'codex' | string;
+
+export type BackendUiMeta = {
+  id: BackendId;
+  label: string;
+  defaultCli: string;
+  defaultEnabled: boolean;
+  settingsRoute: string;
+  Icon: React.ComponentType<{ size?: number; className?: string }>;
+  initials: string;
+  blockCls: string;
+  glyphCls: string;
+  tileCls: string;
+  iconCls: string;
+};
+
+export const AGENT_BACKENDS: BackendUiMeta[] = [
+  {
+    id: 'opencode',
+    label: 'OpenCode',
+    defaultCli: 'opencode',
+    defaultEnabled: true,
+    settingsRoute: '/settings/backends/opencode',
+    Icon: Terminal,
+    initials: 'OP',
+    blockCls: 'border-mint/40 bg-mint/[0.10] text-mint',
+    glyphCls: 'text-mint',
+    tileCls: 'bg-violet-soft',
+    iconCls: 'text-violet',
+  },
+  {
+    id: 'claude',
+    label: 'Claude Code',
+    defaultCli: 'claude',
+    defaultEnabled: true,
+    settingsRoute: '/settings/backends/claude',
+    Icon: Sparkles,
+    initials: 'CL',
+    blockCls: 'border-[rgba(217,119,87,0.4)] bg-[rgba(217,119,87,0.10)] text-[#e8a87c]',
+    glyphCls: 'text-cyan',
+    tileCls: 'bg-cyan-soft',
+    iconCls: 'text-cyan',
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    defaultCli: 'codex',
+    defaultEnabled: false,
+    settingsRoute: '/settings/backends/codex',
+    Icon: Bot,
+    initials: 'CO',
+    blockCls: 'border-violet/40 bg-violet/[0.10] text-violet',
+    glyphCls: 'text-violet',
+    tileCls: 'bg-gold',
+    iconCls: 'text-gold-foreground',
+  },
+];
+
+export const DEFAULT_BACKEND_ID = 'opencode';
+
+export const AGENT_BACKEND_BY_ID = Object.fromEntries(
+  AGENT_BACKENDS.map((backend) => [backend.id, backend]),
+) as Record<string, BackendUiMeta>;
+
+export const DEFAULT_AGENT_STATE = Object.fromEntries(
+  AGENT_BACKENDS.map((backend) => [
+    backend.id,
+    {
+      enabled: backend.defaultEnabled,
+      cli_path: backend.defaultCli,
+      status: 'unknown',
+    },
+  ]),
+);
+
+export function getBackendUiMeta(id: string): BackendUiMeta {
+  return (
+    AGENT_BACKEND_BY_ID[id] || {
+      id,
+      label: id.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
+      defaultCli: id,
+      defaultEnabled: false,
+      settingsRoute: `/settings/backends/${id}`,
+      Icon: Bot,
+      initials: id.slice(0, 2).toUpperCase(),
+      blockCls: 'border-border bg-surface-2 text-foreground',
+      glyphCls: 'text-muted',
+      tileCls: 'bg-surface-2',
+      iconCls: 'text-muted',
+    }
+  );
+}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -40,6 +40,14 @@ from vibe.upgrade import (
     get_safe_cwd,
 )
 from vibe.claude_model_catalog import DEFAULT_CLAUDE_MODEL_ALIASES, load_catalog_models
+from modules.agents.catalog import (
+    agent_backend_catalog_payload,
+    is_agent_backend,
+    latest_probe_for_backend,
+    runtime_refresh_success_message,
+    supports_runtime_refresh,
+    supports_web_oauth,
+)
 from modules.agents.subagent_router import list_codex_subagents
 
 
@@ -439,6 +447,7 @@ def _agent_payload(raw: dict, *, include_secrets: bool) -> dict:
 
 def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dict:
     from config.platform_registry import platform_descriptors
+    from modules.agents.catalog import agent_backend_catalog_payload
 
     platform_payload = {}
     for descriptor in platform_descriptors():
@@ -454,6 +463,7 @@ def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dic
             "primary": config.platforms.primary,
         },
         "platform_catalog": config.platform_catalog(),
+        "agent_backend_catalog": agent_backend_catalog_payload(),
         "setup_state": config.setup_state(),
         "mode": config.mode,
         "version": config.version,
@@ -514,6 +524,10 @@ def get_platform_catalog() -> dict:
     from config.platform_registry import platform_catalog_payload
 
     return {"platforms": platform_catalog_payload()}
+
+
+def get_agent_backend_catalog() -> dict:
+    return {"backends": agent_backend_catalog_payload()}
 
 
 def get_settings(platform: Optional[str] = None) -> dict:
@@ -1739,14 +1753,6 @@ _BACKEND_LATEST_TTL_SECONDS = 3600.0
 _BACKEND_LATEST_FAILURE_TTL_SECONDS = 120.0
 _BACKEND_RUNTIME_USER_AGENT = "vibe-remote/backend-runtime"
 
-_BACKENDS_WITH_RESTART = {"opencode", "codex"}
-_BACKEND_LATEST_PROBES = {
-    "opencode": ("github", "sst/opencode"),
-    "codex": ("npm", "@openai/codex"),
-    "claude": ("npm", "@anthropic-ai/claude-code"),
-}
-
-
 def _parse_semver(text: str) -> str | None:
     """Extract the first dotted-numeric version token from *text*.
 
@@ -1780,7 +1786,7 @@ def _probe_cli_version(cli_path: str | None) -> str | None:
 
 def _fetch_latest_version(name: str) -> str | None:
     """Best-effort upstream lookup. Returns ``None`` on any failure."""
-    probe = _BACKEND_LATEST_PROBES.get(name)
+    probe = latest_probe_for_backend(name)
     if not probe:
         return None
     kind, ident = probe
@@ -2040,7 +2046,7 @@ def get_backend_runtime(name: str) -> dict:
     Versions are cached for short windows so popovers and re-renders do not
     fan out into many CLI invocations or registry HTTP calls.
     """
-    if name not in _BACKEND_LATEST_PROBES:
+    if not is_agent_backend(name):
         return {"ok": False, "error": f"Unknown backend: {name}"}
 
     try:
@@ -2064,6 +2070,8 @@ def get_backend_runtime(name: str) -> dict:
         process_status = _opencode_process_status() if installed else "stopped"
     elif name == "codex":
         process_status = _codex_process_status(resolved_path) if installed else "stopped"
+    elif name == "claude":
+        process_status = "unknown"
     else:
         process_status = "unknown"
 
@@ -2077,7 +2085,7 @@ def get_backend_runtime(name: str) -> dict:
         "current_version": current_version,
         "latest_version": latest_version,
         "has_update": has_update,
-        "supports_restart": name in _BACKENDS_WITH_RESTART,
+        "supports_restart": supports_runtime_refresh(name),
         "process_status": process_status,
     }
 
@@ -2184,9 +2192,10 @@ def restart_backend(name: str) -> dict:
     killing the OS process directly — the controller's recovery logic will
     rebuild state when it next starts.
 
-    Claude has no persistent process and is rejected at the route layer.
+    Claude has no separate daemon, but the controller keeps SDK sessions
+    and a loaded compat config; the marker path refreshes those in memory.
     """
-    if name not in _BACKENDS_WITH_RESTART:
+    if not supports_runtime_refresh(name):
         return {"ok": False, "message": f"Restart is not supported for backend: {name}"}
 
     controller_handled, controller_error = _request_controller_restart(name)
@@ -2202,9 +2211,7 @@ def restart_backend(name: str) -> dict:
                 "ok": False,
                 "message": f"Backend refresh failed: {controller_error}",
             }
-        if name == "opencode":
-            return {"ok": True, "message": "OpenCode server refreshed; it will respawn on next request."}
-        return {"ok": True, "message": "Codex runtime refreshed; transports will respawn on next request."}
+        return {"ok": True, "message": runtime_refresh_success_message(name)}
 
     if name == "opencode":
         from vibe import runtime
@@ -2217,6 +2224,9 @@ def restart_backend(name: str) -> dict:
         if not pid or not runtime.pid_alive(pid):
             return {"ok": True, "message": "OpenCode server is not running; next request will start a fresh one."}
         return {"ok": False, "message": "Failed to stop OpenCode server."}
+
+    if name == "claude":
+        return {"ok": True, "message": "Claude runtime is not running in the controller; next request will use current settings."}
 
     # codex fallback: kill app-server processes; controller recovery rebuilds.
     try:
@@ -2375,16 +2385,13 @@ def _serialize_web_flow_status(payload: dict) -> dict:
     return payload
 
 
-_WEB_OAUTH_BACKENDS = {"claude", "codex", "opencode"}
-
-
 def start_oauth_web(
     backend: str,
     force_reset: bool = True,
     provider_id: Optional[str] = None,
 ) -> dict:
     backend = (backend or "").strip().lower()
-    if backend not in _WEB_OAUTH_BACKENDS:
+    if not supports_web_oauth(backend):
         return {"ok": False, "error": "unsupported_backend"}
     if backend == "opencode" and not (isinstance(provider_id, str) and provider_id.strip()):
         return {"ok": False, "error": "opencode_provider_id_required"}
@@ -2446,7 +2453,7 @@ def submit_oauth_web_code(flow_id: str, code: str) -> dict:
 def remove_backend_auth(backend: str) -> dict:
     """Clear stored credentials for Claude or Codex (web Settings)."""
     backend = (backend or "").strip().lower()
-    if backend not in _WEB_OAUTH_BACKENDS:
+    if not supports_web_oauth(backend):
         return {"ok": False, "error": "unsupported_backend"}
     service = _get_oauth_service()
     try:
@@ -2552,7 +2559,7 @@ def test_backend_auth(backend: str, model: Optional[str] = None) -> dict:
     reasoning model, where even "Hi" can blow past the test timeout.
     """
     backend = (backend or "").strip().lower()
-    if backend not in _WEB_OAUTH_BACKENDS:
+    if not supports_web_oauth(backend):
         return {"ok": False, "error": "unsupported_backend"}
     service = _get_oauth_service()
     try:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2188,9 +2188,9 @@ def restart_backend(name: str) -> dict:
     Preferred path: drop a runtime-command marker that the controller
     observes and reacts to via ``_refresh_backend_runtime``. This keeps the
     controller's in-memory transport/session state consistent. If the
-    controller isn't running (e.g. service not yet started), we fall back to
-    killing the OS process directly — the controller's recovery logic will
-    rebuild state when it next starts.
+    controller isn't running (e.g. service not yet started), backends with a
+    separate runtime can fall back to killing their OS process directly — the
+    controller's recovery logic will rebuild state when it next starts.
 
     Claude has no separate daemon, but the controller keeps SDK sessions
     and a loaded compat config; the marker path refreshes those in memory.
@@ -2226,7 +2226,10 @@ def restart_backend(name: str) -> dict:
         return {"ok": False, "message": "Failed to stop OpenCode server."}
 
     if name == "claude":
-        return {"ok": True, "message": "Claude runtime is not running in the controller; next request will use current settings."}
+        return {
+            "ok": False,
+            "message": "Claude runtime refresh was not acknowledged by the controller; retry after the service is running.",
+        }
 
     # codex fallback: kill app-server processes; controller recovery rebuilds.
     try:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -24,6 +24,7 @@ from flask import Flask, g, request, jsonify, redirect, send_file, Response
 
 from config import paths
 from config.v2_config import CONFIG_LOCK, V2Config
+from modules.agents.catalog import AGENT_BACKENDS, supports_runtime_refresh
 from vibe.runtime import get_ui_dist_path, get_working_dir
 from vibe.sentry_integration import init_sentry
 
@@ -1141,6 +1142,13 @@ def platforms_get():
     return jsonify(api.get_platform_catalog())
 
 
+@app.route("/agent-backends", methods=["GET"])
+def agent_backends_get():
+    from vibe import api
+
+    return jsonify(api.get_agent_backend_catalog())
+
+
 @app.route("/settings", methods=["GET"])
 def settings_get():
     # /settings doubles as a backend JSON API and a user-facing URL the SPA
@@ -1785,9 +1793,7 @@ def codex_models():
 @app.route("/agent/<name>/install", methods=["POST"])
 def agent_install(name):
     """Install an agent CLI tool (opencode, claude, codex)."""
-    # Security: Allowlist validation
-    allowed_agents = {"opencode", "claude", "codex"}
-    if name not in allowed_agents:
+    if name not in _ALLOWED_BACKENDS:
         return jsonify({"ok": False, "message": f"Unknown agent: {name}"}), 400
 
     from vibe import api
@@ -1796,8 +1802,7 @@ def agent_install(name):
     return jsonify(result)
 
 
-_ALLOWED_BACKENDS = {"opencode", "claude", "codex"}
-_BACKENDS_WITH_RESTART = {"opencode", "codex"}
+_ALLOWED_BACKENDS = set(AGENT_BACKENDS)
 
 
 @app.route("/backend/<name>/runtime")
@@ -1813,8 +1818,8 @@ def backend_runtime(name):
 
 @app.route("/backend/<name>/restart", methods=["POST"])
 def backend_restart(name):
-    """Restart a backend's persistent server process (opencode or codex)."""
-    if name not in _BACKENDS_WITH_RESTART:
+    """Refresh a backend's runtime state after settings change."""
+    if not supports_runtime_refresh(name):
         return jsonify({"ok": False, "message": f"Restart is not supported for backend: {name}"}), 400
 
     from vibe import api


### PR DESCRIPTION
## Summary

- add a shared agent backend catalog for backend metadata and capabilities
- refresh live OpenCode, Claude, and Codex runtime state after CLI/config changes saved from Settings
- route API, UI server, runtime command markers, Web OAuth checks, default-backend validation, and backend display names through the catalog
- centralize backend runtime refresh dispatch in `AgentService`
- move Settings/Wizard frontend backend metadata into a reusable UI catalog

## Root Cause

Settings persisted the new CLI path to V2 config, but running backend adapters kept stale in-memory runtime state. OpenCode kept its cached server manager pointed at the old binary path, and the same class of stale runtime problem existed for Codex transports and Claude SDK sessions. The restart/refresh capability was also represented by duplicated backend lists across API, UI server, runtime markers, and frontend code.

## Validation

- `uv run pytest tests/test_agent_backend_catalog.py tests/test_agent_service.py tests/test_agent_auth_service.py tests/test_claude_agent_sessions.py tests/test_claude_cli_path.py tests/test_codex_agent.py tests/test_opencode_server.py tests/test_save_opencode_provider_auth.py tests/test_runtime_commands.py tests/test_codex_api_auth.py tests/test_v2_config_platform_registry.py tests/test_ui_server_reload.py tests/test_web_oauth_flow.py tests/test_ui_api.py -q` (`240 passed`)
- `npm run build`
- `uv run ruff check ...` on changed Python files

## Evidence Layers

- Unit: backend catalog, agent service dispatch, backend adapter refresh, runtime command watcher
- Contract: V2 config payload/catalog exposure and API runtime/restart behavior
- Scenario: existing auth/setup runtime-refresh tests for OpenCode/Codex/Claude paths
- Residual manual checks: not run against the live local Vibe service to avoid interrupting the active agent session
