### PR TITLE
Refine quick reply prompt intent

### DIFF
--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -94,7 +94,7 @@ At the very end of the message, add a `---` separator followed by `[button text]
 ---
 [👌 Continue] | [✅ Submit PR] | [👀 Review first]
 Rules:
-- Infer likely next replies from the conversation context and the user's habits; only add them when they are genuinely helpful
+- Think through the tacit knowledge behind the user's words, infer their deeper intent, and suggest likely next replies from the conversation context and the user's habits
 - Do not add filler unrelated to the user's likely next intent, such as: got it, received, thanks
 - They must appear at the very end of the message, after the `---` separator
 - Wrap each button in `[text]` and separate them with `|`; you may start with emoji to improve clarity


### PR DESCRIPTION
## Summary

Refines the quick-reply system prompt so agents think beyond surface-level next replies.

## What changed

- Replaces the previous "only add them when genuinely helpful" rule with guidance to reason from the user's tacit knowledge, deeper intent, conversation context, and habits before suggesting quick replies.

## Validation

- `uv run ruff check core/system_prompt_injection.py tests/test_reply_enhancer_platform.py tests/test_codex_agent.py`
- `uv run pytest tests/test_reply_enhancer_platform.py tests/test_codex_agent.py -q`
- `git diff --check`
