### PR TITLE
fix(ui): require remote login before setup guard

### DIFF
--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -116,6 +116,40 @@ def test_remote_host_redirects_to_vibe_cloud_login(monkeypatch, tmp_path):
     assert state_payload["retry"] is False
 
 
+def test_remote_setup_route_requires_vibe_cloud_login(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/setup",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].startswith("https://backend.test/oauth/authorize?")
+    state = httpx.URL(response.headers["Location"]).params["state"]
+    state_payload = ui_server._read_oauth_state(config.remote_access.vibe_cloud.session_secret, state)
+    assert state_payload is not None
+    assert state_payload["next"] == "/setup"
+
+
+def test_remote_config_get_without_session_returns_login_required(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/config",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].startswith("https://backend.test/oauth/authorize?")
+
+
 def test_remote_host_strips_retry_marker_from_oauth_next(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -19,56 +19,80 @@ import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { AgentationToggle } from './components/AgentationToggle';
 import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
 import { hasConfiguredPlatformCredentials } from './lib/platforms';
 
+const LOGIN_CHECK_PATHS = new Set(['/doctor/logs', '/logs']);
+
+const RemoteLoginRedirect = ({ target }: { target: string }) => {
+    useEffect(() => {
+        window.location.assign(target);
+    }, [target]);
+
+    return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
+};
+
 // Wrapper to check if setup is needed
-const AuthGuard = ({ children }: { children: any }) => {
-    const { getConfig } = useApi();
+const AuthGuard = ({ children }: { children: ReactNode }) => {
+    const { getConfig, getSession } = useApi();
     const location = useLocation();
-    const [loading, setLoading] = useState(true);
-    const [needsSetup, setNeedsSetup] = useState(false);
-    const bypassSetupGuard = location.pathname === '/doctor/logs' || location.pathname === '/logs';
+    const [guardState, setGuardState] = useState<'loading' | 'ready' | 'needs-setup' | 'remote-login-required'>('loading');
+    const bypassSetupGuard = LOGIN_CHECK_PATHS.has(location.pathname);
 
     useEffect(() => {
+        let cancelled = false;
+
         if (bypassSetupGuard) {
-            setLoading(false);
-            setNeedsSetup(false);
             return;
         }
 
-        let cancelled = false;
-        setLoading(true);
-
-        getConfig().then(config => {
+        getSession().then(session => {
             if (cancelled) return;
-            const setupState = config?.setup_state;
-            const setupReady = typeof setupState?.needs_setup === 'boolean'
-                ? setupState.needs_setup === false
-                : hasConfiguredPlatformCredentials(config);
-            setNeedsSetup(!config || !config.mode || !setupReady);
-            setLoading(false);
-        }).catch(() => {
-             if (cancelled) return;
-             // If fetch fails (e.g. config doesn't exist), setup is needed
-             setNeedsSetup(true);
-             setLoading(false);
+            if (session.remote && !session.authenticated) {
+                setGuardState('remote-login-required');
+                return null;
+            }
+            return getConfig().then(config => {
+                if (cancelled) return;
+                const setupState = config?.setup_state;
+                const setupReady = typeof setupState?.needs_setup === 'boolean'
+                    ? setupState.needs_setup === false
+                    : hasConfiguredPlatformCredentials(config);
+                setGuardState(!config || !config.mode || !setupReady ? 'needs-setup' : 'ready');
+            });
+        }).catch(async (error) => {
+            if (cancelled) return;
+            const session = await getSession().catch(() => null);
+            if (cancelled) return;
+            if (session?.remote && !session.authenticated) {
+                setGuardState('remote-login-required');
+                return;
+            }
+            console.error('[AuthGuard] setup check failed', error);
+            // If fetch fails for local/non-remote use (e.g. config doesn't exist),
+            // setup is needed. Remote 401s are handled by the session branch above.
+            setGuardState('needs-setup');
         });
 
         return () => {
             cancelled = true;
         };
-    }, [bypassSetupGuard]);
+    }, [bypassSetupGuard, getConfig, getSession]);
 
-    if (loading) return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
-    if (needsSetup && !bypassSetupGuard) return <Navigate to="/setup" replace />;
+    if (bypassSetupGuard) return children;
+    if (guardState === 'loading') return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
+    if (guardState === 'remote-login-required') {
+        return <RemoteLoginRedirect target={location.pathname + location.search} />;
+    }
+    if (guardState === 'needs-setup' && !bypassSetupGuard) return <Navigate to="/setup" replace />;
     return children;
 };
 
 function AppRoutes() {
   return (
     <Routes>
-      <Route path="/setup" element={<Wizard />} />
       <Route element={<AuthGuard><AppShell /></AuthGuard>}>
+        <Route path="/setup" element={<Wizard />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/groups" element={<ChannelList isPage />} />
         <Route path="/channels" element={<Navigate to="/groups" replace />} />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -32,11 +32,17 @@ const RemoteLoginRedirect = ({ target }: { target: string }) => {
     return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
 };
 
+type GuardStatus = 'loading' | 'ready' | 'needs-setup' | 'remote-login-required';
+
 // Wrapper to check if setup is needed
 const AuthGuard = ({ children }: { children: ReactNode }) => {
     const { getConfig, getSession } = useApi();
     const location = useLocation();
-    const [guardState, setGuardState] = useState<'loading' | 'ready' | 'needs-setup' | 'remote-login-required'>('loading');
+    const guardTarget = location.pathname + location.search;
+    const [guardState, setGuardState] = useState<{ target: string; status: GuardStatus }>({
+        target: '',
+        status: 'loading',
+    });
     const bypassSetupGuard = LOGIN_CHECK_PATHS.has(location.pathname);
 
     useEffect(() => {
@@ -49,7 +55,7 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
         getSession().then(session => {
             if (cancelled) return;
             if (session.remote && !session.authenticated) {
-                setGuardState('remote-login-required');
+                setGuardState({ target: guardTarget, status: 'remote-login-required' });
                 return null;
             }
             return getConfig().then(config => {
@@ -58,33 +64,41 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
                 const setupReady = typeof setupState?.needs_setup === 'boolean'
                     ? setupState.needs_setup === false
                     : hasConfiguredPlatformCredentials(config);
-                setGuardState(!config || !config.mode || !setupReady ? 'needs-setup' : 'ready');
+                setGuardState({
+                    target: guardTarget,
+                    status: !config || !config.mode || !setupReady ? 'needs-setup' : 'ready',
+                });
             });
         }).catch(async (error) => {
             if (cancelled) return;
             const session = await getSession().catch(() => null);
             if (cancelled) return;
             if (session?.remote && !session.authenticated) {
-                setGuardState('remote-login-required');
+                setGuardState({ target: guardTarget, status: 'remote-login-required' });
                 return;
             }
             console.error('[AuthGuard] setup check failed', error);
             // If fetch fails for local/non-remote use (e.g. config doesn't exist),
             // setup is needed. Remote 401s are handled by the session branch above.
-            setGuardState('needs-setup');
+            setGuardState({ target: guardTarget, status: 'needs-setup' });
         });
 
         return () => {
             cancelled = true;
         };
-    }, [bypassSetupGuard, getConfig, getSession]);
+    }, [bypassSetupGuard, getConfig, getSession, guardTarget]);
 
     if (bypassSetupGuard) return children;
-    if (guardState === 'loading') return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
-    if (guardState === 'remote-login-required') {
-        return <RemoteLoginRedirect target={location.pathname + location.search} />;
+    if (guardState.target !== guardTarget || guardState.status === 'loading') {
+        return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
     }
-    if (guardState === 'needs-setup' && !bypassSetupGuard) return <Navigate to="/setup" replace />;
+    if (guardState.status === 'remote-login-required') {
+        return <RemoteLoginRedirect target={guardTarget} />;
+    }
+    if (guardState.status === 'needs-setup') {
+        if (location.pathname === '/setup') return children;
+        return <Navigate to="/setup" replace />;
+    }
     return children;
 };
 


### PR DESCRIPTION
## What changed
- Require the remote Web UI session check before the setup/config guard decides whether to redirect to `/setup`.
- Put `/setup` behind the same guarded app shell route, so an already-loaded SPA cannot show the setup wizard after remote sign-out.
- Add remote-access regression coverage for unauthenticated `/setup` and `/config` requests.

## Capability and scenarios
- Capability: remote Web UI auth gating for setup/config routes after Vibe Cloud sign-out.
- Scenario IDs: no product scenario catalog entry found for this route; covered by focused remote-access tests.

## Evidence layers
- Unit: `uv run pytest tests/test_ui_remote_access_auth.py tests/test_ui_show_pages.py`
- Contract: remote unauthenticated `/setup` and `/config` now assert OAuth redirect behavior.
- Scenario: existing Show Page public/private access tests still pass, including public `/p/...` login bypass.
- Manual residual checks: `npm run build`; `npx eslint src/App.tsx`; `ruff check tests/test_ui_remote_access_auth.py`.

## Notes
- Full `npm run lint` still fails on existing repo-wide lint debt unrelated to this change; the changed `App.tsx` passes ESLint directly.
