### PR TITLE
fix(wechat): rearm bind menu hint on QR rebind

### DIFF
--- a/tests/test_wechat_auth.py
+++ b/tests/test_wechat_auth.py
@@ -69,7 +69,7 @@ class WeChatAuthManagerTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(user)
         self.assertTrue(user.pending_bind_menu_hint)  # type: ignore[union-attr]
 
-    async def test_auto_bind_wechat_user_does_not_rearm_existing_user_hint(self):
+    async def test_auto_bind_wechat_user_rearms_existing_user_hint(self):
         SettingsStore.reset_instance()
         store = SettingsStore.get_instance()
         store.add_user("wx-user", "WeChat User", platform="wechat")
@@ -78,4 +78,8 @@ class WeChatAuthManagerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(result["ok"])
         self.assertTrue(result["already_bound"])
-        self.assertFalse(result["pending_bind_menu_hint"])
+        self.assertTrue(result["pending_bind_menu_hint"])
+
+        user = SettingsStore.get_instance().get_user("wx-user", platform="wechat")
+        self.assertIsNotNone(user)
+        self.assertTrue(user.pending_bind_menu_hint)  # type: ignore[union-attr]

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -4460,15 +4460,20 @@ def auto_bind_wechat_user(user_id: str) -> dict:
     store = SettingsStore.get_instance()
     platform = "wechat"
 
-    # Skip if already bound
     if store.is_bound_user(user_id, platform=platform):
-        logger.info("WeChat user %s already bound, skipping auto-bind", user_id)
         existing = store.get_user(user_id, platform=platform)
+        if existing is None:
+            logger.warning("WeChat user %s is marked bound but missing settings", user_id)
+        else:
+            existing.pending_bind_menu_hint = True
+            store.update_user(user_id, existing, platform=platform)
+            store.save()
+            logger.info("Re-armed WeChat bind menu hint for already-bound user %s", user_id)
         return {
             "ok": True,
             "already_bound": True,
             "is_admin": bool(getattr(existing, "is_admin", False)),
-            "pending_bind_menu_hint": bool(getattr(existing, "pending_bind_menu_hint", False)),
+            "pending_bind_menu_hint": bool(getattr(existing, "pending_bind_menu_hint", True)),
         }
 
     config = load_config()


### PR DESCRIPTION
## Summary
- re-arm the deferred WeChat `/start` menu hint when an already-bound user completes QR login again
- preserve existing user settings, admin state, routing, and cwd while marking the next inbound WeChat message for the one-time hint
- update the WeChat auth regression test for the rebind path

## Root Cause
PR #317 intentionally avoided duplicate hints by treating already-bound WeChat users as an idempotent no-op during QR login. That missed the product case where a previous WeChat user scans and binds again: the scan is a fresh successful bind event, so the next user message should receive the welcome/menu hint once.

## Validation
- `uv run pytest tests/test_wechat_auth.py tests/test_wechat_bot.py tests/test_ui_server_fastapi.py`
- `uv run ruff check vibe/api.py tests/test_wechat_auth.py`
- rebuilt the Docker regression environment and verified it is healthy through the public Vibe Cloud health endpoint
