### PR TITLE
fix(settings): migrate routing overrides to canonical fields

### DIFF
--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -115,8 +115,9 @@ def normalize_routing_settings(routing: Optional[RoutingSettings]) -> RoutingSet
     return RoutingSettings(
         agent_name=getattr(routing, "agent_name", None),
         agent_backend=backend,
-        model=_legacy_value_for_backend(routing, "model") or getattr(routing, "model", None),
-        reasoning_effort=_legacy_value_for_backend(routing, "reasoning_effort") or getattr(routing, "reasoning_effort", None),
+        model=getattr(routing, "model", None) or _legacy_value_for_backend(routing, "model"),
+        reasoning_effort=getattr(routing, "reasoning_effort", None)
+        or _legacy_value_for_backend(routing, "reasoning_effort"),
         opencode_agent=getattr(routing, "opencode_agent", None),
         opencode_model=None if collapse_legacy else getattr(routing, "opencode_model", None),
         opencode_reasoning_effort=None if collapse_legacy else getattr(routing, "opencode_reasoning_effort", None),

--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -106,6 +106,12 @@ def _legacy_value_for_backend(routing: RoutingSettings, field: str) -> Optional[
     return getattr(routing, field_name, None) if field_name else None
 
 
+def _payload_value(payload: dict, key: str, fallback_key: str) -> Optional[str]:
+    if key in payload:
+        return payload.get(key)
+    return payload.get(fallback_key)
+
+
 def normalize_routing_settings(routing: Optional[RoutingSettings]) -> RoutingSettings:
     """Collapse legacy model/effort fields only when the backend is known."""
     if routing is None:
@@ -201,21 +207,23 @@ class SettingsState:
 
 def _parse_routing(payload: dict) -> RoutingSettings:
     """Parse a routing settings dict into a RoutingSettings dataclass."""
+    model_key_present = "model" in payload
+    reasoning_key_present = "reasoning_effort" in payload
     return normalize_routing_settings(
         RoutingSettings(
             agent_name=payload.get("agent_name") or payload.get("agent"),
             agent_backend=payload.get("agent_backend"),
-            model=payload.get("model") or payload.get("model_override"),
-            reasoning_effort=payload.get("reasoning_effort") or payload.get("reasoning_effort_override"),
+            model=_payload_value(payload, "model", "model_override"),
+            reasoning_effort=_payload_value(payload, "reasoning_effort", "reasoning_effort_override"),
             opencode_agent=payload.get("opencode_agent"),
-            opencode_model=payload.get("opencode_model"),
-            opencode_reasoning_effort=payload.get("opencode_reasoning_effort"),
+            opencode_model=None if model_key_present else payload.get("opencode_model"),
+            opencode_reasoning_effort=None if reasoning_key_present else payload.get("opencode_reasoning_effort"),
             claude_agent=payload.get("claude_agent"),
-            claude_model=payload.get("claude_model"),
-            claude_reasoning_effort=payload.get("claude_reasoning_effort"),
+            claude_model=None if model_key_present else payload.get("claude_model"),
+            claude_reasoning_effort=None if reasoning_key_present else payload.get("claude_reasoning_effort"),
             codex_agent=payload.get("codex_agent"),
-            codex_model=payload.get("codex_model"),
-            codex_reasoning_effort=payload.get("codex_reasoning_effort"),
+            codex_model=None if model_key_present else payload.get("codex_model"),
+            codex_reasoning_effort=None if reasoning_key_present else payload.get("codex_reasoning_effort"),
         )
     )
 

--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -95,6 +95,57 @@ class RoutingSettings:
     codex_reasoning_effort: Optional[str] = None
 
 
+def _backend_field_name(backend: Optional[str], field: str) -> Optional[str]:
+    if backend in {"opencode", "claude", "codex"}:
+        return f"{backend}_{field}"
+    return None
+
+
+def _legacy_value_for_backend(routing: RoutingSettings, field: str) -> Optional[str]:
+    field_name = _backend_field_name(getattr(routing, "agent_backend", None), field)
+    return getattr(routing, field_name, None) if field_name else None
+
+
+def normalize_routing_settings(routing: Optional[RoutingSettings]) -> RoutingSettings:
+    """Collapse legacy model/effort fields only when the backend is known."""
+    if routing is None:
+        return RoutingSettings()
+    backend = getattr(routing, "agent_backend", None)
+    collapse_legacy = backend in {"opencode", "claude", "codex"}
+    return RoutingSettings(
+        agent_name=getattr(routing, "agent_name", None),
+        agent_backend=backend,
+        model=_legacy_value_for_backend(routing, "model") or getattr(routing, "model", None),
+        reasoning_effort=_legacy_value_for_backend(routing, "reasoning_effort") or getattr(routing, "reasoning_effort", None),
+        opencode_agent=getattr(routing, "opencode_agent", None),
+        opencode_model=None if collapse_legacy else getattr(routing, "opencode_model", None),
+        opencode_reasoning_effort=None if collapse_legacy else getattr(routing, "opencode_reasoning_effort", None),
+        claude_agent=getattr(routing, "claude_agent", None),
+        claude_model=None if collapse_legacy else getattr(routing, "claude_model", None),
+        claude_reasoning_effort=None if collapse_legacy else getattr(routing, "claude_reasoning_effort", None),
+        codex_agent=getattr(routing, "codex_agent", None),
+        codex_model=None if collapse_legacy else getattr(routing, "codex_model", None),
+        codex_reasoning_effort=None if collapse_legacy else getattr(routing, "codex_reasoning_effort", None),
+    )
+
+
+def routing_model_for_backend(routing: Optional[RoutingSettings], backend: Optional[str]) -> Optional[str]:
+    normalized = normalize_routing_settings(routing)
+    if normalized.agent_backend and backend and normalized.agent_backend != backend:
+        return None
+    return normalized.model
+
+
+def routing_reasoning_effort_for_backend(
+    routing: Optional[RoutingSettings],
+    backend: Optional[str],
+) -> Optional[str]:
+    normalized = normalize_routing_settings(routing)
+    if normalized.agent_backend and backend and normalized.agent_backend != backend:
+        return None
+    return normalized.reasoning_effort
+
+
 @dataclass
 class ChannelSettings:
     enabled: bool = False
@@ -149,25 +200,28 @@ class SettingsState:
 
 def _parse_routing(payload: dict) -> RoutingSettings:
     """Parse a routing settings dict into a RoutingSettings dataclass."""
-    return RoutingSettings(
-        agent_name=payload.get("agent_name") or payload.get("agent"),
-        agent_backend=payload.get("agent_backend"),
-        model=payload.get("model") or payload.get("model_override"),
-        reasoning_effort=payload.get("reasoning_effort") or payload.get("reasoning_effort_override"),
-        opencode_agent=payload.get("opencode_agent"),
-        opencode_model=payload.get("opencode_model"),
-        opencode_reasoning_effort=payload.get("opencode_reasoning_effort"),
-        claude_agent=payload.get("claude_agent"),
-        claude_model=payload.get("claude_model"),
-        claude_reasoning_effort=payload.get("claude_reasoning_effort"),
-        codex_agent=payload.get("codex_agent"),
-        codex_model=payload.get("codex_model"),
-        codex_reasoning_effort=payload.get("codex_reasoning_effort"),
+    return normalize_routing_settings(
+        RoutingSettings(
+            agent_name=payload.get("agent_name") or payload.get("agent"),
+            agent_backend=payload.get("agent_backend"),
+            model=payload.get("model") or payload.get("model_override"),
+            reasoning_effort=payload.get("reasoning_effort") or payload.get("reasoning_effort_override"),
+            opencode_agent=payload.get("opencode_agent"),
+            opencode_model=payload.get("opencode_model"),
+            opencode_reasoning_effort=payload.get("opencode_reasoning_effort"),
+            claude_agent=payload.get("claude_agent"),
+            claude_model=payload.get("claude_model"),
+            claude_reasoning_effort=payload.get("claude_reasoning_effort"),
+            codex_agent=payload.get("codex_agent"),
+            codex_model=payload.get("codex_model"),
+            codex_reasoning_effort=payload.get("codex_reasoning_effort"),
+        )
     )
 
 
 def _routing_to_dict(routing: RoutingSettings) -> dict:
     """Serialize a RoutingSettings to dict."""
+    routing = normalize_routing_settings(routing)
     return {
         "agent_name": routing.agent_name,
         "agent_backend": routing.agent_backend,
@@ -183,6 +237,17 @@ def _routing_to_dict(routing: RoutingSettings) -> dict:
         "codex_model": routing.codex_model,
         "codex_reasoning_effort": routing.codex_reasoning_effort,
     }
+
+
+def routing_to_compat_dict(routing: RoutingSettings) -> dict:
+    """Serialize routing with legacy read-only aliases derived from canonical fields."""
+    routing = normalize_routing_settings(routing)
+    payload = _routing_to_dict(routing)
+    backend = routing.agent_backend
+    if backend in {"opencode", "claude", "codex"}:
+        payload[f"{backend}_model"] = routing.model
+        payload[f"{backend}_reasoning_effort"] = routing.reasoning_effort
+    return payload
 
 
 def parse_settings_payload(payload: dict) -> tuple[SettingsState, bool]:

--- a/core/controller.py
+++ b/core/controller.py
@@ -626,10 +626,12 @@ class Controller:
         settings_manager = self.get_settings_manager_for_context(context)
         routing = settings_manager.get_channel_routing(settings_key)
         if routing:
+            from config.v2_settings import routing_model_for_backend, routing_reasoning_effort_for_backend
+
             return (
                 routing.opencode_agent,
-                routing.model or routing.opencode_model,
-                routing.reasoning_effort or routing.opencode_reasoning_effort,
+                routing_model_for_backend(routing, "opencode"),
+                routing_reasoning_effort_for_backend(routing, "opencode"),
             )
         return None, None, None
 
@@ -639,10 +641,12 @@ class Controller:
         settings_manager = self.get_settings_manager_for_context(context)
         routing = settings_manager.get_channel_routing(settings_key)
         if routing:
+            from config.v2_settings import routing_model_for_backend, routing_reasoning_effort_for_backend
+
             return (
                 routing.codex_agent,
-                routing.model or routing.codex_model,
-                routing.reasoning_effort or routing.codex_reasoning_effort,
+                routing_model_for_backend(routing, "codex"),
+                routing_reasoning_effort_for_backend(routing, "codex"),
             )
         return None, None, None
 

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -188,9 +188,6 @@ class MessageHandler(BaseHandler):
             else:
                 agent_name = self.controller.resolve_agent_for_context(context)
 
-            scope_model_override = getattr(routing, "model", None) if routing else None
-            scope_reasoning_override = getattr(routing, "reasoning_effort", None) if routing else None
-
             # Check for routing-based agent to maintain session key consistency
             # This ensures session IDs match between MessageHandler and SessionHandler
             routing_agent = None
@@ -201,6 +198,11 @@ class MessageHandler(BaseHandler):
                     routing_agent = getattr(routing, "claude_agent", None)
                 elif agent_name == "codex":
                     routing_agent = getattr(routing, "codex_agent", None)
+
+            from config.v2_settings import routing_model_for_backend, routing_reasoning_effort_for_backend
+
+            scope_model_override = routing_model_for_backend(routing, agent_name)
+            scope_reasoning_override = routing_reasoning_effort_for_backend(routing, agent_name)
 
             matched_prefix = None
             subagent_message = None

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -435,12 +435,10 @@ class SessionHandler(BaseHandler):
         # Note: agent frontmatter model is applied later after loading agent file
         effective_agent = subagent_name or (routing.claude_agent if routing else None)
         # Store explicit model override (not including default yet)
-        explicit_model = subagent_model or (
-            (routing.model or routing.claude_model) if routing else None
-        )
-        explicit_effort = subagent_reasoning_effort or (
-            (routing.reasoning_effort or routing.claude_reasoning_effort) if routing else None
-        )
+        from config.v2_settings import routing_model_for_backend, routing_reasoning_effort_for_backend
+
+        explicit_model = subagent_model or routing_model_for_backend(routing, "claude")
+        explicit_effort = subagent_reasoning_effort or routing_reasoning_effort_for_backend(routing, "claude")
 
         if composite_key in self.claude_sessions and not effective_agent:
             client = self.claude_sessions[composite_key]
@@ -763,17 +761,15 @@ class SessionHandler(BaseHandler):
             session_key = self._get_session_key(context)
             settings_manager = self._get_settings_manager(context)
             current_routing = settings_manager.get_channel_routing(settings_key)
+            preserve_scope_overrides = bool(current_routing and current_routing.agent_backend == agent)
 
             routing = ChannelRouting(
                 agent_backend=agent,
+                model=current_routing.model if preserve_scope_overrides else None,
+                reasoning_effort=current_routing.reasoning_effort if preserve_scope_overrides else None,
                 opencode_agent=current_routing.opencode_agent if current_routing else None,
-                opencode_model=current_routing.opencode_model if current_routing else None,
-                opencode_reasoning_effort=current_routing.opencode_reasoning_effort if current_routing else None,
                 claude_agent=current_routing.claude_agent if current_routing else None,
-                claude_model=current_routing.claude_model if current_routing else None,
-                claude_reasoning_effort=current_routing.claude_reasoning_effort if current_routing else None,
-                codex_model=current_routing.codex_model if current_routing else None,
-                codex_reasoning_effort=current_routing.codex_reasoning_effort if current_routing else None,
+                codex_agent=current_routing.codex_agent if current_routing else None,
             )
             settings_manager.set_channel_routing(settings_key, routing)
 

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -801,30 +801,12 @@ class SettingsHandler(BaseHandler):
                 opencode_agent=opencode_agent
                 if backend == "opencode"
                 else (existing_routing.opencode_agent if existing_routing else None),
-                opencode_model=opencode_model
-                if backend == "opencode"
-                else (existing_routing.opencode_model if existing_routing else None),
-                opencode_reasoning_effort=opencode_reasoning_effort
-                if backend == "opencode"
-                else (existing_routing.opencode_reasoning_effort if existing_routing else None),
                 claude_agent=claude_agent
                 if backend == "claude"
                 else (existing_routing.claude_agent if existing_routing else None),
-                claude_model=claude_model
-                if backend == "claude"
-                else (existing_routing.claude_model if existing_routing else None),
-                claude_reasoning_effort=normalized_claude_reasoning_effort
-                if backend == "claude"
-                else (existing_routing.claude_reasoning_effort if existing_routing else None),
                 codex_agent=resolved_codex_agent
                 if backend == "codex"
                 else (existing_routing.codex_agent if existing_routing else None),
-                codex_model=codex_model
-                if backend == "codex"
-                else (existing_routing.codex_model if existing_routing else None),
-                codex_reasoning_effort=codex_reasoning_effort
-                if backend == "codex"
-                else (existing_routing.codex_reasoning_effort if existing_routing else None),
             )
 
             settings_manager.set_channel_routing(settings_key, routing)

--- a/docs/plans/agent-scope-model.md
+++ b/docs/plans/agent-scope-model.md
@@ -16,13 +16,13 @@ default Agent named after that Backend.
 2. Normalize legacy Scope settings:
    - `agent_backend` maps to the matching built-in Agent when `agent_name` is
      absent.
-   - backend-specific model and reasoning fields become Scope-level overrides.
+   - backend-specific model and reasoning fields are migrated into the
+     canonical Scope-level `model` and `reasoning_effort` overrides.
 3. Resolve runtime settings from Scope first:
    - Scope chooses Agent.
    - Agent supplies Backend and defaults.
    - Scope may override model and reasoning effort.
    - Scope does not override system prompt.
 4. Simplify Scope UI to one Agent selector plus model / reasoning overrides.
-5. Keep migration-period read/write compatibility for old fields without making
-   them target semantics.
-
+5. Keep migration-period input/read-back compatibility for old fields without
+   storing them as independent state.

--- a/modules/im/discord.py
+++ b/modules/im/discord.py
@@ -1432,21 +1432,34 @@ class DiscordBot(BaseIMClient):
                 self.selected_backend = current_backend or (
                     registered_backends[0] if registered_backends else "opencode"
                 )
+                canonical_model = getattr(current_routing, "model", None) if current_routing else None
+                canonical_reasoning = getattr(current_routing, "reasoning_effort", None) if current_routing else None
+
+                def _current_model(field_name: str, backend: str) -> Optional[str]:
+                    value = getattr(current_routing, field_name, None) if current_routing else None
+                    if value is not None:
+                        return value
+                    if self.selected_backend == backend:
+                        return canonical_model
+                    return None
+
+                def _current_reasoning(field_name: str, backend: str) -> Optional[str]:
+                    value = getattr(current_routing, field_name, None) if current_routing else None
+                    if value is not None:
+                        return value
+                    if self.selected_backend == backend:
+                        return canonical_reasoning
+                    return None
+
                 self.oc_agent = getattr(current_routing, "opencode_agent", None) if current_routing else None
-                self.oc_model = getattr(current_routing, "opencode_model", None) if current_routing else None
-                self.oc_reasoning = (
-                    getattr(current_routing, "opencode_reasoning_effort", None) if current_routing else None
-                )
+                self.oc_model = _current_model("opencode_model", "opencode")
+                self.oc_reasoning = _current_reasoning("opencode_reasoning_effort", "opencode")
                 self.claude_agent = getattr(current_routing, "claude_agent", None) if current_routing else None
-                self.claude_model = getattr(current_routing, "claude_model", None) if current_routing else None
-                self.claude_reasoning = (
-                    getattr(current_routing, "claude_reasoning_effort", None) if current_routing else None
-                )
+                self.claude_model = _current_model("claude_model", "claude")
+                self.claude_reasoning = _current_reasoning("claude_reasoning_effort", "claude")
                 self.codex_agent = getattr(current_routing, "codex_agent", None) if current_routing else None
-                self.codex_model = getattr(current_routing, "codex_model", None) if current_routing else None
-                self.codex_reasoning = (
-                    getattr(current_routing, "codex_reasoning_effort", None) if current_routing else None
-                )
+                self.codex_model = _current_model("codex_model", "codex")
+                self.codex_reasoning = _current_reasoning("codex_reasoning_effort", "codex")
                 self._render()
 
             def _render(self):

--- a/modules/im/discord.py
+++ b/modules/im/discord.py
@@ -1432,14 +1432,20 @@ class DiscordBot(BaseIMClient):
                 self.selected_backend = current_backend or (
                     registered_backends[0] if registered_backends else "opencode"
                 )
+                stored_backend = getattr(current_routing, "agent_backend", None) if current_routing else None
                 canonical_model = getattr(current_routing, "model", None) if current_routing else None
                 canonical_reasoning = getattr(current_routing, "reasoning_effort", None) if current_routing else None
+
+                def _canonical_applies_to_backend(backend: str) -> bool:
+                    if stored_backend:
+                        return stored_backend == backend
+                    return backend == (current_backend or "opencode")
 
                 def _current_model(field_name: str, backend: str) -> Optional[str]:
                     value = getattr(current_routing, field_name, None) if current_routing else None
                     if value is not None:
                         return value
-                    if self.selected_backend == backend:
+                    if self.selected_backend == backend and _canonical_applies_to_backend(backend):
                         return canonical_model
                     return None
 
@@ -1447,7 +1453,7 @@ class DiscordBot(BaseIMClient):
                     value = getattr(current_routing, field_name, None) if current_routing else None
                     if value is not None:
                         return value
-                    if self.selected_backend == backend:
+                    if self.selected_backend == backend and _canonical_applies_to_backend(backend):
                         return canonical_reasoning
                     return None
 

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -1868,6 +1868,9 @@ class FeishuBot(BaseIMClient):
 
     @staticmethod
     def _routing_draft_from_current(current_routing: Any) -> Dict[str, Optional[str]]:
+        backend = getattr(current_routing, "agent_backend", None) if current_routing else None
+        canonical_model = getattr(current_routing, "model", None) if current_routing else None
+        canonical_reasoning = getattr(current_routing, "reasoning_effort", None) if current_routing else None
         fields = (
             "opencode_agent",
             "opencode_model",
@@ -1882,6 +1885,9 @@ class FeishuBot(BaseIMClient):
         draft: Dict[str, Optional[str]] = {}
         for field_name in fields:
             draft[field_name] = getattr(current_routing, field_name, None) if current_routing else None
+        if backend in {"opencode", "claude", "codex"}:
+            draft[f"{backend}_model"] = draft.get(f"{backend}_model") or canonical_model
+            draft[f"{backend}_reasoning_effort"] = draft.get(f"{backend}_reasoning_effort") or canonical_reasoning
         return draft
 
     @staticmethod

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -3213,6 +3213,24 @@ class SlackBot(BaseIMClient):
 
         # Determine effective backend for showing backend-specific options
         effective_backend = selected_backend_value or current_backend or "opencode"
+        canonical_model = getattr(current_routing, "model", None) if current_routing else None
+        canonical_reasoning = getattr(current_routing, "reasoning_effort", None) if current_routing else None
+
+        def _current_model_for_backend(field_name: str, backend: str) -> Optional[str]:
+            value = getattr(current_routing, field_name, None) if current_routing else None
+            if value is not None:
+                return value
+            if effective_backend == backend:
+                return canonical_model
+            return None
+
+        def _current_reasoning_for_backend(field_name: str, backend: str) -> Optional[str]:
+            value = getattr(current_routing, field_name, None) if current_routing else None
+            if value is not None:
+                return value
+            if effective_backend == backend:
+                return canonical_reasoning
+            return None
 
         # OpenCode-specific options (only if opencode is selected)
         if effective_backend == "opencode" and "opencode" in registered_backends:
@@ -3223,12 +3241,12 @@ class SlackBot(BaseIMClient):
                 current_oc_agent = selected_opencode_agent
 
             if selected_opencode_model is _UNSET:
-                current_oc_model = current_routing.opencode_model if current_routing else None
+                current_oc_model = _current_model_for_backend("opencode_model", "opencode")
             else:
                 current_oc_model = selected_opencode_model
 
             if selected_opencode_reasoning is _UNSET:
-                current_oc_reasoning = current_routing.opencode_reasoning_effort if current_routing else None
+                current_oc_reasoning = _current_reasoning_for_backend("opencode_reasoning_effort", "opencode")
             else:
                 current_oc_reasoning = selected_opencode_reasoning
 
@@ -3407,12 +3425,12 @@ class SlackBot(BaseIMClient):
                 current_cl_agent = selected_claude_agent
 
             if selected_claude_model is _UNSET:
-                current_cl_model = current_routing.claude_model if current_routing else None
+                current_cl_model = _current_model_for_backend("claude_model", "claude")
             else:
                 current_cl_model = selected_claude_model
 
             if selected_claude_reasoning is _UNSET:
-                current_cl_reasoning = current_routing.claude_reasoning_effort if current_routing else None
+                current_cl_reasoning = _current_reasoning_for_backend("claude_reasoning_effort", "claude")
             else:
                 current_cl_reasoning = selected_claude_reasoning
 
@@ -3575,12 +3593,12 @@ class SlackBot(BaseIMClient):
                 current_cx_agent = selected_codex_agent
 
             if selected_codex_model is _UNSET:
-                current_cx_model = current_routing.codex_model if current_routing else None
+                current_cx_model = _current_model_for_backend("codex_model", "codex")
             else:
                 current_cx_model = selected_codex_model
 
             if selected_codex_reasoning is _UNSET:
-                current_cx_reasoning = current_routing.codex_reasoning_effort if current_routing else None
+                current_cx_reasoning = _current_reasoning_for_backend("codex_reasoning_effort", "codex")
             else:
                 current_cx_reasoning = selected_codex_reasoning
 

--- a/modules/im/slack.py
+++ b/modules/im/slack.py
@@ -3213,14 +3213,20 @@ class SlackBot(BaseIMClient):
 
         # Determine effective backend for showing backend-specific options
         effective_backend = selected_backend_value or current_backend or "opencode"
+        stored_backend = getattr(current_routing, "agent_backend", None) if current_routing else None
         canonical_model = getattr(current_routing, "model", None) if current_routing else None
         canonical_reasoning = getattr(current_routing, "reasoning_effort", None) if current_routing else None
+
+        def _canonical_applies_to_backend(backend: str) -> bool:
+            if stored_backend:
+                return stored_backend == backend
+            return backend == (current_backend or "opencode")
 
         def _current_model_for_backend(field_name: str, backend: str) -> Optional[str]:
             value = getattr(current_routing, field_name, None) if current_routing else None
             if value is not None:
                 return value
-            if effective_backend == backend:
+            if effective_backend == backend and _canonical_applies_to_backend(backend):
                 return canonical_model
             return None
 
@@ -3228,7 +3234,7 @@ class SlackBot(BaseIMClient):
             value = getattr(current_routing, field_name, None) if current_routing else None
             if value is not None:
                 return value
-            if effective_backend == backend:
+            if effective_backend == backend and _canonical_applies_to_backend(backend):
                 return canonical_reasoning
             return None
 

--- a/modules/im/telegram.py
+++ b/modules/im/telegram.py
@@ -1153,6 +1153,9 @@ class TelegramBot(BaseIMClient):
             raise ValueError("Telegram routing flow requires a message context")
         current_routing = kwargs.get("current_routing")
         current_backend = kwargs.get("current_backend") or "opencode"
+        backend = getattr(current_routing, "agent_backend", None) or current_backend or "opencode"
+        current_model = getattr(current_routing, "model", None)
+        current_effort = getattr(current_routing, "reasoning_effort", None)
         state = _TelegramRoutingState(
             message_id="",
             channel_id=channel_id,
@@ -1165,15 +1168,15 @@ class TelegramBot(BaseIMClient):
             claude_agents=list(kwargs.get("claude_agents") or []),
             claude_models=list(kwargs.get("claude_models") or []),
             codex_models=list(kwargs.get("codex_models") or []),
-            backend=(getattr(current_routing, "agent_backend", None) or current_backend or "opencode"),
+            backend=backend,
             opencode_agent=getattr(current_routing, "opencode_agent", None),
-            opencode_model=getattr(current_routing, "opencode_model", None),
-            opencode_reasoning_effort=getattr(current_routing, "opencode_reasoning_effort", None),
+            opencode_model=current_model if backend == "opencode" else None,
+            opencode_reasoning_effort=current_effort if backend == "opencode" else None,
             claude_agent=getattr(current_routing, "claude_agent", None),
-            claude_model=getattr(current_routing, "claude_model", None),
-            claude_reasoning_effort=getattr(current_routing, "claude_reasoning_effort", None),
-            codex_model=getattr(current_routing, "codex_model", None),
-            codex_reasoning_effort=getattr(current_routing, "codex_reasoning_effort", None),
+            claude_model=current_model if backend == "claude" else None,
+            claude_reasoning_effort=current_effort if backend == "claude" else None,
+            codex_model=current_model if backend == "codex" else None,
+            codex_reasoning_effort=current_effort if backend == "codex" else None,
         )
         text, keyboard = self._render_routing_state(state)
         message_id = await self.send_message_with_buttons(context, text, keyboard)

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from config import paths
 from config.v2_sessions import SessionsStore
 from config.v2_settings import SettingsStore, ChannelSettings, GuildSettings, RoutingSettings, SCOPED_KEY_SEP
+from config.v2_settings import normalize_routing_settings
 from config.v2_settings import UserSettings as BoundUserSettings
 from modules.sessions_facade import SessionsFacade
 
@@ -22,12 +23,12 @@ ChannelRouting = RoutingSettings
 def _routing_to_dict(routing: Optional[RoutingSettings]) -> dict:
     if routing is None:
         return {}
-    return asdict(routing)
+    return asdict(normalize_routing_settings(routing))
 
 
 def _routing_from_dict(payload: Optional[dict]) -> RoutingSettings:
     data = payload or {}
-    return RoutingSettings(
+    return normalize_routing_settings(RoutingSettings(
         agent_name=data.get("agent_name") or data.get("agent"),
         agent_backend=data.get("agent_backend"),
         model=data.get("model") or data.get("model_override"),
@@ -41,7 +42,7 @@ def _routing_from_dict(payload: Optional[dict]) -> RoutingSettings:
         codex_agent=data.get("codex_agent"),
         codex_model=data.get("codex_model"),
         codex_reasoning_effort=data.get("codex_reasoning_effort"),
-    )
+    ))
 
 
 def _clone_routing(routing: Optional[RoutingSettings]) -> RoutingSettings:

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -132,9 +132,9 @@ vibe watch add \
 
 Use the current Vibe Remote context:
 
-- `session_id` controls which Agent Session Vibe Remote will continue using
+- `--session-id` controls which Agent Session Vibe Remote will continue using
 - use the current Agent Session ID when the follow-up should continue the same session
-- if the current turn does not expose a usable Agent Session ID, ask the user to retry from an active Vibe Remote session instead of guessing
+- if no usable Agent Session ID is available, confirm the target session first instead of guessing
 - `--post-to channel` only when the follow-up should keep the same Agent Session but publish in the parent channel
 
 ## Timeout And Lifecycle

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -780,9 +780,9 @@ Preferred CLI shape:
 
 Delivery controls (apply to `vibe agent run --create-session`, `vibe task add`, and `vibe watch add`):
 
-- `session_id` controls which Agent Session Vibe Remote continues using
-- when you want to keep the current session, use the current Agent Session ID shown in the prompt
-- if the current turn does not expose a usable Agent Session ID, ask the user to retry from an active Vibe Remote session instead of guessing
+- `--session-id` controls which Agent Session Vibe Remote continues using
+- when you want to keep the current session, use the current Agent Session ID
+- if no usable Agent Session ID is available, confirm the target session first instead of guessing
 - use `--post-to channel` when the task or watch should keep the same Agent Session but publish to the parent channel
 - use `--deliver-key '<key>'` only when delivery must go to a different explicit target than the continued session
 - do not combine `--post-to` and `--deliver-key` in the same command

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -388,6 +388,8 @@ Channel entry shape:
   "require_mention": null,
   "routing": {
     "agent_backend": "codex",
+    "model": "gpt-5.4",
+    "reasoning_effort": "high",
     "opencode_agent": null,
     "opencode_model": null,
     "opencode_reasoning_effort": null,
@@ -408,9 +410,10 @@ Field meanings:
 - `custom_cwd`: scope-level working directory override; empty string or `null` means use global default
 - `require_mention`: `null` inherits the platform default, `true` requires mention, `false` disables mention gating for that channel
 - `routing.agent_backend`: `opencode`, `claude`, `codex`, or `null` to inherit default
+- `routing.model`: canonical scope-level model override for the selected backend
+- `routing.reasoning_effort`: canonical scope-level reasoning override for the selected backend
 - `routing.<backend>_agent`: backend-specific subagent
-- `routing.<backend>_model`: backend-specific model
-- `routing.<backend>_reasoning_effort`: backend-specific reasoning effort
+- `routing.<backend>_model` / `routing.<backend>_reasoning_effort`: legacy aliases accepted on input and derived on read-back; do not treat them as independent state
 
 ### DM users and bind codes
 
@@ -446,6 +449,8 @@ User entry shape:
   "custom_cwd": "/path/to/repo",
   "routing": {
     "agent_backend": "claude",
+    "model": "claude-sonnet-4-6",
+    "reasoning_effort": "high",
     "opencode_agent": null,
     "opencode_model": null,
     "opencode_reasoning_effort": null,
@@ -614,6 +619,8 @@ Merged channel entry:
   "require_mention": null,
   "routing": {
     "agent_backend": "codex",
+    "model": "gpt-5.4",
+    "reasoning_effort": "high",
     "opencode_agent": null,
     "opencode_model": null,
     "opencode_reasoning_effort": null,
@@ -633,8 +640,8 @@ Use `/settings` and set:
 
 - `routing.agent_backend = "opencode"`
 - `routing.opencode_agent = "<agent>"`
-- `routing.opencode_model = "<model>"` if requested
-- `routing.opencode_reasoning_effort = "<effort>"` if requested
+- `routing.model = "<model>"` if requested
+- `routing.reasoning_effort = "<effort>"` if requested
 
 If the user wants OpenCode-native defaults, providers, MCP servers, skills, plugins, or API credentials, use OpenCode config instead of Vibe Remote scope routing.
 
@@ -644,8 +651,8 @@ Use `/settings` for a channel or `/api/users` for a DM user and set:
 
 - `routing.agent_backend = "claude"`
 - `routing.claude_agent = "<agent>"` if requested
-- `routing.claude_model = "<model>"`
-- `routing.claude_reasoning_effort = "<effort>"`
+- `routing.model = "<model>"`
+- `routing.reasoning_effort = "<effort>"`
 
 The API normalizes Claude reasoning for incompatible model combinations; verify by reading back the saved payload.
 

--- a/storage/importer.py
+++ b/storage/importer.py
@@ -42,6 +42,7 @@ from storage.settings_service import SQLiteSettingsService, upsert_scope
 
 JSON_IMPORT_MARKER = "json_import_completed_at"
 BACKGROUND_IMPORT_MARKER = "background_json_import_completed_at"
+ROUTING_CANONICAL_FIELDS_MARKER = "routing_canonical_fields_migrated_at"
 logger = logging.getLogger(__name__)
 
 
@@ -89,11 +90,12 @@ def ensure_sqlite_state(
                             or background_counts.get("background_watches")
                             or background_counts.get("background_runs_imported")
                         )
+                    data_migration_counts = _run_sqlite_data_migrations(conn)
                     return MigrationImportReport(
                         db_path=target_db,
                         imported=imported_background,
                         backup_path=backup_path,
-                        counts=_current_counts(conn) | background_counts,
+                        counts=_current_counts(conn) | background_counts | data_migration_counts,
                     )
 
                 _clear_imported_state(conn)
@@ -106,9 +108,11 @@ def ensure_sqlite_state(
                 _backfill_imported_scope_agent_names(conn)
                 discovered_count = _import_discovered_chats(conn, parsed.discovered)
                 background_counts = _import_background_state(conn, target_state_dir)
+                data_migration_counts = _run_sqlite_data_migrations(conn)
                 counts = _current_counts(conn)
                 counts["discovered_scopes"] = discovered_count
                 counts.update(background_counts)
+                counts.update(data_migration_counts)
                 if parsed.discovered_skipped:
                     counts["discovered_chats_skipped"] = 1
                 _validate_import(conn, counts)
@@ -121,6 +125,7 @@ def ensure_sqlite_state(
                     counts=_current_counts(conn)
                     | {"discovered_scopes": discovered_count}
                     | background_counts
+                    | data_migration_counts
                     | ({"discovered_chats_skipped": 1} if parsed.discovered_skipped else {}),
                 )
         finally:
@@ -219,6 +224,111 @@ def _set_background_import_marker(conn: Connection) -> None:
             updated_at=now,
         )
     )
+
+
+def _has_data_migration_marker(conn: Connection, key: str) -> bool:
+    return conn.execute(select(state_meta.c.value_json).where(state_meta.c.key == key)).scalar_one_or_none() is not None
+
+
+def _set_data_migration_marker(conn: Connection, key: str, metadata: dict[str, Any]) -> None:
+    now = _utc_now_iso()
+    payload = {"completed_at": now, **metadata}
+    conn.execute(state_meta.delete().where(state_meta.c.key == key))
+    conn.execute(
+        state_meta.insert().values(
+            key=key,
+            value_json=_json_dumps(payload),
+            updated_at=now,
+        )
+    )
+
+
+def _run_sqlite_data_migrations(conn: Connection) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    if not _has_data_migration_marker(conn, ROUTING_CANONICAL_FIELDS_MARKER):
+        migrated = _migrate_scope_routing_to_canonical_fields(conn)
+        _set_data_migration_marker(
+            conn,
+            ROUTING_CANONICAL_FIELDS_MARKER,
+            {"scope_settings_migrated": migrated, "version": 1},
+        )
+        if migrated:
+            counts["routing_scope_settings_migrated"] = migrated
+    return counts
+
+
+def _migrate_scope_routing_to_canonical_fields(conn: Connection) -> int:
+    migrated = 0
+    rows = conn.execute(
+        select(
+            scope_settings.c.scope_id,
+            scope_settings.c.agent_backend,
+            scope_settings.c.agent_variant,
+            scope_settings.c.model,
+            scope_settings.c.reasoning_effort,
+            scope_settings.c.settings_json,
+        )
+    ).mappings()
+    for row in rows:
+        payload = _json_loads(row["settings_json"], {})
+        routing = payload.get("routing") if isinstance(payload, dict) else None
+        if not isinstance(routing, dict):
+            continue
+
+        next_routing = dict(routing)
+        backend = str(next_routing.get("agent_backend") or row["agent_backend"] or "").strip() or None
+        if backend not in {"opencode", "claude", "codex"}:
+            continue
+        model = _legacy_backend_value(next_routing, backend, "model") or next_routing.get("model") or row["model"]
+        effort = (
+            _legacy_backend_value(next_routing, backend, "reasoning_effort")
+            or next_routing.get("reasoning_effort")
+            or row["reasoning_effort"]
+        )
+        variant = _agent_variant_for_backend(next_routing, backend) or row["agent_variant"]
+
+        next_routing["agent_backend"] = backend
+        next_routing["model"] = model
+        next_routing["reasoning_effort"] = effort
+        for legacy_key in (
+            "opencode_model",
+            "opencode_reasoning_effort",
+            "claude_model",
+            "claude_reasoning_effort",
+            "codex_model",
+            "codex_reasoning_effort",
+        ):
+            next_routing[legacy_key] = None
+
+        next_payload = dict(payload)
+        next_payload["routing"] = next_routing
+        next_settings_json = _json_dumps(next_payload)
+        values = {
+            "agent_backend": backend,
+            "agent_variant": variant,
+            "model": model,
+            "reasoning_effort": effort,
+            "settings_json": next_settings_json,
+        }
+        if all(row.get(key) == value for key, value in values.items() if key != "settings_json") and row[
+            "settings_json"
+        ] == next_settings_json:
+            continue
+        conn.execute(scope_settings.update().where(scope_settings.c.scope_id == row["scope_id"]).values(**values))
+        migrated += 1
+    return migrated
+
+
+def _legacy_backend_value(routing: dict[str, Any], backend: str | None, field: str) -> Any:
+    if backend not in {"opencode", "claude", "codex"}:
+        return None
+    return routing.get(f"{backend}_{field}")
+
+
+def _agent_variant_for_backend(routing: dict[str, Any], backend: str | None) -> Any:
+    if backend not in {"opencode", "claude", "codex"}:
+        return None
+    return routing.get(f"{backend}_agent")
 
 
 def _backup_json_state(state_dir: Path) -> Path:
@@ -777,6 +887,15 @@ def _read_json_object(path: Path) -> dict[str, Any]:
         logger.warning("Skipping invalid background JSON state %s: %s", path, exc)
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _json_loads(value: str | None, default: Any) -> Any:
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return default
 
 
 

--- a/storage/importer.py
+++ b/storage/importer.py
@@ -279,10 +279,10 @@ def _migrate_scope_routing_to_canonical_fields(conn: Connection) -> int:
         backend = str(next_routing.get("agent_backend") or row["agent_backend"] or "").strip() or None
         if backend not in {"opencode", "claude", "codex"}:
             continue
-        model = _legacy_backend_value(next_routing, backend, "model") or next_routing.get("model") or row["model"]
+        model = next_routing.get("model") or _legacy_backend_value(next_routing, backend, "model") or row["model"]
         effort = (
-            _legacy_backend_value(next_routing, backend, "reasoning_effort")
-            or next_routing.get("reasoning_effort")
+            next_routing.get("reasoning_effort")
+            or _legacy_backend_value(next_routing, backend, "reasoning_effort")
             or row["reasoning_effort"]
         )
         variant = _agent_variant_for_backend(next_routing, backend) or row["agent_variant"]

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -317,16 +317,10 @@ def _routing_columns(routing: RoutingSettings) -> dict[str, str | None]:
     effort = routing.reasoning_effort
     if backend == "codex":
         variant = routing.codex_agent
-        model = model or routing.codex_model
-        effort = effort or routing.codex_reasoning_effort
     elif backend == "claude":
         variant = routing.claude_agent
-        model = model or routing.claude_model
-        effort = effort or routing.claude_reasoning_effort
     elif backend == "opencode":
         variant = routing.opencode_agent
-        model = model or routing.opencode_model
-        effort = effort or routing.opencode_reasoning_effort
     else:
         variant = routing.codex_agent or routing.claude_agent or routing.opencode_agent
     return {
@@ -368,16 +362,10 @@ def _routing_from_row(row: dict[str, Any], payload: dict[str, Any]) -> RoutingSe
     routing.reasoning_effort = routing.reasoning_effort or effort
     if routing.agent_backend == "codex":
         routing.codex_agent = routing.codex_agent or variant
-        routing.codex_model = routing.codex_model or model
-        routing.codex_reasoning_effort = routing.codex_reasoning_effort or effort
     elif routing.agent_backend == "claude":
         routing.claude_agent = routing.claude_agent or variant
-        routing.claude_model = routing.claude_model or model
-        routing.claude_reasoning_effort = routing.claude_reasoning_effort or effort
     elif routing.agent_backend == "opencode":
         routing.opencode_agent = routing.opencode_agent or variant
-        routing.opencode_model = routing.opencode_model or model
-        routing.opencode_reasoning_effort = routing.opencode_reasoning_effort or effort
     return routing
 
 

--- a/tests/test_feishu_routing_card.py
+++ b/tests/test_feishu_routing_card.py
@@ -226,6 +226,31 @@ class FeishuRoutingCardTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(args[10], "gpt-5.4")
         self.assertEqual(args[11], "high")
 
+    async def test_routing_draft_populates_selected_backend_from_canonical_overrides(self):
+        bot = self._make_bot()
+
+        current_routing = SimpleNamespace(
+            agent_backend="claude",
+            model="claude-sonnet-4-6",
+            reasoning_effort="high",
+            claude_agent="helper",
+            claude_model=None,
+            claude_reasoning_effort=None,
+            opencode_agent=None,
+            opencode_model=None,
+            opencode_reasoning_effort=None,
+            codex_agent=None,
+            codex_model=None,
+            codex_reasoning_effort=None,
+        )
+
+        draft = bot._routing_draft_from_current(current_routing)
+
+        self.assertEqual(draft["claude_model"], "claude-sonnet-4-6")
+        self.assertEqual(draft["claude_reasoning_effort"], "high")
+        self.assertIsNone(draft["opencode_model"])
+        self.assertIsNone(draft["codex_model"])
+
     async def test_quick_reply_card_action_sets_lark_platform(self):
         bot = self._make_bot()
         bot.check_authorization = lambda **kwargs: AuthResult(allowed=True)

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -331,6 +331,51 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.vibe_agent_reasoning_effort, "xhigh")
         self.assertEqual(request.vibe_agent_system_prompt, "Default prompt")
 
+    async def test_claude_specific_scope_reasoning_overrides_vibe_agent_default(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+
+        def _resolve_claude_agent(context, override_agent_name=None, required=False):
+            return type(
+                "VibeAgent",
+                (),
+                {
+                    "id": "agent-claude-opus",
+                    "name": "claude-opus",
+                    "backend": "claude",
+                    "model": "claude-opus-4-8",
+                    "reasoning_effort": "high",
+                    "system_prompt": "Claude prompt",
+                },
+            )()
+
+        controller.resolve_vibe_agent_for_context = _resolve_claude_agent
+        controller.settings_manager.routing = type(
+            "Routing",
+            (),
+            {
+                "agent_name": "claude-opus",
+                "agent_backend": "claude",
+                "model": None,
+                "reasoning_effort": None,
+                "opencode_agent": None,
+                "claude_agent": None,
+                "claude_model": "claude-opus-4-8",
+                "claude_reasoning_effort": "max",
+                "codex_agent": None,
+            },
+        )()
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(user_id="U1", channel_id="C1", message_id="m1", platform="slack")
+
+        await handler.handle_user_message(context, "hello")
+
+        agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(agent_name, "claude")
+        self.assertEqual(request.vibe_agent_model, "claude-opus-4-8")
+        self.assertEqual(request.vibe_agent_reasoning_effort, "max")
+        self.assertEqual(request.vibe_agent_system_prompt, "Claude prompt")
+
     async def test_reply_anchor_alias_keeps_original_anchor_mapping(self):
         controller = _StubController(platform="discord", ack_mode="reaction", typing_result=True)
         handler = MessageHandler(controller)
@@ -459,6 +504,41 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(request.vibe_agent_name)
         self.assertIsNone(request.vibe_agent_model)
         self.assertIsNone(request.vibe_agent_system_prompt)
+
+    async def test_existing_session_backend_ignores_other_backend_scope_model_override(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        controller.settings_manager.routing = type(
+            "Routing",
+            (),
+            {
+                "agent_name": None,
+                "agent_backend": "claude",
+                "model": "claude-opus-4-8",
+                "reasoning_effort": "max",
+            },
+        )()
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            message_id="m1",
+            platform="slack",
+            platform_specific={
+                "agent_session_target": {
+                    "session_id": "ses_codex",
+                    "agent_name": None,
+                    "agent_backend": "codex",
+                }
+            },
+        )
+
+        await handler.handle_user_message(context, "continue")
+
+        agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(agent_name, "codex")
+        self.assertIsNone(request.vibe_agent_model)
+        self.assertIsNone(request.vibe_agent_reasoning_effort)
 
     async def test_lark_typing_preference_uses_registry_reaction_capability(self):
         controller = _StubController(platform="lark", ack_mode="typing", typing_result=True)

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -66,8 +66,10 @@ def test_handle_routing_update_preserves_existing_codex_agent_when_omitted() -> 
 
     assert settings_manager.saved_routing is not None
     assert settings_manager.saved_routing.codex_agent == "reviewer"
-    assert settings_manager.saved_routing.codex_model == "gpt-5.4"
-    assert settings_manager.saved_routing.codex_reasoning_effort == "high"
+    assert settings_manager.saved_routing.model == "gpt-5.4"
+    assert settings_manager.saved_routing.reasoning_effort == "high"
+    assert settings_manager.saved_routing.codex_model is None
+    assert settings_manager.saved_routing.codex_reasoning_effort is None
     send_message.assert_not_awaited()
 
 
@@ -101,8 +103,10 @@ def test_handle_routing_update_allows_explicit_codex_agent_clear() -> None:
 
     assert settings_manager.saved_routing is not None
     assert settings_manager.saved_routing.codex_agent is None
-    assert settings_manager.saved_routing.codex_model == "gpt-5.4"
-    assert settings_manager.saved_routing.codex_reasoning_effort == "high"
+    assert settings_manager.saved_routing.model == "gpt-5.4"
+    assert settings_manager.saved_routing.reasoning_effort == "high"
+    assert settings_manager.saved_routing.codex_model is None
+    assert settings_manager.saved_routing.codex_reasoning_effort is None
 
 
 def test_handle_routing_update_handles_first_codex_save_without_existing_routing() -> None:
@@ -128,8 +132,10 @@ def test_handle_routing_update_handles_first_codex_save_without_existing_routing
     assert settings_manager.saved_routing is not None
     assert settings_manager.saved_routing.agent_backend == "codex"
     assert settings_manager.saved_routing.codex_agent is None
-    assert settings_manager.saved_routing.codex_model == "gpt-5.4"
-    assert settings_manager.saved_routing.codex_reasoning_effort == "high"
+    assert settings_manager.saved_routing.model == "gpt-5.4"
+    assert settings_manager.saved_routing.reasoning_effort == "high"
+    assert settings_manager.saved_routing.codex_model is None
+    assert settings_manager.saved_routing.codex_reasoning_effort is None
     send_message.assert_not_awaited()
 
 

--- a/tests/test_slack_app_mention_empty.py
+++ b/tests/test_slack_app_mention_empty.py
@@ -188,5 +188,48 @@ class SlackFileAttachmentTests(unittest.IsolatedAsyncioTestCase):
         slack.web_client.files_info.assert_awaited_once_with(file="F123")
 
 
+class SlackRoutingModalTests(unittest.TestCase):
+    @staticmethod
+    def _find_select(view, block_id):
+        for block in view["blocks"]:
+            if block.get("block_id") == block_id:
+                return block["element"]
+        raise AssertionError(f"block {block_id} not found")
+
+    def test_backend_switch_does_not_reuse_other_backend_canonical_override(self):
+        slack = SlackBot(SlackConfig(bot_token="xoxb-test"))
+        current_routing = SimpleNamespace(
+            agent_backend="codex",
+            model="gpt-5.4",
+            reasoning_effort="high",
+            opencode_agent=None,
+            opencode_model=None,
+            opencode_reasoning_effort=None,
+            claude_agent=None,
+            claude_model=None,
+            claude_reasoning_effort=None,
+            codex_agent=None,
+            codex_model=None,
+            codex_reasoning_effort=None,
+        )
+
+        view = slack._build_routing_modal_view(
+            channel_id="C123",
+            registered_backends=["opencode", "codex"],
+            current_backend="codex",
+            current_routing=current_routing,
+            opencode_agents=[],
+            opencode_models={"openai": {"models": [{"id": "gpt-5.4", "name": "gpt-5.4"}]}},
+            opencode_default_config={},
+            codex_models=["gpt-5.4"],
+            selected_backend="opencode",
+        )
+
+        model_select = self._find_select(view, "opencode_model_block")
+        reasoning_select = self._find_select(view, "opencode_reasoning_block")
+        self.assertEqual(model_select["initial_option"]["value"], "__default__")
+        self.assertEqual(reasoning_select["initial_option"]["value"], "__default__")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -138,7 +138,7 @@ def test_settings_save_preserves_observed_scope_metadata(tmp_path: Path) -> None
     assert json.loads(row["metadata_json"]) == {"username": "general"}
 
 
-def test_settings_save_ignores_legacy_model_fields_without_backend(tmp_path: Path) -> None:
+def test_settings_save_does_not_migrate_legacy_model_fields_without_backend(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     run_migrations(db_path)
     service = SQLiteSettingsService(db_path)
@@ -173,6 +173,37 @@ def test_settings_save_ignores_legacy_model_fields_without_backend(tmp_path: Pat
     assert routing.codex_model == "gpt-stale-codex"
     assert routing.claude_model == "claude-stale"
     assert routing.opencode_model == "openai/stale"
+
+
+def test_settings_save_does_not_migrate_active_backend_legacy_fields(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    run_migrations(db_path)
+    service = SQLiteSettingsService(db_path)
+    try:
+        service.save_state(
+            SettingsState(
+                channels={
+                    "slack::C123": ChannelSettings(
+                        enabled=True,
+                        routing=RoutingSettings(
+                            agent_backend="claude",
+                            claude_model="claude-opus-4-8",
+                            claude_reasoning_effort="max",
+                        ),
+                    ),
+                }
+            )
+        )
+
+        state = service.load_state()
+    finally:
+        service.close()
+
+    routing = state.channels["slack::C123"].routing
+    assert routing.model is None
+    assert routing.reasoning_effort is None
+    assert routing.claude_model == "claude-opus-4-8"
+    assert routing.claude_reasoning_effort == "max"
 
 
 def test_settings_store_bootstrap_uses_config_primary_platform(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -719,6 +719,56 @@ def test_ensure_sqlite_state_migrates_scope_routing_legacy_fields_once(tmp_path:
     assert "routing_scope_settings_migrated" not in second.counts
 
 
+def test_ensure_sqlite_state_prefers_canonical_scope_routing_over_stale_alias(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    run_migrations(db_path)
+
+    service = SQLiteSettingsService(db_path)
+    try:
+        service.save_state(
+            SettingsState(
+                channels={
+                    "slack::C123": ChannelSettings(
+                        enabled=True,
+                        routing=RoutingSettings(
+                            agent_backend="claude",
+                            model="claude-sonnet-4-6",
+                            reasoning_effort="high",
+                            claude_model="claude-opus-4-8",
+                            claude_reasoning_effort="max",
+                        ),
+                    ),
+                }
+            )
+        )
+    finally:
+        service.close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "insert into state_meta (key, value_json, updated_at) values (?, ?, ?)",
+            (JSON_IMPORT_MARKER, '"2026-05-01T00:00:00+00:00"', "2026-05-01T00:00:00+00:00"),
+        )
+        conn.commit()
+
+    ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "select model, reasoning_effort, settings_json from scope_settings where scope_id = ?",
+            ("slack::channel::C123",),
+        ).fetchone()
+
+    routing = json.loads(row[2])["routing"]
+    assert row[:2] == ("claude-sonnet-4-6", "high")
+    assert routing["model"] == "claude-sonnet-4-6"
+    assert routing["reasoning_effort"] == "high"
+    assert routing["claude_model"] is None
+    assert routing["claude_reasoning_effort"] is None
+
+
 def test_ensure_sqlite_state_preserves_legacy_routing_without_backend(tmp_path: Path) -> None:
     state_dir = tmp_path / "state"
     state_dir.mkdir()

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -8,10 +8,12 @@ from pathlib import Path
 import pytest
 
 from config import paths
+from config.v2_settings import ChannelSettings, RoutingSettings, SettingsState, SettingsStore
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
-from storage.importer import ensure_sqlite_state
+from storage.importer import JSON_IMPORT_MARKER, ROUTING_CANONICAL_FIELDS_MARKER, ensure_sqlite_state
 from storage.migrations import background_tables_ready, run_migrations
 from storage.models import metadata
+from storage.settings_service import SQLiteSettingsService
 
 
 HEAD_REVISION = "20260529_0007"
@@ -658,6 +660,142 @@ def test_ensure_sqlite_state_import_skips_agent_name_conflict(tmp_path: Path) ->
     assert channel_agent_name is None
     assert user_agent_name == "opencode"
     assert codex_rows == 1
+
+
+def test_ensure_sqlite_state_migrates_scope_routing_legacy_fields_once(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    run_migrations(db_path)
+
+    service = SQLiteSettingsService(db_path)
+    try:
+        service.save_state(
+            SettingsState(
+                channels={
+                    "slack::C123": ChannelSettings(
+                        enabled=True,
+                        routing=RoutingSettings(
+                            agent_backend="claude",
+                            claude_model="claude-opus-4-8",
+                            claude_reasoning_effort="max",
+                        ),
+                    ),
+                }
+            )
+        )
+    finally:
+        service.close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "insert into state_meta (key, value_json, updated_at) values (?, ?, ?)",
+            (JSON_IMPORT_MARKER, '"2026-05-01T00:00:00+00:00"', "2026-05-01T00:00:00+00:00"),
+        )
+        conn.commit()
+
+    first = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+    second = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "select model, reasoning_effort, settings_json from scope_settings where scope_id = ?",
+            ("slack::channel::C123",),
+        ).fetchone()
+        marker = conn.execute(
+            "select value_json from state_meta where key = ?",
+            (ROUTING_CANONICAL_FIELDS_MARKER,),
+        ).fetchone()
+
+    routing = json.loads(row[2])["routing"]
+    marker_payload = json.loads(marker[0])
+    assert row[:2] == ("claude-opus-4-8", "max")
+    assert routing["model"] == "claude-opus-4-8"
+    assert routing["reasoning_effort"] == "max"
+    assert routing["claude_model"] is None
+    assert routing["claude_reasoning_effort"] is None
+    assert marker_payload["scope_settings_migrated"] == 1
+    assert first.counts["routing_scope_settings_migrated"] == 1
+    assert "routing_scope_settings_migrated" not in second.counts
+
+
+def test_ensure_sqlite_state_preserves_legacy_routing_without_backend(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    run_migrations(db_path)
+
+    service = SQLiteSettingsService(db_path)
+    try:
+        service.save_state(
+            SettingsState(
+                channels={
+                    "slack::C123": ChannelSettings(
+                        enabled=True,
+                        routing=RoutingSettings(
+                            claude_model="claude-opus-4-8",
+                            claude_reasoning_effort="max",
+                        ),
+                    ),
+                }
+            )
+        )
+    finally:
+        service.close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "insert into state_meta (key, value_json, updated_at) values (?, ?, ?)",
+            (JSON_IMPORT_MARKER, '"2026-05-01T00:00:00+00:00"', "2026-05-01T00:00:00+00:00"),
+        )
+        conn.commit()
+
+    result = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "select agent_backend, model, reasoning_effort, settings_json from scope_settings where scope_id = ?",
+            ("slack::channel::C123",),
+        ).fetchone()
+        marker = conn.execute(
+            "select value_json from state_meta where key = ?",
+            (ROUTING_CANONICAL_FIELDS_MARKER,),
+        ).fetchone()
+
+    routing = json.loads(row[3])["routing"]
+    marker_payload = json.loads(marker[0])
+    assert row[:3] == (None, None, None)
+    assert routing["model"] is None
+    assert routing["reasoning_effort"] is None
+    assert routing["claude_model"] == "claude-opus-4-8"
+    assert routing["claude_reasoning_effort"] == "max"
+    assert marker_payload["scope_settings_migrated"] == 0
+    assert "routing_scope_settings_migrated" not in result.counts
+
+    store = SettingsStore(state_dir / "settings.json")
+    try:
+        channel = store.find_channel("C123", platform="slack")
+        assert channel is not None
+        assert channel.routing.model is None
+        assert channel.routing.reasoning_effort is None
+        assert channel.routing.claude_model == "claude-opus-4-8"
+        assert channel.routing.claude_reasoning_effort == "max"
+        store.update_channel("C999", ChannelSettings(enabled=True), platform="slack")
+    finally:
+        store.close()
+
+    with sqlite3.connect(db_path) as conn:
+        roundtrip_row = conn.execute(
+            "select agent_backend, model, reasoning_effort, settings_json from scope_settings where scope_id = ?",
+            ("slack::channel::C123",),
+        ).fetchone()
+
+    roundtrip_routing = json.loads(roundtrip_row[3])["routing"]
+    assert roundtrip_row[:3] == (None, None, None)
+    assert roundtrip_routing["model"] is None
+    assert roundtrip_routing["reasoning_effort"] is None
+    assert roundtrip_routing["claude_model"] == "claude-opus-4-8"
+    assert roundtrip_routing["claude_reasoning_effort"] == "max"
 
 
 def test_ensure_sqlite_state_imports_background_json(tmp_path: Path) -> None:

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -94,6 +94,52 @@ def test_opencode_options_closes_server_http_session(monkeypatch):
     assert fake_manager.closed_loop is not None
 
 
+def test_normalize_backend_routing_payload_promotes_claude_specific_overrides() -> None:
+    result = api._normalize_backend_routing_payload(
+        {
+            "agent_backend": "claude",
+            "model": "claude-opus-4-8",
+            "reasoning_effort": "high",
+            "claude_model": "claude-opus-4-8",
+            "claude_reasoning_effort": "max",
+        }
+    )
+
+    assert result["model"] == "claude-opus-4-8"
+    assert result["reasoning_effort"] == "max"
+    assert result["claude_model"] is None
+    assert result["claude_reasoning_effort"] is None
+
+
+def test_normalize_backend_routing_payload_preserves_legacy_claude_specific_overrides() -> None:
+    result = api._normalize_backend_routing_payload(
+        {
+            "agent_backend": "claude",
+            "claude_model": "claude-opus-4-8",
+            "claude_reasoning_effort": "max",
+        }
+    )
+
+    assert result["model"] == "claude-opus-4-8"
+    assert result["reasoning_effort"] == "max"
+    assert result["claude_model"] is None
+    assert result["claude_reasoning_effort"] is None
+
+
+def test_normalize_backend_routing_payload_preserves_legacy_overrides_without_backend() -> None:
+    result = api._normalize_backend_routing_payload(
+        {
+            "claude_model": "claude-opus-4-8",
+            "claude_reasoning_effort": "max",
+        }
+    )
+
+    assert result["model"] is None
+    assert result["reasoning_effort"] is None
+    assert result["claude_model"] == "claude-opus-4-8"
+    assert result["claude_reasoning_effort"] == "max"
+
+
 def test_sync_start_oauth_web_keeps_background_tasks_on_persistent_loop(monkeypatch):
     async def _start_web_setup(backend, *, force_reset=True, provider_id=None):
         async def _mark_completed():

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -128,6 +128,23 @@ def test_normalize_backend_routing_payload_prefers_canonical_over_round_trip_ali
     assert result["claude_reasoning_effort"] is None
 
 
+def test_normalize_backend_routing_payload_preserves_explicit_canonical_clears() -> None:
+    result = api._normalize_backend_routing_payload(
+        {
+            "agent_backend": "claude",
+            "model": None,
+            "reasoning_effort": None,
+            "claude_model": "claude-opus-4-8",
+            "claude_reasoning_effort": "max",
+        }
+    )
+
+    assert result["model"] is None
+    assert result["reasoning_effort"] is None
+    assert result["claude_model"] is None
+    assert result["claude_reasoning_effort"] is None
+
+
 def test_normalize_backend_routing_payload_preserves_legacy_claude_specific_overrides() -> None:
     result = api._normalize_backend_routing_payload(
         {

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -94,7 +94,7 @@ def test_opencode_options_closes_server_http_session(monkeypatch):
     assert fake_manager.closed_loop is not None
 
 
-def test_normalize_backend_routing_payload_promotes_claude_specific_overrides() -> None:
+def test_normalize_backend_routing_payload_prefers_canonical_claude_overrides() -> None:
     result = api._normalize_backend_routing_payload(
         {
             "agent_backend": "claude",
@@ -106,7 +106,24 @@ def test_normalize_backend_routing_payload_promotes_claude_specific_overrides() 
     )
 
     assert result["model"] == "claude-opus-4-8"
-    assert result["reasoning_effort"] == "max"
+    assert result["reasoning_effort"] == "high"
+    assert result["claude_model"] is None
+    assert result["claude_reasoning_effort"] is None
+
+
+def test_normalize_backend_routing_payload_prefers_canonical_over_round_trip_aliases() -> None:
+    result = api._normalize_backend_routing_payload(
+        {
+            "agent_backend": "claude",
+            "model": "claude-sonnet-4-6",
+            "reasoning_effort": "high",
+            "claude_model": "claude-opus-4-8",
+            "claude_reasoning_effort": "max",
+        }
+    )
+
+    assert result["model"] == "claude-sonnet-4-6"
+    assert result["reasoning_effort"] == "high"
     assert result["claude_model"] is None
     assert result["claude_reasoning_effort"] is None
 

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -141,17 +141,38 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
     }
   };
 
+  const clearLegacyOverrides = (routing: RoutingConfigValue['routing']) => ({
+    ...routing,
+    opencode_model: null,
+    opencode_reasoning_effort: null,
+    claude_model: null,
+    claude_reasoning_effort: null,
+    codex_model: null,
+    codex_reasoning_effort: null,
+  });
+
+  const buildModelRoutingPatch = (model: string | null) => {
+    return clearLegacyOverrides({
+      ...value.routing,
+      model,
+      reasoning_effort: null,
+    });
+  };
+
+  const buildReasoningRoutingPatch = (reasoningEffort: string | null) => {
+    return clearLegacyOverrides({
+      ...value.routing,
+      reasoning_effort: reasoningEffort,
+    });
+  };
+
   const modelOverrideControl = (() => {
     if (effectiveBackend === 'opencode') {
       return (
         <CompactSelect
           value={value.routing.model || ''}
           onChange={(e) => onChange({
-            routing: {
-              ...value.routing,
-              model: e.target.value || null,
-              reasoning_effort: null,
-            },
+            routing: buildModelRoutingPatch(e.target.value || null),
           })}
           className="w-full"
         >
@@ -182,11 +203,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
         options={[{ value: '', label: t('common.default') }, ...models.map(m => ({ value: m, label: m }))]}
         value={value.routing.model || ''}
         onValueChange={(v) => onChange({
-          routing: {
-            ...value.routing,
-            model: v || null,
-            reasoning_effort: null,
-          },
+          routing: buildModelRoutingPatch(v || null),
         })}
         placeholder={placeholder}
         searchPlaceholder={t('channelList.searchModel')}
@@ -255,6 +272,12 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                     agent_backend: nextAgent?.backend || null,
                     model: null,
                     reasoning_effort: null,
+                    opencode_model: null,
+                    opencode_reasoning_effort: null,
+                    claude_model: null,
+                    claude_reasoning_effort: null,
+                    codex_model: null,
+                    codex_reasoning_effort: null,
                   },
                 });
               }}
@@ -351,10 +374,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
           <CompactSelect
             value={value.routing.reasoning_effort || ''}
             onChange={(e) => onChange({
-              routing: {
-                ...value.routing,
-                reasoning_effort: e.target.value || null,
-              },
+              routing: buildReasoningRoutingPatch(e.target.value || null),
             })}
             className="w-full"
           >

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -28,6 +28,7 @@ from config.v2_settings import (
     normalize_show_message_types,
     _parse_routing,
     _routing_to_dict,
+    routing_to_compat_dict,
 )
 from config.v2_sessions import SessionsStore
 from vibe.opencode_config import (
@@ -913,19 +914,21 @@ def get_settings(platform: Optional[str] = None) -> dict:
     return payload
 
 
+def _normalize_backend_routing_payload(routing_payload: dict) -> dict:
+    from modules.agents.opencode.utils import normalize_claude_reasoning_effort
+
+    routing = _parse_routing(routing_payload or {})
+    if routing.agent_backend == "claude":
+        routing.reasoning_effort = normalize_claude_reasoning_effort(
+            routing.model,
+            routing.reasoning_effort,
+        )
+    return _routing_to_dict(routing)
+
+
 def save_settings(payload: dict) -> dict:
     store = SettingsStore.get_instance()
     platform = payload.get("platform") or _current_platform()
-
-    def _normalize_routing_payload(routing_payload: dict) -> dict:
-        from modules.agents.opencode.utils import normalize_claude_reasoning_effort
-
-        routing_data = dict(routing_payload or {})
-        routing_data["claude_reasoning_effort"] = normalize_claude_reasoning_effort(
-            routing_data.get("claude_model"),
-            routing_data.get("claude_reasoning_effort"),
-        )
-        return routing_data
 
     if "channels" in payload:
         channels = {}
@@ -934,7 +937,7 @@ def save_settings(payload: dict) -> dict:
                 enabled=channel_payload.get("enabled", True),
                 show_message_types=normalize_show_message_types(channel_payload.get("show_message_types")),
                 custom_cwd=channel_payload.get("custom_cwd"),
-                routing=_parse_routing(_normalize_routing_payload(channel_payload.get("routing") or {})),
+                routing=_parse_routing(_normalize_backend_routing_payload(channel_payload.get("routing") or {})),
                 require_mention=channel_payload.get("require_mention"),
             )
         store.set_channels_for_platform(platform, channels)
@@ -1504,7 +1507,7 @@ def _settings_to_payload(store: SettingsStore, platform: str) -> dict:
             "show_message_types": normalize_show_message_types(settings.show_message_types),
             "custom_cwd": settings.custom_cwd,
             "require_mention": settings.require_mention,
-            "routing": _routing_to_dict(settings.routing),
+            "routing": routing_to_compat_dict(settings.routing),
         }
     payload["guild_scope_configured"] = store.has_guild_scope_for_platform(platform)
     payload["guild_default_enabled"] = store.get_guild_default_enabled_for_platform(platform)
@@ -1523,7 +1526,7 @@ def _settings_to_payload(store: SettingsStore, platform: str) -> dict:
             "enabled": u.enabled,
             "show_message_types": u.show_message_types,
             "custom_cwd": u.custom_cwd,
-            "routing": _routing_to_dict(u.routing),
+            "routing": routing_to_compat_dict(u.routing),
         }
     for bc in store.settings.bind_codes:
         payload["bind_codes"].append(
@@ -4554,7 +4557,7 @@ def get_users(platform: Optional[str] = None) -> dict:
             "enabled": u.enabled,
             "show_message_types": u.show_message_types,
             "custom_cwd": u.custom_cwd,
-            "routing": _routing_to_dict(u.routing),
+            "routing": routing_to_compat_dict(u.routing),
         }
     return {"ok": True, "users": users}
 
@@ -4563,16 +4566,6 @@ def save_users(payload: dict) -> dict:
     """Save user settings (bulk update from UI)."""
     store = SettingsStore.get_instance()
     platform = payload.get("platform") or _current_platform()
-
-    def _normalize_routing_payload(routing_payload: dict) -> dict:
-        from modules.agents.opencode.utils import normalize_claude_reasoning_effort
-
-        routing_data = dict(routing_payload or {})
-        routing_data["claude_reasoning_effort"] = normalize_claude_reasoning_effort(
-            routing_data.get("claude_model"),
-            routing_data.get("claude_reasoning_effort"),
-        )
-        return routing_data
 
     users = {}
     for user_id, up in (payload.get("users") or {}).items():
@@ -4587,7 +4580,7 @@ def save_users(payload: dict) -> dict:
             enabled=up.get("enabled", True),
             show_message_types=normalize_show_message_types(up.get("show_message_types")),
             custom_cwd=up.get("custom_cwd"),
-            routing=_parse_routing(_normalize_routing_payload(up.get("routing") or {})),
+            routing=_parse_routing(_normalize_backend_routing_payload(up.get("routing") or {})),
             dm_chat_id=existing.dm_chat_id if existing else "",
             pending_bind_menu_hint=existing.pending_bind_menu_hint if existing else False,
         )


### PR DESCRIPTION
## Summary
- Migrates backend-specific routing model/reasoning overrides into canonical `routing.model` / `routing.reasoning_effort` with a one-time SQLite `state_meta` marker.
- Keeps legacy routing inputs/read-back compatible without treating backend-specific fields as independent canonical state.
- Updates UI/API/IM settings paths so new writes use canonical routing fields and clear migrated legacy fields.

## Scenarios
- Scenario IDs: none; routing settings migration does not currently have a scenario catalog entry.

## Evidence Layers
- Unit: `uv run pytest tests/test_sqlite_state_migration.py tests/test_sqlite_settings_store.py tests/test_settings_handler.py tests/test_message_handler_typing.py tests/test_ui_api.py tests/test_claude_reasoning_options.py tests/test_claude_cli_path.py tests/test_controller_vibe_agent_routing.py tests/test_user_platform_scope.py`
- Contract: API routing normalization/read-back tests in `tests/test_ui_api.py`
- Scenario: not updated; no catalog entry exists for this migration path
- Residual manual checks: no live IM/local Vibe Remote state mutation; `npm run build` completed from `ui/`

## Validation
- `uv run ruff check storage/importer.py storage/settings_service.py config/v2_settings.py modules/settings_manager.py core/controller.py core/handlers/message_handler.py core/handlers/session_handler.py core/handlers/settings_handler.py modules/im/telegram.py vibe/api.py vibe/ui_server.py tests/test_sqlite_state_migration.py tests/test_sqlite_settings_store.py tests/test_settings_handler.py tests/test_message_handler_typing.py tests/test_ui_api.py`
- `npm run build`
- Reviewer subagent: no significant findings after fixes