### PR TITLE
Add session Show Pages

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -29,6 +29,14 @@ def get_attachments_dir() -> Path:
     return get_vibe_remote_dir() / "attachments"
 
 
+def get_show_pages_dir() -> Path:
+    return get_vibe_remote_dir() / "show"
+
+
+def get_show_page_dir(session_id: str) -> Path:
+    return get_show_pages_dir() / session_id
+
+
 def get_runtime_pid_path() -> Path:
     return get_runtime_dir() / "vibe.pid"
 
@@ -110,6 +118,7 @@ def ensure_data_dirs() -> None:
     get_logs_dir().mkdir(parents=True, exist_ok=True)
     get_runtime_dir().mkdir(parents=True, exist_ok=True)
     get_attachments_dir().mkdir(parents=True, exist_ok=True)
+    get_show_pages_dir().mkdir(parents=True, exist_ok=True)
     get_state_backups_dir().mkdir(parents=True, exist_ok=True)
     preferences_path = get_user_preferences_path()
     if not preferences_path.exists():

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -313,6 +313,7 @@ class V2Config:
     include_time_info: bool = True  # Prepend current local time to agent messages
     include_user_info: bool = True  # Prepend user identity to agent messages
     reply_enhancements: bool = True  # Enable quick-reply buttons
+    show_pages_prompt: bool = True  # Inject Show Pages capability guidance into agent prompts
     language: str = "en"  # Global language setting (see vibe/i18n)
 
     @classmethod
@@ -495,6 +496,10 @@ class V2Config:
         if not isinstance(reply_enhancements, bool):
             reply_enhancements = True
 
+        show_pages_prompt = payload.get("show_pages_prompt", True)
+        if not isinstance(show_pages_prompt, bool):
+            show_pages_prompt = True
+
         language = normalize_language(payload.get("language"), default="en")
 
         return cls(
@@ -520,6 +525,7 @@ class V2Config:
             include_time_info=include_time_info,
             include_user_info=include_user_info,
             reply_enhancements=reply_enhancements,
+            show_pages_prompt=show_pages_prompt,
             language=language,
         )
 
@@ -569,6 +575,7 @@ class V2Config:
             "include_time_info": self.include_time_info,
             "include_user_info": self.include_user_info,
             "reply_enhancements": self.reply_enhancements,
+            "show_pages_prompt": self.show_pages_prompt,
             "language": self.language,
         }
         content = json.dumps(payload, indent=2)

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -676,6 +676,7 @@ class SessionHandler(BaseHandler):
 
         system_prompt_injection = build_system_prompt_injection(
             include_quick_replies=quick_replies_on and platform != "wechat",
+            include_show_pages=getattr(self.config, "show_pages_prompt", True),
             context=context,
             fallback_platform=platform,
         )

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+from sqlalchemy import insert, select, update
+
+from config import paths
+from config.v2_config import V2Config
+from storage.db import create_sqlite_engine
+from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
+from storage.models import show_pages
+
+VISIBILITY_PRIVATE = "private"
+VISIBILITY_PUBLIC = "public"
+VISIBILITY_OFFLINE = "offline"
+VISIBILITIES = {VISIBILITY_PRIVATE, VISIBILITY_PUBLIC, VISIBILITY_OFFLINE}
+SHARE_ID_BYTES = 8
+_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
+
+class ShowPageError(ValueError):
+    def __init__(self, message: str, *, code: str):
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ShowPage:
+    session_id: str
+    visibility: str
+    share_id: str | None
+    offline_at: str | None
+    created_at: str
+    updated_at: str
+
+    @property
+    def offline(self) -> bool:
+        return self.visibility == VISIBILITY_OFFLINE
+
+
+def validate_session_id(session_id: str) -> str:
+    value = (session_id or "").strip()
+    if not value:
+        raise ShowPageError("Session ID is required.", code="missing_session_id")
+    if not _SESSION_ID_PATTERN.fullmatch(value):
+        raise ShowPageError(
+            "Session ID may contain only letters, numbers, underscore, dash, dot, and colon.",
+            code="invalid_session_id",
+        )
+    return value
+
+
+def show_page_dir(session_id: str) -> Path:
+    return paths.get_show_page_dir(validate_session_id(session_id))
+
+
+def ensure_show_page_dir(session_id: str) -> Path:
+    page_dir = show_page_dir(session_id)
+    page_dir.mkdir(parents=True, exist_ok=True)
+    index_path = page_dir / "index.html"
+    if not index_path.exists():
+        index_path.write_text(_default_index_html(validate_session_id(session_id)), encoding="utf-8")
+    return page_dir
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_share_id() -> str:
+    return secrets.token_urlsafe(SHARE_ID_BYTES).rstrip("_-")
+
+
+def _base_public_url(config: V2Config | None = None) -> str | None:
+    try:
+        cfg = config or V2Config.load()
+    except Exception:
+        return None
+    public_url = (cfg.remote_access.vibe_cloud.public_url or "").strip()
+    return public_url.rstrip("/") if public_url else None
+
+
+def private_url(session_id: str, *, config: V2Config | None = None) -> str | None:
+    base = _base_public_url(config)
+    if not base:
+        return None
+    return urljoin(base + "/", f"show/{validate_session_id(session_id)}/")
+
+
+def public_url(share_id: str | None, *, config: V2Config | None = None) -> str | None:
+    if not share_id:
+        return None
+    base = _base_public_url(config)
+    if not base:
+        return None
+    return urljoin(base + "/", f"p/{share_id}/")
+
+
+class ShowPageStore:
+    def __init__(self, db_path: Path | None = None):
+        self.db_path = db_path or paths.get_sqlite_state_path()
+        if db_path is None:
+            ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(paths.get_state_dir()))
+        else:
+            from storage.migrations import run_migrations
+
+            run_migrations(self.db_path)
+        self.engine = create_sqlite_engine(self.db_path)
+
+    def close(self) -> None:
+        self.engine.dispose()
+
+    def get(self, session_id: str) -> ShowPage | None:
+        session_id = validate_session_id(session_id)
+        with self.engine.connect() as conn:
+            row = conn.execute(select(show_pages).where(show_pages.c.session_id == session_id).limit(1)).mappings().first()
+            return _page_from_row(row) if row else None
+
+    def get_by_share_id(self, share_id: str) -> ShowPage | None:
+        share_id = (share_id or "").strip()
+        if not share_id:
+            return None
+        with self.engine.connect() as conn:
+            row = (
+                conn.execute(select(show_pages).where(show_pages.c.share_id == share_id).limit(1)).mappings().first()
+            )
+            return _page_from_row(row) if row else None
+
+    def ensure(self, session_id: str) -> ShowPage:
+        session_id = validate_session_id(session_id)
+        existing = self.get(session_id)
+        if existing is not None:
+            return existing
+        now = _utc_now_iso()
+        page = ShowPage(
+            session_id=session_id,
+            visibility=VISIBILITY_PRIVATE,
+            share_id=None,
+            offline_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        with self.engine.begin() as conn:
+            conn.execute(
+                insert(show_pages).values(
+                    session_id=page.session_id,
+                    visibility=page.visibility,
+                    share_id=page.share_id,
+                    offline_at=page.offline_at,
+                    created_at=page.created_at,
+                    updated_at=page.updated_at,
+                )
+            )
+        return page
+
+    def update_visibility(self, session_id: str, visibility: str) -> ShowPage:
+        session_id = validate_session_id(session_id)
+        if visibility not in VISIBILITIES:
+            raise ShowPageError(f"Unsupported visibility: {visibility}", code="invalid_visibility")
+        page = self.ensure(session_id)
+        now = _utc_now_iso()
+        values: dict[str, Any] = {
+            "visibility": visibility,
+            "updated_at": now,
+            "offline_at": now if visibility == VISIBILITY_OFFLINE else None,
+        }
+        if visibility == VISIBILITY_PUBLIC and not page.share_id:
+            values["share_id"] = self._unique_share_id()
+        with self.engine.begin() as conn:
+            conn.execute(update(show_pages).where(show_pages.c.session_id == session_id).values(**values))
+        updated = self.get(session_id)
+        assert updated is not None
+        return updated
+
+    def rotate_share(self, session_id: str) -> tuple[ShowPage, str | None]:
+        session_id = validate_session_id(session_id)
+        page = self.ensure(session_id)
+        if page.visibility != VISIBILITY_PUBLIC:
+            raise ShowPageError(
+                "Share links can only be rotated while the Show Page is public.",
+                code="not_public",
+            )
+        previous_share_id = page.share_id
+        new_share_id = self._unique_share_id()
+        now = _utc_now_iso()
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(show_pages)
+                .where(show_pages.c.session_id == session_id)
+                .values(share_id=new_share_id, updated_at=now)
+            )
+        updated = self.get(session_id)
+        assert updated is not None
+        return updated, previous_share_id
+
+    def _unique_share_id(self) -> str:
+        for _ in range(20):
+            candidate = _new_share_id()
+            if self.get_by_share_id(candidate) is None:
+                return candidate
+        raise ShowPageError("Could not allocate a unique share ID.", code="share_id_allocation_failed")
+
+
+def _page_from_row(row: Any) -> ShowPage:
+    return ShowPage(
+        session_id=str(row["session_id"]),
+        visibility=str(row["visibility"]),
+        share_id=str(row["share_id"]) if row["share_id"] else None,
+        offline_at=str(row["offline_at"]) if row["offline_at"] else None,
+        created_at=str(row["created_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def show_page_payload(page: ShowPage, *, config: V2Config | None = None) -> dict[str, Any]:
+    path = show_page_dir(page.session_id)
+    private = private_url(page.session_id, config=config)
+    public = public_url(page.share_id, config=config)
+    active_url = None
+    if page.visibility == VISIBILITY_PRIVATE:
+        active_url = private
+    elif page.visibility == VISIBILITY_PUBLIC:
+        active_url = public
+    return {
+        "session_id": page.session_id,
+        "visibility": page.visibility,
+        "path": str(path),
+        "active_url": active_url,
+        "private_url": private,
+        "public_url": public,
+        "share_id": page.share_id,
+        "offline": page.offline,
+        "offline_at": page.offline_at,
+        "created_at": page.created_at,
+        "updated_at": page.updated_at,
+    }
+
+
+def _default_index_html(session_id: str) -> str:
+    escaped = session_id.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Show Page</title>
+    <style>
+      :root {{
+        color-scheme: light dark;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f7f8fb;
+        color: #172033;
+      }}
+      body {{
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 32px 18px;
+        box-sizing: border-box;
+      }}
+      main {{
+        width: min(720px, 100%);
+        border: 1px solid rgba(23, 32, 51, 0.12);
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.86);
+        padding: clamp(24px, 5vw, 48px);
+        box-shadow: 0 24px 80px rgba(23, 32, 51, 0.10);
+      }}
+      p {{
+        line-height: 1.65;
+        margin: 10px 0 0;
+      }}
+      .eyebrow {{
+        color: #526078;
+        font-size: 13px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }}
+      h1 {{
+        margin: 12px 0 0;
+        font-size: clamp(32px, 8vw, 56px);
+        line-height: 1;
+        letter-spacing: 0;
+      }}
+      code {{
+        background: rgba(82, 96, 120, 0.12);
+        border-radius: 6px;
+        padding: 2px 6px;
+      }}
+      @media (prefers-color-scheme: dark) {{
+        :root {{
+          background: #111827;
+          color: #edf2ff;
+        }}
+        main {{
+          background: rgba(17, 24, 39, 0.86);
+          border-color: rgba(237, 242, 255, 0.14);
+          box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+        }}
+        .eyebrow {{
+          color: #a8b3cf;
+        }}
+        code {{
+          background: rgba(237, 242, 255, 0.12);
+        }}
+      }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="eyebrow">Vibe Remote Show Page</div>
+      <h1>Ready to visualize</h1>
+      <p>This session's Show Page workspace is ready. Replace this file with a focused visual explanation, report, diagram, dashboard, or prototype.</p>
+      <p>Session: <code>{escaped}</code></p>
+    </main>
+  </body>
+</html>
+"""

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -29,7 +29,7 @@ Rules:
 - If nothing remains after stripping silent blocks, Vibe Remote sends no message.
 - Use this for thread messages where you have received context but should not interrupt.
 
-## 1. Send files
+## Send files
 You can send a local file to the user by using a Markdown link with the `file://` protocol:
 Example: [File 1](file:///tmp/result.pdf)
 Vibe Remote will automatically send the file as an attachment.
@@ -37,6 +37,39 @@ Vibe Remote will automatically send the file as an attachment.
 ### Image syntax
 If you want it sent as an image attachment rather than a regular file, use Markdown image syntax:
 Example: ![Page screenshot](file:///tmp/screenshot.jpg)
+"""
+
+_SHOW_PAGES_PROMPT = """\
+
+## Show Pages
+When a visual page would help the user understand a problem, plan, process, result, or complex information more clearly, use Show Pages. They are useful for diagrams, flowcharts, mind maps, timelines, architecture maps, comparison views, dashboards, visual reports, interactive explanations, and small static prototypes.
+
+Each Agent Session has one Show Page. Get this session's page directory:
+
+`vibe show path --session-id {default_session_id}`
+
+Check status:
+
+`vibe show status --session-id {default_session_id}`
+
+Change visibility or manage the share link:
+
+`vibe show update --session-id {default_session_id} --visibility public`
+`vibe show update --session-id {default_session_id} --visibility private`
+`vibe show update --session-id {default_session_id} --visibility offline`
+`vibe show update --session-id {default_session_id} --rotate-share`
+
+Guidance:
+- Write `index.html` and related static assets in the Show Page directory.
+- Design for user understanding, not just for moving text onto a webpage. Choose the visual form that best helps the user inspect, compare, confirm, and continue the discussion.
+- Use diagrams or mind maps for relationships, flowcharts or state machines for processes, timelines for sequences, charts or dashboards for metrics, and side-by-side views for tradeoffs.
+- Make the page visually polished: use clear hierarchy, spacing, typography, contrast, and consistent components. Avoid rough default-looking pages.
+- Make the page work reasonably on mobile because users may open links from an IM app on their phone.
+- You may choose any suitable implementation. Reference options include native HTML/CSS/JavaScript, Excalidraw-style static SVG/PNG diagrams, React Flow, Mermaid, Markmap, Chart.js, and Cytoscape.js.
+- Keep pages private by default. Publish publicly only when the user asks for a shareable or public link.
+- Do not publish secrets, credentials, private logs, or sensitive user data publicly.
+- If a Show Page would clearly help but the user's preference is unclear, briefly ask whether they want one.
+- After creating or updating a page, send the active URL and a short summary of what the page shows.
 """
 
 
@@ -56,7 +89,7 @@ def _build_codex_generated_images_prompt() -> str:
 
 _QUICK_REPLIES_PROMPT = """\
 
-## 2. Quick-reply buttons
+## Quick-reply buttons
 At the very end of the message, add a `---` separator followed by `[button text]` to provide clickable quick replies. Example:
 ---
 [👌 Continue] | [✅ Submit PR] | [👀 Review first]
@@ -70,7 +103,7 @@ Rules:
 
 _SCHEDULED_TASKS_PROMPT = """\
 
-## 3. Scheduled tasks, watches, and hooks
+## Scheduled tasks, watches, and hooks
 Use `vibe task add` for saved work that should run later on a schedule or at one exact time.
 Use `vibe watch add` for managed background waiters that should keep running until a condition is met and then send a follow-up.
 Use `vibe hook send --session-id ... --prompt ...` for one-shot asynchronous sends without saving a task or watch.
@@ -92,7 +125,7 @@ Rules:
 
 _USER_PREFERENCES_PROMPT = """\
 
-## 4. User Context and Preferences
+## User Context and Preferences
 A shared user context and preferences file is available at `{preferences_path}`.
 
 From first principles, serving the user better means thinking proactively about how to make full use of the available context, reduce repetitive communication, and make judgments that better fit the user's habits. For example, the user may currently be receiving your messages through an IM channel, possibly on a mobile device or in a fragmented-attention context.
@@ -118,6 +151,14 @@ def _build_scheduled_tasks_prompt(context: MessageContext, *, fallback_platform:
     )
 
 
+def _build_show_pages_prompt(context: MessageContext) -> str:
+    platform_specific = context.platform_specific or {}
+    default_session_id = platform_specific.get("agent_session_id")
+    if not default_session_id:
+        raise ValueError("agent_session_id is required before building Vibe Remote capability prompt")
+    return _SHOW_PAGES_PROMPT.format(default_session_id=str(default_session_id))
+
+
 def _build_user_preferences_prompt(
     context: Optional[MessageContext],
     *,
@@ -136,6 +177,7 @@ def _build_user_preferences_prompt(
 def build_system_prompt_injection(
     *,
     include_quick_replies: bool = True,
+    include_show_pages: bool = True,
     include_codex_generated_images: bool = False,
     include_user_preferences: bool = True,
     context: Optional[MessageContext] = None,
@@ -146,6 +188,8 @@ def build_system_prompt_injection(
     prompt = _BASE_CAPABILITIES_PROMPT
     if include_codex_generated_images:
         prompt += _build_codex_generated_images_prompt()
+    if include_show_pages and context is not None:
+        prompt += _build_show_pages_prompt(context)
     if include_quick_replies:
         prompt += _QUICK_REPLIES_PROMPT
     if context is not None:

--- a/docs/plans/show-page.md
+++ b/docs/plans/show-page.md
@@ -1,0 +1,321 @@
+# Show Page Plan
+
+## Summary
+
+Show Page gives every Vibe Remote Agent Session one canonical visual
+presentation surface.
+
+When chat text is not enough, an agent can ask Vibe Remote for a
+session-scoped local directory, write a small web experience into that
+directory, and send the user a URL. The user opens the URL through the
+existing Vibe Remote Web UI / Vibe Cloud tunnel and sees the generated
+visualization, report, walkthrough, chart, or interactive explanation.
+
+This is an agent-facing artifact surface:
+
+- chat messages are for conversation
+- file attachments are for deliverables
+- Show Pages are for visual explanation
+
+The first implementation is CLI-first and static-file-first. Hot reload,
+React dev servers, and full-stack app hosting are deferred until the static
+Show Page model is stable.
+
+## Vision
+
+Agents often need to explain work in forms that do not fit well inside IM
+messages: incident timelines, dependency graphs, test dashboards, architecture
+maps, interactive diffs, UI proposals, and visual reports that the user can
+revisit after the chat scrolls away.
+
+Show Page makes visual communication a first-class part of Vibe Remote. The
+agent writes web files. Vibe Remote owns the session binding, URL shape,
+visibility, authentication, CLI ergonomics, and future Web UI entry points.
+
+## Design Philosophy
+
+### Session-scoped, not document-scoped
+
+One Agent Session maps to one Show Page. A session normally represents one
+topic or workstream, so one visual surface is enough. The page can still
+contain tabs, anchors, internal navigation, or client-side routes, but Vibe
+Remote only manages one canonical page per session.
+
+### Local-first data plane
+
+Page contents live on the user's machine under Vibe Remote's local data
+directory:
+
+```text
+~/.vibe_remote/show/<session-id>/
+~/.vibe_remote/show/<session-id>/index.html
+```
+
+Vibe Cloud and `avibe.bot` provide identity, tunnel, and public URL
+reachability. They should not become the data-plane storage layer for page
+contents.
+
+### CLI-first agent contract
+
+The agent process cannot reliably infer the Vibe Agent Session ID from ambient
+context, so V1 commands require an explicit `--session-id`.
+
+The core contract is stable even if the physical path changes later:
+
+```bash
+vibe show path --session-id <session-id>
+```
+
+The command creates or resolves the session's Show Page workspace and prints
+the directory path. The agent can then write `index.html` and related assets
+there.
+
+### Visibility is explicit and canonical
+
+Each Show Page has exactly one active URL path at a time:
+
+- private: the private URL path is active
+- public: the public share URL path is active
+- offline: no URL path is active
+
+This avoids ambiguity where the same content is reachable through both a
+private session URL and a public share URL.
+
+### Private by default
+
+Private pages reuse the existing remote Web UI authorization model. When Vibe
+Cloud tunnel access is enabled, remote browser requests already go through
+OAuth and receive a local authenticated Web UI session cookie. Private Show
+Page requests stay inside that same guard.
+
+### Public means a deliberate unauthenticated share
+
+Public pages do not expose the session ID. They use an independent share ID and
+a short public path:
+
+```text
+/p/<share-id>/
+```
+
+The public path is a narrow authentication bypass for public Show Page assets
+only. It must still preserve host validation, path containment, share lookup,
+visibility checks, and offline checks.
+
+### Offline, not file deletion
+
+Taking a Show Page offline revokes URL access only. It does not delete local
+files. User-facing copy should consistently say that the page is "offline" or
+"taken down" so users do not assume the agent removed local code.
+
+## Confirmed Product Decisions
+
+- One Agent Session has at most one Show Page.
+- V1 commands require `--session-id`; no automatic session inference.
+- Private pages reuse existing Web UI / remote-access login state.
+- Public pages use an independent share ID and skip authentication only for the
+  public Show Page route.
+- Commands support switching between private, public, and offline states.
+- A page has one active canonical path based on its current visibility.
+- Public share IDs support revocation by rotation.
+- No automatic cleanup, quota, or time-based lifecycle in V1.
+- Manual takedown is soft delete: revoke access without deleting local files.
+- Web UI management panels are out of scope for V1.
+- The Show Pages prompt injection is configurable from Web UI messaging
+  settings. Turning it off removes the agent guidance only; CLI commands and
+  page serving remain available.
+- Hot reload and managed dev-server hosting are out of scope for V1.
+
+## URL Model
+
+Assume the user's remote access public URL is:
+
+```text
+https://alex-app.avibe.bot
+```
+
+Private canonical URL:
+
+```text
+https://alex-app.avibe.bot/show/<session-id>/
+```
+
+Public canonical URL:
+
+```text
+https://alex-app.avibe.bot/p/<share-id>/
+```
+
+Rules:
+
+- private visibility serves only `/show/<session-id>/...`
+- public visibility serves only `/p/<share-id>/...`
+- switching from private to public disables the private path
+- switching from public to private disables the public path
+- rotating a public share ID invalidates the old URL
+- offline pages return a stable response explaining that the page is offline
+
+## CLI Model
+
+V1 keeps the command surface small and scriptable:
+
+```bash
+vibe show path --session-id <session-id>
+vibe show status --session-id <session-id>
+vibe show update --session-id <session-id> --visibility public
+vibe show update --session-id <session-id> --visibility private
+vibe show update --session-id <session-id> --visibility offline
+vibe show update --session-id <session-id> --rotate-share
+```
+
+The command model is centered on three actions:
+
+- `path`: get the workspace to write files
+- `status`: inspect current state
+- `update`: change published state or rotate a public share link
+
+Every command that returns state supports `--json` so agents can consume it
+without parsing human text.
+
+CLI output should progressively disclose next useful actions. JSON output
+should be detailed and stable enough for agents to consume, including
+`session_id`, `visibility`, `path`, `active_url`, `private_url`, `public_url`,
+`share_id`, `offline`, timestamps, a human message, and suggested
+`next_actions`.
+
+State transition commands should include the new active URL and, when useful,
+the URL or share ID that just became inactive.
+
+## System Prompt Integration
+
+Vibe Remote injects shared capability guidance through
+`core/system_prompt_injection.py`. Show Pages belong in that same prompt rather
+than in backend-specific wording:
+
+- Claude receives it through `SessionHandler._build_claude_system_prompt(...)`.
+- OpenCode receives it as the per-turn `system` value in `prompt_async(...)`.
+- Codex receives it as `developerInstructions` when a thread starts or resumes.
+
+The Show Pages block should sit near "Send files" because it is an output and
+presentation surface, not a background execution primitive like tasks,
+watches, and hooks.
+
+Recommended ordering, without numbered section titles:
+
+```text
+# Vibe Remote
+
+Silent replies
+Send files
+Show Pages
+Quick-reply buttons
+Scheduled tasks, watches, and hooks
+User Context and Preferences
+```
+
+The prompt should guide agents toward better visual communication practices:
+
+- use Show Pages only when a visual page improves understanding
+- choose the visual form that best fits the information
+- use diagrams, mind maps, flowcharts, timelines, charts, dashboards, or
+  comparison views when appropriate
+- apply good information hierarchy, typography, spacing, contrast, and mobile
+  compatibility
+- keep pages private by default
+- publish publicly only when the user explicitly asks for a shareable link
+- ask briefly when a Show Page would help but the user's preference is unclear
+- send the active URL and a short explanation after creating or updating a page
+
+The prompt should mention useful reference libraries without limiting the
+agent: native HTML/CSS/JavaScript, Excalidraw-style static SVG/PNG diagrams,
+React Flow, Mermaid, Markmap, Chart.js, and Cytoscape.js.
+
+The Web UI setting `show_pages_prompt` controls this prompt section only. It
+does not disable `vibe show`, the local workspace, private serving, or public
+sharing.
+
+## State Model
+
+Show Page state is local runtime state, not global configuration:
+
+```text
+show_pages
+  session_id TEXT PRIMARY KEY
+  visibility TEXT NOT NULL       -- private | public | offline
+  share_id TEXT                  -- independent public token
+  offline_at TEXT
+  created_at TEXT NOT NULL
+  updated_at TEXT NOT NULL
+```
+
+The local file path is derived from `session_id` and does not need to be stored
+unless a later version supports custom roots.
+
+Important invariants:
+
+- `session_id` is the aggregate root
+- `share_id` is never derived from `session_id`
+- `visibility=offline` disables serving but does not delete files
+- switching visibility updates canonical URL behavior but does not move files
+- revoking public access changes `share_id`
+
+## Serving Model
+
+The Web UI server owns Show Page serving because it already owns local auth
+enforcement and remote-access host validation.
+
+Private route:
+
+```text
+GET /show/<session-id>/<asset-path>
+```
+
+Public route:
+
+```text
+GET /p/<share-id>/<asset-path>
+```
+
+Serving rules:
+
+- default `/` under a page to `index.html`
+- serve only files inside the resolved Show Page directory
+- reject path traversal
+- show a small user-facing offline page when a known Show Page has been taken
+  down
+- do not expose arbitrary files outside the Show Page root
+- do not make public auth bypass apply to API routes or the rest of the Web UI
+- add strict response headers where practical without breaking normal static
+  HTML/CSS/JS usage
+
+## Dynamic App And Hot Reload Direction
+
+There are mature ways to support React components and hot loading, but they are
+a V2 capability and should not be mixed into static V1.
+
+The deeper split is between two product concepts:
+
+- Show Page: a durable session artifact that Vibe Remote can safely serve
+- Show App: a live local process that Vibe Remote supervises and proxies
+
+Static Show Page is mainly a file-serving, URL, and permission problem. Show
+App is also a process lifecycle, port allocation, WebSocket proxy, dependency,
+log, and security-boundary problem.
+
+Recommended future path:
+
+- start with static React/Vite builds served through the Show Page routes
+- add private Vite dev-server proxying only after the static model is stable
+- defer public dev-server sharing until there is an explicit security policy
+- treat Next.js-style full-stack app hosting as a later "Show App" adapter, not
+  as part of the static Show Page foundation
+
+## Non-Goals For V1
+
+- Multiple Show Pages per session.
+- A Web UI management panel.
+- Automatic cleanup or quota management.
+- Hosted storage in Vibe Cloud.
+- Public URLs based on session IDs.
+- Running arbitrary Next.js or backend server code as part of static Show Page
+  serving.
+- Hot reload or managed dev-server proxying.

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -710,6 +710,7 @@ class CodexAgent(BaseAgent):
             build_system_prompt_injection(
                 include_quick_replies=getattr(self.controller.config, "reply_enhancements", True)
                 and platform != "wechat",
+                include_show_pages=getattr(self.controller.config, "show_pages_prompt", True),
                 include_codex_generated_images=True,
                 context=request.context,
                 fallback_platform=platform,

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -272,6 +272,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             system_prompt_injection = build_system_prompt_injection(
                 include_quick_replies=getattr(self.controller.config, "reply_enhancements", True)
                 and platform != "wechat",
+                include_show_pages=getattr(self.controller.config, "show_pages_prompt", True),
                 context=request.context,
                 fallback_platform=platform,
             )

--- a/storage/alembic/versions/20260522_0003_show_pages.py
+++ b/storage/alembic/versions/20260522_0003_show_pages.py
@@ -1,0 +1,35 @@
+"""show page state
+
+Revision ID: 20260522_0003
+Revises: 20260515_0002
+Create Date: 2026-05-22
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260522_0003"
+down_revision = "20260515_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "show_pages",
+        sa.Column("session_id", sa.String(), primary_key=True),
+        sa.Column("visibility", sa.String(), nullable=False),
+        sa.Column("share_id", sa.String(), nullable=True),
+        sa.Column("offline_at", sa.String(), nullable=True),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.UniqueConstraint("share_id", name="uq_show_pages_share_id"),
+    )
+    op.create_index("ix_show_pages_share_id", "show_pages", ["share_id"])
+    op.create_index("ix_show_pages_visibility", "show_pages", ["visibility"])
+
+
+def downgrade() -> None:
+    op.drop_table("show_pages")

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -18,7 +18,7 @@ INITIAL_TABLES = {
     "agent_sessions",
     "runtime_records",
 }
-HEAD_TABLES = INITIAL_TABLES | {"background_tasks", "background_runs"}
+HEAD_TABLES = INITIAL_TABLES | {"background_tasks", "background_runs", "show_pages"}
 HEAD_REQUIRED_COLUMNS = {
     "background_tasks": {"deleted_at"},
 }

--- a/storage/models.py
+++ b/storage/models.py
@@ -187,7 +187,22 @@ background_runs = Table(
     Index("ix_background_runs_session_created", "session_id", "created_at"),
 )
 
+show_pages = Table(
+    "show_pages",
+    metadata,
+    Column("session_id", String, primary_key=True),
+    Column("visibility", String, nullable=False),
+    Column("share_id", String, nullable=True),
+    Column("offline_at", String, nullable=True),
+    Column("created_at", String, nullable=False),
+    Column("updated_at", String, nullable=False),
+    UniqueConstraint("share_id", name="uq_show_pages_share_id"),
+    Index("ix_show_pages_share_id", "share_id"),
+    Index("ix_show_pages_visibility", "visibility"),
+)
+
 imported_state_tables = [
+    show_pages,
     background_runs,
     background_tasks,
     scope_settings,

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -80,6 +80,7 @@ def _full_config_payload() -> dict:
         "include_time_info": True,
         "include_user_info": True,
         "reply_enhancements": True,
+        "show_pages_prompt": True,
         "language": "en",
     }
 
@@ -172,6 +173,28 @@ def test_config_load_defaults_missing_audio_asr_to_enabled():
 
     assert created.audio_asr.enabled is True
     assert created.audio_asr.enabled_configured is False
+
+
+def test_save_config_preserves_show_pages_prompt_toggle(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    created = api.save_config(_full_config_payload())
+    assert created.show_pages_prompt is True
+
+    updated = api.save_config({"show_pages_prompt": False})
+    payload = api.config_to_payload(updated)
+
+    assert updated.show_pages_prompt is False
+    assert payload["show_pages_prompt"] is False
+
+
+def test_config_load_defaults_missing_show_pages_prompt_to_enabled():
+    payload = _full_config_payload()
+    payload.pop("show_pages_prompt")
+
+    created = V2Config.from_payload(payload)
+
+    assert created.show_pages_prompt is True
 
 
 def test_config_load_preserves_pre_upgrade_audio_asr_false_as_opt_out():

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -47,7 +47,7 @@ class _Sessions:
 
     @staticmethod
     def ensure_agent_session_id(settings_key, agent_name, base_session_id):
-        return None
+        return "sesk8m4q2p7x"
 
 
 class _SettingsManager:
@@ -234,6 +234,37 @@ def test_session_handler_ensures_agent_session_id_before_prompt(
     assert "Current session id: `sesk8m4q2p7x`" in prompt
     assert "--session-id sesk8m4q2p7x" in prompt
     assert "--session-key" not in prompt
+
+
+def test_session_handler_omits_show_pages_prompt_when_disabled(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    controller.config.show_pages_prompt = False
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    prompt_value = captured["options"].system_prompt
+    prompt = prompt_value["append"] if isinstance(prompt_value, dict) else prompt_value
+    assert captured["connected"] is True
+    assert "# Vibe Remote" in prompt
+    assert "Current session id: `sesk8m4q2p7x`" in prompt
+    assert "## Show Pages" not in prompt
+    assert "vibe show path" not in prompt
 
 
 def test_session_handler_recreates_cached_claude_client_when_prompt_changes(
@@ -536,6 +567,10 @@ def test_session_handler_surfaces_claude_missing_resume_session(monkeypatch, tmp
         def get_agent_session_id(settings_key, base_session_id, agent_name):
             return None
 
+        @staticmethod
+        def ensure_agent_session_id(settings_key, agent_name, base_session_id):
+            return "sesk8m4q2p7x"
+
     class _StubClaudeSDKClient:
         def __init__(self, options):
             captured["options"] = options
@@ -575,6 +610,10 @@ def test_session_handler_uses_scheduled_turn_source_for_dm_anchor(monkeypatch, t
         @staticmethod
         def get_agent_session_id(settings_key, base_session_id, agent_name):
             return None
+
+        @staticmethod
+        def ensure_agent_session_id(settings_key, agent_name, base_session_id):
+            return "sesk8m4q2p7x"
 
     class _ScheduledSettingsManager:
         def __init__(self) -> None:

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -861,7 +861,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(params["approvalPolicy"], "never")
         self.assertEqual(params["sandbox"], "danger-full-access")
         self.assertIn("# Vibe Remote", params["developerInstructions"])
-        self.assertNotIn("## 2. Quick-reply buttons", params["developerInstructions"])
+        self.assertNotIn("## Quick-reply buttons", params["developerInstructions"])
         self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
         agent.sessions.ensure_agent_session_id.assert_called_once_with("channel-1", "codex", "session-1")
         agent.sessions.bind_agent_session.assert_called_once_with("channel-1", "codex", "session-1", "thread-1")
@@ -912,7 +912,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Focus on regressions.", params["developerInstructions"])
         self.assertIn("# Vibe Remote", params["developerInstructions"])
         self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
-        self.assertNotIn("## 2. Quick-reply buttons", params["developerInstructions"])
+        self.assertNotIn("## Quick-reply buttons", params["developerInstructions"])
 
     async def test_start_thread_adds_codex_generated_image_prompt_to_thread_instructions(self):
         agent = object.__new__(CodexAgent)
@@ -944,11 +944,48 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             await agent._start_thread(transport, request)
 
         params = transport.send_request.await_args.args[1]
-        self.assertIn("## 1. Send files", params["developerInstructions"])
+        self.assertIn("## Send files", params["developerInstructions"])
         self.assertIn("### Codex-generated images", params["developerInstructions"])
         self.assertIn("If you generate an image with Codex", params["developerInstructions"])
         self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
         self.assertIn("file:///Users/test/.codex/generated_images/thread-id/image-file.png", params["developerInstructions"])
+
+    async def test_start_thread_omits_show_pages_prompt_when_disabled(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(
+            config=SimpleNamespace(platform="slack", reply_enhancements=True, show_pages_prompt=False)
+        )
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent.sessions = SimpleNamespace(
+            ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"),
+            bind_agent_session=Mock(return_value="sesk8m4q2p7x"),
+        )
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="slack",
+                platform_specific={},
+                user_id="U1",
+                channel_id="C1",
+                thread_id=None,
+            ),
+            base_session_id="session-1",
+            session_key="channel-1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-1"}}))
+
+        await agent._start_thread(transport, request)
+
+        params = transport.send_request.await_args.args[1]
+        self.assertIn("# Vibe Remote", params["developerInstructions"])
+        self.assertIn("## Quick-reply buttons", params["developerInstructions"])
+        self.assertIn("Current session id: `sesk8m4q2p7x`", params["developerInstructions"])
+        self.assertNotIn("## Show Pages", params["developerInstructions"])
+        self.assertNotIn("vibe show path", params["developerInstructions"])
 
     async def test_resume_thread_refreshes_developer_instructions_without_appending(self):
         agent = object.__new__(CodexAgent)
@@ -1253,7 +1290,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("developerInstructions", params)
         self.assertIn("# Vibe Remote", params["developerInstructions"])
         self.assertIn("If you generate an image with Codex", params["developerInstructions"])
-        self.assertNotIn("## 2. Quick-reply buttons", params["developerInstructions"])
+        self.assertNotIn("## Quick-reply buttons", params["developerInstructions"])
 
     def test_build_input_does_not_add_codex_generated_image_prompt_to_each_turn(self):
         agent = object.__new__(CodexAgent)

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -84,11 +84,11 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             "If the user asks you to configure, repair, or operate Vibe Remote itself, read `https://github.com/cyhhao/vibe-remote/raw/master/skills/use-vibe-remote/SKILL.md` before making changes.",
             prompt,
         )
-        self.assertIn("## 1. Send files", prompt)
+        self.assertIn("## Send files", prompt)
         self.assertIn("Vibe Remote provides optional capabilities:", prompt)
         self.assertNotIn("If you generate an image with Codex", prompt)
-        self.assertNotIn("## 2. Quick-reply buttons", prompt)
-        self.assertIn("## 4. User Context and Preferences", prompt)
+        self.assertNotIn("## Quick-reply buttons", prompt)
+        self.assertIn("## User Context and Preferences", prompt)
         self.assertIn("`/tmp/user_preferences.md`", prompt)
         self.assertIn("Use the current platform `<platform>`", prompt)
         self.assertIn("`<platform>/<user_id>`", prompt)
@@ -108,6 +108,25 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("file:///Users/test/.codex/generated_images/thread-id/image-file.png", prompt)
         self.assertIn("Never emit variables, placeholder paths, or sandbox paths like `/mnt/data/...`", prompt)
 
+    def test_prompt_can_exclude_show_pages(self):
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={"agent_session_id": "sesk8m4q2p7x"},
+        )
+
+        with patch.object(paths, "get_user_preferences_path", return_value=Path("/tmp/user_preferences.md")):
+            prompt = build_system_prompt_injection(
+                include_show_pages=False,
+                include_quick_replies=False,
+                context=context,
+            )
+
+        self.assertNotIn("## Show Pages", prompt)
+        self.assertIn("## Scheduled tasks, watches, and hooks", prompt)
+        self.assertIn("Current session id: `sesk8m4q2p7x`", prompt)
+
     def test_prompt_can_exclude_user_preferences(self):
         context = MessageContext(
             user_id="U1",
@@ -124,7 +143,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertIn("Current session id: `sesk8m4q2p7x`", prompt)
-        self.assertNotIn("## 4. User Context and Preferences", prompt)
+        self.assertNotIn("## User Context and Preferences", prompt)
         self.assertNotIn("/tmp/user_preferences.md", prompt)
         self.assertNotIn("slack/U1", prompt)
 
@@ -199,7 +218,11 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         with patch.object(paths, "get_user_preferences_path", return_value=Path("/tmp/user_preferences.md")):
             prompt = build_system_prompt_injection(include_quick_replies=True, context=context)
 
-        self.assertIn("## 3. Scheduled tasks, watches, and hooks", prompt)
+        self.assertIn("## Show Pages", prompt)
+        self.assertIn("`vibe show path --session-id sesk8m4q2p7x`", prompt)
+        self.assertIn("Make the page work reasonably on mobile", prompt)
+        self.assertIn("Excalidraw-style static SVG/PNG diagrams", prompt)
+        self.assertIn("## Scheduled tasks, watches, and hooks", prompt)
         self.assertIn("`vibe task add`", prompt)
         self.assertIn("`vibe hook send --session-id ... --prompt ...`", prompt)
         self.assertIn("`vibe watch add`", prompt)

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -1,0 +1,137 @@
+import json
+
+from config import paths
+from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
+from core.show_pages import ShowPageError, ShowPageStore, ensure_show_page_dir
+from vibe import cli
+
+
+def _save_config() -> V2Config:
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack"], primary="slack"),
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        ui=UiConfig(),
+        remote_access=RemoteAccessConfig(),
+    )
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.public_url = "https://alex.avibe.bot"
+    config.save()
+    return config
+
+
+def test_store_defaults_to_private_and_rotates_public_share(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+
+    store = ShowPageStore()
+    try:
+        page = store.ensure("ses123")
+        assert page.visibility == "private"
+        assert page.share_id is None
+
+        public_page = store.update_visibility("ses123", "public")
+        assert public_page.visibility == "public"
+        assert public_page.share_id
+
+        rotated, old_share_id = store.rotate_share("ses123")
+        assert old_share_id == public_page.share_id
+        assert rotated.share_id != old_share_id
+        assert store.get_by_share_id(old_share_id) is None
+        assert store.get_by_share_id(rotated.share_id).session_id == "ses123"
+
+        private_page = store.update_visibility("ses123", "private")
+        assert private_page.visibility == "private"
+        assert private_page.share_id == rotated.share_id
+
+        offline_page = store.update_visibility("ses123", "offline")
+        assert offline_page.offline
+        assert offline_page.offline_at is not None
+    finally:
+        store.close()
+
+
+def test_rotate_share_requires_public(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+
+    store = ShowPageStore()
+    try:
+        store.ensure("ses123")
+        try:
+            store.rotate_share("ses123")
+        except ShowPageError as exc:
+            assert exc.code == "not_public"
+        else:
+            raise AssertionError("rotate_share should fail while private")
+    finally:
+        store.close()
+
+
+def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    page_dir = ensure_show_page_dir("ses123")
+
+    index_path = page_dir / "index.html"
+    assert page_dir == tmp_path / "show" / "ses123"
+    assert index_path.exists()
+    assert "Ready to visualize" in index_path.read_text(encoding="utf-8")
+
+
+def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+
+    args = cli.build_parser().parse_args(["show", "path", "--session-id", "ses123", "--json"])
+    assert cli.cmd_show_path(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["visibility"] == "private"
+    assert payload["active_url"] == "https://alex.avibe.bot/show/ses123/"
+    assert payload["private_url"] == "https://alex.avibe.bot/show/ses123/"
+    assert payload["public_url"] is None
+    assert (tmp_path / "show" / "ses123" / "index.html").exists()
+
+
+def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+
+    parser = cli.build_parser()
+    assert cli.cmd_show_path(parser.parse_args(["show", "path", "--session-id", "ses123", "--json"])) == 0
+    capsys.readouterr()
+
+    args = parser.parse_args(["show", "update", "--session-id", "ses123", "--visibility", "public", "--json"])
+    assert cli.cmd_show_update(args) == 0
+    public_payload = json.loads(capsys.readouterr().out)
+    assert public_payload["visibility"] == "public"
+    assert public_payload["active_url"] == public_payload["public_url"]
+    assert public_payload["public_url"].startswith("https://alex.avibe.bot/p/")
+    assert public_payload["previous_private_url"] == "https://alex.avibe.bot/show/ses123/"
+
+    args = parser.parse_args(["show", "update", "--session-id", "ses123", "--visibility", "private", "--json"])
+    assert cli.cmd_show_update(args) == 0
+    private_payload = json.loads(capsys.readouterr().out)
+    assert private_payload["visibility"] == "private"
+    assert private_payload["active_url"] == "https://alex.avibe.bot/show/ses123/"
+    assert private_payload["previous_public_url"] == public_payload["public_url"]
+
+
+def test_show_update_rotate_share_fails_while_private(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+
+    parser = cli.build_parser()
+    args = parser.parse_args(["show", "update", "--session-id", "ses123", "--rotate-share", "--json"])
+    assert cli.cmd_show_update(args) == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["code"] == "not_public"

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -41,7 +41,7 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         }
         assert "deleted_at" in background_columns
         version = conn.execute("select version_num from alembic_version").fetchone()
-        assert version == ("20260515_0002",)
+        assert version == ("20260522_0003",)
 
 
 def test_initial_migration_is_schema_snapshot() -> None:
@@ -79,7 +79,7 @@ def test_run_migrations_stamps_existing_initial_schema(tmp_path: Path) -> None:
 
     with sqlite3.connect(db_path) as conn:
         version = conn.execute("select version_num from alembic_version").fetchone()
-    assert version == ("20260515_0002",)
+    assert version == ("20260522_0003",)
 
 
 def test_run_migrations_stamps_existing_initial_schema_with_empty_version_table(tmp_path: Path) -> None:
@@ -99,7 +99,7 @@ def test_run_migrations_stamps_existing_initial_schema_with_empty_version_table(
 
     with sqlite3.connect(db_path) as conn:
         version = conn.execute("select version_num from alembic_version").fetchone()
-    assert version == ("20260515_0002",)
+    assert version == ("20260522_0003",)
 
 
 def test_run_migrations_repairs_head_columns_before_stamping_head(tmp_path: Path) -> None:
@@ -139,7 +139,7 @@ def test_run_migrations_repairs_head_columns_before_stamping_head(tmp_path: Path
     with sqlite3.connect(db_path) as conn:
         version = conn.execute("select version_num from alembic_version").fetchone()
         background_columns = {row[1] for row in conn.execute("pragma table_info(background_tasks)")}
-    assert version == ("20260515_0002",)
+    assert version == ("20260522_0003",)
     assert "deleted_at" in background_columns
     assert background_tables_ready(db_path) is True
 

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1,0 +1,148 @@
+from config import paths
+from core.show_pages import ShowPageStore, ensure_show_page_dir
+from tests.test_ui_remote_access_auth import _remote_peer, _save_config
+from vibe.ui_server import app
+
+
+def _create_show_page(session_id: str, visibility: str) -> str | None:
+    page_dir = ensure_show_page_dir(session_id)
+    (page_dir / "index.html").write_text("<!doctype html><title>Show</title><h1>Show Page</h1>", encoding="utf-8")
+    (page_dir / "app.js").write_text("window.showPage = true;", encoding="utf-8")
+    store = ShowPageStore()
+    try:
+        page = store.update_visibility(session_id, visibility)
+        return page.share_id
+    finally:
+        store.close()
+
+
+def test_private_show_page_requires_remote_login(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+
+    response = app.test_client().get(
+        "/show/ses123/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].startswith("https://backend.test/oauth/authorize?")
+
+
+def test_private_show_page_serves_locally(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+
+    response = app.test_client().get("/show/ses123/", base_url="http://127.0.0.1:5123")
+
+    assert response.status_code == 200
+    assert b"Show Page" in response.content
+
+
+def test_public_show_page_skips_remote_login_but_requires_public_host(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+
+    response = app.test_client().get(
+        f"/p/{share_id}/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert b"Show Page" in response.content
+
+    mismatch = app.test_client().get(
+        f"/p/{share_id}/",
+        base_url="https://evil.example",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert mismatch.status_code == 503
+    assert mismatch.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_public_and_private_paths_are_canonical_by_visibility(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+
+    private_response = app.test_client().get("/show/ses123/", base_url="http://127.0.0.1:5123")
+    assert private_response.status_code == 404
+
+    store = ShowPageStore()
+    try:
+        store.update_visibility("ses123", "private")
+    finally:
+        store.close()
+
+    public_response = app.test_client().get(f"/p/{share_id}/", base_url="http://127.0.0.1:5123")
+    assert public_response.status_code == 404
+
+
+def test_rotated_public_share_url_stops_working(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    old_share_id = _create_show_page("ses123", "public")
+
+    store = ShowPageStore()
+    try:
+        page, _ = store.rotate_share("ses123")
+    finally:
+        store.close()
+
+    old_response = app.test_client().get(f"/p/{old_share_id}/", base_url="http://127.0.0.1:5123")
+    new_response = app.test_client().get(f"/p/{page.share_id}/", base_url="http://127.0.0.1:5123")
+
+    assert old_response.status_code == 404
+    assert new_response.status_code == 200
+
+
+def test_offline_show_page_returns_explanatory_page(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+
+    store = ShowPageStore()
+    try:
+        store.update_visibility("ses123", "offline")
+    finally:
+        store.close()
+
+    response = app.test_client().get(f"/p/{share_id}/", base_url="http://127.0.0.1:5123")
+
+    assert response.status_code == 401
+    assert b"offline" in response.content
+    assert b"deleted" not in response.content.lower()
+
+
+def test_show_page_rejects_path_traversal(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    (tmp_path / "secret.txt").write_text("secret", encoding="utf-8")
+
+    response = app.test_client().get(f"/p/{share_id}/../secret.txt", base_url="http://127.0.0.1:5123")
+
+    assert response.status_code == 404
+    assert b"secret" not in response.content
+
+
+def test_show_page_serves_assets_with_strict_headers(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+
+    response = app.test_client().get(f"/p/{share_id}/app.js", base_url="http://127.0.0.1:5123")
+
+    assert response.status_code == 200
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["Referrer-Policy"] == "no-referrer"
+    assert b"window.showPage" in response.content

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -26,6 +26,7 @@ const SAVE_KEYS = [
   'include_time_info',
   'include_user_info',
   'reply_enhancements',
+  'show_pages_prompt',
   'audio_asr',
   'slack',
   'discord',
@@ -324,6 +325,21 @@ export const SettingsMessagingPage: React.FC = () => {
               enabled={config.reply_enhancements !== false}
               onClick={() =>
                 void persist({ ...config, reply_enhancements: !config.reply_enhancements })
+              }
+            />
+          }
+        />
+        <SettingsRow
+          title={t('dashboard.showPagesPrompt')}
+          description={t('dashboard.showPagesPromptHint')}
+          control={
+            <ToggleSwitch
+              enabled={config.show_pages_prompt !== false}
+              onClick={() =>
+                void persist({
+                  ...config,
+                  show_pages_prompt: !(config.show_pages_prompt !== false),
+                })
               }
             />
           }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -950,6 +950,8 @@
     "includeUserInfoHint": "Prepend [username<user_id>] to messages sent to agents",
     "replyEnhancements": "Quick-reply Buttons",
     "replyEnhancementsHint": "Allow agents to add clickable quick-reply buttons at the end of result messages",
+    "showPagesPrompt": "Show Page Guidance",
+    "showPagesPromptHint": "Tell agents when and how to use visual Show Pages. The vibe show CLI remains available when this is off.",
     "slackLinkPreviews": "Suppress Slack Link Previews",
     "slackLinkPreviewsHint": "Disable Slack URL and media preview cards for messages sent by Vibe Remote",
     "allowedChannels": "Allowed Groups",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -950,6 +950,8 @@
     "includeUserInfoHint": "在发给 Agent 的消息前添加 [用户名<用户ID>]",
     "replyEnhancements": "快捷回复按钮",
     "replyEnhancementsHint": "允许 Agent 在结果消息末尾添加可点击的快捷回复按钮",
+    "showPagesPrompt": "Show Page 引导",
+    "showPagesPromptHint": "提示 Agent 何时以及如何使用可视化 Show Page。关闭后 vibe show CLI 仍然可用。",
     "slackLinkPreviews": "关闭 Slack 链接预览",
     "slackLinkPreviewsHint": "关闭 Vibe Remote 发送到 Slack 的 URL 和媒体预览卡片",
     "allowedChannels": "允许的群组",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -646,6 +646,7 @@ def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dic
         "include_time_info": config.include_time_info,
         "include_user_info": config.include_user_info,
         "reply_enhancements": config.reply_enhancements,
+        "show_pages_prompt": config.show_pages_prompt,
     }
     return payload
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -366,6 +366,80 @@ def _remote_pair_examples_text() -> str:
     )
 
 
+def _show_examples_text() -> str:
+    return dedent(
+        """\
+        A Show Page is one session-scoped visual page that Vibe Remote serves through the Web UI / Vibe Cloud tunnel.
+        One Agent Session has exactly one Show Page.
+
+        Commands:
+          path     Create or resolve the local workspace.
+          status   Inspect local path, visibility, active URL, and share state.
+          update   Switch visibility, rotate public share links, or take the page offline.
+
+        Visibility:
+          private  Authenticated Web UI URL under /show/<session-id>/.
+          public   Short unauthenticated share URL under /p/<share-id>/.
+          offline  URL access is revoked; local files remain.
+
+        Examples:
+          vibe show path --session-id sesk8m4q2p7x
+          vibe show status --session-id sesk8m4q2p7x --json
+          vibe show update --session-id sesk8m4q2p7x --visibility public
+          vibe show update --session-id sesk8m4q2p7x --rotate-share
+          vibe show update --session-id sesk8m4q2p7x --visibility offline
+        """
+    )
+
+
+def _show_path_examples_text() -> str:
+    return dedent(
+        """\
+        Returns the directory where the agent should write index.html and related static assets.
+        The directory is created if needed. On first creation, Vibe Remote writes a default index.html.
+
+        First-run workflow:
+          1. Run: vibe show path --session-id sesk8m4q2p7x
+          2. Write or update index.html in the returned path.
+          3. Share the active URL if the command output includes one.
+          4. Run `vibe show update --visibility public` only when the user asks for a shareable public link.
+        """
+    )
+
+
+def _show_status_examples_text() -> str:
+    return dedent(
+        """\
+        Shows the current Show Page state without creating a new page.
+
+        Fields include:
+          path, visibility, active_url, private_url, public_url, share_id, offline, created_at, updated_at.
+
+        Use --json when another program or agent will consume the result.
+        """
+    )
+
+
+def _show_update_examples_text() -> str:
+    return dedent(
+        """\
+        Change the current Show Page state.
+
+        Examples:
+          vibe show update --session-id sesk8m4q2p7x --visibility public
+          vibe show update --session-id sesk8m4q2p7x --visibility private
+          vibe show update --session-id sesk8m4q2p7x --visibility offline
+          vibe show update --session-id sesk8m4q2p7x --rotate-share
+
+        Notes:
+          private uses the authenticated /show/<session-id>/ URL.
+          public uses a short /p/<share-id>/ URL and disables the private path.
+          offline takes the page down without deleting local files.
+          --rotate-share is allowed only while the page is public.
+        """
+    )
+
+
 def _print_json(payload: dict) -> None:
     print(json.dumps(payload, indent=2))
 
@@ -2560,6 +2634,182 @@ def cmd_remote_stop(args):
     return 0 if result.get("ok") else 1
 
 
+def _show_page_result(page, *, message: str, previous_payload: dict | None = None, extra: dict | None = None) -> dict:
+    from core.show_pages import show_page_payload
+
+    payload = {
+        "ok": True,
+        **show_page_payload(page),
+        "message": message,
+    }
+    if previous_payload:
+        payload.update(previous_payload)
+    if extra:
+        payload.update(extra)
+    payload["next_actions"] = _show_page_next_actions(payload)
+    return payload
+
+
+def _show_page_next_actions(payload: dict) -> list[str]:
+    session_id = payload.get("session_id") or "<session-id>"
+    visibility = payload.get("visibility")
+    actions = ["Write index.html and assets into the returned path."]
+    if visibility == "private":
+        actions.append(
+            f"Run `vibe show update --session-id {session_id} --visibility public` when the user asks for a shareable link."
+        )
+    elif visibility == "public":
+        actions.append(f"Run `vibe show update --session-id {session_id} --rotate-share` to revoke and replace this public link.")
+        actions.append(f"Run `vibe show update --session-id {session_id} --visibility private` to return to authenticated access.")
+    elif visibility == "offline":
+        actions.append(f"Run `vibe show update --session-id {session_id} --visibility private` to bring the page back online privately.")
+    return actions
+
+
+def _print_show_page_result(payload: dict) -> None:
+    print("Show Page:")
+    print(f"  Session: {payload.get('session_id')}")
+    print(f"  Visibility: {payload.get('visibility')}")
+    print(f"  Path: {payload.get('path')}")
+    active_url = payload.get("active_url")
+    if active_url:
+        print(f"  Active URL: {active_url}")
+    else:
+        print("  Active URL: none")
+    if payload.get("private_url"):
+        print(f"  Private URL: {payload.get('private_url')}")
+    if payload.get("public_url"):
+        print(f"  Public URL: {payload.get('public_url')}")
+    if payload.get("previous_private_url"):
+        print(f"  Previous private URL: {payload.get('previous_private_url')} (inactive)")
+    if payload.get("previous_public_url"):
+        print(f"  Previous public URL: {payload.get('previous_public_url')} (inactive)")
+    if payload.get("previous_active_url"):
+        print(f"  Previous active URL: {payload.get('previous_active_url')} (inactive)")
+    if payload.get("share_id"):
+        print(f"  Share ID: {payload.get('share_id')}")
+    if payload.get("message"):
+        print(f"  Message: {payload.get('message')}")
+    next_actions = payload.get("next_actions") or []
+    if next_actions:
+        print("")
+        print("Next:")
+        for action in next_actions:
+            print(f"  - {action}")
+
+
+def _print_show_page_error(exc: Exception) -> None:
+    code = getattr(exc, "code", "show_page_failed")
+    payload = {
+        "ok": False,
+        "code": code,
+        "error": str(exc),
+        "help_command": "vibe show --help",
+    }
+    print(json.dumps(payload, indent=2), file=sys.stderr)
+
+
+def _load_show_page_store():
+    from core.show_pages import ShowPageStore
+
+    return ShowPageStore()
+
+
+def cmd_show_path(args):
+    from core.show_pages import ensure_show_page_dir
+
+    store = _load_show_page_store()
+    try:
+        page = store.ensure(args.session_id)
+        page_dir = ensure_show_page_dir(args.session_id)
+        payload = _show_page_result(page, message=f"Show Page workspace is ready at {page_dir}.")
+        if getattr(args, "json", False):
+            _print_json(payload)
+        else:
+            _print_show_page_result(payload)
+        return 0
+    except Exception as exc:
+        _print_show_page_error(exc)
+        return 1
+    finally:
+        store.close()
+
+
+def cmd_show_status(args):
+    store = _load_show_page_store()
+    try:
+        page = store.get(args.session_id)
+        if page is None:
+            payload = {
+                "ok": False,
+                "code": "show_page_not_found",
+                "session_id": args.session_id,
+                "message": "No Show Page exists for this session.",
+                "next_actions": [f"Run `vibe show path --session-id {args.session_id}` to create the workspace."],
+            }
+            if getattr(args, "json", False):
+                _print_json(payload)
+            else:
+                print("No Show Page exists for this session.")
+                print(f"Run: vibe show path --session-id {args.session_id}")
+            return 1
+        payload = _show_page_result(page, message=f"Show Page is {page.visibility}.")
+        if getattr(args, "json", False):
+            _print_json(payload)
+        else:
+            _print_show_page_result(payload)
+        return 0
+    except Exception as exc:
+        _print_show_page_error(exc)
+        return 1
+    finally:
+        store.close()
+
+
+def cmd_show_update(args):
+    from core.show_pages import public_url, show_page_payload
+
+    store = _load_show_page_store()
+    try:
+        existing = store.ensure(args.session_id)
+        previous = show_page_payload(existing)
+        previous_active_url = previous.get("active_url")
+        previous_public_url = previous.get("public_url")
+        previous_private_url = previous.get("private_url")
+        extra: dict = {}
+
+        if getattr(args, "rotate_share", False):
+            updated, previous_share_id = store.rotate_share(args.session_id)
+            extra = {
+                "previous_public_url": public_url(previous_share_id),
+                "previous_share_id": previous_share_id,
+                "message_detail": "Previous public share URL was revoked.",
+            }
+            message = "Public share link rotated."
+        else:
+            updated = store.update_visibility(args.session_id, args.visibility)
+            message = f"Show Page is now {updated.visibility}."
+            if existing.visibility == "private" and updated.visibility == "public":
+                extra["previous_private_url"] = previous_private_url
+            elif existing.visibility == "public" and updated.visibility == "private":
+                extra["previous_public_url"] = previous_public_url
+            elif updated.visibility == "offline":
+                extra["previous_active_url"] = previous_active_url
+                message = "Show Page has been taken offline. Local files were not deleted."
+
+        payload = _show_page_result(updated, message=message, extra=extra)
+        if getattr(args, "json", False):
+            _print_json(payload)
+        else:
+            _print_show_page_result(payload)
+        return 0
+    except Exception as exc:
+        _print_show_page_error(exc)
+        return 1
+    finally:
+        store.close()
+
+
 def cmd_doctor():
     result = _doctor()
 
@@ -2852,6 +3102,68 @@ def build_parser():
         action="store_true",
         help="Print a machine-readable result with the output path and capture backend.",
     )
+
+    show_parser = subparsers.add_parser(
+        "show",
+        help="Create, inspect, and publish session Show Pages",
+        description=(
+            "Manage the one visual Show Page attached to an Agent Session. "
+            "Use it when an agent needs a web page for diagrams, reports, dashboards, or visual explanations."
+        ),
+        epilog=_show_examples_text(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        error_help_command="vibe show --help",
+        error_hint="Run one of the show subcommands below. Start with: vibe show path --session-id <session-id>",
+    )
+    show_subparsers = show_parser.add_subparsers(dest="show_command", metavar="{path,status,update}")
+    show_subparsers.required = True
+
+    show_path_parser = show_subparsers.add_parser(
+        "path",
+        help="Create or resolve this session's Show Page directory",
+        description="Create or resolve the local workspace for one session Show Page.",
+        epilog=_show_path_examples_text(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        error_help_command="vibe show path --help",
+        error_hint="Pass the current Agent Session ID explicitly.",
+    )
+    show_path_parser.add_argument("--session-id", required=True, help="Agent Session ID for the Show Page.")
+    show_path_parser.add_argument("--json", action="store_true", help="Print machine-readable state.")
+
+    show_status_parser = show_subparsers.add_parser(
+        "status",
+        help="Show this session's Show Page state",
+        description="Inspect one Show Page without creating it.",
+        epilog=_show_status_examples_text(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        error_help_command="vibe show status --help",
+        error_hint="Pass the current Agent Session ID explicitly.",
+    )
+    show_status_parser.add_argument("--session-id", required=True, help="Agent Session ID for the Show Page.")
+    show_status_parser.add_argument("--json", action="store_true", help="Print machine-readable state.")
+
+    show_update_parser = show_subparsers.add_parser(
+        "update",
+        help="Update visibility or rotate the public share link",
+        description="Switch a Show Page between private, public, and offline states, or rotate its public share link.",
+        epilog=_show_update_examples_text(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        error_help_command="vibe show update --help",
+        error_hint="Pass --visibility private|public|offline or --rotate-share.",
+    )
+    show_update_parser.add_argument("--session-id", required=True, help="Agent Session ID for the Show Page.")
+    show_update_action = show_update_parser.add_mutually_exclusive_group(required=True)
+    show_update_action.add_argument(
+        "--visibility",
+        choices=("private", "public", "offline"),
+        help="Set the active Show Page visibility.",
+    )
+    show_update_action.add_argument(
+        "--rotate-share",
+        action="store_true",
+        help="Revoke the current public URL and create a new one. Allowed only while public.",
+    )
+    show_update_parser.add_argument("--json", action="store_true", help="Print machine-readable state.")
 
     task_parser = subparsers.add_parser(
         "task",
@@ -3286,6 +3598,14 @@ def main():
         sys.exit(cmd_doctor())
     if args.command == "screenshot":
         sys.exit(cmd_screenshot(args))
+    if args.command == "show":
+        if args.show_command == "path":
+            sys.exit(cmd_show_path(args))
+        if args.show_command == "status":
+            sys.exit(cmd_show_status(args))
+        if args.show_command == "update":
+            sys.exit(cmd_show_update(args))
+        parser.error("show command is required")
     if args.command == "version":
         sys.exit(cmd_version())
     if args.command == "check-update":

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -827,6 +827,7 @@ def _remote_auth_exempt_path() -> bool:
         or path == "/api/session"
         or path == "/api/csrf-token"
         or path.startswith("/assets/")
+        or path.startswith("/p/")
         or path == "/favicon.ico"
     )
 
@@ -2332,6 +2333,90 @@ if os.environ.get("E2E_TEST_MODE", "").lower() in ("true", "1", "yes"):
 # =============================================================================
 # Static Files (SPA)
 # =============================================================================
+
+
+def _show_page_offline_response():
+    html = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Show Page Offline</title>
+    <style>
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; box-sizing: border-box; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f7f8fb; color: #172033; }
+      main { width: min(560px, 100%); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 12px; background: white; padding: 32px; box-shadow: 0 20px 60px rgba(23, 32, 51, 0.10); }
+      h1 { margin: 0; font-size: clamp(28px, 7vw, 42px); line-height: 1.05; letter-spacing: 0; }
+      p { margin: 14px 0 0; line-height: 1.65; color: #526078; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>This Show Page is offline</h1>
+      <p>The page owner has taken this page offline. The link is no longer available.</p>
+    </main>
+  </body>
+</html>
+"""
+    return Response(html, status=401, mimetype="text/html; charset=utf-8")
+
+
+def _show_page_not_found_response():
+    return jsonify({"error": "not_found"}), 404
+
+
+def _show_page_file_response(root: Path, asset_path: str):
+    relative = (asset_path or "").strip("/")
+    if not relative:
+        relative = "index.html"
+    candidate = (root / unquote(relative)).resolve()
+    root_resolved = root.resolve()
+    if candidate != root_resolved and root_resolved not in candidate.parents:
+        return jsonify({"error": "not_found"}), 404
+    if not candidate.exists() or not candidate.is_file():
+        return _show_page_not_found_response()
+    mime_type, _ = mimetypes.guess_type(str(candidate))
+    response = send_file(candidate, mimetype=mime_type or "application/octet-stream")
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
+@app.route("/show/<session_id>/", defaults={"asset_path": ""})
+@app.route("/show/<session_id>/<path:asset_path>")
+def serve_private_show_page(session_id, asset_path):
+    from core.show_pages import ShowPageStore, show_page_dir
+
+    store = ShowPageStore()
+    try:
+        page = store.get(session_id)
+        if page is None:
+            return _show_page_not_found_response()
+        if page.visibility == "offline":
+            return _show_page_offline_response()
+        if page.visibility != "private":
+            return _show_page_not_found_response()
+        return _show_page_file_response(show_page_dir(page.session_id), asset_path)
+    finally:
+        store.close()
+
+
+@app.route("/p/<share_id>/", defaults={"asset_path": ""})
+@app.route("/p/<share_id>/<path:asset_path>")
+def serve_public_show_page(share_id, asset_path):
+    from core.show_pages import ShowPageStore, show_page_dir
+
+    store = ShowPageStore()
+    try:
+        page = store.get_by_share_id(share_id)
+        if page is None:
+            return _show_page_not_found_response()
+        if page.visibility == "offline":
+            return _show_page_offline_response()
+        if page.visibility != "public":
+            return _show_page_not_found_response()
+        return _show_page_file_response(show_page_dir(page.session_id), asset_path)
+    finally:
+        store.close()
 
 
 @app.route("/", defaults={"path": ""})


### PR DESCRIPTION
## Summary

Adds session-scoped Show Pages as a first-class visual presentation surface for Vibe Remote agents.

## What changed

- Add local Show Page state, storage migration, path helpers, and default `index.html` scaffolding.
- Add `vibe show path`, `vibe show status`, and `vibe show update` for private/public/offline transitions and share-link rotation.
- Serve private pages under `/show/<session-id>/` behind existing Web UI auth, and public pages under short `/p/<share-id>/` links with a narrow auth bypass.
- Add Show Pages guidance to the shared agent prompt, remove ordinal capability headings, and add a Messaging settings toggle that disables only the prompt injection.
- Document the product model, V1 scope, and future hot-reload direction in `docs/plans/show-page.md`.

## Validation

- `uv run ruff check ...`
- `uv run pytest tests/test_api_save_config_merge.py tests/test_reply_enhancer_platform.py tests/test_codex_agent.py tests/test_claude_cli_path.py tests/test_show_pages.py tests/test_ui_show_pages.py -q`
- `npm run build`
- `git diff --check`

## Notes

Full `pytest -q` was attempted during implementation and still hits existing unrelated E2E / legacy test failures. The targeted Show Page, prompt, config, route, CLI, Codex, Claude, and UI checks pass.
