### PR TITLE
Add Show Page list command

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -148,6 +148,17 @@ class ShowPageStore:
             )
             return _page_from_row(row) if row else None
 
+    def list(self, *, visibility: str | None = None) -> list[ShowPage]:
+        if visibility is not None and visibility not in VISIBILITIES:
+            raise ShowPageError(f"Unsupported visibility: {visibility}", code="invalid_visibility")
+        statement = select(show_pages)
+        if visibility is not None:
+            statement = statement.where(show_pages.c.visibility == visibility)
+        statement = statement.order_by(show_pages.c.updated_at.desc(), show_pages.c.session_id.asc())
+        with self.engine.connect() as conn:
+            rows = conn.execute(statement).mappings().all()
+        return [_page_from_row(row) for row in rows]
+
     def ensure(self, session_id: str) -> ShowPage:
         session_id = validate_session_id(session_id)
         existing = self.get(session_id)

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -53,6 +53,10 @@ Check status:
 
 `vibe show status --session-id {default_session_id}`
 
+List existing pages when the user asks what Show Pages exist:
+
+`vibe show list`
+
 Change visibility:
 
 `vibe show update --session-id {default_session_id} --visibility public`

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -53,10 +53,6 @@ Check status:
 
 `vibe show status --session-id {default_session_id}`
 
-List existing pages when the user asks what Show Pages exist:
-
-`vibe show list`
-
 Change visibility:
 
 `vibe show update --session-id {default_session_id} --visibility public`

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -16,7 +16,8 @@ def test_show_without_subcommand_prints_help(capsys):
     assert cli.cmd_show(args) == 0
     captured = capsys.readouterr()
     assert "Manage the one visual Show Page attached to an Agent Session." in captured.out
-    assert "usage: vibe show [-h] {path,status,update} ..." in captured.out
+    assert "usage: vibe show [-h] {list,path,status,update} ..." in captured.out
+    assert "vibe show list" in captured.out
     assert "vibe show path --session-id sesk8m4q2p7x" in captured.out
 
 
@@ -88,6 +89,28 @@ def test_rotate_share_requires_public(monkeypatch, tmp_path):
         store.close()
 
 
+def test_store_lists_pages_by_updated_time_and_visibility(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+
+    store = ShowPageStore()
+    try:
+        store.ensure("ses-old")
+        store.ensure("ses-public")
+        store.update_visibility("ses-public", "public")
+        store.ensure("ses-offline")
+        store.update_visibility("ses-offline", "offline")
+
+        pages = store.list()
+        assert [page.session_id for page in pages] == ["ses-offline", "ses-public", "ses-old"]
+
+        public_pages = store.list(visibility="public")
+        assert [page.session_id for page in public_pages] == ["ses-public"]
+    finally:
+        store.close()
+
+
 def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     page_dir = ensure_show_page_dir("ses123")
@@ -115,6 +138,53 @@ def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
     assert payload["url_available"] is True
     assert payload["url_guidance"] is None
     assert (tmp_path / "show" / "ses123" / "index.html").exists()
+
+
+def test_show_list_cli_json_reports_existing_pages(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+
+    store = ShowPageStore()
+    try:
+        store.ensure("ses-private")
+        store.update_visibility("ses-public", "public")
+    finally:
+        store.close()
+
+    args = cli.build_parser().parse_args(["show", "list", "--json"])
+    assert cli.cmd_show_list(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["count"] == 2
+    assert [page["session_id"] for page in payload["pages"]] == ["ses-public", "ses-private"]
+    public_page = payload["pages"][0]
+    assert public_page["visibility"] == "public"
+    assert public_page["active_url"] == public_page["public_url"]
+    assert public_page["active_url"].startswith("https://alex.avibe.bot/p/")
+
+
+def test_show_list_cli_filters_visibility(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+
+    store = ShowPageStore()
+    try:
+        store.ensure("ses-private")
+        store.update_visibility("ses-public", "public")
+    finally:
+        store.close()
+
+    args = cli.build_parser().parse_args(["show", "list", "--visibility", "private"])
+    assert cli.cmd_show_list(args) == 0
+
+    output = capsys.readouterr().out
+    assert "Count: 1" in output
+    assert "Filter: visibility=private" in output
+    assert "- ses-private" in output
+    assert "- ses-public" not in output
 
 
 def test_show_page_payload_requires_enabled_avibe_cloud(monkeypatch, tmp_path):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -403,6 +403,7 @@ def _show_examples_text() -> str:
         One Agent Session has exactly one Show Page.
 
         Commands:
+          list     List existing Show Pages across sessions.
           path     Create or resolve the local workspace.
           status   Inspect local path, visibility, active URL, and share state.
           update   Switch visibility, rotate public share links, or take the page offline.
@@ -413,12 +414,15 @@ def _show_examples_text() -> str:
           offline  URL access is revoked; local files remain.
 
         Examples:
+          vibe show list
+          vibe show list --visibility public
           vibe show path --session-id sesk8m4q2p7x
           vibe show status --session-id sesk8m4q2p7x --json
           vibe show update --session-id sesk8m4q2p7x --visibility public
           vibe show update --session-id sesk8m4q2p7x --visibility offline
 
         More:
+          vibe show list --help
           vibe show path --help
           vibe show status --help
           vibe show update --help
@@ -3744,6 +3748,34 @@ def _print_show_page_status_missing(session_id: str) -> None:
     print("  - For more options, run: vibe show --help")
 
 
+def _print_show_page_list(payload: dict) -> None:
+    pages = payload.get("pages") or []
+    print("Show Pages:")
+    print(f"  Count: {payload.get('count', 0)}")
+    visibility = payload.get("visibility")
+    if visibility:
+        print(f"  Filter: visibility={visibility}")
+    if payload.get("url_guidance"):
+        print(f"  URL guidance: {payload.get('url_guidance')}")
+    if not pages:
+        print("")
+        print("No Show Pages found.")
+        print("Create one with: vibe show path --session-id <session-id>")
+        return
+    print("")
+    for page in pages:
+        print(f"- {page.get('session_id')}")
+        print(f"  Path: {page.get('path')}")
+        print(f"  URL: {page.get('active_url') or 'none'}")
+        print(f"  Visibility: {page.get('visibility')}")
+        print(f"  Updated: {page.get('updated_at')}")
+    print("")
+    print("Use it:")
+    print("  - Open a page: vibe show status --session-id <session-id>")
+    print("  - Edit files under the listed Path.")
+    print("  - For more options, run: vibe show --help")
+
+
 def _print_show_page_error(exc: Exception) -> None:
     code = getattr(exc, "code", "show_page_failed")
     payload = {
@@ -3759,6 +3791,31 @@ def _load_show_page_store():
     from core.show_pages import ShowPageStore
 
     return ShowPageStore()
+
+
+def cmd_show_list(args):
+    from core.show_pages import avibe_cloud_connect_guidance, show_page_payload
+
+    store = _load_show_page_store()
+    try:
+        pages = store.list(visibility=getattr(args, "visibility", None))
+        payload = {
+            "ok": True,
+            "count": len(pages),
+            "visibility": getattr(args, "visibility", None),
+            "pages": [show_page_payload(page) for page in pages],
+            "url_guidance": avibe_cloud_connect_guidance(),
+        }
+        if getattr(args, "json", False):
+            _print_json(payload)
+        else:
+            _print_show_page_list(payload)
+        return 0
+    except Exception as exc:
+        _print_show_page_error(exc)
+        return 1
+    finally:
+        store.close()
 
 
 def cmd_show_path(args):
@@ -3860,6 +3917,8 @@ def cmd_show(args):
     if args.show_command is None:
         args.show_help_parser.print_help()
         return 0
+    if args.show_command == "list":
+        return cmd_show_list(args)
     if args.show_command == "path":
         return cmd_show_path(args)
     if args.show_command == "status":
@@ -4285,8 +4344,22 @@ def build_parser():
         error_hint="Run one of the show subcommands below. Start with: vibe show path --session-id <session-id>",
     )
     show_parser.set_defaults(show_help_parser=show_parser)
-    show_subparsers = show_parser.add_subparsers(dest="show_command", metavar="{path,status,update}")
+    show_subparsers = show_parser.add_subparsers(dest="show_command", metavar="{list,path,status,update}")
     show_subparsers.required = False
+
+    show_list_parser = show_subparsers.add_parser(
+        "list",
+        help="List existing Show Pages",
+        description="List existing Show Pages across Agent Sessions without creating new pages.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        error_help_command="vibe show list --help",
+    )
+    show_list_parser.add_argument(
+        "--visibility",
+        choices=("private", "public", "offline"),
+        help="Filter by Show Page visibility.",
+    )
+    show_list_parser.add_argument("--json", action="store_true", help="Print machine-readable state.")
 
     show_path_parser = show_subparsers.add_parser(
         "path",


### PR DESCRIPTION
## Summary

- add `vibe show list` to enumerate existing Show Pages across sessions
- support filtering by visibility and JSON output for agent automation
- document the list command in CLI help while keeping the injected Show Pages prompt focused on the current session workflow

## Validation

- `uv run pytest tests/test_show_pages.py tests/test_reply_enhancer_platform.py`
- `uv run ruff check core/show_pages.py core/system_prompt_injection.py vibe/cli.py tests/test_show_pages.py`
- `uv run vibe show --help`
- `uv run vibe show list --help`
- manually exercised `vibe show list` output in an isolated `VIBE_REMOTE_HOME`
