### PR TITLE
fix: attach public session id after agent binding

### DIFF
--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -80,7 +80,6 @@ Current conversation targeting:
 
 Rules:
 - Use `--session-id {default_session_id}` when scheduling work; it targets the exact Vibe Remote agent session to continue.
-- If the current session id is not available yet, do not guess a target; ask the user to retry from an active Vibe Remote session.
 - `--post-to` changes the delivery target, not the session scope. Use `--post-to channel` when the session should stay thread-scoped but the follow-up message should be posted to the parent channel.
 - Use `--cron "<expr>"` for recurring tasks or `--at "<ISO-8601>"` for one-off stored tasks.
 - Use `vibe watch list`, `vibe watch show`, `vibe watch pause`, `vibe watch resume`, and `vibe watch remove` to manage background work after creation.
@@ -111,9 +110,11 @@ Keep entries short, deduplicated, and free of secrets unless the user explicitly
 
 def _build_scheduled_tasks_prompt(context: MessageContext, *, fallback_platform: Optional[str] = None) -> str:
     platform_specific = context.platform_specific or {}
-    default_session_id = str(platform_specific.get("agent_session_id") or "<not available yet>")
+    default_session_id = platform_specific.get("agent_session_id")
+    if not default_session_id:
+        raise ValueError("agent_session_id is required before building Vibe Remote scheduled-task prompt")
     return _SCHEDULED_TASKS_PROMPT.format(
-        default_session_id=default_session_id,
+        default_session_id=str(default_session_id),
     )
 
 

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -128,7 +128,12 @@ class BaseAgent(ABC):
             if callable(setter):
                 setter(request.session_key, self.name, anchor, native_session_id)
             agent_session_id = None
-        return agent_session_id or self.ensure_agent_session_id(request, session_anchor=anchor)
+        if agent_session_id:
+            payload = dict(request.context.platform_specific or {})
+            payload["agent_session_id"] = agent_session_id
+            request.context.platform_specific = payload
+            return agent_session_id
+        return self.ensure_agent_session_id(request, session_anchor=anchor)
 
     async def _remove_ack_reaction(self, request: AgentRequest) -> None:
         """Remove the acknowledgement reaction / typing indicator.

--- a/tests/test_agent_silent_result.py
+++ b/tests/test_agent_silent_result.py
@@ -45,5 +45,33 @@ class AgentSilentResultTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(controller.messages, [("result", "", "markdown")])
 
 
+class AgentSessionIdContextTests(unittest.TestCase):
+    def test_bind_agent_session_id_attaches_returned_public_session_id(self):
+        controller = _StubController()
+        controller.sessions = SimpleNamespace(
+            bind_agent_session=lambda session_key, agent_name, anchor, native_id: "sesk8m4q2p7x"
+        )
+        agent = _StubAgent(controller)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={"platform": "slack"},
+        )
+        request = AgentRequest(
+            context=context,
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="slack_171717.123",
+            composite_session_id="slack_171717.123:/tmp/work",
+            session_key="slack::C1",
+        )
+
+        session_id = agent.bind_agent_session_id(request, "thread-native-1")
+
+        self.assertEqual(session_id, "sesk8m4q2p7x")
+        self.assertEqual(request.context.platform_specific["agent_session_id"], "sesk8m4q2p7x")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -871,7 +871,10 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=False))
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
-        agent.sessions = SimpleNamespace(set_agent_session_mapping=Mock())
+        agent.sessions = SimpleNamespace(
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
+            bind_agent_session=Mock(return_value="sesk8m4q2p7x"),
+        )
         request = SimpleNamespace(
             working_path="/tmp/work",
             context=SimpleNamespace(
@@ -908,6 +911,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(params["sandbox"], "danger-full-access")
         self.assertIn("Focus on regressions.", params["developerInstructions"])
         self.assertIn("# Vibe Remote", params["developerInstructions"])
+        self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
         self.assertNotIn("## 2. Quick-reply buttons", params["developerInstructions"])
 
     async def test_start_thread_adds_codex_generated_image_prompt_to_thread_instructions(self):
@@ -915,7 +919,10 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))
         agent.codex_config = SimpleNamespace(default_model=None)
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
-        agent.sessions = SimpleNamespace(set_agent_session_mapping=Mock())
+        agent.sessions = SimpleNamespace(
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
+            bind_agent_session=Mock(return_value="sesk8m4q2p7x"),
+        )
         request = SimpleNamespace(
             working_path="/tmp/work",
             context=SimpleNamespace(
@@ -940,6 +947,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("## 1. Send files", params["developerInstructions"])
         self.assertIn("### Codex-generated images", params["developerInstructions"])
         self.assertIn("If you generate an image with Codex", params["developerInstructions"])
+        self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
         self.assertIn("file:///Users/test/.codex/generated_images/thread-id/image-file.png", params["developerInstructions"])
 
     async def test_resume_thread_refreshes_developer_instructions_without_appending(self):
@@ -1008,6 +1016,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
             get_agent_session_id=Mock(return_value="thread-existing"),
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
         )
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -1051,6 +1060,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
             get_agent_session_id=Mock(return_value="thread-existing"),
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
         )
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -1094,6 +1104,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
             get_agent_session_id=Mock(return_value="thread-existing"),
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
         )
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -1134,6 +1145,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
             get_agent_session_id=Mock(return_value="thread-existing"),
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
         )
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -1174,6 +1186,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
             get_agent_session_id=Mock(return_value="thread-existing"),
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
         )
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -1213,6 +1226,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
         agent.sessions = SimpleNamespace(
             get_agent_session_id=Mock(return_value="thread-existing"),
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
         )
         request = SimpleNamespace(
             working_path="/tmp/work",

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -253,19 +253,12 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         )
 
         with patch.object(paths, "get_user_preferences_path", return_value=Path("/tmp/user_preferences.md")):
-            prompt = build_system_prompt_injection(
-                include_quick_replies=True,
-                context=context,
-                fallback_platform="slack",
-            )
-
-        self.assertIn("Current session id: `<not available yet>`", prompt)
-        self.assertIn("do not guess a target", prompt)
-        self.assertNotIn("Legacy session key:", prompt)
-        self.assertNotIn("Channel-level session key:", prompt)
-        self.assertIn("Use the current platform `slack`", prompt)
-        self.assertIn("`slack/<user_id>`", prompt)
-        self.assertNotIn("slack/U1", prompt)
+            with self.assertRaisesRegex(ValueError, "agent_session_id is required"):
+                build_system_prompt_injection(
+                    include_quick_replies=True,
+                    context=context,
+                    fallback_platform="slack",
+                )
 
     def test_prompt_handles_missing_platform_specific(self):
         context = MessageContext(
@@ -276,15 +269,12 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         )
 
         with patch.object(paths, "get_user_preferences_path", return_value=Path("/tmp/user_preferences.md")):
-            prompt = build_system_prompt_injection(
-                include_quick_replies=True,
-                context=context,
-                fallback_platform="slack",
-            )
-
-        self.assertIn("Use the current platform `slack`", prompt)
-        self.assertIn("`slack/<user_id>`", prompt)
-        self.assertNotIn("slack/U1", prompt)
+            with self.assertRaisesRegex(ValueError, "agent_session_id is required"):
+                build_system_prompt_injection(
+                    include_quick_replies=True,
+                    context=context,
+                    fallback_platform="slack",
+                )
 
     def test_file_links_with_parentheses_are_preserved(self):
         enhanced = process_reply("![video](file:///Users/test/SaveTwitter.Net_GABV3XNWYAARAZz(gif).mp4)")


### PR DESCRIPTION
## What

Fix the agent-session prompt injection path after backend-native session binding, and make missing public session ids fail fast instead of rendering an unavailable placeholder.

PR #310 ensured Codex/Claude refresh cached system/developer prompts, but Codex resume can bind the backend-native thread before building the refreshed developer instructions. `BaseAgent.bind_agent_session_id()` returned the Vibe-owned public session id but did not attach it back onto the current request context, so the immediately-built prompt could still render a missing session id.

This PR now does two things:

- attaches the returned public session id to `context.platform_specific["agent_session_id"]` from the shared binding helper before returning
- removes the `<not available yet>` prompt fallback and raises if the scheduled task/watch/hook prompt is built before `agent_session_id` is injected

## Validation

- `npm ci && npm run build`
- `uv run ruff check modules/agents/base.py tests/test_agent_silent_result.py`
- `uv run pytest tests/test_agent_silent_result.py tests/test_codex_agent.py::CodexAgentPayloadTests -q`
- `uv run ruff check core/system_prompt_injection.py tests/test_reply_enhancer_platform.py tests/test_codex_agent.py modules/agents/base.py tests/test_agent_silent_result.py`
- `uv run pytest tests/test_reply_enhancer_platform.py tests/test_agent_silent_result.py tests/test_codex_agent.py::CodexAgentPayloadTests tests/test_claude_cli_path.py::test_session_handler_ensures_agent_session_id_before_prompt -q`
- `git diff --check`
- Manual runtime-shaped reproduction: binding the current Slack/Codex thread now immediately leaves `agent_session_id=sesqq22wcpmav` on the same request context.
