### PR TITLE
Fix remote OAuth browser handoff

### DIFF
--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -98,7 +98,7 @@ def _cloudflare_headers() -> dict[str, str]:
 
 def test_remote_host_redirects_to_vibe_cloud_login(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
-    _save_config(tmp_path)
+    config = _save_config(tmp_path)
 
     response = app.test_client().get(
         "/dashboard",
@@ -109,6 +109,30 @@ def test_remote_host_redirects_to_vibe_cloud_login(monkeypatch, tmp_path):
 
     assert response.status_code == 302
     assert response.headers["Location"].startswith("https://backend.test/oauth/authorize?")
+    state = httpx.URL(response.headers["Location"]).params["state"]
+    state_payload = ui_server._read_oauth_state(config.remote_access.vibe_cloud.session_secret, state)
+    assert state_payload is not None
+    assert state_payload["next"] == "/dashboard"
+    assert state_payload["retry"] is False
+
+
+def test_remote_host_strips_retry_marker_from_oauth_next(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+
+    response = app.test_client().get(
+        f"/show/ses123/?foo=bar&{ui_server.REMOTE_OAUTH_RETRY_PARAM}=1",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    state = httpx.URL(response.headers["Location"]).params["state"]
+    state_payload = ui_server._read_oauth_state(config.remote_access.vibe_cloud.session_secret, state)
+    assert state_payload is not None
+    assert state_payload["next"] == "/show/ses123/?foo=bar"
+    assert state_payload["retry"] is True
 
 
 def test_remote_host_with_explicit_port_still_requires_login(monkeypatch, tmp_path):
@@ -847,6 +871,56 @@ def test_remote_callback_rejects_when_remote_access_is_disabled(monkeypatch, tmp
     assert response.status_code == 400
     assert response.get_json()["error"] == "remote_access_disabled"
     assert exchange_calls == []
+
+
+def test_remote_callback_restarts_oauth_when_state_cookie_was_lost(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+    state = ui_server._make_oauth_state(
+        config.remote_access.vibe_cloud.session_secret,
+        next_target="/show/ses123/?tab=flow",
+    )
+    exchange_calls = []
+    monkeypatch.setattr(remote_access, "exchange_oauth_code", lambda *args, **kwargs: exchange_calls.append(args))
+
+    response = client.get(
+        f"/auth/callback?code=test-code&state={state}",
+        base_url="https://alex.avibe.bot",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == f"/show/ses123/?tab=flow&{ui_server.REMOTE_OAUTH_RETRY_PARAM}=1"
+    assert ui_server.REMOTE_OAUTH_COOKIE_NAME in response.headers["Set-Cookie"]
+    assert exchange_calls == []
+
+
+def test_remote_callback_does_not_restart_oauth_twice(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+    state = ui_server._make_oauth_state(
+        config.remote_access.vibe_cloud.session_secret,
+        next_target="/show/ses123/",
+        retry=True,
+    )
+
+    response = client.get(f"/auth/callback?code=test-code&state={state}", base_url="https://alex.avibe.bot")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_oauth_state"
+
+
+def test_remote_callback_preserves_invalid_state_response_for_legacy_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    client = app.test_client()
+
+    response = client.get("/auth/callback?code=test-code&state=state-1", base_url="https://alex.avibe.bot")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_oauth_state"
 
 
 def test_remote_callback_accepts_html_escaped_state_separator(monkeypatch, tmp_path):

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -16,7 +16,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
-from urllib.parse import quote, unquote, urlparse, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse, urlsplit, urlunsplit
 
 import psutil
 from fastapi import WebSocket, WebSocketDisconnect
@@ -44,6 +44,7 @@ TRACEBACK_EXCEPTION_PATTERN = re.compile(
 CSRF_COOKIE_NAME = "vibe_csrf_token"
 CSRF_HEADER_NAME = "X-Vibe-CSRF-Token"
 REMOTE_OAUTH_COOKIE_NAME = "__Host-vibe_remote_oauth"
+REMOTE_OAUTH_RETRY_PARAM = "__vibe_oauth_retry"
 MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 LOG_SOURCES = (
     ("service", "vibe_remote.log", lambda: paths.get_logs_dir() / "vibe_remote.log"),
@@ -863,6 +864,49 @@ def _read_oauth_cookie(secret: str, value: str | None) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}")
+
+
+def _make_oauth_state(secret: str, *, next_target: str, retry: bool = False) -> str:
+    payload = {
+        "v": 1,
+        "r": secrets.token_urlsafe(18),
+        "next": next_target,
+        "retry": bool(retry),
+        "exp": int(datetime.now().timestamp()) + 300,
+    }
+    payload_text = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signature = _b64url_encode(hmac.new(secret.encode("utf-8"), payload_text.encode("ascii"), hashlib.sha256).digest())
+    return f"vr1.{payload_text}.{signature}"
+
+
+def _read_oauth_state(secret: str, value: str | None) -> dict[str, Any] | None:
+    if not value or not value.startswith("vr1."):
+        return None
+    try:
+        _, payload_text, signature = value.split(".", 2)
+    except ValueError:
+        return None
+    expected = _b64url_encode(hmac.new(secret.encode("utf-8"), payload_text.encode("ascii"), hashlib.sha256).digest())
+    if not hmac.compare_digest(signature, expected):
+        return None
+    try:
+        payload = json.loads(_b64url_decode(payload_text).decode("utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or payload.get("v") != 1:
+        return None
+    if int(payload.get("exp", 0)) <= int(datetime.now().timestamp()):
+        return None
+    return payload
+
+
 def _safe_remote_redirect_target(value: Any) -> str:
     if not isinstance(value, str):
         return "/"
@@ -873,6 +917,23 @@ def _safe_remote_redirect_target(value: Any) -> str:
     if parsed.scheme or parsed.netloc or not parsed.path.startswith("/"):
         return "/"
     return urlunsplit(("", "", parsed.path or "/", parsed.query, ""))
+
+
+def _strip_oauth_retry_param(value: str) -> str:
+    target = _safe_remote_redirect_target(value)
+    parsed = urlsplit(target)
+    query = urlencode(
+        [(key, val) for key, val in parse_qsl(parsed.query, keep_blank_values=True) if key != REMOTE_OAUTH_RETRY_PARAM]
+    )
+    return urlunsplit(("", "", parsed.path or "/", query, ""))
+
+
+def _add_oauth_retry_param(value: str) -> str:
+    target = _strip_oauth_retry_param(value)
+    parsed = urlsplit(target)
+    params = parse_qsl(parsed.query, keep_blank_values=True)
+    params.append((REMOTE_OAUTH_RETRY_PARAM, "1"))
+    return urlunsplit(("", "", parsed.path or "/", urlencode(params), ""))
 
 
 def _oauth_callback_arg(name: str) -> str | None:
@@ -886,7 +947,13 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
     code_verifier = secrets.token_urlsafe(48)
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-    state = secrets.token_urlsafe(24)
+    raw_next = request.full_path if request.query_string else request.path
+    next_target = _strip_oauth_retry_param(raw_next)
+    state = _make_oauth_state(
+        cloud.session_secret,
+        next_target=next_target,
+        retry=request.args.get(REMOTE_OAUTH_RETRY_PARAM) == "1",
+    )
     nonce = secrets.token_urlsafe(24)
     oauth_cookie = _make_oauth_cookie(
         cloud.session_secret,
@@ -894,7 +961,7 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
             "state": state,
             "nonce": nonce,
             "code_verifier": code_verifier,
-            "next": request.full_path if request.query_string else request.path,
+            "next": next_target,
             "exp": int(datetime.now().timestamp()) + 300,
         },
     )
@@ -908,6 +975,17 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
         samesite="Lax",
         path="/",
     )
+    return response
+
+
+def _restart_vibe_cloud_login_from_state(config: V2Config, state: str | None):
+    cloud = config.remote_access.vibe_cloud
+    payload = _read_oauth_state(cloud.session_secret, state)
+    if not payload or payload.get("retry"):
+        return None
+    next_target = _safe_remote_redirect_target(payload.get("next"))
+    response = redirect(_add_oauth_retry_param(next_target))
+    response.delete_cookie(REMOTE_OAUTH_COOKIE_NAME, path="/", secure=True, samesite="Lax")
     return response
 
 
@@ -1345,6 +1423,9 @@ def remote_access_auth_callback():
         return jsonify({"error": "remote_access_disabled"}), 400
     oauth_state = _read_oauth_cookie(cloud.session_secret, request.cookies.get(REMOTE_OAUTH_COOKIE_NAME))
     if not oauth_state or oauth_state.get("state") != _oauth_callback_arg("state"):
+        retry_response = _restart_vibe_cloud_login_from_state(config, _oauth_callback_arg("state"))
+        if retry_response is not None:
+            return retry_response
         return jsonify({"error": "invalid_oauth_state"}), 400
     try:
         result = remote_access.exchange_oauth_code(config, _oauth_callback_arg("code") or "", oauth_state["code_verifier"])


### PR DESCRIPTION
## Summary

Fixes remote-access OAuth when a private Vibe Remote URL starts in an IM embedded webview and the user continues the login flow in Safari or another browser container.

## What changed

- Encode a signed, expiring recovery payload in the OAuth `state` value, carrying only the original same-origin `next` path and a retry marker.
- Keep the normal callback path strict: callback still requires the matching `__Host-vibe_remote_oauth` cookie before exchanging the code.
- If callback arrives without the matching cookie but has a valid signed state, discard the current code and redirect back to the original private URL once with a retry marker, so the current browser can start a fresh OAuth transaction and set its own cookie.
- Preserve the old `invalid_oauth_state` response for legacy/invalid state values and for already-retried flows.

## Validation

- `uv run ruff check vibe/ui_server.py tests/test_ui_remote_access_auth.py`
- `uv run pytest tests/test_ui_remote_access_auth.py tests/test_ui_show_pages.py -q`
- `python3 -m py_compile vibe/ui_server.py`
- `npm run build` in `ui/` to satisfy editable package forced include in this worktree
- `git diff --check`
