### PR TITLE
Clarify Show Page agent guidance

### DIFF
--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -137,6 +137,12 @@ def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
     assert payload["public_url"] is None
     assert payload["url_available"] is True
     assert payload["url_guidance"] is None
+    assert "Do not send implementation details such as local paths to the user unless they ask for them." in payload["next_actions"]
+    assert "Treat the Show Page as the primary collaboration surface; put meaningful updates there first." in payload["next_actions"]
+    assert (
+        "Use visual thinking: diagrams, timelines, maps, comparisons, dashboards, or small prototypes when they help."
+        in payload["next_actions"]
+    )
     assert (tmp_path / "show" / "ses123" / "index.html").exists()
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3723,7 +3723,10 @@ def _show_page_result(page, *, message: str, previous_payload: dict | None = Non
 def _show_page_next_actions(payload: dict) -> list[str]:
     session_id = payload.get("session_id") or "<session-id>"
     visibility = payload.get("visibility")
-    actions = [f"Edit files under: {payload.get('path')}"]
+    actions = [
+        f"Use this local workspace internally: {payload.get('path')}",
+        "Do not send implementation details such as local paths to the user unless they ask for them.",
+    ]
     active_url = payload.get("active_url")
     if active_url:
         actions.append(f"Send this URL to the user: {active_url}")
@@ -3731,6 +3734,8 @@ def _show_page_next_actions(payload: dict) -> list[str]:
         actions.append(f"Bring the page online again with: vibe show update --session-id {session_id} --visibility private")
     elif not payload.get("url_guidance"):
         actions.append("No active URL is available right now.")
+    actions.append("Treat the Show Page as the primary collaboration surface; put meaningful updates there first.")
+    actions.append("Use visual thinking: diagrams, timelines, maps, comparisons, dashboards, or small prototypes when they help.")
     actions.append("To update the page later, edit the same directory and refresh.")
     actions.append("For more options, run: vibe show --help")
     return actions


### PR DESCRIPTION
## Summary

Clarifies the agent-facing guidance returned by `vibe show path` so agents treat local Show Page paths as internal implementation details, send users the active URL, and use Show Pages as the primary visual collaboration surface.

## Changed Capability

Show Page CLI agent guidance.

## Affected Scenarios

No scenario catalog entry applies to this copy-only CLI guidance change.

## Evidence Layers

- Unit: updated `tests/test_show_pages.py` to assert the new guidance appears in the JSON payload.
- Contract: `vibe show path --json` keeps the same payload shape and adds guidance through `next_actions`.
- Scenario: not applicable; no scenario catalog entry covers this CLI copy surface.
- Residual manual checks: none.

## Validation

- `uv run pytest tests/test_show_pages.py`
- `uv run ruff check vibe/cli.py tests/test_show_pages.py`
