### PR TITLE
Unify Scope Agent selection

### DIFF
--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -78,6 +78,9 @@ def _infer_user_platform(user_id: str) -> str:
 class RoutingSettings:
     agent_name: Optional[str] = None
     agent_backend: Optional[str] = None
+    # Scope-level overrides applied on top of the selected Vibe Agent.
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
     # OpenCode settings
     opencode_agent: Optional[str] = None
     opencode_model: Optional[str] = None
@@ -149,6 +152,8 @@ def _parse_routing(payload: dict) -> RoutingSettings:
     return RoutingSettings(
         agent_name=payload.get("agent_name") or payload.get("agent"),
         agent_backend=payload.get("agent_backend"),
+        model=payload.get("model") or payload.get("model_override"),
+        reasoning_effort=payload.get("reasoning_effort") or payload.get("reasoning_effort_override"),
         opencode_agent=payload.get("opencode_agent"),
         opencode_model=payload.get("opencode_model"),
         opencode_reasoning_effort=payload.get("opencode_reasoning_effort"),
@@ -166,6 +171,8 @@ def _routing_to_dict(routing: RoutingSettings) -> dict:
     return {
         "agent_name": routing.agent_name,
         "agent_backend": routing.agent_backend,
+        "model": routing.model,
+        "reasoning_effort": routing.reasoning_effort,
         "opencode_agent": routing.opencode_agent,
         "opencode_model": routing.opencode_model,
         "opencode_reasoning_effort": routing.opencode_reasoning_effort,

--- a/core/controller.py
+++ b/core/controller.py
@@ -69,7 +69,7 @@ class Controller:
         # Validate default_backend against registered agents
         self._validate_default_backend()
         self.vibe_agent_store = VibeAgentStore()
-        self.vibe_agent_store.ensure_default_agent(backend=self.agent_router.global_default)
+        self.vibe_agent_store.ensure_builtin_default_agents(self._enabled_agent_backends())
 
         # Setup callbacks
         self._setup_callbacks()
@@ -129,6 +129,20 @@ class Controller:
         # Inject settings_manager into IM client if supported
         for platform, client in self.im_clients.items():
             self._inject_runtime_dependencies(platform, client)
+
+    def _enabled_agent_backends(self) -> list[str]:
+        result: list[str] = []
+        agent_config = getattr(self.config, "agents", None)
+        default_backend = getattr(self.agent_router, "global_default", DEFAULT_AGENT_BACKEND)
+        if agent_config is None:
+            return [default_backend]
+        for backend in ("opencode", "claude", "codex"):
+            cfg = getattr(agent_config, backend, None)
+            if bool(getattr(cfg, "enabled", False)):
+                result.append(backend)
+        if not result:
+            result.append(default_backend)
+        return result
 
     def get_native_session_service(self):
         if self.native_session_service is None:
@@ -530,8 +544,8 @@ class Controller:
         """Unified agent resolution with dynamic override support.
 
         Priority:
-        1. explicit Vibe Agent route
-        2. channel_routing.agent_backend (from settings.json)
+        1. explicit Vibe Agent selected by the Scope
+        2. migration fallback from legacy Scope agent_backend
         3. default Vibe Agent route
         4. AgentRouter platform default (configured in code)
         5. AgentService.default_agent ("claude")
@@ -539,24 +553,19 @@ class Controller:
         settings_key = self._get_settings_key(context)
         settings_manager = self.get_settings_manager_for_context(context)
         routing = settings_manager.get_channel_routing(settings_key)
-        if routing and routing.agent_name:
-            vibe_agent = self.resolve_vibe_agent_for_context(context, required=False)
-            if vibe_agent and vibe_agent.backend in self.agent_service.agents:
-                return vibe_agent.backend
-
-        if routing and routing.agent_backend:
-            # Verify the agent is registered
-            if routing.agent_backend in self.agent_service.agents:
-                return routing.agent_backend
-            else:
-                logger.warning(
-                    f"Channel routing specifies '{routing.agent_backend}' but agent is not registered, "
-                    f"falling back to static routing"
-                )
-
         vibe_agent = self.resolve_vibe_agent_for_context(context, required=False)
         if vibe_agent and vibe_agent.backend in self.agent_service.agents:
             return vibe_agent.backend
+
+        if routing and routing.agent_backend:
+            # Migration fallback for scopes saved before Agent became the unified
+            # selection. New Scope settings should select agent_name instead.
+            if routing.agent_backend in self.agent_service.agents:
+                return routing.agent_backend
+            logger.warning(
+                f"Scope routing specifies legacy backend '{routing.agent_backend}' but it is not registered, "
+                f"falling back to static routing"
+            )
 
         # Fall back to static routing
         platform = context.platform or (context.platform_specific or {}).get("platform") or self.primary_platform
@@ -578,6 +587,11 @@ class Controller:
         try:
             if agent_name:
                 return self.vibe_agent_store.require(agent_name)
+            legacy_backend = routing.agent_backend if routing else None
+            if legacy_backend:
+                agent = self.vibe_agent_store.get_builtin_default_agent_for_backend(legacy_backend)
+                if agent is not None:
+                    return agent
             default_agent = self.vibe_agent_store.get_default_agent()
             if default_agent is not None:
                 return default_agent
@@ -603,8 +617,8 @@ class Controller:
         if routing:
             return (
                 routing.opencode_agent,
-                routing.opencode_model,
-                routing.opencode_reasoning_effort,
+                routing.model or routing.opencode_model,
+                routing.reasoning_effort or routing.opencode_reasoning_effort,
             )
         return None, None, None
 
@@ -616,8 +630,8 @@ class Controller:
         if routing:
             return (
                 routing.codex_agent,
-                routing.codex_model,
-                routing.codex_reasoning_effort,
+                routing.model or routing.codex_model,
+                routing.reasoning_effort or routing.codex_reasoning_effort,
             )
         return None, None, None
 

--- a/core/controller.py
+++ b/core/controller.py
@@ -69,7 +69,10 @@ class Controller:
         # Validate default_backend against registered agents
         self._validate_default_backend()
         self.vibe_agent_store = VibeAgentStore()
-        self.vibe_agent_store.ensure_builtin_default_agents(self._enabled_agent_backends())
+        self.vibe_agent_store.ensure_builtin_default_agents(
+            self._enabled_agent_backends(),
+            default_backend=getattr(self.agent_router, "global_default", DEFAULT_AGENT_BACKEND),
+        )
 
         # Setup callbacks
         self._setup_callbacks()

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -180,6 +180,9 @@ class MessageHandler(BaseHandler):
             else:
                 agent_name = self.controller.resolve_agent_for_context(context)
 
+            scope_model_override = getattr(routing, "model", None) if routing else None
+            scope_reasoning_override = getattr(routing, "reasoning_effort", None) if routing else None
+
             # Check for routing-based agent to maintain session key consistency
             # This ensures session IDs match between MessageHandler and SessionHandler
             routing_agent = None
@@ -317,8 +320,9 @@ class MessageHandler(BaseHandler):
                 vibe_agent_id=vibe_agent.id if vibe_agent else None,
                 vibe_agent_name=vibe_agent.name if vibe_agent else None,
                 vibe_agent_backend=vibe_agent.backend if vibe_agent else None,
-                vibe_agent_model=vibe_agent.model if vibe_agent else None,
-                vibe_agent_reasoning_effort=vibe_agent.reasoning_effort if vibe_agent else None,
+                vibe_agent_model=scope_model_override or (vibe_agent.model if vibe_agent else None),
+                vibe_agent_reasoning_effort=scope_reasoning_override
+                or (vibe_agent.reasoning_effort if vibe_agent else None),
                 vibe_agent_system_prompt=vibe_agent.system_prompt if vibe_agent else None,
                 processing_indicator=processing_indicator,
                 files=processed_files,

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -435,8 +435,12 @@ class SessionHandler(BaseHandler):
         # Note: agent frontmatter model is applied later after loading agent file
         effective_agent = subagent_name or (routing.claude_agent if routing else None)
         # Store explicit model override (not including default yet)
-        explicit_model = subagent_model or (routing.claude_model if routing else None)
-        explicit_effort = subagent_reasoning_effort or (routing.claude_reasoning_effort if routing else None)
+        explicit_model = subagent_model or (
+            (routing.model or routing.claude_model) if routing else None
+        )
+        explicit_effort = subagent_reasoning_effort or (
+            (routing.reasoning_effort or routing.claude_reasoning_effort) if routing else None
+        )
 
         if composite_key in self.claude_sessions and not effective_agent:
             client = self.claude_sessions[composite_key]

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -780,6 +780,24 @@ class SettingsHandler(BaseHandler):
 
             routing = RoutingSettings(
                 agent_backend=backend,
+                model=(
+                    opencode_model
+                    if backend == "opencode"
+                    else claude_model
+                    if backend == "claude"
+                    else codex_model
+                    if backend == "codex"
+                    else None
+                ),
+                reasoning_effort=(
+                    opencode_reasoning_effort
+                    if backend == "opencode"
+                    else normalized_claude_reasoning_effort
+                    if backend == "claude"
+                    else codex_reasoning_effort
+                    if backend == "codex"
+                    else None
+                ),
                 opencode_agent=opencode_agent
                 if backend == "opencode"
                 else (existing_routing.opencode_agent if existing_routing else None),

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -299,7 +299,12 @@ class VibeAgentStore:
             metadata=metadata,
         )
 
-    def ensure_builtin_default_agents(self, backends: Iterable[str]) -> list[VibeAgent]:
+    def ensure_builtin_default_agents(
+        self,
+        backends: Iterable[str],
+        *,
+        default_backend: Optional[str] = None,
+    ) -> list[VibeAgent]:
         ensured: list[VibeAgent] = []
         for backend in backends:
             try:
@@ -308,7 +313,11 @@ class VibeAgentStore:
                 logger.warning("Skipping built-in default Agent for backend %s: %s", backend, exc)
         default_agent = self.get_default_agent()
         if default_agent is None and ensured:
-            self.set_default_agent_name(ensured[0].name)
+            preferred = None
+            if default_backend:
+                preferred_backend = validate_agent_backend(default_backend)
+                preferred = next((agent for agent in ensured if agent.backend == preferred_backend), None)
+            self.set_default_agent_name((preferred or ensured[0]).name)
         return ensured
 
     def get_builtin_default_agent_for_backend(self, backend: str) -> Optional[VibeAgent]:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -20,8 +21,11 @@ from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_
 from storage.migrations import run_migrations
 from storage.models import agent_sessions, agents, run_definitions, scope_settings, state_meta
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_AGENT_NAME = "default"
 DEFAULT_AGENT_META_KEY = "default_agent_name"
+BUILTIN_DEFAULT_AGENT_METADATA = {"builtin": True, "builtin_default": True, "lock_delete": True}
 SUPPORTED_AGENT_BACKENDS = {"codex", "claude", "opencode"}
 _UNSET = object()
 
@@ -198,7 +202,12 @@ class VibeAgentStore:
         return self.require(name)
 
     def remove(self, name: str) -> bool:
-        normalized = normalize_agent_name(name)
+        agent = self.get(name)
+        if agent is None:
+            return False
+        if is_builtin_default_agent(agent):
+            raise ValueError(f"agent '{agent.name}' is built in and cannot be deleted")
+        normalized = agent.normalized_name
         with self.engine.begin() as conn:
             result = conn.execute(agents.delete().where(agents.c.normalized_name == normalized))
             return bool(result.rowcount)
@@ -265,6 +274,56 @@ class VibeAgentStore:
         )
         self.set_default_agent_name(agent.name)
         return agent
+
+    def ensure_builtin_default_agent(self, *, backend: str, name: str | None = None) -> VibeAgent:
+        backend = validate_agent_backend(backend)
+        agent_name = str(name or backend).strip()
+        metadata = dict(BUILTIN_DEFAULT_AGENT_METADATA)
+        metadata["backend"] = backend
+        existing = self.get(agent_name)
+        if existing:
+            if existing.backend != backend:
+                raise ValueError(
+                    f"agent '{agent_name}' already exists with backend '{existing.backend}', "
+                    f"cannot use it as the built-in default for '{backend}'"
+                )
+            merged = {**existing.metadata, **metadata}
+            if existing.source != "builtin" or existing.metadata != merged:
+                return self.update(existing.name, metadata=merged)
+            return existing
+        return self.create(
+            name=agent_name,
+            backend=backend,
+            description=f"Default {agent_name} agent.",
+            source="builtin",
+            metadata=metadata,
+        )
+
+    def ensure_builtin_default_agents(self, backends: Iterable[str]) -> list[VibeAgent]:
+        ensured: list[VibeAgent] = []
+        for backend in backends:
+            try:
+                ensured.append(self.ensure_builtin_default_agent(backend=backend))
+            except ValueError as exc:
+                logger.warning("Skipping built-in default Agent for backend %s: %s", backend, exc)
+        default_agent = self.get_default_agent()
+        if default_agent is None and ensured:
+            self.set_default_agent_name(ensured[0].name)
+        return ensured
+
+    def get_builtin_default_agent_for_backend(self, backend: str) -> Optional[VibeAgent]:
+        backend = validate_agent_backend(backend)
+        for candidate in (backend, DEFAULT_AGENT_NAME):
+            agent = self.get(candidate)
+            if agent and agent.backend == backend:
+                return agent
+        with self.engine.connect() as conn:
+            rows = conn.execute(select(agents).where(agents.c.backend == backend).order_by(agents.c.name)).mappings()
+            for row in rows:
+                agent = self._from_row(row)
+                if is_builtin_default_agent(agent):
+                    return agent
+        return None
 
     def get_default_agent_name(self) -> Optional[str]:
         with self.engine.connect() as conn:
@@ -362,6 +421,10 @@ def parse_agent_file(path: Path, *, backend: str) -> AgentImportCandidate:
         source_ref=str(path),
         metadata=metadata,
     )
+
+
+def is_builtin_default_agent(agent: VibeAgent) -> bool:
+    return bool(agent.metadata.get("builtin_default") or agent.metadata.get("lock_delete"))
 
 
 def iter_global_agent_files(source: str) -> list[tuple[Path, str]]:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -287,6 +287,8 @@ class VibeAgentStore:
                     f"agent '{agent_name}' already exists with backend '{existing.backend}', "
                     f"cannot use it as the built-in default for '{backend}'"
                 )
+            if not is_builtin_default_agent(existing):
+                return existing
             merged = {**existing.metadata, **metadata}
             if existing.source != "builtin" or existing.metadata != merged:
                 return self.update(existing.name, metadata=merged)
@@ -324,7 +326,7 @@ class VibeAgentStore:
         backend = validate_agent_backend(backend)
         for candidate in (backend, DEFAULT_AGENT_NAME):
             agent = self.get(candidate)
-            if agent and agent.backend == backend:
+            if agent and agent.backend == backend and is_builtin_default_agent(agent):
                 return agent
         with self.engine.connect() as conn:
             rows = conn.execute(select(agents).where(agents.c.backend == backend).order_by(agents.c.name)).mappings()

--- a/docs/plans/agent-scope-model.md
+++ b/docs/plans/agent-scope-model.md
@@ -1,0 +1,28 @@
+# Agent / Scope Model
+
+## Goal
+
+Scope remains the workspace and routing context: it connects an Agent, active
+sessions, working directory, and IM output. Scope should no longer expose a
+Backend choice as a first-class setting.
+
+Agent is the robot. It owns the Backend plus default model, reasoning effort,
+and system prompt. Each enabled Backend gets one built-in, non-deletable
+default Agent named after that Backend.
+
+## Implementation Plan
+
+1. Ensure built-in default Agents exist for enabled Backends.
+2. Normalize legacy Scope settings:
+   - `agent_backend` maps to the matching built-in Agent when `agent_name` is
+     absent.
+   - backend-specific model and reasoning fields become Scope-level overrides.
+3. Resolve runtime settings from Scope first:
+   - Scope chooses Agent.
+   - Agent supplies Backend and defaults.
+   - Scope may override model and reasoning effort.
+   - Scope does not override system prompt.
+4. Simplify Scope UI to one Agent selector plus model / reasoning overrides.
+5. Keep migration-period read/write compatibility for old fields without making
+   them target semantics.
+

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -30,6 +30,8 @@ def _routing_from_dict(payload: Optional[dict]) -> RoutingSettings:
     return RoutingSettings(
         agent_name=data.get("agent_name") or data.get("agent"),
         agent_backend=data.get("agent_backend"),
+        model=data.get("model") or data.get("model_override"),
+        reasoning_effort=data.get("reasoning_effort") or data.get("reasoning_effort_override"),
         opencode_agent=data.get("opencode_agent"),
         opencode_model=data.get("opencode_model"),
         opencode_reasoning_effort=data.get("opencode_reasoning_effort"),

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -313,22 +313,24 @@ def _settings_rows(conn: Connection, scope_type: str):
 
 def _routing_columns(routing: RoutingSettings) -> dict[str, str | None]:
     backend = routing.agent_backend
+    model = routing.model
+    effort = routing.reasoning_effort
     if backend == "codex":
         variant = routing.codex_agent
-        model = routing.codex_model
-        effort = routing.codex_reasoning_effort
+        model = model or routing.codex_model
+        effort = effort or routing.codex_reasoning_effort
     elif backend == "claude":
         variant = routing.claude_agent
-        model = routing.claude_model
-        effort = routing.claude_reasoning_effort
+        model = model or routing.claude_model
+        effort = effort or routing.claude_reasoning_effort
     elif backend == "opencode":
         variant = routing.opencode_agent
-        model = routing.opencode_model
-        effort = routing.opencode_reasoning_effort
+        model = model or routing.opencode_model
+        effort = effort or routing.opencode_reasoning_effort
     else:
         variant = routing.codex_agent or routing.claude_agent or routing.opencode_agent
-        model = routing.codex_model or routing.claude_model or routing.opencode_model
-        effort = (
+        model = model or routing.codex_model or routing.claude_model or routing.opencode_model
+        effort = effort or (
             routing.codex_reasoning_effort
             or routing.claude_reasoning_effort
             or routing.opencode_reasoning_effort
@@ -347,6 +349,8 @@ def _routing_from_row(row: dict[str, Any], payload: dict[str, Any]) -> RoutingSe
     routing = RoutingSettings(
         agent_name=routing_payload.get("agent_name") or routing_payload.get("agent"),
         agent_backend=routing_payload.get("agent_backend"),
+        model=routing_payload.get("model") or routing_payload.get("model_override"),
+        reasoning_effort=routing_payload.get("reasoning_effort") or routing_payload.get("reasoning_effort_override"),
         opencode_agent=routing_payload.get("opencode_agent"),
         opencode_model=routing_payload.get("opencode_model"),
         opencode_reasoning_effort=routing_payload.get("opencode_reasoning_effort"),
@@ -366,6 +370,8 @@ def _routing_from_row(row: dict[str, Any], payload: dict[str, Any]) -> RoutingSe
     variant = row.get("agent_variant")
     model = row.get("model")
     effort = row.get("reasoning_effort")
+    routing.model = routing.model or model
+    routing.reasoning_effort = routing.reasoning_effort or effort
     if routing.agent_backend == "codex":
         routing.codex_agent = routing.codex_agent or variant
         routing.codex_model = routing.codex_model or model

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -329,12 +329,6 @@ def _routing_columns(routing: RoutingSettings) -> dict[str, str | None]:
         effort = effort or routing.opencode_reasoning_effort
     else:
         variant = routing.codex_agent or routing.claude_agent or routing.opencode_agent
-        model = model or routing.codex_model or routing.claude_model or routing.opencode_model
-        effort = effort or (
-            routing.codex_reasoning_effort
-            or routing.claude_reasoning_effort
-            or routing.opencode_reasoning_effort
-        )
     return {
         "agent_name": routing.agent_name,
         "agent_backend": backend,

--- a/tests/test_controller_vibe_agent_routing.py
+++ b/tests/test_controller_vibe_agent_routing.py
@@ -27,6 +27,7 @@ def test_resolve_vibe_agent_for_context_uses_catalog_default_when_scope_has_no_a
     controller._get_settings_key = lambda context: context.channel_id
     controller.vibe_agent_store = SimpleNamespace(
         require=lambda name: (_ for _ in ()).throw(ValueError(f"agent '{name}' not found")),
+        get_builtin_default_agent_for_backend=lambda backend: None,
         get_default_agent=lambda: default_agent,
     )
     controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
@@ -35,15 +36,33 @@ def test_resolve_vibe_agent_for_context_uses_catalog_default_when_scope_has_no_a
     assert controller.resolve_vibe_agent_for_context(_context(), required=False) is default_agent
 
 
-def test_resolve_agent_for_context_respects_legacy_backend_before_default_agent() -> None:
+def test_resolve_vibe_agent_for_context_maps_legacy_backend_to_builtin_agent() -> None:
     controller = _StubController()
-    default_agent = SimpleNamespace(name="reviewer", backend="codex")
+    builtin_agent = SimpleNamespace(name="opencode", backend="opencode")
+    controller.primary_platform = "slack"
+    controller._get_settings_key = lambda context: context.channel_id
+    controller.vibe_agent_store = SimpleNamespace(
+        require=lambda name: (_ for _ in ()).throw(ValueError(f"agent '{name}' not found")),
+        get_builtin_default_agent_for_backend=lambda backend: builtin_agent if backend == "opencode" else None,
+        get_default_agent=lambda: SimpleNamespace(name="reviewer", backend="codex"),
+    )
+    controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
+        get_channel_routing=lambda settings_key: SimpleNamespace(agent_name=None, agent_backend="opencode")
+    )
+
+    assert controller.resolve_vibe_agent_for_context(_context(), required=False) is builtin_agent
+
+
+def test_resolve_agent_for_context_uses_legacy_backend_builtin_agent() -> None:
+    controller = _StubController()
+    builtin_agent = SimpleNamespace(name="opencode", backend="opencode")
     controller.primary_platform = "slack"
     controller._get_settings_key = lambda context: context.channel_id
     controller.agent_service = SimpleNamespace(agents={"opencode": object(), "codex": object()})
     controller.vibe_agent_store = SimpleNamespace(
         require=lambda name: (_ for _ in ()).throw(ValueError(f"agent '{name}' not found")),
-        get_default_agent=lambda: default_agent,
+        get_builtin_default_agent_for_backend=lambda backend: builtin_agent if backend == "opencode" else None,
+        get_default_agent=lambda: SimpleNamespace(name="reviewer", backend="codex"),
     )
     controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
         get_channel_routing=lambda settings_key: SimpleNamespace(agent_name=None, agent_backend="opencode")
@@ -51,3 +70,21 @@ def test_resolve_agent_for_context_respects_legacy_backend_before_default_agent(
     controller.agent_router = SimpleNamespace(resolve=lambda platform, settings_key: "claude")
 
     assert controller.resolve_agent_for_context(_context()) == "opencode"
+
+
+def test_codex_overrides_prefer_scope_level_model_and_reasoning() -> None:
+    controller = _StubController()
+    controller.primary_platform = "slack"
+    controller._get_settings_key = lambda context: context.channel_id
+    routing = SimpleNamespace(
+        codex_agent=None,
+        codex_model="gpt-5.4",
+        codex_reasoning_effort="high",
+        model="gpt-5.5",
+        reasoning_effort="xhigh",
+    )
+    controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
+        get_channel_routing=lambda settings_key: routing
+    )
+
+    assert controller.get_codex_overrides(_context()) == (None, "gpt-5.5", "xhigh")

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -91,9 +91,10 @@ class _StubSessions:
 class _StubSettingsManager:
     def __init__(self):
         self.sessions = _StubSessions()
+        self.routing = None
 
     def get_channel_routing(self, settings_key):
-        return None
+        return self.routing
 
 
 class _StubIMClient:
@@ -305,6 +306,29 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.vibe_agent_backend, "codex")
         self.assertEqual(request.vibe_agent_model, "gpt-5.4")
         self.assertEqual(request.vibe_agent_reasoning_effort, "high")
+        self.assertEqual(request.vibe_agent_system_prompt, "Default prompt")
+
+    async def test_scope_model_and_reasoning_override_vibe_agent_defaults(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        controller.settings_manager.routing = type(
+            "Routing",
+            (),
+            {
+                "agent_name": None,
+                "agent_backend": None,
+                "model": "gpt-5.5",
+                "reasoning_effort": "xhigh",
+            },
+        )()
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(user_id="U1", channel_id="C1", message_id="m1", platform="slack")
+
+        await handler.handle_user_message(context, "hello")
+
+        _, request = controller.agent_service.requests[0]
+        self.assertEqual(request.vibe_agent_model, "gpt-5.5")
+        self.assertEqual(request.vibe_agent_reasoning_effort, "xhigh")
         self.assertEqual(request.vibe_agent_system_prompt, "Default prompt")
 
     async def test_reply_anchor_alias_keeps_original_anchor_mapping(self):

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from config import paths
-from config.v2_settings import ChannelSettings, SettingsState, SettingsStore, UserSettings
+from config.v2_settings import ChannelSettings, RoutingSettings, SettingsState, SettingsStore, UserSettings
 from storage.db import create_sqlite_engine
 from storage.migrations import run_migrations
 from storage.models import scopes
@@ -136,6 +136,43 @@ def test_settings_save_preserves_observed_scope_metadata(tmp_path: Path) -> None
     assert row["is_private"] == 1
     assert row["supports_threads"] == 1
     assert json.loads(row["metadata_json"]) == {"username": "general"}
+
+
+def test_settings_save_ignores_legacy_model_fields_without_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    run_migrations(db_path)
+    service = SQLiteSettingsService(db_path)
+    try:
+        service.save_state(
+            SettingsState(
+                channels={
+                    "slack::C123": ChannelSettings(
+                        enabled=True,
+                        routing=RoutingSettings(
+                            agent_name=None,
+                            agent_backend=None,
+                            codex_model="gpt-stale-codex",
+                            claude_model="claude-stale",
+                            opencode_model="openai/stale",
+                            codex_reasoning_effort="high",
+                            claude_reasoning_effort="medium",
+                            opencode_reasoning_effort="low",
+                        ),
+                    ),
+                }
+            )
+        )
+
+        state = service.load_state()
+    finally:
+        service.close()
+
+    routing = state.channels["slack::C123"].routing
+    assert routing.model is None
+    assert routing.reasoning_effort is None
+    assert routing.codex_model == "gpt-stale-codex"
+    assert routing.claude_model == "claude-stale"
+    assert routing.opencode_model == "openai/stale"
 
 
 def test_settings_store_bootstrap_uses_config_primary_platform(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1227,6 +1227,21 @@ def test_builtin_default_agent_does_not_reuse_conflicting_user_agent(tmp_path, m
         store.close()
 
 
+def test_builtin_default_agent_does_not_lock_existing_user_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    store = VibeAgentStore()
+    try:
+        created = store.create(name="opencode", backend="opencode")
+        ensured = store.ensure_builtin_default_agent(backend="opencode")
+
+        assert ensured.id == created.id
+        assert ensured.source == "user"
+        assert ensured.metadata == {}
+        assert api.remove_vibe_agent("opencode")["ok"] is True
+    finally:
+        store.close()
+
+
 def test_vibe_agent_import_reports_unreadable_file_as_client_error(tmp_path, monkeypatch):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
     missing_file = tmp_path / "missing-agent.md"

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from config import paths
+from core.vibe_agents import VibeAgentStore
 from core import chat_discovery
 from vibe import api
 from vibe.opencode_config import parse_jsonc_object
@@ -1189,10 +1190,31 @@ def test_vibe_agent_api_crud_and_settings_catalog(tmp_path, monkeypatch):
 
     assert created["ok"] is True
     assert default_result["default_agent_name"] == "reviewer"
-    assert [agent["name"] for agent in listed["agents"]] == ["reviewer"]
+    assert "reviewer" in [agent["name"] for agent in listed["agents"]]
     assert settings["agent_catalog"]["default_agent_name"] == "reviewer"
-    assert settings["agent_catalog"]["agents"][0]["backend"] == "codex"
+    assert any(agent["backend"] == "codex" for agent in settings["agent_catalog"]["agents"])
     assert updated["agent"]["model"] == "gpt-5.5"
+
+
+def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+
+    listed = api.get_vibe_agents()
+    names = {agent["name"] for agent in listed["agents"]}
+
+    assert {"opencode", "claude"}.issubset(names)
+    assert api.remove_vibe_agent("opencode")["code"] == "agent_builtin"
+
+
+def test_builtin_default_agent_does_not_reuse_conflicting_user_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    store = VibeAgentStore()
+    try:
+        store.create(name="opencode", backend="codex")
+        with pytest.raises(ValueError, match="already exists with backend"):
+            store.ensure_builtin_default_agent(backend="opencode")
+    finally:
+        store.close()
 
 
 def test_vibe_agent_import_reports_unreadable_file_as_client_error(tmp_path, monkeypatch):

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1206,6 +1206,16 @@ def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_pa
     assert api.remove_vibe_agent("opencode")["code"] == "agent_builtin"
 
 
+def test_builtin_default_agents_respect_configured_default_backend(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    store = VibeAgentStore()
+    try:
+        store.ensure_builtin_default_agents(["opencode", "claude", "codex"], default_backend="codex")
+        assert store.get_default_agent_name() == "codex"
+    finally:
+        store.close()
+
+
 def test_builtin_default_agent_does_not_reuse_conflicting_user_agent(tmp_path, monkeypatch):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -247,11 +247,12 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
               value={value.routing.agent_name || ''}
               onChange={(e) => {
                 const nextName = e.target.value || null;
+                const nextAgent = nextName ? vibeAgents.find((agent) => agent.name === nextName) || null : null;
                 onChange({
                   routing: {
                     ...value.routing,
                     agent_name: nextName,
-                    agent_backend: null,
+                    agent_backend: nextAgent?.backend || null,
                     model: null,
                     reasoning_effort: null,
                   },

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -99,8 +99,9 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
 
   const selectedVibeAgent = vibeAgents.find((agent) => agent.name === value.routing.agent_name) || null;
   const defaultVibeAgent = vibeAgents.find((agent) => agent.name === defaultAgentName) || null;
-  const inheritedVibeAgent = selectedVibeAgent || defaultVibeAgent;
-  const effectiveBackend = inheritedVibeAgent?.backend || value.routing.agent_backend || globalConfig?.agents?.default_backend || 'opencode';
+  const legacyBackend = value.routing.agent_backend || null;
+  const inheritedVibeAgent = selectedVibeAgent || (!legacyBackend ? defaultVibeAgent : null);
+  const effectiveBackend = selectedVibeAgent?.backend || legacyBackend || defaultVibeAgent?.backend || globalConfig?.agents?.default_backend || 'opencode';
   const effectiveModel = value.routing.model || inheritedVibeAgent?.model || '';
 
   const getOpenCodeReasoningOptions = (modelKey: string) => {

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -14,7 +14,9 @@ export interface RoutingConfigValue {
   custom_cwd: string;
   routing: {
     agent_name?: string | null;
-    agent_backend: string | null;
+    agent_backend?: string | null;
+    model?: string | null;
+    reasoning_effort?: string | null;
     opencode_agent?: string | null;
     opencode_model?: string | null;
     opencode_reasoning_effort?: string | null;
@@ -87,22 +89,19 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
   vibeAgents = [],
   defaultAgentName,
   opencodeOptions,
-  claudeAgents = [],
   claudeModels = [],
   claudeReasoningOptions = {},
-  codexAgents = [],
   codexModels = [],
   footerActions,
   containerClass = 'border-t border-border/60 px-5 py-4',
 }) => {
   const { t } = useTranslation();
 
-  const defaultBackend = globalConfig?.agents?.default_backend || 'opencode';
   const selectedVibeAgent = vibeAgents.find((agent) => agent.name === value.routing.agent_name) || null;
   const defaultVibeAgent = vibeAgents.find((agent) => agent.name === defaultAgentName) || null;
   const inheritedVibeAgent = selectedVibeAgent || defaultVibeAgent;
-  const hasSelectedVibeAgent = selectedVibeAgent !== null;
-  const effectiveBackend = selectedVibeAgent?.backend || value.routing.agent_backend || defaultVibeAgent?.backend || defaultBackend;
+  const effectiveBackend = inheritedVibeAgent?.backend || value.routing.agent_backend || globalConfig?.agents?.default_backend || 'opencode';
+  const effectiveModel = value.routing.model || inheritedVibeAgent?.model || '';
 
   const getOpenCodeReasoningOptions = (modelKey: string) => {
     const lookup = opencodeOptions?.reasoning_options || {};
@@ -140,6 +139,73 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
       default: return fallback;
     }
   };
+
+  const modelOverrideControl = (() => {
+    if (effectiveBackend === 'opencode') {
+      return (
+        <CompactSelect
+          value={value.routing.model || ''}
+          onChange={(e) => onChange({
+            routing: {
+              ...value.routing,
+              model: e.target.value || null,
+              reasoning_effort: null,
+            },
+          })}
+          className="w-full"
+        >
+          <option value="">{t('common.default')}</option>
+          {(opencodeOptions?.models?.providers || []).flatMap((provider: any) => {
+            const pid = provider.id || provider.provider_id || provider.name;
+            const pLabel = provider.name || pid;
+            const models = provider.models || {};
+            if (Array.isArray(models)) {
+              return models.map((m: any) => {
+                const mid = typeof m === 'string' ? m : m.id;
+                return <option key={`${pid}:${mid}`} value={`${pid}/${mid}`}>{pLabel}/{mid}</option>;
+              });
+            }
+            return Object.keys(models).map((mid) => (
+              <option key={`${pid}:${mid}`} value={`${pid}/${mid}`}>{pLabel}/{mid}</option>
+            ));
+          })}
+        </CompactSelect>
+      );
+    }
+    const models = effectiveBackend === 'claude' ? claudeModels : codexModels;
+    const placeholder = effectiveBackend === 'claude'
+      ? t('channelList.claudeModelPlaceholder')
+      : t('channelList.codexModelPlaceholder');
+    return (
+      <Combobox
+        options={[{ value: '', label: t('common.default') }, ...models.map(m => ({ value: m, label: m }))]}
+        value={value.routing.model || ''}
+        onValueChange={(v) => onChange({
+          routing: {
+            ...value.routing,
+            model: v || null,
+            reasoning_effort: null,
+          },
+        })}
+        placeholder={placeholder}
+        searchPlaceholder={t('channelList.searchModel')}
+        allowCustomValue={true}
+      />
+    );
+  })();
+
+  const reasoningOptions = (() => {
+    if (effectiveBackend === 'claude') {
+      return getClaudeReasoning(effectiveModel)
+        .filter((option) => option.value !== '__default__')
+        .map((option) => ({ value: option.value, label: getReasoningLabel(option.value, option.label) }));
+    }
+    if (effectiveBackend === 'opencode') {
+      const options = getOpenCodeReasoningOptions(effectiveModel);
+      if (options.length) return options;
+    }
+    return ['low', 'medium', 'high', 'xhigh'].map((value) => ({ value, label: getReasoningLabel(value, value) }));
+  })();
 
   // Top row: working dir + Vibe Agent (+ optional require_mention) — dynamic grid columns
   const topGridCols = showRequireMention ? 'md:grid-cols-3' : 'md:grid-cols-2';
@@ -184,6 +250,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                   routing: {
                     ...value.routing,
                     agent_name: nextName,
+                    agent_backend: null,
                   },
                 });
               }}
@@ -269,6 +336,32 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
         })()}
       </div>
 
+      {/* Scope-level overrides */}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div className="space-y-1">
+          <label className="text-xs font-medium uppercase text-muted">{t('channelList.model')}</label>
+          {modelOverrideControl}
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium uppercase text-muted">{t('channelList.reasoningEffort')}</label>
+          <CompactSelect
+            value={value.routing.reasoning_effort || ''}
+            onChange={(e) => onChange({
+              routing: {
+                ...value.routing,
+                reasoning_effort: e.target.value || null,
+              },
+            })}
+            className="w-full"
+          >
+            <option value="">{t('common.default')}</option>
+            {reasoningOptions.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </CompactSelect>
+        </div>
+      </div>
+
       {/* Show message types chips */}
       <div className="space-y-2">
         <div className="flex items-center gap-1 text-xs font-medium uppercase text-muted">
@@ -314,177 +407,6 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
           })}
         </div>
       </div>
-
-      {/* Legacy backend-specific settings remain for scopes without an explicit Vibe Agent. */}
-      {!hasSelectedVibeAgent && effectiveBackend === 'opencode' && (
-        <div className="space-y-3">
-          <div className="text-xs font-medium uppercase text-muted">{t('channelList.opencodeSettings')}</div>
-          <div className="grid grid-cols-1 gap-3 rounded-xl border border-border bg-surface/80 p-3 md:grid-cols-3">
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.agent')}</label>
-              <CompactSelect
-                value={value.routing.opencode_agent || ''}
-                onChange={(e) => onChange({ routing: { ...value.routing, opencode_agent: e.target.value || null } })}
-                className="w-full"
-              >
-                <option value="">{t('common.default')}</option>
-                {(opencodeOptions?.agents || []).map((a: any) => (
-                  <option key={a.name} value={a.name}>{a.name}</option>
-                ))}
-              </CompactSelect>
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.model')}</label>
-              <CompactSelect
-                value={value.routing.opencode_model || ''}
-                onChange={(e) => onChange({
-                  routing: {
-                    ...value.routing,
-                    opencode_model: e.target.value || null,
-                    opencode_reasoning_effort: null,
-                  },
-                })}
-                className="w-full"
-              >
-                <option value="">{t('common.default')}</option>
-                {(opencodeOptions?.models?.providers || []).flatMap((provider: any) => {
-                  const pid = provider.id || provider.provider_id || provider.name;
-                  const pLabel = provider.name || pid;
-                  const models = provider.models || {};
-                  if (Array.isArray(models)) {
-                    return models.map((m: any) => {
-                      const mid = typeof m === 'string' ? m : m.id;
-                      return <option key={`${pid}:${mid}`} value={`${pid}/${mid}`}>{pLabel}/{mid}</option>;
-                    });
-                  }
-                  return Object.keys(models).map((mid) => (
-                    <option key={`${pid}:${mid}`} value={`${pid}/${mid}`}>{pLabel}/{mid}</option>
-                  ));
-                })}
-              </CompactSelect>
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.reasoningEffort')}</label>
-              <CompactSelect
-                value={value.routing.opencode_reasoning_effort || ''}
-                onChange={(e) => onChange({
-                  routing: { ...value.routing, opencode_reasoning_effort: e.target.value || null },
-                })}
-                disabled={!getOpenCodeReasoningOptions(value.routing.opencode_model || '').length}
-                className="w-full disabled:opacity-50"
-              >
-                <option value="">{t('common.default')}</option>
-                {getOpenCodeReasoningOptions(value.routing.opencode_model || '').map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </CompactSelect>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {!hasSelectedVibeAgent && effectiveBackend === 'claude' && (
-        <div className="space-y-3">
-          <div className="text-xs font-medium uppercase text-muted">{t('channelList.claudeSettings')}</div>
-          <div className="grid grid-cols-1 gap-3 rounded-xl border border-border bg-surface/80 p-3 md:grid-cols-3">
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.agent')}</label>
-              <CompactSelect
-                value={value.routing.claude_agent || ''}
-                onChange={(e) => onChange({ routing: { ...value.routing, claude_agent: e.target.value || null } })}
-                className="w-full"
-              >
-                <option value="">{t('common.default')}</option>
-                {claudeAgents.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
-              </CompactSelect>
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.model')}</label>
-              <Combobox
-                options={[{ value: '', label: t('common.default') }, ...claudeModels.map(m => ({ value: m, label: m }))]}
-                value={value.routing.claude_model || ''}
-                onValueChange={(v) => onChange({
-                  routing: {
-                    ...value.routing,
-                    claude_model: v || null,
-                    claude_reasoning_effort: null,
-                  },
-                })}
-                placeholder={t('channelList.claudeModelPlaceholder')}
-                searchPlaceholder={t('channelList.searchModel')}
-                allowCustomValue={true}
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.reasoningEffort')}</label>
-              <CompactSelect
-                value={value.routing.claude_reasoning_effort || ''}
-                onChange={(e) => onChange({
-                  routing: { ...value.routing, claude_reasoning_effort: e.target.value || null },
-                })}
-                className="w-full"
-              >
-                <option value="">{t('common.default')}</option>
-                {getClaudeReasoning(value.routing.claude_model || '')
-                  .filter((option) => option.value !== '__default__')
-                  .map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {getReasoningLabel(option.value, option.label)}
-                    </option>
-                  ))}
-              </CompactSelect>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {!hasSelectedVibeAgent && effectiveBackend === 'codex' && (
-        <div className="space-y-3">
-          <div className="text-xs font-medium uppercase text-muted">{t('channelList.codexSettings')}</div>
-          <div className="grid grid-cols-1 gap-3 rounded-xl border border-border bg-surface/80 p-3 md:grid-cols-3">
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.agent')}</label>
-              <CompactSelect
-                value={value.routing.codex_agent || ''}
-                onChange={(e) => onChange({ routing: { ...value.routing, codex_agent: e.target.value || null } })}
-                className="w-full"
-              >
-                <option value="">{t('common.default')}</option>
-                {codexAgents.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
-              </CompactSelect>
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.model')}</label>
-              <Combobox
-                options={[{ value: '', label: t('common.default') }, ...codexModels.map(m => ({ value: m, label: m }))]}
-                value={value.routing.codex_model || ''}
-                onValueChange={(v) => onChange({
-                  routing: { ...value.routing, codex_model: v || null },
-                })}
-                placeholder={t('channelList.codexModelPlaceholder')}
-                searchPlaceholder={t('channelList.searchModel')}
-                allowCustomValue={true}
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs text-muted">{t('channelList.reasoningEffort')}</label>
-              <CompactSelect
-                value={value.routing.codex_reasoning_effort || ''}
-                onChange={(e) => onChange({
-                  routing: { ...value.routing, codex_reasoning_effort: e.target.value || null },
-                })}
-                className="w-full"
-              >
-                <option value="">{t('common.default')}</option>
-                <option value="low">{t('channelList.reasoningLow')}</option>
-                <option value="medium">{t('channelList.reasoningMedium')}</option>
-                <option value="high">{t('channelList.reasoningHigh')}</option>
-                <option value="xhigh">{t('channelList.reasoningXHigh')}</option>
-              </CompactSelect>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Custom footer slot — e.g., admin/remove buttons on /users */}
       {footerActions && (

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -252,6 +252,8 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                     ...value.routing,
                     agent_name: nextName,
                     agent_backend: null,
+                    model: null,
+                    reasoning_effort: null,
                   },
                 });
               }}

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -618,7 +618,10 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       const raw = configs[channel.id];
       if (!raw || raw.enabled === false) return;
       const effectiveCwd = (raw.custom_cwd ?? '') || defaultCwd;
-      const backend = raw.routing?.agent_backend || defaultBackend;
+      const routing = raw.routing || {};
+      const selectedAgent = routing.agent_name ? agentByName[routing.agent_name] : null;
+      const defaultAgent = !routing.agent_backend ? agentByName[defaultAgentName || ''] : null;
+      const backend = selectedAgent?.backend || routing.agent_backend || defaultAgent?.backend || defaultBackend;
 
       if (backend === 'opencode' && config.agents?.opencode?.enabled) {
         neededOpenCodeCwds.add(effectiveCwd);
@@ -648,7 +651,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
         void loadCodexAgents(cwd);
       }
     });
-  }, [channels, configs, config.runtime?.default_cwd, config.agents?.default_backend, config.agents?.opencode?.enabled, config.agents?.claude?.enabled, config.agents?.codex?.enabled]);
+  }, [channels, configs, config.runtime?.default_cwd, config.agents?.default_backend, config.agents?.opencode?.enabled, config.agents?.claude?.enabled, config.agents?.codex?.enabled, agentByName, defaultAgentName]);
 
   const isChannelEnabled = (channelId: string) => {
     const channel = configs[channelId];

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -1287,8 +1287,9 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               };
               const rowKey = `${channelPlatform}::${channel.id}`;
               const expanded = expandedChannelId === rowKey;
-              const selectedAgent = agentByName[channelConfig.routing.agent_name || ''] || agentByName[defaultAgentName || ''];
-              const effectiveBackend = selectedAgent?.backend || channelConfig.routing.agent_backend || defaultBackend;
+              const legacyBackend = channelConfig.routing.agent_backend || null;
+              const selectedAgent = agentByName[channelConfig.routing.agent_name || ''] || (!legacyBackend ? agentByName[defaultAgentName || ''] : undefined);
+              const effectiveBackend = selectedAgent?.backend || legacyBackend || defaultBackend;
               const effectiveCwd = channelConfig.custom_cwd || config.runtime?.default_cwd || '~/work';
               const opencodeOptions = opencodeOptionsByCwd[effectiveCwd];
               const claudeAgents = claudeAgentsByCwd[effectiveCwd] || [];

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -55,7 +55,9 @@ interface ChannelConfig {
   custom_cwd: string;
   routing: {
     agent_name?: string | null;
-    agent_backend: string | null;
+    agent_backend?: string | null;
+    model?: string | null;
+    reasoning_effort?: string | null;
     opencode_agent?: string | null;
     opencode_model?: string | null;
     opencode_reasoning_effort?: string | null;
@@ -677,7 +679,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       next.show_message_types = defaultConfig().show_message_types;
     }
     if (!next.routing || typeof next.routing !== 'object') {
-      next.routing = { agent_backend: config.agents?.default_backend || 'opencode' };
+      next.routing = { agent_name: null, agent_backend: null };
     }
     const nextConfigs = { ...configs, [channelId]: next };
     setConfigs(nextConfigs);
@@ -691,6 +693,8 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       routing: {
         agent_name: null,
         agent_backend: null,
+        model: null,
+        reasoning_effort: null,
         opencode_agent: null,
         opencode_model: null,
         opencode_reasoning_effort: null,
@@ -734,7 +738,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       next.show_message_types = defaultConfig().show_message_types;
     }
     if (!next.routing || typeof next.routing !== 'object') {
-      next.routing = { agent_backend: config.agents?.default_backend || 'opencode' };
+      next.routing = { agent_name: null, agent_backend: null };
     }
     const nextPlatformConfigs = { ...platformConfigs, [channelId]: next };
     setAllConfigsByPlatform((prev) => ({ ...prev, [platformId]: nextPlatformConfigs }));
@@ -1294,11 +1298,13 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 void updateConfigForPlatform(channelPlatform, channel.id, patch);
               };
 
-              const backendModel = effectiveBackend === 'claude'
-                ? channelConfig.routing.claude_model
-                : effectiveBackend === 'codex'
-                  ? channelConfig.routing.codex_model
-                  : channelConfig.routing.opencode_model;
+              const backendModel = channelConfig.routing.model || (
+                effectiveBackend === 'claude'
+                  ? channelConfig.routing.claude_model
+                  : effectiveBackend === 'codex'
+                    ? channelConfig.routing.codex_model
+                    : channelConfig.routing.opencode_model
+              );
               const agentSummary = selectedAgent
                 ? `${selectedAgent.name}${selectedAgent.model ? ` / ${selectedAgent.model}` : ''}`
                 : `${effectiveBackend === 'claude' ? 'Claude' : effectiveBackend === 'codex' ? 'Codex' : 'OpenCode'}${backendModel ? ` / ${backendModel}` : ''}`;

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -515,7 +515,10 @@ const buildSettingsPayload = (data: any) => {
               custom_cwd: cfg.custom_cwd || null,
               require_mention: cfg.require_mention ?? null,
               routing: {
+                agent_name: cfg.routing?.agent_name || null,
                 agent_backend: cfg.routing?.agent_backend || null,
+                model: cfg.routing?.model || null,
+                reasoning_effort: cfg.routing?.reasoning_effort || null,
                 opencode_agent: cfg.routing?.opencode_agent || null,
                 opencode_model: cfg.routing?.opencode_model || null,
                 opencode_reasoning_effort: cfg.routing?.opencode_reasoning_effort || null,

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -33,7 +33,9 @@ interface UserConfig {
   custom_cwd: string;
   routing: {
     agent_name?: string | null;
-    agent_backend: string | null;
+    agent_backend?: string | null;
+    model?: string | null;
+    reasoning_effort?: string | null;
     opencode_agent?: string | null;
     opencode_model?: string | null;
     opencode_reasoning_effort?: string | null;
@@ -593,7 +595,7 @@ export const UserList: React.FC = () => {
     const base = platformUsers[userId] || defaultUserConfig();
     const next = { ...base, ...patch };
     if (!next.routing || typeof next.routing !== 'object') {
-      next.routing = { agent_backend: config.agents?.default_backend || 'opencode' };
+      next.routing = { agent_name: null, agent_backend: null };
     }
     const nextPlatformUsers = { ...platformUsers, [userId]: next };
     setUsersByPlatform((prev) => ({ ...prev, [platform]: nextPlatformUsers }));
@@ -649,6 +651,8 @@ export const UserList: React.FC = () => {
     routing: {
       agent_name: null,
       agent_backend: null,
+      model: null,
+      reasoning_effort: null,
       opencode_agent: null,
       opencode_model: null,
       opencode_reasoning_effort: null,
@@ -744,11 +748,13 @@ export const UserList: React.FC = () => {
               const isBot = !userConfig.is_admin && (userConfig.display_name || u.userId).toLowerCase().includes('bot');
               const tone = AVATAR_TONES[hashCode(u.userId) % AVATAR_TONES.length];
               const initials = getInitials(userConfig.display_name, u.userId);
-              const backendModel = effectiveBackend === 'claude'
-                ? userConfig.routing.claude_model
-                : effectiveBackend === 'codex'
-                  ? userConfig.routing.codex_model
-                  : userConfig.routing.opencode_model;
+              const backendModel = userConfig.routing.model || (
+                effectiveBackend === 'claude'
+                  ? userConfig.routing.claude_model
+                  : effectiveBackend === 'codex'
+                    ? userConfig.routing.codex_model
+                    : userConfig.routing.opencode_model
+              );
               const displayName = displayNameForUser(u);
               const metaPrefix = userConfig.enabled
                 ? selectedAgent

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -739,8 +739,9 @@ export const UserList: React.FC = () => {
               const expanded = expandedKey === u.key;
               const userConfig = u.config;
               const defaultBackend = config.agents?.default_backend || 'opencode';
-              const selectedAgent = agentByName[userConfig.routing?.agent_name || ''] || agentByName[defaultAgentName || ''];
-              const effectiveBackend = selectedAgent?.backend || userConfig.routing?.agent_backend || defaultBackend;
+              const legacyBackend = userConfig.routing?.agent_backend || null;
+              const selectedAgent = agentByName[userConfig.routing?.agent_name || ''] || (!legacyBackend ? agentByName[defaultAgentName || ''] : undefined);
+              const effectiveBackend = selectedAgent?.backend || legacyBackend || defaultBackend;
               const effectiveCwd = userConfig.custom_cwd || config.runtime?.default_cwd || '~/work';
               const opencodeOptions = opencodeOptionsByCwd[effectiveCwd];
               const claudeAgents = claudeAgentsByCwd[effectiveCwd] || [];

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -571,12 +571,15 @@ export const UserList: React.FC = () => {
     aggregated.forEach((u) => {
       if (!u.config.enabled) return;
       const cwd = u.config.custom_cwd || defaultCwd;
-      const backend = u.config.routing?.agent_backend || defaultBackend;
+      const routing = u.config.routing || {};
+      const selectedAgent = routing.agent_name ? agentByName[routing.agent_name] : null;
+      const defaultAgent = !routing.agent_backend ? agentByName[defaultAgentName || ''] : null;
+      const backend = selectedAgent?.backend || routing.agent_backend || defaultAgent?.backend || defaultBackend;
       if (backend === 'opencode' && config.agents?.opencode?.enabled && !opencodeOptionsByCwd[cwd]) loadOpenCodeOptions(cwd);
       if (backend === 'claude' && config.agents?.claude?.enabled && !claudeAgentsByCwd[cwd]) loadClaudeAgents(cwd);
       if (backend === 'codex' && config.agents?.codex?.enabled && !codexAgentsByCwd[cwd]) loadCodexAgents(cwd);
     });
-  }, [aggregated, config]);
+  }, [aggregated, config, agentByName, defaultAgentName]);
 
   const persistUsers = async (platform: string, next: Record<string, UserConfig>) => {
     setLoading(true);

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, V2Config
+from config.v2_config import CONFIG_LOCK, DEFAULT_AGENT_BACKEND, V2Config
 from config.v2_settings import (
     SettingsStore,
     ChannelSettings,
@@ -94,13 +94,23 @@ def _enabled_agent_backends_from_config(config: Optional[V2Config] = None) -> li
     return result
 
 
+def _default_agent_backend_from_config(config: Optional[V2Config] = None) -> str:
+    try:
+        cfg = config or load_config()
+    except FileNotFoundError:
+        return DEFAULT_AGENT_BACKEND
+    agents = getattr(cfg, "agents", None)
+    return str(getattr(agents, "default_backend", DEFAULT_AGENT_BACKEND) or DEFAULT_AGENT_BACKEND)
+
+
 def _ensure_builtin_default_agents(config: Optional[V2Config] = None) -> None:
     backends = _enabled_agent_backends_from_config(config)
     if not backends:
         return
+    default_backend = _default_agent_backend_from_config(config)
     store = VibeAgentStore()
     try:
-        store.ensure_builtin_default_agents(backends)
+        store.ensure_builtin_default_agents(backends, default_backend=default_backend)
     finally:
         store.close()
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -45,6 +45,7 @@ from vibe.restart_supervisor import schedule_restart
 from vibe.claude_model_catalog import DEFAULT_CLAUDE_MODEL_ALIASES, load_catalog_models
 from modules.agents.catalog import (
     agent_backend_catalog_payload,
+    agent_backend_descriptors,
     is_agent_backend,
     latest_probe_for_backend,
     runtime_refresh_success_message,
@@ -72,6 +73,36 @@ def _parse_agent_import_file(path: Path, *, backend: str):
         return parse_agent_file(path, backend=backend)
     except (OSError, ValueError, TypeError, AttributeError, yaml.YAMLError) as exc:
         raise ValueError(f"Unable to read or parse agent import file: {exc}") from exc
+
+
+def _enabled_agent_backends_from_config(config: Optional[V2Config] = None) -> list[str]:
+    try:
+        cfg = config or load_config()
+    except FileNotFoundError:
+        return [descriptor.id for descriptor in agent_backend_descriptors() if descriptor.default_enabled]
+    result: list[str] = []
+    agents = getattr(cfg, "agents", None)
+    if agents is not None:
+        for backend in ("opencode", "claude", "codex"):
+            backend_cfg = getattr(agents, backend, None)
+            if bool(getattr(backend_cfg, "enabled", False)):
+                result.append(backend)
+    if not result:
+        default_backend = getattr(agents, "default_backend", None) if agents is not None else None
+        if default_backend:
+            result.append(str(default_backend))
+    return result
+
+
+def _ensure_builtin_default_agents(config: Optional[V2Config] = None) -> None:
+    backends = _enabled_agent_backends_from_config(config)
+    if not backends:
+        return
+    store = VibeAgentStore()
+    try:
+        store.ensure_builtin_default_agents(backends)
+    finally:
+        store.close()
 
 
 def _is_executable_file(path: Path) -> bool:
@@ -667,6 +698,7 @@ def _vibe_agent_payload(agent, *, brief: bool = False) -> dict:
 
 
 def get_vibe_agents(*, backend: Optional[str] = None) -> dict:
+    _ensure_builtin_default_agents()
     store = VibeAgentStore()
     try:
         normalized_backend = validate_agent_backend(backend) if backend else None
@@ -769,7 +801,14 @@ def remove_vibe_agent(name: str) -> dict:
                 "message": f"agent '{name}' is still referenced",
                 "references": counts,
             }
-        removed = store.remove(name)
+        try:
+            removed = store.remove(name)
+        except ValueError as exc:
+            return {
+                "ok": False,
+                "code": "agent_builtin",
+                "message": str(exc),
+            }
         if not removed:
             return {"ok": False, "code": "agent_not_found", "message": f"agent '{name}' not found"}
         return {"ok": True, "removed_agent": name}
@@ -4652,7 +4691,7 @@ def auto_bind_wechat_user(user_id: str) -> dict:
         bound_at=_now_iso(),
         enabled=True,
         custom_cwd=config.runtime.default_cwd or None,
-        routing=RoutingSettings(agent_backend=config.agents.default_backend or None),
+        routing=RoutingSettings(),
         pending_bind_menu_hint=True,
     )
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -2205,7 +2205,15 @@ def cmd_agent_remove(args):
                 hint="Reassign or remove the referencing scopes, sessions, tasks, or watches before deleting this Agent.",
                 details={"agent": args.name, "references": counts},
             )
-        removed = store.remove(args.name)
+        try:
+            removed = store.remove(args.name)
+        except ValueError as exc:
+            raise TaskCliError(
+                str(exc),
+                code="agent_builtin",
+                hint="Built-in default Agents are created from enabled Backends and cannot be deleted.",
+                details={"agent": args.name},
+            ) from exc
         if not removed:
             raise TaskCliError(f"agent '{args.name}' not found", code="agent_not_found", details={"agent": args.name})
         _print_cli_payload("agent", removed_agent=args.name)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2449,6 +2449,16 @@ if os.environ.get("E2E_TEST_MODE", "").lower() in ("true", "1", "yes"):
 
                     ch.routing = RoutingSettings(
                         agent_backend=modal_values.get("backend", "opencode"),
+                        model=(
+                            modal_values.get("opencode_model")
+                            or modal_values.get("claude_model")
+                            or modal_values.get("codex_model")
+                        ),
+                        reasoning_effort=(
+                            modal_values.get("opencode_reasoning_effort")
+                            or modal_values.get("claude_reasoning_effort")
+                            or modal_values.get("codex_reasoning_effort")
+                        ),
                         opencode_agent=modal_values.get("opencode_agent"),
                         opencode_model=modal_values.get("opencode_model"),
                         opencode_reasoning_effort=modal_values.get("opencode_reasoning_effort"),
@@ -2491,6 +2501,16 @@ if os.environ.get("E2E_TEST_MODE", "").lower() in ("true", "1", "yes"):
 
                     ch.routing = RoutingSettings(
                         agent_backend=modal_values.get("backend", "opencode"),
+                        model=(
+                            modal_values.get("opencode_model")
+                            or modal_values.get("claude_model")
+                            or modal_values.get("codex_model")
+                        ),
+                        reasoning_effort=(
+                            modal_values.get("opencode_reasoning_effort")
+                            or modal_values.get("claude_reasoning_effort")
+                            or modal_values.get("codex_reasoning_effort")
+                        ),
                         opencode_agent=modal_values.get("opencode_agent"),
                         opencode_model=modal_values.get("opencode_model"),
                         opencode_reasoning_effort=modal_values.get("opencode_reasoning_effort"),


### PR DESCRIPTION
## What changed

- Adds built-in default Vibe Agents for enabled Backends and prevents deleting those built-in Agents.
- Moves Scope settings toward the target model: Scope selects an Agent and may override model/reasoning, while Backend remains internal to Agent.
- Keeps migration compatibility for legacy `agent_backend` and backend-specific model/reasoning fields.
- Simplifies Scope routing UI to Agent + model/reasoning overrides instead of separate Backend-specific panels.

## Evidence layers

- Unit: updated controller, settings, API, and message-handler tests for Agent/Scope resolution.
- Contract: SQLite settings serialization keeps reading legacy fields while emitting unified Scope overrides.
- Scenario: covered legacy backend-only Scope mapping to built-in Agent and Scope override precedence over Agent defaults.
- Residual manual checks: no full Docker IM regression run in this pass.

## Validation

- `uv run pytest tests/test_sqlite_settings_store.py tests/test_ui_api.py tests/test_controller_vibe_agent_routing.py tests/test_message_handler_typing.py`
- `uv run ruff check ...`
- `npm run build`
