### PR TITLE
feat(ui): unify form controls on one design.pen field surface

### DIFF
--- a/ui/src/components/settings/BackendTestPanel.tsx
+++ b/ui/src/components/settings/BackendTestPanel.tsx
@@ -4,6 +4,7 @@ import { Play, Zap } from 'lucide-react';
 import clsx from 'clsx';
 
 import { Button } from '../ui/button';
+import { Select } from '@/components/ui/select';
 import { useApi } from '@/context/ApiContext';
 import type { BackendAuthTestResult } from '@/context/ApiContext';
 import { useToast } from '@/context/ToastContext';
@@ -147,15 +148,12 @@ export const BackendTestPanel: React.FC<BackendTestPanelProps> = ({ backend }) =
               are fetched from the same routing-config catalog so users
               don't have to guess identifiers. Codex users in particular
               want this to bypass a reasoning-heavy config default. */}
-          <select
+          <Select
             value={selectedModel}
             onChange={(e) => setSelectedModel(e.target.value)}
             disabled={testing}
-            className={clsx(
-              'h-9 rounded-md border border-border bg-background px-2 font-mono text-[11px]',
-              'text-foreground transition-colors hover:border-border-strong',
-              'disabled:opacity-60',
-            )}
+            wrapperClassName="w-auto"
+            className="font-mono text-[11px]"
             aria-label={t('settings.backends.testConnectionModelLabel') as string}
           >
             <option value="">{t('settings.backends.testConnectionModelDefault')}</option>
@@ -164,7 +162,7 @@ export const BackendTestPanel: React.FC<BackendTestPanelProps> = ({ backend }) =
                 {m}
               </option>
             ))}
-          </select>
+          </Select>
           {resultLine && (
             <span
               className={clsx(

--- a/ui/src/components/settings/OpencodeProviderTestPanel.tsx
+++ b/ui/src/components/settings/OpencodeProviderTestPanel.tsx
@@ -4,6 +4,7 @@ import { Play, Zap } from 'lucide-react';
 import clsx from 'clsx';
 
 import { Button } from '../ui/button';
+import { Select } from '@/components/ui/select';
 import { useApi } from '@/context/ApiContext';
 import type { BackendAuthTestResult } from '@/context/ApiContext';
 import { useToast } from '@/context/ToastContext';
@@ -135,15 +136,12 @@ export const OpencodeProviderTestPanel: React.FC<OpencodeProviderTestPanelProps>
         </div>
       </div>
       <div className="flex flex-wrap items-center justify-end gap-2">
-        <select
+        <Select
           value={selectedModel}
           onChange={(e) => setSelectedModel(e.target.value)}
           disabled={testing || models.length === 0}
-          className={clsx(
-            'h-8 rounded-md border border-border bg-background px-2 font-mono text-[11px]',
-            'text-foreground transition-colors hover:border-border-strong',
-            'disabled:opacity-60',
-          )}
+          wrapperClassName="w-auto"
+          className="font-mono text-[11px]"
           aria-label={t('settings.backends.testConnectionModelLabel') as string}
         >
           <option value="">
@@ -154,7 +152,7 @@ export const OpencodeProviderTestPanel: React.FC<OpencodeProviderTestPanelProps>
               {m}
             </option>
           ))}
-        </select>
+        </Select>
         <Button
           type="button"
           variant="brand"

--- a/ui/src/components/settings/SettingsPrimitives.tsx
+++ b/ui/src/components/settings/SettingsPrimitives.tsx
@@ -84,11 +84,14 @@ export const CompactField: React.FC<React.InputHTMLAttributes<HTMLInputElement>>
   ...props
 }) => <Input className={clsx('text-[12px]', className)} {...props} />;
 
-// Dense settings dropdown — the unified Select at 12px.
+// Dense settings dropdown — the unified Select at 12px. The caller's className
+// sizes the WRAPPER (width/margins), not the inner <select>, so layout classes
+// like w-full / md:max-w-* / min-w-* / mt-1 size the control box and keep the
+// absolutely-positioned chevron aligned.
 export const CompactSelect: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = ({
   className,
   ...props
-}) => <Select className={clsx('text-[12px]', className)} {...props} />;
+}) => <Select className="text-[12px]" wrapperClassName={className} {...props} />;
 
 type SearchFieldProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
   icon?: LucideIcon;

--- a/ui/src/components/settings/SettingsPrimitives.tsx
+++ b/ui/src/components/settings/SettingsPrimitives.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import clsx from 'clsx';
 import { Search } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { Input } from '../ui/input';
+import { Select } from '../ui/select';
 
 type SettingsPanelProps = {
   title?: React.ReactNode;
@@ -76,40 +78,25 @@ export const SettingsRow: React.FC<SettingsRowProps> = ({
   </div>
 );
 
+// Dense settings text field — the unified field surface (Input) at 12px.
 export const CompactField: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({
   className,
   ...props
-}) => (
-  <input
-    className={clsx(
-      'h-9 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40',
-      className
-    )}
-    {...props}
-  />
-);
+}) => <Input className={clsx('text-[12px]', className)} {...props} />;
 
+// Dense settings dropdown — the unified Select at 12px.
 export const CompactSelect: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = ({
   className,
   ...props
-}) => (
-  <select
-    className={clsx(
-      'h-9 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40',
-      className
-    )}
-    {...props}
-  />
-);
+}) => <Select className={clsx('text-[12px]', className)} {...props} />;
 
 type SearchFieldProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> & {
   icon?: LucideIcon;
   containerClassName?: string;
 };
 
-// Search input with leading icon. Distinct from CompactField on purpose:
-// list pages use a slightly larger 13px shell on bg-surface with a mint
-// focus border (not the cyan focus ring used in dense settings forms).
+// Search input with leading icon — the unified field surface (Input) at 13px
+// with room for the icon. (Previously a one-off bg-surface + mint-border shell.)
 export const SearchField: React.FC<SearchFieldProps> = ({
   icon: Icon = Search,
   className,
@@ -119,16 +106,9 @@ export const SearchField: React.FC<SearchFieldProps> = ({
   <div className={clsx('relative', containerClassName)}>
     <Icon
       size={14}
-      className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+      className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2 text-muted"
     />
-    <input
-      type="search"
-      className={clsx(
-        'h-9 rounded-lg border border-border bg-surface pl-9 pr-3 text-[13px] text-foreground placeholder:text-muted focus:border-mint/50 focus:outline-none',
-        className
-      )}
-      {...props}
-    />
+    <Input type="search" className={clsx('pl-9 pr-3 text-[13px]', className)} {...props} />
   </div>
 );
 

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -3,6 +3,7 @@ import { Bot, FolderOpen, HelpCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { Combobox } from '../ui/combobox';
+import { Input } from '@/components/ui/input';
 import { BackendIcon } from '../visual';
 import { CompactSelect } from '../settings/SettingsPrimitives';
 
@@ -70,7 +71,7 @@ function BlurInput({
   const [local, setLocal] = useState(value);
   useEffect(() => setLocal(value), [value]);
   return (
-    <input
+    <Input
       {...props}
       value={local}
       onChange={(e) => setLocal(e.target.value)}
@@ -240,7 +241,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
               placeholder={globalConfig?.runtime?.default_cwd || t('channelList.useGlobalDefault')}
               value={value.custom_cwd}
               onCommit={(v) => onChange({ custom_cwd: v })}
-              className="h-9 flex-1 rounded-lg border border-border bg-foreground/[0.04] px-3 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/50 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+              className="flex-1 font-mono text-[12px]"
             />
             <button
               type="button"

--- a/ui/src/components/steps/DiscordConfig.tsx
+++ b/ui/src/components/steps/DiscordConfig.tsx
@@ -22,6 +22,7 @@ import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 
 interface DiscordConfigProps {
   data: any;
@@ -241,12 +242,12 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                   <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
                     <KeyRound size={14} className="text-cyan" /> {t('discordConfig.clientId')}
                   </label>
-                  <input
+                  <Input
                     type="text"
                     value={clientId}
                     onChange={(e) => setClientId(e.target.value)}
                     placeholder={t('discordConfig.clientIdPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                    className="w-full font-mono text-[12px]"
                   />
                   <p className="text-[11px] text-muted">{t('discordConfig.clientIdHint')}</p>
                 </div>
@@ -264,12 +265,12 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                       {inviteCopied ? t('discordConfig.inviteUrlCopied') : t('discordConfig.inviteUrlCopy')}
                     </button>
                   </div>
-                  <input
+                  <Input
                     type="text"
                     value={inviteUrl}
                     readOnly
                     placeholder={t('discordConfig.inviteUrlPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2 font-mono text-[11px] text-foreground"
+                    className="w-full font-mono text-[11px]"
                   />
                 </div>
                 <Button
@@ -320,12 +321,12 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
                   <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
                     <KeyRound size={14} className="text-cyan" /> {t('discordConfig.botToken')}
                   </label>
-                  <input
+                  <Input
                     type="password"
                     value={botToken}
                     onChange={(e) => setBotToken(e.target.value)}
                     placeholder={t('discordConfig.botTokenPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                    className="w-full font-mono text-[12px]"
                   />
                   <p className="text-[11px] text-muted">{t('discordConfig.botTokenHint')}</p>
                 </div>

--- a/ui/src/components/steps/LarkConfig.tsx
+++ b/ui/src/components/steps/LarkConfig.tsx
@@ -25,6 +25,7 @@ import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 
 const LinkButton: React.FC<{ url: string; label: string }> = ({ url, label }) => (
   <Button variant="brand" size="sm" onClick={() => window.open(url, '_blank')} disabled={!url}>
@@ -283,12 +284,12 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
                   <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
                     <KeyRound size={14} className="text-cyan" /> {t('larkConfig.appId')}
                   </label>
-                  <input
+                  <Input
                     type="text"
                     value={appId}
                     onChange={(e) => setAppId(e.target.value)}
                     placeholder={t('larkConfig.appIdPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                    className="w-full font-mono text-[12px]"
                   />
                   <p className="text-[11px] text-muted">{t('larkConfig.appIdHint')}</p>
                 </div>
@@ -297,12 +298,12 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
                   <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
                     <KeyRound size={14} className="text-cyan" /> {t('larkConfig.appSecret')}
                   </label>
-                  <input
+                  <Input
                     type="password"
                     value={appSecret}
                     onChange={(e) => setAppSecret(e.target.value)}
                     placeholder={t('larkConfig.appSecretPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                    className="w-full font-mono text-[12px]"
                   />
                   <p className="text-[11px] text-muted">{t('larkConfig.appSecretHint')}</p>
                 </div>

--- a/ui/src/components/steps/LogsPanel.tsx
+++ b/ui/src/components/steps/LogsPanel.tsx
@@ -13,6 +13,8 @@ import clsx from 'clsx';
 
 import { useApi, type LogEntry, type LogSource } from '../../context/ApiContext';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Select } from '../ui/select';
 
 type LogLevel = 'DEBUG' | 'INFO' | 'WARNING' | 'ERROR' | 'ALL';
 
@@ -182,27 +184,28 @@ export const LogsPanel: React.FC<LogsPanelProps> = ({
       <div className="flex flex-wrap items-center gap-3">
         <div className="relative min-w-[220px] flex-1">
           <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted" />
-          <input
+          <Input
             type="text"
             placeholder={t('logs.searchPlaceholder')}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-9 w-full rounded-lg border border-border bg-foreground/[0.04] pl-9 pr-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+            className="w-full pl-9 text-[12px]"
           />
         </div>
         <div className="flex items-center gap-2">
           <Filter className="size-3.5 text-muted" />
-          <select
+          <Select
             value={levelFilter}
             onChange={(e) => setLevelFilter(e.target.value as LogLevel)}
-            className="h-9 rounded-lg border border-border bg-foreground/[0.04] px-3 text-[12px] text-foreground outline-none transition focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+            className="text-[12px]"
+            wrapperClassName="w-auto"
           >
             <option value="ALL">{t('logs.allLevels')}</option>
             <option value="ERROR">{t('logs.error')} ({levelCounts.ERROR})</option>
             <option value="WARNING">{t('logs.warning')} ({levelCounts.WARNING})</option>
             <option value="INFO">{t('logs.info')} ({levelCounts.INFO})</option>
             <option value="DEBUG">{t('logs.debug')} ({levelCounts.DEBUG})</option>
-          </select>
+          </Select>
         </div>
       </div>
 

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -7,6 +7,8 @@ import { useToast } from '../../context/ToastContext';
 import { getEnabledPlatforms, getPlatformCatalog, getPrimaryPlatform } from '../../lib/platforms';
 import { EyebrowBadge, PlatformIcon, WizardCard } from '../visual';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Select } from '../ui/select';
 
 // Per-platform brand-tinted tile container colors (matches design.pen wT*L
 // frames: Slack purple-soft, Discord indigo-soft, etc.).
@@ -251,14 +253,14 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
         <>
           <label className="grid gap-1.5">
             <span className="text-[11px] font-medium text-muted">{t('larkConfig.domainLabel')}</span>
-            <select
+            <Select
               value={activeCredential.domain || 'feishu'}
               onChange={(event) => updateCredential('lark', { domain: event.target.value })}
-              className="h-9 rounded-md border border-border bg-background px-3 text-[12px] text-foreground outline-none focus:border-mint"
+              className="text-[12px]"
             >
               <option value="feishu">{t('larkConfig.domainFeishu')}</option>
               <option value="lark">{t('larkConfig.domainLark')}</option>
-            </select>
+            </Select>
           </label>
           <CredentialInput
             label={t('larkConfig.appId')}
@@ -577,12 +579,12 @@ const CredentialInput: React.FC<{
 }> = ({ label, value, placeholder, hint, type = 'password', onChange }) => (
   <label className="grid gap-1.5">
     <span className="text-[11px] font-medium text-muted">{label}</span>
-    <input
+    <Input
       type={type}
       value={value}
       placeholder={placeholder}
       onChange={(event) => onChange(event.target.value)}
-      className="h-9 rounded-md border border-border bg-background px-3 text-[12px] text-foreground outline-none transition-colors placeholder:text-muted/55 focus:border-mint"
+      className="text-[12px]"
     />
     {hint ? <span className="text-[10px] text-muted">{hint}</span> : null}
   </label>

--- a/ui/src/components/steps/SlackConfig.tsx
+++ b/ui/src/components/steps/SlackConfig.tsx
@@ -9,6 +9,7 @@ import { EmbeddedConfigShell, EyebrowBadge, WizardCard } from '../visual';
 import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 
 interface SlackConfigProps {
   data: any;
@@ -220,12 +221,12 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                   <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
                     <Key size={14} className="text-cyan" /> {t('slackConfig.botToken')}
                   </label>
-                  <input
+                  <Input
                     type="password"
                     value={botToken}
                     onChange={(e) => setBotToken(e.target.value)}
                     placeholder={t('slackConfig.botTokenPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                    className="w-full font-mono text-[12px]"
                   />
                   <p className="text-[11px] text-muted">
                     {t('slackConfig.botTokenHint')}{' '}
@@ -260,12 +261,12 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
                   <label className="flex items-center gap-2 text-[12px] font-medium text-foreground">
                     <Key size={14} className="text-cyan" /> {t('slackConfig.appToken')}
                   </label>
-                  <input
+                  <Input
                     type="password"
                     value={appToken}
                     onChange={(e) => setAppToken(e.target.value)}
                     placeholder={t('slackConfig.appTokenPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                    className="w-full font-mono text-[12px]"
                   />
                   <p className="text-[11px] text-muted">
                     {t('slackConfig.appTokenHint')}{' '}

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -22,6 +22,7 @@ import { ProxyUrlField } from '../shared/ProxyUrlField';
 import { StepHeader, StepShell } from '../shared/WizardStep';
 import { ToggleSwitch } from '../settings/SettingsPrimitives';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 
 interface TelegramConfigProps {
   data: any;
@@ -215,12 +216,12 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
                     <KeyRound size={14} className="text-cyan" />
                     {t('telegramConfig.botToken')}
                   </label>
-                  <input
+                  <Input
                     type="password"
                     value={botToken}
                     onChange={(e) => setBotToken(e.target.value)}
                     placeholder={t('telegramConfig.botTokenPlaceholder')}
-                    className="w-full rounded-lg border border-border bg-background px-3 py-2.5 font-mono text-[12px] text-foreground outline-none transition placeholder:text-muted/55 focus:border-cyan focus:ring-1 focus:ring-cyan/40"
+                    className="w-full font-mono text-[12px]"
                   />
                   <p className="text-[11px] text-muted">{t('telegramConfig.botTokenHint')}</p>
                 </div>

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -23,6 +23,7 @@ import { PlatformIcon } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
 import { SearchField, ToggleSwitch } from '../settings/SettingsPrimitives';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 
 interface UserConfig {
   display_name: string;
@@ -290,12 +291,11 @@ const BindCodeCard: React.FC<BindCodeCardProps> = ({ refreshTrigger, onCodesChan
             {newType === 'expiring' && (
               <div className="flex items-center gap-3">
                 <label className="text-muted">{t('bindCode.expirationDate')}</label>
-                <input
+                <Input
                   type="date"
                   value={newExpiry}
                   onChange={(e) => setNewExpiry(e.target.value)}
                   min={new Date().toISOString().split('T')[0]}
-                  className="rounded-lg border border-border bg-surface px-3 py-1.5 text-foreground focus:border-cyan focus:outline-none"
                 />
               </div>
             )}

--- a/ui/src/components/ui/combobox.tsx
+++ b/ui/src/components/ui/combobox.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { Check, ChevronsUpDown } from "lucide-react"
 
 import { cn } from "../../lib/utils"
+import { fieldBaseClass } from "./field"
 import {
   Command,
   CommandEmpty,
@@ -72,7 +73,8 @@ export function Combobox({
           role="combobox"
           aria-expanded={open}
           className={cn(
-            "flex h-9 w-full items-center justify-between rounded-md border border-border bg-panel px-3 py-2 text-sm focus:outline-none focus:border-accent disabled:cursor-not-allowed disabled:opacity-50",
+            fieldBaseClass,
+            "flex h-9 items-center justify-between px-3",
             className
           )}
         >

--- a/ui/src/components/ui/field.ts
+++ b/ui/src/components/ui/field.ts
@@ -1,0 +1,9 @@
+// Shared base styling for every form-control surface — Input, Select,
+// Textarea, and the Combobox trigger. Mirrors design.pen's single
+// "inset field" treatment so all controls read identically when idle:
+//   fill   = --background (bg-background)    border = --input (border-input)
+//   radius = 6px (rounded-md)                focus  = mint ring (ring-ring)
+// Callers add only size/layout differences (height, padding, chevron) on top
+// via cn(fieldBaseClass, ...). Do not re-roll these tokens per component.
+export const fieldBaseClass =
+  'w-full rounded-md border border-input bg-background text-sm text-foreground shadow-sm transition-colors placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50';

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { fieldBaseClass } from './field';
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
@@ -8,10 +9,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className
   <input
     ref={ref}
     type={type}
-    className={cn(
-      'flex h-9 w-full rounded-lg border border-input bg-card px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50',
-      className
-    )}
+    className={cn(fieldBaseClass, 'flex h-9 px-3 py-1', className)}
     {...props}
   />
 ));

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { ChevronDown } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { fieldBaseClass } from './field';
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
+  // Styles the positioning wrapper; `className` styles the <select> itself.
+  wrapperClassName?: string;
+};
+
+// The non-search dropdown. A styled native <select> so it stays fully
+// accessible, with the unified field surface + a custom chevron. When closed
+// it is intentionally identical to Combobox's trigger (design.pen Select
+// Group/Default === Combobox/Default minus the chevron icon).
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, wrapperClassName, children, disabled, ...props }, ref) => (
+    <div className={cn('relative w-full', wrapperClassName)}>
+      <select
+        ref={ref}
+        disabled={disabled}
+        className={cn(fieldBaseClass, 'flex h-9 cursor-pointer appearance-none px-3 pr-9', className)}
+        {...props}
+      >
+        {children}
+      </select>
+      <ChevronDown
+        className={cn(
+          'pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-muted opacity-70',
+          disabled && 'opacity-40'
+        )}
+        aria-hidden="true"
+      />
+    </div>
+  )
+);
+Select.displayName = 'Select';

--- a/ui/src/components/ui/textarea.tsx
+++ b/ui/src/components/ui/textarea.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+import { fieldBaseClass } from './field';
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+// Multi-line field. Shares the unified field surface (design.pen Textarea
+// Group/Default); only the height + vertical padding differ from Input.
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(fieldBaseClass, 'flex min-h-[72px] px-3 py-2', className)}
+    {...props}
+  />
+));
+Textarea.displayName = 'Textarea';

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -27,6 +27,7 @@ import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
 import { Combobox } from '../ui/combobox';
 import type { ComboboxOption } from '../ui/combobox';
+import { Textarea } from '../ui/textarea';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { estimateTokens } from '../../lib/tokenEstimate';
 
@@ -237,7 +238,7 @@ export const AgentsPage: React.FC = () => {
 
       {/* Toolbar — design.pen Imduv: search + backend filter + spacer + Import + 新建 Agent */}
       <div className="flex flex-wrap items-center gap-2.5">
-        <div className="flex w-[320px] items-center gap-2 rounded-md border border-border-strong bg-surface px-3 py-2">
+        <div className="flex h-9 w-[320px] items-center gap-2 rounded-md border border-input bg-background px-3 transition-colors focus-within:border-ring focus-within:ring-2 focus-within:ring-ring">
           <Search className="size-3.5 shrink-0 text-muted" />
           <input
             value={search}
@@ -782,7 +783,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
           </span>
         </button>
         {systemPromptOpen && (
-          <textarea
+          <Textarea
             value={systemPrompt}
             onChange={(e) => setSystemPrompt(e.target.value)}
             onBlur={() => {
@@ -792,7 +793,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
             }}
             rows={6}
             placeholder={t('agents.create.systemPromptPlaceholder')}
-            className="rounded-md border border-border-strong bg-surface-3 px-3 py-2 text-[12px] text-foreground outline-none focus:border-cyan"
+            className="text-[12px]"
           />
         )}
       </div>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -11,6 +11,7 @@ import type { VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../c
 import { apiFetch } from '../../lib/apiFetch';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 
 interface PendingChunk {
@@ -292,7 +293,7 @@ const Compose: React.FC<ComposeProps> = ({ onSend, onStop, composing }) => {
           rows={3}
           placeholder={t('chat.compose.placeholder')}
           disabled={composing}
-          className="resize-none rounded-md border border-border bg-surface-3 px-3 py-2 text-[13px] text-foreground outline-none focus:border-cyan disabled:opacity-60"
+          className="w-full resize-none bg-transparent text-[13px] text-foreground outline-none placeholder:text-muted disabled:opacity-60"
         />
         <div className="flex items-center justify-between text-[11px] text-muted">
           <span>{t('chat.compose.hint')}</span>
@@ -431,7 +432,7 @@ const TitleField: React.FC<TitleFieldProps> = ({ title, onCommit }) => {
   };
 
   return (
-    <input
+    <Input
       ref={inputRef}
       value={value}
       onChange={(e) => setValue(e.target.value)}
@@ -444,7 +445,7 @@ const TitleField: React.FC<TitleFieldProps> = ({ title, onCommit }) => {
         }
       }}
       placeholder={t('chat.titlePlaceholder')}
-      className="flex-1 rounded-md border border-cyan/40 bg-surface-2 px-2 py-1 text-[15px] font-bold text-foreground outline-none focus:border-cyan"
+      className="h-8 flex-1 px-2 text-[15px] font-bold"
     />
   );
 };
@@ -538,14 +539,14 @@ const ModelField: React.FC<ModelFieldProps> = ({ model, onCommit }) => {
   }, [model]);
 
   return (
-    <input
+    <Input
       value={value}
       onChange={(e) => setValue(e.target.value)}
       onBlur={() => {
         if (value !== (model ?? '')) onCommit(value.trim() || null);
       }}
       placeholder={t('chat.modelPlaceholder')}
-      className="w-[200px] rounded-md border border-border-strong bg-surface-2 px-2 py-1 font-mono text-[11px] text-foreground outline-none focus:border-cyan"
+      className="h-7 w-[200px] px-2 font-mono text-[11px]"
     />
   );
 };

--- a/ui/src/components/workbench/CreateViaChatDialog.tsx
+++ b/ui/src/components/workbench/CreateViaChatDialog.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, Loader2, Sparkles, X } from 'lucide-react';
 import { useApi } from '../../context/ApiContext';
 import type { WorkbenchProject } from '../../context/ApiContext';
 import { Button } from '../ui/button';
+import { Select } from '../ui/select';
 
 export type CreateViaChatKind = 'task' | 'watch';
 
@@ -141,17 +142,17 @@ export const CreateViaChatDialog: React.FC<CreateViaChatDialogProps> = ({ kind, 
               {t('harness.createDialog.noProject')}
             </div>
           ) : (
-            <select
+            <Select
               value={projectId}
               onChange={(e) => setProjectId(e.target.value)}
-              className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 text-[12.5px] text-foreground outline-none transition focus:border-violet"
+              className="text-[12.5px]"
             >
               {projects.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.display_name} · {p.folder_path}
                 </option>
               ))}
-            </select>
+            </Select>
           )}
         </div>
 

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -367,7 +367,7 @@ export const HarnessPage: React.FC = () => {
           runs tab has its own server-side query in /api/harness/runs. */}
       {showSearchBar && (
         <div className="flex flex-wrap items-center gap-2.5">
-          <div className="flex w-[320px] items-center gap-2 rounded-md border border-border-strong bg-surface px-3 py-2">
+          <div className="flex h-9 w-[320px] items-center gap-2 rounded-md border border-input bg-background px-3 transition-colors focus-within:border-ring focus-within:ring-2 focus-within:ring-ring">
             <Search className="size-3.5 shrink-0 text-muted" />
             <input
               value={search}

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -7,6 +7,8 @@ import { useApi } from '../../context/ApiContext';
 import type { VibeAgentFull } from '../../context/ApiContext';
 import { Combobox } from '../ui/combobox';
 import type { ComboboxOption } from '../ui/combobox';
+import { Input } from '../ui/input';
+import { Textarea } from '../ui/textarea';
 
 type BackendKey = 'claude' | 'opencode' | 'codex';
 
@@ -200,14 +202,14 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
           <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
             {t('agents.create.name')}
           </div>
-          <input
+          <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && canSubmit) handleSubmit();
             }}
             placeholder="reviewer"
-            className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 font-mono text-[13px] text-foreground outline-none focus:border-cyan"
+            className="font-mono text-[13px]"
           />
         </div>
 
@@ -259,12 +261,12 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
             </div>
             <span className="text-[10px] text-muted">{t('agents.create.systemPromptHint')}</span>
           </div>
-          <textarea
+          <Textarea
             value={systemPrompt}
             onChange={(e) => setSystemPrompt(e.target.value)}
             rows={3}
             placeholder={t('agents.create.systemPromptPlaceholder')}
-            className="rounded-md border border-border-strong bg-surface-3 px-3 py-2 text-[12px] text-foreground outline-none focus:border-cyan"
+            className="text-[12px]"
           />
         </div>
 

--- a/ui/src/components/workbench/NewProjectDialog.tsx
+++ b/ui/src/components/workbench/NewProjectDialog.tsx
@@ -6,6 +6,7 @@ import { useApi } from '../../context/ApiContext';
 import type { WorkbenchProject } from '../../context/ApiContext';
 import { DirectoryBrowser } from '../ui/directory-browser';
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 
 interface NewProjectDialogProps {
   onClose: () => void;
@@ -109,13 +110,13 @@ export const NewProjectDialog: React.FC<NewProjectDialogProps> = ({ onClose, onC
           >
             {t('workbench.newProjectDialog.displayName')}
           </label>
-          <input
+          <Input
             id="new-project-display-name"
             type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             placeholder={folderBasename}
-            className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 text-[13px] text-foreground outline-none transition focus:border-mint placeholder:text-muted"
+            className="text-[13px]"
             onKeyDown={(e) => {
               if (e.key === 'Enter') submit();
             }}

--- a/ui/src/components/workbench/RunAgentDialog.tsx
+++ b/ui/src/components/workbench/RunAgentDialog.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, Loader2, Play, X } from 'lucide-react';
 import { useApi } from '../../context/ApiContext';
 import type { VibeAgentFull, WorkbenchProject } from '../../context/ApiContext';
 import { Button } from '../ui/button';
+import { Select } from '../ui/select';
 
 interface RunAgentDialogProps {
   agent: VibeAgentFull;
@@ -118,17 +119,17 @@ export const RunAgentDialog: React.FC<RunAgentDialogProps> = ({ agent, onClose }
               {t('agents.runDialog.noProject')}
             </div>
           ) : (
-            <select
+            <Select
               value={projectId}
               onChange={(e) => setProjectId(e.target.value)}
-              className="rounded-md border border-border-strong bg-surface-2 px-3 py-2 text-[12.5px] text-foreground outline-none transition focus:border-mint"
+              className="text-[12.5px]"
             >
               {projects.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.display_name} · {p.folder_path}
                 </option>
               ))}
-            </select>
+            </Select>
           )}
         </div>
 

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -25,6 +25,7 @@ import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { WorkbenchMessage, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Input } from '../ui/input';
 import { NewProjectDialog } from './NewProjectDialog';
 
 interface CapabilityNavItem {
@@ -204,7 +205,7 @@ const ProjectRow: React.FC<{
         {renaming ? (
           <div className="flex flex-1 items-center gap-1.5">
             <Folder className="size-3.5 shrink-0 text-muted" />
-            <input
+            <Input
               ref={renameInputRef}
               value={renameDraft}
               onChange={(e) => setRenameDraft(e.target.value)}
@@ -217,7 +218,7 @@ const ProjectRow: React.FC<{
                 }
               }}
               placeholder={t('workbench.projectRenamePlaceholder')}
-              className="flex-1 rounded border border-mint/40 bg-surface-2 px-1.5 py-0.5 text-[12px] font-medium text-foreground outline-none focus:border-mint"
+              className="h-7 flex-1 px-1.5 text-[12px] font-medium"
             />
           </div>
         ) : (


### PR DESCRIPTION
## Capability
Web UI **design system — unified form-control styling**. Fixes the reported inconsistency where dropdowns/inputs/search boxes used different backgrounds (one looked disabled next to another) and there was no shared `Select`/`Textarea` primitive.

## Root cause
Form controls had drifted into **4 different idle backgrounds** (`bg-card`, `bg-panel`, `bg-foreground/[0.04]`, `bg-background`), **2 radii**, and **3 focus styles**; the non-search dropdown had **no primitive** (raw `<select>` styled ad-hoc, the gray `bg-foreground/[0.04]` that read as "disabled" beside the white Combobox). `design.pen` actually defines **one inset field surface** for Input/Select/Textarea/Combobox — the code had just diverged.

## Change (aligned to design.pen)
- **`ui/components/ui/field.ts`** — shared `fieldBaseClass`: `bg-background` + `border-input` + `rounded-md` + `text-foreground` + mint `ring-ring` focus + `disabled:opacity-50`.
- **Input** → uses `fieldBaseClass` (was `bg-card`/`rounded-lg`).
- **Select** (new) → styled native `<select>` + chevron; the non-search dropdown. Closed state is intentionally identical to the Combobox trigger (design.pen `Select Group/Default` === `Combobox/Default` minus the chevron icon).
- **Textarea** (new) → multi-line field on the same surface.
- **Combobox** trigger → uses `fieldBaseClass` (was `bg-panel`/`border-border`/cyan focus).
- **SettingsPrimitives** `CompactField`/`CompactSelect`/`SearchField` now delegate to `Input`/`Select`.
- Swept ~20 feature files: raw `<input>/<select>/<textarea>` → primitives; workbench search-box wrappers moved onto the field surface.
- **Left intentionally** (Phase 2): chat composers (seamless transparent textarea inside an elevated panel — ChatGPT/Slack style), checkboxes/radios/toggles/segmented controls, and the directory-browser inline editors.

## Result
Closed dropdowns are identical whether searchable or not; inputs and search boxes share one surface; disabled is a distinct dimmed state — so "gray == disabled" no longer happens.

## Scenario IDs
No `tests/scenarios` catalog applies — this is pure Web UI styling. Coverage = type/build + visual review.

## Evidence layers
- **Build / type:** `npm run build` (`tsc -b` + `vite build`) clean across all 24 changed files.
- **Manual (diff review):** caught and reverted a regression where the chat composer got a nested bordered field; verified composers stay seamless and only standalone fields use the bordered primitive.
- **Residual manual:** recommend a visual pass in the Docker regression env (light + dark) on settings, routing, wizard steps, and workbench dialogs. No automated visual test in repo.

## Known caveat
Native `<select>`'s **open** option list is OS-styled (not themeable); only the **closed trigger** is unified (which is the reported issue — "未点击的时候"). A fully-custom non-search select could come later if needed.
