### PR TITLE
fix(storage): remove legacy default agent

### DIFF
--- a/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
+++ b/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
@@ -8,6 +8,7 @@ Create Date: 2026-05-30
 from __future__ import annotations
 
 import json
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
@@ -21,6 +22,7 @@ depends_on = None
 _BACKENDS = {"opencode", "claude", "codex"}
 _LEGACY_DEFAULT_AGENT_NAME = "default"
 _DEFAULT_AGENT_META_KEY = "default_agent_name"
+_BUILTIN_DEFAULT_METADATA = {"builtin": True, "builtin_default": True, "lock_delete": True}
 
 
 def upgrade() -> None:
@@ -114,7 +116,7 @@ def _backend_default_agent(bind, backend: str) -> dict[str, Any] | None:
         (backend,),
     ).fetchone()
     if row is None:
-        return None
+        return _insert_backend_default_agent(bind, backend)
 
     agent_id, name, existing_backend, enabled, source, metadata_json = row
     metadata = _json_loads(metadata_json, {})
@@ -128,6 +130,31 @@ def _backend_default_agent(bind, backend: str) -> dict[str, Any] | None:
     ):
         return None
     return {"id": agent_id, "name": str(name), "backend": existing_backend}
+
+
+def _insert_backend_default_agent(bind, backend: str) -> dict[str, Any]:
+    now = _utc_now_iso()
+    metadata = {**_BUILTIN_DEFAULT_METADATA, "backend": backend, "backend_enabled": True}
+    agent_id = uuid.uuid4().hex[:12]
+    bind.exec_driver_sql(
+        """
+        insert into agents (
+            id, name, normalized_name, description, backend, model, reasoning_effort,
+            system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, null, null, null, 1, 'builtin', null, ?, ?, ?)
+        """,
+        (
+            agent_id,
+            backend,
+            backend,
+            f"Default {backend} agent.",
+            backend,
+            _json_dumps(metadata),
+            now,
+            now,
+        ),
+    )
+    return {"id": agent_id, "name": backend, "backend": backend}
 
 
 def _retarget_agent_references(bind, tables: set[str], legacy: dict[str, Any], target: dict[str, Any]) -> None:

--- a/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
+++ b/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
@@ -165,8 +165,8 @@ def _retarget_agent_references(bind, tables: set[str], legacy: dict[str, Any], t
 
     if "scope_settings" in tables:
         columns = _columns(bind, "scope_settings")
-        if "agent_name" in columns:
-            _retarget_scope_settings(bind, legacy_name, target_name)
+        if "scope_id" in columns and ("agent_name" in columns or "settings_json" in columns):
+            _retarget_scope_settings(bind, columns, legacy_name, target_name)
         if "agent_variant" in columns:
             _retarget_agent_variant(bind, "scope_settings", legacy_name, target_name)
     if "agent_sessions" in tables:
@@ -180,23 +180,37 @@ def _retarget_agent_references(bind, tables: set[str], legacy: dict[str, Any], t
         _retarget_agent_table(bind, "agent_runs", columns, legacy_name, target_name, legacy_id, target_id)
 
 
-def _retarget_scope_settings(bind, legacy_name: str, target_name: str) -> None:
+def _retarget_scope_settings(bind, columns: set[str], legacy_name: str, target_name: str) -> None:
+    agent_name_expr = "agent_name" if "agent_name" in columns else "null"
+    settings_json_expr = "settings_json" if "settings_json" in columns else "null"
     rows = bind.exec_driver_sql(
-        """
-        select scope_id, settings_json
+        f"""
+        select scope_id, {agent_name_expr}, {settings_json_expr}
         from scope_settings
-        where agent_name = ?
-        """,
-        (legacy_name,),
+        """
     ).fetchall()
-    for scope_id, settings_json in rows:
+    for scope_id, agent_name, settings_json in rows:
+        assignments = []
+        params = []
+        settings_json_changed = False
+        if "settings_json" in columns:
+            retargeted_settings_json = _settings_json_retarget_agent(settings_json, legacy_name, target_name)
+            settings_json_changed = retargeted_settings_json != settings_json
+            if settings_json_changed:
+                assignments.append("settings_json = ?")
+                params.append(retargeted_settings_json)
+        if "agent_name" in columns and (agent_name == legacy_name or (settings_json_changed and _is_empty(agent_name))):
+            assignments.insert(0, "agent_name = ?")
+            params.insert(0, target_name)
+        if not assignments:
+            continue
         bind.exec_driver_sql(
-            """
+            f"""
             update scope_settings
-            set agent_name = ?, settings_json = ?
+            set {", ".join(assignments)}
             where scope_id = ?
             """,
-            (target_name, _settings_json_retarget_agent(settings_json, legacy_name, target_name), scope_id),
+            (*params, scope_id),
         )
 
 
@@ -246,17 +260,22 @@ def _retarget_default_agent_pointer(bind, tables: set[str], target_name: str) ->
     )
 
 
-def _settings_json_retarget_agent(value: str | None, legacy_name: str, target_name: str) -> str:
+def _settings_json_retarget_agent(value: str | None, legacy_name: str, target_name: str) -> str | None:
     payload = _json_loads(value, None)
     if not isinstance(payload, dict):
-        return value or "{}"
+        return value
     routing = payload.get("routing")
     if not isinstance(routing, dict):
-        return _json_dumps(payload)
+        return value
+    changed = False
     if routing.get("agent_name") == legacy_name:
         routing["agent_name"] = target_name
+        changed = True
     if routing.get("agent") == legacy_name:
         routing["agent"] = target_name
+        changed = True
+    if not changed:
+        return value
     payload["routing"] = routing
     return _json_dumps(payload)
 

--- a/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
+++ b/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
@@ -39,6 +39,12 @@ def upgrade() -> None:
     target = _backend_default_agent(bind, backend, legacy_enabled=bool(legacy["enabled"]))
     if target is None:
         return
+    if not bool(legacy["enabled"]) and not bool(target.get("created")) and _legacy_default_has_references(
+        bind,
+        tables,
+        legacy,
+    ):
+        return
 
     _retarget_agent_references(bind, tables, legacy, target)
     _retarget_default_agent_pointer(bind, tables, target["name"])
@@ -129,7 +135,7 @@ def _backend_default_agent(bind, backend: str, *, legacy_enabled: bool) -> dict[
         or not bool(metadata.get("builtin_default") or metadata.get("lock_delete"))
     ):
         return None
-    return {"id": agent_id, "name": str(name), "backend": existing_backend}
+    return {"id": agent_id, "name": str(name), "backend": existing_backend, "created": False}
 
 
 def _insert_backend_default_agent(bind, backend: str, *, enabled: bool) -> dict[str, Any]:
@@ -155,7 +161,60 @@ def _insert_backend_default_agent(bind, backend: str, *, enabled: bool) -> dict[
             now,
         ),
     )
-    return {"id": agent_id, "name": backend, "backend": backend}
+    return {"id": agent_id, "name": backend, "backend": backend, "created": True}
+
+
+def _legacy_default_has_references(bind, tables: set[str], legacy: dict[str, Any]) -> bool:
+    legacy_name = str(legacy["name"])
+    legacy_id = str(legacy["id"])
+
+    if "state_meta" in tables:
+        row = bind.exec_driver_sql(
+            "select value_json from state_meta where key = ? limit 1",
+            (_DEFAULT_AGENT_META_KEY,),
+        ).fetchone()
+        if row is not None and _json_loads(row[0], None) == legacy_name:
+            return True
+
+    if "scope_settings" in tables:
+        columns = _columns(bind, "scope_settings")
+        if _table_has_agent_reference(bind, "scope_settings", columns, legacy_name, legacy_id):
+            return True
+        if "settings_json" in columns:
+            rows = bind.exec_driver_sql('select settings_json from "scope_settings"').fetchall()
+            if any(_settings_json_references_agent(settings_json, legacy_name) for (settings_json,) in rows):
+                return True
+
+    for table in ("agent_sessions", "run_definitions", "agent_runs"):
+        if table not in tables:
+            continue
+        if _table_has_agent_reference(bind, table, _columns(bind, table), legacy_name, legacy_id):
+            return True
+    return False
+
+
+def _table_has_agent_reference(
+    bind,
+    table: str,
+    columns: set[str],
+    legacy_name: str,
+    legacy_id: str,
+) -> bool:
+    checks: list[tuple[str, str]] = []
+    if "agent_name" in columns:
+        checks.append(("agent_name", legacy_name))
+    if "agent_id" in columns:
+        checks.append(("agent_id", legacy_id))
+    if "agent_variant" in columns:
+        checks.append(("agent_variant", legacy_name))
+    for column, value in checks:
+        row = bind.exec_driver_sql(
+            f'select 1 from "{table}" where "{column}" = ? limit 1',
+            (value,),
+        ).fetchone()
+        if row is not None:
+            return True
+    return False
 
 
 def _retarget_agent_references(bind, tables: set[str], legacy: dict[str, Any], target: dict[str, Any]) -> None:
@@ -279,6 +338,16 @@ def _settings_json_retarget_agent(value: str | None, legacy_name: str, target_na
         return value
     payload["routing"] = routing
     return _json_dumps(payload)
+
+
+def _settings_json_references_agent(value: str | None, legacy_name: str) -> bool:
+    payload = _json_loads(value, None)
+    if not isinstance(payload, dict):
+        return False
+    routing = payload.get("routing")
+    if not isinstance(routing, dict):
+        return False
+    return routing.get("agent_name") == legacy_name or routing.get("agent") == legacy_name
 
 
 def _json_loads(value: str | None, default: Any) -> Any:

--- a/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
+++ b/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
@@ -1,0 +1,255 @@
+"""remove legacy builtin default Agent
+
+Revision ID: 20260530_0008
+Revises: 20260529_0007
+Create Date: 2026-05-30
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from alembic import op
+
+revision = "20260530_0008"
+down_revision = "20260529_0007"
+branch_labels = None
+depends_on = None
+
+_BACKENDS = {"opencode", "claude", "codex"}
+_LEGACY_DEFAULT_AGENT_NAME = "default"
+_DEFAULT_AGENT_META_KEY = "default_agent_name"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    tables = _tables(bind)
+    if "agents" not in tables:
+        return
+
+    legacy = _legacy_default_agent(bind)
+    if legacy is None or not _is_unmodified_legacy_default_agent(legacy):
+        return
+
+    backend = str(legacy["backend"])
+    target = _backend_default_agent(bind, backend)
+    if target is None:
+        return
+
+    _retarget_agent_references(bind, tables, legacy, target)
+    _retarget_default_agent_pointer(bind, tables, target["name"])
+    bind.exec_driver_sql("delete from agents where id = ?", (legacy["id"],))
+
+
+def downgrade() -> None:
+    pass
+
+
+def _tables(bind) -> set[str]:
+    return {row[0] for row in bind.exec_driver_sql("select name from sqlite_master where type = 'table'")}
+
+
+def _columns(bind, table: str) -> set[str]:
+    return {row[1] for row in bind.exec_driver_sql(f'pragma table_info("{table}")')}
+
+
+def _legacy_default_agent(bind) -> dict[str, Any] | None:
+    row = bind.exec_driver_sql(
+        """
+        select id, name, normalized_name, description, backend, model, reasoning_effort,
+               system_prompt, enabled, source, source_ref, metadata_json
+        from agents
+        where normalized_name = ?
+        limit 1
+        """,
+        (_LEGACY_DEFAULT_AGENT_NAME,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "name": row[1],
+        "normalized_name": row[2],
+        "description": row[3],
+        "backend": row[4],
+        "model": row[5],
+        "reasoning_effort": row[6],
+        "system_prompt": row[7],
+        "enabled": row[8],
+        "source": row[9],
+        "source_ref": row[10],
+        "metadata": _json_loads(row[11], {}),
+    }
+
+
+def _is_unmodified_legacy_default_agent(agent: dict[str, Any]) -> bool:
+    metadata = agent["metadata"]
+    if not isinstance(metadata, dict):
+        return False
+    if metadata != {"builtin": True}:
+        return False
+    return (
+        agent["name"] == _LEGACY_DEFAULT_AGENT_NAME
+        and agent["normalized_name"] == _LEGACY_DEFAULT_AGENT_NAME
+        and agent["backend"] in _BACKENDS
+        and agent["source"] == "builtin"
+        and _is_empty(agent["source_ref"])
+        and agent["description"] == "Default Vibe Remote agent."
+        and _is_empty(agent["model"])
+        and _is_empty(agent["reasoning_effort"])
+        and _is_empty(agent["system_prompt"])
+    )
+
+
+def _backend_default_agent(bind, backend: str) -> dict[str, Any] | None:
+    row = bind.exec_driver_sql(
+        """
+        select id, name, backend, enabled, source, metadata_json
+        from agents
+        where normalized_name = ?
+        limit 1
+        """,
+        (backend,),
+    ).fetchone()
+    if row is None:
+        return None
+
+    agent_id, name, existing_backend, enabled, source, metadata_json = row
+    metadata = _json_loads(metadata_json, {})
+    if (
+        existing_backend != backend
+        or not bool(enabled)
+        or source != "builtin"
+        or not isinstance(metadata, dict)
+        or metadata.get("backend") != backend
+        or not bool(metadata.get("builtin_default") or metadata.get("lock_delete"))
+    ):
+        return None
+    return {"id": agent_id, "name": str(name), "backend": existing_backend}
+
+
+def _retarget_agent_references(bind, tables: set[str], legacy: dict[str, Any], target: dict[str, Any]) -> None:
+    legacy_name = str(legacy["name"])
+    legacy_id = str(legacy["id"])
+    target_name = str(target["name"])
+    target_id = str(target["id"])
+
+    if "scope_settings" in tables:
+        columns = _columns(bind, "scope_settings")
+        if "agent_name" in columns:
+            _retarget_scope_settings(bind, legacy_name, target_name)
+        if "agent_variant" in columns:
+            _retarget_agent_variant(bind, "scope_settings", legacy_name, target_name)
+    if "agent_sessions" in tables:
+        columns = _columns(bind, "agent_sessions")
+        _retarget_agent_table(bind, "agent_sessions", columns, legacy_name, target_name, legacy_id, target_id)
+    if "run_definitions" in tables:
+        columns = _columns(bind, "run_definitions")
+        _retarget_agent_table(bind, "run_definitions", columns, legacy_name, target_name, legacy_id, target_id)
+    if "agent_runs" in tables:
+        columns = _columns(bind, "agent_runs")
+        _retarget_agent_table(bind, "agent_runs", columns, legacy_name, target_name, legacy_id, target_id)
+
+
+def _retarget_scope_settings(bind, legacy_name: str, target_name: str) -> None:
+    rows = bind.exec_driver_sql(
+        """
+        select scope_id, settings_json
+        from scope_settings
+        where agent_name = ?
+        """,
+        (legacy_name,),
+    ).fetchall()
+    for scope_id, settings_json in rows:
+        bind.exec_driver_sql(
+            """
+            update scope_settings
+            set agent_name = ?, settings_json = ?
+            where scope_id = ?
+            """,
+            (target_name, _settings_json_retarget_agent(settings_json, legacy_name, target_name), scope_id),
+        )
+
+
+def _retarget_agent_table(
+    bind,
+    table: str,
+    columns: set[str],
+    legacy_name: str,
+    target_name: str,
+    legacy_id: str,
+    target_id: str,
+) -> None:
+    if "agent_name" in columns:
+        bind.exec_driver_sql(
+            f'update "{table}" set agent_name = ? where agent_name = ?',
+            (target_name, legacy_name),
+        )
+    if "agent_id" in columns:
+        bind.exec_driver_sql(
+            f'update "{table}" set agent_id = ? where agent_id = ?',
+            (target_id, legacy_id),
+        )
+    if "agent_variant" in columns:
+        _retarget_agent_variant(bind, table, legacy_name, target_name)
+
+
+def _retarget_agent_variant(bind, table: str, legacy_name: str, target_name: str) -> None:
+    bind.exec_driver_sql(
+        f'update "{table}" set agent_variant = ? where agent_variant = ?',
+        (target_name, legacy_name),
+    )
+
+
+def _retarget_default_agent_pointer(bind, tables: set[str], target_name: str) -> None:
+    if "state_meta" not in tables:
+        return
+    row = bind.exec_driver_sql(
+        "select value_json from state_meta where key = ? limit 1",
+        (_DEFAULT_AGENT_META_KEY,),
+    ).fetchone()
+    if row is None or _json_loads(row[0], None) != _LEGACY_DEFAULT_AGENT_NAME:
+        return
+    now = _utc_now_iso()
+    bind.exec_driver_sql(
+        "update state_meta set value_json = ?, updated_at = ? where key = ?",
+        (_json_dumps(target_name), now, _DEFAULT_AGENT_META_KEY),
+    )
+
+
+def _settings_json_retarget_agent(value: str | None, legacy_name: str, target_name: str) -> str:
+    payload = _json_loads(value, None)
+    if not isinstance(payload, dict):
+        return value or "{}"
+    routing = payload.get("routing")
+    if not isinstance(routing, dict):
+        return _json_dumps(payload)
+    if routing.get("agent_name") == legacy_name:
+        routing["agent_name"] = target_name
+    if routing.get("agent") == legacy_name:
+        routing["agent"] = target_name
+    payload["routing"] = routing
+    return _json_dumps(payload)
+
+
+def _json_loads(value: str | None, default: Any) -> Any:
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _json_dumps(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def _is_empty(value: Any) -> bool:
+    return value is None or value == ""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
+++ b/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
@@ -36,7 +36,7 @@ def upgrade() -> None:
         return
 
     backend = str(legacy["backend"])
-    target = _backend_default_agent(bind, backend)
+    target = _backend_default_agent(bind, backend, legacy_enabled=bool(legacy["enabled"]))
     if target is None:
         return
 
@@ -105,7 +105,7 @@ def _is_unmodified_legacy_default_agent(agent: dict[str, Any]) -> bool:
     )
 
 
-def _backend_default_agent(bind, backend: str) -> dict[str, Any] | None:
+def _backend_default_agent(bind, backend: str, *, legacy_enabled: bool) -> dict[str, Any] | None:
     row = bind.exec_driver_sql(
         """
         select id, name, backend, enabled, source, metadata_json
@@ -116,7 +116,7 @@ def _backend_default_agent(bind, backend: str) -> dict[str, Any] | None:
         (backend,),
     ).fetchone()
     if row is None:
-        return _insert_backend_default_agent(bind, backend)
+        return _insert_backend_default_agent(bind, backend, enabled=legacy_enabled)
 
     agent_id, name, existing_backend, enabled, source, metadata_json = row
     metadata = _json_loads(metadata_json, {})
@@ -132,7 +132,7 @@ def _backend_default_agent(bind, backend: str) -> dict[str, Any] | None:
     return {"id": agent_id, "name": str(name), "backend": existing_backend}
 
 
-def _insert_backend_default_agent(bind, backend: str) -> dict[str, Any]:
+def _insert_backend_default_agent(bind, backend: str, *, enabled: bool) -> dict[str, Any]:
     now = _utc_now_iso()
     metadata = {**_BUILTIN_DEFAULT_METADATA, "backend": backend, "backend_enabled": True}
     agent_id = uuid.uuid4().hex[:12]
@@ -141,7 +141,7 @@ def _insert_backend_default_agent(bind, backend: str) -> dict[str, Any]:
         insert into agents (
             id, name, normalized_name, description, backend, model, reasoning_effort,
             system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
-        ) values (?, ?, ?, ?, ?, null, null, null, 1, 'builtin', null, ?, ?, ?)
+        ) values (?, ?, ?, ?, ?, null, null, null, ?, 'builtin', null, ?, ?, ?)
         """,
         (
             agent_id,
@@ -149,6 +149,7 @@ def _insert_backend_default_agent(bind, backend: str) -> dict[str, Any]:
             backend,
             f"Default {backend} agent.",
             backend,
+            1 if enabled else 0,
             _json_dumps(metadata),
             now,
             now,

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -270,7 +270,7 @@ def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> 
             ) values
                 (
                     'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
-                    null, null, null, 0, 'builtin', null, '{"builtin":true}', 'now', 'now'
+                    null, null, null, 1, 'builtin', null, '{"builtin":true}', 'now', 'now'
                 ),
                 (
                     'agent-opencode', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
@@ -434,6 +434,98 @@ def test_run_migrations_creates_backend_default_before_removing_legacy_default(t
         "backend_enabled": True,
     }
     assert json.loads(default_pointer) == "opencode"
+
+
+def test_run_migrations_removes_unreferenced_disabled_legacy_default_with_existing_backend_default(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values
+                (
+                    'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
+                    null, null, null, 0, 'builtin', null, '{"builtin":true}', 'now', 'now'
+                ),
+                (
+                    'agent-opencode', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    null, null, null, 1, 'builtin', null,
+                    '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
+                    'now', 'now'
+                );
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        agents = dict(conn.execute("select name, enabled from agents order by name"))
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    assert version == (HEAD_REVISION,)
+    assert agents == {"opencode": 1}
+
+
+def test_run_migrations_skips_disabled_legacy_default_with_existing_backend_target_references(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values
+                (
+                    'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
+                    null, null, null, 0, 'builtin', null, '{"builtin":true}', 'now', 'now'
+                ),
+                (
+                    'agent-opencode', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    null, null, null, 1, 'builtin', null,
+                    '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
+                    'now', 'now'
+                );
+            insert into state_meta (key, value_json, updated_at)
+            values ('default_agent_name', '"default"', 'now');
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        agents = dict(conn.execute("select name, enabled from agents order by name"))
+        default_pointer = conn.execute(
+            "select value_json from state_meta where key = 'default_agent_name'"
+        ).fetchone()[0]
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    assert version == (HEAD_REVISION,)
+    assert agents == {"default": 0, "opencode": 1}
+    assert json.loads(default_pointer) == "default"
 
 
 def test_run_migrations_preserves_disabled_legacy_default_when_creating_backend_default(tmp_path: Path) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -436,6 +436,55 @@ def test_run_migrations_creates_backend_default_before_removing_legacy_default(t
     assert json.loads(default_pointer) == "opencode"
 
 
+def test_run_migrations_preserves_disabled_legacy_default_when_creating_backend_default(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values (
+                'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
+                null, null, null, 0, 'builtin', null, '{"builtin":true}', 'now', 'now'
+            );
+            insert into state_meta (key, value_json, updated_at)
+            values ('default_agent_name', '"default"', 'now');
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        agent = conn.execute(
+            "select name, backend, enabled, source, metadata_json from agents"
+        ).fetchone()
+        default_pointer = conn.execute(
+            "select value_json from state_meta where key = 'default_agent_name'"
+        ).fetchone()[0]
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    assert version == (HEAD_REVISION,)
+    assert agent[0:4] == ("opencode", "opencode", 0, "builtin")
+    assert json.loads(agent[4]) == {
+        "builtin": True,
+        "builtin_default": True,
+        "lock_delete": True,
+        "backend": "opencode",
+        "backend_enabled": True,
+    }
+    assert json.loads(default_pointer) == "opencode"
+
+
 def test_run_migrations_skips_user_owned_default_agent(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     engine = create_sqlite_engine(db_path)

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -16,7 +16,7 @@ from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
 
 
-HEAD_REVISION = "20260529_0007"
+HEAD_REVISION = "20260530_0008"
 
 
 def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
@@ -251,6 +251,222 @@ def test_run_migrations_backfills_existing_session_policy_only_for_targeted_defi
     assert rows["with-session-id"] == "existing"
     assert rows["with-session-key"] == "existing"
     assert rows["without-target"] is None
+
+
+def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values
+                (
+                    'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
+                    null, null, null, 0, 'builtin', null, '{"builtin":true}', 'now', 'now'
+                ),
+                (
+                    'agent-opencode', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    null, null, null, 1, 'builtin', null,
+                    '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
+                    'now', 'now'
+                );
+            insert into state_meta (key, value_json, updated_at)
+            values ('default_agent_name', '"default"', 'now');
+            insert into scopes (
+                id, platform, scope_type, native_id, parent_scope_id, display_name, native_type,
+                is_private, supports_threads, metadata_json, first_seen_at, last_seen_at, updated_at
+            ) values (
+                'slack::channel::C1', 'slack', 'channel', 'C1', null, null, null, 0, 1, '{}', 'now', 'now', 'now'
+            );
+            insert into scope_settings (
+                scope_id, enabled, role, workdir, agent_name, agent_backend, agent_variant,
+                model, reasoning_effort, require_mention, settings_version, settings_json, created_at, updated_at
+            ) values (
+                'slack::channel::C1', 1, null, '/repo', 'default', 'opencode', 'default', null, null, null, 1,
+                '{"routing":{"agent_name":"default","agent":"default","agent_backend":"opencode"}}', 'now', 'now'
+            );
+            insert into agent_sessions (
+                id, scope_id, agent_id, agent_name, agent_backend, agent_variant, model, reasoning_effort,
+                session_anchor, workdir, native_session_id, title, status, metadata_json, created_at, updated_at
+            ) values (
+                'session-1', 'slack::channel::C1', 'agent-default', 'default', 'opencode', 'default',
+                null, null, 'thread-1', '/repo', 'native-1', null, 'active', '{}', 'now', 'now'
+            );
+            insert into run_definitions (
+                id, definition_type, name, agent_name, session_policy, message, enabled, created_at, updated_at,
+                metadata_json
+            ) values (
+                'definition-1', 'task', 'task', 'default', 'new', 'hello', 1, 'now', 'now', '{}'
+            );
+            insert into agent_runs (
+                id, run_type, status, agent_name, agent_id, agent_backend, message, created_at, updated_at,
+                metadata_json, cancel_requested
+            ) values (
+                'run-1', 'task', 'queued', 'default', 'agent-default', 'opencode', 'hello', 'now', 'now', '{}', 0
+            );
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        agents = dict(conn.execute("select name, id from agents"))
+        default_pointer = conn.execute(
+            "select value_json from state_meta where key = 'default_agent_name'"
+        ).fetchone()[0]
+        scope_agent, scope_variant, settings_json = conn.execute(
+            "select agent_name, agent_variant, settings_json from scope_settings where scope_id = 'slack::channel::C1'"
+        ).fetchone()
+        session_agent = conn.execute(
+            "select agent_id, agent_name, agent_variant from agent_sessions where id = 'session-1'"
+        ).fetchone()
+        definition_agent = conn.execute(
+            "select agent_name from run_definitions where id = 'definition-1'"
+        ).fetchone()[0]
+        run_agent = conn.execute(
+            "select agent_id, agent_name from agent_runs where id = 'run-1'"
+        ).fetchone()
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    payload = json.loads(settings_json)
+    assert version == (HEAD_REVISION,)
+    assert "default" not in agents
+    assert agents["opencode"] == "agent-opencode"
+    assert json.loads(default_pointer) == "opencode"
+    assert scope_agent == "opencode"
+    assert scope_variant == "opencode"
+    assert payload["routing"]["agent_name"] == "opencode"
+    assert payload["routing"]["agent"] == "opencode"
+    assert session_agent == ("agent-opencode", "opencode", "opencode")
+    assert definition_agent == "opencode"
+    assert run_agent == ("agent-opencode", "opencode")
+
+
+def test_run_migrations_skips_user_owned_default_agent(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values (
+                'agent-default', 'default', 'default', 'User default agent.', 'opencode',
+                null, null, 'custom prompt', 1, 'user', null, '{}', 'now', 'now'
+            );
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        default_agent = conn.execute(
+            "select source, system_prompt from agents where normalized_name = 'default'"
+        ).fetchone()
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    assert version == (HEAD_REVISION,)
+    assert default_agent == ("user", "custom prompt")
+
+
+def test_run_migrations_skips_legacy_default_when_backend_target_is_user_agent(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values
+                (
+                    'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
+                    null, null, null, 1, 'builtin', null, '{"builtin":true}', 'now', 'now'
+                ),
+                (
+                    'agent-opencode-user', 'opencode', 'opencode', 'User opencode agent.', 'opencode',
+                    null, null, 'custom prompt', 1, 'user', null, '{}', 'now', 'now'
+                );
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = dict(conn.execute("select name, source from agents order by name"))
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    assert version == (HEAD_REVISION,)
+    assert rows == {"default": "builtin", "opencode": "user"}
+
+
+def test_run_migrations_skips_legacy_default_when_backend_target_is_disabled(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values
+                (
+                    'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
+                    null, null, null, 1, 'builtin', null, '{"builtin":true}', 'now', 'now'
+                ),
+                (
+                    'agent-opencode-disabled', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    null, null, null, 0, 'builtin', null,
+                    '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
+                    'now', 'now'
+                );
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = dict(conn.execute("select name, enabled from agents order by name"))
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    assert version == (HEAD_REVISION,)
+    assert rows == {"default": 1, "opencode": 0}
 
 
 def test_run_migrations_backfills_scope_agent_names_from_legacy_backend(tmp_path: Path) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -283,16 +283,31 @@ def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> 
             insert into scopes (
                 id, platform, scope_type, native_id, parent_scope_id, display_name, native_type,
                 is_private, supports_threads, metadata_json, first_seen_at, last_seen_at, updated_at
-            ) values (
-                'slack::channel::C1', 'slack', 'channel', 'C1', null, null, null, 0, 1, '{}', 'now', 'now', 'now'
-            );
+            ) values
+                (
+                    'slack::channel::C1', 'slack', 'channel', 'C1',
+                    null, null, null, 0, 1, '{}', 'now', 'now', 'now'
+                ),
+                (
+                    'discord::guild::G1', 'discord', 'guild', 'G1',
+                    null, null, null, 0, 0, '{}', 'now', 'now', 'now'
+                );
             insert into scope_settings (
                 scope_id, enabled, role, workdir, agent_name, agent_backend, agent_variant,
                 model, reasoning_effort, require_mention, settings_version, settings_json, created_at, updated_at
-            ) values (
-                'slack::channel::C1', 1, null, '/repo', 'default', 'opencode', 'default', null, null, null, 1,
-                '{"routing":{"agent_name":"default","agent":"default","agent_backend":"opencode"}}', 'now', 'now'
-            );
+            ) values
+                (
+                    'slack::channel::C1', 1, null, '/repo', 'default', 'opencode', 'default',
+                    null, null, null, 1,
+                    '{"routing":{"agent_name":"default","agent":"default","agent_backend":"opencode"}}',
+                    'now', 'now'
+                ),
+                (
+                    'discord::guild::G1', 1, null, null, null, 'opencode', null,
+                    null, null, null, 1,
+                    '{"routing":{"agent_name":"default","agent":"default","agent_backend":"opencode"}}',
+                    'now', 'now'
+                );
             insert into agent_sessions (
                 id, scope_id, agent_id, agent_name, agent_backend, agent_variant, model, reasoning_effort,
                 session_anchor, workdir, native_session_id, title, status, metadata_json, created_at, updated_at
@@ -328,6 +343,9 @@ def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> 
         scope_agent, scope_variant, settings_json = conn.execute(
             "select agent_name, agent_variant, settings_json from scope_settings where scope_id = 'slack::channel::C1'"
         ).fetchone()
+        json_only_scope_agent, json_only_scope_variant, json_only_settings_json = conn.execute(
+            "select agent_name, agent_variant, settings_json from scope_settings where scope_id = 'discord::guild::G1'"
+        ).fetchone()
         session_agent = conn.execute(
             "select agent_id, agent_name, agent_variant from agent_sessions where id = 'session-1'"
         ).fetchone()
@@ -340,6 +358,7 @@ def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> 
         version = conn.execute("select version_num from alembic_version").fetchone()
 
     payload = json.loads(settings_json)
+    json_only_payload = json.loads(json_only_settings_json)
     assert version == (HEAD_REVISION,)
     assert "default" not in agents
     assert agents["opencode"] == "agent-opencode"
@@ -348,6 +367,10 @@ def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> 
     assert scope_variant == "opencode"
     assert payload["routing"]["agent_name"] == "opencode"
     assert payload["routing"]["agent"] == "opencode"
+    assert json_only_scope_agent == "opencode"
+    assert json_only_scope_variant is None
+    assert json_only_payload["routing"]["agent_name"] == "opencode"
+    assert json_only_payload["routing"]["agent"] == "opencode"
     assert session_agent == ("agent-opencode", "opencode", "opencode")
     assert definition_agent == "opencode"
     assert run_agent == ("agent-opencode", "opencode")

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -353,6 +353,66 @@ def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> 
     assert run_agent == ("agent-opencode", "opencode")
 
 
+def test_run_migrations_creates_backend_default_before_removing_legacy_default(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            insert into agents (
+                id, name, normalized_name, description, backend, model, reasoning_effort,
+                system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
+            ) values (
+                'agent-default', 'default', 'default', 'Default Vibe Remote agent.', 'opencode',
+                null, null, null, 1, 'builtin', null, '{"builtin":true}', 'now', 'now'
+            );
+            insert into state_meta (key, value_json, updated_at)
+            values ('default_agent_name', '"default"', 'now');
+            create table alembic_version (version_num varchar(32) not null);
+            insert into alembic_version values ('20260529_0007');
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        agents = {
+            row[0]: {
+                "id": row[1],
+                "backend": row[2],
+                "enabled": row[3],
+                "source": row[4],
+                "metadata": json.loads(row[5]),
+            }
+            for row in conn.execute("select name, id, backend, enabled, source, metadata_json from agents")
+        }
+        default_pointer = conn.execute(
+            "select value_json from state_meta where key = 'default_agent_name'"
+        ).fetchone()[0]
+        version = conn.execute("select version_num from alembic_version").fetchone()
+
+    assert version == (HEAD_REVISION,)
+    assert set(agents) == {"opencode"}
+    assert agents["opencode"]["id"] != "agent-default"
+    assert agents["opencode"]["backend"] == "opencode"
+    assert agents["opencode"]["enabled"] == 1
+    assert agents["opencode"]["source"] == "builtin"
+    assert agents["opencode"]["metadata"] == {
+        "builtin": True,
+        "builtin_default": True,
+        "lock_delete": True,
+        "backend": "opencode",
+        "backend_enabled": True,
+    }
+    assert json.loads(default_pointer) == "opencode"
+
+
 def test_run_migrations_skips_user_owned_default_agent(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     engine = create_sqlite_engine(db_path)


### PR DESCRIPTION
## Summary
- add a one-time SQLite data migration that removes the legacy builtin `default` Agent
- retarget legacy `default` references to the enabled backend builtin default Agent when one exists
- skip cleanup when the backend target is user-owned, disabled, or otherwise not a builtin default Agent

## Scenario IDs
- none; no scenario catalog entry covers this storage repair

## Evidence Layers
- Unit: `PYTHONPATH=. .venv/bin/python -m pytest tests/test_sqlite_state_migration.py -q`
- Contract: `PYTHONPATH=. .venv/bin/python -m pytest tests/test_ui_api.py::test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends tests/test_ui_api.py::test_builtin_default_agent_enabled_state_follows_backend_config tests/test_ui_api.py::test_user_can_disable_builtin_default_agent_without_catalog_reenabling_it -q`
- Scenario: not applicable
- Residual manual checks: isolated SQLite probe matching the regression shape verified that only `opencode` remains after migration

## Notes
- `LATEST_SCHEMA_REVISION` intentionally remains on the latest structural schema revision so existing head-shaped databases are stamped before pure data migrations run.
