### PR TITLE
fix(sessions): atomically claim processed messages

### DIFF
--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -385,8 +385,7 @@ class SessionsStore:
         """Check if a message ID is in the processed set."""
         return message_ts in self._get_processed_set(channel_id, thread_ts)
 
-    def add_to_processed_set(self, channel_id: str, thread_ts: str, message_ts: str) -> None:
-        """Add a message ID to the processed set (bounded)."""
+    def _remember_processed_message(self, channel_id: str, thread_ts: str, message_ts: str) -> None:
         if channel_id not in self.state.processed_message_ts:
             self.state.processed_message_ts[channel_id] = {}
         value = self.state.processed_message_ts[channel_id].get(thread_ts)
@@ -404,6 +403,19 @@ class SessionsStore:
             if len(processed) > self._DEDUP_SET_MAX:
                 processed = processed[-self._DEDUP_SET_MAX :]
         self.state.processed_message_ts[channel_id][thread_ts] = processed
+
+    def try_add_to_processed_set(self, channel_id: str, thread_ts: str, message_ts: str) -> bool:
+        """Atomically add a message ID to the processed set."""
+        self._ensure_service()
+        if not self._service.try_record_processed_message(channel_id, thread_ts, message_ts):
+            self.maybe_reload()
+            return False
+        self._remember_processed_message(channel_id, thread_ts, message_ts)
+        return True
+
+    def add_to_processed_set(self, channel_id: str, thread_ts: str, message_ts: str) -> None:
+        """Add a message ID to the processed set (bounded)."""
+        self._remember_processed_message(channel_id, thread_ts, message_ts)
         self.save()
 
     def add_active_poll(self, poll_info: ActivePollInfo) -> None:

--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -287,19 +287,30 @@ class SessionsStore:
 
         Also removes empty orphan keys left behind by the migration.
         """
+        previous_keys = set(self.state.session_mappings.keys())
         migrated_count, old_key_count, empty_key_count = migrate_session_state_mappings(self.state, default_platform)
+        removed_keys = previous_keys - set(self.state.session_mappings.keys())
         if migrated_count == 0 and old_key_count == 0:
             if empty_key_count:
+                self._delete_session_scope_keys(removed_keys)
                 self.save()
                 logger.info("Cleaned up %d empty session_mapping keys", empty_key_count)
             return
         self.save()
+        self._delete_session_scope_keys(removed_keys)
         logger.info(
             "Migrated %d session entries from %d legacy keys; removed %d empty keys",
             migrated_count,
             old_key_count,
             empty_key_count,
         )
+
+    def _delete_session_scope_keys(self, scope_keys: set[str]) -> int:
+        self._ensure_service()
+        deleted = 0
+        for scope_key in scope_keys:
+            deleted += self._service.delete_agent_sessions(scope_key=str(scope_key))
+        return deleted
 
     def _ensure_user_namespace(self, user_id: str) -> None:
         if user_id not in self.state.session_mappings:
@@ -309,6 +320,7 @@ class SessionsStore:
 
     def get_agent_map(self, user_id: str, agent_name: str) -> Dict[str, str]:
         """Get mapping of thread_id -> session_id for a user and agent."""
+        self.maybe_reload()
         self._ensure_user_namespace(user_id)
         agent_map = self.state.session_mappings[user_id].get(agent_name)
         if agent_map is None:
@@ -351,13 +363,77 @@ class SessionsStore:
         self.get_agent_map(user_id, agent_name)[thread_id] = session_id
         return agent_session_id
 
+    def remove_agent_session(self, user_id: str, agent_name: str, thread_id: str) -> bool:
+        self._ensure_service()
+        removed = self._service.delete_agent_session(
+            scope_key=user_id,
+            agent_name=agent_name,
+            session_anchor=thread_id,
+        )
+        agent_map = self.get_agent_map(user_id, agent_name)
+        if thread_id in agent_map:
+            del agent_map[thread_id]
+            removed = True
+        return removed
+
+    def clear_agent_sessions(self, user_id: str, agent_name: str | None = None) -> int:
+        self._ensure_service()
+        removed = self._service.delete_agent_sessions(scope_key=user_id, agent_name=agent_name)
+        self._ensure_user_namespace(user_id)
+        if agent_name is None:
+            count = sum(len(agent_map) for agent_map in self.state.session_mappings[user_id].values())
+            self.state.session_mappings[user_id] = {}
+            return max(removed, count)
+        count = len(self.state.session_mappings[user_id].get(agent_name, {}))
+        self.state.session_mappings[user_id][agent_name] = {}
+        return max(removed, count)
+
+    def clear_session_base(self, user_id: str, base_session_id: str) -> int:
+        self._ensure_service()
+        removed = self._service.delete_agent_sessions(
+            scope_key=user_id,
+            session_anchor_prefix=base_session_id,
+        )
+        self._ensure_user_namespace(user_id)
+        cleared = 0
+        for agent_map in self.state.session_mappings[user_id].values():
+            keys_to_remove = [
+                mapping_key
+                for mapping_key in list(agent_map.keys())
+                if mapping_key == base_session_id or mapping_key.startswith(f"{base_session_id}:")
+            ]
+            for mapping_key in keys_to_remove:
+                del agent_map[mapping_key]
+                cleared += 1
+        return max(removed, cleared)
+
     def get_thread_map(self, user_id: str, channel_id: str) -> Dict[str, float]:
+        self.maybe_reload()
         self._ensure_user_namespace(user_id)
         channel_map = self.state.active_slack_threads[user_id].get(channel_id)
         if channel_map is None:
             channel_map = {}
             self.state.active_slack_threads[user_id][channel_id] = channel_map
         return channel_map
+
+    def mark_thread_active(self, user_id: str, channel_id: str, thread_ts: str, last_active_at: float) -> None:
+        self._ensure_service()
+        self._service.mark_thread_active(user_id, channel_id, thread_ts, last_active_at)
+        self._ensure_user_namespace(user_id)
+        self.state.active_slack_threads[user_id].setdefault(channel_id, {})[thread_ts] = last_active_at
+
+    def remove_active_thread(self, user_id: str, channel_id: str, thread_ts: str) -> bool:
+        self._ensure_service()
+        removed = self._service.delete_active_thread(user_id, channel_id, thread_ts)
+        channel_map = self.get_thread_map(user_id, channel_id)
+        if thread_ts in channel_map:
+            del channel_map[thread_ts]
+            removed = True
+        if not channel_map:
+            self.state.active_slack_threads[user_id].pop(channel_id, None)
+        if not self.state.active_slack_threads[user_id]:
+            self.state.active_slack_threads.pop(user_id, None)
+        return removed
 
     # Max number of message IDs to keep per thread for dedup
     _DEDUP_SET_MAX = 200
@@ -415,22 +491,28 @@ class SessionsStore:
 
     def add_to_processed_set(self, channel_id: str, thread_ts: str, message_ts: str) -> None:
         """Add a message ID to the processed set (bounded)."""
+        self._ensure_service()
+        self._service.upsert_processed_message(channel_id, thread_ts, message_ts)
         self._remember_processed_message(channel_id, thread_ts, message_ts)
-        self.save()
 
     def add_active_poll(self, poll_info: ActivePollInfo) -> None:
         """Add an active poll to track."""
+        self._ensure_service()
+        self._service.upsert_active_poll(poll_info)
         self.state.active_polls[poll_info.opencode_session_id] = poll_info.to_dict()
-        self.save()
 
-    def remove_active_poll(self, opencode_session_id: str) -> None:
+    def remove_active_poll(self, opencode_session_id: str) -> bool:
         """Remove an active poll."""
+        self._ensure_service()
+        removed = self._service.delete_active_poll(opencode_session_id)
         if opencode_session_id in self.state.active_polls:
             del self.state.active_polls[opencode_session_id]
-            self.save()
+            removed = True
+        return removed
 
     def get_active_poll(self, opencode_session_id: str) -> Optional[ActivePollInfo]:
         """Get active poll info by session ID."""
+        self.maybe_reload()
         data = self.state.active_polls.get(opencode_session_id)
         if data:
             return ActivePollInfo.from_dict(data)
@@ -438,13 +520,14 @@ class SessionsStore:
 
     def get_all_active_polls(self) -> Dict[str, ActivePollInfo]:
         """Get all active polls."""
+        self.maybe_reload()
         return {sid: ActivePollInfo.from_dict(data) for sid, data in self.state.active_polls.items()}
 
     def update_active_poll(self, poll_info: ActivePollInfo) -> None:
         """Update an existing active poll."""
-        if poll_info.opencode_session_id in self.state.active_polls:
-            self.state.active_polls[poll_info.opencode_session_id] = poll_info.to_dict()
-            self.save()
+        self._ensure_service()
+        self._service.upsert_active_poll(poll_info)
+        self.state.active_polls[poll_info.opencode_session_id] = poll_info.to_dict()
 
     def save(self) -> None:
         self._ensure_service()

--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -489,6 +489,23 @@ class SessionsStore:
         self._remember_processed_message(channel_id, thread_ts, message_ts)
         return True
 
+    def try_record_runtime_event(
+        self,
+        record_type: str,
+        record_key: str,
+        payload: Dict[str, Any] | None = None,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> bool:
+        """Atomically claim a short-lived runtime event."""
+        self._ensure_service()
+        return self._service.try_record_runtime_event(
+            record_type,
+            record_key,
+            payload,
+            ttl_seconds=ttl_seconds,
+        )
+
     def add_to_processed_set(self, channel_id: str, thread_ts: str, message_ts: str) -> None:
         """Add a message ID to the processed set (bounded)."""
         self._ensure_service()

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -79,21 +79,28 @@ class MessageHandler(BaseHandler):
                 return None
 
             if is_human:
-                # Deduplication: check if this message has already been processed
-                # This prevents duplicate processing when vibe-remote restarts and
-                # Slack resends events
+                # Claim the message before processing so duplicate IM deliveries or
+                # parallel runtime instances cannot start separate agent turns.
                 message_ts = context.message_id
                 thread_ts = context.thread_id or context.message_id
                 if message_ts and thread_ts:
-                    if self.sessions.is_message_already_processed(context.channel_id, thread_ts, message_ts):
+                    try_record = getattr(self.sessions, "try_record_processed_message", None)
+                    if callable(try_record):
+                        recorded = try_record(context.channel_id, thread_ts, message_ts)
+                    else:
+                        recorded = not self.sessions.is_message_already_processed(
+                            context.channel_id,
+                            thread_ts,
+                            message_ts,
+                        )
+                        if recorded:
+                            self.sessions.record_processed_message(context.channel_id, thread_ts, message_ts)
+                    if not recorded:
                         logger.info(
                             f"Skipping already processed message: channel={context.channel_id}, "
                             f"thread={thread_ts}, message={message_ts}"
                         )
                         return None
-                    # Record this message as processed immediately to prevent duplicates
-                    # even if processing fails (we don't want to retry failed messages forever)
-                    self.sessions.record_processed_message(context.channel_id, thread_ts, message_ts)
 
             if is_human and not has_files:
                 maybe_consume_setup_reply = getattr(self.controller.agent_auth_service, "maybe_consume_setup_reply", None)

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -78,6 +78,7 @@ class SlackBot(BaseIMClient):
         self._controller = None
         self._recent_event_ids: Dict[str, float] = {}
         self._processed_mention_event_keys: Dict[str, float] = {}
+        self._event_tasks: set[asyncio.Task] = set()
         self._user_info_cache: Dict[str, Dict[str, Any]] = {}
         self._channel_info_cache: Dict[str, Dict[str, Any]] = {}
         self._bot_user_id: Optional[str] = None
@@ -199,19 +200,34 @@ class SlackBot(BaseIMClient):
         self._persist_bound_dm_channel(user_id, record, canonical_dm_channel)
         return canonical_dm_channel == channel_id
 
-    def _is_duplicate_event(self, event_id: Optional[str]) -> bool:
-        """Deduplicate Slack events using event_id with a short TTL."""
+    def _is_duplicate_event(self, event_id: Optional[str], team_id: Optional[str] = None) -> bool:
+        """Deduplicate Slack events using a persistent short-lived event claim."""
         if not event_id:
             return False
+        record_key = f"{team_id}:{event_id}" if team_id else event_id
+        recorder = getattr(self.sessions, "try_record_runtime_event", None)
+        if callable(recorder):
+            try:
+                if not recorder(
+                    "slack_event",
+                    record_key,
+                    {"event_id": event_id, "team_id": team_id or ""},
+                    ttl_seconds=300,
+                ):
+                    logger.debug("Ignoring duplicate Slack event_id %s", event_id)
+                    return True
+                return False
+            except Exception:
+                logger.debug("Failed to persist Slack event dedup claim for %s", event_id, exc_info=True)
         now = time.time()
         expiry = now - 30  # retain for 30s
         for key in list(self._recent_event_ids.keys()):
             if self._recent_event_ids[key] < expiry:
                 del self._recent_event_ids[key]
-        if event_id in self._recent_event_ids:
+        if record_key in self._recent_event_ids:
             logger.debug(f"Ignoring duplicate Slack event_id {event_id}")
             return True
-        self._recent_event_ids[event_id] = now
+        self._recent_event_ids[record_key] = now
         return False
 
     def _mark_mention_event_processed(self, channel_id: Optional[str], message_id: Optional[str]) -> bool:
@@ -1544,11 +1560,11 @@ class SlackBot(BaseIMClient):
         """Handle incoming Socket Mode requests"""
         try:
             if req.type == "events_api":
-                # Handle Events API events
-                await self._handle_event(req.payload)
-                # Acknowledge after handling events
+                # Acknowledge Events API immediately; file downloads, ASR, and
+                # agent turns can exceed Slack's Socket Mode ack deadline.
                 response = SocketModeResponse(envelope_id=req.envelope_id)
                 await client.send_socket_mode_response(response)
+                self._create_event_task(req.payload)
             elif req.type == "slash_commands":
                 # Handle slash commands
                 await self._handle_slash_command(req.payload)
@@ -1576,12 +1592,26 @@ class SlackBot(BaseIMClient):
             except Exception:
                 pass  # Already acknowledged or connection issue
 
+    def _create_event_task(self, payload: Dict[str, Any]) -> None:
+        task = asyncio.create_task(self._handle_event(payload))
+        self._event_tasks.add(task)
+        task.add_done_callback(self._handle_event_task_done)
+
+    def _handle_event_task_done(self, task: asyncio.Task) -> None:
+        self._event_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.error("Error handling Slack event asynchronously", exc_info=True)
+
     async def _handle_event(self, payload: Dict[str, Any]):
         """Handle Events API events"""
         event = payload.get("event", {})
         event_type = event.get("type")
         event_id = payload.get("event_id")
-        if self._is_duplicate_event(event_id):
+        if self._is_duplicate_event(event_id, payload.get("team_id")):
             return
 
         if event_type == "message":
@@ -2436,6 +2466,13 @@ class SlackBot(BaseIMClient):
         await self._async_close()
 
     async def _async_close(self) -> None:
+        if self._event_tasks:
+            tasks = list(self._event_tasks)
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._event_tasks.clear()
+
         await self._close_rtm()
 
         if self.socket_client is not None:

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -45,6 +45,7 @@ _SLACK_SECTION_TEXT_LIMIT = 3000
 _SLACK_MARKDOWN_TEXT_LIMIT = 12000
 _BARE_HTTP_URL_RE = re.compile(r"https?://[^\s<>\|]+")
 _TRAILING_URL_PUNCTUATION = ".,!?;:"
+_EVENT_TASK_SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 70.0
 
 
 class SlackBot(BaseIMClient):
@@ -79,6 +80,7 @@ class SlackBot(BaseIMClient):
         self._recent_event_ids: Dict[str, float] = {}
         self._processed_mention_event_keys: Dict[str, float] = {}
         self._event_tasks: set[asyncio.Task] = set()
+        self._event_task_shutdown_drain_timeout = _EVENT_TASK_SHUTDOWN_DRAIN_TIMEOUT_SECONDS
         self._user_info_cache: Dict[str, Dict[str, Any]] = {}
         self._channel_info_cache: Dict[str, Dict[str, Any]] = {}
         self._bot_user_id: Optional[str] = None
@@ -1606,6 +1608,32 @@ class SlackBot(BaseIMClient):
         except Exception:
             logger.error("Error handling Slack event asynchronously", exc_info=True)
 
+    async def _drain_event_tasks(self) -> None:
+        if not self._event_tasks:
+            return
+        tasks = list(self._event_tasks)
+        timeout = max(0.0, float(self._event_task_shutdown_drain_timeout))
+        logger.info("Waiting for %s in-flight Slack event task(s) before shutdown", len(tasks))
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        for task in done:
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.error("Error handling Slack event during shutdown drain", exc_info=True)
+        if not pending:
+            return
+        logger.warning(
+            "Canceling %s Slack event task(s) that did not finish within %.1fs shutdown drain",
+            len(pending),
+            timeout,
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        self._event_tasks.difference_update(pending)
+
     async def _handle_event(self, payload: Dict[str, Any]):
         """Handle Events API events"""
         event = payload.get("event", {})
@@ -2466,15 +2494,6 @@ class SlackBot(BaseIMClient):
         await self._async_close()
 
     async def _async_close(self) -> None:
-        if self._event_tasks:
-            tasks = list(self._event_tasks)
-            for task in tasks:
-                task.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
-            self._event_tasks.clear()
-
-        await self._close_rtm()
-
         if self.socket_client is not None:
             try:
                 disconnect = getattr(self.socket_client, "disconnect", None)
@@ -2492,6 +2511,9 @@ class SlackBot(BaseIMClient):
                         await result
             except Exception as exc:
                 logger.debug(f"Socket mode close failed: {exc}")
+
+        await self._drain_event_tasks()
+        await self._close_rtm()
 
         if self.web_client is not None:
             try:

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -35,14 +35,7 @@ class SessionsFacade:
         thread_id: str,
         session_id: str,
     ) -> None:
-        binder = getattr(self.sessions_store, "bind_agent_session", None)
-        if callable(binder):
-            binder(self._normalize_user_id(user_id), agent_name, thread_id, session_id)
-            logger.info("Stored %s session mapping for %s: %s -> %s", agent_name, user_id, thread_id, session_id)
-            return
-        agent_map = self._ensure_agent_namespace(user_id, agent_name)
-        agent_map[thread_id] = session_id
-        self.sessions_store.save()
+        self.sessions_store.bind_agent_session(self._normalize_user_id(user_id), agent_name, thread_id, session_id)
         logger.info("Stored %s session mapping for %s: %s -> %s", agent_name, user_id, thread_id, session_id)
 
     def get_agent_session_id(
@@ -62,10 +55,7 @@ class SessionsFacade:
         agent_name: str,
     ) -> Optional[str]:
         user_key = self._normalize_user_id(user_id)
-        getter = getattr(self.sessions_store, "get_agent_session_row_id", None)
-        if not callable(getter):
-            return None
-        return getter(user_key, agent_name, thread_id)
+        return self.sessions_store.get_agent_session_row_id(user_key, agent_name, thread_id)
 
     def ensure_agent_session_id(
         self,
@@ -74,10 +64,7 @@ class SessionsFacade:
         thread_id: str,
     ) -> Optional[str]:
         user_key = self._normalize_user_id(user_id)
-        ensure = getattr(self.sessions_store, "ensure_agent_session_id", None)
-        if callable(ensure):
-            return ensure(user_key, agent_name, thread_id)
-        return self.get_agent_session_row_id(user_key, thread_id, agent_name)
+        return self.sessions_store.ensure_agent_session_id(user_key, agent_name, thread_id)
 
     def bind_agent_session(
         self,
@@ -87,11 +74,7 @@ class SessionsFacade:
         session_id: Any,
     ) -> Optional[str]:
         user_key = self._normalize_user_id(user_id)
-        binder = getattr(self.sessions_store, "bind_agent_session", None)
-        if callable(binder):
-            return binder(user_key, agent_name, thread_id, session_id)
-        self.set_agent_session_mapping(user_key, agent_name, thread_id, session_id)
-        return self.get_agent_session_row_id(user_key, thread_id, agent_name)
+        return self.sessions_store.bind_agent_session(user_key, agent_name, thread_id, session_id)
 
     def clear_agent_session_mapping(
         self,
@@ -100,27 +83,20 @@ class SessionsFacade:
         thread_id: str,
     ) -> None:
         user_key = self._normalize_user_id(user_id)
-        agent_map = self.sessions_store.get_agent_map(user_key, agent_name)
-        if thread_id in agent_map:
-            del agent_map[thread_id]
-            self.sessions_store.save()
+        removed = self.sessions_store.remove_agent_session(user_key, agent_name, thread_id)
+        if removed:
             logger.info("Cleared %s session mapping for user %s: %s", agent_name, user_id, thread_id)
 
     def clear_agent_sessions(self, user_id: Union[int, str], agent_name: str) -> None:
         user_key = self._normalize_user_id(user_id)
-        agent_map = self.sessions_store.get_agent_map(user_key, agent_name)
-        if agent_map:
-            self.sessions_store.state.session_mappings[user_key][agent_name] = {}
-            self.sessions_store.save()
+        cleared = self.sessions_store.clear_agent_sessions(user_key, agent_name)
+        if cleared:
             logger.info("Cleared all %s session namespaces for user %s", agent_name, user_id)
 
     def clear_all_session_mappings(self, user_id: Union[int, str]) -> None:
         user_key = self._normalize_user_id(user_id)
-        agent_maps = self.sessions_store.state.session_mappings.get(user_key, {})
-        if agent_maps:
-            count = sum(len(agent_map) for agent_map in agent_maps.values())
-            self.sessions_store.state.session_mappings[user_key] = {}
-            self.sessions_store.save()
+        count = self.sessions_store.clear_agent_sessions(user_key)
+        if count:
             logger.info("Cleared all session mappings (%s bases) for user %s", count, user_id)
 
     def list_agent_sessions(self, user_id: Union[int, str], agent_name: str) -> Dict[str, str]:
@@ -182,7 +158,10 @@ class SessionsFacade:
                 )
 
         if changed:
-            self.sessions_store.save()
+            for agent_name, agent_map in agent_maps.items():
+                for mapping_key, native_session_id in agent_map.items():
+                    if self._matches_base_prefix(mapping_key, alias_base_session_id):
+                        self.sessions_store.bind_agent_session(user_key, agent_name, mapping_key, native_session_id)
         return changed
 
     def alias_session_base_across_scopes(
@@ -226,34 +205,17 @@ class SessionsFacade:
                 )
 
         if changed:
-            self.sessions_store.save()
+            for agent_name, target_agent_map in target_agent_maps.items():
+                for mapping_key, native_session_id in target_agent_map.items():
+                    if self._matches_base_prefix(mapping_key, alias_base_session_id):
+                        self.sessions_store.bind_agent_session(target_key, agent_name, mapping_key, native_session_id)
         return changed
 
     def clear_session_base(self, user_id: Union[int, str], base_session_id: str) -> int:
         user_key = self._normalize_user_id(user_id)
-        self.sessions_store._ensure_user_namespace(user_key)
-        agent_maps = self.sessions_store.state.session_mappings.get(user_key, {})
-        cleared = 0
-
-        for agent_name, agent_map in agent_maps.items():
-            keys_to_remove = [
-                mapping_key for mapping_key in list(agent_map.keys()) if self._matches_base_prefix(mapping_key, base_session_id)
-            ]
-            if not keys_to_remove:
-                continue
-            for mapping_key in keys_to_remove:
-                del agent_map[mapping_key]
-                cleared += 1
-            logger.info(
-                "Cleared %s session base for %s: %s (%s keys)",
-                agent_name,
-                user_key,
-                base_session_id,
-                len(keys_to_remove),
-            )
-
+        cleared = self.sessions_store.clear_session_base(user_key, base_session_id)
         if cleared:
-            self.sessions_store.save()
+            logger.info("Cleared session base for %s: %s (%s keys)", user_key, base_session_id, cleared)
         return cleared
 
     def get_all_session_mappings(self) -> Dict[str, Dict[str, Dict[str, str]]]:
@@ -275,9 +237,7 @@ class SessionsFacade:
 
     def mark_thread_active(self, user_id: Union[int, str], channel_id: str, thread_ts: str) -> None:
         user_key = self._normalize_user_id(user_id)
-        channel_map = self.sessions_store.get_thread_map(user_key, channel_id)
-        channel_map[thread_ts] = time.time()
-        self.sessions_store.save()
+        self.sessions_store.mark_thread_active(user_key, channel_id, thread_ts, time.time())
         logger.info("Marked thread active for user %s: channel=%s, thread=%s", user_id, channel_id, thread_ts)
 
     def is_thread_active(self, user_id: Union[int, str], channel_id: str, thread_ts: str) -> bool:
@@ -309,20 +269,12 @@ class SessionsFacade:
             if last_active is None:
                 continue
             if last_active < cutoff:
-                del channel_map[thread_ts]
-                if not channel_map:
-                    channels.pop(channel_id, None)
-                if not channels:
-                    self.sessions_store.state.active_slack_threads.pop(user_key, None)
+                self.sessions_store.remove_active_thread(user_key, channel_id, thread_ts)
                 changed = True
                 continue
 
-            if changed:
-                self.sessions_store.save()
             return True
 
-        if changed:
-            self.sessions_store.save()
         return False
 
     def _cleanup_expired_threads_for_channel(self, user_id: Union[int, str], channel_id: str) -> None:
@@ -341,12 +293,7 @@ class SessionsFacade:
             return
 
         for thread_ts in expired_threads:
-            del channel_map[thread_ts]
-
-        if not channel_map:
-            self.sessions_store.state.active_slack_threads[user_key].pop(channel_id, None)
-
-        self.sessions_store.save()
+            self.sessions_store.remove_active_thread(user_key, channel_id, thread_ts)
         logger.info("Cleaned up %s expired threads for channel %s", len(expired_threads), channel_id)
 
     def cleanup_all_expired_threads(self, user_id: Union[int, str]) -> None:

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -364,6 +364,17 @@ class SessionsFacade:
         self.sessions_store.add_to_processed_set(channel_id, thread_ts, message_ts)
         logger.debug("Recorded processed message: channel=%s, thread=%s, message=%s", channel_id, thread_ts, message_ts)
 
+    def try_record_processed_message(self, channel_id: str, thread_ts: str, message_ts: str) -> bool:
+        recorded = self.sessions_store.try_add_to_processed_set(channel_id, thread_ts, message_ts)
+        if recorded:
+            logger.debug(
+                "Recorded processed message: channel=%s, thread=%s, message=%s",
+                channel_id,
+                thread_ts,
+                message_ts,
+            )
+        return recorded
+
     def add_active_poll(
         self,
         opencode_session_id: str,

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -328,6 +328,26 @@ class SessionsFacade:
             )
         return recorded
 
+    def try_record_runtime_event(
+        self,
+        record_type: str,
+        record_key: str,
+        payload: Optional[Dict[str, Any]] = None,
+        *,
+        ttl_seconds: Optional[int] = None,
+    ) -> bool:
+        recorder = getattr(self.sessions_store, "try_record_runtime_event", None)
+        if not callable(recorder):
+            return True
+        return bool(
+            recorder(
+                record_type,
+                record_key,
+                payload,
+                ttl_seconds=ttl_seconds,
+            )
+        )
+
     def add_active_poll(
         self,
         opencode_session_id: str,

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -55,7 +55,10 @@ class SessionsFacade:
         agent_name: str,
     ) -> Optional[str]:
         user_key = self._normalize_user_id(user_id)
-        return self.sessions_store.get_agent_session_row_id(user_key, agent_name, thread_id)
+        getter = getattr(self.sessions_store, "get_agent_session_row_id", None)
+        if not callable(getter):
+            return None
+        return getter(user_key, agent_name, thread_id)
 
     def ensure_agent_session_id(
         self,
@@ -64,7 +67,10 @@ class SessionsFacade:
         thread_id: str,
     ) -> Optional[str]:
         user_key = self._normalize_user_id(user_id)
-        return self.sessions_store.ensure_agent_session_id(user_key, agent_name, thread_id)
+        ensure = getattr(self.sessions_store, "ensure_agent_session_id", None)
+        if callable(ensure):
+            return ensure(user_key, agent_name, thread_id)
+        return self.get_agent_session_row_id(user_key, thread_id, agent_name)
 
     def bind_agent_session(
         self,

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -183,7 +183,7 @@ class SessionsFacade:
         self.sessions_store._ensure_user_namespace(target_key)
 
         source_agent_maps = self.sessions_store.state.session_mappings.get(source_key, {})
-        target_agent_maps = self.sessions_store.state.session_mappings.get(target_key, {})
+        aliases_to_bind: List[tuple[str, str, Any]] = []
         changed = False
 
         for agent_name, source_agent_map in source_agent_maps.items():
@@ -199,6 +199,10 @@ class SessionsFacade:
                 additions[alias_key] = native_session_id
             if additions:
                 target_agent_map.update(additions)
+                aliases_to_bind.extend(
+                    (agent_name, alias_key, native_session_id)
+                    for alias_key, native_session_id in additions.items()
+                )
                 changed = True
                 logger.info(
                     "Aliased %s session base across scopes: %s/%s -> %s/%s (%s keys)",
@@ -211,10 +215,8 @@ class SessionsFacade:
                 )
 
         if changed:
-            for agent_name, target_agent_map in target_agent_maps.items():
-                for mapping_key, native_session_id in target_agent_map.items():
-                    if self._matches_base_prefix(mapping_key, alias_base_session_id):
-                        self.sessions_store.bind_agent_session(target_key, agent_name, mapping_key, native_session_id)
+            for agent_name, mapping_key, native_session_id in aliases_to_bind:
+                self.sessions_store.bind_agent_session(target_key, agent_name, mapping_key, native_session_id)
         return changed
 
     def clear_session_base(self, user_id: Union[int, str], base_session_id: str) -> int:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -221,6 +221,45 @@ class SQLiteSessionsService:
             return False
         return True
 
+    def try_record_runtime_event(
+        self,
+        record_type: str,
+        record_key: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        ttl_seconds: int | None = None,
+    ) -> bool:
+        """Atomically claim a short-lived runtime event."""
+        now_dt = datetime.now(timezone.utc)
+        now = now_dt.isoformat()
+        event_type = str(record_type or "").strip()
+        event_key = str(record_key or "").strip()
+        if not event_type or not event_key:
+            return True
+        values = _runtime_record_values(
+            record_type=event_type,
+            record_key=event_key,
+            scope_id=None,
+            session_anchor=None,
+            workdir=None,
+            payload=dict(payload or {}),
+            now=now,
+        )
+        if ttl_seconds is not None and ttl_seconds > 0:
+            values["expires_at"] = (now_dt + timedelta(seconds=ttl_seconds)).isoformat()
+        try:
+            with self.engine.begin() as conn:
+                conn.execute(
+                    runtime_records.delete()
+                    .where(runtime_records.c.record_type == event_type)
+                    .where(runtime_records.c.expires_at.is_not(None))
+                    .where(runtime_records.c.expires_at < now)
+                )
+                conn.execute(runtime_records.insert().values(**values))
+        except IntegrityError:
+            return False
+        return True
+
     def upsert_processed_message(self, channel_id: str, thread_ts: str, message_ts: str) -> None:
         now = _utc_now_iso()
         channel_key = str(channel_id)

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -166,9 +166,10 @@ class SQLiteSessionsService:
                 stmt = stmt.where(agent_sessions.c.agent_variant == (str(agent_name) or "default"))
             if session_anchor_prefix is not None:
                 prefix = str(session_anchor_prefix)
+                prefix_pattern = f"{_escape_sql_like(prefix)}:%"
                 stmt = stmt.where(
                     (agent_sessions.c.session_anchor == prefix)
-                    | (agent_sessions.c.session_anchor.like(f"{prefix}:%"))
+                    | (agent_sessions.c.session_anchor.like(prefix_pattern, escape="\\"))
                 )
             result = conn.execute(stmt)
             return int(result.rowcount or 0)

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import Connection, select
+from sqlalchemy.exc import IntegrityError
 
 from config.v2_sessions import ActivePollInfo, SessionState
 from config.v2_settings import _split_scoped_key
@@ -137,9 +138,51 @@ class SQLiteSessionsService:
                 last_activity=self._load_last_activity(conn),
             )
 
+    def try_record_processed_message(self, channel_id: str, thread_ts: str, message_ts: str) -> bool:
+        """Atomically claim a message for processing.
+
+        Multiple Socket Mode clients or stale runtime instances can receive the same
+        IM event. The unique runtime record is the cross-process source of truth.
+        """
+        now = _utc_now_iso()
+        channel_key = str(channel_id)
+        thread_key = str(thread_ts)
+        message_key = str(message_ts)
+        record_key = "|".join((channel_key, thread_key, message_key))
+        try:
+            with self.engine.begin() as conn:
+                conn.execute(
+                    runtime_records.insert().values(
+                        id=f"runtime::processed_message::{record_key}",
+                        record_type="processed_message",
+                        record_key=record_key,
+                        scope_id=None,
+                        session_anchor=thread_key,
+                        workdir=None,
+                        payload_json=_json_dumps(
+                            {
+                                "channel_id": channel_key,
+                                "thread_id": thread_key,
+                                "message_id": message_key,
+                                "processed_at": now,
+                            }
+                        ),
+                        expires_at=None,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
+        except IntegrityError:
+            return False
+        return True
+
     def save_state(self, state: SessionState) -> None:
         with self.engine.begin() as conn:
             existing_session_ids = self._load_existing_session_ids(conn)
+            state.processed_message_ts = _merge_processed_message_maps(
+                state.processed_message_ts,
+                self._load_processed_messages(conn),
+            )
             self._clear(conn)
             now = _utc_now_iso()
             used_session_ids: set[str] = set(existing_session_ids.values())
@@ -414,6 +457,34 @@ def decode_session_value(value: Any) -> Any:
         return json.loads(value[len(JSON_VALUE_PREFIX) :])
     except (TypeError, ValueError):
         return value
+
+
+def _merge_processed_message_maps(
+    primary: dict[str, dict[str, Any]],
+    secondary: dict[str, dict[str, list[str]]],
+) -> dict[str, dict[str, list[str]]]:
+    result: dict[str, dict[str, list[str]]] = {}
+    seen: set[tuple[str, str, str]] = set()
+    for source in (secondary, primary):
+        if not isinstance(source, dict):
+            continue
+        for channel_id, thread_map in source.items():
+            if not isinstance(thread_map, dict):
+                continue
+            channel_key = str(channel_id)
+            for thread_id, value in thread_map.items():
+                thread_key = str(thread_id)
+                message_ids = [value] if isinstance(value, str) else list(value or [])
+                for message_id in message_ids[-200:]:
+                    key = (channel_key, thread_key, str(message_id))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    result.setdefault(channel_key, {}).setdefault(thread_key, []).append(str(message_id))
+    for thread_map in result.values():
+        for thread_id, message_ids in list(thread_map.items()):
+            thread_map[thread_id] = message_ids[-200:]
+    return result
 
 
 def _legacy_scope_key(row: dict[str, Any]) -> str:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -193,7 +193,7 @@ class SQLiteSessionsService:
         channel_key = str(channel_id)
         thread_key = str(thread_ts)
         message_key = str(message_ts)
-        record_key = "|".join((channel_key, thread_key, message_key))
+        record_key = _processed_message_record_key(channel_key, thread_key, message_key)
         try:
             with self.engine.begin() as conn:
                 conn.execute(
@@ -226,7 +226,7 @@ class SQLiteSessionsService:
         channel_key = str(channel_id)
         thread_key = str(thread_ts)
         message_key = str(message_ts)
-        record_key = "|".join((channel_key, thread_key, message_key))
+        record_key = _processed_message_record_key(channel_key, thread_key, message_key)
         values = _runtime_record_values(
             record_type="processed_message",
             record_key=record_key,
@@ -340,7 +340,16 @@ class SQLiteSessionsService:
                             session_anchor=thread_key,
                             native_session_id=encoded_session_id,
                         )
-                        row_id = existing_session_ids.get(row_key) or _new_session_id(used_session_ids)
+                        row_id = (
+                            _find_agent_session_row_id(
+                                conn,
+                                scope_id=scope_id,
+                                agent_name=str(agent_name),
+                                session_anchor=thread_key,
+                            )
+                            or existing_session_ids.get(row_key)
+                            or _new_session_id(used_session_ids)
+                        )
                         stmt = sqlite_insert(agent_sessions).values(
                             id=row_id,
                             scope_id=scope_id,
@@ -429,6 +438,7 @@ class SQLiteSessionsService:
                 )
 
             seen_messages: set[tuple[str, str, str]] = set()
+            retained_processed_records: dict[tuple[str, str], set[str]] = {}
             message_order = 0
             for channel_id, thread_map in state.processed_message_ts.items():
                 if not isinstance(thread_map, dict):
@@ -440,7 +450,8 @@ class SQLiteSessionsService:
                         if key in seen_messages:
                             continue
                         seen_messages.add(key)
-                        record_key = "|".join(key)
+                        record_key = _processed_message_record_key(*key)
+                        retained_processed_records.setdefault((key[0], key[1]), set()).add(record_key)
                         ordered_at = (now_dt + timedelta(microseconds=message_order)).isoformat()
                         message_order += 1
                         _upsert_runtime_record(
@@ -461,6 +472,14 @@ class SQLiteSessionsService:
                             ),
                             update_created_at=True,
                         )
+
+            for (channel_id, thread_id), record_keys in retained_processed_records.items():
+                conn.execute(
+                    runtime_records.delete()
+                    .where(runtime_records.c.record_type == "processed_message")
+                    .where(runtime_records.c.record_key.like(f"{channel_id}|{thread_id}|%"))
+                    .where(runtime_records.c.record_key.not_in(record_keys))
+                )
 
             if state.last_activity is not None:
                 stmt = sqlite_insert(state_meta).values(
@@ -750,6 +769,10 @@ def _runtime_record_values(
         "created_at": now,
         "updated_at": now,
     }
+
+
+def _processed_message_record_key(channel_id: str, thread_id: str, message_id: str) -> str:
+    return "|".join((str(channel_id), str(thread_id), str(message_id)))
 
 
 def _upsert_runtime_record(conn: Connection, values: dict[str, Any], *, update_created_at: bool = False) -> None:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -217,6 +217,7 @@ class SQLiteSessionsService:
                         updated_at=now,
                     )
                 )
+                _prune_processed_message_records(conn, channel_id=channel_key, thread_id=thread_key)
         except IntegrityError:
             return False
         return True
@@ -282,6 +283,7 @@ class SQLiteSessionsService:
         )
         with self.engine.begin() as conn:
             _upsert_runtime_record(conn, values)
+            _prune_processed_message_records(conn, channel_id=channel_key, thread_id=thread_key)
 
     def mark_thread_active(self, scope_key: str, channel_id: str, thread_ts: str, last_active_at: float) -> None:
         now = _utc_now_iso()
@@ -513,11 +515,11 @@ class SQLiteSessionsService:
                         )
 
             for (channel_id, thread_id), record_keys in retained_processed_records.items():
-                conn.execute(
-                    runtime_records.delete()
-                    .where(runtime_records.c.record_type == "processed_message")
-                    .where(runtime_records.c.record_key.like(f"{channel_id}|{thread_id}|%"))
-                    .where(runtime_records.c.record_key.not_in(record_keys))
+                _prune_processed_message_records(
+                    conn,
+                    channel_id=channel_id,
+                    thread_id=thread_id,
+                    retained_record_keys=record_keys,
                 )
 
             if state.last_activity is not None:
@@ -812,6 +814,55 @@ def _runtime_record_values(
 
 def _processed_message_record_key(channel_id: str, thread_id: str, message_id: str) -> str:
     return "|".join((str(channel_id), str(thread_id), str(message_id)))
+
+
+def _processed_message_like_prefix(channel_id: str, thread_id: str) -> str:
+    prefix = _processed_message_record_key(channel_id, thread_id, "")
+    return f"{_escape_sql_like(prefix)}%"
+
+
+def _escape_sql_like(value: str) -> str:
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+
+
+def _prune_processed_message_records(
+    conn: Connection,
+    *,
+    channel_id: str,
+    thread_id: str,
+    retained_record_keys: set[str] | None = None,
+) -> None:
+    retained = set(retained_record_keys or [])
+    prefix_pattern = _processed_message_like_prefix(channel_id, thread_id)
+    if retained:
+        conn.execute(
+            runtime_records.delete()
+            .where(runtime_records.c.record_type == "processed_message")
+            .where(runtime_records.c.record_key.like(prefix_pattern, escape="\\"))
+            .where(runtime_records.c.record_key.not_in(retained))
+        )
+        return
+
+    rows = conn.execute(
+        select(runtime_records.c.record_key)
+        .where(runtime_records.c.record_type == "processed_message")
+        .where(runtime_records.c.record_key.like(prefix_pattern, escape="\\"))
+        .order_by(runtime_records.c.created_at.desc())
+        .offset(200)
+    ).all()
+    old_record_keys = [row[0] for row in rows]
+    if not old_record_keys:
+        return
+    conn.execute(
+        runtime_records.delete()
+        .where(runtime_records.c.record_type == "processed_message")
+        .where(runtime_records.c.record_key.in_(old_record_keys))
+    )
 
 
 def _upsert_runtime_record(conn: Connection, values: dict[str, Any], *, update_created_at: bool = False) -> None:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -465,7 +465,7 @@ def _merge_processed_message_maps(
 ) -> dict[str, dict[str, list[str]]]:
     result: dict[str, dict[str, list[str]]] = {}
     seen: set[tuple[str, str, str]] = set()
-    for source in (secondary, primary):
+    for source in (primary, secondary):
         if not isinstance(source, dict):
             continue
         for channel_id, thread_map in source.items():

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 import secrets
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any
 
 from sqlalchemy import Connection, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 
 from config.v2_sessions import ActivePollInfo, SessionState
@@ -128,6 +129,50 @@ class SQLiteSessionsService:
             )
             return row_id
 
+    def delete_agent_session(
+        self,
+        *,
+        scope_key: str,
+        agent_name: str,
+        session_anchor: str,
+    ) -> bool:
+        now = _utc_now_iso()
+        with self.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
+            if scope_id is None:
+                return False
+            result = conn.execute(
+                agent_sessions.delete()
+                .where(agent_sessions.c.scope_id == scope_id)
+                .where(agent_sessions.c.agent_variant == (str(agent_name) or "default"))
+                .where(agent_sessions.c.session_anchor == str(session_anchor))
+            )
+            return bool(result.rowcount)
+
+    def delete_agent_sessions(
+        self,
+        *,
+        scope_key: str,
+        agent_name: str | None = None,
+        session_anchor_prefix: str | None = None,
+    ) -> int:
+        now = _utc_now_iso()
+        with self.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
+            if scope_id is None:
+                return 0
+            stmt = agent_sessions.delete().where(agent_sessions.c.scope_id == scope_id)
+            if agent_name is not None:
+                stmt = stmt.where(agent_sessions.c.agent_variant == (str(agent_name) or "default"))
+            if session_anchor_prefix is not None:
+                prefix = str(session_anchor_prefix)
+                stmt = stmt.where(
+                    (agent_sessions.c.session_anchor == prefix)
+                    | (agent_sessions.c.session_anchor.like(f"{prefix}:%"))
+                )
+            result = conn.execute(stmt)
+            return int(result.rowcount or 0)
+
     def load_state(self) -> SessionState:
         with self.engine.connect() as conn:
             return SessionState(
@@ -176,15 +221,107 @@ class SQLiteSessionsService:
             return False
         return True
 
+    def upsert_processed_message(self, channel_id: str, thread_ts: str, message_ts: str) -> None:
+        now = _utc_now_iso()
+        channel_key = str(channel_id)
+        thread_key = str(thread_ts)
+        message_key = str(message_ts)
+        record_key = "|".join((channel_key, thread_key, message_key))
+        values = _runtime_record_values(
+            record_type="processed_message",
+            record_key=record_key,
+            scope_id=None,
+            session_anchor=thread_key,
+            workdir=None,
+            payload={
+                "channel_id": channel_key,
+                "thread_id": thread_key,
+                "message_id": message_key,
+                "processed_at": now,
+            },
+            now=now,
+        )
+        with self.engine.begin() as conn:
+            _upsert_runtime_record(conn, values)
+
+    def mark_thread_active(self, scope_key: str, channel_id: str, thread_ts: str, last_active_at: float) -> None:
+        now = _utc_now_iso()
+        with self.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
+            record_key = f"{scope_key}|{channel_id}|{thread_ts}"
+            _upsert_runtime_record(
+                conn,
+                _runtime_record_values(
+                    record_type="active_thread",
+                    record_key=record_key,
+                    scope_id=scope_id,
+                    session_anchor=str(thread_ts),
+                    workdir=None,
+                    payload={
+                        "scope_key": str(scope_key),
+                        "channel_id": str(channel_id),
+                        "thread_id": str(thread_ts),
+                        "last_active_at": _float(last_active_at),
+                    },
+                    now=now,
+                ),
+            )
+
+    def delete_active_thread(self, scope_key: str, channel_id: str, thread_ts: str) -> bool:
+        record_key = f"{scope_key}|{channel_id}|{thread_ts}"
+        with self.engine.begin() as conn:
+            result = conn.execute(
+                runtime_records.delete()
+                .where(runtime_records.c.record_type == "active_thread")
+                .where(runtime_records.c.record_key == record_key)
+            )
+            return bool(result.rowcount)
+
+    def upsert_active_poll(self, poll_info: ActivePollInfo | dict[str, Any]) -> None:
+        now = _utc_now_iso()
+        data = poll_info.to_dict() if isinstance(poll_info, ActivePollInfo) else dict(poll_info)
+        record_key = str(data.get("opencode_session_id") or "")
+        if not record_key:
+            return
+        settings_key = str(data.get("settings_key") or "")
+        platform = str(data.get("platform") or "")
+        with self.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(
+                conn,
+                f"{platform}::{settings_key}" if platform and "::" not in settings_key else settings_key,
+                now=now,
+            )
+            _upsert_runtime_record(
+                conn,
+                _runtime_record_values(
+                    record_type="active_poll",
+                    record_key=record_key,
+                    scope_id=scope_id,
+                    session_anchor=str(data.get("base_session_id") or data.get("thread_id") or ""),
+                    workdir=str(data.get("working_path") or "") or None,
+                    payload=data,
+                    now=now,
+                ),
+            )
+
+    def delete_active_poll(self, opencode_session_id: str) -> bool:
+        with self.engine.begin() as conn:
+            result = conn.execute(
+                runtime_records.delete()
+                .where(runtime_records.c.record_type == "active_poll")
+                .where(runtime_records.c.record_key == str(opencode_session_id))
+            )
+            return bool(result.rowcount)
+
     def save_state(self, state: SessionState) -> None:
         with self.engine.begin() as conn:
-            existing_session_ids = self._load_existing_session_ids(conn)
             state.processed_message_ts = _merge_processed_message_maps(
                 state.processed_message_ts,
                 self._load_processed_messages(conn),
             )
-            self._clear(conn)
-            now = _utc_now_iso()
+            now_dt = datetime.now(timezone.utc)
+            now = now_dt.isoformat()
+            existing_session_ids = self._load_existing_session_ids(conn)
             used_session_ids: set[str] = set(existing_session_ids.values())
 
             for scope_key, agent_maps in state.session_mappings.items():
@@ -203,23 +340,39 @@ class SQLiteSessionsService:
                             session_anchor=thread_key,
                             native_session_id=encoded_session_id,
                         )
+                        row_id = existing_session_ids.get(row_key) or _new_session_id(used_session_ids)
+                        stmt = sqlite_insert(agent_sessions).values(
+                            id=row_id,
+                            scope_id=scope_id,
+                            agent_backend=_agent_backend(str(agent_name)),
+                            agent_variant=str(agent_name) or "default",
+                            model=None,
+                            reasoning_effort=None,
+                            session_anchor=thread_key,
+                            workdir=_workdir_from_anchor(thread_key),
+                            native_session_id=encoded_session_id,
+                            title=None,
+                            status="active",
+                            metadata_json=_json_dumps({"legacy_scope_key": str(scope_key)}),
+                            created_at=now,
+                            updated_at=now,
+                            last_active_at=now,
+                        )
                         conn.execute(
-                            agent_sessions.insert().values(
-                                id=existing_session_ids.get(row_key) or _new_session_id(used_session_ids),
-                                scope_id=scope_id,
-                                agent_backend=_agent_backend(str(agent_name)),
-                                agent_variant=str(agent_name) or "default",
-                                model=None,
-                                reasoning_effort=None,
-                                session_anchor=thread_key,
-                                workdir=_workdir_from_anchor(thread_key),
-                                native_session_id=encoded_session_id,
-                                title=None,
-                                status="active",
-                                metadata_json=_json_dumps({"legacy_scope_key": str(scope_key)}),
-                                created_at=now,
-                                updated_at=now,
-                                last_active_at=now,
+                            stmt.on_conflict_do_update(
+                                index_elements=[agent_sessions.c.id],
+                                set_={
+                                    "scope_id": stmt.excluded.scope_id,
+                                    "agent_backend": stmt.excluded.agent_backend,
+                                    "agent_variant": stmt.excluded.agent_variant,
+                                    "session_anchor": stmt.excluded.session_anchor,
+                                    "workdir": stmt.excluded.workdir,
+                                    "native_session_id": stmt.excluded.native_session_id,
+                                    "status": stmt.excluded.status,
+                                    "metadata_json": stmt.excluded.metadata_json,
+                                    "updated_at": stmt.excluded.updated_at,
+                                    "last_active_at": stmt.excluded.last_active_at,
+                                },
                             )
                         )
 
@@ -232,26 +385,22 @@ class SQLiteSessionsService:
                         continue
                     for thread_id, last_active_at in thread_map.items():
                         record_key = f"{scope_key}|{channel_id}|{thread_id}"
-                        conn.execute(
-                            runtime_records.insert().values(
-                                id=f"runtime::active_thread::{record_key}",
+                        _upsert_runtime_record(
+                            conn,
+                            _runtime_record_values(
                                 record_type="active_thread",
                                 record_key=record_key,
                                 scope_id=scope_id,
                                 session_anchor=str(thread_id),
                                 workdir=None,
-                                payload_json=_json_dumps(
-                                    {
-                                        "scope_key": str(scope_key),
-                                        "channel_id": str(channel_id),
-                                        "thread_id": str(thread_id),
-                                        "last_active_at": _float(last_active_at),
-                                    }
-                                ),
-                                expires_at=None,
-                                created_at=now,
-                                updated_at=now,
-                            )
+                                payload={
+                                    "scope_key": str(scope_key),
+                                    "channel_id": str(channel_id),
+                                    "thread_id": str(thread_id),
+                                    "last_active_at": _float(last_active_at),
+                                },
+                                now=now,
+                            ),
                         )
 
             for opencode_session_id, item in state.active_polls.items():
@@ -266,22 +415,21 @@ class SQLiteSessionsService:
                     f"{platform}::{settings_key}" if platform and "::" not in settings_key else settings_key,
                     now=now,
                 )
-                conn.execute(
-                    runtime_records.insert().values(
-                        id=f"runtime::active_poll::{record_key}",
+                _upsert_runtime_record(
+                    conn,
+                    _runtime_record_values(
                         record_type="active_poll",
                         record_key=record_key,
                         scope_id=scope_id,
                         session_anchor=str(data.get("base_session_id") or data.get("thread_id") or ""),
                         workdir=str(data.get("working_path") or "") or None,
-                        payload_json=_json_dumps(data),
-                        expires_at=None,
-                        created_at=now,
-                        updated_at=now,
-                    )
+                        payload=data,
+                        now=now,
+                    ),
                 )
 
             seen_messages: set[tuple[str, str, str]] = set()
+            message_order = 0
             for channel_id, thread_map in state.processed_message_ts.items():
                 if not isinstance(thread_map, dict):
                     continue
@@ -293,41 +441,42 @@ class SQLiteSessionsService:
                             continue
                         seen_messages.add(key)
                         record_key = "|".join(key)
-                        conn.execute(
-                            runtime_records.insert().values(
-                                id=f"runtime::processed_message::{record_key}",
+                        ordered_at = (now_dt + timedelta(microseconds=message_order)).isoformat()
+                        message_order += 1
+                        _upsert_runtime_record(
+                            conn,
+                            _runtime_record_values(
                                 record_type="processed_message",
                                 record_key=record_key,
                                 scope_id=None,
                                 session_anchor=str(thread_id),
                                 workdir=None,
-                                payload_json=_json_dumps(
-                                    {
-                                        "channel_id": str(channel_id),
-                                        "thread_id": str(thread_id),
-                                        "message_id": str(message_id),
-                                        "processed_at": now,
-                                    }
-                                ),
-                                expires_at=None,
-                                created_at=now,
-                                updated_at=now,
-                            )
+                                payload={
+                                    "channel_id": str(channel_id),
+                                    "thread_id": str(thread_id),
+                                    "message_id": str(message_id),
+                                    "processed_at": ordered_at,
+                                },
+                                now=ordered_at,
+                            ),
+                            update_created_at=True,
                         )
 
             if state.last_activity is not None:
+                stmt = sqlite_insert(state_meta).values(
+                    key=SESSIONS_LAST_ACTIVITY_KEY,
+                    value_json=_json_dumps(state.last_activity),
+                    updated_at=now,
+                )
                 conn.execute(
-                    state_meta.insert().values(
-                        key=SESSIONS_LAST_ACTIVITY_KEY,
-                        value_json=_json_dumps(state.last_activity),
-                        updated_at=now,
+                    stmt.on_conflict_do_update(
+                        index_elements=[state_meta.c.key],
+                        set_={
+                            "value_json": stmt.excluded.value_json,
+                            "updated_at": stmt.excluded.updated_at,
+                        },
                     )
                 )
-
-    def _clear(self, conn: Connection) -> None:
-        conn.execute(agent_sessions.delete())
-        conn.execute(runtime_records.delete())
-        conn.execute(state_meta.delete().where(state_meta.c.key == SESSIONS_LAST_ACTIVITY_KEY))
 
     def _load_existing_session_ids(self, conn: Connection) -> dict[tuple[str | None, str, str, str], str]:
         rows = conn.execute(
@@ -577,6 +726,50 @@ def _insert_agent_session_row(
         )
     )
     return row_id
+
+
+def _runtime_record_values(
+    *,
+    record_type: str,
+    record_key: str,
+    scope_id: str | None,
+    session_anchor: str | None,
+    workdir: str | None,
+    payload: dict[str, Any],
+    now: str,
+) -> dict[str, Any]:
+    return {
+        "id": f"runtime::{record_type}::{record_key}",
+        "record_type": record_type,
+        "record_key": record_key,
+        "scope_id": scope_id,
+        "session_anchor": session_anchor,
+        "workdir": workdir,
+        "payload_json": _json_dumps(payload),
+        "expires_at": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _upsert_runtime_record(conn: Connection, values: dict[str, Any], *, update_created_at: bool = False) -> None:
+    stmt = sqlite_insert(runtime_records).values(**values)
+    set_values = {
+        "scope_id": stmt.excluded.scope_id,
+        "session_anchor": stmt.excluded.session_anchor,
+        "workdir": stmt.excluded.workdir,
+        "payload_json": stmt.excluded.payload_json,
+        "expires_at": stmt.excluded.expires_at,
+        "updated_at": stmt.excluded.updated_at,
+    }
+    if update_created_at:
+        set_values["created_at"] = stmt.excluded.created_at
+    conn.execute(
+        stmt.on_conflict_do_update(
+            index_elements=[runtime_records.c.record_type, runtime_records.c.record_key],
+            set_=set_values,
+        )
+    )
 
 
 def _session_row_key(

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -1,4 +1,5 @@
 import importlib.util
+import asyncio
 import unittest
 import sys
 import types
@@ -1373,6 +1374,94 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         await slack._handle_event(payload)
 
         self.assertEqual(marked, [("U123", "C_CONNECT", "1710000000.000360")])
+
+    async def test_socket_mode_events_ack_before_message_processing_finishes(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        started = asyncio.Event()
+        release = asyncio.Event()
+        received = []
+        acks = []
+
+        class _Client:
+            async def send_socket_mode_response(self, response):
+                acks.append(response)
+
+        async def _on_message(_context, text):
+            started.set()
+            await release.wait()
+            received.append(text)
+
+        slack.register_callbacks(on_message=_on_message)
+        payload = {
+            "event_id": "evt-ack-before-processing",
+            "team_id": "T1",
+            "event": {
+                "type": "message",
+                "channel": "D123",
+                "user": "U123",
+                "text": "hello",
+                "ts": "1710000000.000370",
+            },
+        }
+
+        await slack._handle_socket_mode_request(
+            _Client(),
+            SimpleNamespace(type="events_api", envelope_id="env-1", payload=payload),
+        )
+
+        self.assertEqual(len(acks), 1)
+        self.assertEqual(received, [])
+        await asyncio.wait_for(started.wait(), timeout=1)
+        release.set()
+        if slack._event_tasks:
+            await asyncio.gather(*list(slack._event_tasks))
+        self.assertEqual(received, ["hello"])
+
+    async def test_slack_event_dedup_uses_persistent_runtime_claim(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        claims = set()
+        calls = []
+        received = []
+
+        class _Sessions:
+            def try_record_runtime_event(self, record_type, record_key, payload=None, *, ttl_seconds=None):
+                calls.append((record_type, record_key, payload, ttl_seconds))
+                key = (record_type, record_key)
+                if key in claims:
+                    return False
+                claims.add(key)
+                return True
+
+        class _SettingsManager:
+            sessions = _Sessions()
+
+            def get_require_mention(self, _channel_id, global_default=False):
+                return global_default
+
+        async def _on_message(_context, text):
+            received.append(text)
+
+        slack.set_settings_manager(_SettingsManager())
+        slack.register_callbacks(on_message=_on_message)
+        payload = {
+            "event_id": "evt-persistent-dedup",
+            "team_id": "T1",
+            "event": {
+                "type": "message",
+                "channel": "D123",
+                "user": "U123",
+                "text": "hello",
+                "ts": "1710000000.000371",
+            },
+        }
+
+        await slack._handle_event(payload)
+        await slack._handle_event(payload)
+
+        self.assertEqual(received, ["hello"])
+        self.assertEqual(calls[0][0], "slack_event")
+        self.assertEqual(calls[0][1], "T1:evt-persistent-dedup")
+        self.assertEqual(calls[0][3], 300)
 
     async def test_slack_connect_message_then_app_mention_is_handled_once(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))

--- a/tests/test_slack_dm_mentions.py
+++ b/tests/test_slack_dm_mentions.py
@@ -1463,6 +1463,63 @@ class SlackDmMentionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(calls[0][1], "T1:evt-persistent-dedup")
         self.assertEqual(calls[0][3], 300)
 
+    async def test_async_close_drains_pending_event_tasks_before_closing_web_client(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        started = asyncio.Event()
+        release = asyncio.Event()
+        events = []
+
+        class _WebClient:
+            async def close(self):
+                events.append("web-close")
+
+        async def _handler():
+            events.append("handler-start")
+            started.set()
+            await release.wait()
+            events.append("handler-finish")
+
+        slack.web_client = _WebClient()
+        task = asyncio.create_task(_handler())
+        slack._event_tasks.add(task)
+        task.add_done_callback(slack._handle_event_task_done)
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        close_task = asyncio.create_task(slack._async_close())
+        await asyncio.sleep(0)
+        self.assertEqual(events, ["handler-start"])
+
+        release.set()
+        await asyncio.wait_for(close_task, timeout=1)
+
+        self.assertEqual(events, ["handler-start", "handler-finish", "web-close"])
+        self.assertEqual(slack._event_tasks, set())
+
+    async def test_async_close_cancels_event_tasks_after_drain_timeout(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        started = asyncio.Event()
+        canceled = asyncio.Event()
+
+        async def _handler():
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                canceled.set()
+                raise
+
+        slack._event_task_shutdown_drain_timeout = 0.01
+        task = asyncio.create_task(_handler())
+        slack._event_tasks.add(task)
+        task.add_done_callback(slack._handle_event_task_done)
+
+        await asyncio.wait_for(started.wait(), timeout=1)
+        await slack._async_close()
+
+        await asyncio.wait_for(canceled.wait(), timeout=1)
+        self.assertTrue(task.cancelled())
+        self.assertEqual(slack._event_tasks, set())
+
     async def test_slack_connect_message_then_app_mention_is_handled_once(self):
         slack = SlackBot(SlackConfig(bot_token="xoxb-test", require_mention=True))
         received = []

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 
 from config import paths
 from config.v2_sessions import ActivePollInfo, SessionState, SessionsStore
+from modules.sessions_facade import SessionsFacade
 from storage.db import create_sqlite_engine
 from storage.models import agent_sessions
 from storage.sessions_service import SQLiteSessionsService
@@ -313,6 +314,37 @@ def test_sessions_store_lifecycle_survives_followup_save(tmp_path: Path) -> None
         )
     finally:
         reloaded.close()
+
+
+def test_sessions_facade_cross_scope_alias_persists_after_reload_during_target_map_read(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    facade = SessionsFacade(store)
+    try:
+        store.bind_agent_session("slack::C123", "codex", "slack_source-1", "native-base")
+        store.bind_agent_session("slack::C123", "codex", "slack_source-1:/repo", "native-workdir")
+        external = SQLiteSessionsService(tmp_path / "vibe.sqlite")
+        try:
+            external.try_record_runtime_event("test_external_write", "reload-marker")
+        finally:
+            external.close()
+
+        assert facade.alias_session_base_across_scopes(
+            "slack::C123",
+            "slack::C999",
+            "slack_source-1",
+            "slack_target-1",
+        )
+
+        reloaded = SessionsStore(sessions_path)
+        try:
+            target_map = reloaded.state.session_mappings["slack::C999"]["codex"]
+            assert target_map["slack_target-1"] == "native-base"
+            assert target_map["slack_target-1:/repo"] == "native-workdir"
+        finally:
+            reloaded.close()
+    finally:
+        store.close()
 
 
 def test_sessions_store_atomically_claims_processed_messages_across_instances(tmp_path: Path) -> None:

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -158,6 +158,46 @@ def test_sqlite_sessions_service_preserves_agent_session_ids_on_save(tmp_path: P
         service.close()
 
 
+def test_sqlite_sessions_service_updates_logical_agent_session_on_save(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "thread-native-1",
+                        }
+                    }
+                }
+            )
+        )
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "thread-native-2",
+                        }
+                    }
+                }
+            )
+        )
+
+        engine = create_sqlite_engine(db_path)
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(select(agent_sessions.c.native_session_id)).scalars().all()
+        finally:
+            engine.dispose()
+
+        assert rows == ["thread-native-2"]
+        assert service.load_state().session_mappings["slack::C123"]["codex"]["slack_171717.123"] == "thread-native-2"
+    finally:
+        service.close()
+
+
 def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -306,6 +346,41 @@ def test_sessions_store_save_keeps_newest_external_processed_claims(tmp_path: Pa
     finally:
         stale.close()
         external.close()
+
+
+def test_sessions_store_save_prunes_stale_processed_claim_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        service.save_state(
+            SessionState(
+                processed_message_ts={
+                    "C123": {
+                        "171717.123": [f"msg-{index:03d}" for index in range(205)],
+                    }
+                }
+            )
+        )
+
+        engine = create_sqlite_engine(db_path)
+        try:
+            with engine.connect() as conn:
+                count = conn.execute(
+                    select(agent_sessions.c.id)
+                ).all()
+                runtime_count = conn.exec_driver_sql(
+                    "select count(*) from runtime_records where record_type = 'processed_message'"
+                ).scalar_one()
+        finally:
+            engine.dispose()
+
+        assert count == []
+        assert runtime_count == 200
+        processed = service.load_state().processed_message_ts["C123"]["171717.123"]
+        assert processed[0] == "msg-005"
+        assert processed[-1] == "msg-204"
+    finally:
+        service.close()
 
 
 def test_sessions_store_runtime_updates_do_not_flush_stale_snapshots(tmp_path: Path) -> None:

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -282,6 +282,44 @@ def test_sessions_store_save_preserves_external_processed_claims(tmp_path: Path)
         external.close()
 
 
+def test_sessions_store_save_keeps_newest_external_processed_claims(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    stale = SessionsStore(sessions_path)
+    external = SessionsStore(sessions_path)
+    try:
+        stale.state.processed_message_ts = {
+            "C123": {
+                "171717.123": [f"old-{index:03d}" for index in range(200)],
+            }
+        }
+        for index in range(5):
+            assert external.try_add_to_processed_set("C123", "171717.123", f"new-{index:03d}") is True
+
+        stale.add_active_poll(
+            ActivePollInfo(
+                opencode_session_id="oc-stale",
+                base_session_id="base",
+                channel_id="C123",
+                thread_id="171717.123",
+                settings_key="C123",
+                working_path="/repo",
+                platform="slack",
+            )
+        )
+
+        reloaded = SessionsStore(sessions_path)
+        try:
+            processed = reloaded._get_processed_set("C123", "171717.123")
+            assert len(processed) == 200
+            assert processed[-5:] == [f"new-{index:03d}" for index in range(5)]
+            assert "old-000" not in processed
+        finally:
+            reloaded.close()
+    finally:
+        stale.close()
+        external.close()
+
+
 def test_sessions_store_bootstrap_uses_config_primary_platform(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     paths.ensure_data_dirs()

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -293,6 +293,19 @@ def test_sessions_store_atomically_claims_processed_messages_across_instances(tm
         second.close()
 
 
+def test_sessions_store_atomically_claims_runtime_events_across_instances(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    first = SessionsStore(sessions_path)
+    second = SessionsStore(sessions_path)
+    try:
+        assert first.try_record_runtime_event("slack_event", "T1:Ev123", {"event_id": "Ev123"}) is True
+        assert second.try_record_runtime_event("slack_event", "T1:Ev123", {"event_id": "Ev123"}) is False
+        assert second.try_record_runtime_event("slack_event", "T1:Ev124", {"event_id": "Ev124"}) is True
+    finally:
+        first.close()
+        second.close()
+
+
 def test_sessions_store_save_preserves_external_processed_claims(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     stale = SessionsStore(sessions_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -283,17 +283,42 @@ def test_sessions_store_save_preserves_external_processed_claims(tmp_path: Path)
 
 
 def test_sessions_store_save_keeps_newest_external_processed_claims(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    stale = SQLiteSessionsService(db_path)
+    external = SQLiteSessionsService(db_path)
+    try:
+        stale_state = SessionState(
+            processed_message_ts={
+                "C123": {
+                    "171717.123": [f"old-{index:03d}" for index in range(200)],
+                }
+            }
+        )
+        for index in range(5):
+            assert external.try_record_processed_message("C123", "171717.123", f"new-{index:03d}") is True
+
+        stale.save_state(stale_state)
+
+        processed = stale.load_state().processed_message_ts["C123"]["171717.123"]
+        assert len(processed) == 200
+        assert processed[-5:] == [f"new-{index:03d}" for index in range(5)]
+        assert "old-000" not in processed
+    finally:
+        stale.close()
+        external.close()
+
+
+def test_sessions_store_runtime_updates_do_not_flush_stale_snapshots(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     stale = SessionsStore(sessions_path)
     external = SessionsStore(sessions_path)
     try:
         stale.state.processed_message_ts = {
             "C123": {
-                "171717.123": [f"old-{index:03d}" for index in range(200)],
+                "171717.123": ["stale-message"],
             }
         }
-        for index in range(5):
-            assert external.try_add_to_processed_set("C123", "171717.123", f"new-{index:03d}") is True
+        assert external.try_add_to_processed_set("C123", "171717.123", "external-message") is True
 
         stale.add_active_poll(
             ActivePollInfo(
@@ -310,9 +335,8 @@ def test_sessions_store_save_keeps_newest_external_processed_claims(tmp_path: Pa
         reloaded = SessionsStore(sessions_path)
         try:
             processed = reloaded._get_processed_set("C123", "171717.123")
-            assert len(processed) == 200
-            assert processed[-5:] == [f"new-{index:03d}" for index in range(5)]
-            assert "old-000" not in processed
+            assert processed == ["external-message"]
+            assert reloaded.get_active_poll("oc-stale") is not None
         finally:
             reloaded.close()
     finally:

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -228,6 +228,41 @@ def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: 
         service.close()
 
 
+def test_sqlite_sessions_service_delete_agent_sessions_escapes_anchor_prefix(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        service.bind_agent_session(
+            scope_key="slack::C123",
+            agent_name="codex",
+            session_anchor="slack_1_2%3",
+            native_session_id="target-base",
+        )
+        service.bind_agent_session(
+            scope_key="slack::C123",
+            agent_name="codex",
+            session_anchor="slack_1_2%3:/repo",
+            native_session_id="target-child",
+        )
+        service.bind_agent_session(
+            scope_key="slack::C123",
+            agent_name="codex",
+            session_anchor="slack_1A2X3:/repo",
+            native_session_id="unrelated",
+        )
+
+        removed = service.delete_agent_sessions(
+            scope_key="slack::C123",
+            session_anchor_prefix="slack_1_2%3",
+        )
+
+        assert removed == 2
+        mappings = service.load_state().session_mappings["slack::C123"]["codex"]
+        assert mappings == {"slack_1A2X3:/repo": "unrelated"}
+    finally:
+        service.close()
+
+
 def test_sessions_store_lifecycle_updates_in_memory_state(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     store = SessionsStore(sessions_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -396,6 +396,46 @@ def test_sessions_store_save_prunes_stale_processed_claim_rows(tmp_path: Path) -
         service.close()
 
 
+def test_sessions_store_hot_path_prunes_processed_claim_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        for index in range(205):
+            assert service.try_record_processed_message("C123", "171717.123", f"msg-{index:03d}") is True
+
+        engine = create_sqlite_engine(db_path)
+        try:
+            with engine.connect() as conn:
+                runtime_count = conn.exec_driver_sql(
+                    "select count(*) from runtime_records where record_type = 'processed_message'"
+                ).scalar_one()
+        finally:
+            engine.dispose()
+
+        assert runtime_count == 200
+        processed = service.load_state().processed_message_ts["C123"]["171717.123"]
+        assert processed[0] == "msg-005"
+        assert processed[-1] == "msg-204"
+    finally:
+        service.close()
+
+
+def test_sessions_store_prunes_processed_claims_with_escaped_like_prefix(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        for index in range(205):
+            assert service.try_record_processed_message("C_1", "thread%1", f"msg-{index:03d}") is True
+        assert service.try_record_processed_message("CA1", "threadX1", "other-thread-message") is True
+
+        processed = service.load_state().processed_message_ts
+        assert processed["C_1"]["thread%1"][0] == "msg-005"
+        assert processed["C_1"]["thread%1"][-1] == "msg-204"
+        assert processed["CA1"]["threadX1"] == ["other-thread-message"]
+    finally:
+        service.close()
+
+
 def test_sessions_store_runtime_updates_do_not_flush_stale_snapshots(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     stale = SessionsStore(sessions_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -240,6 +240,48 @@ def test_sessions_store_lifecycle_survives_followup_save(tmp_path: Path) -> None
         reloaded.close()
 
 
+def test_sessions_store_atomically_claims_processed_messages_across_instances(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    first = SessionsStore(sessions_path)
+    second = SessionsStore(sessions_path)
+    try:
+        assert first.try_add_to_processed_set("C123", "171717.123", "171717.456") is True
+        assert second.try_add_to_processed_set("C123", "171717.123", "171717.456") is False
+        assert second.is_message_in_processed_set("C123", "171717.123", "171717.456") is True
+    finally:
+        first.close()
+        second.close()
+
+
+def test_sessions_store_save_preserves_external_processed_claims(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    stale = SessionsStore(sessions_path)
+    external = SessionsStore(sessions_path)
+    try:
+        assert external.try_add_to_processed_set("C123", "171717.123", "171717.456") is True
+
+        stale.add_active_poll(
+            ActivePollInfo(
+                opencode_session_id="oc-stale",
+                base_session_id="base",
+                channel_id="C123",
+                thread_id="171717.123",
+                settings_key="C123",
+                working_path="/repo",
+                platform="slack",
+            )
+        )
+
+        reloaded = SessionsStore(sessions_path)
+        try:
+            assert reloaded.is_message_in_processed_set("C123", "171717.123", "171717.456") is True
+        finally:
+            reloaded.close()
+    finally:
+        stale.close()
+        external.close()
+
+
 def test_sessions_store_bootstrap_uses_config_primary_platform(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     paths.ensure_data_dirs()

--- a/tests/test_v2_sessions.py
+++ b/tests/test_v2_sessions.py
@@ -192,6 +192,7 @@ def test_migrate_session_mappings_moves_old_key_to_prefixed(tmp_path, monkeypatc
     reloaded = SessionsStore()
     reloaded.load()
     reloaded.migrate_session_mappings("slack")
+    reloaded.load()
 
     # Old raw key should be gone
     assert "C0A6U2GH6P5" not in reloaded.state.session_mappings
@@ -225,6 +226,7 @@ def test_migrate_session_mappings_merges_without_overwriting(tmp_path, monkeypat
     reloaded = SessionsStore()
     reloaded.load()
     reloaded.migrate_session_mappings("slack")
+    reloaded.load()
 
     assert "C123" not in reloaded.state.session_mappings
     oc = reloaded.state.session_mappings["slack::C123"]["opencode"]
@@ -248,6 +250,7 @@ def test_migrate_session_mappings_cleans_empty_keys(tmp_path, monkeypatch):
     reloaded = SessionsStore()
     reloaded.load()
     reloaded.migrate_session_mappings("slack")
+    reloaded.load()
 
     assert "U0E0FM3QT" not in reloaded.state.session_mappings
     assert "749794605024936027" not in reloaded.state.session_mappings
@@ -290,6 +293,7 @@ def test_migrate_session_mappings_infers_platform_from_thread_ids(tmp_path, monk
     reloaded = SessionsStore()
     reloaded.load()
     reloaded.migrate_session_mappings("slack")  # default is slack, but data is discord
+    reloaded.load()
 
     # Should migrate to discord:: not slack::
     assert "D456" not in reloaded.state.session_mappings
@@ -316,6 +320,7 @@ def test_migrate_session_mappings_is_idempotent(tmp_path, monkeypatch):
     store2 = SessionsStore()
     store2.load()
     store2.migrate_session_mappings("slack")
+    store2.load()
 
     assert set(store2.state.session_mappings.keys()) == {"slack::C123"}
     assert store2.state.session_mappings["slack::C123"]["opencode"]["slack_123.456:/work"] == "ses_abc"


### PR DESCRIPTION
## Summary

Fix duplicate agent turns when the same IM message is delivered to more than one Vibe Remote runtime or handler path, and finish the SQLite migration for session/runtime state hot paths.

The message handler previously used a check-then-write dedup flow backed by in-memory session state. In a regression setup with more than one Slack Socket Mode consumer, both runtimes could pass the check, start separate agent sessions, and reply in the same Slack thread.

This change now does three things:

- claims processed messages atomically through the SQLite `runtime_records` unique key
- moves runtime session/thread/poll/message updates to explicit SQLite upsert/delete operations
- removes the session service full-table clear/rewrite behavior from normal save paths, keeping snapshot saves as upsert-style cold-path sync only

## Evidence

- Unit: added cross-instance processed-message claim tests in `tests/test_sqlite_sessions_store.py`
- Unit: added stale snapshot/runtime-update tests to verify hot-path writes do not flush stale state
- Unit: tightened session-mapping migration tests to reload from SQLite and catch legacy row resurrection
- Contract: message handler now gates human turns on `try_record_processed_message`
- Scenario: covers duplicate Slack/IM event delivery to parallel runtime instances
- Residual manual checks: regression Slack voice test should be re-run after deploy to confirm only one agent turn is started

## Validation

- `uv run pytest tests/test_sqlite_sessions_store.py tests/test_v2_sessions.py tests/test_session_handler_base_id.py tests/test_message_handler_typing.py tests/test_message_handler_auth_setup.py tests/test_update_checker_platforms.py tests/test_agent_auth_service.py tests/test_api_save_config_merge.py tests/test_sqlite_state_migration.py -q`
- `uv run ruff check storage/sessions_service.py config/v2_sessions.py modules/sessions_facade.py tests/test_sqlite_sessions_store.py tests/test_v2_sessions.py`
