### PR TITLE
fix(ui): show access-blocked screen instead of /setup when config is policy-blocked

### DIFF
--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -150,6 +150,25 @@ def test_remote_config_get_without_session_returns_login_required(monkeypatch, t
     assert response.headers["Location"].startswith("https://backend.test/oauth/authorize?")
 
 
+def test_api_config_blocked_host_returns_machine_readable_error(monkeypatch, tmp_path):
+    """Contract the SPA AuthGuard depends on: a blocked GET /api/config returns
+    503 with a machine-readable ``error`` code (not a redirect, not an opaque
+    body). The guard reads this to show an explicit "access blocked" screen
+    instead of bouncing the visitor to the setup wizard."""
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/api/config",
+        base_url="https://old-alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
 def test_remote_host_strips_retry_marker_from_oauth_next(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,7 +21,7 @@ import { SettingsMessagingPage } from './components/settings/SettingsMessagingPa
 import { SettingsPlatformsPage } from './components/settings/SettingsPlatformsPage';
 import { SettingsServicePage } from './components/settings/SettingsServicePage';
 import { StatusProvider } from './context/StatusContext';
-import { ApiProvider, useApi } from './context/ApiContext';
+import { ApiProvider, useApi, ApiError } from './context/ApiContext';
 import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { WorkbenchInboxProvider } from './context/WorkbenchInboxContext';
@@ -29,6 +29,9 @@ import { AgentationToggle } from './components/AgentationToggle';
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import { hasConfiguredPlatformCredentials } from './lib/platforms';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './components/ui/card';
+import { Button } from './components/ui/button';
 
 // Paths that bypass the setup guard so the wizard and diagnostics can show
 // logs / doctor output even before configuration is complete.
@@ -42,7 +45,57 @@ const RemoteLoginRedirect = ({ target }: { target: string }) => {
     return <div className="min-h-screen flex items-center justify-center bg-bg text-text">Loading...</div>;
 };
 
-type GuardStatus = 'loading' | 'ready' | 'needs-setup' | 'remote-login-required';
+// Server error codes (from the Web UI's enforce_remote_access_cookie guard)
+// that mean the control UI is reachable but is refusing THIS request on
+// policy grounds — a disallowed entry host, or broken remote-access config —
+// NOT that the instance is unconfigured. They must surface as an explicit
+// "access blocked" screen; routing them to the setup wizard (the old
+// catch-all) is what made a host mismatch look like a fresh install.
+const ACCESS_BLOCKED_CODES = new Set<string>([
+    'remote_access_host_mismatch',
+    'remote_access_config_unavailable',
+    'remote_access_public_url_invalid',
+    'remote_access_disabled',
+    'remote_access_session_secret_missing',
+]);
+
+// Return the blocking code when a failed config/session fetch is a recognized
+// remote-access policy block, else null. A 401/403 also counts: the session
+// probe said we were fine, yet the config endpoint still refused us — that is
+// "no permission", not "needs setup".
+const accessBlockedCode = (error: unknown): string | null => {
+    if (error instanceof ApiError) {
+        if (error.code && ACCESS_BLOCKED_CODES.has(error.code)) return error.code;
+        if (error.status === 401 || error.status === 403) return error.code ?? 'forbidden';
+    }
+    return null;
+};
+
+// Shown when the server is up but refuses to open the control panel at this
+// entry point. Tells the user which URL to use instead of stranding them in
+// the setup wizard.
+const AccessBlocked = ({ code }: { code: string | null }) => {
+    const { t } = useTranslation();
+    return (
+        <main className="min-h-screen flex items-center justify-center bg-bg text-text p-4">
+            <Card className="max-w-md w-full">
+                <CardHeader>
+                    <CardTitle>{t('accessBlocked.title')}</CardTitle>
+                    <CardDescription>{t('accessBlocked.body')}</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <p className="text-sm text-muted">{t('accessBlocked.hint')}</p>
+                    {code ? (
+                        <p className="text-xs text-muted font-mono">{t('accessBlocked.codeLabel')}: {code}</p>
+                    ) : null}
+                    <Button onClick={() => window.location.reload()}>{t('accessBlocked.retry')}</Button>
+                </CardContent>
+            </Card>
+        </main>
+    );
+};
+
+type GuardStatus = 'loading' | 'ready' | 'needs-setup' | 'remote-login-required' | 'access-blocked';
 
 // Wrapper to check if setup is needed.
 //
@@ -57,6 +110,7 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
     const location = useLocation();
     const guardTarget = location.pathname + location.search;
     const [guardStatus, setGuardStatus] = useState<GuardStatus>('loading');
+    const [blockedCode, setBlockedCode] = useState<string | null>(null);
     const bypassSetupGuard = LOGIN_CHECK_PATHS.has(location.pathname);
     // Re-validate only when crossing the setup boundary, not on every
     // route change. The wizard completes by saving config and navigating
@@ -101,6 +155,17 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
                 setGuardStatus('remote-login-required');
                 return;
             }
+            const blocked = accessBlockedCode(error);
+            if (blocked) {
+                // Server is up and the session probe was fine, but it refused
+                // the config read on policy grounds (e.g. the entry host isn't
+                // allowed while remote access is on). Say so explicitly instead
+                // of bouncing the visitor to /setup as if nothing is configured.
+                console.warn('[AuthGuard] config access blocked', error);
+                setBlockedCode(blocked);
+                setGuardStatus('access-blocked');
+                return;
+            }
             console.error('[AuthGuard] setup check failed', error);
             // If fetch fails for local/non-remote use (e.g. config doesn't exist),
             // setup is needed. Remote 401s are handled by the session branch above.
@@ -123,6 +188,9 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
     }
     if (guardStatus === 'remote-login-required') {
         return <RemoteLoginRedirect target={guardTarget} />;
+    }
+    if (guardStatus === 'access-blocked') {
+        return <AccessBlocked code={blockedCode} />;
     }
     if (guardStatus === 'needs-setup') {
         if (location.pathname === '/setup') return children;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -51,6 +51,15 @@ const RemoteLoginRedirect = ({ target }: { target: string }) => {
 // NOT that the instance is unconfigured. They must surface as an explicit
 // "access blocked" screen; routing them to the setup wizard (the old
 // catch-all) is what made a host mismatch look like a fresh install.
+//
+// Reachability: host_mismatch (the common case — opening a raw LAN/Tailscale
+// setup_host while the tunnel is on) makes /api/session report {remote:false},
+// so it reaches this catch directly. For a Host that matches the public remote
+// URL, an unauthenticated session is classified remote-login-required *before*
+// /api/config is fetched, so the disabled / session_secret_missing codes are
+// hit mainly when an already-authenticated session loses remote access. Telling
+// those host-matching-but-disabled visitors apart from "just log in" would need
+// /api/session to carry the block reason — tracked as a follow-up.
 const ACCESS_BLOCKED_CODES = new Set<string>([
     'remote_access_host_mismatch',
     'remote_access_config_unavailable',

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -683,6 +683,23 @@ export type OpencodeMutationResult = {
   default_provider?: string;
 };
 
+// Error thrown by the JSON helpers below when a request fails. Carries the
+// HTTP status and the server's machine-readable ``error`` code (when the body
+// includes one) so callers can branch on *why* a request failed instead of
+// only seeing a human string. The AuthGuard relies on this to tell a policy
+// block (e.g. ``remote_access_host_mismatch``) apart from an unconfigured
+// instance.
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  constructor(message: string, status: number, code: string | null) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
 const ApiContext = createContext<ApiContextType | undefined>(undefined);
 
 export const useApi = () => {
@@ -699,10 +716,12 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   const handleApiError = async (res: Response, path: string) => {
     let errorMessage = `Request failed: ${path} (${res.status})`;
+    let errorCode: string | null = null;
     
     try {
       const data = await res.json();
       if (data.error) {
+        errorCode = typeof data.error === 'string' ? data.error : null;
         errorMessage = t(`errors.${data.error}`, { defaultValue: data.error });
       }
     } catch {
@@ -720,7 +739,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     // Show toast to user
     showToast(errorMessage, 'error');
 
-    throw new Error(errorMessage);
+    throw new ApiError(errorMessage, res.status, errorCode);
   };
 
   const getJson = async (path: string) => {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -371,7 +371,18 @@
     "ready": "Ready",
     "stateNeedsAttention": "Needs attention"
   },
+  "accessBlocked": {
+    "title": "Can't open the control panel here",
+    "body": "Vibe Remote is running, but it refused to open the control panel at this address.",
+    "hint": "Open Vibe Remote from your https://<your-slug>.avibe.bot link, or use http://127.0.0.1:5123 on the machine running Vibe Remote. A raw LAN or Tailscale IP is blocked while remote access is on.",
+    "codeLabel": "Reason",
+    "retry": "Retry"
+  },
   "errors": {
+    "remote_access_host_mismatch": "This address can't open the Vibe Remote control panel. Open it from your https://<your-slug>.avibe.bot link, or http://127.0.0.1:5123 on the machine running Vibe Remote.",
+    "remote_access_config_unavailable": "Vibe Remote couldn't read its configuration. Check that the service is healthy and try again.",
+    "remote_access_public_url_invalid": "Remote access is misconfigured (the public URL is invalid). Re-pair this device or fix the remote-access settings.",
+    "remote_access_session_secret_missing": "Remote access is misconfigured (missing session secret). Re-pair this device to restore access.",
     "remote_access_unknown": "The operation did not finish. Refresh the status and try again; if it still fails, check the remote access runtime logs.",
     "invalid_pairing_key": "This pairing key is invalid or expired. Create a new key at avibe.bot, then paste it here.",
     "missing_pairing_key": "Paste the pairing key first.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -371,7 +371,18 @@
     "ready": "已就绪",
     "stateNeedsAttention": "需要检查"
   },
+  "accessBlocked": {
+    "title": "无法在此地址打开控制台",
+    "body": "Vibe Remote 正在运行，但拒绝在当前地址打开控制台。",
+    "hint": "请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Vibe Remote 的机器上访问 http://127.0.0.1:5123。开启远程访问时，直接用局域网或 Tailscale IP 会被拦截。",
+    "codeLabel": "原因",
+    "retry": "重试"
+  },
   "errors": {
+    "remote_access_host_mismatch": "这个地址无法打开 Vibe Remote 控制台。请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Vibe Remote 的机器上访问 http://127.0.0.1:5123。",
+    "remote_access_config_unavailable": "Vibe Remote 无法读取配置。请确认服务运行正常后重试。",
+    "remote_access_public_url_invalid": "远程访问配置有误（公网地址无效）。请重新配对此设备或修正远程访问设置。",
+    "remote_access_session_secret_missing": "远程访问配置有误（缺少会话密钥）。请重新配对此设备以恢复访问。",
     "remote_access_unknown": "操作没有完成。请刷新状态后再试一次；如果仍然失败，请查看远程访问运行日志。",
     "invalid_pairing_key": "这个 pairing key 无效或已过期。请回到 avibe.bot 重新生成一个 key，然后粘贴到这里。",
     "missing_pairing_key": "请先粘贴 pairing key。",


### PR DESCRIPTION
## Capability
Web UI **remote-access entry / AuthGuard routing** — what the React app does when the control panel is reachable but the config probe is refused.

## Problem
`AuthGuard` treated *any* failed `GET /api/config` as "needs setup" and redirected to the `/setup` wizard. So when the Web UI is reachable but refuses the request on policy grounds — most visibly `remote_access_host_mismatch` (503), returned when you open a raw LAN/Tailscale `setup_host` while Vibe Cloud is on — the visitor was bounced into the setup wizard instead of being told access was blocked. A user hit this opening their `*.avibe.bot` URL during a half-applied upgrade, and again opening the Tailscale IP directly. The wizard appears even though the instance is fully configured (`needs_setup=false`).

## Change
- **`ui/src/context/ApiContext.tsx`** — the JSON helpers now throw a typed `ApiError` carrying the HTTP `status` and the server's machine-readable `error` code, so callers can branch on *why* a request failed.
- **`ui/src/App.tsx`** — recognized remote-access policy codes (`remote_access_host_mismatch`, `…_config_unavailable`, `…_public_url_invalid`, `…_disabled`, `…_session_secret_missing`) and `401/403` now resolve to a new `access-blocked` guard state that renders an explicit screen pointing the user at the correct entry URL. Genuine missing config still routes to `/setup`. Remote-login and ready paths are unchanged.
- **`ui/src/i18n/{en,zh}.json`** — strings for the access-blocked screen + the new error codes (en/zh parity).

## Scenario IDs
No `tests/scenarios/auth_setup` scenario applies — that catalog covers IM-driven backend credential auth (Codex/Claude/OpenCode device flows), not the Web UI remote-access guard. Coverage for this change lives in the UI remote-access guard contract layer instead.

## Evidence layers
- **Contract/unit:** added `test_api_config_blocked_host_returns_machine_readable_error` in `tests/test_ui_remote_access_auth.py` locking `GET /api/config` on a blocked host → `503` + `error == remote_access_host_mismatch` (the signal the guard keys on). Full file: **97 passed**.
- **Build/type:** `npm run build` in `ui/` (`tsc -b` + `vite build`) clean.
- **Manual:** reproduced the original host_mismatch → `/setup` behavior on the live instance; confirmed `/api/config` returns the machine-readable code that the new branch consumes.
- **Residual manual:** visual check of the access-blocked screen (repo has no JS test runner; classification kept in a pure `accessBlockedCode()` helper and is `tsc`-typed).

## Review notes
Codex review: **PASS** (1×P2, 0×P1). The P2 (documented in-code): an *unauthenticated* visitor to a Host that matches the public URL but with remote access disabled/misconfigured is classified remote-login-required *before* `/api/config` is read, so those two codes are reached mainly when an already-authenticated session loses remote access. Distinguishing host-matching-but-disabled from "just log in" would require `/api/session` to carry the block reason — noted as a follow-up rather than expanding this fix's scope (it would alter the working login redirect).
