### PR TITLE
feat(workbench): Agent Workbench shell · 15 commits · avibe platform + sessions/messages REST + Inbox/Agents/Harness/Chat pages + IM mirror + design doc

### DIFF
--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -209,6 +209,32 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             force_preferred_processing_indicator=True,
         ),
     ),
+    # The Vibe Remote Web UI itself, surfaced as a peer platform so the
+    # workbench shares ``scopes`` / ``agent_sessions`` / routing machinery
+    # with Slack/Discord/etc. The adapter has no remote credentials —
+    # transport is REST + SSE hosted by ``vibe/ui_server.py`` (wired in
+    # later commits).
+    "avibe": PlatformDescriptor(
+        id="avibe",
+        config_key="avibe",
+        config_module="config.v2_config",
+        config_class="AvibeConfig",
+        client_module="modules.im.avibe",
+        client_class="AvibeBot",
+        formatter_module="modules.im.formatters",
+        formatter_class="AvibeFormatter",
+        credential_fields=(),
+        capabilities=PlatformCapabilities(
+            supports_channels=True,
+            supports_threads=True,
+            supports_buttons=True,
+            supports_quick_replies=True,
+            supports_message_editing=True,
+            markdown_upload_returns_message_id=True,
+            supports_typing_indicator=True,
+            supports_reaction_indicator=True,
+        ),
+    ),
 }
 
 

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -129,6 +129,21 @@ class WeChatConfig(BaseIMConfig):
 
 
 @dataclass
+class AvibeConfig(BaseIMConfig):
+    """Avibe — Vibe Remote's own Web UI surfaced as a first-class IM platform.
+
+    Runs in-process; no remote credentials. ``enabled`` lets headless
+    deployments skip the workbench surface entirely while keeping the
+    other IM-bridge platforms (Slack/Discord/...) wired up.
+    """
+
+    enabled: bool = True
+
+    def validate(self) -> None:
+        return None
+
+
+@dataclass
 class GatewayConfig:
     relay_url: Optional[str] = None
     workspace_token: Optional[str] = None
@@ -302,6 +317,9 @@ class V2Config:
     telegram: Optional[TelegramConfig] = None
     lark: Optional[LarkConfig] = None
     wechat: Optional[WeChatConfig] = None
+    # Always present: Avibe is in-process and has no credentials, so legacy
+    # configs that pre-date the platform still get a usable adapter.
+    avibe: AvibeConfig = field(default_factory=AvibeConfig)
     platform_configs: dict[str, BaseIMConfig] = field(default_factory=dict)
     gateway: Optional[GatewayConfig] = None
     ui: UiConfig = field(default_factory=UiConfig)
@@ -376,6 +394,12 @@ class V2Config:
                 continue
 
             platform_configs[descriptor.id] = descriptor.create_config(platform_payload)
+
+        # Avibe runs in-process with no credentials — auto-populate its
+        # config when missing so legacy ``platforms.enabled`` lists that
+        # mention "avibe" don't trip the validation loop below.
+        if platform_configs.get("avibe") is None:
+            platform_configs["avibe"] = AvibeConfig()
 
         # Validate that every enabled platform has its config section present.
         for _ep in platforms.enabled:
@@ -512,6 +536,9 @@ class V2Config:
             telegram=platform_configs["telegram"],
             lark=platform_configs["lark"],
             wechat=platform_configs["wechat"],
+            # Default Avibe to an enabled instance when the payload is missing
+            # the section — legacy configs predate the platform.
+            avibe=platform_configs.get("avibe") or AvibeConfig(),
             platform_configs={key: value for key, value in platform_configs.items() if value is not None},
             runtime=runtime,
             agents=agents,

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -124,6 +124,14 @@ class MessageHandler(BaseHandler):
 
             context = await self._prepare_turn_context(context, source)
 
+            # Mirror the user's message into the workbench messages table
+            # before we kick off the agent. Wrapped in try/except inside
+            # the helper so a mirror failure can't take down the turn.
+            if source == self.TURN_SOURCE_HUMAN:
+                from core.message_mirror import mirror_inbound
+
+                mirror_inbound(context, control_message)
+
             base_session_id, working_path, composite_key = self.session_handler.get_session_info(context, source=source)
             payload = dict(context.platform_specific or {})
             payload["turn_source"] = source

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -13,6 +13,7 @@ from typing import Optional
 
 from config.platform_registry import get_platform_descriptor
 from modules.im import MessageContext
+from core.message_mirror import mirror_outbound
 from core.reply_enhancer import process_reply, strip_file_links, strip_silent_blocks
 from storage.background import SQLiteBackgroundTaskStore
 from vibe.i18n import t as i18n_t
@@ -349,7 +350,9 @@ class ConsolidatedMessageDispatcher:
         if canonical_type == "notify":
             target_context = self._get_target_context(context)
             try:
-                return await im_client.send_message(target_context, text, parse_mode=parse_mode)
+                message_id = await im_client.send_message(target_context, text, parse_mode=parse_mode)
+                mirror_outbound(context, text, native_message_id=message_id, kind="notify")
+                return message_id
             except Exception as err:
                 logger.error("Failed to send notify message: %s", err)
             return None
@@ -496,6 +499,14 @@ class ConsolidatedMessageDispatcher:
             # assistant/tool/system message state so the next user turn starts
             # a fresh log message instead of appending to the previous one.
             await self._clear_consolidated_state(context)
+
+            if primary_message_id and display_text:
+                mirror_outbound(
+                    context,
+                    display_text,
+                    native_message_id=primary_message_id,
+                    kind="result",
+                )
 
             return primary_message_id
 

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -351,7 +351,12 @@ class ConsolidatedMessageDispatcher:
             target_context = self._get_target_context(context)
             try:
                 message_id = await im_client.send_message(target_context, text, parse_mode=parse_mode)
-                mirror_outbound(context, text, native_message_id=message_id, kind="notify")
+                # ``target_context`` carries the post-override platform / channel
+                # / thread, so the mirror row lands in the scope where the
+                # message was actually delivered. Mirroring the original
+                # ``context`` would mis-attribute scheduled or post_to-routed
+                # replies to their source scope.
+                mirror_outbound(target_context, text, native_message_id=message_id, kind="notify")
                 return message_id
             except Exception as err:
                 logger.error("Failed to send notify message: %s", err)
@@ -501,8 +506,10 @@ class ConsolidatedMessageDispatcher:
             await self._clear_consolidated_state(context)
 
             if primary_message_id and display_text:
+                # Use ``target_context`` so scheduled / post_to-routed replies
+                # mirror under their actual delivery scope, not the source.
                 mirror_outbound(
-                    context,
+                    target_context,
                     display_text,
                     native_message_id=primary_message_id,
                     kind="result",

--- a/core/message_mirror.py
+++ b/core/message_mirror.py
@@ -1,0 +1,141 @@
+"""Best-effort mirror of inbound + outbound IM traffic into ``messages``.
+
+This is the cross-platform write path that feeds the workbench: every
+non-avibe IM event (Slack DM, Discord channel reply, Telegram private
+chat, Lark/Feishu group ping, WeChat push) lands a row in the same
+``messages`` table that avibe sessions write to. Downstream views — the
+Inbox feed, per-session transcript, future cross-platform search — read
+from one shape regardless of origin.
+
+Hooks live in two places:
+
+* ``core/handlers/message_handler.py`` calls :func:`mirror_inbound` once
+  per human-originated turn, after session resolution.
+* ``core/message_dispatcher.py`` calls :func:`mirror_outbound` once per
+  successful agent ``result`` / ``notify`` send.
+
+Failures are swallowed and logged. A bad mirror write must never break
+the live IM reply path.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+
+from modules.im.base import MessageContext
+from storage import messages_service, settings_service
+from storage.db import create_sqlite_engine
+
+logger = logging.getLogger(__name__)
+
+# Non-avibe IM scopes are stored as 'channel' rows — one per DM/group/topic.
+# avibe projects are 'project' typed and pre-created via ``/api/projects``;
+# this module never touches those.
+DEFAULT_SCOPE_TYPE = "channel"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolve_scope_id(conn, context: MessageContext) -> Optional[str]:
+    platform = (context.platform or "").strip()
+    native_id = (context.channel_id or "").strip()
+    if not platform or not native_id:
+        return None
+    try:
+        return settings_service.upsert_scope(
+            conn,
+            platform=platform,
+            scope_type=DEFAULT_SCOPE_TYPE,
+            native_id=native_id,
+            now=_now(),
+            supports_threads=bool(context.thread_id),
+        )
+    except Exception:
+        logger.exception("mirror: failed to upsert scope for %s::%s", platform, native_id)
+        return None
+
+
+def _append_quietly(conn, **kwargs) -> None:
+    """Insert one row, swallowing the unique-constraint clash that fires
+    when the same native message id is delivered twice (rare retry path).
+    """
+    try:
+        messages_service.append(conn, **kwargs)
+    except IntegrityError:
+        logger.debug(
+            "mirror: skipped duplicate native_message_id %s on platform %s",
+            kwargs.get("native_message_id"),
+            kwargs.get("platform"),
+        )
+
+
+def mirror_inbound(context: MessageContext, text: str) -> None:
+    """Record a human-originated message into the messages table."""
+
+    if not text or not text.strip():
+        return
+    if not context.platform:
+        return
+    if context.platform == "avibe":
+        # avibe's REST endpoint already writes through ``messages_service``;
+        # mirroring here would double-count the row.
+        return
+    try:
+        engine = create_sqlite_engine()
+        with engine.begin() as conn:
+            scope_id = _resolve_scope_id(conn, context)
+            if scope_id is None:
+                return
+            _append_quietly(
+                conn,
+                scope_id=scope_id,
+                session_id=None,
+                platform=context.platform,
+                author="user",
+                text=text,
+                author_id=context.user_id,
+                native_message_id=context.message_id,
+                parent_native_message_id=context.thread_id,
+            )
+    except Exception:
+        logger.exception("mirror_inbound: unexpected failure on platform=%s", context.platform)
+
+
+def mirror_outbound(
+    context: MessageContext,
+    text: str,
+    *,
+    native_message_id: Optional[str],
+    kind: str = "result",
+) -> None:
+    """Record a successful agent reply into the messages table."""
+
+    if not text or not text.strip():
+        return
+    if not context.platform or context.platform == "avibe":
+        return
+    try:
+        engine = create_sqlite_engine()
+        with engine.begin() as conn:
+            scope_id = _resolve_scope_id(conn, context)
+            if scope_id is None:
+                return
+            _append_quietly(
+                conn,
+                scope_id=scope_id,
+                session_id=None,
+                platform=context.platform,
+                author="agent",
+                text=text,
+                native_message_id=native_message_id,
+                parent_native_message_id=context.thread_id,
+                content={"kind": kind} if kind else None,
+            )
+    except Exception:
+        logger.exception("mirror_outbound: unexpected failure on platform=%s", context.platform)

--- a/docs/plans/workbench-dispatch-architecture.md
+++ b/docs/plans/workbench-dispatch-architecture.md
@@ -1,0 +1,371 @@
+# Workbench Dispatch Architecture · Design Document
+
+> **Branches**:
+> - `feature/workbench-shell` — commit 01..13 (workbench UI + adapters + mirror)
+> - `refactor/services-layer` (new) — Plan 1 + Plan 2 implementation
+>
+> **Status**: Accepted (2026-05-26). Implementation pending.
+>
+> **Owner**: cyhhao
+>
+> **Related show page**: [dispatch-architecture.html](https://alex-app.avibe.bot/p/PjyD9_QC9pU/dispatch-architecture.html) (decision tracker, kept until shipped)
+
+## 1. Why This Document Exists
+
+The workbench UI rewrite (commits 01-13 on `feature/workbench-shell`) added an Agent-Workbench mode
+that reads from the shared SQLite store. The next step is **send/compose** — letting the user type
+a message in the web Chat surface and trigger a real agent turn.
+
+Implementing this surfaces two structural problems that have been quietly accumulating:
+
+1. **Data-control duplication** — UI server and CLI both directly import `storage/*_service.py`
+   modules. For the `agent_sessions` table specifically, two wrappers exist with diverging APIs
+   (`storage/workbench_sessions_service.py` for the UI, `storage/sessions_service.py::SQLiteSessionsService`
+   for IM/CLI). Same table, two business APIs. Every new feature that touches sessions has to
+   pick a side.
+
+2. **No cross-process trigger from Web UI to Controller** — UI server and Controller run as
+   separate subprocesses (per `vibe/runtime.py::spawn_background`). When the user clicks "send"
+   in the web Chat surface, there is no path for the UI server process to ask the Controller
+   process to run an agent turn. IM adapters (Slack/Discord/Telegram/Lark/WeChat) are in-process
+   with Controller and call `message_handler.handle_user_message` directly. CLI uses the
+   `agent_runs` queue (async, ~2s scheduler poll, batch JSON output).
+
+These are two independent concerns but they collapse onto **one shared abstraction**: a
+`dispatch_turn()` entry point that all three callers (IM adapters, CLI, Web UI) converge on.
+Solve them together and the architecture stays clean. Solve only one and the other festers.
+
+## 2. Goal
+
+When this design lands:
+
+- A user can compose a message in the web Chat surface, hit send, and see the agent's reply
+  stream in token-by-token (or chunk-by-chunk) — comparable latency to talking to the bot from
+  Slack/Discord.
+- IM adapters, CLI, and Web UI all funnel through a single `dispatch_turn()` function that
+  encapsulates the agent-turn lifecycle. Behavior changes there propagate to all three callers
+  without copy-paste.
+- The UI server process never imports `storage/sessions_service.py` directly — it goes through
+  `core/services/sessions.py`. Same for the CLI. Contract tests pin the shape so the two
+  callers cannot drift again.
+- `~/.vibe_remote/state/dispatch.sock` exists at runtime and exposes a minimum set of internal
+  RPC endpoints over which the UI server can trigger Controller-side runtime side-effects
+  (turn dispatch, cancel). The socket is `0o600` and local-only.
+- Pure data CRUD (list projects, update session title, mark read) **does not** go through the
+  socket. The boundary rules (§7) are enforced by code review.
+
+## 3. Non-Goals (Explicit)
+
+- **Process merge (combining UI server + Controller into one process)** is out of scope and
+  rejected. The two-process model is intentional (separate reload lifecycles) and changing it
+  would also conflict with the IM thread / uvicorn worker model.
+- **WebSocket** is rejected in favor of SSE chunked over Unix socket. Rationale: SSE rides on
+  plain HTTP, auto-reconnects via `EventSource`, and matches the existing `/api/events` pattern
+  in `vibe/sse_broker.py`. Cloudflare Tunnel research from 2026-05-24 also favored SSE.
+- **Polling-only mode for send/compose** (the original "enqueue `agent_runs`" approach) is
+  rejected as the primary path. ~2s scheduler delay and no streaming would lock us out of the
+  streaming UX. The queue path stays as a fallback when the socket is unreachable.
+- **gRPC, JSON-RPC, or any structured RPC framework** is out of scope. RESTful endpoints on a
+  Unix socket suffice for ~5-10 RPC verbs.
+
+## 4. Current State (Post-Master 2026-05-26)
+
+Authoritative inventory. Verified against the current `feature/workbench-shell` head.
+
+### 4.1 Data domains and their access paths
+
+| Domain | Underlying table | Storage layer (CRUD) | Business layer (UI / CLI / IM) | Status |
+| --- | --- | --- | --- | --- |
+| Agents | `vibe_agents` | `core/vibe_agents.py::VibeAgentStore` | shared across UI + CLI | **Unified** |
+| Sessions | `agent_sessions` | SQLAlchemy table | UI: `workbench_sessions_service`; IM/CLI: `SQLiteSessionsService` | **Split (target of Plan 1)** |
+| Messages | `messages` | `messages_service` | UI + commit 13 mirror both go through service | **Unified** |
+| Projects | `scopes` + `scope_settings` | `projects_service` | UI only | **Unified** |
+| Runs / Tasks queue | `agent_runs` + `run_definitions` | `storage/background.py::SQLiteBackgroundTaskStore` | `core/scheduled_tasks.py::TaskExecutionStore` delegates to storage layer | **Properly layered** |
+| Watches | `watches` (runtime records) | `core/watches.py` | CLI writes, UI reads via background store | **Partial** |
+| Settings / Config | JSON file + `scope_settings` | `settings_service` | UI reads `config.json` directly; CLI uses `SettingsStore` | **Split (Plan 1 phase 2 target)** |
+| Auth codes | `auth_codes` | `settings_service` | shared | **Unified** |
+
+The actual duplication is **only Sessions and Settings**. Everything else is either already
+unified or layered correctly. This was misjudged in the v1 exploration of this design;
+verified again on 2026-05-26.
+
+### 4.2 Cross-process facts
+
+- **UI server** runs as a subprocess started by `vibe/runtime.py::spawn_background` (line 835).
+- **Controller** runs in a separate process (`main.py:165 controller.run()`), holding the IM
+  thread and the agent-runtime asyncio loop.
+- **SSE broker** (`vibe/sse_broker.py`) is **in-process** — UI server and Controller each have
+  their own `SSEBroker()` singleton, not shared.
+- **`agent_runs` queue** is the only existing cross-process trigger path. It is consumed by
+  `core/scheduled_tasks.py::ScheduledTaskService._drain_requests` on a ~2s poll. Already
+  supports `request_type="agent_run"` which routes to `message_handler.handle_scheduled_message`.
+- **Process merge is documented as forbidden** in `docs/CLI.md:262-276` ("Vibe Remote manages
+  two types of processes" with independent reload lifecycles).
+
+## 5. Architecture (Target State)
+
+```
+  +-------------------+     +-------------------+
+  |  Web UI (Chrome)  |     |  vibe agent run   |
+  +---------+---------+     +---------+---------+
+            |                         |
+            | POST + EventSource      | --async  --sync
+            v                         |   (queue)   (socket)
+  +-------------------+               |     |          |
+  |  UI server proc   |               |     v          v
+  |  - SSE proxy      |   <----- HTTP+SSE chunked  --->|
+  |  - /api/*         |   over ~/.vibe_remote/state/dispatch.sock
+  |  - core/services  |               |                |
+  +---------+---------+               |                |
+            |                         |                |
+            |   (data layer)          |                |
+            v                         v                v
+  +------------------------------------------------------------+
+  |               core/services/                               |
+  |   sessions.py  messages.py  dispatch.py  ...               |
+  |               (shared business API)                        |
+  +------------------------------------------------------------+
+            |                         |                |
+            v                         v                v
+  +------------------------------------------------------------+
+  |               storage/  (SQLAlchemy CRUD)                  |
+  |    + core/internal_server.py  (Controller-only unix sock)  |
+  +------------------------------------------------------------+
+                                      |
+                                      |  IM adapters (same process as Controller)
+                                      |  call dispatch_turn() directly (no socket)
+                                      v
+                              +---------------+
+                              |  Controller   |
+                              |  + IM thread  |
+                              |  + asyncio    |
+                              |  + scheduled  |
+                              +---------------+
+```
+
+Key insight: `core/services/dispatch.py::dispatch_turn(context, text, *, on_chunk=None)` is
+the single shared entry. Three callers reach it differently:
+
+- **IM adapter** (Slack, Discord, …): same Python process as Controller → `await dispatch_turn(...)`
+  directly. Zero IPC overhead. Unchanged from today's behavior; the entry point just moves
+  into `core/services/`.
+- **Web UI**: separate process → `httpx.stream("POST", "http+unix://.../internal/dispatch", json=...)`
+  → Controller's `core/internal_server.py` calls `dispatch_turn(...)` and yields SSE chunks
+  back over the same socket. UI server proxies the chunks to the browser's `EventSource`.
+- **CLI** (`vibe agent run --sync`): also through the socket. `--async` keeps using the
+  `agent_runs` queue for cron/hook use cases that should not block.
+
+## 6. Plan 1 · Data Control Layer
+
+### 6.1 Target
+
+A new package `core/services/` holds business-level APIs that take a SQLAlchemy `Connection`
+(or transaction context) and never own engines or process-level state. UI server, CLI, and
+Controller all import from there. Storage layer (`storage/`) stays as pure CRUD.
+
+### 6.2 Scope
+
+- **In scope (Phase 1A)**:
+  - `core/services/sessions.py` — merges `workbench_sessions_service` + `SQLiteSessionsService`.
+  - `core/services/dispatch.py` — extracts `dispatch_turn()` from
+    `message_handler._handle_turn`. This is also Plan 2's dependency.
+- **In scope (Phase 1B)**:
+  - `core/services/settings.py` — unifies CLI `SettingsStore` ↔ UI direct `config.json` reads.
+- **Out of scope (already unified)**:
+  - Agents, Messages, Projects, Runs — no work needed.
+- **Out of scope (later phase)**:
+  - Watches, vaults, skills — UI hasn't fully wired them, defer until UX direction settles.
+
+### 6.3 Service API conventions
+
+- All public functions take `conn: Connection` as their first argument. Never construct
+  engines inside the service.
+- Return shapes are plain `dict[str, Any]` matching the existing `_row_to_payload` style in
+  `messages_service`. No ORM mappers leaking out.
+- Errors raise `LookupError`, `ValueError`, or domain-specific exceptions defined in
+  `core/services/errors.py`. Routes / CLI translate them to HTTP status / exit codes.
+- No side effects (SSE publish, log writes) inside service functions. Side effects belong in
+  the calling layer (routes for UI, controller for IM, CLI for terminal output).
+
+### 6.4 Commit breakdown
+
+- **C1** · Extract `core/services/sessions.py` + `core/services/dispatch.py` + contract tests.
+  IM adapter and UI server change `import` paths; CLI unchanged.
+- **C2** · Migrate CLI `_session_service()` to `core/services/sessions.py`. Verify
+  `vibe agent run --json` output schema is byte-identical (pinned in test).
+- **C3** · Extract `core/services/settings.py`. UI server direct `config.json` reads and CLI
+  `SettingsStore` both go through it.
+
+### 6.5 Risks
+
+- CLI `--json` schema stability (decision Q8: strict). Mitigated by snapshot test in C2.
+- `SQLiteSessionsService` carries a lot of legacy semantics (session reservation, anchor
+  resolution). These need to move with the API; some are IM-only and should remain hidden
+  behind helper functions inside `sessions.py`, not exposed as the public surface.
+
+## 7. Plan 2 · Cross-Process Dispatch (N3)
+
+### 7.1 Target
+
+Controller process binds a Unix socket at `~/.vibe_remote/state/dispatch.sock` and runs a
+minimal FastAPI app on it. UI server uses `httpx.AsyncClient(transport=AsyncHTTPTransport(uds=...))`
+to stream RPC calls over the socket. SSE chunked responses flow turn output back to UI server,
+which proxies it to the browser's `EventSource`.
+
+### 7.2 Why N3 over alternatives
+
+| Candidate | Decision | Reason |
+| --- | --- | --- |
+| N1 · `agent_runs` queue + polling | Fallback only | ~2s scheduler delay, no streaming. Future streaming would require recreating this path. |
+| N2 · Process merge | Rejected | `docs/CLI.md` explicitly enforces separate processes. Also conflicts with IM thread / uvicorn worker model. |
+| N3 · Unix socket SSE | **Selected** | ~5ms trigger latency, native streaming via SSE chunked, shares `dispatch_turn()` with IM and CLI, doesn't break process boundaries. |
+
+### 7.3 Component changes
+
+- **New** · `core/internal_server.py` — FastAPI app bound to a unix domain socket. Exposes:
+  - `POST /internal/dispatch` (body: session_id, text, scope_id, agent_overrides) → SSE
+    chunked response. Each `emit_agent_message` chunk produced by `dispatch_turn` is yielded
+    as `data: {...}\n\n`.
+  - `POST /internal/cancel/<run_id>` → marks the in-flight turn for cancellation, returns
+    when the cancel hook fires.
+- **New** · `vibe/internal_client.py` — `httpx` wrapper for UI server. Handles connection
+  setup, reconnect on transient drops, and SSE parsing into `AsyncIterator[dict]`.
+- **Modified** · `core/controller.py` — `controller.run()` starts the internal server as a
+  background asyncio task. Same event loop, no separate thread.
+- **Modified** · `vibe/ui_server.py` — `POST /api/sessions/<id>/messages?stream=1` becomes a
+  `StreamingResponse(text/event-stream)` that streams from the internal client.
+- **Modified** · `core/message_dispatcher.py::emit_agent_message` — adds an optional
+  `on_chunk` callback that `dispatch_turn` passes in. When present, every emit also feeds
+  `on_chunk(envelope)`. When absent, behavior is unchanged for IM adapters (which don't need
+  the stream-out side channel).
+- **Modified** · `ui/src/components/workbench/ChatPage.tsx` — adds compose textarea, send
+  button, Cmd/Ctrl+Enter binding, optimistic user-message append, and a `fetch`+`ReadableStream`
+  consumer that appends agent chunks to the transcript as they arrive.
+
+### 7.4 Endpoint catalog (v1 + v2)
+
+| Endpoint | Type | Purpose | Phase |
+| --- | --- | --- | --- |
+| `POST /internal/dispatch` | B | Trigger a turn, SSE chunked response | **v1** |
+| `POST /internal/cancel/<run_id>` | B | Cancel in-flight turn | **v1** |
+| `POST /internal/platform/<name>/start\|stop` | B | Start / stop an IM platform adapter | v2 |
+| `POST /internal/backend/<name>/restart` | B | Restart agent backend (replaces `RuntimeCommandWatcher` markers) | v2 |
+| `POST /internal/config/reload` | B | Controller reloads `V2Config` | v2 |
+| `GET /internal/events` | C | Long-lived SSE: Controller pushes non-request-driven events to UI server | v2 |
+
+v1 is the smallest set that unblocks send/compose. v2 work doesn't block v1 release.
+
+### 7.5 Commit breakdown
+
+- **C4** · `core/internal_server.py` + `vibe/internal_client.py` + dispatch endpoint. Tests
+  cover socket up/down, basic dispatch round-trip, and SSE chunked framing.
+- **C5** · UI server POST route emits via internal client; ChatPage compose UI; en/zh i18n;
+  fallback to N1 queue when socket is unreachable.
+- **C6** · `POST /internal/cancel` endpoint + UI "stop" button on running turn.
+
+### 7.6 Boundary rules (R1 / R2 / R3)
+
+These are enforced by code review. PR descriptions must state which rule each new endpoint
+or function falls under.
+
+- **R1** · **Type A (pure data CRUD) never goes through the socket.** If the operation can
+  be completed in the UI server process by reading/writing SQLite, it must use
+  `core/services/*` directly. Examples: list projects, create session, update session title,
+  mark messages read.
+- **R2** · **Type B (Controller runtime side effects) uniformly goes through N3 socket.**
+  Examples: trigger a turn, cancel a turn, restart a backend, start/stop an IM platform,
+  reload config. One transport, one mental model.
+- **R3** · **Type C (Controller → UI async push) goes through SSE.** First version: only
+  in-call SSE chunked response (already covered by N3 `dispatch`). Future: a long-lived
+  `GET /internal/events` SSE if non-request-triggered pushes are needed.
+
+### 7.7 Anti-examples (must not go through socket)
+
+- Listing projects / sessions / messages / agents — pure queries.
+- Updating session title / model / effort — pure UPDATE on `agent_sessions`.
+- Marking messages read — pure UPDATE.
+- Listing watches / logs / runs — pure queries.
+
+If a Type-A operation is found going through the socket during code review, that PR is
+blocked until it's moved to `core/services/`.
+
+### 7.8 Failure modes
+
+- **Socket unavailable on UI server startup** — UI server logs a warning and falls back to
+  N1 queue mode for `dispatch`. Cancel returns 503. UI surfaces "high-latency mode" badge.
+- **Controller crashes mid-turn** — Internal server shutdown triggers cleanup of pending
+  responses; UI server `httpx.stream` raises, caught, surfaced to ChatPage as
+  "agent disconnected". User can retry; turn state in DB is left in `running` (next
+  controller boot reclaims via existing `recover_processing_runs`).
+- **UI server restarts mid-turn** — Browser `EventSource` auto-reconnects to the new UI
+  server; in-flight messages on the Controller side complete and write to messages table;
+  the reconnected browser refetches the transcript and shows the now-completed agent reply.
+- **Socket file permissions wrong** — Refuse to start UI server with explicit error pointing
+  to the socket path.
+
+## 8. Resolved Decisions (from Q1..Q10)
+
+| # | Question | Decision |
+| --- | --- | --- |
+| Q1 | Cross-process candidate | **N3** Unix Socket SSE |
+| Q2 | Plan 1 / Plan 2 order | Co-implemented (Plan 1 extracts `dispatch_turn`, Plan 2 uses it) |
+| Q3 | Service layer location | `core/services/` |
+| Q4 | First domain to slice | Sessions + dispatch_turn together |
+| Q5 | Socket path | `~/.vibe_remote/state/dispatch.sock` with `0o600` perms |
+| Q6 | Fallback path | UI server falls back to N1 queue when socket unreachable |
+| Q7 | session_id resolution | UI server auto-creates avibe session when missing |
+| Q8 | CLI schema stability | Strict — `vibe agent run --json` schema unchanged, pinned in test |
+| Q9 | Existing 13 commits | Open PR now into Codex review; new work on a separate branch |
+| Q10 | Refactor branch | New `refactor/services-layer` worktree |
+
+## 9. Execution Order
+
+1. **PR-A** — Open PR from `feature/workbench-shell` (commits 01-13 + this document = 14 commits)
+   into `master` for Codex review. Keep the review loop running via `background-watch-hook`.
+2. **Worktree setup** — Create `~/vibe-remote-project/.worktrees/vibe-remote/refactor/services-layer/`
+   from latest master once PR-A merges (or branch from `feature/workbench-shell` if we want to
+   start before merge — to be decided based on PR-A timing).
+3. **C1** — Extract `core/services/sessions.py` + `core/services/dispatch.py` + contract
+   tests. IM adapter `import` change. No behavior change. Open PR-B for Codex review.
+4. **C2** — Migrate CLI `_session_service()` to the new service. `vibe agent run --json`
+   schema snapshot test. PR-C.
+5. **C3** — `core/services/settings.py`. PR-D.
+6. **C4** — `core/internal_server.py` + `vibe/internal_client.py` + `POST /internal/dispatch`.
+   PR-E.
+7. **C5** — UI server `POST /api/sessions/<id>/messages?stream=1` + ChatPage compose UI +
+   fallback to N1. PR-F.
+8. **C6** — `POST /internal/cancel` + UI stop button. PR-G.
+
+Each PR is independently reviewable. The chain of dependencies is C1 → (C2, C4) → C5 → C6.
+C3 can land anywhere after C1.
+
+## 10. Test Strategy
+
+- **Contract tests** in `tests/contract/test_services_*.py` — assert that the same business
+  call (e.g. `services.sessions.create()`) produces identical row shape regardless of caller.
+  Pin field names, types, default values.
+- **Snapshot tests** for `vibe agent run --json` output. Test diffs on schema change.
+- **Integration test** for the socket round-trip: spawn a fake controller, send a dispatch,
+  assert SSE chunks arrive in order and the transcript matches.
+- **Existing tests** (`test_message_dispatcher_*`, `test_message_handler_*`, etc.) must
+  continue to pass without modification — IM adapter behavior is the regression backstop.
+- **No new test framework** introduced. Pytest only.
+
+## 11. Open Items (Not Blocking)
+
+- Whether `vibe agent run --sync` should become the default once the socket path is
+  reliable. Defer to a separate UX discussion.
+- Whether the long-lived `GET /internal/events` SSE for Controller→UI push (v2) should
+  replace `vibe/sse_broker.py` entirely or complement it. Defer to v2.
+- Cancellation semantics: should a cancelled run leave a `cancelled` row in `agent_runs` or
+  delete the row? Current `storage/background.py` supports `cancelled` status; reuse it.
+
+## 12. Out of Scope, Recorded for Future
+
+- gRPC / Protobuf — would force schema versioning overhead. Reconsider if endpoint count
+  exceeds ~15.
+- Replacing `RuntimeCommandWatcher` (`core/runtime_commands.py`) entirely with the new
+  internal endpoints. Listed as v2 work above; not blocking v1.
+- Web UI sending messages **to other IM platforms** (e.g. Web UI → Slack channel) — this is
+  a product decision, not a transport decision; current scope keeps web Chat strictly
+  avibe-platform.

--- a/modules/im/avibe.py
+++ b/modules/im/avibe.py
@@ -1,0 +1,228 @@
+"""Avibe — Vibe Remote's own Web UI surfaced as a first-class IM platform.
+
+Most IM adapters wrap an external API (Slack RTM, Discord gateway, etc.)
+with a long-poll or socket loop. Avibe is different: the workbench Web
+UI lives in the same process as the Vibe Remote service, so there is no
+remote handshake to perform. Inbound messages arrive via REST POST
+(handled by ``vibe/ui_server.py`` in commit 07) and outbound messages
+get fanned out to subscribed browsers via Server-Sent Events (commit
+08).
+
+This module ships the platform-side contract that the
+``core/handlers`` / ``message_dispatcher`` layer can call uniformly
+across every platform. The REST + SSE wiring lands in later commits and
+will register itself with the ``AvibeBot`` instance held by the
+controller (see ``IMFactory.create_client``).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from .base import BaseIMClient, BaseIMConfig, InlineKeyboard, MessageContext
+from .formatters.avibe_formatter import AvibeFormatter
+
+logger = logging.getLogger(__name__)
+
+
+SsePublisher = Callable[..., Awaitable[None]]
+
+
+@dataclass
+class AvibeConfig(BaseIMConfig):
+    """Avibe platform config.
+
+    Avibe runs in-process inside the Vibe Remote service — there are no
+    credentials to validate. ``enabled`` lets headless deployments skip
+    the workbench surface entirely when they only need the IM-bridge
+    platforms.
+    """
+
+    enabled: bool = True
+
+    def validate(self) -> None:
+        # No remote credentials to check.
+        return None
+
+
+def _new_message_id() -> str:
+    return f"msg_{uuid.uuid4().hex[:16]}"
+
+
+class AvibeBot(BaseIMClient):
+    """Avibe (Web UI) platform client.
+
+    Methods stay deliberately thin: the REST + SSE plumbing is owned by
+    ``vibe/ui_server.py`` (commit 07+) and outbound transport flows
+    through whatever publisher the UI server registers via
+    :meth:`bind_sse_publisher`. The shape of every method matches every
+    other ``BaseIMClient`` so ``core/handlers`` can dispatch Avibe like
+    any other platform.
+    """
+
+    def __init__(self, config: AvibeConfig):
+        super().__init__(config)
+        self.formatter = AvibeFormatter()
+        self._sse_publisher: Optional[SsePublisher] = None
+
+    # ------------------------------------------------------------------
+    # SSE binding — used by ui_server in commit 08 to register a fan-out
+    # function. Kept on the bot so the controller can hand its single
+    # AvibeBot instance to whoever owns the SSE broker.
+    # ------------------------------------------------------------------
+    def bind_sse_publisher(self, publisher: Optional[SsePublisher]) -> None:
+        self._sse_publisher = publisher
+
+    # ------------------------------------------------------------------
+    # Capability hints used by core/message_dispatcher and friends.
+    # ------------------------------------------------------------------
+    def get_default_parse_mode(self) -> Optional[str]:
+        # Web UI renders CommonMark + GFM (strikethrough, tables, fenced
+        # code) natively, so we tell the dispatcher to emit markdown
+        # straight through.
+        return "markdown"
+
+    def supports_message_editing(self, context: Optional[MessageContext] = None) -> bool:
+        # The browser tracks each message by id and re-renders on edit.
+        return True
+
+    def should_use_thread_for_dm_session(self) -> bool:
+        # Every workbench session is its own scope (mapped to a project)
+        # — the session_handler already maps session -> scope_key, so we
+        # don't need an extra "thread" level here.
+        return False
+
+    # ------------------------------------------------------------------
+    # Outbound messaging — stub today, SSE-backed once commit 08 lands.
+    # ------------------------------------------------------------------
+    async def send_message(
+        self,
+        context: MessageContext,
+        text: str,
+        parse_mode: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> str:
+        message_id = _new_message_id()
+        logger.debug(
+            "AvibeBot.send_message: scope=%s message_id=%s len=%s reply_to=%s",
+            getattr(context, "channel_id", None),
+            message_id,
+            len(text or ""),
+            reply_to,
+        )
+        if self._sse_publisher is not None:
+            await self._sse_publisher(
+                "message.new",
+                context=context,
+                message_id=message_id,
+                text=text,
+                parse_mode=parse_mode,
+                reply_to=reply_to,
+            )
+        return message_id
+
+    async def send_message_with_buttons(
+        self,
+        context: MessageContext,
+        text: str,
+        keyboard: InlineKeyboard,
+        parse_mode: Optional[str] = None,
+    ) -> str:
+        message_id = _new_message_id()
+        button_count = len(getattr(keyboard, "buttons", []) or [])
+        logger.debug(
+            "AvibeBot.send_message_with_buttons: scope=%s message_id=%s buttons=%s",
+            getattr(context, "channel_id", None),
+            message_id,
+            button_count,
+        )
+        if self._sse_publisher is not None:
+            await self._sse_publisher(
+                "message.new",
+                context=context,
+                message_id=message_id,
+                text=text,
+                parse_mode=parse_mode,
+                keyboard=keyboard,
+            )
+        return message_id
+
+    async def edit_message(
+        self,
+        context: MessageContext,
+        message_id: str,
+        text: Optional[str] = None,
+        keyboard: Optional[InlineKeyboard] = None,
+        parse_mode: Optional[str] = None,
+    ) -> bool:
+        logger.debug(
+            "AvibeBot.edit_message: scope=%s message_id=%s text_len=%s keyboard=%s",
+            getattr(context, "channel_id", None),
+            message_id,
+            len(text or "") if text is not None else None,
+            keyboard is not None,
+        )
+        if self._sse_publisher is not None:
+            await self._sse_publisher(
+                "message.updated",
+                context=context,
+                message_id=message_id,
+                text=text,
+                parse_mode=parse_mode,
+                keyboard=keyboard,
+            )
+        return True
+
+    async def answer_callback(
+        self,
+        callback_id: str,
+        text: Optional[str] = None,
+        show_alert: bool = False,
+    ) -> bool:
+        # The browser handles its own button clicks (no remote callback
+        # to ack), so this just logs for parity with other platforms.
+        logger.debug(
+            "AvibeBot.answer_callback: callback_id=%s text=%s show_alert=%s",
+            callback_id,
+            text,
+            show_alert,
+        )
+        return True
+
+    # ------------------------------------------------------------------
+    # Lifecycle — nothing to start. The HTTP server (ui_server) is the
+    # transport; this bot just exposes the contract.
+    # ------------------------------------------------------------------
+    def register_handlers(self) -> None:
+        # No inbound webhook to mount. REST handlers in ui_server route
+        # incoming user messages straight into ``self.on_message_callback``
+        # (set by ``register_callbacks`` on controller wiring).
+        return None
+
+    def run(self) -> None:
+        logger.debug(
+            "AvibeBot.run: no event loop to start "
+            "(REST + SSE owned by vibe/ui_server.py)"
+        )
+
+    # ------------------------------------------------------------------
+    # Introspection — returns the locally-known identity for the single
+    # workbench user. Vibe Cloud remote-access state owns the real
+    # identity; Avibe surfaces a stable shape for the dispatcher.
+    # ------------------------------------------------------------------
+    async def get_user_info(self, user_id: str) -> Dict[str, Any]:
+        return {"id": user_id, "name": user_id, "platform": "avibe"}
+
+    async def get_channel_info(self, channel_id: str) -> Dict[str, Any]:
+        # channel_id is the project scope's native_id (commit 05 wires
+        # the lookup through the scopes table; this stub keeps the
+        # contract intact in the meantime).
+        return {"id": channel_id, "name": channel_id, "platform": "avibe"}
+
+    def format_markdown(self, text: str) -> str:
+        # Web UI consumes CommonMark + GFM directly; no platform-level
+        # rewriting needed.
+        return text

--- a/modules/im/formatters/__init__.py
+++ b/modules/im/formatters/__init__.py
@@ -4,6 +4,7 @@ from .discord_formatter import DiscordFormatter
 from .telegram_formatter import TelegramFormatter
 from .feishu_formatter import FeishuFormatter
 from .wechat_formatter import WeChatFormatter
+from .avibe_formatter import AvibeFormatter
 
 __all__ = [
     "BaseMarkdownFormatter",
@@ -12,4 +13,5 @@ __all__ = [
     "TelegramFormatter",
     "FeishuFormatter",
     "WeChatFormatter",
+    "AvibeFormatter",
 ]

--- a/modules/im/formatters/avibe_formatter.py
+++ b/modules/im/formatters/avibe_formatter.py
@@ -1,0 +1,35 @@
+"""Avibe (Web UI) markdown formatter.
+
+The Vibe Remote workbench renders agent output as CommonMark + GFM in
+the browser, so the formatter uses standard markdown syntax for every
+operation. Mirrors ``DiscordFormatter`` — both render through a
+CommonMark pipeline.
+"""
+
+from .base_formatter import BaseMarkdownFormatter
+
+
+class AvibeFormatter(BaseMarkdownFormatter):
+    """Standard CommonMark + GFM formatter for the Web UI."""
+
+    def format_bold(self, text: str) -> str:
+        return f"**{text}**"
+
+    def format_italic(self, text: str) -> str:
+        return f"*{text}*"
+
+    def format_strikethrough(self, text: str) -> str:
+        return f"~~{text}~~"
+
+    def format_link(self, text: str, url: str) -> str:
+        return f"[{text}]({url})"
+
+    def escape_special_chars(self, text: str) -> str:
+        for ch in ("\\", "*", "_", "~", "`", "|"):
+            text = text.replace(ch, f"\\{ch}")
+        return text
+
+    def format_code_block(self, code: str, language: str = "") -> str:
+        if language:
+            return f"```{language}\n{code}\n```"
+        return f"```\n{code}\n```"

--- a/storage/alembic/versions/20260526_0006_messages.py
+++ b/storage/alembic/versions/20260526_0006_messages.py
@@ -1,0 +1,83 @@
+"""platform-agnostic messages table
+
+Revision ID: 20260526_0006
+Revises: 20260525_0005
+Create Date: 2026-05-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260526_0006"
+down_revision = "20260525_0005"
+branch_labels = None
+depends_on = None
+
+
+def _tables() -> set[str]:
+    bind = op.get_bind()
+    return {row[0] for row in bind.exec_driver_sql("select name from sqlite_master where type = 'table'")}
+
+
+def upgrade() -> None:
+    if "messages" not in _tables():
+        op.create_table(
+            "messages",
+            sa.Column("id", sa.String(), primary_key=True),
+            sa.Column(
+                "scope_id",
+                sa.String(),
+                sa.ForeignKey("scopes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "session_id",
+                sa.String(),
+                sa.ForeignKey("agent_sessions.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("platform", sa.String(), nullable=False),
+            sa.Column("author", sa.String(), nullable=False),
+            sa.Column("author_id", sa.String(), nullable=True),
+            sa.Column("author_name", sa.Text(), nullable=True),
+            sa.Column("native_message_id", sa.String(), nullable=True),
+            sa.Column("parent_native_message_id", sa.String(), nullable=True),
+            sa.Column("content_text", sa.Text(), nullable=True),
+            sa.Column("content_json", sa.Text(), nullable=False),
+            sa.Column("metadata_json", sa.Text(), nullable=False),
+            sa.Column("created_at", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False),
+            sa.Column("delivered_at", sa.String(), nullable=True),
+            sa.Column("read_at", sa.String(), nullable=True),
+            sa.UniqueConstraint("platform", "native_message_id", name="uq_messages_platform_native"),
+        )
+    op.create_index(
+        "ix_messages_session_created",
+        "messages",
+        ["session_id", "created_at"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_messages_scope_created",
+        "messages",
+        ["scope_id", "created_at"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_messages_scope_unread",
+        "messages",
+        ["scope_id", "read_at"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_messages_author_created",
+        "messages",
+        ["author", "created_at"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("messages")

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -133,11 +133,13 @@ def list_session_messages(
                     and_(messages.c.created_at == anchor, messages.c.id > after_id),
                 )
             )
-    query = query.order_by(messages.c.created_at.asc(), messages.c.id.asc()).limit(
-        min(max(int(limit), 1), 500)
-    )
+    effective_limit = min(max(int(limit), 1), 500)
+    query = query.order_by(messages.c.created_at.asc(), messages.c.id.asc()).limit(effective_limit)
     rows = [_row_to_payload(dict(row)) for row in conn.execute(query).mappings().all()]
-    next_after = rows[-1]["id"] if len(rows) == limit else None
+    # Compare against the clamped page size; a caller requesting > 500
+    # would otherwise receive a full 500-row page with a null cursor and
+    # silently stop paginating.
+    next_after = rows[-1]["id"] if len(rows) == effective_limit else None
     return {"messages": rows, "next_after_id": next_after}
 
 
@@ -175,11 +177,12 @@ def list_inbox(
                     and_(messages.c.created_at == anchor, messages.c.id < before_id),
                 )
             )
-    query = query.order_by(messages.c.created_at.desc(), messages.c.id.desc()).limit(
-        min(max(int(limit), 1), 200)
-    )
+    effective_limit = min(max(int(limit), 1), 200)
+    query = query.order_by(messages.c.created_at.desc(), messages.c.id.desc()).limit(effective_limit)
     rows = [_row_to_payload(dict(row)) for row in conn.execute(query).mappings().all()]
-    next_before = rows[-1]["id"] if len(rows) == limit else None
+    # Same fix as ``list_session_messages``: gate the cursor on the
+    # clamped page size, not the raw caller-supplied limit.
+    next_before = rows[-1]["id"] if len(rows) == effective_limit else None
     return {"messages": rows, "next_before_id": next_before}
 
 

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -229,7 +229,19 @@ def mark_session_read(
             select(messages.c.created_at).where(messages.c.id == until_message_id)
         ).scalar_one_or_none()
         if anchor is not None:
-            base = base.where(messages.c.created_at <= anchor)
+            # ``created_at`` is stored at second precision, so a bare
+            # ``<= anchor`` would also mark newer messages created in the
+            # same second as read. Tie-break on ``id`` so only rows at-or-
+            # before the anchor message itself are affected.
+            base = base.where(
+                or_(
+                    messages.c.created_at < anchor,
+                    and_(
+                        messages.c.created_at == anchor,
+                        messages.c.id <= until_message_id,
+                    ),
+                )
+            )
     result = conn.execute(base)
     return result.rowcount or 0
 

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -1,0 +1,251 @@
+"""CRUD over the platform-agnostic ``messages`` table.
+
+The workbench Inbox + per-session history both read through this
+module so they get a consistent shape regardless of which platform
+originated the row. ``append`` is the canonical write path —
+adapters and REST routes call it instead of touching the table
+directly so future invariants (e.g. SSE fan-out hooks, audit logging)
+land in one place.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
+
+from sqlalchemy import and_, func, or_, select, update
+from sqlalchemy.engine import Connection
+
+from storage.models import messages
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_message_id() -> str:
+    return f"msg_{uuid.uuid4().hex[:16]}"
+
+
+def _row_to_payload(row: dict[str, Any]) -> dict[str, Any]:
+    try:
+        content = json.loads(row.get("content_json") or "{}")
+    except json.JSONDecodeError:
+        content = {}
+    try:
+        metadata = json.loads(row.get("metadata_json") or "{}")
+    except json.JSONDecodeError:
+        metadata = {}
+    return {
+        "id": row["id"],
+        "scope_id": row.get("scope_id"),
+        "session_id": row.get("session_id"),
+        "platform": row.get("platform"),
+        "author": row.get("author"),
+        "author_id": row.get("author_id"),
+        "author_name": row.get("author_name"),
+        "native_message_id": row.get("native_message_id"),
+        "parent_native_message_id": row.get("parent_native_message_id"),
+        "text": row.get("content_text") or content.get("text") or "",
+        "content": content,
+        "metadata": metadata,
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+        "delivered_at": row.get("delivered_at"),
+        "read_at": row.get("read_at"),
+    }
+
+
+def append(
+    conn: Connection,
+    *,
+    scope_id: str,
+    session_id: Optional[str],
+    platform: str,
+    author: str,
+    text: Optional[str] = None,
+    content: Optional[dict[str, Any]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    author_id: Optional[str] = None,
+    author_name: Optional[str] = None,
+    native_message_id: Optional[str] = None,
+    parent_native_message_id: Optional[str] = None,
+    delivered_at: Optional[str] = None,
+    read_at: Optional[str] = None,
+) -> dict[str, Any]:
+    """Insert a new message row and return its payload.
+
+    ``content`` is the rich blob (text + attachments + tool_calls); if
+    ``text`` is omitted we project ``content['text']`` into
+    ``content_text`` so plain-text search keeps working.
+    """
+
+    body: dict[str, Any] = {}
+    if content:
+        body.update(content)
+    if text is not None:
+        body.setdefault("text", text)
+    plain = text if text is not None else body.get("text") or None
+
+    now = _utc_now_iso()
+    payload = {
+        "id": _new_message_id(),
+        "scope_id": scope_id,
+        "session_id": session_id,
+        "platform": platform,
+        "author": author,
+        "author_id": author_id,
+        "author_name": author_name,
+        "native_message_id": native_message_id,
+        "parent_native_message_id": parent_native_message_id,
+        "content_text": plain,
+        "content_json": json.dumps(body),
+        "metadata_json": json.dumps(metadata or {}),
+        "created_at": now,
+        "updated_at": now,
+        "delivered_at": delivered_at,
+        "read_at": read_at,
+    }
+    conn.execute(messages.insert().values(**payload))
+    return _row_to_payload(payload)
+
+
+def list_session_messages(
+    conn: Connection,
+    *,
+    session_id: str,
+    after_id: Optional[str] = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Return messages for one session in chronological order with cursor pagination."""
+
+    query = select(messages).where(messages.c.session_id == session_id)
+    if after_id:
+        anchor = conn.execute(
+            select(messages.c.created_at).where(messages.c.id == after_id)
+        ).scalar_one_or_none()
+        if anchor is not None:
+            query = query.where(
+                or_(
+                    messages.c.created_at > anchor,
+                    and_(messages.c.created_at == anchor, messages.c.id > after_id),
+                )
+            )
+    query = query.order_by(messages.c.created_at.asc(), messages.c.id.asc()).limit(
+        min(max(int(limit), 1), 500)
+    )
+    rows = [_row_to_payload(dict(row)) for row in conn.execute(query).mappings().all()]
+    next_after = rows[-1]["id"] if len(rows) == limit else None
+    return {"messages": rows, "next_after_id": next_after}
+
+
+def list_inbox(
+    conn: Connection,
+    *,
+    platform: Optional[str] = None,
+    unread_only: bool = False,
+    limit: int = 30,
+    before_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Cross-session feed for the workbench Inbox.
+
+    Returns the most recent agent-authored messages first (the human
+    sent them, they don't need to see their own as "new"). The
+    ``platform`` filter defaults to nothing so users opting into
+    cross-platform mirroring see Slack/Discord here too; per the
+    workbench scope the UI passes ``platform='avibe'`` to scope it
+    down.
+    """
+
+    query = select(messages).where(messages.c.author == "agent")
+    if platform is not None:
+        query = query.where(messages.c.platform == platform)
+    if unread_only:
+        query = query.where(messages.c.read_at.is_(None))
+    if before_id:
+        anchor = conn.execute(
+            select(messages.c.created_at).where(messages.c.id == before_id)
+        ).scalar_one_or_none()
+        if anchor is not None:
+            query = query.where(
+                or_(
+                    messages.c.created_at < anchor,
+                    and_(messages.c.created_at == anchor, messages.c.id < before_id),
+                )
+            )
+    query = query.order_by(messages.c.created_at.desc(), messages.c.id.desc()).limit(
+        min(max(int(limit), 1), 200)
+    )
+    rows = [_row_to_payload(dict(row)) for row in conn.execute(query).mappings().all()]
+    next_before = rows[-1]["id"] if len(rows) == limit else None
+    return {"messages": rows, "next_before_id": next_before}
+
+
+def unread_counts(
+    conn: Connection,
+    *,
+    platform: Optional[str] = None,
+) -> dict[str, int]:
+    """Return ``{scope_id: count}`` for unread agent messages.
+
+    Used by the sidebar / hover popover to show per-session unread dots
+    plus the global count without dragging every row through Python.
+    """
+
+    query = (
+        select(messages.c.scope_id, func.count(messages.c.id))
+        .where(messages.c.author == "agent")
+        .where(messages.c.read_at.is_(None))
+        .group_by(messages.c.scope_id)
+    )
+    if platform is not None:
+        query = query.where(messages.c.platform == platform)
+    return {scope: int(count) for scope, count in conn.execute(query).all()}
+
+
+def mark_session_read(
+    conn: Connection,
+    session_id: str,
+    *,
+    until_message_id: Optional[str] = None,
+) -> int:
+    """Mark unread agent messages in a session as read, up to ``until_message_id``.
+
+    Returns the number of rows updated.
+    """
+
+    now = _utc_now_iso()
+    base = (
+        update(messages)
+        .where(messages.c.session_id == session_id)
+        .where(messages.c.author == "agent")
+        .where(messages.c.read_at.is_(None))
+        .values(read_at=now, updated_at=now)
+    )
+    if until_message_id:
+        anchor = conn.execute(
+            select(messages.c.created_at).where(messages.c.id == until_message_id)
+        ).scalar_one_or_none()
+        if anchor is not None:
+            base = base.where(messages.c.created_at <= anchor)
+    result = conn.execute(base)
+    return result.rowcount or 0
+
+
+def list_messages_for_inbox_scope(
+    conn: Connection,
+    scope_id: str,
+    *,
+    limit: int = 1,
+) -> Iterable[dict[str, Any]]:
+    """Return the latest N messages for a given scope (for inbox previews)."""
+
+    query = (
+        select(messages)
+        .where(messages.c.scope_id == scope_id)
+        .order_by(messages.c.created_at.desc(), messages.c.id.desc())
+        .limit(min(max(int(limit), 1), 50))
+    )
+    return [_row_to_payload(dict(row)) for row in conn.execute(query).mappings().all()]

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -19,7 +19,7 @@ INITIAL_TABLES = {
     "agent_sessions",
     "runtime_records",
 }
-HEAD_TABLES = INITIAL_TABLES | {"run_definitions", "agent_runs", "show_pages"}
+HEAD_TABLES = INITIAL_TABLES | {"run_definitions", "agent_runs", "show_pages", "messages"}
 HEAD_REQUIRED_COLUMNS = {
     "agents": {"enabled"},
     "scope_settings": {"agent_name"},

--- a/storage/models.py
+++ b/storage/models.py
@@ -255,6 +255,39 @@ show_pages = Table(
     Index("ix_show_pages_visibility", "visibility"),
 )
 
+# Platform-agnostic chat message store. Every IM adapter (Slack, Discord,
+# Telegram, Lark, WeChat, Avibe/Web UI) writes user+agent turns here so the
+# workbench Inbox and per-session history can read from a single ORM
+# surface instead of round-tripping the platform's own API. ``platform`` +
+# ``native_message_id`` is unique when present so a duplicate webhook
+# delivery is a no-op upsert. ``read_at`` drives unread counts for the
+# Inbox; legacy IM platforms ignore it.
+messages = Table(
+    "messages",
+    metadata,
+    Column("id", String, primary_key=True),
+    Column("scope_id", String, ForeignKey("scopes.id", ondelete="CASCADE"), nullable=False),
+    Column("session_id", String, ForeignKey("agent_sessions.id", ondelete="SET NULL"), nullable=True),
+    Column("platform", String, nullable=False),
+    Column("author", String, nullable=False),
+    Column("author_id", String, nullable=True),
+    Column("author_name", Text, nullable=True),
+    Column("native_message_id", String, nullable=True),
+    Column("parent_native_message_id", String, nullable=True),
+    Column("content_text", Text, nullable=True),
+    Column("content_json", Text, nullable=False),
+    Column("metadata_json", Text, nullable=False),
+    Column("created_at", String, nullable=False),
+    Column("updated_at", String, nullable=False),
+    Column("delivered_at", String, nullable=True),
+    Column("read_at", String, nullable=True),
+    UniqueConstraint("platform", "native_message_id", name="uq_messages_platform_native"),
+    Index("ix_messages_session_created", "session_id", "created_at"),
+    Index("ix_messages_scope_created", "scope_id", "created_at"),
+    Index("ix_messages_scope_unread", "scope_id", "read_at"),
+    Index("ix_messages_author_created", "author", "created_at"),
+)
+
 imported_state_tables = [
     show_pages,
     background_runs,
@@ -264,4 +297,5 @@ imported_state_tables = [
     agent_sessions,
     runtime_records,
     scopes,
+    messages,
 ]

--- a/storage/projects_service.py
+++ b/storage/projects_service.py
@@ -1,0 +1,249 @@
+"""CRUD service for avibe projects.
+
+Projects are first-class entities in the workbench but reuse the
+existing ``scopes`` + ``scope_settings`` tables instead of introducing
+a parallel store: an avibe project is just a scope row with
+``platform='avibe'`` and ``scope_type='project'``. The local folder
+path lives in ``scope_settings.workdir`` so Agent runs can pick it up
+without a second lookup, and "archived" is modelled as
+``scope_settings.enabled = 0`` for parity with how other scopes get
+disabled.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from sqlalchemy import select, update
+from sqlalchemy.engine import Connection
+
+from storage.models import scope_settings, scopes
+
+
+PROJECT_PLATFORM = "avibe"
+PROJECT_SCOPE_TYPE = "project"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_project_id() -> str:
+    # 12 hex chars = 48 bits → plenty for a single-user installation, and
+    # the prefix keeps the id self-documenting in logs / UI tooltips.
+    return f"proj_{uuid.uuid4().hex[:12]}"
+
+
+def _make_scope_id(native_id: str) -> str:
+    # Mirrors ``storage.settings_service.make_scope_id`` — kept inline so
+    # this module stays decoupled from the broader settings surface.
+    return f"{PROJECT_PLATFORM}::{PROJECT_SCOPE_TYPE}::{native_id}"
+
+
+def _resolve_folder(folder_path: str) -> Path:
+    folder = Path(folder_path).expanduser().resolve()
+    if not folder.exists():
+        raise FileNotFoundError(f"Folder does not exist: {folder}")
+    if not folder.is_dir():
+        raise NotADirectoryError(f"Not a directory: {folder}")
+    return folder
+
+
+def list_projects(conn: Connection, *, include_archived: bool = False) -> list[dict[str, Any]]:
+    """Return all avibe projects sorted by recency, optionally including archived ones."""
+
+    query = (
+        select(
+            scopes.c.id.label("scope_id"),
+            scopes.c.native_id,
+            scopes.c.display_name,
+            scopes.c.metadata_json,
+            scopes.c.first_seen_at,
+            scopes.c.last_seen_at,
+            scope_settings.c.enabled,
+            scope_settings.c.workdir,
+            scope_settings.c.updated_at.label("settings_updated_at"),
+        )
+        .select_from(scopes.outerjoin(scope_settings, scope_settings.c.scope_id == scopes.c.id))
+        .where(scopes.c.platform == PROJECT_PLATFORM, scopes.c.scope_type == PROJECT_SCOPE_TYPE)
+        .order_by(scopes.c.last_seen_at.desc())
+    )
+    rows = conn.execute(query).mappings().all()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        enabled = bool(row["enabled"]) if row["enabled"] is not None else True
+        if not include_archived and not enabled:
+            continue
+        try:
+            metadata = json.loads(row["metadata_json"] or "{}")
+        except json.JSONDecodeError:
+            metadata = {}
+        out.append({
+            "id": row["native_id"],
+            "scope_id": row["scope_id"],
+            "display_name": row["display_name"] or row["native_id"],
+            "folder_path": row["workdir"] or "",
+            "created_at": row["first_seen_at"],
+            "last_active_at": row["last_seen_at"],
+            "archived": not enabled,
+            "metadata": metadata,
+        })
+    return out
+
+
+def get_project(conn: Connection, project_id: str) -> dict[str, Any]:
+    scope_id = _make_scope_id(project_id)
+    return _project_payload(conn, scope_id)
+
+
+def create_project(
+    conn: Connection,
+    folder_path: str,
+    display_name: Optional[str] = None,
+) -> dict[str, Any]:
+    folder = _resolve_folder(folder_path)
+
+    project_id = _new_project_id()
+    scope_id = _make_scope_id(project_id)
+    now = _utc_now_iso()
+    name = (display_name or folder.name).strip() or project_id
+
+    conn.execute(
+        scopes.insert().values(
+            id=scope_id,
+            platform=PROJECT_PLATFORM,
+            scope_type=PROJECT_SCOPE_TYPE,
+            native_id=project_id,
+            parent_scope_id=None,
+            display_name=name,
+            native_type="project",
+            is_private=1,
+            supports_threads=1,
+            metadata_json=json.dumps({}),
+            first_seen_at=now,
+            last_seen_at=now,
+            updated_at=now,
+        )
+    )
+    conn.execute(
+        scope_settings.insert().values(
+            scope_id=scope_id,
+            enabled=1,
+            role=None,
+            workdir=str(folder),
+            agent_name=None,
+            agent_backend=None,
+            agent_variant=None,
+            model=None,
+            reasoning_effort=None,
+            require_mention=None,
+            settings_version=1,
+            settings_json=json.dumps({}),
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    return _project_payload(conn, scope_id)
+
+
+def update_project(
+    conn: Connection,
+    project_id: str,
+    *,
+    display_name: Optional[str] = None,
+    folder_path: Optional[str] = None,
+) -> dict[str, Any]:
+    scope_id = _make_scope_id(project_id)
+    existing = conn.execute(select(scopes.c.id).where(scopes.c.id == scope_id)).scalar_one_or_none()
+    if existing is None:
+        raise LookupError(f"Project not found: {project_id}")
+
+    now = _utc_now_iso()
+    if display_name is not None:
+        cleaned = display_name.strip()
+        if cleaned:
+            conn.execute(
+                update(scopes)
+                .where(scopes.c.id == scope_id)
+                .values(display_name=cleaned, updated_at=now, last_seen_at=now)
+            )
+    if folder_path is not None:
+        folder = _resolve_folder(folder_path)
+        conn.execute(
+            update(scope_settings)
+            .where(scope_settings.c.scope_id == scope_id)
+            .values(workdir=str(folder), updated_at=now)
+        )
+
+    return _project_payload(conn, scope_id)
+
+
+def archive_project(conn: Connection, project_id: str) -> dict[str, Any]:
+    scope_id = _make_scope_id(project_id)
+    existing = conn.execute(select(scopes.c.id).where(scopes.c.id == scope_id)).scalar_one_or_none()
+    if existing is None:
+        raise LookupError(f"Project not found: {project_id}")
+
+    now = _utc_now_iso()
+    conn.execute(
+        update(scope_settings)
+        .where(scope_settings.c.scope_id == scope_id)
+        .values(enabled=0, updated_at=now)
+    )
+    conn.execute(
+        update(scopes)
+        .where(scopes.c.id == scope_id)
+        .values(updated_at=now)
+    )
+    return _project_payload(conn, scope_id)
+
+
+def _project_payload(conn: Connection, scope_id: str) -> dict[str, Any]:
+    row = conn.execute(
+        select(
+            scopes.c.id.label("scope_id"),
+            scopes.c.native_id,
+            scopes.c.display_name,
+            scopes.c.metadata_json,
+            scopes.c.first_seen_at,
+            scopes.c.last_seen_at,
+            scope_settings.c.enabled,
+            scope_settings.c.workdir,
+        )
+        .select_from(scopes.outerjoin(scope_settings, scope_settings.c.scope_id == scopes.c.id))
+        .where(scopes.c.id == scope_id)
+    ).mappings().first()
+    if row is None:
+        raise LookupError(f"Project not found: {scope_id}")
+    enabled = bool(row["enabled"]) if row["enabled"] is not None else True
+    try:
+        metadata = json.loads(row["metadata_json"] or "{}")
+    except json.JSONDecodeError:
+        metadata = {}
+    return {
+        "id": row["native_id"],
+        "scope_id": row["scope_id"],
+        "display_name": row["display_name"] or row["native_id"],
+        "folder_path": row["workdir"] or "",
+        "created_at": row["first_seen_at"],
+        "last_active_at": row["last_seen_at"],
+        "archived": not enabled,
+        "metadata": metadata,
+    }
+
+
+def make_directory(path: str) -> str:
+    """Create a directory (with parents) and return its absolute path.
+
+    Mirrors the folder picker's expectation that mkdir errors when the
+    target already exists — that keeps the UI from silently overwriting
+    a different folder when the user supplies an existing name.
+    """
+
+    folder = Path(path).expanduser().resolve()
+    folder.mkdir(parents=True, exist_ok=False)
+    return str(folder)

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -1,0 +1,247 @@
+"""Workbench-scoped session CRUD over ``agent_sessions``.
+
+``storage/sessions_service.py`` exposes the runtime-facing primitives
+that IM dispatchers use to reserve sessions during message handling.
+The workbench REST API needs different shapes — listing sessions in a
+project, creating one with explicit Agent / model / effort, renaming,
+archiving — so this module wraps the same ``agent_sessions`` table
+with workbench-friendly queries instead of bolting another concern
+onto ``SQLiteSessionsService``.
+
+Avibe scope_ids look like ``avibe::project::proj_<hex12>`` — see
+``storage/projects_service.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from sqlalchemy import select, update
+from sqlalchemy.engine import Connection
+
+from storage.models import agent_sessions, scope_settings, scopes
+
+
+SESSION_ID_ALPHABET = "23456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _new_session_id(conn: Connection) -> str:
+    used = {str(value) for value in conn.execute(select(agent_sessions.c.id)).scalars()}
+    while True:
+        candidate = "ses" + "".join(secrets.choice(SESSION_ID_ALPHABET) for _ in range(10))
+        if candidate not in used:
+            return candidate
+
+
+def _row_to_payload(row: dict[str, Any]) -> dict[str, Any]:
+    try:
+        metadata = json.loads(row.get("metadata_json") or "{}")
+    except json.JSONDecodeError:
+        metadata = {}
+    return {
+        "id": row["id"],
+        "scope_id": row.get("scope_id"),
+        "project_id": (row.get("scope_id") or "").rsplit("::", 1)[-1] or None,
+        "title": row.get("title"),
+        "agent_id": row.get("agent_id"),
+        "agent_name": row.get("agent_name"),
+        "agent_backend": row.get("agent_backend"),
+        "agent_variant": row.get("agent_variant"),
+        "model": row.get("model"),
+        "reasoning_effort": row.get("reasoning_effort"),
+        "status": row.get("status"),
+        "workdir": row.get("workdir"),
+        "native_session_id": row.get("native_session_id"),
+        "created_at": row.get("created_at"),
+        "updated_at": row.get("updated_at"),
+        "last_active_at": row.get("last_active_at"),
+        "metadata": metadata,
+    }
+
+
+def list_sessions(
+    conn: Connection,
+    *,
+    scope_id: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+    before_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Return sessions for the workbench list. Cursor pagination via ``before_id``.
+
+    ``status`` accepts ``active`` / ``archived`` (or omit for both). The
+    cursor is the row id; results are sorted by ``last_active_at DESC``
+    so the cursor row is "the last id you already saw".
+    """
+
+    query = select(agent_sessions)
+    if scope_id is not None:
+        query = query.where(agent_sessions.c.scope_id == scope_id)
+    if status is not None and status != "all":
+        query = query.where(agent_sessions.c.status == status)
+    if before_id is not None:
+        cursor_row = conn.execute(
+            select(agent_sessions.c.last_active_at, agent_sessions.c.created_at).where(agent_sessions.c.id == before_id)
+        ).first()
+        if cursor_row is not None:
+            cursor_active, cursor_created = cursor_row
+            query = query.where(
+                (agent_sessions.c.last_active_at < cursor_active)
+                | (
+                    (agent_sessions.c.last_active_at == cursor_active)
+                    & (agent_sessions.c.created_at < cursor_created)
+                )
+            )
+    query = (
+        query.order_by(
+            agent_sessions.c.last_active_at.desc(),
+            agent_sessions.c.created_at.desc(),
+        )
+        .limit(min(max(int(limit), 1), 200))
+    )
+    rows = [dict(row) for row in conn.execute(query).mappings().all()]
+    sessions = [_row_to_payload(row) for row in rows]
+    next_cursor = sessions[-1]["id"] if len(sessions) == limit else None
+    return {"sessions": sessions, "next_before_id": next_cursor}
+
+
+def get_session(conn: Connection, session_id: str) -> dict[str, Any]:
+    row = conn.execute(
+        select(agent_sessions).where(agent_sessions.c.id == session_id)
+    ).mappings().first()
+    if row is None:
+        raise LookupError(f"Session not found: {session_id}")
+    return _row_to_payload(dict(row))
+
+
+def create_session(
+    conn: Connection,
+    *,
+    scope_id: str,
+    agent_backend: str,
+    agent_name: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    agent_variant: Optional[str] = None,
+    model: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    title: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Create a workbench session inside the given project scope.
+
+    Pulls ``workdir`` from ``scope_settings`` so Agent runs already know
+    where to cd. ``native_session_id`` stays empty — Claude / OpenCode /
+    Codex fill it on their first turn.
+    """
+
+    scope_row = conn.execute(
+        select(scopes.c.id, scope_settings.c.workdir, scope_settings.c.enabled)
+        .select_from(scopes.outerjoin(scope_settings, scope_settings.c.scope_id == scopes.c.id))
+        .where(scopes.c.id == scope_id)
+    ).mappings().first()
+    if scope_row is None:
+        raise LookupError(f"Scope not found: {scope_id}")
+    if scope_row.get("enabled") == 0:
+        raise PermissionError(f"Scope is archived: {scope_id}")
+    workdir = scope_row.get("workdir")
+
+    now = _utc_now_iso()
+    session_id = _new_session_id(conn)
+    variant = agent_variant or agent_name or "default"
+    metadata_payload = {"created_via": "workbench"}
+    if metadata:
+        metadata_payload.update(metadata)
+
+    conn.execute(
+        agent_sessions.insert().values(
+            id=session_id,
+            scope_id=scope_id,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            agent_backend=agent_backend,
+            agent_variant=str(variant),
+            model=model,
+            reasoning_effort=reasoning_effort,
+            session_anchor=session_id,  # workbench sessions self-anchor; IM platforms use the parent message ts
+            workdir=workdir,
+            native_session_id="",
+            title=title.strip() if (title or "").strip() else None,
+            status="active",
+            metadata_json=json.dumps(metadata_payload),
+            created_at=now,
+            updated_at=now,
+            last_active_at=now,
+        )
+    )
+    return get_session(conn, session_id)
+
+
+def update_session(
+    conn: Connection,
+    session_id: str,
+    *,
+    title: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    agent_name: Optional[str] = None,
+    agent_backend: Optional[str] = None,
+    agent_variant: Optional[str] = None,
+    model: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+) -> dict[str, Any]:
+    existing = conn.execute(
+        select(agent_sessions.c.id).where(agent_sessions.c.id == session_id)
+    ).scalar_one_or_none()
+    if existing is None:
+        raise LookupError(f"Session not found: {session_id}")
+
+    values: dict[str, Any] = {"updated_at": _utc_now_iso()}
+    if title is not None:
+        cleaned = title.strip()
+        values["title"] = cleaned or None
+    if agent_id is not None:
+        values["agent_id"] = agent_id or None
+    if agent_name is not None:
+        values["agent_name"] = agent_name or None
+    if agent_backend is not None:
+        values["agent_backend"] = agent_backend
+    if agent_variant is not None:
+        values["agent_variant"] = str(agent_variant)
+    if model is not None:
+        values["model"] = model or None
+    if reasoning_effort is not None:
+        values["reasoning_effort"] = reasoning_effort or None
+
+    conn.execute(update(agent_sessions).where(agent_sessions.c.id == session_id).values(**values))
+    return get_session(conn, session_id)
+
+
+def archive_session(conn: Connection, session_id: str) -> dict[str, Any]:
+    existing = conn.execute(
+        select(agent_sessions.c.id).where(agent_sessions.c.id == session_id)
+    ).scalar_one_or_none()
+    if existing is None:
+        raise LookupError(f"Session not found: {session_id}")
+    now = _utc_now_iso()
+    conn.execute(
+        update(agent_sessions)
+        .where(agent_sessions.c.id == session_id)
+        .values(status="archived", updated_at=now)
+    )
+    return get_session(conn, session_id)
+
+
+def touch_session(conn: Connection, session_id: str) -> None:
+    """Bump ``last_active_at`` after a new message arrives."""
+
+    conn.execute(
+        update(agent_sessions)
+        .where(agent_sessions.c.id == session_id)
+        .values(last_active_at=_utc_now_iso(), updated_at=_utc_now_iso())
+    )

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -92,17 +92,27 @@ def list_sessions(
         ).first()
         if cursor_row is not None:
             cursor_active, cursor_created = cursor_row
+            # ``last_active_at`` + ``created_at`` are both second-granularity
+            # ISO strings, so multiple sessions can share the same pair and
+            # become unreachable on later pages without an ``id`` tie-breaker
+            # that matches the ORDER BY shape.
             query = query.where(
                 (agent_sessions.c.last_active_at < cursor_active)
                 | (
                     (agent_sessions.c.last_active_at == cursor_active)
                     & (agent_sessions.c.created_at < cursor_created)
                 )
+                | (
+                    (agent_sessions.c.last_active_at == cursor_active)
+                    & (agent_sessions.c.created_at == cursor_created)
+                    & (agent_sessions.c.id < before_id)
+                )
             )
     query = (
         query.order_by(
             agent_sessions.c.last_active_at.desc(),
             agent_sessions.c.created_at.desc(),
+            agent_sessions.c.id.desc(),
         )
         .limit(min(max(int(limit), 1), 200))
     )

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -108,17 +108,21 @@ def list_sessions(
                     & (agent_sessions.c.id < before_id)
                 )
             )
+    effective_limit = min(max(int(limit), 1), 200)
     query = (
         query.order_by(
             agent_sessions.c.last_active_at.desc(),
             agent_sessions.c.created_at.desc(),
             agent_sessions.c.id.desc(),
         )
-        .limit(min(max(int(limit), 1), 200))
+        .limit(effective_limit)
     )
     rows = [dict(row) for row in conn.execute(query).mappings().all()]
     sessions = [_row_to_payload(row) for row in rows]
-    next_cursor = sessions[-1]["id"] if len(sessions) == limit else None
+    # Use the clamped page size for the cursor check — comparing against
+    # the raw ``limit`` would emit ``next_before_id=null`` for callers who
+    # requested > 200 and force them to stop paginating mid-history.
+    next_cursor = sessions[-1]["id"] if len(sessions) == effective_limit else None
     return {"sessions": sessions, "next_before_id": next_cursor}
 
 

--- a/tests/test_message_mirror.py
+++ b/tests/test_message_mirror.py
@@ -1,0 +1,116 @@
+"""Unit tests for the cross-platform message mirror.
+
+These cover the contract that
+``core.handlers.message_handler.MessageHandler`` and
+``core.message_dispatcher.ConsolidatedMessageDispatcher`` rely on:
+
+* a fresh ``(platform, channel_id)`` is auto-upserted as a 'channel'-typed
+  scope on first inbound mirror,
+* the same call also writes an author='user' row,
+* a follow-up outbound mirror lands an author='agent' row on the same
+  scope,
+* repeated mirror calls with the same ``native_message_id`` are
+  idempotent (no extra rows, no raised exception),
+* ``platform='avibe'`` is a no-op so the workbench REST writer stays the
+  single source of truth.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.message_mirror import mirror_inbound, mirror_outbound
+from modules.im import MessageContext
+from storage.db import create_sqlite_engine
+from storage.importer import ensure_sqlite_state
+from storage.models import messages, scopes
+
+
+@pytest.fixture()
+def isolated_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    yield tmp_path
+
+
+def _slack_ctx(message_id="m_001") -> MessageContext:
+    return MessageContext(
+        user_id="U_alice",
+        channel_id="C_general",
+        platform="slack",
+        thread_id=None,
+        message_id=message_id,
+    )
+
+
+def test_inbound_creates_scope_and_user_row(isolated_state):
+    mirror_inbound(_slack_ctx(), "hello there")
+
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        scope_row = conn.execute(
+            select(scopes).where(scopes.c.platform == "slack", scopes.c.native_id == "C_general")
+        ).mappings().first()
+        assert scope_row is not None
+        assert scope_row["scope_type"] == "channel"
+
+        message_rows = conn.execute(
+            select(messages).where(messages.c.platform == "slack")
+        ).mappings().all()
+        assert len(message_rows) == 1
+        assert message_rows[0]["author"] == "user"
+        assert message_rows[0]["content_text"] == "hello there"
+        assert message_rows[0]["author_id"] == "U_alice"
+
+
+def test_outbound_writes_agent_row_on_same_scope(isolated_state):
+    ctx = _slack_ctx()
+    mirror_inbound(ctx, "ping")
+    mirror_outbound(ctx, "pong", native_message_id="slack_m_002", kind="result")
+
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        rows = conn.execute(
+            select(messages).where(messages.c.platform == "slack").order_by(messages.c.created_at)
+        ).mappings().all()
+        assert [row["author"] for row in rows] == ["user", "agent"]
+        assert rows[1]["content_text"] == "pong"
+        assert rows[1]["native_message_id"] == "slack_m_002"
+        # Both rows share the scope auto-created on first inbound.
+        assert rows[0]["scope_id"] == rows[1]["scope_id"]
+
+
+def test_duplicate_native_message_id_is_swallowed(isolated_state):
+    ctx = _slack_ctx(message_id="dup_id")
+    mirror_inbound(ctx, "first")
+    mirror_inbound(ctx, "duplicate delivery")
+
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        rows = conn.execute(select(messages).where(messages.c.platform == "slack")).mappings().all()
+    # Unique (platform, native_message_id) constraint keeps the second
+    # write from materializing.
+    assert len(rows) == 1
+    assert rows[0]["content_text"] == "first"
+
+
+def test_avibe_platform_is_noop(isolated_state):
+    avibe_ctx = MessageContext(
+        user_id="U_alice",
+        channel_id="avibe-channel",
+        platform="avibe",
+        message_id="avibe_001",
+    )
+    mirror_inbound(avibe_ctx, "this should not land")
+    mirror_outbound(avibe_ctx, "neither should this", native_message_id="avibe_002")
+
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        rows = conn.execute(select(messages)).mappings().all()
+    assert rows == []

--- a/tests/test_message_mirror.py
+++ b/tests/test_message_mirror.py
@@ -114,3 +114,31 @@ def test_avibe_platform_is_noop(isolated_state):
     with engine.connect() as conn:
         rows = conn.execute(select(messages)).mappings().all()
     assert rows == []
+
+
+def test_outbound_mirror_uses_delivery_target_scope(isolated_state):
+    """Regression: dispatcher calls mirror_outbound with ``target_context``,
+    which may carry a different channel/platform than the inbound ``context``
+    (e.g. ``post_to`` overrides on scheduled / watch-driven runs). The mirror
+    must land under the delivery scope, not the source scope.
+    """
+    delivery_ctx = MessageContext(
+        user_id="agent",
+        channel_id="C_delivery",  # different from any inbound channel
+        platform="slack",
+        thread_id=None,
+        message_id=None,
+    )
+    mirror_outbound(delivery_ctx, "agent reply", native_message_id="slack_out_42", kind="result")
+
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        scope_row = conn.execute(
+            select(scopes).where(scopes.c.platform == "slack", scopes.c.native_id == "C_delivery")
+        ).mappings().first()
+        assert scope_row is not None, "outbound scope must be auto-upserted under the delivery target"
+        rows = conn.execute(select(messages).where(messages.c.platform == "slack")).mappings().all()
+    assert len(rows) == 1
+    assert rows[0]["author"] == "agent"
+    assert rows[0]["content_text"] == "agent reply"
+    assert rows[0]["scope_id"] == scope_row["id"]

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -135,3 +135,54 @@ def test_mark_session_read_without_anchor_marks_all(isolated_state):
     with engine.begin() as conn:
         updated = messages_service.mark_session_read(conn, "ses_all")
     assert updated == 3
+
+
+def test_list_session_messages_cursor_uses_clamped_limit(isolated_state):
+    """Regression: callers that pass ``limit > 500`` must still get a
+    cursor when the result is a full clamped page, so they can paginate
+    past the 500 mark instead of silently truncating at the cap.
+    """
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        _seed_session(conn, scope_id, "ses_page")
+        # 501 rows so the clamped 500-row page returns full and a
+        # follow-up cursor is needed.
+        for _ in range(501):
+            messages_service.append(
+                conn,
+                scope_id=scope_id,
+                session_id="ses_page",
+                platform="avibe",
+                author="agent",
+                text="row",
+            )
+
+    with engine.connect() as conn:
+        page = messages_service.list_session_messages(conn, session_id="ses_page", limit=1000)
+    # Pre-fix this returned ``next_after_id=None`` even though there were
+    # 501 rows total. The clamp-aware fix emits a cursor.
+    assert len(page["messages"]) == 500
+    assert page["next_after_id"] is not None
+
+
+def test_list_inbox_cursor_uses_clamped_limit(isolated_state):
+    """Same regression as the per-session pagination, for the Inbox feed."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        _seed_session(conn, scope_id, "ses_inbox")
+        for _ in range(201):
+            messages_service.append(
+                conn,
+                scope_id=scope_id,
+                session_id="ses_inbox",
+                platform="avibe",
+                author="agent",
+                text="ping",
+            )
+
+    with engine.connect() as conn:
+        page = messages_service.list_inbox(conn, platform="avibe", limit=1000)
+    assert len(page["messages"]) == 200
+    assert page["next_before_id"] is not None

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -1,0 +1,137 @@
+"""Focused tests for storage.messages_service behaviours that are easy to
+regress: pagination cursor and the ``mark_session_read`` boundary check.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from storage import messages_service
+from storage.db import create_sqlite_engine
+from storage.importer import ensure_sqlite_state
+from storage.models import agent_sessions, messages
+from storage.settings_service import upsert_scope
+
+
+@pytest.fixture()
+def isolated_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    yield tmp_path
+
+
+def _seed_scope(conn) -> str:
+    now = messages_service._utc_now_iso()
+    return upsert_scope(conn, platform="avibe", scope_type="project", native_id="proj_test", now=now)
+
+
+def _seed_session(conn, scope_id: str, session_id: str) -> None:
+    now = messages_service._utc_now_iso()
+    conn.execute(
+        agent_sessions.insert().values(
+            id=session_id,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_variant="default",
+            session_anchor="anchor_" + session_id,
+            native_session_id="",
+            status="active",
+            metadata_json="{}",
+            created_at=now,
+            updated_at=now,
+            last_active_at=now,
+        )
+    )
+
+
+def test_mark_session_read_ties_break_on_id(isolated_state):
+    """When ``until_message_id`` points at a message whose ``created_at``
+    is shared by newer messages (second precision), only rows at-or-before
+    the anchor *by id* should be marked read. Otherwise the user's still-
+    unread newest reply gets cleared.
+    """
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        _seed_session(conn, scope_id, "ses_test")
+        # Use a fixed timestamp so all three rows share the same created_at
+        # (mimicking the second-precision collision).
+        fixed_now = "2026-05-26T13:00:00Z"
+        for content in ("first", "second", "third"):
+            payload = {
+                "id": messages_service._new_message_id(),
+                "scope_id": scope_id,
+                "session_id": "ses_test",
+                "platform": "avibe",
+                "author": "agent",
+                "author_id": None,
+                "author_name": None,
+                "native_message_id": None,
+                "parent_native_message_id": None,
+                "content_text": content,
+                "content_json": "{}",
+                "metadata_json": "{}",
+                "created_at": fixed_now,
+                "updated_at": fixed_now,
+                "delivered_at": None,
+                "read_at": None,
+            }
+            conn.execute(messages.insert().values(**payload))
+
+    with engine.connect() as conn:
+        ordered = conn.execute(
+            select(messages.c.id, messages.c.content_text)
+            .where(messages.c.session_id == "ses_test")
+            .order_by(messages.c.id.asc())
+        ).all()
+        # Take the middle row as the anchor: its lexicographically-smaller
+        # id puts "first" before it and one row after it.
+        anchor_id = ordered[1][0]
+        anchor_text = ordered[1][1]
+
+    with engine.begin() as conn:
+        updated = messages_service.mark_session_read(conn, "ses_test", until_message_id=anchor_id)
+
+    assert updated == 2, "should mark only the anchor + the row with smaller id"
+
+    with engine.connect() as conn:
+        rows = conn.execute(
+            select(messages.c.content_text, messages.c.read_at)
+            .where(messages.c.session_id == "ses_test")
+            .order_by(messages.c.id.asc())
+        ).all()
+    read_states = {text: (read_at is not None) for text, read_at in rows}
+    # The two rows up to and including the anchor are marked read…
+    assert read_states[anchor_text] is True
+    # …and the row with the larger id (same timestamp) stays unread.
+    unread = [text for text, read in read_states.items() if not read]
+    assert len(unread) == 1, "exactly one row after the anchor must remain unread"
+
+
+def test_mark_session_read_without_anchor_marks_all(isolated_state):
+    """No ``until_message_id`` → mark every unread agent row."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        _seed_session(conn, scope_id, "ses_all")
+        for _ in range(3):
+            messages_service.append(
+                conn,
+                scope_id=scope_id,
+                session_id="ses_all",
+                platform="avibe",
+                author="agent",
+                text="payload",
+            )
+            time.sleep(0.001)
+
+    with engine.begin() as conn:
+        updated = messages_service.mark_session_read(conn, "ses_all")
+    assert updated == 3

--- a/tests/test_sse_broker.py
+++ b/tests/test_sse_broker.py
@@ -1,0 +1,76 @@
+"""Threading invariants for ``vibe.sse_broker.SSEBroker``.
+
+Reviewers flagged that ``publish`` runs from arbitrary threads (sync REST
+routes, IM threads) while ``subscribe`` / ``unsubscribe`` mutate the
+subscriber map on the event loop thread. A bare ``list(dict.values())``
+can raise ``RuntimeError: dictionary changed size during iteration`` and
+take down whichever caller was publishing the event. The lock added to
+``SSEBroker`` removes that race; this test exercises it under load.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vibe.sse_broker import SSEBroker
+
+
+def test_publish_survives_concurrent_subscribe_churn():
+    broker = SSEBroker()
+
+    # Seed an event loop the broker can reuse — publish() captures it
+    # lazily, normally on the first subscribe() call.
+    loop = asyncio.new_event_loop()
+
+    def _runner() -> None:
+        try:
+            loop.run_forever()
+        except Exception:
+            pass
+
+    runner = threading.Thread(target=_runner, daemon=True)
+    runner.start()
+
+    async def _seed_initial_subscriber():
+        broker.subscribe()
+
+    asyncio.run_coroutine_threadsafe(_seed_initial_subscriber(), loop).result(timeout=5)
+
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    def _publisher() -> None:
+        try:
+            while not stop.is_set():
+                broker.publish("ping", {"n": 1})
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    publisher = threading.Thread(target=_publisher, daemon=True)
+    publisher.start()
+
+    # Hammer subscribe/unsubscribe on the loop thread while the publisher
+    # is iterating. Without the lock this reliably trips
+    # ``RuntimeError: dictionary changed size during iteration`` within
+    # a few hundred churn cycles.
+    async def _churn(iterations: int = 800) -> None:
+        for _ in range(iterations):
+            sub_id, _ = broker.subscribe()
+            broker.unsubscribe(sub_id)
+            await asyncio.sleep(0)
+
+    asyncio.run_coroutine_threadsafe(_churn(), loop).result(timeout=15)
+
+    stop.set()
+    publisher.join(timeout=5)
+
+    loop.call_soon_threadsafe(loop.stop)
+    runner.join(timeout=5)
+    loop.close()
+
+    assert not errors, f"publish() raised under concurrent churn: {errors!r}"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -44,7 +44,7 @@ type GuardStatus = 'loading' | 'ready' | 'needs-setup' | 'remote-login-required'
 
 // Wrapper to check if setup is needed
 const AuthGuard = ({ children }: { children: ReactNode }) => {
-    const { getConfig, getSession } = useApi();
+    const { getConfig, getAuthSession } = useApi();
     const location = useLocation();
     const guardTarget = location.pathname + location.search;
     const [guardState, setGuardState] = useState<{ target: string; status: GuardStatus }>({
@@ -60,7 +60,7 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
             return;
         }
 
-        getSession().then(session => {
+        getAuthSession().then(session => {
             if (cancelled) return;
             if (session.remote && !session.authenticated) {
                 setGuardState({ target: guardTarget, status: 'remote-login-required' });
@@ -79,7 +79,7 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
             });
         }).catch(async (error) => {
             if (cancelled) return;
-            const session = await getSession().catch(() => null);
+            const session = await getAuthSession().catch(() => null);
             if (cancelled) return;
             if (session?.remote && !session.authenticated) {
                 setGuardState({ target: guardTarget, status: 'remote-login-required' });
@@ -94,7 +94,7 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
         return () => {
             cancelled = true;
         };
-    }, [bypassSetupGuard, getConfig, getSession, guardTarget]);
+    }, [bypassSetupGuard, getConfig, getAuthSession, guardTarget]);
 
     if (bypassSetupGuard) return children;
     if (guardState.target !== guardTarget || guardState.status === 'loading') {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Wizard } from './components/Wizard';
 import { AppShell } from './components/AppShell';
+import { Workbench } from './components/Workbench';
 import { Dashboard } from './components/Dashboard';
 import { ChannelList } from './components/steps/ChannelList';
 import { UserList } from './components/steps/UserList';
@@ -22,7 +23,9 @@ import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { hasConfiguredPlatformCredentials } from './lib/platforms';
 
-const LOGIN_CHECK_PATHS = new Set(['/doctor/logs', '/logs']);
+// Paths that bypass the setup guard so the wizard and diagnostics can show
+// logs / doctor output even before configuration is complete.
+const LOGIN_CHECK_PATHS = new Set(['/admin/logs', '/admin/settings/diagnostics']);
 
 const RemoteLoginRedirect = ({ target }: { target: string }) => {
     useEffect(() => {
@@ -107,27 +110,51 @@ function AppRoutes() {
     <Routes>
       <Route element={<AuthGuard><AppShell /></AuthGuard>}>
         <Route path="/setup" element={<Wizard />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/groups" element={<ChannelList isPage />} />
-        <Route path="/channels" element={<Navigate to="/groups" replace />} />
-        <Route path="/users" element={<UserList />} />
-        <Route path="/logs" element={<SettingsLogsPage standalone />} />
-        {/* No client-side route at /settings: Flask owns GET /settings as a
-            JSON API, so a hard refresh would hit the API instead of the SPA.
-            The Flask handler redirects browser-Accept hits to /settings/service. */}
-        <Route path="/settings/service" element={<SettingsServicePage />} />
-        <Route path="/settings/platforms" element={<SettingsPlatformsPage />} />
-        <Route path="/settings/backends" element={<SettingsBackendsPage />} />
-        <Route path="/settings/backends/opencode" element={<SettingsOpencodeProviderPage />} />
-        <Route path="/settings/backends/claude" element={<SettingsClaudeProviderPage />} />
-        <Route path="/settings/backends/codex" element={<SettingsCodexProviderPage />} />
-        <Route path="/settings/messaging" element={<SettingsMessagingPage />} />
-        <Route path="/settings/diagnostics" element={<SettingsDiagnosticsPage />} />
-        <Route path="/settings/logs" element={<SettingsLogsPage />} />
-        <Route path="/remote-access" element={<Navigate to="/settings/service" replace />} />
-        <Route path="/doctor" element={<Navigate to="/settings/diagnostics" replace />} />
-        <Route path="/doctor/logs" element={<Navigate to="/logs" replace />} />
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+
+        {/* Workbench mode — the new default at `/`. Commit 01 ships a
+            placeholder; the capability modules + projects + canvas land
+            in later commits. */}
+        <Route path="/" element={<Workbench />} />
+
+        {/* Control Panel mode — existing pages moved under /admin/* */}
+        <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
+        <Route path="/admin/dashboard" element={<Dashboard />} />
+        <Route path="/admin/groups" element={<ChannelList isPage />} />
+        <Route path="/admin/users" element={<UserList />} />
+        <Route path="/admin/logs" element={<SettingsLogsPage standalone />} />
+        {/* No client-side route at /admin/settings: Flask owns GET /settings as
+            a JSON API. The Flask handler redirects browser-Accept hits to
+            /admin/settings/service. */}
+        <Route path="/admin/settings/service" element={<SettingsServicePage />} />
+        <Route path="/admin/settings/platforms" element={<SettingsPlatformsPage />} />
+        <Route path="/admin/settings/backends" element={<SettingsBackendsPage />} />
+        <Route path="/admin/settings/backends/opencode" element={<SettingsOpencodeProviderPage />} />
+        <Route path="/admin/settings/backends/claude" element={<SettingsClaudeProviderPage />} />
+        <Route path="/admin/settings/backends/codex" element={<SettingsCodexProviderPage />} />
+        <Route path="/admin/settings/messaging" element={<SettingsMessagingPage />} />
+        <Route path="/admin/settings/diagnostics" element={<SettingsDiagnosticsPage />} />
+        <Route path="/admin/settings/logs" element={<SettingsLogsPage />} />
+
+        {/* Legacy redirects: old top-level paths → /admin/* equivalents.
+            Bookmarked URLs and external links keep working without a server
+            round-trip. */}
+        <Route path="/dashboard" element={<Navigate to="/admin/dashboard" replace />} />
+        <Route path="/groups" element={<Navigate to="/admin/groups" replace />} />
+        <Route path="/channels" element={<Navigate to="/admin/groups" replace />} />
+        <Route path="/users" element={<Navigate to="/admin/users" replace />} />
+        <Route path="/logs" element={<Navigate to="/admin/logs" replace />} />
+        <Route path="/settings/service" element={<Navigate to="/admin/settings/service" replace />} />
+        <Route path="/settings/platforms" element={<Navigate to="/admin/settings/platforms" replace />} />
+        <Route path="/settings/backends" element={<Navigate to="/admin/settings/backends" replace />} />
+        <Route path="/settings/backends/opencode" element={<Navigate to="/admin/settings/backends/opencode" replace />} />
+        <Route path="/settings/backends/claude" element={<Navigate to="/admin/settings/backends/claude" replace />} />
+        <Route path="/settings/backends/codex" element={<Navigate to="/admin/settings/backends/codex" replace />} />
+        <Route path="/settings/messaging" element={<Navigate to="/admin/settings/messaging" replace />} />
+        <Route path="/settings/diagnostics" element={<Navigate to="/admin/settings/diagnostics" replace />} />
+        <Route path="/settings/logs" element={<Navigate to="/admin/settings/logs" replace />} />
+        <Route path="/remote-access" element={<Navigate to="/admin/settings/service" replace />} />
+        <Route path="/doctor" element={<Navigate to="/admin/settings/diagnostics" replace />} />
+        <Route path="/doctor/logs" element={<Navigate to="/admin/logs" replace />} />
       </Route>
     </Routes>
   );

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,6 +23,7 @@ import { StatusProvider } from './context/StatusContext';
 import { ApiProvider, useApi } from './context/ApiContext';
 import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
+import { WorkbenchInboxProvider } from './context/WorkbenchInboxContext';
 import { AgentationToggle } from './components/AgentationToggle';
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -177,10 +178,12 @@ function App() {
       <StatusProvider>
         <ToastProvider>
           <ApiProvider>
-            <BrowserRouter>
-               <AppRoutes />
-            </BrowserRouter>
-            <AgentationToggle />
+            <WorkbenchInboxProvider>
+              <BrowserRouter>
+                <AppRoutes />
+              </BrowserRouter>
+              <AgentationToggle />
+            </WorkbenchInboxProvider>
           </ApiProvider>
         </ToastProvider>
       </StatusProvider>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,11 @@ import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-route
 import { Wizard } from './components/Wizard';
 import { AppShell } from './components/AppShell';
 import { Workbench } from './components/Workbench';
+import { InboxPage } from './components/workbench/InboxPage';
+import { AgentsPage } from './components/workbench/AgentsPage';
+import { SkillsPage } from './components/workbench/SkillsPage';
+import { HarnessPage } from './components/workbench/HarnessPage';
+import { VaultsPage } from './components/workbench/VaultsPage';
 import { Dashboard } from './components/Dashboard';
 import { ChannelList } from './components/steps/ChannelList';
 import { UserList } from './components/steps/UserList';
@@ -111,10 +116,16 @@ function AppRoutes() {
       <Route element={<AuthGuard><AppShell /></AuthGuard>}>
         <Route path="/setup" element={<Wizard />} />
 
-        {/* Workbench mode — the new default at `/`. Commit 01 ships a
-            placeholder; the capability modules + projects + canvas land
-            in later commits. */}
+        {/* Workbench mode — `/` is the canvas root, the five capability
+            entries (Inbox + Agents/Skills/Harness/Vaults) live alongside
+            it. Commit 02 ships sidebar + placeholder pages; the real
+            module screens land in later commits. */}
         <Route path="/" element={<Workbench />} />
+        <Route path="/inbox" element={<InboxPage />} />
+        <Route path="/agents" element={<AgentsPage />} />
+        <Route path="/skills" element={<SkillsPage />} />
+        <Route path="/harness" element={<HarnessPage />} />
+        <Route path="/vaults" element={<VaultsPage />} />
 
         {/* Control Panel mode — existing pages moved under /admin/* */}
         <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,6 +7,7 @@ import { AgentsPage } from './components/workbench/AgentsPage';
 import { SkillsPage } from './components/workbench/SkillsPage';
 import { HarnessPage } from './components/workbench/HarnessPage';
 import { VaultsPage } from './components/workbench/VaultsPage';
+import { ChatPage } from './components/workbench/ChatPage';
 import { Dashboard } from './components/Dashboard';
 import { ChannelList } from './components/steps/ChannelList';
 import { UserList } from './components/steps/UserList';
@@ -127,6 +128,7 @@ function AppRoutes() {
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/harness" element={<HarnessPage />} />
         <Route path="/vaults" element={<VaultsPage />} />
+        <Route path="/chat/:sessionId" element={<ChatPage />} />
 
         {/* Control Panel mode — existing pages moved under /admin/* */}
         <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />

--- a/ui/src/components/AccountMenu.tsx
+++ b/ui/src/components/AccountMenu.tsx
@@ -13,7 +13,7 @@ const initialFor = (email: string): string => {
 
 export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = false }) => {
   const { t } = useTranslation();
-  const { getSession, signOut } = useApi();
+  const { getAuthSession, signOut } = useApi();
   const [email, setEmail] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
@@ -21,7 +21,7 @@ export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = f
 
   useEffect(() => {
     let cancelled = false;
-    getSession()
+    getAuthSession()
       .then((session) => {
         if (cancelled) return;
         if (session.remote && session.authenticated) {
@@ -36,7 +36,7 @@ export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = f
     return () => {
       cancelled = true;
     };
-  }, [getSession]);
+  }, [getAuthSession]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { NavLink, Outlet, useLocation } from 'react-router-dom';
-import { Hash, LayoutDashboard, Settings, Users } from 'lucide-react';
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, Hash, LayoutDashboard, Settings, SlidersHorizontal, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -10,6 +10,7 @@ import { AccountMenu } from './AccountMenu';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { ThemeToggle } from './ThemeToggle';
 import { VersionBadge } from './VersionBadge';
+import { WorkbenchSidebar } from './workbench/WorkbenchSidebar';
 import logoImg from '../assets/logo.png';
 import { getEnabledPlatforms, platformSupportsChannels } from '../lib/platforms';
 
@@ -128,7 +129,7 @@ export const AppShell: React.FC = () => {
               </div>
             </div>
 
-            {items.length > 0 && (
+            {shellMode === 'admin' && items.length > 0 && (
               <div className="flex flex-col gap-2">
                 <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
                   {t('appShell.workspaceLabel')}
@@ -138,6 +139,7 @@ export const AppShell: React.FC = () => {
                 </nav>
               </div>
             )}
+            {shellMode === 'workbench' && <WorkbenchSidebar />}
           </div>
 
           {/* Bottom: Status (with embedded version badge) + toggles + hostname */}
@@ -175,6 +177,28 @@ export const AppShell: React.FC = () => {
               <div className="truncate font-mono text-[10px] text-muted">
                 {config.runtime.hostname}
               </div>
+            )}
+
+            {/* Mode switch — flips between Workbench (`/`) and Control Panel
+                (`/admin/*`). Distinct visual hierarchy from the toggle row
+                above so users notice it as a destination, not a quick toggle. */}
+            {shellMode === 'workbench' ? (
+              <Link
+                to="/admin/dashboard"
+                className="flex items-center justify-center gap-2 rounded-lg border border-border-strong px-3 py-2.5 text-[12px] font-medium text-foreground transition hover:bg-foreground/[0.04]"
+              >
+                <SlidersHorizontal className="size-3.5" />
+                <span>{t('appShell.openControlPanel')}</span>
+                <ArrowRight className="size-3 text-muted" />
+              </Link>
+            ) : (
+              <Link
+                to="/"
+                className="flex items-center justify-center gap-2 rounded-lg border border-mint/30 bg-mint/[0.06] px-3 py-2.5 text-[12px] font-semibold text-mint transition hover:bg-mint/[0.12]"
+              >
+                <ArrowLeft className="size-3.5" />
+                <span>{t('appShell.backToWorkbench')}</span>
+              </Link>
             )}
           </div>
         </div>

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -84,17 +84,27 @@ export const AppShell: React.FC = () => {
     return <Outlet />;
   }
 
-  const items: ShellNavItem[] = [
-    { to: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
-    ...(hasChannelPlatforms ? [{ to: '/groups', label: t('nav.channels'), icon: Hash }] : []),
-    { to: '/users', label: t('nav.users'), icon: Users },
+  // Two shell modes share the same chrome (brand + bottom status):
+  //   - admin: control-panel pages under /admin/* (legacy dashboard/groups/...
+  //     paths are now Navigate redirects to /admin/*).
+  //   - workbench: the new `/` entry. Commit 01 ships a placeholder with no
+  //     sidebar nav; commit 02 layers in the capability modules + projects.
+  const shellMode: 'workbench' | 'admin' =
+    location.pathname.startsWith('/admin') ? 'admin' : 'workbench';
+
+  const adminItems: ShellNavItem[] = [
+    { to: '/admin/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
+    ...(hasChannelPlatforms ? [{ to: '/admin/groups', label: t('nav.channels'), icon: Hash }] : []),
+    { to: '/admin/users', label: t('nav.users'), icon: Users },
     {
-      to: '/settings/service',
+      to: '/admin/settings/service',
       label: t('nav.settings'),
       icon: Settings,
-      match: (pathname) => pathname.startsWith('/settings'),
+      match: (pathname) => pathname.startsWith('/admin/settings'),
     },
   ];
+
+  const items: ShellNavItem[] = shellMode === 'admin' ? adminItems : [];
 
   // Mobile nav uses the same routes as desktop; diagnostics lives under
   // the Settings tab so we don't promote it to its own bottom-nav slot.
@@ -118,14 +128,16 @@ export const AppShell: React.FC = () => {
               </div>
             </div>
 
-            <div className="flex flex-col gap-2">
-              <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
-                {t('appShell.workspaceLabel')}
+            {items.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
+                  {t('appShell.workspaceLabel')}
+                </div>
+                <nav className="flex flex-col gap-0.5">
+                  {items.map((item) => <ShellNavLink key={item.to} item={item} />)}
+                </nav>
               </div>
-              <nav className="flex flex-col gap-0.5">
-                {items.map((item) => <ShellNavLink key={item.to} item={item} />)}
-              </nav>
-            </div>
+            )}
           </div>
 
           {/* Bottom: Status (with embedded version badge) + toggles + hostname */}
@@ -188,7 +200,7 @@ export const AppShell: React.FC = () => {
       <main
         className={clsx(
           'min-h-screen pb-[calc(5.5rem+env(safe-area-inset-bottom))] md:ml-[240px] md:pb-0',
-          location.pathname.startsWith('/settings') ? 'page-glow-settings' : 'page-glow-console'
+          location.pathname.startsWith('/admin/settings') ? 'page-glow-settings' : 'page-glow-console'
         )}
       >
         <div className="mx-auto w-full px-4 py-5 md:px-10 md:py-8">
@@ -196,11 +208,13 @@ export const AppShell: React.FC = () => {
         </div>
       </main>
 
-      <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-surface/96 px-2 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur md:hidden">
-        <div className="flex gap-1">
-          {mobileItems.map((item) => <MobileNavLink key={item.to} item={item} />)}
-        </div>
-      </nav>
+      {mobileItems.length > 0 && (
+        <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-surface/96 px-2 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur md:hidden">
+          <div className="flex gap-1">
+            {mobileItems.map((item) => <MobileNavLink key={item.to} item={item} />)}
+          </div>
+        </nav>
+      )}
     </div>
   );
 };

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -213,7 +213,7 @@ export const Dashboard: React.FC = () => {
       supportsGroups,
       activeGroups,
       discoveredGroups,
-      actionHref: supportsGroups ? '/groups' : '/settings/platforms',
+      actionHref: supportsGroups ? '/admin/groups' : '/settings/platforms',
       actionLabel: supportsGroups ? t('dashboard.manageRoute') : t('dashboard.configure'),
     };
   });
@@ -377,21 +377,21 @@ export const Dashboard: React.FC = () => {
           value={`${enabledPlatforms.length} / ${platformCatalog.length}`}
           hint={enabledPlatformTitles || t('dashboard.metricPlatformsHint')}
           icon={<PlugZap className="size-4" />}
-          to="/settings/platforms"
+          to="/admin/settings/platforms"
         />
         <StatCard
           label={t('dashboard.metricGroups')}
           value={String(totalActiveGroups)}
           hint={t('dashboard.metricGroupsHint').replace('{{count}}', String(totalDiscoveredGroups))}
           icon={<Hash className="size-4" />}
-          to="/groups"
+          to="/admin/groups"
         />
         <StatCard
           label={t('dashboard.metricUsers')}
           value={String(usersCount)}
           hint={t('dashboard.metricUsersHint')}
           icon={<MessageSquare className="size-4" />}
-          to="/users"
+          to="/admin/users"
         />
         <CloudStatCard
           label={t('dashboard.metricCloud')}
@@ -399,7 +399,7 @@ export const Dashboard: React.FC = () => {
           hint={cloudHint}
           icon={<Cloud className="size-4" />}
           cloudHomeUrl="https://avibe.bot"
-          settingsHref="/settings/service#remote-access"
+          settingsHref="/admin/settings/service#remote-access"
           publicUrl={cloudPublicHref}
         />
       </div>
@@ -417,7 +417,7 @@ export const Dashboard: React.FC = () => {
               <p className="text-[12px] text-muted">{t('dashboard.platformOverviewSubtitle')}</p>
             </div>
             <Link
-              to="/settings/platforms"
+              to="/admin/settings/platforms"
               className="inline-flex items-center gap-1 rounded-lg border border-border bg-foreground/[0.04] px-3 py-1.5 text-[12px] font-medium text-foreground transition hover:border-border-strong"
             >
               {t('dashboard.manageAll')}
@@ -475,7 +475,7 @@ export const Dashboard: React.FC = () => {
               <p className="text-[12px] text-muted">{t('dashboard.recentActivitySubtitle')}</p>
             </div>
             <Link
-              to="/logs"
+              to="/admin/logs"
               className="inline-flex items-center gap-1 text-[12px] font-medium text-foreground transition hover:text-mint"
             >
               {t('common.viewLogs')}

--- a/ui/src/components/Workbench.tsx
+++ b/ui/src/components/Workbench.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { ArrowRight, SlidersHorizontal } from 'lucide-react';
+
+import { Button } from './ui/button';
+
+// Commit 01 placeholder: the full Workbench shell (capability modules,
+// projects, inbox, canvas) is built in later commits. This stub keeps `/`
+// routable while the new shell is staged in.
+export const Workbench: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-200px)] max-w-2xl flex-col items-center justify-center gap-5 text-center">
+      <div className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-mint">
+        {t('workbench.eyebrow')}
+      </div>
+      <h1 className="text-3xl font-bold text-foreground">{t('workbench.placeholderTitle')}</h1>
+      <p className="text-sm leading-relaxed text-muted">{t('workbench.placeholderBody')}</p>
+      <Button asChild variant="outline" size="sm">
+        <Link to="/admin/dashboard" className="inline-flex items-center gap-2">
+          <SlidersHorizontal className="size-3.5" />
+          {t('workbench.openControlPanel')}
+          <ArrowRight className="size-3.5" />
+        </Link>
+      </Button>
+    </div>
+  );
+};

--- a/ui/src/components/settings/SettingsClaudeProviderPage.tsx
+++ b/ui/src/components/settings/SettingsClaudeProviderPage.tsx
@@ -202,7 +202,7 @@ export const SettingsClaudeProviderPage: React.FC = () => {
       title={t('settings.backends.claudeTitle')}
       subtitle={t('settings.backends.claudeSubtitle')}
       breadcrumb={
-        <Link to="/settings/backends" className="inline-flex items-center gap-1.5 hover:text-foreground">
+        <Link to="/admin/settings/backends" className="inline-flex items-center gap-1.5 hover:text-foreground">
           <ArrowLeft className="size-3" />
           {t('settings.backends.codexBackToBackends')}
         </Link>

--- a/ui/src/components/settings/SettingsCodexProviderPage.tsx
+++ b/ui/src/components/settings/SettingsCodexProviderPage.tsx
@@ -212,7 +212,7 @@ export const SettingsCodexProviderPage: React.FC = () => {
       title={t('settings.backends.codexTitle')}
       subtitle={t('settings.backends.codexSubtitle')}
       breadcrumb={
-        <Link to="/settings/backends" className="inline-flex items-center gap-1.5 hover:text-foreground">
+        <Link to="/admin/settings/backends" className="inline-flex items-center gap-1.5 hover:text-foreground">
           <ArrowLeft className="size-3" />
           {t('settings.backends.codexBackToBackends')}
         </Link>

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -380,7 +380,7 @@ export const SettingsMessagingPage: React.FC = () => {
           description={t('settings.messagingGroupsHint')}
           control={
             <Link
-              to="/groups"
+              to="/admin/groups"
               className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] font-medium text-foreground transition hover:border-border-strong"
             >
               {t('common.manageChannels')}

--- a/ui/src/components/settings/SettingsOpencodeProviderPage.tsx
+++ b/ui/src/components/settings/SettingsOpencodeProviderPage.tsx
@@ -497,7 +497,7 @@ export const SettingsOpencodeProviderPage: React.FC = () => {
       title={t('settings.backends.opencodeTitle')}
       subtitle={t('settings.backends.opencodeSubtitle')}
       breadcrumb={
-        <Link to="/settings/backends" className="inline-flex items-center gap-1.5 hover:text-foreground">
+        <Link to="/admin/settings/backends" className="inline-flex items-center gap-1.5 hover:text-foreground">
           <ArrowLeft className="size-3" />
           {t('settings.backends.codexBackToBackends')}
         </Link>

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -984,7 +984,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             type="button"
             variant="brand"
             size="default"
-            onClick={() => navigate('/users')}
+            onClick={() => navigate('/admin/users')}
           >
             <Users size={18} />
             {t('wechat.manageUserSettings')}

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -127,7 +127,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
         setSaving(false);
         showToast(t('wechat.setupComplete'));
         setTimeout(() => {
-          navigate('/dashboard');
+          navigate('/');
         }, 1000);
         return;
       }
@@ -144,7 +144,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
       }
 
       setTimeout(() => {
-        navigate('/dashboard');
+        navigate('/');
       }, 1000);
     } catch (exc: any) {
       const message = exc && exc.message ? exc.message : 'Failed to save configuration';
@@ -226,7 +226,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
               <p className="mt-2 text-[11px] text-mint">{t('summary.bindCodeCopied')}</p>
             )}
           </div>
-          <Button variant="brand" size="lg" onClick={() => navigate('/dashboard')}>
+          <Button variant="brand" size="lg" onClick={() => navigate('/')}>
             {t('summary.goToDashboard')}
             <ArrowRight size={16} strokeWidth={2.25} />
           </Button>

--- a/ui/src/components/ui/directory-browser.tsx
+++ b/ui/src/components/ui/directory-browser.tsx
@@ -1,8 +1,24 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { Folder, FolderOpen, ChevronRight, ArrowUp, X, Check, RefreshCw, Eye, EyeOff } from 'lucide-react';
+import {
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Eye,
+  EyeOff,
+  FileText,
+  Folder,
+  FolderOpen,
+  FolderPlus,
+  Home,
+  Monitor,
+  RefreshCw,
+  X,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useApi } from '../../context/ApiContext';
 import clsx from 'clsx';
+
+import { useApi } from '../../context/ApiContext';
 
 interface DirectoryBrowserProps {
   /** Initial path to show when opening */
@@ -13,6 +29,9 @@ interface DirectoryBrowserProps {
   onClose: () => void;
 }
 
+// Mirrors design.pen y5cQ5 — macOS Finder-style folder picker: traffic
+// lights + toolbar (history nav + breadcrumb + show-hidden + new-folder)
+// + favorites sidebar + folder list + footer (path + cancel + select).
 export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
   initialPath,
   onSelect,
@@ -27,25 +46,54 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showHidden, setShowHidden] = useState(false);
+  // Linear history so the < / > arrows behave like a real file browser
+  // instead of just walking the directory tree.
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  // Inline "create new folder" prompt — shown at the end of the list so
+  // it feels like a continuation of the directory rather than a modal.
+  const [creating, setCreating] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
+  const [createError, setCreateError] = useState<string | null>(null);
+  const newFolderInputRef = useRef<HTMLInputElement | null>(null);
 
-  // Guard against setState after unmount / stale responses
   const mountedRef = useRef(true);
   const reqIdRef = useRef(0);
 
   useEffect(() => {
-    return () => { mountedRef.current = false; };
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
-  // Esc key to close
+  // Esc closes the picker, ⌘N opens the new-folder prompt — both familiar
+  // shortcuts from Finder.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        if (creating) {
+          setCreating(false);
+          setNewFolderName('');
+          setCreateError(null);
+        } else {
+          onClose();
+        }
+      } else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'n' && !creating) {
+        e.preventDefault();
+        setCreating(true);
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  }, [creating, onClose]);
 
-  const browse = useCallback(
+  useEffect(() => {
+    if (creating) {
+      newFolderInputRef.current?.focus();
+    }
+  }, [creating]);
+
+  const fetchPath = useCallback(
     async (path: string, hidden?: boolean) => {
       const id = ++reqIdRef.current;
       setLoading(true);
@@ -53,17 +101,21 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
       const useHidden = hidden ?? showHidden;
       try {
         const result = await api.browseDirectory(path, useHidden);
-        if (!mountedRef.current || reqIdRef.current !== id) return;
+        if (!mountedRef.current || reqIdRef.current !== id) {
+          return null;
+        }
         if (result.ok) {
           setCurrentPath(result.path ?? path);
           setParent(result.parent ?? null);
           setDirs(result.dirs ?? []);
-        } else {
-          setError(result.error ?? 'Unknown error');
+          return result.path ?? path;
         }
+        setError(result.error ?? 'Unknown error');
+        return null;
       } catch (e: any) {
-        if (!mountedRef.current || reqIdRef.current !== id) return;
+        if (!mountedRef.current || reqIdRef.current !== id) return null;
         setError(e.message ?? String(e));
+        return null;
       } finally {
         if (mountedRef.current && reqIdRef.current === id) {
           setLoading(false);
@@ -73,134 +125,353 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
     [api, showHidden],
   );
 
+  const navigate = useCallback(
+    async (path: string, hidden?: boolean) => {
+      // Reset the inline new-folder state whenever the user moves around —
+      // a half-typed name shouldn't survive navigating away.
+      setCreating(false);
+      setNewFolderName('');
+      setCreateError(null);
+      const resolved = await fetchPath(path, hidden);
+      if (resolved) {
+        setHistory((prev) => [...prev.slice(0, historyIndex + 1), resolved]);
+        setHistoryIndex((prev) => prev + 1);
+      }
+    },
+    [fetchPath, historyIndex],
+  );
+
+  const goBack = useCallback(() => {
+    if (historyIndex <= 0) return;
+    const next = historyIndex - 1;
+    setHistoryIndex(next);
+    fetchPath(history[next]);
+  }, [history, historyIndex, fetchPath]);
+
+  const goForward = useCallback(() => {
+    if (historyIndex >= history.length - 1) return;
+    const next = historyIndex + 1;
+    setHistoryIndex(next);
+    fetchPath(history[next]);
+  }, [history, historyIndex, fetchPath]);
+
   useEffect(() => {
-    browse(initialPath || '~');
+    navigate(initialPath || '~');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Build breadcrumb segments from currentPath
-  const breadcrumbs = currentPath
-    ? currentPath.split('/').reduce<{ label: string; path: string }[]>((acc, seg, i) => {
-        if (i === 0 && seg === '') {
-          acc.push({ label: '/', path: '/' });
-        } else if (seg) {
-          const prev = acc.length ? acc[acc.length - 1].path : '';
-          const full = prev === '/' ? `/${seg}` : `${prev}/${seg}`;
-          acc.push({ label: seg, path: full });
-        }
-        return acc;
-      }, [])
-    : [];
+  const toggleHidden = () => {
+    const next = !showHidden;
+    setShowHidden(next);
+    fetchPath(currentPath, next);
+  };
+
+  const submitNewFolder = async () => {
+    const name = newFolderName.trim();
+    if (!name) return;
+    setCreateError(null);
+    try {
+      const target = currentPath ? `${currentPath.replace(/\/$/, '')}/${name}` : name;
+      await api.browseMkdir(target);
+      setCreating(false);
+      setNewFolderName('');
+      await fetchPath(currentPath);
+    } catch (err: any) {
+      const message: string = err?.message ?? String(err);
+      if (/exists/i.test(message)) {
+        setCreateError(t('directoryBrowser.newFolderExists'));
+      } else {
+        setCreateError(message);
+      }
+    }
+  };
+
+  // Breadcrumb: collapse the home prefix to ⌂ so deeply-nested paths still fit
+  // in the toolbar without scrolling.
+  const breadcrumbs = (() => {
+    if (!currentPath) return [] as { label: string; path: string; isHome?: boolean }[];
+    const home = (typeof window !== 'undefined' && (window as any).__USER_HOME__) || '';
+    const startsAtHome = home && currentPath.startsWith(home);
+    const segments = (startsAtHome ? currentPath.slice(home.length) : currentPath)
+      .split('/')
+      .filter(Boolean);
+    const out: { label: string; path: string; isHome?: boolean }[] = [];
+    if (startsAtHome) {
+      out.push({ label: '⌂', path: home, isHome: true });
+    } else {
+      out.push({ label: '/', path: '/' });
+    }
+    let acc = startsAtHome ? home : '';
+    for (const seg of segments) {
+      acc = acc === '/' || acc === '' ? `${acc}${seg}` : `${acc}/${seg}`;
+      if (!acc.startsWith('/')) acc = `/${acc}`;
+      out.push({ label: seg, path: acc });
+    }
+    return out;
+  })();
 
   const canConfirm = !!currentPath && !loading && !error;
+  const canBack = historyIndex > 0;
+  const canForward = historyIndex < history.length - 1;
+
+  // Static shortcuts mirroring Finder's Favorites column. We just hand
+  // these to the existing `browseDirectory` endpoint — the backend
+  // expands ``~`` so we don't need to resolve them client-side.
+  const favorites: { i18nKey: string; path: string; icon: React.ReactNode }[] = [
+    { i18nKey: 'directoryBrowser.favoritesHome', path: '~', icon: <Home className="size-3.5" /> },
+    { i18nKey: 'directoryBrowser.favoritesDesktop', path: '~/Desktop', icon: <Monitor className="size-3.5" /> },
+    { i18nKey: 'directoryBrowser.favoritesDocuments', path: '~/Documents', icon: <FileText className="size-3.5" /> },
+    { i18nKey: 'directoryBrowser.favoritesDownloads', path: '~/Downloads', icon: <Download className="size-3.5" /> },
+  ];
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       role="dialog"
       aria-modal="true"
       aria-label={t('directoryBrowser.title')}
       onClick={onClose}
     >
       <div
-        className="bg-panel border border-border rounded-xl shadow-xl w-full max-w-lg max-h-[70vh] flex flex-col"
+        className="flex max-h-[80vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-border-strong bg-surface shadow-[0_24px_64px_-12px_rgba(0,0,0,0.6)]"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-          <h3 className="font-semibold text-text text-sm">{t('directoryBrowser.title')}</h3>
+        {/* Traffic-light header */}
+        <div className="flex items-center gap-3 border-b border-border bg-surface-2 px-4 py-3">
           <div className="flex items-center gap-2">
             <button
-              onClick={() => {
-                const next = !showHidden;
-                setShowHidden(next);
-                browse(currentPath, next);
-              }}
-              className={clsx(
-                'p-1 rounded transition-colors',
-                showHidden ? 'text-accent' : 'text-muted hover:text-text',
-              )}
-              title={showHidden ? t('directoryBrowser.hideHidden') : t('directoryBrowser.showHidden')}
-            >
-              {showHidden ? <Eye size={15} /> : <EyeOff size={15} />}
-            </button>
-            <button onClick={onClose} className="text-muted hover:text-text transition-colors">
-              <X size={16} />
-            </button>
+              type="button"
+              aria-label="Close"
+              onClick={onClose}
+              className="size-3 rounded-full bg-[#FF5F57] transition hover:brightness-110"
+            />
+            <span className="size-3 rounded-full bg-[#FFBD2E]" />
+            <span className="size-3 rounded-full bg-[#28C840]" />
+          </div>
+          <div className="flex flex-1 items-center justify-center gap-2 text-[13px] font-semibold text-foreground">
+            <FolderOpen className="size-3.5 text-mint" />
+            {t('directoryBrowser.title')}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('directoryBrowser.cancel')}
+            className="text-muted transition hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {/* Toolbar — history arrows + breadcrumb + show-hidden + new-folder */}
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+          <button
+            type="button"
+            onClick={goBack}
+            disabled={!canBack}
+            aria-label={t('directoryBrowser.back')}
+            className={clsx(
+              'flex size-7 items-center justify-center rounded-md border border-border-strong transition',
+              canBack ? 'text-foreground hover:bg-foreground/[0.06]' : 'cursor-not-allowed text-muted opacity-50',
+            )}
+          >
+            <ChevronLeft className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={goForward}
+            disabled={!canForward}
+            aria-label={t('directoryBrowser.forward')}
+            className={clsx(
+              'flex size-7 items-center justify-center rounded-md border border-border-strong transition',
+              canForward ? 'text-foreground hover:bg-foreground/[0.06]' : 'cursor-not-allowed text-muted opacity-50',
+            )}
+          >
+            <ChevronRight className="size-3.5" />
+          </button>
+
+          <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto rounded-md border border-border-strong bg-surface-2 px-2 py-1 font-mono text-[11px]">
+            {breadcrumbs.map((crumb, i) => (
+              <React.Fragment key={`${crumb.path}-${i}`}>
+                {i > 0 && <ChevronRight className="size-3 shrink-0 text-muted" />}
+                <button
+                  type="button"
+                  onClick={() => navigate(crumb.path)}
+                  className={clsx(
+                    'shrink-0 rounded px-1 py-0.5 transition hover:bg-foreground/[0.04]',
+                    i === breadcrumbs.length - 1 ? 'font-semibold text-cyan' : 'text-muted',
+                  )}
+                >
+                  {crumb.label}
+                </button>
+              </React.Fragment>
+            ))}
+            {loading && <RefreshCw className="ml-auto size-3 shrink-0 animate-spin text-muted" />}
+          </div>
+
+          <button
+            type="button"
+            onClick={toggleHidden}
+            className={clsx(
+              'flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-[11px] font-semibold transition',
+              showHidden
+                ? 'border-cyan/40 bg-cyan/[0.08] text-cyan'
+                : 'border-border-strong text-muted hover:text-foreground',
+            )}
+          >
+            {showHidden ? <Eye className="size-3" /> : <EyeOff className="size-3" />}
+            {showHidden ? t('directoryBrowser.showHidden') : t('directoryBrowser.hideHidden')}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              setCreating(true);
+              setNewFolderName('');
+              setCreateError(null);
+            }}
+            className="flex items-center gap-1.5 rounded-md border border-border-strong px-2.5 py-1.5 text-[11px] font-medium text-foreground transition hover:bg-foreground/[0.04]"
+          >
+            <FolderPlus className="size-3" />
+            {t('directoryBrowser.newFolder')}
+          </button>
+        </div>
+
+        {/* Body — favorites sidebar + folder list */}
+        <div className="flex min-h-0 flex-1">
+          {/* Favorites sidebar */}
+          <aside className="hidden w-[180px] shrink-0 flex-col gap-1 border-r border-border bg-surface-2 px-2 py-3 sm:flex">
+            <div className="px-2 pb-1 font-mono text-[9px] font-bold uppercase tracking-[0.16em] text-muted">
+              {t('directoryBrowser.favorites')}
+            </div>
+            {favorites.map((fav) => (
+              <button
+                key={fav.path}
+                type="button"
+                onClick={() => navigate(fav.path)}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
+              >
+                <span className="text-muted">{fav.icon}</span>
+                <span className="truncate">{t(fav.i18nKey)}</span>
+              </button>
+            ))}
+          </aside>
+
+          {/* Folder list */}
+          <div className="flex min-w-0 flex-1 flex-col overflow-y-auto px-2 py-2">
+            {error && (
+              <div className="mx-2 mb-2 rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {parent && (
+              <button
+                onClick={() => navigate(parent)}
+                className="flex items-center gap-2.5 rounded-md px-3 py-2 text-[13px] text-muted transition hover:bg-foreground/[0.04]"
+              >
+                <ChevronLeft className="size-3.5" />
+                <span className="font-mono">..</span>
+              </button>
+            )}
+
+            {dirs.map((dir) => (
+              <button
+                key={dir.path}
+                onClick={() => navigate(dir.path)}
+                className="group flex items-center gap-2.5 rounded-md px-3 py-2 text-left text-[13px] text-foreground transition hover:bg-foreground/[0.04]"
+              >
+                <Folder className="size-4 shrink-0 text-gold group-hover:hidden" />
+                <FolderOpen className="hidden size-4 shrink-0 text-gold group-hover:block" />
+                <span className="truncate">{dir.name}</span>
+              </button>
+            ))}
+
+            {!loading && !error && dirs.length === 0 && !creating && (
+              <div className="px-3 py-6 text-center text-[12px] italic text-muted">
+                {t('directoryBrowser.empty')}
+              </div>
+            )}
+
+            {/* Inline new-folder prompt — sits at the bottom of the list so
+                the user keeps context of which directory they're creating in */}
+            {creating ? (
+              <div className="mt-2 flex flex-col gap-1.5 rounded-md border border-dashed border-border-strong bg-foreground/[0.03] px-3 py-2.5">
+                <div className="flex items-center gap-2">
+                  <FolderPlus className="size-4 shrink-0 text-mint" />
+                  <input
+                    ref={newFolderInputRef}
+                    value={newFolderName}
+                    onChange={(e) => setNewFolderName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') submitNewFolder();
+                    }}
+                    placeholder={t('directoryBrowser.newFolderPlaceholder')}
+                    className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCreating(false);
+                      setNewFolderName('');
+                      setCreateError(null);
+                    }}
+                    className="rounded-md px-2 py-0.5 text-[11px] text-muted transition hover:text-foreground"
+                  >
+                    {t('directoryBrowser.cancel')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={submitNewFolder}
+                    disabled={!newFolderName.trim()}
+                    className={clsx(
+                      'rounded-md px-2.5 py-0.5 text-[11px] font-semibold transition',
+                      newFolderName.trim()
+                        ? 'bg-mint text-[#080812] hover:brightness-110'
+                        : 'bg-muted-soft text-muted',
+                    )}
+                  >
+                    {t('directoryBrowser.newFolder')}
+                  </button>
+                </div>
+                {createError && <div className="pl-6 text-[11px] text-destructive">{createError}</div>}
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setCreating(true)}
+                className="mt-2 flex items-center gap-2.5 rounded-md border border-dashed border-border-strong bg-foreground/[0.02] px-3 py-2 text-[12px] italic text-muted transition hover:bg-foreground/[0.04]"
+              >
+                <FolderPlus className="size-4 shrink-0" />
+                {t('directoryBrowser.createHere')}
+              </button>
+            )}
           </div>
         </div>
 
-        {/* Breadcrumb */}
-        <div className="px-4 py-2 border-b border-border flex items-center gap-1 text-xs overflow-x-auto min-h-[32px]">
-          {breadcrumbs.map((crumb, i) => (
-            <React.Fragment key={crumb.path}>
-              {i > 0 && <ChevronRight size={10} className="text-muted shrink-0" />}
-              <button
-                onClick={() => browse(crumb.path)}
-                className={clsx(
-                  'shrink-0 px-1 py-0.5 rounded hover:bg-foreground/5 transition-colors font-mono',
-                  i === breadcrumbs.length - 1 ? 'text-accent font-medium' : 'text-muted',
-                )}
-              >
-                {crumb.label}
-              </button>
-            </React.Fragment>
-          ))}
-          {loading && <RefreshCw size={12} className="animate-spin text-muted ml-auto shrink-0" />}
-        </div>
-
-        {/* Directory list */}
-        <div className="flex-1 overflow-y-auto px-2 py-1 min-h-[200px]">
-          {error && (
-            <div className="px-3 py-2 text-sm text-danger">{error}</div>
-          )}
-
-          {/* Parent directory */}
-          {parent && (
-            <button
-              onClick={() => browse(parent)}
-              className="flex items-center gap-2 w-full px-3 py-1.5 rounded-lg hover:bg-foreground/5 transition-colors text-sm text-muted"
-            >
-              <ArrowUp size={14} />
-              <span>..</span>
-            </button>
-          )}
-
-          {/* Sub-directories */}
-          {dirs.map((dir) => (
-            <button
-              key={dir.path}
-              onClick={() => browse(dir.path)}
-              className="flex items-center gap-2 w-full px-3 py-1.5 rounded-lg hover:bg-foreground/5 transition-colors text-sm text-text group"
-            >
-              <Folder size={14} className="text-gold group-hover:hidden shrink-0" />
-              <FolderOpen size={14} className="text-gold hidden group-hover:block shrink-0" />
-              <span className="truncate text-left">{dir.name}</span>
-            </button>
-          ))}
-
-          {!loading && !error && dirs.length === 0 && (
-            <div className="px-3 py-4 text-sm text-muted text-center italic">
-              {t('directoryBrowser.empty')}
-            </div>
-          )}
-        </div>
-
-        {/* Footer — current path + confirm */}
-        <div className="px-4 py-3 border-t border-border flex items-center gap-2">
-          <code className="flex-1 text-xs font-mono text-text bg-bg border border-border rounded px-2 py-1.5 truncate">
+        {/* Footer — current path + cancel + select */}
+        <div className="flex items-center gap-3 border-t border-border bg-surface-2 px-4 py-3">
+          <code className="flex-1 truncate rounded-md border border-border-strong bg-surface-3 px-2.5 py-1.5 font-mono text-[11px] text-foreground">
             {currentPath || '—'}
           </code>
           <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border-strong px-4 py-1.5 text-[12px] font-medium text-foreground transition hover:bg-foreground/[0.04]"
+          >
+            {t('directoryBrowser.cancel')}
+          </button>
+          <button
+            type="button"
             onClick={() => canConfirm && onSelect(currentPath)}
             disabled={!canConfirm}
             className={clsx(
-              'flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-sm font-medium transition-colors shrink-0',
+              'flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-semibold transition',
               canConfirm
-                ? 'bg-accent hover:bg-accent/90 text-accent-foreground'
-                : 'bg-muted-soft text-muted cursor-not-allowed',
+                ? 'bg-mint text-[#080812] shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
+                : 'cursor-not-allowed bg-muted-soft text-muted',
             )}
           >
-            <Check size={14} />
+            <Check className="size-3.5" />
             {t('directoryBrowser.select')}
           </button>
         </div>

--- a/ui/src/components/ui/directory-browser.tsx
+++ b/ui/src/components/ui/directory-browser.tsx
@@ -41,6 +41,10 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
   const api = useApi();
 
   const [currentPath, setCurrentPath] = useState('');
+  // Resolved user home — captured on the first browse('~') response so the
+  // breadcrumb collapse to ⌂ has a real prefix to match against. Falls back
+  // to '' (no collapse) if the user opened the picker with an absolute path.
+  const [homePath, setHomePath] = useState<string>('');
   const [parent, setParent] = useState<string | null>(null);
   const [dirs, setDirs] = useState<{ name: string; path: string }[]>([]);
   const [loading, setLoading] = useState(false);
@@ -105,10 +109,24 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
           return null;
         }
         if (result.ok) {
-          setCurrentPath(result.path ?? path);
+          const resolvedPath = result.path ?? path;
+          setCurrentPath(resolvedPath);
           setParent(result.parent ?? null);
           setDirs(result.dirs ?? []);
-          return result.path ?? path;
+          // Snapshot the resolved user home the first time the backend
+          // expands a tilde-prefixed path. Backend behavior: passing "~"
+          // returns the home directory in result.path; passing "~/x"
+          // returns "<home>/x". We derive home by trimming the requested
+          // suffix off the resolved path.
+          if (!homePath && path.startsWith('~')) {
+            const suffix = path === '~' ? '' : path.slice(1);
+            const derived = suffix && resolvedPath.endsWith(suffix)
+              ? resolvedPath.slice(0, resolvedPath.length - suffix.length)
+              : resolvedPath;
+            const cleaned = derived.replace(/\/+$/, '');
+            if (cleaned) setHomePath(cleaned);
+          }
+          return resolvedPath;
         }
         setError(result.error ?? 'Unknown error');
         return null;
@@ -122,7 +140,7 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
         }
       }
     },
-    [api, showHidden],
+    [api, showHidden, homePath],
   );
 
   const navigate = useCallback(
@@ -187,21 +205,21 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
   };
 
   // Breadcrumb: collapse the home prefix to ⌂ so deeply-nested paths still fit
-  // in the toolbar without scrolling.
+  // in the toolbar without scrolling. ``homePath`` is captured on the first
+  // tilde-expanded browse response (see fetchPath).
   const breadcrumbs = (() => {
     if (!currentPath) return [] as { label: string; path: string; isHome?: boolean }[];
-    const home = (typeof window !== 'undefined' && (window as any).__USER_HOME__) || '';
-    const startsAtHome = home && currentPath.startsWith(home);
-    const segments = (startsAtHome ? currentPath.slice(home.length) : currentPath)
+    const startsAtHome = !!homePath && currentPath.startsWith(homePath);
+    const segments = (startsAtHome ? currentPath.slice(homePath.length) : currentPath)
       .split('/')
       .filter(Boolean);
     const out: { label: string; path: string; isHome?: boolean }[] = [];
     if (startsAtHome) {
-      out.push({ label: '⌂', path: home, isHome: true });
+      out.push({ label: '⌂', path: homePath, isHome: true });
     } else {
       out.push({ label: '/', path: '/' });
     }
-    let acc = startsAtHome ? home : '';
+    let acc = startsAtHome ? homePath : '';
     for (const seg of segments) {
       acc = acc === '/' || acc === '' ? `${acc}${seg}` : `${acc}/${seg}`;
       if (!acc.startsWith('/')) acc = `/${acc}`;

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -1,0 +1,6 @@
+import { Bot } from 'lucide-react';
+import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+
+export const AgentsPage: React.FC = () => (
+  <WorkbenchModulePlaceholder icon={<Bot className="size-6" />} i18nPrefix="workbench.modules.agents" />
+);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -1,6 +1,462 @@
-import { Bot } from 'lucide-react';
-import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Bot, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import clsx from 'clsx';
 
-export const AgentsPage: React.FC = () => (
-  <WorkbenchModulePlaceholder icon={<Bot className="size-6" />} i18nPrefix="workbench.modules.agents" />
-);
+import { useApi } from '../../context/ApiContext';
+import type { VibeAgentBrief, VibeAgentFull } from '../../context/ApiContext';
+import { NewAgentDialog } from './NewAgentDialog';
+
+const BACKEND_ORDER = ['claude', 'opencode', 'codex'] as const;
+type Backend = (typeof BACKEND_ORDER)[number];
+
+const BACKEND_LABEL: Record<Backend, string> = {
+  claude: 'Claude',
+  opencode: 'OpenCode',
+  codex: 'Codex',
+};
+
+const BACKEND_COLOR: Record<Backend, { ic: string; text: string; soft: string }> = {
+  claude: { ic: 'text-mint', text: 'text-mint', soft: 'border-mint/30 bg-mint/[0.06]' },
+  opencode: { ic: 'text-cyan', text: 'text-cyan', soft: 'border-cyan/30 bg-cyan/[0.06]' },
+  codex: { ic: 'text-violet', text: 'text-violet', soft: 'border-violet/30 bg-violet/[0.06]' },
+};
+
+const EFFORT_OPTIONS = ['low', 'medium', 'high', 'max'];
+
+function isSystemAgent(agent: { source: string }): boolean {
+  return agent.source === 'builtin' || agent.source === 'system';
+}
+
+export const AgentsPage: React.FC = () => {
+  const { t } = useTranslation();
+  const api = useApi();
+  const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
+  const [defaultName, setDefaultName] = useState<string | null>(null);
+  const [selected, setSelected] = useState<VibeAgentFull | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showDisabled, setShowDisabled] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await api.listVibeAgents({ includeDisabled: showDisabled });
+      setAgents(result.agents);
+      setDefaultName(result.default_agent_name);
+      // Keep the currently-selected agent fresh after edits / refreshes.
+      if (selected) {
+        const fresh = result.agents.find((a) => a.name === selected.name);
+        if (!fresh) {
+          setSelected(null);
+        }
+      }
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [api, showDisabled, selected]);
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showDisabled]);
+
+  const selectAgent = useCallback(
+    async (name: string) => {
+      try {
+        const result = await api.getVibeAgent(name);
+        if (result.ok) setSelected(result.agent);
+      } catch (err: any) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [api],
+  );
+
+  const grouped = useMemo(() => {
+    const groups: Record<Backend, VibeAgentBrief[]> = { claude: [], opencode: [], codex: [] };
+    for (const agent of agents) {
+      const key = (agent.backend as Backend) in groups ? (agent.backend as Backend) : null;
+      if (key) groups[key].push(agent);
+    }
+    return groups;
+  }, [agents]);
+
+  const onCreated = (agent: VibeAgentFull) => {
+    refresh().then(() => setSelected(agent));
+  };
+
+  const updateField = async (patch: Partial<VibeAgentFull>) => {
+    if (!selected) return;
+    try {
+      const result = await api.updateVibeAgent(selected.name, patch as any);
+      if (result.ok) {
+        setSelected(result.agent);
+        refresh();
+      }
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    }
+  };
+
+  const onDelete = async () => {
+    if (!selected || isSystemAgent(selected)) return;
+    const confirmed = window.confirm(t('agents.deleteConfirm', { name: selected.name }));
+    if (!confirmed) return;
+    try {
+      const result = await api.removeVibeAgent(selected.name);
+      if (result.ok) {
+        setSelected(null);
+        refresh();
+      } else if (result.code === 'agent_in_use') {
+        setError(t('agents.deleteInUse', { name: selected.name }));
+      } else if (result.message) {
+        setError(result.message);
+      }
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-5 py-2">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-mint/30 bg-mint/[0.08] text-mint shadow-[0_0_24px_-6px_rgba(91,255,160,0.5)]">
+          <Bot className="size-5" />
+        </div>
+        <div className="flex flex-1 flex-col">
+          <h1 className="text-2xl font-bold text-foreground">{t('agents.title')}</h1>
+          <p className="text-[13px] text-muted">
+            {t('agents.subtitle', { count: agents.length })}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refresh()}
+          disabled={loading}
+          className={clsx(
+            'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12px] font-medium transition',
+            loading
+              ? 'cursor-wait border-border bg-foreground/[0.02] text-muted'
+              : 'border-border-strong text-foreground hover:bg-foreground/[0.04]',
+          )}
+        >
+          <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} />
+          {t('common.refresh')}
+        </button>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-2">
+        <label className="inline-flex cursor-pointer items-center gap-2 text-[12px] text-muted">
+          <input
+            type="checkbox"
+            checked={showDisabled}
+            onChange={(e) => setShowDisabled(e.target.checked)}
+            className="accent-mint"
+          />
+          {t('agents.showDisabled')}
+        </label>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={() => setShowNew(true)}
+          className="inline-flex items-center gap-1.5 rounded-md bg-mint px-3 py-1.5 text-[12px] font-bold text-[#080812] shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110"
+        >
+          <Plus className="size-3.5" />
+          {t('agents.newAgent')}
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Body: list + detail */}
+      <div className="grid grid-cols-[1fr_380px] gap-5">
+        <div className="flex flex-col gap-5">
+          {BACKEND_ORDER.map((backend) => {
+            const items = grouped[backend];
+            if (!items || items.length === 0) return null;
+            const color = BACKEND_COLOR[backend];
+            return (
+              <div key={backend} className="flex flex-col gap-2">
+                <div className="flex items-center gap-2 px-1">
+                  <Bot className={clsx('size-3.5', color.ic)} />
+                  <span className={clsx('text-[13px] font-bold', color.text)}>
+                    {BACKEND_LABEL[backend]}
+                  </span>
+                  <span className="font-mono text-[10px] text-muted">{items.length} agents</span>
+                </div>
+                <div className="flex flex-col gap-2">
+                  {items.map((agent) => {
+                    const isSelected = selected?.name === agent.name;
+                    const isDefault = defaultName === agent.name;
+                    return (
+                      <button
+                        key={agent.id}
+                        type="button"
+                        onClick={() => selectAgent(agent.name)}
+                        className={clsx(
+                          'flex items-center gap-3 rounded-lg border px-4 py-3 text-left transition',
+                          isSelected
+                            ? 'border-mint/40 bg-mint/[0.05]'
+                            : 'border-border bg-surface hover:bg-foreground/[0.03]',
+                        )}
+                      >
+                        <div className="flex flex-1 flex-col gap-0.5">
+                          <div className="flex items-center gap-2">
+                            <span className="text-[14px] font-semibold text-foreground">{agent.name}</span>
+                            {isDefault && (
+                              <span className="rounded border border-mint/40 bg-mint/[0.10] px-1.5 py-0 font-mono text-[9px] font-bold text-mint">
+                                DEFAULT
+                              </span>
+                            )}
+                            {isSystemAgent(agent) && (
+                              <span className="rounded border border-border-strong bg-surface-2 px-1.5 py-0 font-mono text-[9px] text-muted">
+                                SYSTEM
+                              </span>
+                            )}
+                          </div>
+                          <div className="text-[11px] text-muted">
+                            {[agent.model, agent.reasoning_effort, agent.description]
+                              .filter(Boolean)
+                              .join(' · ') || t('agents.noConfig')}
+                          </div>
+                        </div>
+                        <span
+                          className={clsx(
+                            'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-mono font-bold',
+                            agent.enabled
+                              ? 'border-mint/30 bg-mint/[0.08] text-mint'
+                              : 'border-border-strong bg-foreground/[0.04] text-muted',
+                          )}
+                        >
+                          <span className={clsx('size-1.5 rounded-full', agent.enabled ? 'bg-mint' : 'bg-muted')} />
+                          {agent.enabled ? 'enabled' : 'disabled'}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+
+          {agents.length === 0 && !loading && (
+            <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-surface px-6 py-16 text-center">
+              <Bot className="size-8 text-muted" />
+              <div className="text-[14px] font-semibold text-foreground">{t('agents.empty')}</div>
+              <button
+                type="button"
+                onClick={() => setShowNew(true)}
+                className="rounded-md bg-mint px-3 py-1.5 text-[12px] font-bold text-[#080812]"
+              >
+                {t('agents.newAgent')}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Detail panel */}
+        <div className="flex flex-col gap-3 self-start rounded-xl border border-border-strong bg-surface p-5">
+          {selected ? (
+            <AgentDetailPanel
+              agent={selected}
+              isDefault={defaultName === selected.name}
+              onChange={updateField}
+              onSetDefault={async () => {
+                try {
+                  const result = await api.setDefaultVibeAgent(selected.name);
+                  if (result.ok) setDefaultName(result.default_agent_name);
+                } catch (err: any) {
+                  setError(err?.message ?? String(err));
+                }
+              }}
+              onDelete={onDelete}
+            />
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-3 py-12 text-center text-[12px] text-muted">
+              <Bot className="size-6 text-muted" />
+              {t('agents.selectPrompt')}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <NewAgentDialog open={showNew} onClose={() => setShowNew(false)} onCreated={onCreated} />
+    </div>
+  );
+};
+
+interface DetailProps {
+  agent: VibeAgentFull;
+  isDefault: boolean;
+  onChange: (patch: Partial<VibeAgentFull>) => void;
+  onSetDefault: () => void;
+  onDelete: () => void;
+}
+
+const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, onSetDefault, onDelete }) => {
+  const { t } = useTranslation();
+  const system = isSystemAgent(agent);
+  const [model, setModel] = useState(agent.model ?? '');
+  const [effort, setEffort] = useState(agent.reasoning_effort ?? 'medium');
+  const [systemPrompt, setSystemPrompt] = useState(agent.system_prompt ?? '');
+
+  useEffect(() => {
+    setModel(agent.model ?? '');
+    setEffort(agent.reasoning_effort ?? 'medium');
+    setSystemPrompt(agent.system_prompt ?? '');
+  }, [agent.id]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        {system && (
+          <span className="rounded border border-border-strong bg-surface-2 px-1.5 py-0 font-mono text-[9px] text-muted">
+            SYSTEM
+          </span>
+        )}
+        <div className="flex-1 truncate text-[15px] font-bold text-foreground">{agent.name}</div>
+        {isDefault ? (
+          <span className="rounded border border-mint/40 bg-mint/[0.10] px-1.5 py-0 font-mono text-[9px] font-bold text-mint">
+            DEFAULT
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={onSetDefault}
+            className="rounded border border-border-strong px-2 py-0.5 font-mono text-[9px] text-muted hover:text-foreground"
+          >
+            {t('agents.makeDefault')}
+          </button>
+        )}
+      </div>
+
+      {/* Enable toggle */}
+      <div
+        className={clsx(
+          'flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5',
+          agent.enabled
+            ? 'border-mint/30 bg-mint/[0.06]'
+            : 'border-border-strong bg-foreground/[0.02]',
+        )}
+      >
+        <div className="flex flex-col">
+          <span className="text-[12px] font-bold text-foreground">{t('agents.detail.enabled')}</span>
+          <span className="text-[10px] text-muted">{t('agents.detail.enabledHint')}</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onChange({ enabled: !agent.enabled })}
+          className={clsx(
+            'flex h-6 w-11 items-center rounded-full px-0.5 transition',
+            agent.enabled ? 'justify-end bg-mint' : 'justify-start bg-muted-soft',
+          )}
+        >
+          <span className="size-5 rounded-full bg-white shadow" />
+        </button>
+      </div>
+
+      {/* Backend (read-only) */}
+      <div className="flex flex-col gap-1.5">
+        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+          {t('agents.detail.backend')}
+        </div>
+        <div className="rounded-md border border-border bg-surface-3 px-3 py-2 text-[12px] text-muted">
+          <span className="font-mono font-semibold text-foreground">{agent.backend}</span>
+          <span className="ml-2 text-[10px]">{t('agents.detail.backendLocked')}</span>
+        </div>
+      </div>
+
+      {/* Model */}
+      <div className="flex flex-col gap-1.5">
+        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+          {t('agents.detail.model')}
+        </div>
+        <input
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          onBlur={() => {
+            if (model !== (agent.model ?? '')) {
+              onChange({ model: model.trim() || null });
+            }
+          }}
+          placeholder={t('agents.create.modelPlaceholder')}
+          className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 font-mono text-[12px] text-foreground outline-none focus:border-cyan"
+        />
+      </div>
+
+      {/* Effort */}
+      <div className="flex flex-col gap-1.5">
+        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+          {t('agents.detail.effort')}
+        </div>
+        <div className="flex rounded-md border border-border-strong bg-surface-2 p-0.5">
+          {EFFORT_OPTIONS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => {
+                setEffort(opt);
+                onChange({ reasoning_effort: opt });
+              }}
+              className={clsx(
+                'flex-1 rounded text-[11px] font-semibold capitalize transition',
+                effort === opt ? 'bg-mint/[0.10] text-mint' : 'text-muted hover:text-foreground',
+              )}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* System prompt */}
+      <div className="flex flex-col gap-1.5">
+        <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+          {t('agents.detail.systemPrompt')}
+        </div>
+        <textarea
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          onBlur={() => {
+            if (systemPrompt !== (agent.system_prompt ?? '')) {
+              onChange({ system_prompt: systemPrompt.trim() || null });
+            }
+          }}
+          rows={5}
+          placeholder={t('agents.create.systemPromptPlaceholder')}
+          className="rounded-md border border-border-strong bg-surface-3 px-3 py-2 text-[12px] text-foreground outline-none focus:border-cyan"
+        />
+        <span className="text-[10px] text-muted">{t('agents.detail.systemPromptHint')}</span>
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex items-center gap-2 pt-1">
+        {!system && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="inline-flex items-center gap-1.5 rounded-md border border-pink/40 bg-pink/[0.08] px-3 py-1.5 text-[11px] font-bold text-pink hover:bg-pink/[0.14]"
+          >
+            <Trash2 className="size-3.5" />
+            {t('common.delete')}
+          </button>
+        )}
+        {system && (
+          <span className="text-[10px] text-muted">{t('agents.detail.systemLocked')}</span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, Bot, ChevronDown, Loader2, MessageSquare, Pencil } from 'lucide-react';
+import clsx from 'clsx';
+
+import { useApi } from '../../context/ApiContext';
+import type { VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+
+const EFFORT_OPTIONS = ['low', 'medium', 'high', 'max'];
+
+// Mirrors design.pen kxEkn — the inline header replaces the old "Session
+// settings" dialog. Title is click-to-edit; the cyan-bordered pill on the
+// right opens a single popover that drives agent / model / effort all at
+// once so the user doesn't have to navigate three different menus.
+export const ChatPage: React.FC = () => {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const api = useApi();
+  const [session, setSession] = useState<WorkbenchSession | null>(null);
+  const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
+  const [messages, setMessages] = useState<WorkbenchMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!sessionId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [fetched, agentList, msgs] = await Promise.all([
+        api.getSession(sessionId),
+        api.listVibeAgents({ includeDisabled: false }),
+        api.listSessionMessages(sessionId, { limit: 50 }),
+      ]);
+      setSession(fetched);
+      setAgents(agentList.agents);
+      setMessages(msgs.messages);
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [api, sessionId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const patch = useCallback(
+    async (changes: Partial<WorkbenchSession>) => {
+      if (!session) return;
+      try {
+        const updated = await api.updateSession(session.id, changes as any);
+        setSession(updated);
+      } catch (err: any) {
+        setError(err?.message ?? String(err));
+      }
+    },
+    [api, session],
+  );
+
+  if (!sessionId) {
+    return <ChatMissing onBack={() => navigate('/inbox')} />;
+  }
+
+  if (loading && !session) {
+    return (
+      <div className="flex h-[60vh] flex-col items-center justify-center gap-2 text-muted">
+        <Loader2 className="size-5 animate-spin" />
+        <span className="text-[12px]">{t('common.loading')}</span>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 py-8">
+        <button
+          type="button"
+          onClick={() => navigate('/inbox')}
+          className="inline-flex items-center gap-1.5 text-[12px] text-cyan hover:underline"
+        >
+          <ArrowLeft className="size-3.5" />
+          {t('chat.backToInbox')}
+        </button>
+        <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+          {error ?? t('chat.notFound')}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4 py-2">
+      <button
+        type="button"
+        onClick={() => navigate('/inbox')}
+        className="inline-flex items-center gap-1.5 self-start text-[12px] text-muted hover:text-foreground"
+      >
+        <ArrowLeft className="size-3.5" />
+        {t('chat.backToInbox')}
+      </button>
+
+      <ChatHeaderBar session={session} agents={agents} onPatch={patch} />
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Transcript messages={messages} session={session} />
+    </div>
+  );
+};
+
+interface ChatHeaderBarProps {
+  session: WorkbenchSession;
+  agents: VibeAgentBrief[];
+  onPatch: (changes: Partial<WorkbenchSession>) => Promise<void>;
+}
+
+const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, onPatch }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-3.5 rounded-2xl border border-border bg-surface px-5 py-3.5">
+      <div className="flex items-center gap-3">
+        <ProjectPill projectId={session.project_id} />
+        <TitleField key={session.id} title={session.title} onCommit={(title) => onPatch({ title })} />
+      </div>
+      <div className="flex items-center gap-2">
+        <AgentPicker session={session} agents={agents} onPatch={onPatch} />
+        <ModelField key={`model-${session.id}`} model={session.model} onCommit={(model) => onPatch({ model })} />
+        <EffortPicker effort={session.reasoning_effort} onPick={(value) => onPatch({ reasoning_effort: value })} />
+        <span className="ml-auto font-mono text-[10px] text-muted">{t('chat.changesPersist')}</span>
+      </div>
+    </div>
+  );
+};
+
+const ProjectPill: React.FC<{ projectId: string | null }> = ({ projectId }) => (
+  <span className="inline-flex items-center gap-1.5 rounded-md border border-cyan/40 bg-cyan/[0.08] px-2 py-0.5 font-mono text-[10px] font-semibold text-cyan">
+    <span className="size-1.5 rounded-full bg-cyan" />
+    {projectId || 'workbench'}
+  </span>
+);
+
+interface TitleFieldProps {
+  title: string | null;
+  onCommit: (next: string | null) => void;
+}
+
+const TitleField: React.FC<TitleFieldProps> = ({ title, onCommit }) => {
+  const { t } = useTranslation();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(title ?? '');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setValue(title ?? '');
+  }, [title]);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => setEditing(true)}
+        className="group inline-flex flex-1 items-center gap-2 truncate text-left text-[16px] font-bold text-foreground hover:text-foreground"
+      >
+        <span className="truncate">{title || t('chat.untitled')}</span>
+        <Pencil className="size-3.5 shrink-0 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
+      </button>
+    );
+  }
+
+  const commit = (next: string) => {
+    const trimmed = next.trim();
+    if (trimmed === (title ?? '')) {
+      setEditing(false);
+      return;
+    }
+    onCommit(trimmed || null);
+    setEditing(false);
+  };
+
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => commit(value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') commit(value);
+        if (e.key === 'Escape') {
+          setValue(title ?? '');
+          setEditing(false);
+        }
+      }}
+      placeholder={t('chat.titlePlaceholder')}
+      className="flex-1 rounded-md border border-cyan/40 bg-surface-2 px-2 py-1 text-[15px] font-bold text-foreground outline-none focus:border-cyan"
+    />
+  );
+};
+
+interface AgentPickerProps {
+  session: WorkbenchSession;
+  agents: VibeAgentBrief[];
+  onPatch: (changes: Partial<WorkbenchSession>) => Promise<void>;
+}
+
+const AgentPicker: React.FC<AgentPickerProps> = ({ session, agents, onPatch }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const current = session.agent_name;
+
+  const grouped = useMemo(() => {
+    const groups: Record<string, VibeAgentBrief[]> = {};
+    for (const agent of agents) {
+      groups[agent.backend] = groups[agent.backend] || [];
+      groups[agent.backend].push(agent);
+    }
+    return groups;
+  }, [agents]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 rounded-md border border-cyan/30 bg-cyan/[0.06] px-2 py-1 text-[12px] font-semibold text-foreground hover:bg-cyan/[0.10]"
+        >
+          <Bot className="size-3.5 text-cyan" />
+          <span>{current || t('chat.pickAgent')}</span>
+          <ChevronDown className="size-3 text-muted" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[260px] p-2">
+        {Object.keys(grouped).length === 0 && (
+          <div className="px-3 py-4 text-center text-[12px] text-muted">{t('chat.noAgents')}</div>
+        )}
+        {Object.entries(grouped).map(([backend, list]) => (
+          <div key={backend} className="flex flex-col gap-1 py-1">
+            <div className="px-2 font-mono text-[9px] font-bold uppercase tracking-[0.12em] text-muted">{backend}</div>
+            <div className="flex flex-col">
+              {list.map((agent) => {
+                const active = agent.name === current;
+                return (
+                  <button
+                    key={agent.id}
+                    type="button"
+                    onClick={async () => {
+                      setOpen(false);
+                      if (active) return;
+                      await onPatch({
+                        agent_name: agent.name,
+                        agent_id: agent.id,
+                        agent_backend: agent.backend,
+                        model: agent.model,
+                        reasoning_effort: agent.reasoning_effort,
+                      });
+                    }}
+                    className={clsx(
+                      'flex items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] transition',
+                      active ? 'bg-cyan/[0.10] text-cyan' : 'text-foreground hover:bg-foreground/[0.04]',
+                    )}
+                  >
+                    <span className="flex-1 truncate font-semibold">{agent.name}</span>
+                    {agent.model && <span className="font-mono text-[10px] text-muted">{agent.model}</span>}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+interface ModelFieldProps {
+  model: string | null;
+  onCommit: (next: string | null) => void;
+}
+
+const ModelField: React.FC<ModelFieldProps> = ({ model, onCommit }) => {
+  const { t } = useTranslation();
+  const [value, setValue] = useState(model ?? '');
+
+  useEffect(() => {
+    setValue(model ?? '');
+  }, [model]);
+
+  return (
+    <input
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => {
+        if (value !== (model ?? '')) onCommit(value.trim() || null);
+      }}
+      placeholder={t('chat.modelPlaceholder')}
+      className="w-[200px] rounded-md border border-border-strong bg-surface-2 px-2 py-1 font-mono text-[11px] text-foreground outline-none focus:border-cyan"
+    />
+  );
+};
+
+const EffortPicker: React.FC<{ effort: string | null; onPick: (value: string) => void }> = ({ effort, onPick }) => (
+  <div className="flex rounded-md border border-border-strong bg-surface-2 p-0.5">
+    {EFFORT_OPTIONS.map((opt) => (
+      <button
+        key={opt}
+        type="button"
+        onClick={() => onPick(opt)}
+        className={clsx(
+          'rounded px-2 py-0.5 text-[11px] font-semibold capitalize transition',
+          effort === opt ? 'bg-mint/[0.10] text-mint' : 'text-muted hover:text-foreground',
+        )}
+      >
+        {opt}
+      </button>
+    ))}
+  </div>
+);
+
+interface TranscriptProps {
+  messages: WorkbenchMessage[];
+  session: WorkbenchSession;
+}
+
+const Transcript: React.FC<TranscriptProps> = ({ messages, session }) => {
+  const { t } = useTranslation();
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-surface px-6 py-16 text-center">
+        <MessageSquare className="size-8 text-muted" />
+        <div className="text-[14px] font-semibold text-foreground">{t('chat.transcriptEmpty')}</div>
+        <div className="max-w-md text-[12px] text-muted">{t('chat.transcriptEmptyHint')}</div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      {messages.map((message) => (
+        <MessageRow key={message.id} message={message} session={session} />
+      ))}
+    </div>
+  );
+};
+
+const MessageRow: React.FC<{ message: WorkbenchMessage; session: WorkbenchSession }> = ({ message, session }) => {
+  const isAgent = message.author === 'agent';
+  const isSystem = message.author === 'system';
+  return (
+    <div
+      className={clsx(
+        'flex flex-col gap-1 rounded-xl border px-4 py-3',
+        isAgent
+          ? 'border-mint/20 bg-mint/[0.04]'
+          : isSystem
+          ? 'border-border bg-foreground/[0.02]'
+          : 'border-border bg-surface',
+      )}
+    >
+      <div className="flex items-center gap-2 text-[10px]">
+        <span
+          className={clsx(
+            'rounded border px-1.5 py-0 font-mono font-bold uppercase',
+            isAgent ? 'border-mint/40 bg-mint/[0.10] text-mint' : 'border-border-strong bg-foreground/[0.04] text-muted',
+          )}
+        >
+          {message.author}
+        </span>
+        {message.author_name && <span className="font-semibold text-foreground">{message.author_name}</span>}
+        {isAgent && session.agent_name && <span className="font-mono text-muted">{session.agent_name}</span>}
+        <span className="ml-auto font-mono text-muted">{message.created_at}</span>
+      </div>
+      <div className="whitespace-pre-wrap text-[13px] text-foreground">{message.text || '—'}</div>
+    </div>
+  );
+};
+
+const ChatMissing: React.FC<{ onBack: () => void }> = ({ onBack }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 py-8">
+      <button
+        type="button"
+        onClick={onBack}
+        className="inline-flex items-center gap-1.5 text-[12px] text-cyan hover:underline"
+      >
+        <ArrowLeft className="size-3.5" />
+        {t('chat.backToInbox')}
+      </button>
+      <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+        {t('chat.missingSessionId')}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -1,0 +1,6 @@
+import { Activity } from 'lucide-react';
+import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+
+export const HarnessPage: React.FC = () => (
+  <WorkbenchModulePlaceholder icon={<Activity className="size-6" />} i18nPrefix="workbench.modules.harness" />
+);

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -1,6 +1,718 @@
-import { Activity } from 'lucide-react';
-import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Activity,
+  Calendar,
+  Eye,
+  Webhook,
+  History,
+  RefreshCw,
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Clock,
+  PauseCircle,
+} from 'lucide-react';
+import clsx from 'clsx';
 
-export const HarnessPage: React.FC = () => (
-  <WorkbenchModulePlaceholder icon={<Activity className="size-6" />} i18nPrefix="workbench.modules.harness" />
+import { useApi } from '../../context/ApiContext';
+import type {
+  HarnessRun,
+  HarnessRunStatus,
+  HarnessTask,
+  HarnessWatch,
+} from '../../context/ApiContext';
+
+type TabKey = 'tasks' | 'watches' | 'webhooks' | 'runs';
+
+const TAB_ORDER: TabKey[] = ['tasks', 'watches', 'webhooks', 'runs'];
+
+type Selection =
+  | { kind: 'task'; id: string }
+  | { kind: 'watch'; id: string }
+  | { kind: 'run'; id: string }
+  | null;
+
+export const HarnessPage: React.FC = () => {
+  const { t } = useTranslation();
+  const api = useApi();
+  const [tab, setTab] = useState<TabKey>('tasks');
+  const [tasks, setTasks] = useState<HarnessTask[]>([]);
+  const [watches, setWatches] = useState<HarnessWatch[]>([]);
+  const [runs, setRuns] = useState<HarnessRun[]>([]);
+  const [runsHasMore, setRunsHasMore] = useState(false);
+  const [runsPage, setRunsPage] = useState(1);
+  const [selection, setSelection] = useState<Selection>(null);
+  const [selectedRun, setSelectedRun] = useState<HarnessRun | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      if (tab === 'tasks') {
+        const result = await api.listHarnessTasks();
+        setTasks(result.tasks);
+      } else if (tab === 'watches') {
+        const result = await api.listHarnessWatches();
+        setWatches(result.watches);
+      } else if (tab === 'runs') {
+        const result = await api.listHarnessRuns({ page: runsPage, limit: 30 });
+        setRuns(result.runs);
+        setRunsHasMore(result.has_more);
+      }
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [api, tab, runsPage]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Fetch run detail (stdout/stderr) whenever a run is selected so the
+  // detail panel always shows the full body, not just the list excerpt.
+  useEffect(() => {
+    if (selection?.kind !== 'run') {
+      setSelectedRun(null);
+      return;
+    }
+    let cancelled = false;
+    api
+      .getHarnessRun(selection.id)
+      .then((result) => {
+        if (!cancelled && result.ok) setSelectedRun(result.run);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err?.message ?? String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, selection]);
+
+  const counts = useMemo(
+    () => ({
+      tasks: tasks.length,
+      watches: watches.length,
+      webhooks: 0,
+      runs: runs.length + (runsHasMore ? 1 : 0),
+    }),
+    [tasks.length, watches.length, runs.length, runsHasMore],
+  );
+
+  const selectedTask = useMemo(
+    () => (selection?.kind === 'task' ? tasks.find((task) => task.id === selection.id) ?? null : null),
+    [selection, tasks],
+  );
+  const selectedWatch = useMemo(
+    () => (selection?.kind === 'watch' ? watches.find((watch) => watch.id === selection.id) ?? null : null),
+    [selection, watches],
+  );
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1180px] flex-col gap-5 py-2">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-violet/30 bg-violet/[0.08] text-violet shadow-[0_0_24px_-6px_rgba(124,91,255,0.5)]">
+          <Activity className="size-5" />
+        </div>
+        <div className="flex flex-1 flex-col">
+          <h1 className="text-2xl font-bold text-foreground">{t('harness.title')}</h1>
+          <p className="text-[13px] text-muted">{t('harness.subtitle')}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refresh()}
+          disabled={loading}
+          className={clsx(
+            'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12px] font-medium transition',
+            loading
+              ? 'cursor-wait border-border bg-foreground/[0.02] text-muted'
+              : 'border-border-strong text-foreground hover:bg-foreground/[0.04]',
+          )}
+        >
+          <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} />
+          {t('common.refresh')}
+        </button>
+      </div>
+
+      {/* Tab row */}
+      <div className="flex items-center gap-0 border-b border-border">
+        {TAB_ORDER.map((key) => {
+          const active = tab === key;
+          const count = counts[key];
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => {
+                setTab(key);
+                setSelection(null);
+              }}
+              className={clsx(
+                'flex items-center gap-2 px-4 py-3 text-[13px] transition',
+                active ? 'border-b-2 border-violet font-bold text-violet' : 'font-medium text-muted hover:text-foreground',
+              )}
+            >
+              <HarnessTabIcon tab={key} active={active} />
+              {t(`harness.tabs.${key}`)}
+              {key !== 'webhooks' && (
+                <span
+                  className={clsx(
+                    'rounded-full border px-1.5 py-0 font-mono text-[9px] font-bold',
+                    active
+                      ? 'border-violet/30 bg-violet/[0.10] text-violet'
+                      : 'border-border-strong bg-foreground/[0.04] text-muted',
+                  )}
+                >
+                  {count}
+                </span>
+              )}
+              {key === 'webhooks' && (
+                <span className="font-mono text-[9px] text-muted">{t('harness.soon')}</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Body: list + detail */}
+      <div className="grid grid-cols-[1fr_440px] gap-5">
+        <div className="flex flex-col gap-2">
+          {tab === 'tasks' && (
+            <TasksList tasks={tasks} loading={loading} selectedId={selection?.kind === 'task' ? selection.id : null} onSelect={(id) => setSelection({ kind: 'task', id })} />
+          )}
+          {tab === 'watches' && (
+            <WatchesList watches={watches} loading={loading} selectedId={selection?.kind === 'watch' ? selection.id : null} onSelect={(id) => setSelection({ kind: 'watch', id })} />
+          )}
+          {tab === 'webhooks' && <WebhooksEmpty />}
+          {tab === 'runs' && (
+            <RunsList
+              runs={runs}
+              loading={loading}
+              selectedId={selection?.kind === 'run' ? selection.id : null}
+              onSelect={(id) => setSelection({ kind: 'run', id })}
+              page={runsPage}
+              hasMore={runsHasMore}
+              onPageChange={setRunsPage}
+            />
+          )}
+        </div>
+
+        <div className="flex flex-col gap-3 self-start rounded-xl border border-border-strong bg-surface p-5">
+          {selectedTask ? (
+            <TaskDetail task={selectedTask} />
+          ) : selectedWatch ? (
+            <WatchDetail watch={selectedWatch} />
+          ) : selectedRun ? (
+            <RunDetail run={selectedRun} />
+          ) : (
+            <div className="flex flex-col items-center justify-center gap-3 py-12 text-center text-[12px] text-muted">
+              <Activity className="size-6 text-muted" />
+              {t('harness.selectPrompt')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface TabIconProps {
+  tab: TabKey;
+  active: boolean;
+}
+
+const HarnessTabIcon: React.FC<TabIconProps> = ({ tab, active }) => {
+  const cls = clsx('size-3.5', active ? 'text-violet' : 'text-muted');
+  if (tab === 'tasks') return <Calendar className={cls} />;
+  if (tab === 'watches') return <Eye className={cls} />;
+  if (tab === 'webhooks') return <Webhook className={cls} />;
+  return <History className={cls} />;
+};
+
+// ---------------------------------------------------------------------------
+// Tasks tab
+// ---------------------------------------------------------------------------
+
+interface TasksListProps {
+  tasks: HarnessTask[];
+  loading: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+const TasksList: React.FC<TasksListProps> = ({ tasks, loading, selectedId, onSelect }) => {
+  const { t } = useTranslation();
+  if (tasks.length === 0 && !loading) return <EmptyState i18nKey="harness.emptyTasks" />;
+  return (
+    <>
+      {tasks.map((task) => {
+        const active = selectedId === task.id;
+        const scheduleLabel = task.cron
+          ? `cron · ${task.cron}`
+          : task.run_at
+          ? `one-shot · ${task.run_at}`
+          : task.schedule_type || t('harness.unknownSchedule');
+        return (
+          <button
+            key={task.id}
+            type="button"
+            onClick={() => onSelect(task.id)}
+            className={clsx(
+              'flex items-center gap-3 rounded-lg border px-4 py-3 text-left transition',
+              active ? 'border-violet/40 bg-violet/[0.05]' : 'border-border bg-surface hover:bg-foreground/[0.03]',
+            )}
+          >
+            <div className="flex flex-1 flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <span className="text-[14px] font-semibold text-foreground">{task.name || task.id}</span>
+                {!task.enabled && (
+                  <span className="rounded border border-border-strong bg-foreground/[0.04] px-1.5 py-0 font-mono text-[9px] text-muted">
+                    DISABLED
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-3 text-[11px] text-muted">
+                <span className="inline-flex items-center gap-1 font-mono">
+                  <Clock className="size-3" />
+                  {scheduleLabel}
+                </span>
+                {task.agent_name && <span>· {task.agent_name}</span>}
+              </div>
+            </div>
+            {task.last_run_at && (
+              <span className="font-mono text-[10px] text-muted">{formatRelative(task.last_run_at)}</span>
+            )}
+          </button>
+        );
+      })}
+    </>
+  );
+};
+
+interface TaskDetailProps {
+  task: HarnessTask;
+}
+
+const TaskDetail: React.FC<TaskDetailProps> = ({ task }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Calendar className="size-4 text-violet" />
+        <div className="flex-1 truncate text-[15px] font-bold text-foreground">{task.name || task.id}</div>
+        <StatusPill enabled={task.enabled} />
+      </div>
+      <DetailField label={t('harness.detail.schedule')}>
+        <span className="font-mono text-[12px] text-foreground">
+          {task.cron ?? task.run_at ?? task.schedule_type ?? '—'}
+        </span>
+        {task.timezone && <span className="ml-2 text-[10px] text-muted">{task.timezone}</span>}
+      </DetailField>
+      <DetailField label={t('harness.detail.agent')}>
+        <span className="text-[12px] text-foreground">{task.agent_name || '—'}</span>
+      </DetailField>
+      <DetailField label={t('harness.detail.message')}>
+        <pre className="max-h-44 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-3 p-2 font-mono text-[11px] text-foreground">
+          {task.message || task.prompt || '—'}
+        </pre>
+      </DetailField>
+      {task.last_run_at && (
+        <DetailField label={t('harness.detail.lastRun')}>
+          <span className="font-mono text-[11px] text-muted">{task.last_run_at}</span>
+          {task.last_error && (
+            <div className="mt-1 rounded-md border border-destructive/40 bg-destructive/[0.06] px-2 py-1 text-[11px] text-destructive">
+              {task.last_error}
+            </div>
+          )}
+        </DetailField>
+      )}
+      <DetailField label={t('harness.detail.id')}>
+        <code className="font-mono text-[11px] text-muted">{task.id}</code>
+      </DetailField>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Watches tab
+// ---------------------------------------------------------------------------
+
+interface WatchesListProps {
+  watches: HarnessWatch[];
+  loading: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+const WatchesList: React.FC<WatchesListProps> = ({ watches, loading, selectedId, onSelect }) => {
+  const { t } = useTranslation();
+  if (watches.length === 0 && !loading) return <EmptyState i18nKey="harness.emptyWatches" />;
+  return (
+    <>
+      {watches.map((watch) => {
+        const active = selectedId === watch.id;
+        const cmd = watch.shell_command || (Array.isArray(watch.command) ? watch.command.join(' ') : '') || '—';
+        return (
+          <button
+            key={watch.id}
+            type="button"
+            onClick={() => onSelect(watch.id)}
+            className={clsx(
+              'flex items-center gap-3 rounded-lg border px-4 py-3 text-left transition',
+              active ? 'border-violet/40 bg-violet/[0.05]' : 'border-border bg-surface hover:bg-foreground/[0.03]',
+            )}
+          >
+            <div className="flex flex-1 flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <span className="text-[14px] font-semibold text-foreground">{watch.name || watch.id}</span>
+                {watch.runtime.running ? (
+                  <span className="inline-flex items-center gap-1 rounded-full border border-mint/30 bg-mint/[0.08] px-2 py-0 font-mono text-[9px] font-bold text-mint">
+                    <span className="size-1.5 rounded-full bg-mint" />
+                    RUNNING
+                  </span>
+                ) : !watch.enabled ? (
+                  <span className="inline-flex items-center gap-1 rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] text-muted">
+                    <PauseCircle className="size-2.5" />
+                    PAUSED
+                  </span>
+                ) : (
+                  <span className="rounded border border-border-strong bg-foreground/[0.04] px-1.5 py-0 font-mono text-[9px] text-muted">
+                    IDLE
+                  </span>
+                )}
+              </div>
+              <div className="truncate font-mono text-[11px] text-muted">{cmd}</div>
+            </div>
+            {watch.last_event_at && (
+              <span className="font-mono text-[10px] text-muted">{formatRelative(watch.last_event_at)}</span>
+            )}
+          </button>
+        );
+      })}
+      {watches.length === 0 && loading && <div className="px-4 py-6 text-[12px] text-muted">{t('common.loading')}</div>}
+    </>
+  );
+};
+
+interface WatchDetailProps {
+  watch: HarnessWatch;
+}
+
+const WatchDetail: React.FC<WatchDetailProps> = ({ watch }) => {
+  const { t } = useTranslation();
+  const cmd = watch.shell_command || (Array.isArray(watch.command) ? watch.command.join(' ') : '') || '—';
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Eye className="size-4 text-violet" />
+        <div className="flex-1 truncate text-[15px] font-bold text-foreground">{watch.name || watch.id}</div>
+        <StatusPill enabled={watch.enabled} runtimeRunning={watch.runtime.running} />
+      </div>
+      <DetailField label={t('harness.detail.command')}>
+        <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-3 p-2 font-mono text-[11px] text-foreground">
+          {cmd}
+        </pre>
+      </DetailField>
+      <DetailField label={t('harness.detail.agent')}>
+        <span className="text-[12px] text-foreground">{watch.agent_name || '—'}</span>
+      </DetailField>
+      <DetailField label={t('harness.detail.cwd')}>
+        <code className="font-mono text-[11px] text-muted">{watch.cwd || '—'}</code>
+      </DetailField>
+      <DetailField label={t('harness.detail.mode')}>
+        <span className="font-mono text-[11px] text-muted">{watch.mode}</span>
+      </DetailField>
+      <DetailField label={t('harness.detail.followUp')}>
+        <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-3 p-2 font-mono text-[11px] text-foreground">
+          {watch.message || watch.prefix || '—'}
+        </pre>
+      </DetailField>
+      {watch.runtime.running && watch.runtime.pid != null && (
+        <DetailField label={t('harness.detail.runtime')}>
+          <span className="font-mono text-[11px] text-muted">
+            pid {watch.runtime.pid} · started {watch.runtime.started_at}
+          </span>
+        </DetailField>
+      )}
+      {watch.last_error && (
+        <DetailField label={t('harness.detail.lastError')}>
+          <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-2 py-1 text-[11px] text-destructive">
+            {watch.last_error}
+          </div>
+        </DetailField>
+      )}
+      <DetailField label={t('harness.detail.id')}>
+        <code className="font-mono text-[11px] text-muted">{watch.id}</code>
+      </DetailField>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Webhooks tab — coming soon
+// ---------------------------------------------------------------------------
+
+const WebhooksEmpty: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border bg-surface px-6 py-16 text-center">
+      <Webhook className="size-8 text-muted" />
+      <div className="text-[14px] font-semibold text-foreground">{t('harness.webhooksSoon')}</div>
+      <div className="max-w-md text-[12px] text-muted">{t('harness.webhooksSoonBody')}</div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Runs tab
+// ---------------------------------------------------------------------------
+
+interface RunsListProps {
+  runs: HarnessRun[];
+  loading: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  page: number;
+  hasMore: boolean;
+  onPageChange: (page: number) => void;
+}
+
+const RunsList: React.FC<RunsListProps> = ({ runs, loading, selectedId, onSelect, page, hasMore, onPageChange }) => {
+  const { t } = useTranslation();
+  if (runs.length === 0 && !loading) return <EmptyState i18nKey="harness.emptyRuns" />;
+  return (
+    <>
+      {runs.map((run) => {
+        const active = selectedId === run.id;
+        return (
+          <button
+            key={run.id}
+            type="button"
+            onClick={() => onSelect(run.id)}
+            className={clsx(
+              'flex items-center gap-3 rounded-lg border px-4 py-3 text-left transition',
+              active ? 'border-violet/40 bg-violet/[0.05]' : 'border-border bg-surface hover:bg-foreground/[0.03]',
+            )}
+          >
+            <RunStatusIcon status={run.status} />
+            <div className="flex flex-1 flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-[12px] font-semibold text-foreground">{run.id}</span>
+                <span className="rounded border border-border-strong bg-foreground/[0.04] px-1.5 py-0 font-mono text-[9px] text-muted">
+                  {run.run_type || 'run'}
+                </span>
+              </div>
+              <div className="flex items-center gap-3 text-[11px] text-muted">
+                <span>{run.agent_name || '—'}</span>
+                {run.created_at && <span>· {formatRelative(run.created_at)}</span>}
+              </div>
+            </div>
+          </button>
+        );
+      })}
+      {(page > 1 || hasMore) && (
+        <div className="mt-2 flex items-center justify-end gap-2 px-1">
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => onPageChange(page - 1)}
+            className="rounded border border-border-strong px-2 py-1 font-mono text-[10px] text-muted hover:text-foreground disabled:opacity-40"
+          >
+            {t('common.previous')}
+          </button>
+          <span className="font-mono text-[10px] text-muted">{t('harness.pageLabel', { page })}</span>
+          <button
+            type="button"
+            disabled={!hasMore}
+            onClick={() => onPageChange(page + 1)}
+            className="rounded border border-border-strong px-2 py-1 font-mono text-[10px] text-muted hover:text-foreground disabled:opacity-40"
+          >
+            {t('common.next')}
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+interface RunDetailProps {
+  run: HarnessRun;
+}
+
+const RunDetail: React.FC<RunDetailProps> = ({ run }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <RunStatusIcon status={run.status} />
+        <code className="flex-1 truncate font-mono text-[13px] font-bold text-foreground">{run.id}</code>
+        <span
+          className={clsx(
+            'rounded border px-2 py-0 font-mono text-[9px] font-bold uppercase',
+            STATUS_PILL_CLASS[run.status as HarnessRunStatus] ?? 'border-border-strong bg-foreground/[0.04] text-muted',
+          )}
+        >
+          {run.status}
+        </span>
+      </div>
+      <DetailField label={t('harness.detail.type')}>
+        <span className="font-mono text-[11px] text-muted">{run.run_type || run.request_type || '—'}</span>
+      </DetailField>
+      <DetailField label={t('harness.detail.agent')}>
+        <span className="text-[12px] text-foreground">{run.agent_name || '—'}</span>
+        {run.agent_backend && <span className="ml-2 font-mono text-[10px] text-muted">{run.agent_backend}</span>}
+        {run.model && <span className="ml-2 font-mono text-[10px] text-muted">{run.model}</span>}
+      </DetailField>
+      {run.definition_id && (
+        <DetailField label={t('harness.detail.definition')}>
+          <code className="font-mono text-[11px] text-muted">{run.definition_id}</code>
+        </DetailField>
+      )}
+      {(run.message || run.prompt) && (
+        <DetailField label={t('harness.detail.message')}>
+          <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-3 p-2 font-mono text-[11px] text-foreground">
+            {run.message || run.prompt}
+          </pre>
+        </DetailField>
+      )}
+      {run.result_text && (
+        <DetailField label={t('harness.detail.result')}>
+          <pre className="max-h-44 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-3 p-2 font-mono text-[11px] text-foreground">
+            {run.result_text}
+          </pre>
+        </DetailField>
+      )}
+      {run.error && (
+        <DetailField label={t('harness.detail.error')}>
+          <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-destructive/40 bg-destructive/[0.06] p-2 font-mono text-[11px] text-destructive">
+            {run.error}
+          </pre>
+        </DetailField>
+      )}
+      {run.stdout && (
+        <DetailField label="stdout">
+          <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-3 p-2 font-mono text-[10px] text-foreground">
+            {run.stdout}
+          </pre>
+        </DetailField>
+      )}
+      {run.stderr && (
+        <DetailField label="stderr">
+          <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-3 p-2 font-mono text-[10px] text-foreground">
+            {run.stderr}
+          </pre>
+        </DetailField>
+      )}
+      <DetailField label={t('harness.detail.timing')}>
+        <div className="flex flex-col gap-0.5 font-mono text-[10px] text-muted">
+          <span>created {run.created_at ?? '—'}</span>
+          {run.started_at && <span>started {run.started_at}</span>}
+          {run.completed_at && <span>completed {run.completed_at}</span>}
+          {run.exit_code != null && <span>exit_code {run.exit_code}</span>}
+          {run.pid != null && <span>pid {run.pid}</span>}
+        </div>
+      </DetailField>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_PILL_CLASS: Record<HarnessRunStatus, string> = {
+  queued: 'border-cyan/30 bg-cyan/[0.08] text-cyan',
+  running: 'border-violet/30 bg-violet/[0.08] text-violet',
+  succeeded: 'border-mint/30 bg-mint/[0.08] text-mint',
+  failed: 'border-pink/30 bg-pink/[0.08] text-pink',
+  canceled: 'border-border-strong bg-foreground/[0.04] text-muted',
+};
+
+const RunStatusIcon: React.FC<{ status: HarnessRunStatus }> = ({ status }) => {
+  const cls = 'size-4 shrink-0';
+  if (status === 'succeeded') return <CheckCircle2 className={clsx(cls, 'text-mint')} />;
+  if (status === 'failed') return <XCircle className={clsx(cls, 'text-pink')} />;
+  if (status === 'running') return <Loader2 className={clsx(cls, 'animate-spin text-violet')} />;
+  if (status === 'queued') return <Clock className={clsx(cls, 'text-cyan')} />;
+  if (status === 'canceled') return <AlertTriangle className={clsx(cls, 'text-muted')} />;
+  return <Activity className={clsx(cls, 'text-muted')} />;
+};
+
+interface StatusPillProps {
+  enabled: boolean;
+  runtimeRunning?: boolean;
+}
+
+const StatusPill: React.FC<StatusPillProps> = ({ enabled, runtimeRunning }) => {
+  if (runtimeRunning) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-mint/30 bg-mint/[0.08] px-2 py-0 font-mono text-[9px] font-bold text-mint">
+        <span className="size-1.5 rounded-full bg-mint" />
+        RUNNING
+      </span>
+    );
+  }
+  if (!enabled) {
+    return (
+      <span className="rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] text-muted">
+        DISABLED
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] text-muted">
+      ENABLED
+    </span>
+  );
+};
+
+interface DetailFieldProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+const DetailField: React.FC<DetailFieldProps> = ({ label, children }) => (
+  <div className="flex flex-col gap-1.5">
+    <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">{label}</div>
+    <div>{children}</div>
+  </div>
 );
+
+const EmptyState: React.FC<{ i18nKey: string }> = ({ i18nKey }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border bg-surface px-6 py-12 text-center">
+      <Activity className="size-6 text-muted" />
+      <div className="text-[13px] text-muted">{t(i18nKey)}</div>
+    </div>
+  );
+};
+
+function formatRelative(value: string | null | undefined): string {
+  if (!value) return '—';
+  const dt = new Date(value);
+  if (Number.isNaN(dt.valueOf())) return value;
+  const diffMs = Date.now() - dt.valueOf();
+  const secs = Math.round(diffMs / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return dt.toISOString().slice(0, 10);
+}

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -23,6 +23,7 @@ import type {
   HarnessTask,
   HarnessWatch,
 } from '../../context/ApiContext';
+import { formatRelativeTime } from '../../lib/relativeTime';
 
 type TabKey = 'tasks' | 'watches' | 'webhooks' | 'runs';
 
@@ -279,8 +280,8 @@ const TasksList: React.FC<TasksListProps> = ({ tasks, loading, selectedId, onSel
               <div className="flex items-center gap-2">
                 <span className="text-[14px] font-semibold text-foreground">{task.name || task.id}</span>
                 {!task.enabled && (
-                  <span className="rounded border border-border-strong bg-foreground/[0.04] px-1.5 py-0 font-mono text-[9px] text-muted">
-                    DISABLED
+                  <span className="rounded border border-border-strong bg-foreground/[0.04] px-1.5 py-0 font-mono text-[9px] uppercase text-muted">
+                    {t('harness.runtime.disabled')}
                   </span>
                 )}
               </div>
@@ -293,7 +294,7 @@ const TasksList: React.FC<TasksListProps> = ({ tasks, loading, selectedId, onSel
               </div>
             </div>
             {task.last_run_at && (
-              <span className="font-mono text-[10px] text-muted">{formatRelative(task.last_run_at)}</span>
+              <span className="font-mono text-[10px] text-muted">{formatRelativeTime(task.last_run_at, t)}</span>
             )}
           </button>
         );
@@ -379,25 +380,25 @@ const WatchesList: React.FC<WatchesListProps> = ({ watches, loading, selectedId,
               <div className="flex items-center gap-2">
                 <span className="text-[14px] font-semibold text-foreground">{watch.name || watch.id}</span>
                 {watch.runtime.running ? (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-mint/30 bg-mint/[0.08] px-2 py-0 font-mono text-[9px] font-bold text-mint">
+                  <span className="inline-flex items-center gap-1 rounded-full border border-mint/30 bg-mint/[0.08] px-2 py-0 font-mono text-[9px] font-bold uppercase text-mint">
                     <span className="size-1.5 rounded-full bg-mint" />
-                    RUNNING
+                    {t('harness.runtime.running')}
                   </span>
                 ) : !watch.enabled ? (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] text-muted">
+                  <span className="inline-flex items-center gap-1 rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] uppercase text-muted">
                     <PauseCircle className="size-2.5" />
-                    PAUSED
+                    {t('harness.runtime.paused')}
                   </span>
                 ) : (
-                  <span className="rounded border border-border-strong bg-foreground/[0.04] px-1.5 py-0 font-mono text-[9px] text-muted">
-                    IDLE
+                  <span className="rounded border border-border-strong bg-foreground/[0.04] px-1.5 py-0 font-mono text-[9px] uppercase text-muted">
+                    {t('harness.runtime.idle')}
                   </span>
                 )}
               </div>
               <div className="truncate font-mono text-[11px] text-muted">{cmd}</div>
             </div>
             {watch.last_event_at && (
-              <span className="font-mono text-[10px] text-muted">{formatRelative(watch.last_event_at)}</span>
+              <span className="font-mono text-[10px] text-muted">{formatRelativeTime(watch.last_event_at, t)}</span>
             )}
           </button>
         );
@@ -517,7 +518,7 @@ const RunsList: React.FC<RunsListProps> = ({ runs, loading, selectedId, onSelect
               </div>
               <div className="flex items-center gap-3 text-[11px] text-muted">
                 <span>{run.agent_name || '—'}</span>
-                {run.created_at && <span>· {formatRelative(run.created_at)}</span>}
+                {run.created_at && <span>· {formatRelativeTime(run.created_at, t)}</span>}
               </div>
             </div>
           </button>
@@ -657,24 +658,25 @@ interface StatusPillProps {
 }
 
 const StatusPill: React.FC<StatusPillProps> = ({ enabled, runtimeRunning }) => {
+  const { t } = useTranslation();
   if (runtimeRunning) {
     return (
-      <span className="inline-flex items-center gap-1 rounded-full border border-mint/30 bg-mint/[0.08] px-2 py-0 font-mono text-[9px] font-bold text-mint">
+      <span className="inline-flex items-center gap-1 rounded-full border border-mint/30 bg-mint/[0.08] px-2 py-0 font-mono text-[9px] font-bold uppercase text-mint">
         <span className="size-1.5 rounded-full bg-mint" />
-        RUNNING
+        {t('harness.runtime.running')}
       </span>
     );
   }
   if (!enabled) {
     return (
-      <span className="rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] text-muted">
-        DISABLED
+      <span className="rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] uppercase text-muted">
+        {t('harness.runtime.disabled')}
       </span>
     );
   }
   return (
-    <span className="rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] text-muted">
-      ENABLED
+    <span className="rounded-full border border-border-strong bg-foreground/[0.04] px-2 py-0 font-mono text-[9px] uppercase text-muted">
+      {t('harness.runtime.enabled')}
     </span>
   );
 };
@@ -701,18 +703,3 @@ const EmptyState: React.FC<{ i18nKey: string }> = ({ i18nKey }) => {
   );
 };
 
-function formatRelative(value: string | null | undefined): string {
-  if (!value) return '—';
-  const dt = new Date(value);
-  if (Number.isNaN(dt.valueOf())) return value;
-  const diffMs = Date.now() - dt.valueOf();
-  const secs = Math.round(diffMs / 1000);
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.round(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.round(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return dt.toISOString().slice(0, 10);
-}

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -1,0 +1,6 @@
+import { Inbox } from 'lucide-react';
+import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+
+export const InboxPage: React.FC = () => (
+  <WorkbenchModulePlaceholder icon={<Inbox className="size-6" />} i18nPrefix="workbench.modules.inbox" />
+);

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -32,11 +32,11 @@ export const InboxPage: React.FC = () => {
   }, [filter, recentMessages]);
 
   const onRowOpen = (message: WorkbenchMessage) => {
-    // Per-session chat route lands in commit 12. For now we stay on the
-    // inbox and just mark the message read so the unread state stops
-    // pestering the user.
     if (message.session_id && !message.read_at) {
       markRead(message.session_id);
+    }
+    if (message.session_id) {
+      navigate(`/chat/${encodeURIComponent(message.session_id)}`);
     }
   };
 

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -6,17 +6,7 @@ import clsx from 'clsx';
 
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { WorkbenchMessage } from '../../context/ApiContext';
-
-function formatRelativeTime(iso: string): string {
-  if (!iso) return '';
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const diff = (Date.now() - then) / 1000;
-  if (diff < 60) return 'just now';
-  if (diff < 3600) return `${Math.floor(diff / 60)} min ago`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)} h ago`;
-  return `${Math.floor(diff / 86400)} d ago`;
-}
+import { formatRelativeTime } from '../../lib/relativeTime';
 
 type FilterMode = 'unread' | 'all';
 
@@ -157,7 +147,7 @@ export const InboxPage: React.FC = () => {
                   <span className="flex-1 truncate text-[13px] font-semibold text-foreground">
                     {sessionLabel}
                   </span>
-                  <span className="font-mono text-muted">{formatRelativeTime(m.created_at)}</span>
+                  <span className="font-mono text-muted">{formatRelativeTime(m.created_at, t)}</span>
                 </div>
 
                 <div className="flex flex-col gap-1">

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -1,6 +1,213 @@
-import { Inbox } from 'lucide-react';
-import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { ArrowRight, CheckCheck, Filter, Inbox, MessageSquareReply, RefreshCw } from 'lucide-react';
+import clsx from 'clsx';
 
-export const InboxPage: React.FC = () => (
-  <WorkbenchModulePlaceholder icon={<Inbox className="size-6" />} i18nPrefix="workbench.modules.inbox" />
-);
+import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
+import type { WorkbenchMessage } from '../../context/ApiContext';
+
+function formatRelativeTime(iso: string): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diff = (Date.now() - then) / 1000;
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)} min ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)} h ago`;
+  return `${Math.floor(diff / 86400)} d ago`;
+}
+
+type FilterMode = 'unread' | 'all';
+
+export const InboxPage: React.FC = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { recentMessages, totalUnread, refresh, markRead, loading } = useWorkbenchInbox();
+  const [filter, setFilter] = useState<FilterMode>('unread');
+
+  const visible = useMemo(() => {
+    if (filter === 'all') return recentMessages;
+    return recentMessages.filter((m) => m.author === 'agent' && !m.read_at);
+  }, [filter, recentMessages]);
+
+  const onRowOpen = (message: WorkbenchMessage) => {
+    // Per-session chat route lands in commit 12. For now we stay on the
+    // inbox and just mark the message read so the unread state stops
+    // pestering the user.
+    if (message.session_id && !message.read_at) {
+      markRead(message.session_id);
+    }
+  };
+
+  const onMarkAllRead = async () => {
+    const sessionsToMark = new Set<string>();
+    for (const m of recentMessages) {
+      if (m.author === 'agent' && !m.read_at && m.session_id) {
+        sessionsToMark.add(m.session_id);
+      }
+    }
+    await Promise.all(Array.from(sessionsToMark).map((id) => markRead(id)));
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 py-2">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-mint/30 bg-mint/[0.08] text-mint shadow-[0_0_24px_-6px_rgba(91,255,160,0.5)]">
+          <Inbox className="size-5" />
+        </div>
+        <div className="flex flex-1 flex-col">
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-mint">
+            {t('workbench.inbox.eyebrow')}
+          </div>
+          <h1 className="text-2xl font-bold text-foreground">{t('workbench.inbox.title')}</h1>
+          <p className="text-[13px] text-muted">
+            {t('workbench.inbox.headerCount', { unread: totalUnread, total: recentMessages.length })}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refresh()}
+          disabled={loading}
+          className={clsx(
+            'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12px] font-medium transition',
+            loading
+              ? 'cursor-wait border-border bg-foreground/[0.02] text-muted'
+              : 'border-border-strong text-foreground hover:bg-foreground/[0.04]',
+          )}
+        >
+          <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} />
+          {t('workbench.inbox.refresh')}
+        </button>
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex items-center gap-2">
+        <div className="inline-flex items-center gap-1 rounded-lg border border-border-strong bg-surface-2 p-0.5">
+          {([
+            { key: 'unread', label: t('workbench.inbox.filterUnread') },
+            { key: 'all', label: t('workbench.inbox.filterAll') },
+          ] as { key: FilterMode; label: string }[]).map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setFilter(key)}
+              className={clsx(
+                'flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[12px] font-semibold transition',
+                filter === key
+                  ? 'bg-mint/[0.10] text-mint shadow-[0_0_12px_-4px_rgba(91,255,160,0.5)]'
+                  : 'text-muted hover:text-foreground',
+              )}
+            >
+              <Filter className="size-3" />
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={onMarkAllRead}
+          disabled={totalUnread === 0}
+          className={clsx(
+            'flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12px] font-semibold transition',
+            totalUnread === 0
+              ? 'cursor-not-allowed border-border bg-foreground/[0.02] text-muted'
+              : 'border-mint/30 bg-mint/[0.06] text-mint hover:bg-mint/[0.12]',
+          )}
+        >
+          <CheckCheck className="size-3.5" />
+          {t('workbench.inbox.markAllRead')}
+        </button>
+      </div>
+
+      {/* Empty state */}
+      {visible.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-border bg-surface px-6 py-16 text-center">
+          <CheckCheck className="size-8 text-mint" />
+          <div className="text-[15px] font-semibold text-foreground">
+            {filter === 'unread' ? t('workbench.inbox.allClearTitle') : t('workbench.inbox.emptyTitle')}
+          </div>
+          <div className="max-w-md text-[12.5px] text-muted">
+            {filter === 'unread' ? t('workbench.inbox.allClearBody') : t('workbench.inbox.emptyBody')}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {visible.map((m) => {
+            const unread = m.author === 'agent' && !m.read_at;
+            const projectId = m.scope_id ? m.scope_id.split('::').pop() : null;
+            const sessionLabel = (m.metadata?.session_title as string | undefined) || m.session_id || '—';
+            return (
+              <article
+                key={m.id}
+                className={clsx(
+                  'flex flex-col gap-3 rounded-xl border p-4 transition',
+                  unread
+                    ? 'border-mint/30 bg-mint/[0.05] shadow-[0_0_24px_-12px_rgba(91,255,160,0.4)]'
+                    : 'border-border bg-surface',
+                )}
+              >
+                <div className="flex items-center gap-2 text-[11px]">
+                  <span className="inline-flex items-center gap-1 rounded-md border border-border-strong bg-surface-2 px-2 py-0.5 font-mono font-semibold text-cyan">
+                    {projectId || 'avibe'}
+                  </span>
+                  <span className="text-muted">·</span>
+                  <span className="flex-1 truncate text-[13px] font-semibold text-foreground">
+                    {sessionLabel}
+                  </span>
+                  <span className="font-mono text-muted">{formatRelativeTime(m.created_at)}</span>
+                </div>
+
+                <div className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2 text-[10px]">
+                    <span className={clsx('font-bold uppercase tracking-wider', m.author === 'agent' ? 'text-mint' : 'text-cyan')}>
+                      {m.author === 'agent' ? t('workbench.inbox.agent') : t('workbench.inbox.you')}
+                    </span>
+                  </div>
+                  <p className={clsx('text-[13px] leading-relaxed', unread ? 'text-foreground' : 'text-muted')}>
+                    {m.text || '—'}
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onRowOpen(m)}
+                    className="inline-flex items-center gap-1.5 rounded-md border border-mint/30 bg-mint/[0.06] px-3 py-1.5 text-[11px] font-semibold text-mint transition hover:bg-mint/[0.12]"
+                  >
+                    {t('workbench.inbox.openSession')}
+                    <ArrowRight className="size-3" />
+                  </button>
+                  {unread && (
+                    <button
+                      type="button"
+                      onClick={() => m.session_id && markRead(m.session_id)}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-border-strong px-3 py-1.5 text-[11px] font-medium text-foreground transition hover:bg-foreground/[0.04]"
+                    >
+                      <MessageSquareReply className="size-3" />
+                      {t('workbench.inbox.markRead')}
+                    </button>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Footer placeholder — pagination via before_id arrives once the
+          inbox accrues real volume. */}
+      {visible.length > 0 && (
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          className="self-center text-[11px] text-muted hover:text-foreground"
+        >
+          {t('workbench.inbox.backToCanvas')}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ArrowRight, Bot, X } from 'lucide-react';
+import clsx from 'clsx';
+
+import { useApi } from '../../context/ApiContext';
+import type { VibeAgentFull } from '../../context/ApiContext';
+
+type BackendKey = 'claude' | 'opencode' | 'codex';
+
+interface BackendOption {
+  key: BackendKey;
+  label: string;
+  publisher: string;
+  color: 'mint' | 'cyan' | 'violet';
+}
+
+const BACKEND_OPTIONS: BackendOption[] = [
+  { key: 'claude', label: 'Claude', publisher: 'Anthropic', color: 'mint' },
+  { key: 'opencode', label: 'OpenCode', publisher: 'sst.dev', color: 'cyan' },
+  { key: 'codex', label: 'Codex', publisher: 'OpenAI', color: 'violet' },
+];
+
+const EFFORT_OPTIONS = ['low', 'medium', 'high', 'max'];
+
+interface NewAgentDialogProps {
+  /** When false the modal renders nothing — controlled by the parent. */
+  open: boolean;
+  onClose: () => void;
+  /** Called after a successful POST /agents with the new agent. */
+  onCreated: (agent: VibeAgentFull) => void;
+}
+
+// Mirrors design.pen ``gwn5C``. Single-step form: backend (immutable after
+// create) → name → model + effort → optional system prompt.
+export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, onCreated }) => {
+  const { t } = useTranslation();
+  const api = useApi();
+  const [backend, setBackend] = useState<BackendKey>('claude');
+  const [name, setName] = useState('');
+  const [model, setModel] = useState('');
+  const [effort, setEffort] = useState<string>('medium');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setName('');
+      setModel('');
+      setEffort('medium');
+      setSystemPrompt('');
+      setBackend('claude');
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const canSubmit = name.trim().length > 0 && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const result = await api.createVibeAgent({
+        name: name.trim(),
+        backend,
+        model: model.trim() || null,
+        reasoning_effort: effort,
+        system_prompt: systemPrompt.trim() || null,
+        enabled: true,
+      });
+      if (result.ok) {
+        onCreated(result.agent);
+        onClose();
+      }
+    } catch (err: any) {
+      setError(err?.message ?? String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const colorClasses: Record<BackendOption['color'], { border: string; bg: string; text: string }> = {
+    mint: { border: 'border-mint', bg: 'bg-mint/[0.08]', text: 'text-mint' },
+    cyan: { border: 'border-cyan', bg: 'bg-cyan/[0.08]', text: 'text-cyan' },
+    violet: { border: 'border-violet', bg: 'bg-violet/[0.08]', text: 'text-violet' },
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="flex w-full max-w-[520px] flex-col gap-5 rounded-2xl border border-border-strong bg-surface p-7 shadow-[0_24px_64px_-12px_rgba(0,0,0,0.6)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-[18px] font-bold text-foreground">{t('agents.create.title')}</h2>
+            <p className="mt-1 max-w-[420px] text-[11.5px] leading-relaxed text-muted">
+              {t('agents.create.body')}
+            </p>
+          </div>
+          <button onClick={onClose} className="text-muted hover:text-foreground" aria-label={t('common.close')}>
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {/* Backend picker */}
+        <div className="flex flex-col gap-2">
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+            {t('agents.create.backend')}
+          </div>
+          <div className="grid grid-cols-3 gap-2.5">
+            {BACKEND_OPTIONS.map((opt) => {
+              const active = backend === opt.key;
+              const cc = colorClasses[opt.color];
+              return (
+                <button
+                  key={opt.key}
+                  type="button"
+                  onClick={() => setBackend(opt.key)}
+                  className={clsx(
+                    'flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 px-3 py-3.5 transition',
+                    active ? `${cc.border} ${cc.bg}` : 'border-border-strong bg-surface-2 hover:bg-foreground/[0.04]',
+                  )}
+                >
+                  <div className={clsx('flex size-8 items-center justify-center rounded-lg border', active ? cc.border + ' ' + cc.bg : 'border-border-strong')}>
+                    <Bot className={clsx('size-4', active ? cc.text : 'text-muted')} />
+                  </div>
+                  <span className={clsx('text-[12px] font-bold', active ? cc.text : 'text-foreground')}>
+                    {opt.label}
+                  </span>
+                  <span className="text-[10px] text-muted">{opt.publisher}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Name */}
+        <div className="flex flex-col gap-1.5">
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+            {t('agents.create.name')}
+          </div>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && canSubmit) handleSubmit();
+            }}
+            placeholder="slack-triage"
+            className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 font-mono text-[13px] text-foreground outline-none focus:border-cyan"
+          />
+        </div>
+
+        {/* Model + Effort */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex flex-col gap-1.5">
+            <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+              {t('agents.create.model')}
+            </div>
+            <input
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder={t('agents.create.modelPlaceholder')}
+              className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 font-mono text-[12px] text-foreground outline-none focus:border-cyan"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+              {t('agents.create.effort')}
+            </div>
+            <div className="flex rounded-md border border-border-strong bg-surface-2 p-0.5">
+              {EFFORT_OPTIONS.map((opt) => (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => setEffort(opt)}
+                  className={clsx(
+                    'flex-1 rounded text-[11px] font-semibold capitalize transition',
+                    effort === opt ? 'bg-mint/[0.10] text-mint' : 'text-muted hover:text-foreground',
+                  )}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* System prompt */}
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+              {t('agents.create.systemPrompt')}
+            </div>
+            <span className="text-[10px] text-muted">{t('agents.create.systemPromptHint')}</span>
+          </div>
+          <textarea
+            value={systemPrompt}
+            onChange={(e) => setSystemPrompt(e.target.value)}
+            rows={3}
+            placeholder={t('agents.create.systemPromptPlaceholder')}
+            className="rounded-md border border-border-strong bg-surface-3 px-3 py-2 text-[12px] text-foreground outline-none focus:border-cyan"
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border-strong px-4 py-1.5 text-[12px] font-medium text-foreground hover:bg-foreground/[0.04]"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className={clsx(
+              'inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-bold transition',
+              canSubmit
+                ? 'bg-mint text-[#080812] shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
+                : 'cursor-not-allowed bg-muted-soft text-muted',
+            )}
+          >
+            {t('agents.create.submit')}
+            <ArrowRight className="size-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/SkillsPage.tsx
+++ b/ui/src/components/workbench/SkillsPage.tsx
@@ -1,0 +1,6 @@
+import { WandSparkles } from 'lucide-react';
+import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+
+export const SkillsPage: React.FC = () => (
+  <WorkbenchModulePlaceholder icon={<WandSparkles className="size-6" />} i18nPrefix="workbench.modules.skills" />
+);

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -1,0 +1,6 @@
+import { KeyRound } from 'lucide-react';
+import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+
+export const VaultsPage: React.FC = () => (
+  <WorkbenchModulePlaceholder icon={<KeyRound className="size-6" />} i18nPrefix="workbench.modules.vaults" />
+);

--- a/ui/src/components/workbench/WorkbenchModulePlaceholder.tsx
+++ b/ui/src/components/workbench/WorkbenchModulePlaceholder.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface WorkbenchModulePlaceholderProps {
+  icon: ReactNode;
+  /** i18n key prefix (e.g. `workbench.modules.agents`). The component reads
+   *  `${prefix}.title` and `${prefix}.description` plus the shared
+   *  `workbench.modules.comingSoon` hint. */
+  i18nPrefix: string;
+}
+
+// Shared placeholder used by all four capability modules and the inbox
+// landing route while the real pages are staged in by later commits.
+// Keeps the routes resolvable so the sidebar links never 404 and lets the
+// shell layout get exercised end-to-end on day 1.
+export const WorkbenchModulePlaceholder: React.FC<WorkbenchModulePlaceholderProps> = ({
+  icon,
+  i18nPrefix,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-center gap-5 py-16 text-center">
+      <div className="flex size-14 items-center justify-center rounded-2xl border border-mint/30 bg-mint/[0.08] text-mint shadow-[0_0_24px_-6px_rgba(91,255,160,0.5)]">
+        {icon}
+      </div>
+      <div className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-mint">
+        {t(`${i18nPrefix}.eyebrow`, { defaultValue: t('workbench.modules.comingSoonEyebrow') })}
+      </div>
+      <h1 className="text-2xl font-bold text-foreground">{t(`${i18nPrefix}.title`)}</h1>
+      <p className="text-sm leading-relaxed text-muted">{t(`${i18nPrefix}.description`)}</p>
+      <p className="text-[12px] text-muted">{t('workbench.modules.comingSoon')}</p>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -18,6 +18,7 @@ import type { LucideIcon } from 'lucide-react';
 
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { WorkbenchMessage } from '../../context/ApiContext';
+import { formatRelativeTime } from '../../lib/relativeTime';
 
 interface CapabilityNavItem {
   to: string;
@@ -107,7 +108,7 @@ const InboxHoverPopover: React.FC<{
                     {m.metadata?.session_title as string | undefined || m.session_id}
                   </span>
                   <span className="font-mono text-muted">
-                    {formatRelativeTime(m.created_at)}
+                    {formatRelativeTime(m.created_at, t)}
                   </span>
                 </div>
                 <div
@@ -136,18 +137,6 @@ const InboxHoverPopover: React.FC<{
   );
 };
 
-// Render an ISO timestamp as a Slack-ish relative label (2m / 14m / 3h / 1d).
-// Browser-side only; keeps the popover snappy without pulling a date lib.
-function formatRelativeTime(iso: string): string {
-  if (!iso) return '';
-  const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return '';
-  const diff = (Date.now() - then) / 1000;
-  if (diff < 60) return 'now';
-  if (diff < 3600) return `${Math.floor(diff / 60)}m`;
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
-  return `${Math.floor(diff / 86400)}d`;
-}
 
 export const WorkbenchSidebar: React.FC = () => {
   const { t } = useTranslation();

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -1,0 +1,102 @@
+import { useTranslation } from 'react-i18next';
+import { NavLink } from 'react-router-dom';
+import { Activity, Bot, ChevronRight, Folder, Inbox, KeyRound, Plus, WandSparkles } from 'lucide-react';
+import clsx from 'clsx';
+import type { LucideIcon } from 'lucide-react';
+
+interface CapabilityNavItem {
+  to: string;
+  i18nKey: string;
+  icon: LucideIcon;
+}
+
+// Order mirrors design.pen DnkGJ — capability modules below the global
+// inbox entry, projects beneath that.
+const CAPABILITY_NAV: CapabilityNavItem[] = [
+  { to: '/agents', i18nKey: 'workbench.nav.agents', icon: Bot },
+  { to: '/skills', i18nKey: 'workbench.nav.skills', icon: WandSparkles },
+  { to: '/harness', i18nKey: 'workbench.nav.harness', icon: Activity },
+  { to: '/vaults', i18nKey: 'workbench.nav.vaults', icon: KeyRound },
+];
+
+// Inbox + 4 capabilities + Projects header for the workbench-mode sidebar
+// middle. Brand and bottom controls live in AppShell so the chrome stays
+// consistent across modes. Project data and the Inbox hover popover are
+// staged in by later commits — commit 02 only ships the entries themselves.
+export const WorkbenchSidebar: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <NavLink
+        to="/inbox"
+        className={({ isActive }) =>
+          clsx(
+            'group flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-[13px] font-semibold transition-colors',
+            isActive
+              ? 'border-mint/30 bg-mint/[0.08] text-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]'
+              : 'border-border-strong text-foreground hover:bg-foreground/[0.04]'
+          )
+        }
+      >
+        {({ isActive }) => (
+          <>
+            <Inbox className={clsx('size-4', isActive ? 'text-mint' : 'text-foreground')} />
+            <span className="flex-1">{t('workbench.nav.inbox')}</span>
+            <ChevronRight className="size-3.5 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
+          </>
+        )}
+      </NavLink>
+
+      <div className="flex flex-col gap-2">
+        <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
+          {t('workbench.capabilitiesLabel')}
+        </div>
+        <nav className="flex flex-col gap-0.5">
+          {CAPABILITY_NAV.map(({ to, i18nKey, icon: Icon }) => (
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) =>
+                clsx(
+                  'group flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors',
+                  isActive
+                    ? 'border border-mint/30 bg-mint/[0.08] text-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]'
+                    : 'border border-transparent text-muted hover:bg-foreground/[0.04] hover:text-foreground'
+                )
+              }
+            >
+              {({ isActive }) => (
+                <>
+                  <Icon className={clsx('size-4', isActive ? 'text-mint' : 'text-muted group-hover:text-foreground')} />
+                  <span>{t(i18nKey)}</span>
+                </>
+              )}
+            </NavLink>
+          ))}
+        </nav>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between px-1">
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
+            {t('workbench.projectsLabel')}
+          </div>
+          <button
+            type="button"
+            aria-label={t('workbench.addProject')}
+            className="flex size-5 items-center justify-center rounded-md border border-border-strong text-foreground transition hover:bg-foreground/[0.04]"
+            // Wired up in commit 05 (projects REST + folder picker).
+            disabled
+          >
+            <Plus className="size-3" />
+          </button>
+        </div>
+        <div className="flex flex-col items-center gap-1.5 rounded-lg border border-dashed border-border px-3 py-4 text-center">
+          <Folder className="size-4 text-muted" />
+          <div className="text-[11px] text-muted">{t('workbench.projectsEmpty')}</div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -183,11 +183,11 @@ export const WorkbenchSidebar: React.FC = () => {
 
   const onItemClick = (message: WorkbenchMessage) => {
     setPopoverOpen(false);
-    // Chat-per-session route lands in commit 12; for now we send the user
-    // to the full inbox so the click goes somewhere meaningful.
-    navigate('/inbox');
-    if (message.session_id && !message.read_at) {
-      markRead(message.session_id);
+    if (message.session_id) {
+      navigate(`/chat/${encodeURIComponent(message.session_id)}`);
+      if (!message.read_at) markRead(message.session_id);
+    } else {
+      navigate('/inbox');
     }
   };
 

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -1,8 +1,23 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router-dom';
-import { Activity, Bot, ChevronRight, Folder, Inbox, KeyRound, Plus, WandSparkles } from 'lucide-react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import {
+  Activity,
+  ArrowRight,
+  Bot,
+  CheckCheck,
+  ChevronRight,
+  Folder,
+  Inbox,
+  KeyRound,
+  Plus,
+  WandSparkles,
+} from 'lucide-react';
 import clsx from 'clsx';
 import type { LucideIcon } from 'lucide-react';
+
+import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
+import type { WorkbenchMessage } from '../../context/ApiContext';
 
 interface CapabilityNavItem {
   to: string;
@@ -10,8 +25,6 @@ interface CapabilityNavItem {
   icon: LucideIcon;
 }
 
-// Order mirrors design.pen DnkGJ — capability modules below the global
-// inbox entry, projects beneath that.
 const CAPABILITY_NAV: CapabilityNavItem[] = [
   { to: '/agents', i18nKey: 'workbench.nav.agents', icon: Bot },
   { to: '/skills', i18nKey: 'workbench.nav.skills', icon: WandSparkles },
@@ -19,34 +32,227 @@ const CAPABILITY_NAV: CapabilityNavItem[] = [
   { to: '/vaults', i18nKey: 'workbench.nav.vaults', icon: KeyRound },
 ];
 
-// Inbox + 4 capabilities + Projects header for the workbench-mode sidebar
-// middle. Brand and bottom controls live in AppShell so the chrome stays
-// consistent across modes. Project data and the Inbox hover popover are
-// staged in by later commits — commit 02 only ships the entries themselves.
+// 360px floating popover that opens when the user hovers the Inbox entry.
+// Mirrors design.pen KmQ1L — header + a few rows + footer "open full inbox"
+// link. Pure presentational; data comes from <WorkbenchInboxProvider>.
+const InboxHoverPopover: React.FC<{
+  visible: boolean;
+  messages: WorkbenchMessage[];
+  totalUnread: number;
+  onItemClick: (message: WorkbenchMessage) => void;
+  onMarkAllRead: () => void;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}> = ({ visible, messages, totalUnread, onItemClick, onMarkAllRead, onMouseEnter, onMouseLeave }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  if (!visible) return null;
+  const shown = messages.slice(0, 5);
+  const isUnread = (m: WorkbenchMessage) => m.author === 'agent' && !m.read_at;
+  return (
+    <div
+      role="dialog"
+      aria-label={t('workbench.inbox.title')}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      className="absolute left-full top-0 z-50 ml-3 flex w-[360px] flex-col gap-2.5 rounded-2xl border border-border-strong bg-surface-2 p-3.5 shadow-[0_24px_64px_-12px_rgba(0,0,0,0.6)]"
+    >
+      <div className="flex items-start gap-2">
+        <div className="flex flex-1 flex-col">
+          <div className="text-[13px] font-bold text-foreground">{t('workbench.inbox.title')}</div>
+          <div className="text-[10px] text-muted">
+            {t('workbench.inbox.headerCount', { unread: totalUnread, total: messages.length })}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onMarkAllRead}
+          disabled={totalUnread === 0}
+          className={clsx(
+            'rounded-md border px-2 py-1 text-[10px] font-medium transition',
+            totalUnread === 0
+              ? 'cursor-not-allowed border-border bg-foreground/[0.02] text-muted'
+              : 'border-border-strong text-foreground hover:bg-foreground/[0.04]',
+          )}
+        >
+          {t('workbench.inbox.markAllRead')}
+        </button>
+      </div>
+
+      {shown.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border px-3 py-6 text-center text-[12px] text-muted">
+          {t('workbench.inbox.empty')}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {shown.map((m) => {
+            const unread = isUnread(m);
+            const projectId = m.scope_id ? m.scope_id.split('::').pop() : null;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => onItemClick(m)}
+                className={clsx(
+                  'flex flex-col gap-1.5 rounded-lg px-3 py-2.5 text-left transition',
+                  unread
+                    ? 'border-l-2 border-mint bg-mint/[0.06] hover:bg-mint/[0.10]'
+                    : 'hover:bg-foreground/[0.04]',
+                )}
+              >
+                <div className="flex items-center gap-1.5 text-[10px]">
+                  <span className="truncate font-mono font-semibold text-cyan">{projectId || 'avibe'}</span>
+                  <span className="text-muted">·</span>
+                  <span className="flex-1 truncate font-semibold text-foreground">
+                    {m.metadata?.session_title as string | undefined || m.session_id}
+                  </span>
+                  <span className="font-mono text-muted">
+                    {formatRelativeTime(m.created_at)}
+                  </span>
+                </div>
+                <div
+                  className={clsx(
+                    'line-clamp-2 text-[11.5px] leading-relaxed',
+                    unread ? 'text-foreground' : 'text-muted',
+                  )}
+                >
+                  {m.text || '—'}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => navigate('/inbox')}
+        className="flex items-center justify-center gap-1.5 rounded-md pt-1 text-[11px] font-medium text-cyan hover:underline"
+      >
+        {t('workbench.inbox.viewAll')}
+        <ArrowRight className="size-3" />
+      </button>
+    </div>
+  );
+};
+
+// Render an ISO timestamp as a Slack-ish relative label (2m / 14m / 3h / 1d).
+// Browser-side only; keeps the popover snappy without pulling a date lib.
+function formatRelativeTime(iso: string): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diff = (Date.now() - then) / 1000;
+  if (diff < 60) return 'now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+  return `${Math.floor(diff / 86400)}d`;
+}
+
 export const WorkbenchSidebar: React.FC = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { totalUnread, recentMessages, markRead } = useWorkbenchInbox();
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const closeTimer = useRef<number | null>(null);
+
+  // Small open/close delays so the popover doesn't flicker as the cursor
+  // brushes through the inbox row on its way somewhere else, and survives
+  // the gap between the row and the popover body.
+  const openPopover = () => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setPopoverOpen(true);
+  };
+  const queueClose = () => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+    }
+    closeTimer.current = window.setTimeout(() => {
+      setPopoverOpen(false);
+      closeTimer.current = null;
+    }, 180);
+  };
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+    };
+  }, []);
+
+  const onItemClick = (message: WorkbenchMessage) => {
+    setPopoverOpen(false);
+    // Chat-per-session route lands in commit 12; for now we send the user
+    // to the full inbox so the click goes somewhere meaningful.
+    navigate('/inbox');
+    if (message.session_id && !message.read_at) {
+      markRead(message.session_id);
+    }
+  };
+
+  const onMarkAllRead = async () => {
+    // Mark every session with at least one unread agent message as read.
+    // Cheaper than a dedicated endpoint for now since we already know the
+    // candidate session ids from recentMessages.
+    const sessionsToMark = new Set<string>();
+    for (const m of recentMessages) {
+      if (m.author === 'agent' && !m.read_at && m.session_id) {
+        sessionsToMark.add(m.session_id);
+      }
+    }
+    await Promise.all(Array.from(sessionsToMark).map((id) => markRead(id)));
+  };
+
+  const badge = useMemo(() => {
+    if (totalUnread <= 0) return null;
+    return totalUnread > 99 ? '99+' : String(totalUnread);
+  }, [totalUnread]);
 
   return (
     <div className="flex flex-col gap-4">
-      <NavLink
-        to="/inbox"
-        className={({ isActive }) =>
-          clsx(
-            'group flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-[13px] font-semibold transition-colors',
-            isActive
-              ? 'border-mint/30 bg-mint/[0.08] text-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]'
-              : 'border-border-strong text-foreground hover:bg-foreground/[0.04]'
-          )
-        }
+      {/* Inbox entry — hover opens the floating popover. The wrapper element
+          owns the group's hover state so moving from the row into the popover
+          stays inside the open zone. */}
+      <div
+        className="relative"
+        onMouseEnter={openPopover}
+        onMouseLeave={queueClose}
       >
-        {({ isActive }) => (
-          <>
-            <Inbox className={clsx('size-4', isActive ? 'text-mint' : 'text-foreground')} />
-            <span className="flex-1">{t('workbench.nav.inbox')}</span>
-            <ChevronRight className="size-3.5 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
-          </>
-        )}
-      </NavLink>
+        <NavLink
+          to="/inbox"
+          className={({ isActive }) =>
+            clsx(
+              'group flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-[13px] font-semibold transition-colors',
+              isActive
+                ? 'border-mint/30 bg-mint/[0.08] text-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]'
+                : 'border-border-strong text-foreground hover:bg-foreground/[0.04]',
+            )
+          }
+        >
+          {({ isActive }) => (
+            <>
+              <Inbox className={clsx('size-4', isActive ? 'text-mint' : 'text-foreground')} />
+              <span className="flex-1">{t('workbench.nav.inbox')}</span>
+              {badge && (
+                <span className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-mint px-1.5 py-0.5 font-mono text-[9px] font-bold text-[#080812] shadow-[0_0_10px_-2px_rgba(91,255,160,0.7)]">
+                  {badge}
+                </span>
+              )}
+              <ChevronRight className="size-3.5 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
+            </>
+          )}
+        </NavLink>
+        <InboxHoverPopover
+          visible={popoverOpen}
+          messages={recentMessages}
+          totalUnread={totalUnread}
+          onItemClick={onItemClick}
+          onMarkAllRead={onMarkAllRead}
+          onMouseEnter={openPopover}
+          onMouseLeave={queueClose}
+        />
+      </div>
 
       <div className="flex flex-col gap-2">
         <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
@@ -62,7 +268,7 @@ export const WorkbenchSidebar: React.FC = () => {
                   'group flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors',
                   isActive
                     ? 'border border-mint/30 bg-mint/[0.08] text-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]'
-                    : 'border border-transparent text-muted hover:bg-foreground/[0.04] hover:text-foreground'
+                    : 'border border-transparent text-muted hover:bg-foreground/[0.04] hover:text-foreground',
                 )
               }
             >
@@ -86,7 +292,6 @@ export const WorkbenchSidebar: React.FC = () => {
             type="button"
             aria-label={t('workbench.addProject')}
             className="flex size-5 items-center justify-center rounded-md border border-border-strong text-foreground transition hover:bg-foreground/[0.04]"
-            // Wired up in commit 05 (projects REST + folder picker).
             disabled
           >
             <Plus className="size-3" />
@@ -100,3 +305,9 @@ export const WorkbenchSidebar: React.FC = () => {
     </div>
   );
 };
+
+// Re-export for tests / future inbox-specific UIs.
+export { InboxHoverPopover };
+// Silence the import that exists only for the un-used CheckCheck icon —
+// it'll be wired into the full Inbox view in commit 09 too.
+void CheckCheck;

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -112,6 +112,10 @@ export type ApiContextType = {
   updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   setDefaultVibeAgent: (name: string) => Promise<{ ok: boolean; default_agent_name: string; agent: VibeAgentBrief }>;
   removeVibeAgent: (name: string) => Promise<{ ok: boolean; code?: string; message?: string; references?: Record<string, number>; removed_agent?: string }>;
+  listHarnessTasks: () => Promise<{ tasks: HarnessTask[] }>;
+  listHarnessWatches: () => Promise<{ watches: HarnessWatch[] }>;
+  listHarnessRuns: (params?: HarnessRunsParams) => Promise<{ runs: HarnessRun[]; page: number; limit: number; has_more: boolean }>;
+  getHarnessRun: (runId: string) => Promise<{ ok: boolean; run: HarnessRun }>;
   remoteAccessStatus: () => Promise<any>;
   pairVibeCloudRemoteAccess: (payload: { backend_url: string; pairing_key: string; device_name?: string }) => Promise<any>;
   startRemoteAccess: () => Promise<any>;
@@ -262,6 +266,125 @@ export type WorkbenchMessage = {
   updated_at: string;
   delivered_at: string | null;
   read_at: string | null;
+};
+
+// =============================================================================
+// Harness (scheduled tasks / watches / runs)
+// =============================================================================
+
+export type HarnessTask = {
+  id: string;
+  name: string | null;
+  agent_name: string | null;
+  session_policy: string | null;
+  session_id: string | null;
+  session_key: string;
+  prompt: string;
+  message: string;
+  message_payload: Record<string, unknown> | null;
+  schedule_type: string;
+  cron: string | null;
+  run_at: string | null;
+  timezone: string;
+  post_to: string | null;
+  deliver_key: string | null;
+  enabled: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+  last_run_at: string | null;
+  last_run_id: string | null;
+  last_error: string | null;
+};
+
+export type HarnessWatchRuntime = {
+  running: boolean;
+  pid?: number | null;
+  started_at?: string | null;
+  updated_at?: string | null;
+};
+
+export type HarnessWatch = {
+  id: string;
+  name: string | null;
+  agent_name: string | null;
+  session_policy: string | null;
+  session_id: string | null;
+  session_key: string;
+  command: unknown[];
+  shell_command: string | null;
+  prefix: string | null;
+  message: string | null;
+  message_payload: Record<string, unknown> | null;
+  cwd: string | null;
+  mode: string;
+  timeout_seconds: number;
+  lifetime_timeout_seconds: number;
+  retry_exit_codes: number[];
+  retry_delay_seconds: number;
+  post_to: string | null;
+  deliver_key: string | null;
+  enabled: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+  last_started_at: string | null;
+  last_finished_at: string | null;
+  last_event_at: string | null;
+  last_error: string | null;
+  last_exit_code: number | null;
+  runtime: HarnessWatchRuntime;
+};
+
+export type HarnessRunStatus = 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled' | (string & {});
+
+export type HarnessRun = {
+  id: string;
+  request_type: string | null;
+  run_type: string | null;
+  status: HarnessRunStatus;
+  definition_id: string | null;
+  task_id: string | null;
+  source_kind: string | null;
+  source_actor: string | null;
+  parent_run_id: string | null;
+  agent_name: string | null;
+  agent_id: string | null;
+  agent_backend: string | null;
+  model: string | null;
+  reasoning_effort: string | null;
+  session_policy: string | null;
+  session_key: string | null;
+  session_id: string | null;
+  post_to: string | null;
+  deliver_key: string | null;
+  prompt: string | null;
+  message: string | null;
+  message_payload: Record<string, unknown> | null;
+  result_text: string | null;
+  result_payload: Record<string, unknown> | null;
+  message_ids: string[];
+  cancel_requested: boolean;
+  cancel_requested_at: string | null;
+  pid: number | null;
+  exit_code: number | null;
+  error: string | null;
+  stdout: string | null;
+  stderr: string | null;
+  created_at: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  updated_at: string | null;
+  metadata: Record<string, unknown>;
+  ok: boolean | null;
+};
+
+export type HarnessRunsParams = {
+  status?: HarnessRunStatus;
+  runType?: string;
+  agentName?: string;
+  definitionId?: string;
+  query?: string;
+  page?: number;
+  limit?: number;
 };
 
 export type SessionInfo =
@@ -854,6 +977,21 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     },
     setDefaultVibeAgent: (name) => postJson('/agents/default', { name }),
     removeVibeAgent: (name) => deleteJson(`/agents/${encodeURIComponent(name)}`),
+    listHarnessTasks: () => getJson('/api/harness/tasks'),
+    listHarnessWatches: () => getJson('/api/harness/watches'),
+    listHarnessRuns: (params) => {
+      const search = new URLSearchParams();
+      if (params?.status) search.set('status', params.status);
+      if (params?.runType) search.set('run_type', params.runType);
+      if (params?.agentName) search.set('agent_name', params.agentName);
+      if (params?.definitionId) search.set('definition_id', params.definitionId);
+      if (params?.query) search.set('query', params.query);
+      if (params?.page) search.set('page', String(params.page));
+      if (params?.limit) search.set('limit', String(params.limit));
+      const qs = search.toString();
+      return getJson(qs ? `/api/harness/runs?${qs}` : '/api/harness/runs');
+    },
+    getHarnessRun: (runId) => getJson(`/api/harness/runs/${encodeURIComponent(runId)}`),
     connectWorkbenchEvents: (handlers) => {
       // EventSource auto-reconnects on transient drops, so callers don't
       // have to implement their own retry. Returns a `disconnect` thunk so

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -106,6 +106,12 @@ export type ApiContextType = {
   markSessionRead: (sessionId: string, untilMessageId?: string) => Promise<{ updated: number; unread_counts: Record<string, number> }>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; beforeId?: string }) => Promise<{ messages: WorkbenchMessage[]; next_before_id: string | null; unread_counts: Record<string, number> }>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
+  listVibeAgents: (params?: { backend?: string; includeDisabled?: boolean }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
+  getVibeAgent: (name: string) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
+  createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
+  updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
+  setDefaultVibeAgent: (name: string) => Promise<{ ok: boolean; default_agent_name: string; agent: VibeAgentBrief }>;
+  removeVibeAgent: (name: string) => Promise<{ ok: boolean; code?: string; message?: string; references?: Record<string, number>; removed_agent?: string }>;
   remoteAccessStatus: () => Promise<any>;
   pairVibeCloudRemoteAccess: (payload: { backend_url: string; pairing_key: string; device_name?: string }) => Promise<any>;
   startRemoteAccess: () => Promise<any>;
@@ -170,6 +176,48 @@ export type WorkbenchSessionUpdate = {
   agent_variant: string;
   model: string | null;
   reasoning_effort: string | null;
+};
+
+// One Vibe Agent row from ``/agents`` (brief view used in list rendering).
+// ``source`` distinguishes system-builtin agents from user-created ones —
+// system agents lock the ``backend`` field and refuse delete, but their
+// model / effort / system_prompt / enabled state are still editable.
+export type VibeAgentBrief = {
+  id: string;
+  name: string;
+  description: string | null;
+  backend: string;
+  model: string | null;
+  reasoning_effort: string | null;
+  enabled: boolean;
+  source: string;
+  updated_at: string;
+};
+
+export type VibeAgentFull = VibeAgentBrief & {
+  system_prompt: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+};
+
+export type VibeAgentCreatePayload = {
+  name: string;
+  backend: string;
+  description?: string | null;
+  model?: string | null;
+  reasoning_effort?: string | null;
+  system_prompt?: string | null;
+  metadata?: Record<string, unknown>;
+  enabled?: boolean;
+};
+
+export type VibeAgentUpdatePayload = {
+  description?: string | null;
+  model?: string | null;
+  reasoning_effort?: string | null;
+  system_prompt?: string | null;
+  metadata?: Record<string, unknown>;
+  enabled?: boolean;
 };
 
 // Events streamed by ``GET /api/events`` — the broker JSON-encodes each
@@ -786,6 +834,26 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       const qs = search.toString();
       return getJson(qs ? `/api/inbox?${qs}` : '/api/inbox');
     },
+    listVibeAgents: (params) => {
+      const search = new URLSearchParams();
+      if (params?.backend) search.set('backend', params.backend);
+      if (params?.includeDisabled) search.set('include_disabled', '1');
+      const qs = search.toString();
+      return getJson(qs ? `/agents?${qs}` : '/agents');
+    },
+    getVibeAgent: (name) => getJson(`/agents/${encodeURIComponent(name)}`),
+    createVibeAgent: (payload) => postJson('/agents', payload),
+    updateVibeAgent: async (name, payload) => {
+      const res = await apiFetch(`/agents/${encodeURIComponent(name)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) await handleApiError(res, `PATCH /agents/${name}`);
+      return res.json();
+    },
+    setDefaultVibeAgent: (name) => postJson('/agents/default', { name }),
+    removeVibeAgent: (name) => deleteJson(`/agents/${encodeURIComponent(name)}`),
     connectWorkbenchEvents: (handlers) => {
       // EventSource auto-reconnects on transient drops, so callers don't
       // have to implement their own retry. Returns a `disconnect` thunk so

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -103,8 +103,9 @@ export type ApiContextType = {
   archiveSession: (sessionId: string) => Promise<WorkbenchSession>;
   listSessionMessages: (sessionId: string, params?: { afterId?: string; limit?: number }) => Promise<{ messages: WorkbenchMessage[]; next_after_id: string | null }>;
   sendSessionMessage: (sessionId: string, payload: { text?: string; content?: Record<string, unknown>; metadata?: Record<string, unknown>; author_id?: string; author_name?: string }) => Promise<WorkbenchMessage>;
-  markSessionRead: (sessionId: string, untilMessageId?: string) => Promise<{ updated: number }>;
+  markSessionRead: (sessionId: string, untilMessageId?: string) => Promise<{ updated: number; unread_counts: Record<string, number> }>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; beforeId?: string }) => Promise<{ messages: WorkbenchMessage[]; next_before_id: string | null; unread_counts: Record<string, number> }>;
+  connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
   remoteAccessStatus: () => Promise<any>;
   pairVibeCloudRemoteAccess: (payload: { backend_url: string; pairing_key: string; device_name?: string }) => Promise<any>;
   startRemoteAccess: () => Promise<any>;
@@ -169,6 +170,30 @@ export type WorkbenchSessionUpdate = {
   agent_variant: string;
   model: string | null;
   reasoning_effort: string | null;
+};
+
+// Events streamed by ``GET /api/events`` — the broker JSON-encodes each
+// payload as ``{type, data, ts}``. ``connectWorkbenchEvents`` parses and
+// dispatches to type-specific handlers; subscribers can also catch any
+// event via ``onAny`` for logging/analytics.
+export type WorkbenchEventEnvelope<T = unknown> = {
+  type: string;
+  data: T;
+  ts: number;
+};
+
+export type WorkbenchEventHandlers = {
+  onConnected?: (data: { sub_id: number }) => void;
+  onMessageNew?: (data: WorkbenchMessage) => void;
+  onSessionActivity?: (data: { session_id: string; scope_id: string | null; event: string }) => void;
+  onInboxUnreadChanged?: (data: {
+    session_id?: string;
+    scope_id?: string | null;
+    delta?: number;
+    unread_counts: Record<string, number>;
+  }) => void;
+  onAny?: (event: WorkbenchEventEnvelope) => void;
+  onError?: (err: Event) => void;
 };
 
 // One row from the platform-agnostic ``messages`` table.
@@ -760,6 +785,64 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       if (params?.beforeId) search.set('before_id', params.beforeId);
       const qs = search.toString();
       return getJson(qs ? `/api/inbox?${qs}` : '/api/inbox');
+    },
+    connectWorkbenchEvents: (handlers) => {
+      // EventSource auto-reconnects on transient drops, so callers don't
+      // have to implement their own retry. Returns a `disconnect` thunk so
+      // React effects can clean up.
+      const source = new EventSource('/api/events');
+      const safeDispatch = <T,>(handler: ((data: T) => void) | undefined, raw: string) => {
+        if (!handler) return;
+        try {
+          handler(JSON.parse(raw));
+        } catch (err) {
+          console.error('[workbench-events] parse failed', err, raw);
+        }
+      };
+      source.addEventListener('connected', (e: MessageEvent) =>
+        safeDispatch(handlers.onConnected, e.data),
+      );
+      source.addEventListener('message.new', (e: MessageEvent) => {
+        const envelope = (() => {
+          try {
+            return JSON.parse(e.data) as WorkbenchEventEnvelope<WorkbenchMessage>;
+          } catch {
+            return null;
+          }
+        })();
+        if (envelope) {
+          handlers.onAny?.(envelope);
+          handlers.onMessageNew?.(envelope.data);
+        }
+      });
+      source.addEventListener('session.activity', (e: MessageEvent) => {
+        const envelope = (() => {
+          try {
+            return JSON.parse(e.data) as WorkbenchEventEnvelope<any>;
+          } catch {
+            return null;
+          }
+        })();
+        if (envelope) {
+          handlers.onAny?.(envelope);
+          handlers.onSessionActivity?.(envelope.data);
+        }
+      });
+      source.addEventListener('inbox.unread.changed', (e: MessageEvent) => {
+        const envelope = (() => {
+          try {
+            return JSON.parse(e.data) as WorkbenchEventEnvelope<any>;
+          } catch {
+            return null;
+          }
+        })();
+        if (envelope) {
+          handlers.onAny?.(envelope);
+          handlers.onInboxUnreadChanged?.(envelope.data);
+        }
+      });
+      source.onerror = (err) => handlers.onError?.(err);
+      return () => source.close();
     },
     remoteAccessStatus: () => getJson('/remote-access/status'),
     pairVibeCloudRemoteAccess: (payload) => postJson('/remote-access/vibe-cloud/pair', payload),

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -91,12 +91,31 @@ export type ApiContextType = {
   getVersion: () => Promise<VersionInfo>;
   doUpgrade: () => Promise<UpgradeResult>;
   browseDirectory: (path: string, showHidden?: boolean) => Promise<{ ok: boolean; path?: string; parent?: string | null; dirs?: { name: string; path: string }[]; error?: string }>;
+  browseMkdir: (path: string) => Promise<{ path: string }>;
+  listProjects: (includeArchived?: boolean) => Promise<{ projects: WorkbenchProject[] }>;
+  createProject: (payload: { folder_path: string; display_name?: string }) => Promise<WorkbenchProject>;
+  updateProject: (projectId: string, payload: { display_name?: string; folder_path?: string }) => Promise<WorkbenchProject>;
+  archiveProject: (projectId: string) => Promise<WorkbenchProject>;
   remoteAccessStatus: () => Promise<any>;
   pairVibeCloudRemoteAccess: (payload: { backend_url: string; pairing_key: string; device_name?: string }) => Promise<any>;
   startRemoteAccess: () => Promise<any>;
   stopRemoteAccess: () => Promise<any>;
   getSession: () => Promise<SessionInfo>;
   signOut: () => Promise<{ ok: boolean }>;
+};
+
+// Workbench project — a scope row with platform='avibe' / scope_type='project'.
+// ``folder_path`` mirrors ``scope_settings.workdir`` and is what Agent runs
+// pick up as their cwd.
+export type WorkbenchProject = {
+  id: string;
+  scope_id: string;
+  display_name: string;
+  folder_path: string;
+  created_at: string;
+  last_active_at: string | null;
+  archived: boolean;
+  metadata?: Record<string, unknown>;
 };
 
 export type SessionInfo =
@@ -606,6 +625,22 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     getVersion: () => getJson('/version'),
     doUpgrade: () => postJson('/upgrade', {}),
     browseDirectory: (path, showHidden) => postJson('/browse', { path, show_hidden: showHidden || false }),
+    browseMkdir: (path) => postJson('/api/browse/mkdir', { path }),
+    listProjects: (includeArchived) =>
+      getJson(`/api/projects${includeArchived ? '?include_archived=1' : ''}`),
+    createProject: (payload) => postJson('/api/projects', payload),
+    updateProject: async (projectId, payload) => {
+      const res = await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        await handleApiError(res, `PATCH /api/projects/${projectId}`);
+      }
+      return res.json();
+    },
+    archiveProject: (projectId) => deleteJson(`/api/projects/${encodeURIComponent(projectId)}`),
     remoteAccessStatus: () => getJson('/remote-access/status'),
     pairVibeCloudRemoteAccess: (payload) => postJson('/remote-access/vibe-cloud/pair', payload),
     startRemoteAccess: () => postJson('/remote-access/start', {}),

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -96,11 +96,20 @@ export type ApiContextType = {
   createProject: (payload: { folder_path: string; display_name?: string }) => Promise<WorkbenchProject>;
   updateProject: (projectId: string, payload: { display_name?: string; folder_path?: string }) => Promise<WorkbenchProject>;
   archiveProject: (projectId: string) => Promise<WorkbenchProject>;
+  listSessions: (params?: { projectId?: string; status?: 'active' | 'archived' | 'all'; limit?: number; beforeId?: string }) => Promise<{ sessions: WorkbenchSession[]; next_before_id: string | null }>;
+  createSession: (payload: WorkbenchSessionCreate) => Promise<WorkbenchSession>;
+  getSession: (sessionId: string) => Promise<WorkbenchSession>;
+  updateSession: (sessionId: string, payload: Partial<WorkbenchSessionUpdate>) => Promise<WorkbenchSession>;
+  archiveSession: (sessionId: string) => Promise<WorkbenchSession>;
+  listSessionMessages: (sessionId: string, params?: { afterId?: string; limit?: number }) => Promise<{ messages: WorkbenchMessage[]; next_after_id: string | null }>;
+  sendSessionMessage: (sessionId: string, payload: { text?: string; content?: Record<string, unknown>; metadata?: Record<string, unknown>; author_id?: string; author_name?: string }) => Promise<WorkbenchMessage>;
+  markSessionRead: (sessionId: string, untilMessageId?: string) => Promise<{ updated: number }>;
+  listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; beforeId?: string }) => Promise<{ messages: WorkbenchMessage[]; next_before_id: string | null; unread_counts: Record<string, number> }>;
   remoteAccessStatus: () => Promise<any>;
   pairVibeCloudRemoteAccess: (payload: { backend_url: string; pairing_key: string; device_name?: string }) => Promise<any>;
   startRemoteAccess: () => Promise<any>;
   stopRemoteAccess: () => Promise<any>;
-  getSession: () => Promise<SessionInfo>;
+  getAuthSession: () => Promise<SessionInfo>;
   signOut: () => Promise<{ ok: boolean }>;
 };
 
@@ -116,6 +125,70 @@ export type WorkbenchProject = {
   last_active_at: string | null;
   archived: boolean;
   metadata?: Record<string, unknown>;
+};
+
+// Workbench session — a row in ``agent_sessions`` created via /api/sessions.
+// ``project_id`` is the short ``proj_<hex>`` suffix of ``scope_id``.
+export type WorkbenchSession = {
+  id: string;
+  scope_id: string | null;
+  project_id: string | null;
+  title: string | null;
+  agent_id: string | null;
+  agent_name: string | null;
+  agent_backend: string | null;
+  agent_variant: string | null;
+  model: string | null;
+  reasoning_effort: string | null;
+  status: string;
+  workdir: string | null;
+  native_session_id: string | null;
+  created_at: string;
+  updated_at: string;
+  last_active_at: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type WorkbenchSessionCreate = {
+  project_id: string;
+  agent_backend: string;
+  agent_id?: string;
+  agent_name?: string;
+  agent_variant?: string;
+  model?: string;
+  reasoning_effort?: string;
+  title?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type WorkbenchSessionUpdate = {
+  title: string | null;
+  agent_id: string | null;
+  agent_name: string | null;
+  agent_backend: string;
+  agent_variant: string;
+  model: string | null;
+  reasoning_effort: string | null;
+};
+
+// One row from the platform-agnostic ``messages`` table.
+export type WorkbenchMessage = {
+  id: string;
+  scope_id: string | null;
+  session_id: string | null;
+  platform: string;
+  author: 'user' | 'agent' | 'system' | string;
+  author_id: string | null;
+  author_name: string | null;
+  native_message_id: string | null;
+  parent_native_message_id: string | null;
+  text: string;
+  content: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+  delivered_at: string | null;
+  read_at: string | null;
 };
 
 export type SessionInfo =
@@ -641,11 +714,58 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       return res.json();
     },
     archiveProject: (projectId) => deleteJson(`/api/projects/${encodeURIComponent(projectId)}`),
+    listSessions: (params) => {
+      const search = new URLSearchParams();
+      if (params?.projectId) search.set('project_id', params.projectId);
+      if (params?.status) search.set('status', params.status);
+      if (params?.limit) search.set('limit', String(params.limit));
+      if (params?.beforeId) search.set('before_id', params.beforeId);
+      const qs = search.toString();
+      return getJson(qs ? `/api/sessions?${qs}` : '/api/sessions');
+    },
+    createSession: (payload) => postJson('/api/sessions', payload),
+    getSession: (sessionId) => getJson(`/api/sessions/${encodeURIComponent(sessionId)}`),
+    updateSession: async (sessionId, payload) => {
+      const res = await apiFetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        await handleApiError(res, `PATCH /api/sessions/${sessionId}`);
+      }
+      return res.json();
+    },
+    archiveSession: (sessionId) => deleteJson(`/api/sessions/${encodeURIComponent(sessionId)}`),
+    listSessionMessages: (sessionId, params) => {
+      const search = new URLSearchParams();
+      if (params?.afterId) search.set('after_id', params.afterId);
+      if (params?.limit) search.set('limit', String(params.limit));
+      const qs = search.toString();
+      const base = `/api/sessions/${encodeURIComponent(sessionId)}/messages`;
+      return getJson(qs ? `${base}?${qs}` : base);
+    },
+    sendSessionMessage: (sessionId, payload) =>
+      postJson(`/api/sessions/${encodeURIComponent(sessionId)}/messages`, payload),
+    markSessionRead: (sessionId, untilMessageId) =>
+      postJson(
+        `/api/sessions/${encodeURIComponent(sessionId)}/mark-read`,
+        untilMessageId ? { until_message_id: untilMessageId } : {},
+      ),
+    listInbox: (params) => {
+      const search = new URLSearchParams();
+      if (params?.platform) search.set('platform', params.platform);
+      if (params?.unreadOnly) search.set('unread_only', '1');
+      if (params?.limit) search.set('limit', String(params.limit));
+      if (params?.beforeId) search.set('before_id', params.beforeId);
+      const qs = search.toString();
+      return getJson(qs ? `/api/inbox?${qs}` : '/api/inbox');
+    },
     remoteAccessStatus: () => getJson('/remote-access/status'),
     pairVibeCloudRemoteAccess: (payload) => postJson('/remote-access/vibe-cloud/pair', payload),
     startRemoteAccess: () => postJson('/remote-access/start', {}),
     stopRemoteAccess: () => postJson('/remote-access/stop', {}),
-    getSession: () => getJson('/api/session'),
+    getAuthSession: () => getJson('/api/session'),
     signOut: () => postJson('/auth/logout', {}),
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [showToast, t]);

--- a/ui/src/context/WorkbenchInboxContext.tsx
+++ b/ui/src/context/WorkbenchInboxContext.tsx
@@ -1,0 +1,121 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { useApi } from './ApiContext';
+import type { WorkbenchMessage } from './ApiContext';
+
+interface InboxState {
+  /** Per-scope unread counts (only agent-authored messages count). */
+  unreadByScope: Record<string, number>;
+  /** Sum of ``unreadByScope`` — cached so consumers don't re-derive. */
+  totalUnread: number;
+  /** Recent agent messages across all sessions (reverse-chronological). */
+  recentMessages: WorkbenchMessage[];
+  loading: boolean;
+  refresh: () => Promise<void>;
+  markRead: (sessionId: string, untilMessageId?: string) => Promise<void>;
+}
+
+const WorkbenchInboxContext = createContext<InboxState | undefined>(undefined);
+
+/** Provider that owns the Inbox state shared across WorkbenchSidebar + InboxPage.
+ *
+ *  Connects to ``/api/events`` once on mount and updates state in place when
+ *  new messages or unread-count changes arrive. The provider value is memoized
+ *  per [[feedback_react_context_value_memoize]] so consumer ``useEffect``
+ *  hooks that depend on context functions don't re-fire on every parent
+ *  render. */
+export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) => {
+  const api = useApi();
+  const [unreadByScope, setUnreadByScope] = useState<Record<string, number>>({});
+  const [recentMessages, setRecentMessages] = useState<WorkbenchMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  // Avoid duplicate refresh-on-first-mount during StrictMode double-invoke.
+  const initialFetched = useRef(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await api.listInbox({ platform: 'avibe', limit: 30 });
+      setRecentMessages(result.messages);
+      setUnreadByScope(result.unread_counts);
+    } catch (err) {
+      console.error('[inbox] refresh failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  const markRead = useCallback(
+    async (sessionId: string, untilMessageId?: string) => {
+      const result = await api.markSessionRead(sessionId, untilMessageId);
+      setUnreadByScope(result.unread_counts);
+    },
+    [api],
+  );
+
+  useEffect(() => {
+    if (!initialFetched.current) {
+      initialFetched.current = true;
+      refresh();
+    }
+    const disconnect = api.connectWorkbenchEvents({
+      onMessageNew: (message) => {
+        // Only agent turns belong on the inbox feed — the user's own
+        // messages don't need to come back as "new" notifications.
+        if (message.author !== 'agent' || message.platform !== 'avibe') return;
+        setRecentMessages((prev) => {
+          // Skip duplicates if the REST POST optimistic update already
+          // added the row (rare for agent-authored events, but defensive).
+          if (prev.some((m) => m.id === message.id)) return prev;
+          return [message, ...prev].slice(0, 30);
+        });
+        if (!message.read_at && message.scope_id) {
+          setUnreadByScope((prev) => ({
+            ...prev,
+            [message.scope_id as string]: (prev[message.scope_id as string] ?? 0) + 1,
+          }));
+        }
+      },
+      onInboxUnreadChanged: (data) => {
+        if (data?.unread_counts) {
+          setUnreadByScope(data.unread_counts);
+        }
+      },
+      onError: (err) => {
+        // Browser EventSource will auto-reconnect; keep this as a log
+        // entry rather than a crash so the workbench stays usable when
+        // the dev proxy is restarting / etc.
+        console.debug('[inbox] sse error', err);
+      },
+    });
+    return disconnect;
+  }, [api, refresh]);
+
+  const totalUnread = useMemo(
+    () => Object.values(unreadByScope).reduce((sum, n) => sum + (n || 0), 0),
+    [unreadByScope],
+  );
+
+  const value = useMemo<InboxState>(
+    () => ({
+      unreadByScope,
+      totalUnread,
+      recentMessages,
+      loading,
+      refresh,
+      markRead,
+    }),
+    [unreadByScope, totalUnread, recentMessages, loading, refresh, markRead],
+  );
+
+  return <WorkbenchInboxContext.Provider value={value}>{children}</WorkbenchInboxContext.Provider>;
+};
+
+export const useWorkbenchInbox = (): InboxState => {
+  const ctx = useContext(WorkbenchInboxContext);
+  if (ctx === undefined) {
+    throw new Error('useWorkbenchInbox must be used inside <WorkbenchInboxProvider>');
+  }
+  return ctx;
+};

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1070,11 +1070,23 @@
     "zh": "Chinese"
   },
   "directoryBrowser": {
-    "title": "Browse Directory",
+    "title": "Select Project Folder",
     "select": "Select",
+    "cancel": "Cancel",
     "empty": "No subdirectories",
-    "showHidden": "Show hidden directories",
-    "hideHidden": "Hide hidden directories"
+    "showHidden": "Show hidden",
+    "hideHidden": "Hide hidden",
+    "newFolder": "New Folder",
+    "newFolderPlaceholder": "Folder name",
+    "createHere": "Create new folder here…",
+    "favorites": "Favorites",
+    "favoritesHome": "Home",
+    "favoritesDesktop": "Desktop",
+    "favoritesDocuments": "Documents",
+    "favoritesDownloads": "Downloads",
+    "back": "Back",
+    "forward": "Forward",
+    "newFolderExists": "A folder with that name already exists."
   },
   "wechat": {
     "userBound": "Your WeChat account is automatically configured as the bot owner.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -47,6 +47,7 @@
     "copyFailed": "Copy failed, please copy it manually",
     "remove": "Remove",
     "removing": "Removing…",
+    "delete": "Delete",
     "test": "Test",
     "testing": "Testing…",
     "themeSystem": "System theme",
@@ -1177,5 +1178,41 @@
     "noAvailableCodes": "No active bind codes. Create a new code to start binding users.",
     "noUnavailableCodes": "No unavailable bind codes.",
     "close": "Close"
+  },
+  "agents": {
+    "title": "Agents",
+    "subtitle": "{{count}} agents registered across all backends.",
+    "showDisabled": "Show disabled",
+    "newAgent": "New agent",
+    "noConfig": "No model or system prompt configured",
+    "empty": "No agents yet. Create one to start a conversation.",
+    "selectPrompt": "Select an agent to view its configuration.",
+    "makeDefault": "Make default",
+    "deleteConfirm": "Delete agent \"{{name}}\"? This cannot be undone.",
+    "deleteInUse": "Agent \"{{name}}\" is currently in use by one or more channels and cannot be deleted.",
+    "detail": {
+      "enabled": "Enabled",
+      "enabledHint": "Disabled agents stay in the registry but cannot be picked when starting a session.",
+      "backend": "Backend",
+      "backendLocked": "Backend is set at creation and cannot be changed.",
+      "model": "Model",
+      "effort": "Reasoning effort",
+      "systemPrompt": "System prompt",
+      "systemPromptHint": "Optional. Prepended to every conversation that uses this agent.",
+      "systemLocked": "System agents cannot be deleted. You can still adjust model, effort, and system prompt."
+    },
+    "create": {
+      "title": "New Agent",
+      "body": "Pick a backend, name the agent, and fine-tune model and effort. Backend cannot be changed after creation.",
+      "backend": "Backend",
+      "name": "Name",
+      "model": "Model",
+      "modelPlaceholder": "e.g. claude-sonnet-4-6",
+      "effort": "Effort",
+      "systemPrompt": "System prompt",
+      "systemPromptHint": "Optional",
+      "systemPromptPlaceholder": "Optional. Prepended to every conversation that uses this agent.",
+      "submit": "Create agent"
+    }
   }
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1253,5 +1253,18 @@
       "error": "Error",
       "timing": "Timing"
     }
+  },
+  "chat": {
+    "backToInbox": "Back to inbox",
+    "untitled": "Untitled session",
+    "titlePlaceholder": "Session title",
+    "pickAgent": "Pick an agent",
+    "noAgents": "No enabled agents. Create one on the Agents page.",
+    "modelPlaceholder": "Model override",
+    "changesPersist": "changes apply on the next reply",
+    "notFound": "Session not found.",
+    "missingSessionId": "Missing session id in the URL.",
+    "transcriptEmpty": "No messages yet",
+    "transcriptEmptyHint": "Send a message from your IM platform — Slack, Discord, Telegram, Lark, or WeChat — and it will appear here."
   }
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -381,6 +381,8 @@
     "title": "Vibe Remote",
     "subtitle": "Local agent gateway",
     "workspaceLabel": "Workspace",
+    "openControlPanel": "Control Panel",
+    "backToWorkbench": "Back to Workbench",
     "navigationLabel": "Console",
     "statusLabel": "Service status",
     "versionLabel": "Version",
@@ -393,7 +395,47 @@
     "eyebrow": "Workbench",
     "placeholderTitle": "Your AI workbench is coming together",
     "placeholderBody": "Agents, Skills, Harness, and Vaults will live here. For now, jump into the control panel to configure platforms and backends.",
-    "openControlPanel": "Open Control Panel"
+    "openControlPanel": "Open Control Panel",
+    "capabilitiesLabel": "Capabilities",
+    "projectsLabel": "Projects",
+    "addProject": "Add project",
+    "projectsEmpty": "No projects yet — coming next commit.",
+    "nav": {
+      "inbox": "Inbox",
+      "agents": "Agents",
+      "skills": "Skills",
+      "harness": "Harness",
+      "vaults": "Vaults"
+    },
+    "modules": {
+      "comingSoonEyebrow": "Coming soon",
+      "comingSoon": "The full screen lands in a later commit; the route is reserved so the sidebar entry navigates somewhere stable.",
+      "inbox": {
+        "eyebrow": "Inbox",
+        "title": "Inbox",
+        "description": "Cross-project notifications from every avibe session. Hover popover + full list view will land in a later commit."
+      },
+      "agents": {
+        "eyebrow": "Agents",
+        "title": "Agents",
+        "description": "Global registry of every Vibe Agent — Claude / OpenCode / Codex variants you can pick when starting a session."
+      },
+      "skills": {
+        "eyebrow": "Skills",
+        "title": "Skills",
+        "description": "Manage Agent Skills (global + project-scoped) on top of the askill CLI."
+      },
+      "harness": {
+        "eyebrow": "Harness",
+        "title": "Harness",
+        "description": "Background tasks, watches, webhooks, and the run history of all three. Created by chatting with an Agent."
+      },
+      "vaults": {
+        "eyebrow": "Vaults",
+        "title": "Vaults",
+        "description": "Secrets and API keys that the Agent can pull into ENV / .env without you copy-pasting."
+      }
+    }
   },
   "wizard": {
     "title": "Vibe Remote Setup"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -389,6 +389,12 @@
     "signOut": "Sign out",
     "signingOut": "Signing out…"
   },
+  "workbench": {
+    "eyebrow": "Workbench",
+    "placeholderTitle": "Your AI workbench is coming together",
+    "placeholderBody": "Agents, Skills, Harness, and Vaults will live here. For now, jump into the control panel to configure platforms and backends.",
+    "openControlPanel": "Open Control Panel"
+  },
   "wizard": {
     "title": "Vibe Remote Setup"
   },

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -48,6 +48,8 @@
     "remove": "Remove",
     "removing": "Removing…",
     "delete": "Delete",
+    "previous": "Previous",
+    "next": "Next",
     "test": "Test",
     "testing": "Testing…",
     "themeSystem": "System theme",
@@ -1213,6 +1215,43 @@
       "systemPromptHint": "Optional",
       "systemPromptPlaceholder": "Optional. Prepended to every conversation that uses this agent.",
       "submit": "Create agent"
+    }
+  },
+  "harness": {
+    "title": "Harness",
+    "subtitle": "Scheduled tasks, watches, webhooks, and the run history of all three.",
+    "soon": "soon",
+    "selectPrompt": "Select a row to view its full configuration.",
+    "emptyTasks": "No scheduled tasks. Ask an agent to create one in chat.",
+    "emptyWatches": "No watches running. Ask an agent to start one in chat.",
+    "emptyRuns": "No runs yet. They appear here once a task or watch fires.",
+    "webhooksSoon": "Webhooks are coming soon",
+    "webhooksSoonBody": "Inbound HTTP triggers will land in a follow-up release. Tasks and watches cover scheduled and event-driven runs today.",
+    "unknownSchedule": "unknown schedule",
+    "pageLabel": "page {{page}}",
+    "tabs": {
+      "tasks": "Tasks",
+      "watches": "Watches",
+      "webhooks": "Webhooks",
+      "runs": "Runs"
+    },
+    "detail": {
+      "schedule": "Schedule",
+      "agent": "Agent",
+      "message": "Message",
+      "lastRun": "Last run",
+      "id": "ID",
+      "command": "Command",
+      "cwd": "Working directory",
+      "mode": "Mode",
+      "followUp": "Follow-up message",
+      "runtime": "Runtime",
+      "lastError": "Last error",
+      "type": "Type",
+      "definition": "Definition",
+      "result": "Result",
+      "error": "Error",
+      "timing": "Timing"
     }
   }
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -50,6 +50,12 @@
     "delete": "Delete",
     "previous": "Previous",
     "next": "Next",
+    "relative": {
+      "justNow": "just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
+    },
     "test": "Test",
     "testing": "Testing…",
     "themeSystem": "System theme",
@@ -1229,6 +1235,13 @@
     "webhooksSoonBody": "Inbound HTTP triggers will land in a follow-up release. Tasks and watches cover scheduled and event-driven runs today.",
     "unknownSchedule": "unknown schedule",
     "pageLabel": "page {{page}}",
+    "runtime": {
+      "running": "Running",
+      "paused": "Paused",
+      "idle": "Idle",
+      "enabled": "Enabled",
+      "disabled": "Disabled"
+    },
     "tabs": {
       "tasks": "Tasks",
       "watches": "Watches",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -407,6 +407,26 @@
       "harness": "Harness",
       "vaults": "Vaults"
     },
+    "inbox": {
+      "eyebrow": "Inbox",
+      "title": "Inbox",
+      "headerCount": "{{unread}} unread · {{total}} total",
+      "markAllRead": "Mark all read",
+      "markRead": "Mark read",
+      "viewAll": "Open full inbox",
+      "openSession": "Open session",
+      "refresh": "Refresh",
+      "filterUnread": "Unread",
+      "filterAll": "All",
+      "empty": "Nothing in your inbox yet — agent replies will surface here.",
+      "emptyTitle": "Inbox is empty",
+      "emptyBody": "When an agent posts back from a session, it shows up here.",
+      "allClearTitle": "All caught up",
+      "allClearBody": "No unread agent messages right now. Switch to \"All\" to browse history.",
+      "backToCanvas": "Back to canvas",
+      "agent": "Agent",
+      "you": "You"
+    },
     "modules": {
       "comingSoonEyebrow": "Coming soon",
       "comingSoon": "The full screen lands in a later commit; the route is reserved so the sidebar entry navigates somewhere stable.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -48,6 +48,8 @@
     "remove": "移除",
     "removing": "移除中…",
     "delete": "删除",
+    "previous": "上一页",
+    "next": "下一页",
     "test": "测试",
     "testing": "测试中…",
     "themeSystem": "跟随系统主题",
@@ -1213,6 +1215,43 @@
       "systemPromptHint": "可选",
       "systemPromptPlaceholder": "可选。会拼接到使用本 Agent 的每一段对话前。",
       "submit": "创建 Agent"
+    }
+  },
+  "harness": {
+    "title": "Harness",
+    "subtitle": "定时任务、Watch、Webhook 及其运行历史。",
+    "soon": "敬请期待",
+    "selectPrompt": "选择左侧条目查看完整配置。",
+    "emptyTasks": "暂无定时任务。在 Chat 中让 Agent 创建一个。",
+    "emptyWatches": "没有正在运行的 Watch。在 Chat 中让 Agent 开启一个。",
+    "emptyRuns": "暂无运行记录。任务或 Watch 触发后会出现在这里。",
+    "webhooksSoon": "Webhook 即将上线",
+    "webhooksSoonBody": "入站 HTTP 触发将在后续版本中落地。Tasks 和 Watches 已覆盖定时与事件驱动的运行。",
+    "unknownSchedule": "未知计划",
+    "pageLabel": "第 {{page}} 页",
+    "tabs": {
+      "tasks": "Tasks",
+      "watches": "Watches",
+      "webhooks": "Webhooks",
+      "runs": "Runs"
+    },
+    "detail": {
+      "schedule": "计划",
+      "agent": "Agent",
+      "message": "消息",
+      "lastRun": "上次运行",
+      "id": "ID",
+      "command": "命令",
+      "cwd": "工作目录",
+      "mode": "模式",
+      "followUp": "跟进消息",
+      "runtime": "运行时",
+      "lastError": "上次错误",
+      "type": "类型",
+      "definition": "定义",
+      "result": "结果",
+      "error": "错误",
+      "timing": "时间线"
     }
   }
 }

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -381,6 +381,8 @@
     "title": "Vibe Remote",
     "subtitle": "本地 agent 网关",
     "workspaceLabel": "工作区",
+    "openControlPanel": "控制面板",
+    "backToWorkbench": "返回工作台",
     "navigationLabel": "控制台",
     "statusLabel": "服务状态",
     "versionLabel": "版本",
@@ -393,7 +395,47 @@
     "eyebrow": "工作台",
     "placeholderTitle": "你的 AI 工作台正在搭建",
     "placeholderBody": "Agents、Skills、Harness、Vaults 将会汇聚到这里。现在先进控制面板配置平台和 backend。",
-    "openControlPanel": "进入控制面板"
+    "openControlPanel": "进入控制面板",
+    "capabilitiesLabel": "能力模块",
+    "projectsLabel": "项目",
+    "addProject": "添加项目",
+    "projectsEmpty": "还没有项目 — 下一个 commit 接上。",
+    "nav": {
+      "inbox": "收件箱",
+      "agents": "Agents",
+      "skills": "Skills",
+      "harness": "Harness",
+      "vaults": "Vaults"
+    },
+    "modules": {
+      "comingSoonEyebrow": "即将就位",
+      "comingSoon": "完整页面在后续 commit 接入,先占住路由让侧栏点击有地方落。",
+      "inbox": {
+        "eyebrow": "收件箱",
+        "title": "收件箱",
+        "description": "跨项目汇聚所有 avibe 会话的通知。hover 浮层和完整列表视图后续 commit 接入。"
+      },
+      "agents": {
+        "eyebrow": "Agents",
+        "title": "Agents",
+        "description": "全局 Vibe Agent 注册表 —— Claude / OpenCode / Codex 各自的变体,开会话时可选。"
+      },
+      "skills": {
+        "eyebrow": "Skills",
+        "title": "Skills",
+        "description": "在 askill CLI 之上管理 Agent Skills(全局 + 项目级)。"
+      },
+      "harness": {
+        "eyebrow": "Harness",
+        "title": "Harness",
+        "description": "后台任务、watch、webhook,以及三者的运行历史。创建走和 Agent 对话。"
+      },
+      "vaults": {
+        "eyebrow": "Vaults",
+        "title": "Vaults",
+        "description": "secrets 和 API key,Agent 可以直接写进 ENV / .env,不用你复制粘贴。"
+      }
+    }
   },
   "wizard": {
     "title": "Vibe Remote 设置向导"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -47,6 +47,7 @@
     "copyFailed": "复制失败，请手动复制",
     "remove": "移除",
     "removing": "移除中…",
+    "delete": "删除",
     "test": "测试",
     "testing": "测试中…",
     "themeSystem": "跟随系统主题",
@@ -1177,5 +1178,41 @@
     "noAvailableCodes": "暂无可用绑定码，请先创建新的绑定码。",
     "noUnavailableCodes": "暂无不可用绑定码。",
     "close": "关闭"
+  },
+  "agents": {
+    "title": "Agents",
+    "subtitle": "已登记 {{count}} 个 Agent。",
+    "showDisabled": "显示已禁用",
+    "newAgent": "新建 Agent",
+    "noConfig": "未配置模型或系统提示词",
+    "empty": "还没有 Agent。先创建一个,再开始对话。",
+    "selectPrompt": "选择左侧 Agent 查看详情。",
+    "makeDefault": "设为默认",
+    "deleteConfirm": "确认删除 Agent \"{{name}}\"？此操作不可撤销。",
+    "deleteInUse": "Agent \"{{name}}\" 正被一个或多个频道使用,无法删除。",
+    "detail": {
+      "enabled": "已启用",
+      "enabledHint": "禁用后仍保留在注册表中,但启动会话时无法选中。",
+      "backend": "后端",
+      "backendLocked": "后端在创建时确定,之后不可更改。",
+      "model": "模型",
+      "effort": "推理 Effort",
+      "systemPrompt": "系统提示词",
+      "systemPromptHint": "可选。会拼接到使用本 Agent 的每一段对话前。",
+      "systemLocked": "系统 Agent 不可删除,仍可调整模型、Effort 与系统提示词。"
+    },
+    "create": {
+      "title": "新建 Agent",
+      "body": "选择后端,命名 Agent,微调模型与 Effort。后端在创建后不可更改。",
+      "backend": "后端",
+      "name": "名称",
+      "model": "模型",
+      "modelPlaceholder": "例如 claude-sonnet-4-6",
+      "effort": "Effort",
+      "systemPrompt": "系统提示词",
+      "systemPromptHint": "可选",
+      "systemPromptPlaceholder": "可选。会拼接到使用本 Agent 的每一段对话前。",
+      "submit": "创建 Agent"
+    }
   }
 }

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -50,6 +50,12 @@
     "delete": "删除",
     "previous": "上一页",
     "next": "下一页",
+    "relative": {
+      "justNow": "刚刚",
+      "minutesAgo": "{{count}} 分钟前",
+      "hoursAgo": "{{count}} 小时前",
+      "daysAgo": "{{count}} 天前"
+    },
     "test": "测试",
     "testing": "测试中…",
     "themeSystem": "跟随系统主题",
@@ -1229,6 +1235,13 @@
     "webhooksSoonBody": "入站 HTTP 触发将在后续版本中落地。Tasks 和 Watches 已覆盖定时与事件驱动的运行。",
     "unknownSchedule": "未知计划",
     "pageLabel": "第 {{page}} 页",
+    "runtime": {
+      "running": "运行中",
+      "paused": "已暂停",
+      "idle": "空闲",
+      "enabled": "已启用",
+      "disabled": "已禁用"
+    },
     "tabs": {
       "tasks": "Tasks",
       "watches": "Watches",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1253,5 +1253,18 @@
       "error": "错误",
       "timing": "时间线"
     }
+  },
+  "chat": {
+    "backToInbox": "返回收件箱",
+    "untitled": "未命名会话",
+    "titlePlaceholder": "会话标题",
+    "pickAgent": "选择 Agent",
+    "noAgents": "暂无已启用的 Agent。请先在 Agents 页创建。",
+    "modelPlaceholder": "模型覆盖",
+    "changesPersist": "下次回复时生效",
+    "notFound": "未找到该会话。",
+    "missingSessionId": "URL 缺少 session id。",
+    "transcriptEmpty": "暂无消息",
+    "transcriptEmptyHint": "从 Slack/Discord/Telegram/Lark/WeChat 任一平台发条消息,这里就会出现。"
   }
 }

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -407,6 +407,26 @@
       "harness": "Harness",
       "vaults": "Vaults"
     },
+    "inbox": {
+      "eyebrow": "收件箱",
+      "title": "收件箱",
+      "headerCount": "{{unread}} 条未读 · {{total}} 条全部",
+      "markAllRead": "全部已读",
+      "markRead": "标记已读",
+      "viewAll": "查看完整收件箱",
+      "openSession": "打开会话",
+      "refresh": "刷新",
+      "filterUnread": "未读",
+      "filterAll": "全部",
+      "empty": "收件箱还是空的 — Agent 回复会出现在这里。",
+      "emptyTitle": "收件箱是空的",
+      "emptyBody": "当 Agent 从某个会话回过来,就会显示在这里。",
+      "allClearTitle": "全部看完了",
+      "allClearBody": "当前没有未读的 Agent 消息。切到\"全部\"可以浏览历史。",
+      "backToCanvas": "回到画布",
+      "agent": "Agent",
+      "you": "我"
+    },
     "modules": {
       "comingSoonEyebrow": "即将就位",
       "comingSoon": "完整页面在后续 commit 接入,先占住路由让侧栏点击有地方落。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1070,11 +1070,23 @@
     "zh": "中文"
   },
   "directoryBrowser": {
-    "title": "浏览目录",
-    "select": "选择",
+    "title": "选择项目文件夹",
+    "select": "选择此目录",
+    "cancel": "取消",
     "empty": "没有子目录",
-    "showHidden": "显示隐藏目录",
-    "hideHidden": "隐藏隐藏目录"
+    "showHidden": "显示隐藏",
+    "hideHidden": "隐藏隐藏",
+    "newFolder": "新建文件夹",
+    "newFolderPlaceholder": "文件夹名称",
+    "createHere": "在这里新建文件夹…",
+    "favorites": "收藏",
+    "favoritesHome": "主目录",
+    "favoritesDesktop": "桌面",
+    "favoritesDocuments": "文稿",
+    "favoritesDownloads": "下载",
+    "back": "后退",
+    "forward": "前进",
+    "newFolderExists": "已存在同名文件夹。"
   },
   "wechat": {
     "userBound": "您的微信账号已自动配置为机器人所有者。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -389,6 +389,12 @@
     "signOut": "退出登录",
     "signingOut": "正在退出…"
   },
+  "workbench": {
+    "eyebrow": "工作台",
+    "placeholderTitle": "你的 AI 工作台正在搭建",
+    "placeholderBody": "Agents、Skills、Harness、Vaults 将会汇聚到这里。现在先进控制面板配置平台和 backend。",
+    "openControlPanel": "进入控制面板"
+  },
   "wizard": {
     "title": "Vibe Remote 设置向导"
   },

--- a/ui/src/lib/relativeTime.ts
+++ b/ui/src/lib/relativeTime.ts
@@ -1,0 +1,19 @@
+// Shared relative-time formatter. Three workbench surfaces (Inbox popover,
+// full Inbox page, Harness page) had near-identical copies that hardcoded
+// English suffixes; centralise here so the i18n strings live in one place.
+import type { TFunction } from 'i18next';
+
+export function formatRelativeTime(iso: string | null | undefined, t: TFunction): string {
+  if (!iso) return '—';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffSec = Math.round((Date.now() - then) / 1000);
+  if (diffSec < 60) return t('common.relative.justNow');
+  const mins = Math.round(diffSec / 60);
+  if (mins < 60) return t('common.relative.minutesAgo', { count: mins });
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return t('common.relative.hoursAgo', { count: hours });
+  const days = Math.round(hours / 24);
+  if (days < 7) return t('common.relative.daysAgo', { count: days });
+  return new Date(iso).toISOString().slice(0, 10);
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -10,4 +10,18 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  server: {
+    proxy: {
+      '/config': 'http://localhost:5100',
+      '/session': 'http://localhost:5100',
+      '/status': 'http://localhost:5100',
+      '/settings': 'http://localhost:5100',
+      '/logs': 'http://localhost:5100',
+      '/doctor': 'http://localhost:5100',
+      '/remote-access': 'http://localhost:5100',
+      '/control': 'http://localhost:5100',
+      '/upgrade': 'http://localhost:5100',
+      '/api': 'http://localhost:5100',
+    },
+  },
 })

--- a/vibe/sse_broker.py
+++ b/vibe/sse_broker.py
@@ -1,0 +1,88 @@
+"""In-process pub/sub for workbench Server-Sent Events.
+
+Every workbench browser opens a long-lived ``GET /api/events`` request
+and the handler subscribes here. The REST routes that mutate messages
+/ sessions / unread counts publish events back through ``broker.publish``;
+the broker fans them out to every subscriber.
+
+Why SSE over WebSocket (per Cloudflare Tunnel research, 2026-05-24):
+    SSE rides on plain HTTP, has automatic browser reconnect via
+    ``EventSource``, and Cloudflare proxies + tunnels handle it without
+    the WS upgrade handshake. A 15-second keep-alive comment line keeps
+    intermediaries from killing idle streams.
+
+Threading model:
+    - Subscribers hold ``asyncio.Queue``; the SSE generator awaits them.
+    - ``publish`` is safe to call from any thread (Flask-style sync
+      routes, Agent worker threads, etc.) — it schedules
+      ``call_soon_threadsafe`` on the event loop captured at first
+      subscribe time. Sync callers don't need to know about the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SSEBroker:
+    def __init__(self) -> None:
+        self._subscribers: dict[int, asyncio.Queue] = {}
+        self._next_id = 0
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def subscribe(self) -> tuple[int, asyncio.Queue]:
+        """Register a new subscriber. Must be called from an event-loop coroutine."""
+
+        self._loop = asyncio.get_event_loop()
+        sub_id = self._next_id
+        self._next_id += 1
+        queue: asyncio.Queue = asyncio.Queue(maxsize=200)
+        self._subscribers[sub_id] = queue
+        logger.debug("SSE subscriber %s connected (total=%s)", sub_id, len(self._subscribers))
+        return sub_id, queue
+
+    def unsubscribe(self, sub_id: int) -> None:
+        if self._subscribers.pop(sub_id, None) is not None:
+            logger.debug("SSE subscriber %s disconnected (total=%s)", sub_id, len(self._subscribers))
+
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+    def publish(self, event_type: str, data: Any) -> None:
+        """Fan a JSON event out to every subscriber.
+
+        Safe from any thread. No-op when there are no subscribers (the
+        common case during boot / headless setups).
+        """
+
+        loop = self._loop
+        if loop is None or not self._subscribers:
+            return
+        payload = json.dumps({"type": event_type, "data": data, "ts": time.time()})
+        # Snapshot the queue list before scheduling so a concurrent
+        # unsubscribe during fan-out doesn't drop a publish on the floor.
+        for queue in list(self._subscribers.values()):
+            try:
+                loop.call_soon_threadsafe(self._put_nowait, queue, event_type, payload)
+            except RuntimeError:
+                # Loop was closed; skip silently — next subscribe will
+                # capture a fresh loop.
+                pass
+
+    @staticmethod
+    def _put_nowait(queue: asyncio.Queue, event_type: str, payload: str) -> None:
+        try:
+            queue.put_nowait((event_type, payload))
+        except asyncio.QueueFull:
+            logger.warning("SSE subscriber queue full; dropping %s event", event_type)
+
+
+# Module-level singleton — ui_server.py imports this and Avibe / REST
+# routes call ``broker.publish`` from their write paths.
+broker = SSEBroker()

--- a/vibe/sse_broker.py
+++ b/vibe/sse_broker.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import time
 from typing import Any
 
@@ -35,24 +36,36 @@ class SSEBroker:
         self._subscribers: dict[int, asyncio.Queue] = {}
         self._next_id = 0
         self._loop: asyncio.AbstractEventLoop | None = None
+        # ``subscribe`` / ``unsubscribe`` run on the event loop thread while
+        # ``publish`` runs from any thread (sync REST routes, IM threads).
+        # Plain ``list(dict.values())`` mid-mutation can raise
+        # ``RuntimeError: dictionary changed size during iteration``, so we
+        # guard the read with a short-held lock.
+        self._lock = threading.Lock()
 
     def subscribe(self) -> tuple[int, asyncio.Queue]:
         """Register a new subscriber. Must be called from an event-loop coroutine."""
 
         self._loop = asyncio.get_event_loop()
-        sub_id = self._next_id
-        self._next_id += 1
         queue: asyncio.Queue = asyncio.Queue(maxsize=200)
-        self._subscribers[sub_id] = queue
-        logger.debug("SSE subscriber %s connected (total=%s)", sub_id, len(self._subscribers))
+        with self._lock:
+            sub_id = self._next_id
+            self._next_id += 1
+            self._subscribers[sub_id] = queue
+            total = len(self._subscribers)
+        logger.debug("SSE subscriber %s connected (total=%s)", sub_id, total)
         return sub_id, queue
 
     def unsubscribe(self, sub_id: int) -> None:
-        if self._subscribers.pop(sub_id, None) is not None:
-            logger.debug("SSE subscriber %s disconnected (total=%s)", sub_id, len(self._subscribers))
+        with self._lock:
+            removed = self._subscribers.pop(sub_id, None) is not None
+            total = len(self._subscribers)
+        if removed:
+            logger.debug("SSE subscriber %s disconnected (total=%s)", sub_id, total)
 
     def subscriber_count(self) -> int:
-        return len(self._subscribers)
+        with self._lock:
+            return len(self._subscribers)
 
     def publish(self, event_type: str, data: Any) -> None:
         """Fan a JSON event out to every subscriber.
@@ -62,12 +75,16 @@ class SSEBroker:
         """
 
         loop = self._loop
-        if loop is None or not self._subscribers:
+        if loop is None:
             return
+        # Snapshot under the lock so a concurrent subscribe/unsubscribe on
+        # the event loop thread cannot mutate the dict mid-iteration.
+        with self._lock:
+            if not self._subscribers:
+                return
+            queues = list(self._subscribers.values())
         payload = json.dumps({"type": event_type, "data": data, "ts": time.time()})
-        # Snapshot the queue list before scheduling so a concurrent
-        # unsubscribe during fan-out doesn't drop a publish on the floor.
-        for queue in list(self._subscribers.values()):
+        for queue in queues:
             try:
                 loop.call_soon_threadsafe(self._put_nowait, queue, event_type, payload)
             except RuntimeError:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1396,7 +1396,7 @@ def settings_get():
     # bookmarked / hard-refreshed browser hits to the canonical settings page
     # instead of serving raw JSON.
     if "text/html" in request.headers.get("Accept", ""):
-        return redirect("/settings/service")
+        return redirect("/admin/settings/service")
     from vibe import api
 
     return jsonify(api.get_settings(request.args.get("platform") or None))

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -13,6 +13,7 @@ import socket
 import subprocess
 import threading
 import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -2743,22 +2744,33 @@ def inbox_list():
 # lands in a follow-up commit.
 
 
+@contextmanager
 def _harness_store():
+    # ``SQLiteBackgroundTaskStore`` opens a dedicated ``SqliteInvalidationProbe``
+    # connection in __init__ that only closes when ``store.close()`` is
+    # called. Harness routes are polled frequently from the workbench UI,
+    # so leaking a connection per request exhausts the SQLite pool. The
+    # context manager makes ownership explicit at every call site.
     from storage.background import SQLiteBackgroundTaskStore
 
-    return SQLiteBackgroundTaskStore()
+    store = SQLiteBackgroundTaskStore()
+    try:
+        yield store
+    finally:
+        store.close()
 
 
 @app.route("/api/harness/tasks", methods=["GET"])
 def harness_tasks_list():
-    return jsonify({"tasks": _harness_store().list_scheduled_tasks()})
+    with _harness_store() as store:
+        return jsonify({"tasks": store.list_scheduled_tasks()})
 
 
 @app.route("/api/harness/watches", methods=["GET"])
 def harness_watches_list():
-    store = _harness_store()
-    watches = store.list_watches()
-    runtime = store.load_watch_runtime().get("watches") or {}
+    with _harness_store() as store:
+        watches = store.list_watches()
+        runtime = store.load_watch_runtime().get("watches") or {}
     for watch in watches:
         watch["runtime"] = runtime.get(watch["id"]) or {"running": False}
     return jsonify({"watches": watches})
@@ -2783,15 +2795,16 @@ def harness_runs_list():
     query = request.args.get("query") or None
 
     page_request = make_page_request(page=page, limit=limit)
-    page_result = _harness_store().list_runs_page(
-        status=status,
-        run_type=run_type,
-        agent_name=agent_name,
-        definition_id=definition_id,
-        query=query,
-        page_request=page_request,
-        newest_first=True,
-    )
+    with _harness_store() as store:
+        page_result = store.list_runs_page(
+            status=status,
+            run_type=run_type,
+            agent_name=agent_name,
+            definition_id=definition_id,
+            query=query,
+            page_request=page_request,
+            newest_first=True,
+        )
     return jsonify(
         {
             "runs": page_result.items,
@@ -2804,7 +2817,8 @@ def harness_runs_list():
 
 @app.route("/api/harness/runs/<run_id>", methods=["GET"])
 def harness_run_detail(run_id: str):
-    run = _harness_store().get_run(run_id)
+    with _harness_store() as store:
+        run = store.get_run(run_id)
     if not run:
         return jsonify({"ok": False, "code": "run_not_found"}), 404
     return jsonify({"ok": True, "run": run})

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2419,6 +2419,248 @@ def browse_mkdir():
 
 
 # =============================================================================
+# Workbench: Sessions + Messages + Inbox
+# =============================================================================
+# All endpoints below talk directly to the SQLite store via the workbench
+# service modules — ORM all the way down, no CLI shell-outs.
+# ``project_id`` (short ``proj_<hex>`` form) is the public id; we expand to
+# the full scope_id ``avibe::project::proj_xxx`` inside.
+
+
+def _project_to_scope_id(project_id: str) -> str:
+    return f"avibe::project::{project_id}"
+
+
+@app.route("/api/sessions", methods=["GET"])
+def sessions_list():
+    from storage import workbench_sessions_service
+
+    project_id = request.args.get("project_id")
+    scope_id = _project_to_scope_id(project_id) if project_id else None
+    status = request.args.get("status") or "active"
+    try:
+        limit = int(request.args.get("limit") or 50)
+    except (TypeError, ValueError):
+        limit = 50
+    before_id = request.args.get("before_id") or None
+
+    engine = _projects_engine()
+    with engine.connect() as conn:
+        result = workbench_sessions_service.list_sessions(
+            conn,
+            scope_id=scope_id,
+            status=status,
+            limit=limit,
+            before_id=before_id,
+        )
+    return jsonify(result)
+
+
+@app.route("/api/sessions", methods=["POST"])
+def sessions_create():
+    from storage import workbench_sessions_service
+
+    payload = request.json or {}
+    project_id = (payload.get("project_id") or "").strip()
+    agent_backend = (payload.get("agent_backend") or "").strip()
+    if not project_id:
+        return jsonify({"error": "project_id is required"}), 400
+    if not agent_backend:
+        return jsonify({"error": "agent_backend is required"}), 400
+
+    scope_id = _project_to_scope_id(project_id)
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            session = workbench_sessions_service.create_session(
+                conn,
+                scope_id=scope_id,
+                agent_backend=agent_backend,
+                agent_id=payload.get("agent_id"),
+                agent_name=payload.get("agent_name"),
+                agent_variant=payload.get("agent_variant"),
+                model=payload.get("model"),
+                reasoning_effort=payload.get("reasoning_effort"),
+                title=payload.get("title"),
+                metadata=payload.get("metadata"),
+            )
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+    except PermissionError as err:
+        return jsonify({"error": str(err)}), 403
+    return jsonify(session), 201
+
+
+@app.route("/api/sessions/<session_id>", methods=["GET"])
+def sessions_get(session_id: str):
+    from storage import workbench_sessions_service
+
+    engine = _projects_engine()
+    try:
+        with engine.connect() as conn:
+            return jsonify(workbench_sessions_service.get_session(conn, session_id))
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+
+
+@app.route("/api/sessions/<session_id>", methods=["PATCH"])
+def sessions_update(session_id: str):
+    from storage import workbench_sessions_service
+
+    payload = request.json or {}
+    updatable = {
+        key: payload[key]
+        for key in (
+            "title",
+            "agent_id",
+            "agent_name",
+            "agent_backend",
+            "agent_variant",
+            "model",
+            "reasoning_effort",
+        )
+        if key in payload
+    }
+    if not updatable:
+        return jsonify({"error": "no updatable fields supplied"}), 400
+
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            session = workbench_sessions_service.update_session(conn, session_id, **updatable)
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+    return jsonify(session)
+
+
+@app.route("/api/sessions/<session_id>", methods=["DELETE"])
+def sessions_archive(session_id: str):
+    from storage import workbench_sessions_service
+
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            session = workbench_sessions_service.archive_session(conn, session_id)
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+    return jsonify(session)
+
+
+@app.route("/api/sessions/<session_id>/messages", methods=["GET"])
+def sessions_messages_list(session_id: str):
+    from storage import messages_service, workbench_sessions_service
+
+    after_id = request.args.get("after_id") or None
+    try:
+        limit = int(request.args.get("limit") or 50)
+    except (TypeError, ValueError):
+        limit = 50
+
+    engine = _projects_engine()
+    with engine.connect() as conn:
+        try:
+            workbench_sessions_service.get_session(conn, session_id)
+        except LookupError as err:
+            return jsonify({"error": str(err)}), 404
+        result = messages_service.list_session_messages(
+            conn,
+            session_id=session_id,
+            after_id=after_id,
+            limit=limit,
+        )
+    return jsonify(result)
+
+
+@app.route("/api/sessions/<session_id>/messages", methods=["POST"])
+def sessions_messages_create(session_id: str):
+    """Persist a user message under a session and touch its activity.
+
+    The actual Agent dispatch (calling into ``core/controller`` to run the
+    backend CLI) wires up in commit 13 alongside the IM-mirror change so
+    every platform funnels through one entry point. For now the message
+    lands in the table and the session's ``last_active_at`` bumps — UI
+    can render the user's turn immediately.
+    """
+
+    from storage import messages_service, workbench_sessions_service
+
+    payload = request.json or {}
+    text = payload.get("text")
+    content = payload.get("content")
+    if text is None and not content:
+        return jsonify({"error": "text or content is required"}), 400
+
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            session = workbench_sessions_service.get_session(conn, session_id)
+            message = messages_service.append(
+                conn,
+                scope_id=session["scope_id"],
+                session_id=session_id,
+                platform="avibe",
+                author="user",
+                text=text if isinstance(text, str) else None,
+                content=content if isinstance(content, dict) else None,
+                metadata=payload.get("metadata") or {},
+                author_id=payload.get("author_id"),
+                author_name=payload.get("author_name"),
+            )
+            workbench_sessions_service.touch_session(conn, session_id)
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+    return jsonify(message), 201
+
+
+@app.route("/api/sessions/<session_id>/mark-read", methods=["POST"])
+def sessions_mark_read(session_id: str):
+    from storage import messages_service, workbench_sessions_service
+
+    payload = request.json or {}
+    until_message_id = payload.get("until_message_id")
+
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            workbench_sessions_service.get_session(conn, session_id)
+            updated = messages_service.mark_session_read(
+                conn, session_id, until_message_id=until_message_id
+            )
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+    return jsonify({"updated": updated})
+
+
+@app.route("/api/inbox", methods=["GET"])
+def inbox_list():
+    """Cross-session inbox feed. Defaults to avibe-only per workbench scope."""
+
+    from storage import messages_service
+
+    platform = request.args.get("platform") or "avibe"
+    unread_only = request.args.get("unread_only") in {"1", "true", "yes"}
+    try:
+        limit = int(request.args.get("limit") or 30)
+    except (TypeError, ValueError):
+        limit = 30
+    before_id = request.args.get("before_id") or None
+
+    engine = _projects_engine()
+    with engine.connect() as conn:
+        result = messages_service.list_inbox(
+            conn,
+            platform=platform if platform != "all" else None,
+            unread_only=unread_only,
+            limit=limit,
+            before_id=before_id,
+        )
+        result["unread_counts"] = messages_service.unread_counts(
+            conn, platform=platform if platform != "all" else None
+        )
+    return jsonify(result)
+
+
+# =============================================================================
 # User & Bind Code Endpoints
 # =============================================================================
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2459,6 +2459,7 @@ def sessions_list():
 @app.route("/api/sessions", methods=["POST"])
 def sessions_create():
     from storage import workbench_sessions_service
+    from vibe.sse_broker import broker
 
     payload = request.json or {}
     project_id = (payload.get("project_id") or "").strip()
@@ -2488,6 +2489,7 @@ def sessions_create():
         return jsonify({"error": str(err)}), 404
     except PermissionError as err:
         return jsonify({"error": str(err)}), 403
+    broker.publish("session.activity", {"session_id": session["id"], "scope_id": session["scope_id"], "event": "created"})
     return jsonify(session), 201
 
 
@@ -2583,6 +2585,7 @@ def sessions_messages_create(session_id: str):
     """
 
     from storage import messages_service, workbench_sessions_service
+    from vibe.sse_broker import broker
 
     payload = request.json or {}
     text = payload.get("text")
@@ -2609,12 +2612,18 @@ def sessions_messages_create(session_id: str):
             workbench_sessions_service.touch_session(conn, session_id)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
+    broker.publish("message.new", message)
+    broker.publish(
+        "session.activity",
+        {"session_id": session_id, "scope_id": session["scope_id"], "event": "user_message"},
+    )
     return jsonify(message), 201
 
 
 @app.route("/api/sessions/<session_id>/mark-read", methods=["POST"])
 def sessions_mark_read(session_id: str):
     from storage import messages_service, workbench_sessions_service
+    from vibe.sse_broker import broker
 
     payload = request.json or {}
     until_message_id = payload.get("until_message_id")
@@ -2622,13 +2631,76 @@ def sessions_mark_read(session_id: str):
     engine = _projects_engine()
     try:
         with engine.begin() as conn:
-            workbench_sessions_service.get_session(conn, session_id)
+            session = workbench_sessions_service.get_session(conn, session_id)
             updated = messages_service.mark_session_read(
                 conn, session_id, until_message_id=until_message_id
             )
+            unread_counts = messages_service.unread_counts(conn, platform="avibe")
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
-    return jsonify({"updated": updated})
+    if updated:
+        broker.publish(
+            "inbox.unread.changed",
+            {
+                "session_id": session_id,
+                "scope_id": session["scope_id"],
+                "delta": -updated,
+                "unread_counts": unread_counts,
+            },
+        )
+    return jsonify({"updated": updated, "unread_counts": unread_counts})
+
+
+@app.route("/api/events", methods=["GET"])
+async def workbench_events():
+    """Server-Sent Events stream for the workbench.
+
+    Browsers open this once and keep it open; the route streams JSON
+    events (message.new, session.activity, inbox.unread.changed) as
+    they happen elsewhere in the app, plus a 15-second keep-alive
+    comment line so Cloudflare-style proxies don't kill the idle TCP
+    connection.
+
+    Native FastAPI ``StreamingResponse`` so the loop stays async and
+    each browser only costs one task, not one OS thread.
+    """
+
+    import asyncio
+
+    from fastapi.responses import StreamingResponse
+
+    from vibe.sse_broker import broker
+
+    async def generate():
+        sub_id, queue = broker.subscribe()
+        try:
+            # First chunk = handshake + sub_id so the client can include it in
+            # subsequent debug logs / cancel calls if we ever need them.
+            yield ": stream connected\n\n"
+            yield f"event: connected\ndata: {{\"sub_id\": {sub_id}}}\n\n"
+            while True:
+                try:
+                    event_type, payload = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    yield f"event: {event_type}\ndata: {payload}\n\n"
+                except asyncio.TimeoutError:
+                    # 15s keep-alive — Cloudflare Tunnel default idle is well
+                    # below 100s but this still keeps mid-tier proxies happy.
+                    yield ": ping\n\n"
+        except asyncio.CancelledError:
+            raise
+        finally:
+            broker.unsubscribe(sub_id)
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            # Disable nginx/cloudflare body buffering on the response side
+            # so chunks reach the client immediately.
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @app.route("/api/inbox", methods=["GET"])

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2733,6 +2733,84 @@ def inbox_list():
 
 
 # =============================================================================
+# Harness Endpoints (read-only v1)
+# =============================================================================
+#
+# Workbench Harness page reads scheduled tasks, watches, and agent runs out
+# of the same SQLite store the scheduler writes to. Mutations (delete /
+# cancel / pause-resume) need to talk to the live ScheduledTaskService and
+# WatchSupervisor so the in-memory schedule stays consistent — that wiring
+# lands in a follow-up commit.
+
+
+def _harness_store():
+    from storage.background import SQLiteBackgroundTaskStore
+
+    return SQLiteBackgroundTaskStore()
+
+
+@app.route("/api/harness/tasks", methods=["GET"])
+def harness_tasks_list():
+    return jsonify({"tasks": _harness_store().list_scheduled_tasks()})
+
+
+@app.route("/api/harness/watches", methods=["GET"])
+def harness_watches_list():
+    store = _harness_store()
+    watches = store.list_watches()
+    runtime = store.load_watch_runtime().get("watches") or {}
+    for watch in watches:
+        watch["runtime"] = runtime.get(watch["id"]) or {"running": False}
+    return jsonify({"watches": watches})
+
+
+@app.route("/api/harness/runs", methods=["GET"])
+def harness_runs_list():
+    from storage.pagination import make_page_request
+
+    try:
+        limit = int(request.args.get("limit") or 30)
+    except (TypeError, ValueError):
+        limit = 30
+    try:
+        page = int(request.args.get("page") or 1)
+    except (TypeError, ValueError):
+        page = 1
+    status = request.args.get("status") or None
+    run_type = request.args.get("run_type") or None
+    agent_name = request.args.get("agent_name") or None
+    definition_id = request.args.get("definition_id") or None
+    query = request.args.get("query") or None
+
+    page_request = make_page_request(page=page, limit=limit)
+    page_result = _harness_store().list_runs_page(
+        status=status,
+        run_type=run_type,
+        agent_name=agent_name,
+        definition_id=definition_id,
+        query=query,
+        page_request=page_request,
+        newest_first=True,
+    )
+    return jsonify(
+        {
+            "runs": page_result.items,
+            "page": page_result.page,
+            "limit": page_result.limit,
+            "has_more": page_result.has_more,
+        }
+    )
+
+
+@app.route("/api/harness/runs/<run_id>", methods=["GET"])
+def harness_run_detail(run_id: str):
+    run = _harness_store().get_run(run_id)
+    if not run:
+        return jsonify({"ok": False, "code": "run_not_found"}), 404
+    return jsonify({"ok": True, "run": run})
+
+
+# =============================================================================
 # User & Bind Code Endpoints
 # =============================================================================
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2294,6 +2294,131 @@ def browse_directory():
 
 
 # =============================================================================
+# Workbench: Projects + folder-picker helpers
+# =============================================================================
+# Projects are stored as avibe scopes (platform='avibe', scope_type='project')
+# with the local folder path on ``scope_settings.workdir``. See
+# ``storage/projects_service.py`` for the CRUD semantics; the routes below
+# are a thin REST surface over the same service so the workbench UI and any
+# future CLI both round-trip the same shape.
+
+
+def _projects_engine():
+    from storage.db import create_sqlite_engine
+
+    return create_sqlite_engine()
+
+
+@app.route("/api/projects", methods=["GET"])
+def projects_list():
+    from storage import projects_service
+
+    include_archived = request.args.get("include_archived") in {"1", "true", "yes"}
+    engine = _projects_engine()
+    with engine.connect() as conn:
+        return jsonify({"projects": projects_service.list_projects(conn, include_archived=include_archived)})
+
+
+@app.route("/api/projects", methods=["POST"])
+def projects_create():
+    from storage import projects_service
+
+    payload = request.json or {}
+    folder_path = (payload.get("folder_path") or "").strip()
+    if not folder_path:
+        return jsonify({"error": "folder_path is required"}), 400
+    display_name = payload.get("display_name")
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            project = projects_service.create_project(conn, folder_path, display_name=display_name)
+    except (FileNotFoundError, NotADirectoryError) as err:
+        return jsonify({"error": str(err)}), 400
+    return jsonify(project), 201
+
+
+@app.route("/api/projects/<project_id>", methods=["GET"])
+def projects_get(project_id: str):
+    from storage import projects_service
+
+    engine = _projects_engine()
+    try:
+        with engine.connect() as conn:
+            return jsonify(projects_service.get_project(conn, project_id))
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+
+
+@app.route("/api/projects/<project_id>", methods=["PATCH"])
+def projects_update(project_id: str):
+    from storage import projects_service
+
+    payload = request.json or {}
+    display_name = payload.get("display_name")
+    folder_path = payload.get("folder_path")
+    if display_name is None and folder_path is None:
+        return jsonify({"error": "display_name or folder_path is required"}), 400
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            project = projects_service.update_project(
+                conn,
+                project_id,
+                display_name=display_name,
+                folder_path=folder_path,
+            )
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+    except (FileNotFoundError, NotADirectoryError) as err:
+        return jsonify({"error": str(err)}), 400
+    return jsonify(project)
+
+
+@app.route("/api/projects/<project_id>", methods=["DELETE"])
+def projects_archive(project_id: str):
+    """Soft-delete a project by marking ``scope_settings.enabled = 0``.
+
+    The scope row itself sticks around so any related agent_sessions /
+    messages keep their foreign-key target. Pass ``include_archived=1``
+    on the list endpoint to surface archived projects in the UI.
+    """
+
+    from storage import projects_service
+
+    engine = _projects_engine()
+    try:
+        with engine.begin() as conn:
+            project = projects_service.archive_project(conn, project_id)
+    except LookupError as err:
+        return jsonify({"error": str(err)}), 404
+    return jsonify(project)
+
+
+@app.route("/api/browse/mkdir", methods=["POST"])
+def browse_mkdir():
+    """Create a new folder for the directory picker.
+
+    Used by the workbench folder picker's "New Folder" button. Errors
+    when the target already exists so the UI never silently selects
+    someone else's data dir.
+    """
+
+    from storage import projects_service
+
+    payload = request.json or {}
+    path = (payload.get("path") or "").strip()
+    if not path:
+        return jsonify({"error": "path is required"}), 400
+    try:
+        resolved = projects_service.make_directory(path)
+    except FileExistsError:
+        return jsonify({"error": f"Folder already exists: {path}"}), 409
+    except OSError as err:
+        return jsonify({"error": str(err)}), 400
+    return jsonify({"path": resolved}), 201
+
+
+# =============================================================================
 # User & Bind Code Endpoints
 # =============================================================================
 


### PR DESCRIPTION
## Summary

This PR rebuilds the Vibe Remote Web UI as an **Agent Workbench** layered on top of the existing Control Panel. It introduces a new `avibe` IM platform adapter for in-process workbench traffic, a platform-agnostic `messages` table, REST + SSE endpoints, and four full pages (Inbox, Agents, Harness, Chat). The final commit is a design doc that captures the architectural decisions for the next refactor branch.

Send/compose (typing in the Chat surface and triggering an agent) is deferred to the next PR series (`refactor/services-layer`) because it requires both a data-control-layer extraction and a cross-process dispatch channel — see `docs/plans/workbench-dispatch-architecture.md`.

## What changed (capability)

- **Dual-mode AppShell** — Workbench mode at `/`, Control Panel at `/admin/*`, with a sidebar toggle.
- **WorkbenchSidebar** — Inbox entry (hover popover + badge), capability nav (Agents / Skills / Harness / Vaults), projects placeholder.
- **avibe IM platform adapter** (`modules/im/avibe.py`) — a first-class IM platform served in-process, parallel to Slack/Discord/Telegram/Lark/WeChat.
- **`messages` table** — single platform-agnostic message store, `(platform, native_message_id)` unique.
- **Projects REST** — `/api/projects` CRUD over the existing `scopes` + `scope_settings` rows.
- **Native folder picker** — macOS-Finder-style; browse + mkdir + show-hidden + linear history.
- **Sessions + messages REST** — `/api/sessions`, `/api/sessions/<id>/messages`, `/api/inbox`, `/api/sessions/<id>/mark-read`.
- **SSE push channel** — `/api/events` long-lived stream; REST mutation routes publish through `vibe/sse_broker.py`.
- **Inbox** — hover popover (180ms close debounce) + full page with filter (Unread/All) + mark-all-read.
- **Agents page** — grouped list by backend with detail panel (Enable toggle, model, effort, system prompt) + create dialog.
- **Harness page** — read-only Tasks/Watches/Runs tabs.
- **Chat page** — inline editable title + agent/model/effort header (`/chat/:sessionId`), read-only transcript for now.
- **Cross-platform message mirror** (`core/message_mirror.py`) — Slack/Discord/Telegram/Lark/WeChat traffic mirrored into the new `messages` table; `platform="avibe"` is a no-op so the workbench REST writer stays the sole writer for its own platform.
- **Design doc** (`docs/plans/workbench-dispatch-architecture.md`) — captures Plan 1 (`core/services/` extraction) + Plan 2 (Unix-socket SSE for cross-process dispatch) + 10 resolved decisions.

## Evidence layers updated

- **Unit**: 4 new tests in `tests/test_message_mirror.py` (scope auto-upsert, agent row sharing scope, duplicate suppression, avibe no-op). 39 existing dispatcher/handler tests continue to pass.
- **Contract / Scenario**: no scenario catalog entries (this is a brand-new capability set). Plan 1's contract tests are scheduled in the follow-up branch.
- **Manual**: ran `npm run build` in `ui/` (clean), `ruff check` on all touched Python (clean), `pytest tests/test_message_mirror.py tests/test_message_dispatcher_*.py tests/test_message_handler_*.py` (all green). Pre-PR reviewer subagent found three block-PR issues — all fixed in commit `4a14bf4` before opening this PR.

## What is intentionally NOT in this PR

- Send/compose path (Web UI → agent dispatch). Documented in the design doc; lands in the follow-up `refactor/services-layer` branch.
- Settings extraction to `core/services/settings.py` — also follow-up.
- Cancellation UI for in-flight turns — follow-up.

## Reviewer notes

- The cross-process dispatch architecture is described in `docs/plans/workbench-dispatch-architecture.md`. The design intentionally rejects (a) queue-polling-only and (b) process-merge in favor of (c) Unix-socket SSE on the controller process — see §7.
- `core/message_mirror.py` writes are wrapped in try/except and an `IntegrityError` swallow so a malformed mirror cannot break the live IM reply path.
- `agent_runs` schema is unchanged; this PR does not touch the scheduled-task / harness worker path.