### PR TITLE
feat(show): consume prebuilt Show Runtime archives

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        include:
+          - os: ubuntu-latest
+            artifact: linux-x64
+          - os: macos-13
+            artifact: darwin-x64
+          - os: macos-14
+            artifact: darwin-arm64
+          - os: windows-latest
+            artifact: win32-x64
     steps:
       - name: Checkout Show Runtime
         uses: actions/checkout@v5
@@ -39,7 +47,7 @@ jobs:
       - name: Upload Show Runtime bundle
         uses: actions/upload-artifact@v6
         with:
-          name: show-runtime-${{ matrix.os }}
+          name: show-runtime-${{ matrix.artifact }}
           path: dist/vibe-show-runtime-node-*.tgz
 
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,35 @@ permissions:
   contents: read
 
 jobs:
+  show-runtime-bundles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    steps:
+      - name: Checkout Show Runtime
+        uses: actions/checkout@v5
+        with:
+          repository: avibe-bot/vibe-show-runtime
+          ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.14.0"
+          cache: "npm"
+      - name: Build Show Runtime bundle
+        run: |
+          npm ci
+          npm run build
+          npm run bundle:vibe-remote
+      - name: Upload Show Runtime bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: show-runtime-${{ matrix.os }}
+          path: dist/vibe-show-runtime-node-*.tgz
+
   build:
+    needs: show-runtime-bundles
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,6 +63,13 @@ jobs:
         run: |
           npm ci
           npm run build
+
+      - name: Download Show Runtime bundles
+        uses: actions/download-artifact@v6
+        with:
+          pattern: show-runtime-*
+          path: vibe/show_runtime
+          merge-multiple: true
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ logs/
 ui/node_modules/
 ui/dist/
 ui/.vite/
+vibe/show_runtime/*.tgz
 tmp/
 .bot.pid
 user_settings.json

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -537,11 +537,16 @@ def _runtime_platform_tag() -> str:
 def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
     destination_resolved = destination.resolve()
     for member in tar.getmembers():
-        if not (member.isfile() or member.isdir()):
+        if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
             raise ValueError(f"Unsafe archive member type: {member.name}")
         target = (destination / member.name).resolve()
         if target != destination_resolved and destination_resolved not in target.parents:
             raise ValueError(f"Unsafe archive member path: {member.name}")
+        if member.issym() or member.islnk():
+            link_target = (destination / member.name).parent / member.linkname
+            link_target_resolved = link_target.resolve()
+            if link_target_resolved != destination_resolved and destination_resolved not in link_target_resolved.parents:
+                raise ValueError(f"Unsafe archive link target: {member.name}")
     try:
         tar.extractall(destination, filter="data")
     except TypeError:

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -545,8 +545,13 @@ def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
         target = (destination / member.name).resolve()
         if target != destination_resolved and destination_resolved not in target.parents:
             raise ValueError(f"Unsafe archive member path: {member.name}")
-        if member.issym() or member.islnk():
+        if member.issym():
             link_target = (destination / member.name).parent / member.linkname
+            link_target_resolved = link_target.resolve()
+            if link_target_resolved != destination_resolved and destination_resolved not in link_target_resolved.parents:
+                raise ValueError(f"Unsafe archive link target: {member.name}")
+        elif member.islnk():
+            link_target = destination / member.linkname
             link_target_resolved = link_target.resolve()
             if link_target_resolved != destination_resolved and destination_resolved not in link_target_resolved.parents:
                 raise ValueError(f"Unsafe archive link target: {member.name}")

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import atexit
 import asyncio
+import importlib.resources as package_resources
 import logging
 import os
 import shlex
 import shutil
 import signal
 import subprocess
+import tarfile
+import tempfile
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+from sysconfig import get_platform
 from typing import Any
 
 import httpx
@@ -21,8 +26,11 @@ from core.process_isolation import KILL_SIGNAL, isolated_subprocess_kwargs, sign
 logger = logging.getLogger(__name__)
 _RUNTIME_BIN = "avibe-show-runtime"
 _RUNTIME_PACKAGE = "@avibe/show-runtime"
+_RUNTIME_ARCHIVE_PREFIX = "vibe-show-runtime-node"
+_RUNTIME_ARCHIVE_RELEASE_BASE_URL = "https://github.com/avibe-bot/vibe-show-runtime/releases/latest/download"
 _RUNTIME_GITHUB_REPO = "https://github.com/avibe-bot/vibe-show-runtime.git"
 _RUNTIME_GITHUB_REF = "main"
+_RUNTIME_SOURCE_ARCHIVE = "archive"
 _RUNTIME_SOURCE_GITHUB = "github"
 _RUNTIME_SOURCE_NPM = "npm"
 _FALSE_VALUES = {"0", "false", "no", "off"}
@@ -45,6 +53,8 @@ class ShowRuntimeManager:
         auto_install: bool | None = None,
         package_spec: str | None = None,
         runtime_source: str | None = None,
+        archive_path: Path | str | None = None,
+        archive_url: str | None = None,
         github_repo: str | None = None,
         github_ref: str | None = None,
     ) -> None:
@@ -54,6 +64,12 @@ class ShowRuntimeManager:
         self.auto_install = _auto_install_enabled() if auto_install is None else auto_install
         self.package_spec = package_spec or os.environ.get("VIBE_SHOW_RUNTIME_PACKAGE_SPEC") or _RUNTIME_PACKAGE
         self.runtime_source = _normalize_runtime_source(runtime_source or os.environ.get("VIBE_SHOW_RUNTIME_SOURCE"))
+        archive_path_value = archive_path or os.environ.get("VIBE_SHOW_RUNTIME_ARCHIVE_PATH")
+        self.archive_path = Path(archive_path_value).expanduser() if archive_path_value else None
+        self.archive_url = archive_url if archive_url is not None else os.environ.get(
+            "VIBE_SHOW_RUNTIME_ARCHIVE_URL",
+            _default_runtime_archive_url(),
+        )
         self.github_repo = github_repo or os.environ.get("VIBE_SHOW_RUNTIME_GITHUB_REPO") or _RUNTIME_GITHUB_REPO
         self.github_ref = github_ref or os.environ.get("VIBE_SHOW_RUNTIME_GITHUB_REF") or _RUNTIME_GITHUB_REF
         self.stdout_path = self.runtime_dir / "stdout.log"
@@ -165,12 +181,20 @@ class ShowRuntimeManager:
         if self.command != _RUNTIME_BIN:
             self._install_reason = "runtime_command_missing"
             return None
-        managed = self._managed_bin_path()
-        resolved = _resolve_executable_path(managed)
-        if resolved:
-            return [resolved]
-        if self._managed_command:
-            return self._managed_command
+        if self.runtime_source == _RUNTIME_SOURCE_ARCHIVE:
+            command = self._installed_archive_runtime_command()
+            if command:
+                self._managed_command = command
+                return command
+            if self._managed_command:
+                return self._managed_command
+        else:
+            managed = self._managed_bin_path()
+            resolved = _resolve_executable_path(managed)
+            if resolved:
+                return [resolved]
+            if self._managed_command:
+                return self._managed_command
         if self.runtime_source == _RUNTIME_SOURCE_GITHUB:
             command = self._installed_github_runtime_command()
             if command:
@@ -188,6 +212,8 @@ class ShowRuntimeManager:
         return command
 
     def _install_managed_runtime(self) -> list[str] | None:
+        if self.runtime_source == _RUNTIME_SOURCE_ARCHIVE:
+            return self._install_archive_runtime()
         if self.runtime_source == _RUNTIME_SOURCE_GITHUB:
             return self._install_github_runtime()
         if self.runtime_source == _RUNTIME_SOURCE_NPM:
@@ -195,14 +221,107 @@ class ShowRuntimeManager:
         self._install_reason = "runtime_source_unsupported"
         return None
 
+    def _installed_archive_runtime_command(self) -> list[str] | None:
+        node = _resolve_node_command()
+        if not node:
+            return None
+        return self._archive_runtime_command(self._archive_install_dir(), node)
+
+    def _install_archive_runtime(self) -> list[str] | None:
+        node = _resolve_node_command()
+        if not node:
+            self._install_reason = "runtime_node_missing"
+            return None
+        self.runtime_dir.mkdir(parents=True, exist_ok=True)
+        install_dir = self._archive_install_dir()
+        existing_command = self._archive_runtime_command(install_dir, node)
+        archive = self._resolve_prebuilt_archive()
+        if not archive:
+            return self._reuse_existing_archive_runtime(existing_command)
+        tmp_dir = Path(tempfile.mkdtemp(prefix="prebuilt-", dir=self.runtime_dir))
+        try:
+            with tarfile.open(archive, "r:gz") as tar:
+                _safe_extract_tar(tar, tmp_dir)
+            command = self._archive_runtime_command(tmp_dir, node)
+            if not command:
+                self._install_reason = "runtime_install_missing_bin"
+                return self._reuse_existing_archive_runtime(existing_command)
+            if install_dir.exists():
+                shutil.rmtree(install_dir)
+            install_dir.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(tmp_dir), str(install_dir))
+            self._install_reason = None
+            return self._archive_runtime_command(install_dir, node)
+        except Exception:
+            logger.exception("Failed to install prebuilt Show Runtime")
+            self._install_reason = "runtime_install_failed"
+            return self._reuse_existing_archive_runtime(existing_command)
+        finally:
+            if tmp_dir.exists():
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    def _resolve_prebuilt_archive(self) -> Path | None:
+        if self.archive_path:
+            if self.archive_path.exists():
+                return self.archive_path
+            self._install_reason = "runtime_archive_missing"
+            return None
+        packaged = self._copy_packaged_runtime_archive()
+        if packaged:
+            return packaged
+        if not self.archive_url:
+            self._install_reason = "runtime_archive_missing"
+            return None
+        return self._download_runtime_archive(self.archive_url)
+
+    def _copy_packaged_runtime_archive(self) -> Path | None:
+        try:
+            resource = package_resources.files("vibe").joinpath("show_runtime", _runtime_archive_name())
+        except Exception:
+            return None
+        if not resource.is_file():
+            return None
+        target = self.runtime_dir / "downloads" / _runtime_archive_name()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with resource.open("rb") as source, target.open("wb") as destination:
+            shutil.copyfileobj(source, destination)
+        return target
+
+    def _download_runtime_archive(self, archive_url: str) -> Path | None:
+        target = self.runtime_dir / "downloads" / _runtime_archive_name()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with urllib.request.urlopen(archive_url, timeout=60) as response, target.open("wb") as destination:
+                shutil.copyfileobj(response, destination)
+        except Exception:
+            logger.exception("Failed to download prebuilt Show Runtime from %s", archive_url)
+            self._install_reason = "runtime_archive_download_failed"
+            return None
+        return target
+
+    def _archive_install_dir(self) -> Path:
+        return self.runtime_dir / "prebuilt" / "current"
+
+    def _archive_runtime_command(self, install_dir: Path, node: list[str]) -> list[str] | None:
+        cli_path = install_dir / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
+        if not cli_path.exists():
+            return None
+        return [*node, str(cli_path)]
+
+    def _reuse_existing_archive_runtime(self, command: list[str] | None) -> list[str] | None:
+        if command:
+            self._install_reason = None
+            return command
+        return None
+
     def _installed_github_runtime_command(self) -> list[str] | None:
-        node = _resolve_command("node")
+        node = _resolve_node_command()
         if not node:
             return None
         return self._github_runtime_command(self._github_source_dir(), node)
 
     def _install_github_runtime(self) -> list[str] | None:
-        node = _resolve_command("node")
+        node = _resolve_node_command()
         if not node:
             self._install_reason = "runtime_node_missing"
             return None
@@ -347,8 +466,50 @@ def _auto_install_enabled() -> bool:
 
 
 def _normalize_runtime_source(value: str | None) -> str:
-    normalized = (value or _RUNTIME_SOURCE_GITHUB).strip().lower()
-    return normalized or _RUNTIME_SOURCE_GITHUB
+    normalized = (value or _RUNTIME_SOURCE_ARCHIVE).strip().lower()
+    return normalized or _RUNTIME_SOURCE_ARCHIVE
+
+
+def _runtime_archive_name() -> str:
+    return f"{_RUNTIME_ARCHIVE_PREFIX}-{_runtime_platform_tag()}.tgz"
+
+
+def _default_runtime_archive_url() -> str:
+    return f"{_RUNTIME_ARCHIVE_RELEASE_BASE_URL}/{_runtime_archive_name()}"
+
+
+def _runtime_platform_tag() -> str:
+    raw = get_platform().lower()
+    machine = raw.rsplit("-", 1)[-1]
+    if machine in {"amd64", "x86_64"}:
+        arch = "x64"
+    elif machine in {"arm64", "aarch64"}:
+        arch = "arm64"
+    else:
+        arch = machine
+    if raw.startswith("macosx"):
+        os_name = "darwin"
+    elif raw.startswith("linux"):
+        os_name = "linux"
+    elif raw.startswith("win"):
+        os_name = "win32"
+    else:
+        os_name = os.name
+    return f"{os_name}-{arch}"
+
+
+def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
+    destination_resolved = destination.resolve()
+    for member in tar.getmembers():
+        if not (member.isfile() or member.isdir()):
+            raise ValueError(f"Unsafe archive member type: {member.name}")
+        target = (destination / member.name).resolve()
+        if target != destination_resolved and destination_resolved not in target.parents:
+            raise ValueError(f"Unsafe archive member path: {member.name}")
+    try:
+        tar.extractall(destination, filter="data")
+    except TypeError:
+        tar.extractall(destination)
 
 
 def _safe_path_part(value: str) -> str:
@@ -369,6 +530,13 @@ def _resolve_command(command: str) -> list[str] | None:
     if not resolved:
         return None
     return [resolved, *parts[1:]]
+
+
+def _resolve_node_command() -> list[str] | None:
+    configured = os.environ.get("VIBE_SHOW_RUNTIME_NODE_BIN")
+    if configured:
+        return _resolve_command(configured)
+    return _resolve_command("node")
 
 
 def _resolve_executable_path(path: Path) -> str | None:

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import atexit
 import asyncio
+import hashlib
 import importlib.resources as package_resources
+import json
 import logging
 import os
 import shlex
@@ -182,6 +184,12 @@ class ShowRuntimeManager:
             self._install_reason = "runtime_command_missing"
             return None
         if self.runtime_source == _RUNTIME_SOURCE_ARCHIVE:
+            if self.auto_install and not self._install_attempted:
+                self._install_attempted = True
+                command = await asyncio.to_thread(self._install_managed_runtime)
+                if command:
+                    self._managed_command = command
+                    return command
             command = self._installed_archive_runtime_command()
             if command:
                 self._managed_command = command
@@ -238,6 +246,10 @@ class ShowRuntimeManager:
         archive = self._resolve_prebuilt_archive()
         if not archive:
             return self._reuse_existing_archive_runtime(existing_command)
+        archive_digest = _file_sha256(archive)
+        if existing_command and self._archive_manifest_matches(archive_digest):
+            self._install_reason = None
+            return existing_command
         tmp_dir = Path(tempfile.mkdtemp(prefix="prebuilt-", dir=self.runtime_dir))
         try:
             with tarfile.open(archive, "r:gz") as tar:
@@ -250,6 +262,7 @@ class ShowRuntimeManager:
                 shutil.rmtree(install_dir)
             install_dir.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(tmp_dir), str(install_dir))
+            self._write_archive_manifest(archive_digest)
             self._install_reason = None
             return self._archive_runtime_command(install_dir, node)
         except Exception:
@@ -301,6 +314,29 @@ class ShowRuntimeManager:
 
     def _archive_install_dir(self) -> Path:
         return self.runtime_dir / "prebuilt" / "current"
+
+    def _archive_manifest_path(self) -> Path:
+        return self._archive_install_dir() / ".vibe-show-runtime.json"
+
+    def _archive_manifest_matches(self, archive_digest: str) -> bool:
+        try:
+            payload = json.loads(self._archive_manifest_path().read_text(encoding="utf-8"))
+        except Exception:
+            return False
+        return payload.get("archive_name") == _runtime_archive_name() and payload.get("sha256") == archive_digest
+
+    def _write_archive_manifest(self, archive_digest: str) -> None:
+        self._archive_manifest_path().write_text(
+            json.dumps(
+                {
+                    "archive_name": _runtime_archive_name(),
+                    "sha256": archive_digest,
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
     def _archive_runtime_command(self, install_dir: Path, node: list[str]) -> list[str] | None:
         cli_path = install_dir / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
@@ -510,6 +546,14 @@ def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
         tar.extractall(destination, filter="data")
     except TypeError:
         tar.extractall(destination)
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _safe_path_part(value: str) -> str:

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -7,6 +7,7 @@ import importlib.resources as package_resources
 import json
 import logging
 import os
+import platform
 import shlex
 import shutil
 import signal
@@ -517,6 +518,8 @@ def _default_runtime_archive_url() -> str:
 def _runtime_platform_tag() -> str:
     raw = get_platform().lower()
     machine = raw.rsplit("-", 1)[-1]
+    if machine == "universal2":
+        machine = platform.machine().lower()
     if machine in {"amd64", "x86_64"}:
         arch = "x64"
     elif machine in {"arm64", "aarch64"}:

--- a/install.ps1
+++ b/install.ps1
@@ -9,6 +9,7 @@ $ErrorActionPreference = "Stop"
 $REPO = "cyhhao/vibe-remote"
 $PACKAGE_NAME = "vibe-remote"
 $TSINGHUA_INDEX_URL = "https://pypi.tuna.tsinghua.edu.cn/simple"
+$NODE_VERSION_MAJOR = 20
 
 function Write-Banner {
     Write-Host @"
@@ -51,6 +52,57 @@ function Test-Command {
     param([string]$Command)
     $null = Get-Command $Command -ErrorAction SilentlyContinue
     return $?
+}
+
+function Test-Node {
+    if (-not (Test-Command "node")) {
+        return $false
+    }
+    try {
+        $version = (& node --version).Trim().TrimStart("v")
+        $major = [int]($version.Split(".")[0])
+        return $major -ge $NODE_VERSION_MAJOR
+    } catch {
+        return $false
+    }
+}
+
+function Install-Node {
+    if ($env:VIBE_INSTALL_SKIP_NODE -eq "1") {
+        Write-Warning "Skipping Node.js installation because VIBE_INSTALL_SKIP_NODE=1"
+        return
+    }
+
+    if (Test-Node) {
+        Write-Success "Node.js is already installed"
+        return
+    }
+
+    Write-Info "Installing Node.js for Show Pages runtime..."
+    if (Test-Command "winget") {
+        $result = Invoke-NativeCommand -FilePath "winget" -Arguments @(
+            "install",
+            "OpenJS.NodeJS.LTS",
+            "--accept-source-agreements",
+            "--accept-package-agreements",
+            "--silent"
+        )
+        if (-not $result.Success) {
+            $message = "Failed to install Node.js with winget"
+            if ($result.Output) {
+                $message += ":`n$($result.Output)"
+            }
+            Write-Error $message
+        }
+
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+        if (Test-Node) {
+            Write-Success "Node.js installed successfully"
+            return
+        }
+    }
+
+    Write-Error "Node.js 20+ is required for Show Pages runtime. Please install Node.js LTS from https://nodejs.org/ and rerun this script."
 }
 
 function Install-Uv {
@@ -284,6 +336,9 @@ function Main {
     
     # Install uv (which manages Python automatically)
     Install-Uv
+
+    # Install Node.js for managed Show Page runtime if needed.
+    Install-Node
     
     # Install vibe-remote
     Install-Vibe

--- a/install.ps1
+++ b/install.ps1
@@ -95,7 +95,8 @@ function Install-Node {
             Write-Error $message
         }
 
-        $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+        $persistedPath = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+        $env:Path = $env:Path + ";" + $persistedPath
         if (Test-Node) {
             Write-Success "Node.js installed successfully"
             return

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,8 @@ NC='\033[0m' # No Color
 # Configuration
 REPO="cyhhao/vibe-remote"
 PACKAGE_NAME="vibe-remote"
+NODE_VERSION="22.16.0"
+NODE_VERSION_MAJOR="20"
 VIBE_BIN_PATH=""
 VIBE_TOOL_BIN_DIR=""
 ORIGINAL_PATH="$PATH"
@@ -259,6 +261,101 @@ uv_is_native_for_host() {
     uv_binary_is_acceptable "$uv_path"
 }
 
+node_major_version() {
+    local version=""
+    version="$(node --version 2>/dev/null || true)"
+    version="${version#v}"
+    version="${version%%.*}"
+    case "$version" in
+        ''|*[!0-9]*) return 1 ;;
+        *) printf '%s\n' "$version" ;;
+    esac
+}
+
+node_is_acceptable() {
+    local major=""
+    major="$(node_major_version || true)"
+    [ -n "$major" ] && [ "$major" -ge 20 ]
+}
+
+node_platform_arch() {
+    local os="$1"
+    local machine=""
+    machine="$(uname -m 2>/dev/null || true)"
+
+    case "$machine" in
+        arm64|aarch64) machine="arm64" ;;
+        x86_64|amd64) machine="x64" ;;
+        *) return 1 ;;
+    esac
+
+    case "$os" in
+        macos) printf 'darwin-%s\n' "$machine" ;;
+        linux) printf 'linux-%s\n' "$machine" ;;
+        *) return 1 ;;
+    esac
+}
+
+run_as_root() {
+    if [ "$(id -u 2>/dev/null || echo 1)" = "0" ]; then
+        "$@"
+    elif command_exists sudo; then
+        sudo "$@"
+    else
+        return 127
+    fi
+}
+
+install_node() {
+    if [ "${VIBE_INSTALL_SKIP_NODE:-}" = "1" ]; then
+        warn "Skipping Node.js installation because VIBE_INSTALL_SKIP_NODE=1"
+        return 0
+    fi
+
+    if command_exists node && node_is_acceptable; then
+        success "Node.js is already installed"
+        return 0
+    fi
+
+    local os
+    os="$(detect_os)"
+
+    info "Installing Node.js ${NODE_VERSION_MAJOR:-20}+ for Show Pages runtime..."
+    case "$os" in
+        macos)
+            if command_exists brew; then
+                brew install node || error "Failed to install Node.js with Homebrew"
+            else
+                error "Node.js 20+ is required. Install Homebrew or Node.js from https://nodejs.org/ and rerun this script."
+            fi
+            ;;
+        linux)
+            if command_exists apt-get; then
+                curl -fsSL https://deb.nodesource.com/setup_22.x | run_as_root bash - || error "Failed to configure NodeSource repository"
+                run_as_root apt-get install -y nodejs || error "Failed to install Node.js with apt"
+            elif command_exists dnf; then
+                run_as_root dnf install -y nodejs npm || error "Failed to install Node.js with dnf"
+            elif command_exists yum; then
+                run_as_root yum install -y nodejs npm || error "Failed to install Node.js with yum"
+            elif command_exists pacman; then
+                run_as_root pacman -S --noconfirm nodejs npm || error "Failed to install Node.js with pacman"
+            else
+                error "Node.js 20+ is required. Please install Node.js globally with your system package manager and rerun this script."
+            fi
+            ;;
+        *)
+            error "Node.js 20+ is required. Please install Node.js globally and rerun this script."
+            ;;
+    esac
+
+    if command_exists node && node_is_acceptable; then
+        success "Node.js installed successfully"
+        return 0
+    fi
+
+    error "Node.js installation completed but node 20+ is not available in PATH"
+}
+
 uv_tool_install() {
     if [ -n "$VIBE_TOOL_BIN_DIR" ]; then
         UV_TOOL_BIN_DIR="$VIBE_TOOL_BIN_DIR" uv tool install "$@"
@@ -472,6 +569,16 @@ main() {
     
     # Install uv (which manages Python automatically)
     install_uv
+
+    VIBE_TOOL_BIN_DIR="$(choose_tool_bin_dir || true)"
+    if [ -n "$VIBE_TOOL_BIN_DIR" ]; then
+        info "Using tool bin directory $VIBE_TOOL_BIN_DIR"
+    else
+        warn "Could not find a writable directory in PATH; falling back to ~/.local/bin where possible"
+    fi
+
+    # Install Node.js for managed Show Page runtime if needed.
+    install_node
     
     # Install vibe-remote
     install_vibe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ source = "vcs"
 version-file = "vibe/_version.py"
 
 [tool.hatch.build]
-# Include ui/dist even though it's in .gitignore (build artifacts)
-artifacts = ["ui/dist/**"]
+# Include generated assets even though they are in .gitignore (build artifacts)
+artifacts = ["ui/dist/**", "vibe/show_runtime/*.tgz"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["vibe", "config", "core", "modules", "storage"]
@@ -93,6 +93,7 @@ packages = ["vibe", "config", "core", "modules", "storage"]
 [tool.hatch.build.targets.wheel.force-include]
 "main.py" = "vibe/service_main.py"
 "ui/dist" = "vibe/ui/dist"
+"vibe/show_runtime" = "vibe/show_runtime"
 
 [tool.hatch.build.targets.sdist]
 # Include ui/dist for source distribution
@@ -104,6 +105,7 @@ include = [
     "storage/**",
     "main.py",
     "ui/dist/**",
+    "vibe/show_runtime/**",
     "README.md",
     "LICENSE",
 ]

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -58,6 +58,20 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
     )
 
 
+def _write_fake_node(path: Path, version: str = "v22.16.0") -> None:
+    _write_executable(
+        path,
+        f"""\
+        #!/usr/bin/env bash
+        if [ "${{1:-}}" = "--version" ]; then
+            echo "{version}"
+        else
+            echo "node"
+        fi
+        """,
+    )
+
+
 def _write_fake_file(path: Path, mapping: dict[Path, str]) -> None:
     cases = "\n".join(
         f'        "{target}") echo "${{prefix}}{description}" ;;' for target, description in mapping.items()
@@ -112,6 +126,8 @@ def _write_fake_sysctl(path: Path, arm64: bool = True) -> None:
 
 
 def _install(env: dict[str, str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    env = {**env}
+    env.setdefault("VIBE_INSTALL_SKIP_NODE", "1")
     return _run(f'bash "{INSTALL_SCRIPT}"', cwd=cwd, env=env)
 
 
@@ -142,6 +158,48 @@ def test_install_script_keeps_vibe_available_on_current_path(tmp_path):
     assert version_result.returncode == 0, version_result.stdout + version_result.stderr
     assert "vibe-remote 9.9.9" in version_result.stdout
     assert uv_log.read_text(encoding="utf-8")
+
+
+def test_install_script_installs_node_when_missing(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    _write_fake_uv(path_dir / "uv", uv_log)
+    _write_fake_uname(path_dir / "uname", machine="arm64")
+    _write_executable(
+        path_dir / "brew",
+        f"""\
+        #!/usr/bin/env bash
+        if [ "${{1:-}}" = "install" ] && [ "${{2:-}}" = "node" ]; then
+            cat > "{path_dir / 'node'}" <<'EOF'
+        #!/usr/bin/env bash
+        if [ "${1:-}" = "--version" ]; then
+            echo "v22.16.0"
+        else
+            echo "node"
+        fi
+        EOF
+            chmod +x "{path_dir / 'node'}"
+            exit 0
+        fi
+        exit 1
+        """,
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["VIBE_INSTALL_SKIP_NODE"] = "0"
+
+    install_result = _install(env, cwd=tmp_path)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert "Installing Node.js 20+" in install_result.stdout
+    assert "Node.js installed successfully" in install_result.stdout
+    assert (path_dir / "node").exists()
 
 
 def test_install_script_prefers_new_bin_over_stale_local_bin(tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1,9 +1,12 @@
 import asyncio
 import tarfile
+from pathlib import Path
+
+import pytest
 
 from config import paths
 from core.show_pages import ShowPageStore, ensure_show_page_dir
-from core.show_runtime import ShowRuntimeManager, set_show_runtime_manager_for_tests
+from core.show_runtime import ShowRuntimeManager, _safe_extract_tar, set_show_runtime_manager_for_tests
 from tests.test_ui_remote_access_auth import _mock_interface, _remote_peer, _save_config
 from vibe import remote_access
 from vibe.ui_server import app
@@ -323,6 +326,53 @@ def test_show_runtime_manager_installs_from_prebuilt_archive(monkeypatch, tmp_pa
         str(tmp_path / "runtime" / "prebuilt" / "current" / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"),
     ]
     assert manager._install_reason is None
+
+
+def test_show_runtime_manager_installs_prebuilt_archive_with_internal_symlinks(monkeypatch, tmp_path):
+    archive_root = tmp_path / "archive-root"
+    package_dir = archive_root / "packages" / "runtime"
+    cli_path = package_dir / "dist" / "cli.js"
+    cli_path.parent.mkdir(parents=True)
+    cli_path.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    scope_dir = archive_root / "node_modules" / "@avibe"
+    bin_dir = archive_root / "node_modules" / ".bin"
+    scope_dir.mkdir(parents=True)
+    bin_dir.mkdir(parents=True)
+    (scope_dir / "show-runtime").symlink_to("../../packages/runtime")
+    (bin_dir / "avibe-show-runtime").symlink_to("../@avibe/show-runtime/dist/cli.js")
+    archive_path = tmp_path / "vibe-show-runtime-node.tgz"
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(archive_root / "packages", arcname="packages")
+        tar.add(archive_root / "node_modules", arcname="node_modules")
+
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+        archive_path=archive_path,
+    )
+    monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: ["/bin/node"] if command == "node" else None)
+
+    command = manager._install_managed_runtime()
+
+    assert command == [
+        "/bin/node",
+        str(tmp_path / "runtime" / "prebuilt" / "current" / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"),
+    ]
+    assert Path(command[1]).resolve().read_text(encoding="utf-8") == "#!/usr/bin/env node\n"
+    assert manager._install_reason is None
+
+
+def test_show_runtime_safe_extract_rejects_external_symlink(tmp_path):
+    archive_root = tmp_path / "archive-root"
+    archive_root.mkdir()
+    (archive_root / "escape").symlink_to("../../outside")
+    archive_path = tmp_path / "unsafe.tgz"
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(archive_root / "escape", arcname="escape")
+
+    with tarfile.open(archive_path, "r:gz") as tar:
+        with pytest.raises(ValueError, match="Unsafe archive link target"):
+            _safe_extract_tar(tar, tmp_path / "destination")
 
 
 def test_show_runtime_manager_reuses_installed_prebuilt_runtime_without_archive(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import tarfile
 from pathlib import Path
 
@@ -376,6 +377,23 @@ def test_show_runtime_safe_extract_rejects_external_symlink(tmp_path):
     archive_path = tmp_path / "unsafe.tgz"
     with tarfile.open(archive_path, "w:gz") as tar:
         tar.add(archive_root / "escape", arcname="escape")
+
+    with tarfile.open(archive_path, "r:gz") as tar:
+        with pytest.raises(ValueError, match="Unsafe archive link target"):
+            _safe_extract_tar(tar, tmp_path / "destination")
+
+
+def test_show_runtime_safe_extract_rejects_external_hardlink(tmp_path):
+    archive_path = tmp_path / "unsafe-hardlink.tgz"
+    with tarfile.open(archive_path, "w:gz") as tar:
+        data = b"safe\n"
+        safe = tarfile.TarInfo("safe")
+        safe.size = len(data)
+        tar.addfile(safe, io.BytesIO(data))
+        hardlink = tarfile.TarInfo("dir/h")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "../outside"
+        tar.addfile(hardlink)
 
     with tarfile.open(archive_path, "r:gz") as tar:
         with pytest.raises(ValueError, match="Unsafe archive link target"):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1,4 +1,5 @@
 import asyncio
+import tarfile
 
 from config import paths
 from core.show_pages import ShowPageStore, ensure_show_page_dir
@@ -294,10 +295,50 @@ def test_show_runtime_manager_uses_managed_runtime_bin(tmp_path):
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",
         runtime_dir=runtime_dir,
+        runtime_source="npm",
         auto_install=False,
     )
 
     assert asyncio.run(manager._resolve_managed_command()) == [str(bin_path)]
+
+
+def test_show_runtime_manager_installs_from_prebuilt_archive(monkeypatch, tmp_path):
+    archive_root = tmp_path / "archive-root"
+    cli_path = archive_root / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
+    cli_path.parent.mkdir(parents=True)
+    cli_path.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+    archive_path = tmp_path / "vibe-show-runtime-node.tgz"
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(archive_root / "node_modules", arcname="node_modules")
+
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+        archive_path=archive_path,
+    )
+    monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: ["/bin/node"] if command == "node" else None)
+
+    assert manager._install_managed_runtime() == [
+        "/bin/node",
+        str(tmp_path / "runtime" / "prebuilt" / "current" / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"),
+    ]
+    assert manager._install_reason is None
+
+
+def test_show_runtime_manager_reuses_installed_prebuilt_runtime_without_archive(monkeypatch, tmp_path):
+    cli_path = tmp_path / "runtime" / "prebuilt" / "current" / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
+    cli_path.parent.mkdir(parents=True)
+    cli_path.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+        archive_path=tmp_path / "missing.tgz",
+    )
+    monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: ["/bin/node"] if command == "node" else None)
+
+    assert manager._install_managed_runtime() == ["/bin/node", str(cli_path)]
+    assert manager._install_reason is None
 
 
 def test_show_runtime_manager_can_disable_auto_install(tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -6,7 +6,7 @@ import pytest
 
 from config import paths
 from core.show_pages import ShowPageStore, ensure_show_page_dir
-from core.show_runtime import ShowRuntimeManager, _safe_extract_tar, set_show_runtime_manager_for_tests
+from core.show_runtime import ShowRuntimeManager, _runtime_platform_tag, _safe_extract_tar, set_show_runtime_manager_for_tests
 from tests.test_ui_remote_access_auth import _mock_interface, _remote_peer, _save_config
 from vibe import remote_access
 from vibe.ui_server import app
@@ -303,6 +303,13 @@ def test_show_runtime_manager_uses_managed_runtime_bin(tmp_path):
     )
 
     assert asyncio.run(manager._resolve_managed_command()) == [str(bin_path)]
+
+
+def test_show_runtime_archive_platform_tag_maps_macos_universal2_to_machine(monkeypatch):
+    monkeypatch.setattr("core.show_runtime.get_platform", lambda: "macosx-14.0-universal2")
+    monkeypatch.setattr("core.show_runtime.platform.machine", lambda: "arm64")
+
+    assert _runtime_platform_tag() == "darwin-arm64"
 
 
 def test_show_runtime_manager_installs_from_prebuilt_archive(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -341,6 +341,31 @@ def test_show_runtime_manager_reuses_installed_prebuilt_runtime_without_archive(
     assert manager._install_reason is None
 
 
+def test_show_runtime_manager_refreshes_stale_prebuilt_archive(monkeypatch, tmp_path):
+    runtime_dir = tmp_path / "runtime"
+    installed_cli = runtime_dir / "prebuilt" / "current" / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
+    installed_cli.parent.mkdir(parents=True)
+    installed_cli.write_text("old runtime\n", encoding="utf-8")
+
+    archive_root = tmp_path / "archive-root"
+    archive_cli = archive_root / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
+    archive_cli.parent.mkdir(parents=True)
+    archive_cli.write_text("new runtime\n", encoding="utf-8")
+    archive_path = tmp_path / "vibe-show-runtime-node.tgz"
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(archive_root / "node_modules", arcname="node_modules")
+
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=runtime_dir,
+        archive_path=archive_path,
+    )
+    monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: ["/bin/node"] if command == "node" else None)
+
+    assert asyncio.run(manager._resolve_managed_command()) == ["/bin/node", str(installed_cli)]
+    assert installed_cli.read_text(encoding="utf-8") == "new runtime\n"
+
+
 def test_show_runtime_manager_can_disable_auto_install(tmp_path):
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",


### PR DESCRIPTION
## Summary
- Switch Show Runtime resolution to prebuilt platform archives instead of cloning/building the runtime on user machines.
- Package platform-specific Show Runtime archives into release wheels and install Node.js 20+ globally during installer setup.
- Harden archive extraction and keep explicit GitHub/npm source modes for development overrides.

## Dependency
- Depends on https://github.com/avibe-bot/vibe-show-runtime/pull/1 landing first, because the Vibe Remote publish workflow calls `npm run bundle:vibe-remote` from the runtime repo.

## Evidence Layers
- Unit: `uv run pytest tests/test_ui_show_pages.py tests/test_install_script.py -q`
- Contract: Show Runtime archive manager tests cover prebuilt install and legacy npm mode isolation.
- Scenario: not updated; no scenario catalog entry exists for Show Runtime packaging.
- Manual residual: full release workflow and multi-OS archive build need CI confirmation after both PRs land.

## Validation
- `uv run pytest tests/test_ui_show_pages.py tests/test_install_script.py -q`
- `uv run ruff check core/show_runtime.py tests/test_ui_show_pages.py tests/test_install_script.py`