### PR TITLE
Add enabled state for Vibe Agents

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -143,8 +143,6 @@ class Controller:
             cfg = getattr(agent_config, backend, None)
             if bool(getattr(cfg, "enabled", False)):
                 result.append(backend)
-        if not result:
-            result.append(default_backend)
         return result
 
     def get_native_session_service(self):
@@ -589,7 +587,7 @@ class Controller:
         agent_name = override_agent_name or (routing.agent_name if routing else None)
         try:
             if agent_name:
-                return self.vibe_agent_store.require(agent_name)
+                return self.vibe_agent_store.require_enabled(agent_name)
             legacy_backend = routing.agent_backend if routing else None
             if legacy_backend:
                 agent = self.vibe_agent_store.get_builtin_default_agent_for_backend(legacy_backend)

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1303,11 +1303,9 @@ class ScheduledTaskService:
         ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(config_paths.get_state_dir()))
         agent_store = VibeAgentStore()
         try:
-            agent = agent_store.get(agent_name) if agent_name else None
+            agent = agent_store.require_enabled(agent_name) if agent_name else None
         finally:
             agent_store.close()
-        if agent_name and agent is None:
-            raise ValueError(f"agent '{agent_name}' not found")
         agent_backend = agent.backend if agent else self._resolve_scope_agent_backend(deliver_key)
         service = SQLiteSessionsService(config_paths.get_sqlite_state_path())
         try:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_AGENT_NAME = "default"
 DEFAULT_AGENT_META_KEY = "default_agent_name"
 BUILTIN_DEFAULT_AGENT_METADATA = {"builtin": True, "builtin_default": True, "lock_delete": True}
+BUILTIN_BACKEND_ENABLED_META_KEY = "backend_enabled"
 SUPPORTED_AGENT_BACKENDS = {"codex", "claude", "opencode"}
 _UNSET = object()
 
@@ -72,6 +73,7 @@ class VibeAgent:
     model: Optional[str] = None
     reasoning_effort: Optional[str] = None
     system_prompt: Optional[str] = None
+    enabled: bool = True
     source: str = "user"
     source_ref: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -119,9 +121,12 @@ class VibeAgentStore:
     def maybe_reload(self) -> bool:
         return self._probe.has_external_write()
 
-    def list_agents(self) -> list[VibeAgent]:
+    def list_agents(self, *, include_disabled: bool = True) -> list[VibeAgent]:
         with self.engine.connect() as conn:
-            rows = conn.execute(select(agents).order_by(agents.c.name)).mappings()
+            stmt = select(agents).order_by(agents.c.name)
+            if not include_disabled:
+                stmt = stmt.where(agents.c.enabled == 1)
+            rows = conn.execute(stmt).mappings()
             return [self._from_row(row) for row in rows]
 
     def get(self, name: str) -> Optional[VibeAgent]:
@@ -138,6 +143,12 @@ class VibeAgentStore:
             raise ValueError(f"agent '{name}' not found")
         return agent
 
+    def require_enabled(self, name: str) -> VibeAgent:
+        agent = self.require(name)
+        if not agent.enabled:
+            raise ValueError(f"agent '{agent.name}' is disabled")
+        return agent
+
     def create(
         self,
         *,
@@ -150,6 +161,7 @@ class VibeAgentStore:
         source: str = "user",
         source_ref: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
+        enabled: bool = True,
     ) -> VibeAgent:
         normalized = normalize_agent_name(name)
         now = _utc_now_iso()
@@ -162,6 +174,7 @@ class VibeAgentStore:
             model=_clean_optional(model),
             reasoning_effort=_clean_optional(reasoning_effort),
             system_prompt=_clean_optional(system_prompt),
+            enabled=bool(enabled),
             source=str(source or "user"),
             source_ref=_clean_optional(source_ref),
             metadata=dict(metadata or {}),
@@ -184,6 +197,7 @@ class VibeAgentStore:
         reasoning_effort: Any = _UNSET,
         system_prompt: Any = _UNSET,
         metadata: Any = _UNSET,
+        enabled: Any = _UNSET,
     ) -> VibeAgent:
         existing = self.require(name)
         values: dict[str, Any] = {"updated_at": _utc_now_iso()}
@@ -197,9 +211,14 @@ class VibeAgentStore:
             values["system_prompt"] = _clean_optional(system_prompt)
         if metadata is not _UNSET:
             values["metadata_json"] = _json_dumps(dict(metadata or {}))
+        if enabled is not _UNSET:
+            values["enabled"] = 1 if bool(enabled) else 0
         with self.engine.begin() as conn:
             conn.execute(agents.update().where(agents.c.id == existing.id).values(**values))
         return self.require(name)
+
+    def set_enabled(self, name: str, enabled: bool) -> VibeAgent:
+        return self.update(name, enabled=enabled)
 
     def remove(self, name: str) -> bool:
         agent = self.get(name)
@@ -271,6 +290,7 @@ class VibeAgentStore:
             description="Default Vibe Remote agent.",
             source="builtin",
             metadata={"builtin": True},
+            enabled=True,
         )
         self.set_default_agent_name(agent.name)
         return agent
@@ -299,7 +319,29 @@ class VibeAgentStore:
             description=f"Default {agent_name} agent.",
             source="builtin",
             metadata=metadata,
+            enabled=True,
         )
+
+    def sync_builtin_default_agent(self, *, backend: str, backend_enabled: bool, name: str | None = None) -> VibeAgent:
+        backend = validate_agent_backend(backend)
+        agent = self.ensure_builtin_default_agent(backend=backend, name=name)
+        if not is_builtin_default_agent(agent):
+            return agent
+
+        previous_backend_enabled = agent.metadata.get(BUILTIN_BACKEND_ENABLED_META_KEY)
+        metadata = {**agent.metadata, BUILTIN_BACKEND_ENABLED_META_KEY: bool(backend_enabled)}
+        should_enable = bool(backend_enabled) and previous_backend_enabled is not True
+        should_disable = not bool(backend_enabled) and agent.enabled
+        updates: dict[str, Any] = {}
+        if metadata != agent.metadata:
+            updates["metadata"] = metadata
+        if should_enable:
+            updates["enabled"] = True
+        elif should_disable:
+            updates["enabled"] = False
+        if updates:
+            return self.update(agent.name, **updates)
+        return agent
 
     def ensure_builtin_default_agents(
         self,
@@ -308,31 +350,53 @@ class VibeAgentStore:
         default_backend: Optional[str] = None,
     ) -> list[VibeAgent]:
         ensured: list[VibeAgent] = []
+        enabled_backends: list[str] = []
         for backend in backends:
+            normalized_backend = validate_agent_backend(backend)
+            if normalized_backend not in enabled_backends:
+                enabled_backends.append(normalized_backend)
+        enabled_backend_set = set(enabled_backends)
+        for backend in enabled_backends:
             try:
-                ensured.append(self.ensure_builtin_default_agent(backend=backend))
+                ensured.append(self.sync_builtin_default_agent(backend=backend, backend_enabled=True))
             except ValueError as exc:
                 logger.warning("Skipping built-in default Agent for backend %s: %s", backend, exc)
-        default_agent = self.get_default_agent()
-        if default_agent is None and ensured:
+        with self.engine.connect() as conn:
+            rows = conn.execute(select(agents)).mappings().all()
+        for row in rows:
+            agent = self._from_row(row)
+            if (
+                is_builtin_default_agent(agent)
+                and agent.backend not in enabled_backend_set
+            ):
+                self.sync_builtin_default_agent(backend=agent.backend, backend_enabled=False, name=agent.name)
+        default_name = self.get_default_agent_name()
+        default_agent = self.get(default_name) if default_name else None
+        enabled_ensured = [agent for agent in ensured if agent.enabled]
+        if (default_agent is None or not default_agent.enabled) and enabled_ensured:
             preferred = None
             if default_backend:
                 preferred_backend = validate_agent_backend(default_backend)
-                preferred = next((agent for agent in ensured if agent.backend == preferred_backend), None)
-            self.set_default_agent_name((preferred or ensured[0]).name)
+                preferred = next((agent for agent in enabled_ensured if agent.backend == preferred_backend), None)
+            self.set_default_agent_name((preferred or enabled_ensured[0]).name)
         return ensured
 
-    def get_builtin_default_agent_for_backend(self, backend: str) -> Optional[VibeAgent]:
+    def get_builtin_default_agent_for_backend(self, backend: str, *, enabled_only: bool = True) -> Optional[VibeAgent]:
         backend = validate_agent_backend(backend)
         for candidate in (backend, DEFAULT_AGENT_NAME):
             agent = self.get(candidate)
-            if agent and agent.backend == backend and is_builtin_default_agent(agent):
+            if (
+                agent
+                and agent.backend == backend
+                and is_builtin_default_agent(agent)
+                and (agent.enabled or not enabled_only)
+            ):
                 return agent
         with self.engine.connect() as conn:
             rows = conn.execute(select(agents).where(agents.c.backend == backend).order_by(agents.c.name)).mappings()
             for row in rows:
                 agent = self._from_row(row)
-                if is_builtin_default_agent(agent):
+                if is_builtin_default_agent(agent) and (agent.enabled or not enabled_only):
                     return agent
         return None
 
@@ -345,7 +409,7 @@ class VibeAgentStore:
         return str(payload).strip() if payload else None
 
     def set_default_agent_name(self, name: str) -> None:
-        agent = self.require(name)
+        agent = self.require_enabled(name)
         now = _utc_now_iso()
         with self.engine.begin() as conn:
             conn.execute(state_meta.delete().where(state_meta.c.key == DEFAULT_AGENT_META_KEY))
@@ -357,13 +421,19 @@ class VibeAgentStore:
                 )
             )
 
-    def get_default_agent(self) -> Optional[VibeAgent]:
+    def get_default_agent(self, *, enabled_only: bool = True) -> Optional[VibeAgent]:
         name = self.get_default_agent_name()
         if name:
             agent = self.get(name)
-            if agent is not None:
+            if agent is not None and (agent.enabled or not enabled_only):
                 return agent
-        return self.get(DEFAULT_AGENT_NAME)
+        fallback = self.get(DEFAULT_AGENT_NAME)
+        if fallback is not None and (fallback.enabled or not enabled_only):
+            return fallback
+        if enabled_only:
+            agents_list = self.list_agents(include_disabled=False)
+            return agents_list[0] if agents_list else None
+        return None
 
     @staticmethod
     def _from_row(row: Any) -> VibeAgent:
@@ -376,6 +446,7 @@ class VibeAgentStore:
             model=row["model"],
             reasoning_effort=row["reasoning_effort"],
             system_prompt=row["system_prompt"],
+            enabled=bool(row["enabled"]),
             source=row["source"],
             source_ref=row["source_ref"],
             metadata=_json_loads(row["metadata_json"], {}),
@@ -394,6 +465,7 @@ class VibeAgentStore:
             "model": agent.model,
             "reasoning_effort": agent.reasoning_effort,
             "system_prompt": agent.system_prompt,
+            "enabled": 1 if agent.enabled else 0,
             "source": agent.source,
             "source_ref": agent.source_ref,
             "metadata_json": _json_dumps(agent.metadata),

--- a/docs/plans/agent-enabled-state.md
+++ b/docs/plans/agent-enabled-state.md
@@ -1,0 +1,38 @@
+# Agent Enabled State Plan
+
+## Goal
+
+Add first-class enablement to Vibe Agents before the Agent feature ships. The
+final model should be simple and explicit: every Agent has `enabled`, including
+built-in default Agents, and backend toggles synchronize the matching built-in
+Agent state.
+
+## Semantics
+
+- `agents.enabled` is the persisted Agent-level switch.
+- User-created, imported, and built-in Agents default to enabled.
+- A disabled Agent is not eligible for default routing or Scope/session fallback.
+- Built-in default Agents remain non-deletable, but can be disabled.
+- Backend enablement is synchronized to its built-in default Agent on backend
+  state changes:
+  - backend enabled: ensure `<backend>` built-in Agent exists and enable it if
+    the backend state just transitioned to enabled
+  - backend disabled: if `<backend>` built-in Agent exists, set `enabled=false`
+  - a normal Agent catalog refresh must not undo a user/manual disable of a
+    built-in Agent while the backend remains enabled
+- Because Agent features are not shipped yet, schema and tests can target the final shape without legacy data migration complexity beyond normal SQLite schema readiness.
+
+## Implementation
+
+- Add `enabled` to the `agents` table/model and VibeAgent dataclass.
+- Teach `VibeAgentStore` create/update/import/default-agent APIs about `enabled`.
+- Add store helpers for `set_enabled`, enabled list/default selection, and backend sync.
+- Call backend sync from startup/API ensure paths and after config save.
+- Expose CLI enable/disable and update/list payloads.
+- Keep routing/default resolution on enabled Agents only.
+- Add focused tests for store behavior, backend sync, CLI toggles, and routing fallback.
+
+## Validation
+
+- Ruff on changed Python files.
+- Targeted pytest for Agent store/API/CLI/routing tests.

--- a/storage/alembic/versions/20260501_0001_initial_sqlite_state.py
+++ b/storage/alembic/versions/20260501_0001_initial_sqlite_state.py
@@ -33,6 +33,7 @@ def upgrade() -> None:
         sa.Column("model", sa.String(), nullable=True),
         sa.Column("reasoning_effort", sa.String(), nullable=True),
         sa.Column("system_prompt", sa.Text(), nullable=True),
+        sa.Column("enabled", sa.Integer(), nullable=False),
         sa.Column("source", sa.String(), nullable=False),
         sa.Column("source_ref", sa.Text(), nullable=True),
         sa.Column("metadata_json", sa.Text(), nullable=False),

--- a/storage/alembic/versions/20260522_0003_agent_runs_schema.py
+++ b/storage/alembic/versions/20260522_0003_agent_runs_schema.py
@@ -44,6 +44,7 @@ def upgrade() -> None:
             sa.Column("model", sa.String(), nullable=True),
             sa.Column("reasoning_effort", sa.String(), nullable=True),
             sa.Column("system_prompt", sa.Text(), nullable=True),
+            sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"),
             sa.Column("source", sa.String(), nullable=False),
             sa.Column("source_ref", sa.Text(), nullable=True),
             sa.Column("metadata_json", sa.Text(), nullable=False),
@@ -51,6 +52,8 @@ def upgrade() -> None:
             sa.Column("updated_at", sa.String(), nullable=False),
             sa.UniqueConstraint("normalized_name", name="uq_agents_normalized_name"),
         )
+    else:
+        _add_column_if_missing("agents", "enabled", sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"))
     op.create_index("ix_agents_backend", "agents", ["backend"], if_not_exists=True)
     op.create_index("ix_agents_updated", "agents", ["updated_at"], if_not_exists=True)
 

--- a/storage/alembic/versions/20260525_0005_agent_enabled.py
+++ b/storage/alembic/versions/20260525_0005_agent_enabled.py
@@ -1,0 +1,30 @@
+"""add enabled state to vibe agents
+
+Revision ID: 20260525_0005
+Revises: 20260523_0004
+Create Date: 2026-05-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260525_0005"
+down_revision = "20260523_0004"
+branch_labels = None
+depends_on = None
+
+
+def _columns(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {row[1] for row in bind.exec_driver_sql(f'pragma table_info("{table_name}")')}
+
+
+def upgrade() -> None:
+    if "enabled" not in _columns("agents"):
+        op.add_column("agents", sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"))
+
+
+def downgrade() -> None:
+    pass

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -21,6 +21,7 @@ INITIAL_TABLES = {
 }
 HEAD_TABLES = INITIAL_TABLES | {"run_definitions", "agent_runs", "show_pages"}
 HEAD_REQUIRED_COLUMNS = {
+    "agents": {"enabled"},
     "scope_settings": {"agent_name"},
     "agent_sessions": {"agent_id", "agent_name"},
     "run_definitions": {
@@ -315,6 +316,7 @@ def _ensure_agents_table(conn: sqlite3.Connection, tables: set[str]) -> bool:
             model varchar,
             reasoning_effort varchar,
             system_prompt text,
+            enabled integer not null default 1,
             source varchar not null,
             source_ref text,
             metadata_json text not null,
@@ -331,6 +333,11 @@ def _ensure_agents_table(conn: sqlite3.Connection, tables: set[str]) -> bool:
 
 def _repair_initial_required_columns(conn: sqlite3.Connection, tables: set[str]) -> bool:
     changed = False
+    if "agents" in tables:
+        columns = _column_names(conn, "agents")
+        if "enabled" not in columns:
+            conn.execute('alter table "agents" add column "enabled" INTEGER not null default 1')
+            changed = True
     if "scope_settings" in tables:
         columns = _column_names(conn, "scope_settings")
         if "agent_name" not in columns:

--- a/storage/models.py
+++ b/storage/models.py
@@ -34,6 +34,7 @@ agents = Table(
     Column("model", String, nullable=True),
     Column("reasoning_effort", String, nullable=True),
     Column("system_prompt", Text, nullable=True),
+    Column("enabled", Integer, nullable=False),
     Column("source", String, nullable=False),
     Column("source_ref", Text, nullable=True),
     Column("metadata_json", Text, nullable=False),

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -59,6 +59,42 @@ def _capture_stderr_json(func, *args):
     return result, json.loads(stderr.getvalue())
 
 
+def test_agent_enable_disable_cli_toggles_enabled_state(tmp_path: Path, capsys) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    agent_store.create(name="worker", backend="codex")
+
+    with patch("vibe.cli._agent_store", return_value=agent_store):
+        assert cli.cmd_agent_set_enabled(_parse_agent(["disable", "worker"]), enabled=False) == 0
+        disabled_payload = json.loads(capsys.readouterr().out)
+        assert disabled_payload["agent"]["enabled"] is False
+
+        assert cli.cmd_agent_list(_parse_agent(["list", "--brief"])) == 0
+        assert json.loads(capsys.readouterr().out)["agents"] == []
+
+        assert cli.cmd_agent_list(_parse_agent(["list", "--all", "--brief"])) == 0
+        all_payload = json.loads(capsys.readouterr().out)
+        assert all_payload["agents"][0]["name"] == "worker"
+        assert all_payload["agents"][0]["enabled"] is False
+
+        assert cli.cmd_agent_set_enabled(_parse_agent(["enable", "worker"]), enabled=True) == 0
+        enabled_payload = json.loads(capsys.readouterr().out)
+        assert enabled_payload["agent"]["enabled"] is True
+
+
+def test_disabled_agent_cannot_run(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    agent_store.create(name="worker", backend="codex", enabled=False)
+    args = _parse_agent_run(["--agent", "worker", "--async", "--message", "hello"])
+
+    with patch("vibe.cli._agent_store", return_value=agent_store):
+        result, payload = _capture_stderr_json(cli.cmd_agent_run, args)
+
+    assert result == 1
+    assert payload["error"] == "agent 'worker' is disabled"
+
+
 def test_task_add_rejects_unsupported_platform() -> None:
     args = _parse_task_add(
         [

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1248,6 +1248,19 @@ def test_disabled_agent_cannot_be_set_as_default(tmp_path, monkeypatch):
         store.close()
 
 
+def test_vibe_agent_api_rejects_non_boolean_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+
+    with pytest.raises(ValueError, match="Agent enabled must be a JSON boolean"):
+        api.create_vibe_agent({"name": "reviewer", "backend": "codex", "enabled": "false"})
+
+    api.create_vibe_agent({"name": "reviewer", "backend": "codex"})
+    with pytest.raises(ValueError, match="Agent enabled must be a JSON boolean"):
+        api.update_vibe_agent("reviewer", {"enabled": "false"})
+
+    assert api.update_vibe_agent("reviewer", {"enabled": False})["agent"]["enabled"] is False
+
+
 def test_builtin_default_agents_respect_configured_default_backend(tmp_path, monkeypatch):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1206,6 +1206,48 @@ def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_pa
     assert api.remove_vibe_agent("opencode")["code"] == "agent_builtin"
 
 
+def test_builtin_default_agent_enabled_state_follows_backend_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    store = VibeAgentStore()
+    try:
+        store.ensure_builtin_default_agents(["opencode", "claude"], default_backend="opencode")
+        assert store.require("opencode").enabled is True
+        assert store.require("claude").enabled is True
+
+        store.ensure_builtin_default_agents(["opencode"], default_backend="opencode")
+
+        assert store.require("opencode").enabled is True
+        assert store.require("claude").enabled is False
+        assert "claude" not in [agent.name for agent in store.list_agents(include_disabled=False)]
+        assert "claude" in [agent.name for agent in store.list_agents(include_disabled=True)]
+    finally:
+        store.close()
+
+
+def test_user_can_disable_builtin_default_agent_without_catalog_reenabling_it(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    store = VibeAgentStore()
+    try:
+        store.ensure_builtin_default_agents(["opencode"], default_backend="opencode")
+        store.set_enabled("opencode", False)
+
+        assert "opencode" not in [agent["name"] for agent in api.get_vibe_agents()["agents"]]
+        assert store.require("opencode").enabled is False
+    finally:
+        store.close()
+
+
+def test_disabled_agent_cannot_be_set_as_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    store = VibeAgentStore()
+    try:
+        store.create(name="reviewer", backend="codex", enabled=False)
+        with pytest.raises(ValueError, match="disabled"):
+            store.set_default_agent_name("reviewer")
+    finally:
+        store.close()
+
+
 def test_builtin_default_agents_respect_configured_default_backend(tmp_path, monkeypatch):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -703,6 +703,15 @@ def _vibe_agent_payload(agent, *, brief: bool = False) -> dict:
     return payload
 
 
+def _parse_agent_enabled_field(payload: dict, *, default: Optional[bool] = None) -> Optional[bool]:
+    if "enabled" not in payload:
+        return default
+    value = payload.get("enabled")
+    if isinstance(value, bool):
+        return value
+    raise ValueError("Agent enabled must be a JSON boolean")
+
+
 def get_vibe_agents(*, backend: Optional[str] = None, include_disabled: bool = False) -> dict:
     _ensure_builtin_default_agents()
     store = VibeAgentStore()
@@ -751,7 +760,7 @@ def create_vibe_agent(payload: dict) -> dict:
             reasoning_effort=payload.get("reasoning_effort") or payload.get("effort"),
             system_prompt=payload.get("system_prompt"),
             metadata=metadata,
-            enabled=bool(payload.get("enabled", True)),
+            enabled=_parse_agent_enabled_field(payload, default=True),
         )
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
@@ -793,7 +802,7 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
             raise ValueError("Agent metadata must be an object")
         kwargs["metadata"] = metadata
     if "enabled" in payload:
-        kwargs["enabled"] = bool(payload.get("enabled"))
+        kwargs["enabled"] = _parse_agent_enabled_field(payload)
     unknown = sorted(set(payload) - allowed_fields - {"name"})
     if unknown:
         raise ValueError(f"Unsupported Agent fields: {', '.join(unknown)}")

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -87,10 +87,6 @@ def _enabled_agent_backends_from_config(config: Optional[V2Config] = None) -> li
             backend_cfg = getattr(agents, backend, None)
             if bool(getattr(backend_cfg, "enabled", False)):
                 result.append(backend)
-    if not result:
-        default_backend = getattr(agents, "default_backend", None) if agents is not None else None
-        if default_backend:
-            result.append(str(default_backend))
     return result
 
 
@@ -105,8 +101,6 @@ def _default_agent_backend_from_config(config: Optional[V2Config] = None) -> str
 
 def _ensure_builtin_default_agents(config: Optional[V2Config] = None) -> None:
     backends = _enabled_agent_backends_from_config(config)
-    if not backends:
-        return
     default_backend = _default_agent_backend_from_config(config)
     store = VibeAgentStore()
     try:
@@ -572,6 +566,7 @@ def save_config(payload: dict) -> V2Config:
                 if existing_update is not None:
                     _save_discord_guild_scope_update(*existing_update, store=store)
         config.save()
+        _ensure_builtin_default_agents(config)
         return config
 
 
@@ -701,18 +696,19 @@ def _vibe_agent_payload(agent, *, brief: bool = False) -> dict:
             "backend": payload["backend"],
             "model": payload["model"],
             "reasoning_effort": payload["reasoning_effort"],
+            "enabled": payload["enabled"],
             "source": payload["source"],
             "updated_at": payload["updated_at"],
         }
     return payload
 
 
-def get_vibe_agents(*, backend: Optional[str] = None) -> dict:
+def get_vibe_agents(*, backend: Optional[str] = None, include_disabled: bool = False) -> dict:
     _ensure_builtin_default_agents()
     store = VibeAgentStore()
     try:
         normalized_backend = validate_agent_backend(backend) if backend else None
-        agents = store.list_agents()
+        agents = store.list_agents(include_disabled=include_disabled)
         if normalized_backend:
             agents = [agent for agent in agents if agent.backend == normalized_backend]
         default_agent = store.get_default_agent()
@@ -755,6 +751,7 @@ def create_vibe_agent(payload: dict) -> dict:
             reasoning_effort=payload.get("reasoning_effort") or payload.get("effort"),
             system_prompt=payload.get("system_prompt"),
             metadata=metadata,
+            enabled=bool(payload.get("enabled", True)),
         )
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
@@ -769,7 +766,16 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
     if "backend" in payload:
         raise ValueError("Agent backend is immutable")
 
-    allowed_fields = {"description", "model", "reasoning_effort", "effort", "system_prompt", "metadata", "metadata_json"}
+    allowed_fields = {
+        "description",
+        "model",
+        "reasoning_effort",
+        "effort",
+        "system_prompt",
+        "metadata",
+        "metadata_json",
+        "enabled",
+    }
     kwargs: dict[str, object] = {}
     if "description" in payload:
         kwargs["description"] = payload.get("description")
@@ -786,6 +792,8 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
         if not isinstance(metadata, dict):
             raise ValueError("Agent metadata must be an object")
         kwargs["metadata"] = metadata
+    if "enabled" in payload:
+        kwargs["enabled"] = bool(payload.get("enabled"))
     unknown = sorted(set(payload) - allowed_fields - {"name"})
     if unknown:
         raise ValueError(f"Unsupported Agent fields: {', '.join(unknown)}")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1322,7 +1322,7 @@ def _validate_agent_name_arg(agent_name: Optional[str]) -> Optional[str]:
     value = (agent_name or "").strip()
     if not value:
         return None
-    _agent_store().require(value)
+    _agent_store().require_enabled(value)
     return value
 
 
@@ -1370,12 +1370,12 @@ def _resolve_agent_for_target(
 ):
     store = _agent_store()
     try:
-        requested = store.require(agent_name) if agent_name else None
+        requested = store.require_enabled(agent_name) if agent_name else None
         if session_id:
             target = resolve_session_id_target(session_id)
             resolved = requested
             if resolved is None and target.agent_name:
-                resolved = store.require(target.agent_name)
+                resolved = store.require_enabled(target.agent_name)
             if resolved is not None and target.agent_backend and resolved.backend != target.agent_backend:
                 raise TaskCliError(
                     "agent backend does not match the existing session backend",
@@ -1397,7 +1397,7 @@ def _resolve_agent_for_target(
         if session_key:
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
-                return store.require(scope_target.agent_name)
+                return store.require_enabled(scope_target.agent_name)
             if scope_target.agent_backend:
                 return None
 
@@ -1410,7 +1410,7 @@ def _resolve_agent_backend_for_session_reservation(*, agent_name: Optional[str],
     if agent_name:
         store = _agent_store()
         try:
-            return store.require(agent_name).backend
+            return store.require_enabled(agent_name).backend
         finally:
             store.close()
     scope_target = _resolve_scope_routing_target(deliver_key)
@@ -1508,6 +1508,7 @@ def _agent_payload(agent, *, brief: bool = False) -> dict:
             "backend": payload["backend"],
             "model": payload["model"],
             "reasoning_effort": payload["reasoning_effort"],
+            "enabled": payload["enabled"],
             "source": payload["source"],
             "updated_at": payload["updated_at"],
         }
@@ -2189,9 +2190,15 @@ def _add_json_noop(parser) -> None:
 def cmd_agent_list(args):
     store = _agent_store()
     backend = getattr(args, "backend", None)
-    agents = store.list_agents()
+    if getattr(args, "disabled", False):
+        include_disabled = True
+    else:
+        include_disabled = bool(getattr(args, "all", False))
+    agents = store.list_agents(include_disabled=include_disabled)
     if backend:
         agents = [agent for agent in agents if agent.backend == backend]
+    if getattr(args, "disabled", False):
+        agents = [agent for agent in agents if not agent.enabled]
     agents = [_agent_payload(agent, brief=getattr(args, "brief", False)) for agent in agents]
     _print_cli_payload("agents", agents=agents)
     return 0
@@ -2220,6 +2227,7 @@ def cmd_agent_create(args):
             reasoning_effort=args.reasoning_effort,
             system_prompt=system_prompt,
             metadata=_parse_metadata_json(args.metadata),
+            enabled=not bool(getattr(args, "disabled", False)),
         )
         _print_cli_payload("agent", agent=_agent_payload(agent))
         return 0
@@ -2251,6 +2259,10 @@ def cmd_agent_update(args):
             kwargs["system_prompt"] = None
         if args.metadata is not None:
             kwargs["metadata"] = _parse_metadata_json(args.metadata)
+        if getattr(args, "enable", False):
+            kwargs["enabled"] = True
+        if getattr(args, "disable", False):
+            kwargs["enabled"] = False
         if not kwargs:
             raise TaskCliError(
                 "no agent fields were changed",
@@ -2258,6 +2270,16 @@ def cmd_agent_update(args):
                 hint="Pass at least one editable field. Agent name and backend are immutable.",
             )
         agent = _agent_store().update(args.name, **kwargs)
+        _print_cli_payload("agent", agent=_agent_payload(agent))
+        return 0
+    except Exception as exc:
+        _print_task_error(exc)
+        return 1
+
+
+def cmd_agent_set_enabled(args, *, enabled: bool):
+    try:
+        agent = _agent_store().set_enabled(args.name, enabled)
         _print_cli_payload("agent", agent=_agent_payload(agent))
         return 0
     except Exception as exc:
@@ -2531,7 +2553,7 @@ def _reserve_cli_session(*, agent, deliver_key: Optional[str]) -> str:
 
 def _reserve_definition_session(*, agent_name: Optional[str], deliver_key: str, help_command: str) -> str:
     target = _parse_validated_session_key(deliver_key, help_command=help_command)
-    agent = _agent_store().require(agent_name) if agent_name else None
+    agent = _agent_store().require_enabled(agent_name) if agent_name else None
     agent_backend = (
         agent.backend
         if agent
@@ -2585,7 +2607,7 @@ def cmd_agent_run(args):
             )
         session_id = (args.session_id or "").strip() or None
         session_key = ""
-        agent = _agent_store().require(agent_name) if agent_name else None
+        agent = _agent_store().require_enabled(agent_name) if agent_name else None
         if session_policy == "create":
             session_id = _reserve_cli_session(agent=agent, deliver_key=args.deliver_key)
         elif session_policy == "none":
@@ -4463,13 +4485,15 @@ def build_parser():
     )
     agent_subparsers = agent_parser.add_subparsers(
         dest="agent_command",
-        metavar="{list,show,create,update,remove,import,run}",
+        metavar="{list,show,create,update,enable,disable,remove,import,run}",
     )
     agent_subparsers.required = True
 
     agent_list_parser = agent_subparsers.add_parser("list", help="List Vibe Agents")
     agent_list_parser.add_argument("--brief", action="store_true", help="Show compact Agent rows")
     agent_list_parser.add_argument("--backend", choices=("codex", "claude", "opencode"), help="Filter by backend")
+    agent_list_parser.add_argument("--all", action="store_true", help="Include disabled Agents")
+    agent_list_parser.add_argument("--disabled", action="store_true", help="Show only disabled Agents")
     _add_json_noop(agent_list_parser)
 
     agent_show_parser = agent_subparsers.add_parser("show", help="Show one Vibe Agent")
@@ -4487,6 +4511,7 @@ def build_parser():
     system_prompt_group.add_argument("--system-prompt")
     system_prompt_group.add_argument("--system-prompt-file")
     agent_create_parser.add_argument("--metadata", help="JSON object stored with the Agent")
+    agent_create_parser.add_argument("--disabled", action="store_true", help="Create the Agent disabled")
     _add_json_noop(agent_create_parser)
 
     agent_update_parser = agent_subparsers.add_parser("update", help="Update editable Vibe Agent fields")
@@ -4503,7 +4528,18 @@ def build_parser():
     update_prompt_group.add_argument("--system-prompt-file")
     update_prompt_group.add_argument("--clear-system-prompt", action="store_true")
     agent_update_parser.add_argument("--metadata", help="Replace metadata with a JSON object")
+    enabled_group = agent_update_parser.add_mutually_exclusive_group()
+    enabled_group.add_argument("--enable", action="store_true", help="Enable this Agent")
+    enabled_group.add_argument("--disable", action="store_true", help="Disable this Agent")
     _add_json_noop(agent_update_parser)
+
+    agent_enable_parser = agent_subparsers.add_parser("enable", help="Enable a Vibe Agent")
+    agent_enable_parser.add_argument("name", help="Agent name")
+    _add_json_noop(agent_enable_parser)
+
+    agent_disable_parser = agent_subparsers.add_parser("disable", help="Disable a Vibe Agent")
+    agent_disable_parser.add_argument("name", help="Agent name")
+    _add_json_noop(agent_disable_parser)
 
     agent_remove_parser = agent_subparsers.add_parser("remove", help="Remove a Vibe Agent")
     agent_remove_parser.add_argument("name", help="Agent name")
@@ -5202,6 +5238,10 @@ def main():
             sys.exit(cmd_agent_create(args))
         if args.agent_command == "update":
             sys.exit(cmd_agent_update(args))
+        if args.agent_command == "enable":
+            sys.exit(cmd_agent_set_enabled(args, enabled=True))
+        if args.agent_command == "disable":
+            sys.exit(cmd_agent_set_enabled(args, enabled=False))
         if args.agent_command == "remove":
             sys.exit(cmd_agent_remove(args))
         if args.agent_command == "import":

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1316,7 +1316,12 @@ def vibe_agents_get():
     from vibe import api
 
     try:
-        return jsonify(api.get_vibe_agents(backend=request.args.get("backend") or None))
+        include_disabled = str(request.args.get("include_disabled") or request.args.get("all") or "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        return jsonify(api.get_vibe_agents(backend=request.args.get("backend") or None, include_disabled=include_disabled))
     except ValueError as exc:
         return _vibe_agent_error_response(exc)
 


### PR DESCRIPTION
## Summary
- add first-class `enabled` state to Vibe Agents and SQLite schema
- sync built-in default Agent state from backend enablement without undoing manual Agent disables during normal catalog refresh
- expose CLI/API enable-disable controls and keep routing/session reservation on enabled Agents only

## Evidence
- Unit/API/CLI/routing: `uv run pytest tests/test_cli_task_command.py tests/test_ui_api.py tests/test_controller_vibe_agent_routing.py -q`
- Lint: `uv run ruff check core/vibe_agents.py core/controller.py core/scheduled_tasks.py storage/migrations.py storage/models.py vibe/api.py vibe/cli.py vibe/ui_server.py tests/test_cli_task_command.py tests/test_ui_api.py`
- Frontend build: `npm run build` in `ui/`

## Notes
- Agent features are not shipped yet, so this targets the final schema shape directly while still keeping SQLite schema readiness/migration paths intact.
