### PR TITLE
fix(audio): enable ASR by default when paired

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -139,8 +139,9 @@ class GatewayConfig:
 
 @dataclass
 class AudioAsrConfig:
-    enabled: bool = False
+    enabled: bool = True
     echo_transcript: bool = True
+    enabled_configured: bool = False
     timeout_seconds: float = 60.0
     endpoint_path: str = "/v1/audio/transcriptions"
     model: str = "qwen3-asr-flash"
@@ -448,7 +449,10 @@ class V2Config:
         audio_asr_payload = payload.get("audio_asr") or {}
         if not isinstance(audio_asr_payload, dict):
             raise ValueError("Config 'audio_asr' must be an object")
+        audio_asr_enabled_present = "enabled" in audio_asr_payload
         audio_asr = AudioAsrConfig(**_filter_dataclass_fields(AudioAsrConfig, audio_asr_payload))
+        if audio_asr_enabled_present and audio_asr.enabled is False and not audio_asr.enabled_configured:
+            audio_asr.enabled_configured = True
         try:
             audio_asr.timeout_seconds = max(0.1, float(audio_asr.timeout_seconds))
         except (TypeError, ValueError):

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from config.v2_config import V2Config
 from vibe import api
 
 
@@ -136,17 +137,67 @@ def test_save_config_merges_audio_asr_settings(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
 
     created = api.save_config(_full_config_payload())
-    assert created.audio_asr.enabled is False
+    assert created.audio_asr.enabled is True
+    assert created.audio_asr.enabled_configured is False
     assert created.audio_asr.echo_transcript is True
 
-    updated = api.save_config({"audio_asr": {"enabled": True, "echo_transcript": False}})
+    updated = api.save_config({"audio_asr": {"enabled": False, "enabled_configured": True, "echo_transcript": False}})
     payload = api.config_to_payload(updated)
 
-    assert updated.audio_asr.enabled is True
+    assert updated.audio_asr.enabled is False
+    assert updated.audio_asr.enabled_configured is True
     assert updated.audio_asr.echo_transcript is False
     assert updated.audio_asr.endpoint_path == "/v1/audio/transcriptions"
-    assert payload["audio_asr"]["enabled"] is True
+    assert payload["audio_asr"]["enabled"] is False
+    assert payload["audio_asr"]["enabled_configured"] is True
     assert payload["audio_asr"]["echo_transcript"] is False
+
+
+def test_save_config_marks_explicit_audio_asr_disable_patch(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    api.save_config(_full_config_payload())
+
+    updated = api.save_config({"audio_asr": {"enabled": False}})
+
+    assert updated.audio_asr.enabled is False
+    assert updated.audio_asr.enabled_configured is True
+
+
+def test_config_load_defaults_missing_audio_asr_to_enabled():
+    payload = _full_config_payload()
+    payload.pop("audio_asr", None)
+
+    created = V2Config.from_payload(payload)
+
+    assert created.audio_asr.enabled is True
+    assert created.audio_asr.enabled_configured is False
+
+
+def test_config_load_preserves_pre_upgrade_audio_asr_false_as_opt_out():
+    payload = _full_config_payload()
+    payload["audio_asr"] = {"enabled": False, "echo_transcript": True}
+
+    created = V2Config.from_payload(payload)
+
+    assert created.audio_asr.enabled is False
+    assert created.audio_asr.enabled_configured is True
+
+
+def test_save_config_preserves_explicit_audio_asr_opt_out(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    payload = _full_config_payload()
+    payload["audio_asr"] = {
+        "enabled": False,
+        "enabled_configured": True,
+        "echo_transcript": True,
+    }
+
+    created = api.save_config(payload)
+
+    assert created.audio_asr.enabled is False
+    assert created.audio_asr.enabled_configured is True
 
 
 def test_config_to_payload_redacts_remote_access_secrets_and_save_preserves_them(monkeypatch, tmp_path):

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { ArrowRight, Bot, MessageSquare, Radio, Send, Sparkles } from 'lucide-react';
+import { ArrowRight, Bot, HelpCircle, MessageSquare, Radio, Send, Sparkles } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
@@ -108,10 +108,10 @@ export const SettingsMessagingPage: React.FC = () => {
   ];
   const includeTimeInfoEnabled = config.include_time_info !== false;
   const audioAsr = config.audio_asr || {};
-  const audioAsrEnabled = Boolean(audioAsr.enabled);
   const audioEchoEnabled = audioAsr.echo_transcript !== false;
   const vibeCloud = config.remote_access?.vibe_cloud || {};
   const vibeCloudPaired = Boolean(vibeCloud.enabled && vibeCloud.instance_id);
+  const audioAsrEnabled = vibeCloudPaired && audioAsr.enabled !== false;
 
   return (
     <SettingsPageShell
@@ -146,7 +146,19 @@ export const SettingsMessagingPage: React.FC = () => {
         description={t('settings.messagingInputEnrichmentDescription')}
       >
         <SettingsRow
-          title={t('dashboard.audioTranscription')}
+          title={
+            <span className="inline-flex items-center gap-1.5">
+              {t('dashboard.audioTranscription')}
+              {!vibeCloudPaired && (
+                <span className="group relative inline-flex">
+                  <HelpCircle className="size-3.5 cursor-help text-muted/60" />
+                  <span className="pointer-events-none absolute bottom-full left-0 z-20 mb-2 w-64 whitespace-normal rounded bg-text px-3 py-2 text-[11px] font-normal text-bg opacity-0 shadow-lg transition-opacity group-hover:opacity-100">
+                    {t('dashboard.audioTranscriptionRequiresRemoteAccessTooltip')}
+                  </span>
+                </span>
+              )}
+            </span>
+          }
           description={
             vibeCloudPaired
               ? t('dashboard.audioTranscriptionHint')
@@ -162,6 +174,7 @@ export const SettingsMessagingPage: React.FC = () => {
                   audio_asr: {
                     ...audioAsr,
                     enabled: !audioAsrEnabled,
+                    enabled_configured: true,
                   },
                 })
               }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -937,6 +937,7 @@
     "audioTranscription": "Audio Transcription",
     "audioTranscriptionHint": "Transcribe supported audio attachments before sending the turn to the agent",
     "audioTranscriptionRequiresVibeCloud": "Pair this Vibe Remote with Vibe Cloud before enabling audio transcription",
+    "audioTranscriptionRequiresRemoteAccessTooltip": "Open Remote Access and pair this device with avibe.bot to enable audio transcription.",
     "audioTranscriptEcho": "Echo Transcript",
     "audioTranscriptEchoHint": "Send recognized text back to the chat when transcription succeeds",
     "errorRetryLimit": "Error Retry Limit",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -937,6 +937,7 @@
     "audioTranscription": "语音转文字",
     "audioTranscriptionHint": "在把消息交给 Agent 前，先转写支持的语音附件",
     "audioTranscriptionRequiresVibeCloud": "请先将 Vibe Remote 配对到 Vibe Cloud，再启用语音转文字",
+    "audioTranscriptionRequiresRemoteAccessTooltip": "请先在远程访问页将本设备配对到 avibe.bot，然后即可启用语音转文字。",
     "audioTranscriptEcho": "回显转写结果",
     "audioTranscriptEchoHint": "语音识别成功后，把转写文本也发回当前对话",
     "errorRetryLimit": "错误重试次数",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -522,11 +522,28 @@ def _strip_agent_auth_fields(payload: dict) -> dict:
     return {**payload, "agents": cleaned_agents}
 
 
+def _mark_explicit_audio_asr_enabled(payload: dict) -> dict:
+    """Record explicit ASR enablement changes from config API payloads.
+
+    Persisted configs from older versions may contain ``enabled: false`` only
+    because that was the old default. A current API request that includes the
+    same field is different: it is the user's requested value and must survive
+    the migration default.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    audio_asr = payload.get("audio_asr")
+    if not isinstance(audio_asr, dict) or "enabled" not in audio_asr or "enabled_configured" in audio_asr:
+        return payload
+    return {**payload, "audio_asr": {**audio_asr, "enabled_configured": True}}
+
+
 def save_config(payload: dict) -> V2Config:
     if not isinstance(payload, dict):
         raise ValueError("Config payload must be an object")
 
     payload = _strip_agent_auth_fields(payload)
+    payload = _mark_explicit_audio_asr_enabled(payload)
 
     with CONFIG_LOCK:
         base_payload: dict = {}


### PR DESCRIPTION
## Summary
- enable inbound audio ASR by default in config, while runtime still requires Vibe Cloud pairing credentials before transcribing
- keep the Messaging settings switch disabled when Vibe Cloud is not paired, and add a help tooltip pointing users to avibe.bot remote access pairing
- update ASR config merge coverage for the new default and explicit user opt-out

## Validation
- `npm run build`
- `uv run pytest tests/test_api_save_config_merge.py tests/test_audio_asr.py`
