### PR TITLE
feat(update): support silent release notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,7 @@ Testing guidance:
 ## 9. Release Notes
 
 - tags follow the latest version number +1 (for example `v1.0.1` -> `v1.0.2`)
+- before publishing a release, explicitly decide whether the version should notify users; add `<!-- vibe-remote:update-notification=none -->` to the GitHub Release body when update and post-update notifications should be suppressed while automatic update behavior remains enabled
 - GitHub-only pre-releases should use the `gh-vX.Y.ZrcN` format (for example `gh-v2.2.8rc2`) so they stay distinct from PyPI-triggering `v*` tags
 - GitHub-only pre-releases must include installable artifacts (at minimum a wheel built with `ui/dist`) in the GitHub release assets
 - releases are published automatically by workflow after tagging/push

--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -11,6 +11,7 @@ import asyncio
 import calendar
 import json
 import logging
+import re
 import tempfile
 import time
 import urllib.parse
@@ -41,6 +42,13 @@ MIN_CHECK_INTERVAL_MINUTES = 1
 NOTIFICATION_GRACE_PERIOD_MINUTES = 10
 
 GITHUB_RELEASE_TAG_BASE_URL = "https://github.com/cyhhao/vibe-remote/releases/tag"
+GITHUB_RELEASE_API_BASE_URL = "https://api.github.com/repos/cyhhao/vibe-remote/releases/tags"
+UPDATE_NOTIFICATION_POLICY_DEFAULT = "default"
+UPDATE_NOTIFICATION_POLICY_NONE = "none"
+UPDATE_NOTIFICATION_POLICY_MARKER_RE = re.compile(
+    r"<!--\s*vibe-remote:update-notification\s*=\s*(?P<policy>none|default)\s*-->",
+    re.IGNORECASE,
+)
 
 
 def _fetch_pypi_version_sync() -> Dict[str, Any]:
@@ -70,6 +78,45 @@ def _github_release_url(version: str) -> str:
     version_text = str(version).strip()
     tag = version_text if version_text.startswith(("v", "gh-v")) else f"v{version_text}"
     return f"{GITHUB_RELEASE_TAG_BASE_URL}/{urllib.parse.quote(tag, safe='')}"
+
+
+def _github_release_tag(version: str) -> str:
+    version_text = str(version).strip()
+    return version_text if version_text.startswith(("v", "gh-v")) else f"v{version_text}"
+
+
+def _github_release_api_url(version: str) -> str:
+    tag = _github_release_tag(version)
+    return f"{GITHUB_RELEASE_API_BASE_URL}/{urllib.parse.quote(tag, safe='')}"
+
+
+def _parse_update_notification_policy(body: object) -> str:
+    if not isinstance(body, str):
+        return UPDATE_NOTIFICATION_POLICY_DEFAULT
+    match = UPDATE_NOTIFICATION_POLICY_MARKER_RE.search(body)
+    if not match:
+        return UPDATE_NOTIFICATION_POLICY_DEFAULT
+    return match.group("policy").lower()
+
+
+def _fetch_update_notification_policy_sync(version: str) -> Dict[str, Any]:
+    result = {"version": version, "policy": UPDATE_NOTIFICATION_POLICY_DEFAULT, "error": None}
+
+    try:
+        req = urllib.request.Request(
+            _github_release_api_url(version),
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "vibe-remote",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        result["policy"] = _parse_update_notification_policy(data.get("body"))
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
 
 
 def _format_release_version_link(version: str, platform: str = "markdown") -> str:
@@ -254,38 +301,71 @@ class UpdateChecker:
             latest = version_info["latest"]
             current = version_info["current"]
             logger.info(f"Update available: {current} -> {latest}")
+            release_notifications_enabled: Optional[bool] = None
 
             # Notification flow — failure must not block auto-update
             if self.config.notify_admins and self.state.notified_version != latest:
-                delivered = False
-                try:
-                    delivered = await self._send_update_notification(current, latest)
-                except Exception as e:
-                    logger.error(f"Failed to send update notification: {e}", exc_info=True)
-                if delivered:
-                    self.state.notified_version = latest
-                    self.state.notified_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-                else:
-                    logger.warning(
-                        "Update notification for %s was not delivered; skipping grace period",
-                        latest,
-                    )
-                self.state.save()
+                release_notifications_enabled = await self._should_send_release_notifications(
+                    latest,
+                    cached=release_notifications_enabled,
+                )
+                if release_notifications_enabled:
+                    delivered = False
+                    try:
+                        delivered = await self._send_update_notification(current, latest)
+                    except Exception as e:
+                        logger.error(f"Failed to send update notification: {e}", exc_info=True)
+                    if delivered:
+                        self.state.notified_version = latest
+                        self.state.notified_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                    else:
+                        logger.warning(
+                            "Update notification for %s was not delivered; skipping grace period",
+                            latest,
+                        )
+                    self.state.save()
 
             # Auto-update flow — respect a grace period after successful notification
             # so the admin has time to read the notification before auto-update kicks in.
             if self.config.auto_update and self._is_idle():
-                if self._within_notification_grace_period(latest):
+                release_notifications = await self._should_send_release_notifications(
+                    latest,
+                    cached=release_notifications_enabled,
+                )
+                if release_notifications and self._within_notification_grace_period(latest):
                     logger.info("Within notification grace period, deferring auto-update")
                 else:
                     logger.info("System is idle, performing auto-update...")
-                    await self._perform_update(latest)
+                    update_kwargs = {}
+                    if not release_notifications:
+                        update_kwargs["suppress_post_update_notification"] = True
+                    await self._perform_update(latest, **update_kwargs)
         except Exception as e:
             logger.error(f"Update check failed: {e}", exc_info=True)
 
     async def _get_version_info_async(self) -> Dict[str, Any]:
         """Get version info asynchronously."""
         return await asyncio.to_thread(_fetch_pypi_version_sync)
+
+    async def _should_send_release_notifications(self, latest: str, cached: Optional[bool] = None) -> bool:
+        """Return whether update notifications should be sent for the release."""
+        if cached is not None:
+            return cached
+
+        policy_info = await asyncio.to_thread(_fetch_update_notification_policy_sync, latest)
+        if policy_info.get("error"):
+            logger.warning(
+                "Failed to check update notification policy for %s: %s",
+                latest,
+                policy_info["error"],
+            )
+            return True
+
+        policy = policy_info.get("policy") or UPDATE_NOTIFICATION_POLICY_DEFAULT
+        enabled = policy != UPDATE_NOTIFICATION_POLICY_NONE
+        if not enabled:
+            logger.info("Update notifications suppressed by release metadata for %s", latest)
+        return enabled
 
     def _is_idle(self) -> bool:
         """Check if the system is idle (no active sessions and no recent activity)."""
@@ -673,6 +753,7 @@ class UpdateChecker:
         channel_id: Optional[str] = None,
         message_id: Optional[str] = None,
         platform: Optional[str] = None,
+        suppress_post_update_notification: bool = False,
     ) -> Dict[str, Any]:
         """Perform the actual update and restart. Returns do_upgrade result dict."""
         # Prevent concurrent upgrades
@@ -697,12 +778,16 @@ class UpdateChecker:
                 logger.info(f"Upgrade successful: {result['message']}")
                 if result.get("restarting"):
                     # Write marker only if restart is scheduled
-                    self._write_update_marker(
-                        target_version,
-                        channel_id=channel_id,
-                        message_id=message_id,
-                        platform=platform,
-                    )
+                    if suppress_post_update_notification:
+                        logger.info("Post-update notification suppressed for %s", target_version)
+                        self._remove_update_marker()
+                    else:
+                        self._write_update_marker(
+                            target_version,
+                            channel_id=channel_id,
+                            message_id=message_id,
+                            platform=platform,
+                        )
                 else:
                     logger.warning("Upgrade completed without restart; manual restart required")
                 return result

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -111,6 +111,31 @@ def test_update_notification_release_url_normalizes_github_tags():
     )
 
 
+def test_update_notification_policy_marker_parses_hidden_release_metadata():
+    body = """
+    ## Changes
+
+    - Small internal fix.
+
+    <!-- vibe-remote:update-notification=none -->
+    """
+
+    assert update_checker._parse_update_notification_policy(body) == "none"
+    assert update_checker._parse_update_notification_policy("## Changes") == "default"
+    assert update_checker._parse_update_notification_policy(None) == "default"
+
+
+def test_fetch_update_notification_policy_reads_github_release_body():
+    payload = b'{"body": "<!-- vibe-remote:update-notification=none -->"}'
+
+    with patch.object(update_checker.urllib.request, "urlopen", return_value=_FakeResponse(payload)) as urlopen:
+        info = update_checker._fetch_update_notification_policy_sync("1.0.1")
+
+    req = urlopen.call_args.args[0]
+    assert req.full_url == "https://api.github.com/repos/cyhhao/vibe-remote/releases/tags/v1.0.1"
+    assert info == {"version": "1.0.1", "policy": "none", "error": None}
+
+
 def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
@@ -147,6 +172,11 @@ def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch,
         "_fetch_pypi_version_sync",
         lambda: {"current": "1.0.0", "latest": "1.0.1", "has_update": True, "error": None},
     )
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_update_notification_policy_sync",
+        lambda version: {"version": version, "policy": "default", "error": None},
+    )
     monkeypatch.setattr(checker, "_is_idle", lambda: True)
     performed = []
 
@@ -161,6 +191,68 @@ def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch,
     assert checker.state.notified_version is None
     assert checker.state.notified_at is None
     assert performed == [("1.0.1", {})]
+
+
+def test_silent_release_metadata_skips_notifications_but_keeps_auto_update(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    store = SettingsStore.get_instance()
+    store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
+    store.save()
+
+    controller = _StubController(store)
+    controller.im_clients = {"slack": _FakeIMClient()}
+    controller.im_client = controller.im_clients["slack"]
+    checker = UpdateChecker(controller, UpdateConfig(check_interval_minutes=1, notify_admins=True, auto_update=True))
+    checker.state.last_activity_at = time.time() - 3600
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_pypi_version_sync",
+        lambda: {"current": "1.0.0", "latest": "1.0.1", "has_update": True, "error": None},
+    )
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_update_notification_policy_sync",
+        lambda version: {"version": version, "policy": "none", "error": None},
+    )
+    monkeypatch.setattr(checker, "_is_idle", lambda: True)
+    notified = []
+    performed = []
+
+    async def fake_send_update_notification(current, latest):
+        notified.append((current, latest))
+        return True
+
+    async def fake_perform_update(target_version, **kwargs):
+        performed.append((target_version, kwargs))
+        return {"ok": True, "restarting": False, "message": "ok"}
+
+    monkeypatch.setattr(checker, "_send_update_notification", fake_send_update_notification)
+    monkeypatch.setattr(checker, "_perform_update", fake_perform_update)
+
+    asyncio.run(checker._do_check())
+
+    assert notified == []
+    assert checker.state.notified_version is None
+    assert checker.state.notified_at is None
+    assert performed == [("1.0.1", {"suppress_post_update_notification": True})]
+
+
+def test_suppressed_post_update_notification_does_not_write_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
+
+    monkeypatch.setattr(
+        "vibe.api.do_upgrade",
+        lambda restart: {"ok": True, "restarting": True, "message": "ok", "output": None},
+    )
+
+    result = asyncio.run(checker._perform_update("1.0.1", suppress_post_update_notification=True))
+
+    assert result["ok"] is True
+    marker = tmp_path / "state" / "pending_update_notification.json"
+    assert not marker.exists()
 
 
 def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

- Add a hidden GitHub Release body marker, `<!-- vibe-remote:update-notification=none -->`, to suppress update notifications for a specific release.
- Keep PyPI-based version selection and idle auto-update behavior unchanged.
- Suppress the post-restart update confirmation marker when an automatic update was triggered for a silent release.
- Document the release checklist item in `AGENTS.md`.

## Why

Some releases should still roll out through the normal automatic update path without creating admin/user-facing update messages.

## Testing

- `npm ci && npm run build` in `ui/` to provide packaged UI assets required by editable Python checks.
- `uv run pytest tests/test_update_checker_platforms.py`
- `uv run ruff check core/update_checker.py tests/test_update_checker_platforms.py`

## Evidence Layers

- Unit: updated update checker tests for marker parsing, GitHub release metadata fetch, silent release notification suppression, and post-update marker suppression.
- Contract: no external API contract changes; GitHub Release metadata is optional and failure defaults to current notification behavior.
- Scenario: not updated; release notification policy is covered by focused unit tests.
- Residual manual checks: release authors must choose whether to include the hidden marker before publishing each release.
