### PR TITLE
Workbench sidebar: folder-icon states, add-project icon, live session-title sync

### DIFF
--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -10,6 +10,8 @@ import {
   ChevronRight,
   Ellipsis,
   Folder,
+  FolderOpen,
+  FolderPlus,
   Inbox,
   KeyRound,
   Loader2,
@@ -204,7 +206,11 @@ const ProjectRow: React.FC<{
       >
         {renaming ? (
           <div className="flex flex-1 items-center gap-1.5">
-            <Folder className="size-3.5 shrink-0 text-muted" />
+            {expanded ? (
+              <FolderOpen className="size-3.5 shrink-0 text-muted" />
+            ) : (
+              <Folder className="size-3.5 shrink-0 text-muted" />
+            )}
             <Input
               ref={renameInputRef}
               value={renameDraft}
@@ -228,7 +234,11 @@ const ProjectRow: React.FC<{
             className="flex flex-1 items-center gap-1.5 text-left"
           >
             <Chevron className="size-3 shrink-0 text-muted" />
-            <Folder className="size-3.5 shrink-0 text-muted" />
+            {expanded ? (
+              <FolderOpen className="size-3.5 shrink-0 text-muted" />
+            ) : (
+              <Folder className="size-3.5 shrink-0 text-muted" />
+            )}
             <span className="flex-1 truncate text-[12px] font-medium text-foreground">
               {project.display_name}
             </span>
@@ -382,6 +392,35 @@ export const WorkbenchSidebar: React.FC = () => {
   useEffect(() => {
     fetchProjects();
   }, [fetchProjects]);
+
+  // Keep cached session rows in sync with edits made elsewhere (e.g. renaming
+  // a session from the chat header). The server broadcasts session.activity
+  // with event "updated"; patch the matching row's title in place so the
+  // sidebar label tracks the chat header without a manual refresh.
+  useEffect(() => {
+    const disconnect = api.connectWorkbenchEvents({
+      onSessionActivity: (data) => {
+        if (data.event !== 'updated' || !data.scope_id) return;
+        const projectId = data.scope_id.split('::').pop();
+        if (!projectId) return;
+        const nextTitle = data.title ?? null;
+        setSessionsByProject((prev) => {
+          const list = prev[projectId];
+          if (!list) return prev;
+          let changed = false;
+          const next = list.map((s) => {
+            if (s.id === data.session_id && s.title !== nextTitle) {
+              changed = true;
+              return { ...s, title: nextTitle };
+            }
+            return s;
+          });
+          return changed ? { ...prev, [projectId]: next } : prev;
+        });
+      },
+    });
+    return disconnect;
+  }, [api]);
 
   const fetchSessions = useCallback(
     async (projectId: string) => {
@@ -646,7 +685,7 @@ export const WorkbenchSidebar: React.FC = () => {
             onClick={() => setShowNewProject(true)}
             className="flex size-[22px] items-center justify-center rounded-md border border-border-strong text-foreground transition hover:bg-foreground/[0.04]"
           >
-            <Plus className="size-3" />
+            <FolderPlus className="size-3" />
           </button>
         </div>
 

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -244,7 +244,7 @@ export type WorkbenchEventEnvelope<T = unknown> = {
 export type WorkbenchEventHandlers = {
   onConnected?: (data: { sub_id: number }) => void;
   onMessageNew?: (data: WorkbenchMessage) => void;
-  onSessionActivity?: (data: { session_id: string; scope_id: string | null; event: string }) => void;
+  onSessionActivity?: (data: { session_id: string; scope_id: string | null; event: string; title?: string | null }) => void;
   onInboxUnreadChanged?: (data: {
     session_id?: string;
     scope_id?: string | null;

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2786,6 +2786,7 @@ def sessions_get(session_id: str):
 @app.route("/api/sessions/<session_id>", methods=["PATCH"])
 def sessions_update(session_id: str):
     from core.services import sessions as workbench_sessions_service
+    from vibe.sse_broker import broker
 
     payload = request.json or {}
     updatable = {
@@ -2810,6 +2811,18 @@ def sessions_update(session_id: str):
             session = workbench_sessions_service.update_session(conn, session_id, **updatable)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
+    # Broadcast so other surfaces (e.g. the sidebar session list) reflect the
+    # edit live — renaming a session in the chat header should rename its
+    # sidebar row without a manual refresh.
+    broker.publish(
+        "session.activity",
+        {
+            "session_id": session_id,
+            "scope_id": session.get("scope_id"),
+            "event": "updated",
+            "title": session.get("title"),
+        },
+    )
     return jsonify(session)
 
 


### PR DESCRIPTION
## Capability

Three Workbench sidebar polish items from page feedback:

1. **Folder icon reflects expand state** — the project row showed a static `Folder` regardless of expand/collapse. It now renders `FolderOpen` when the project is expanded and `Folder` when collapsed (both the toggle row and the rename row).
2. **Add-project icon** — the "添加项目" button used a bare `Plus`; it now uses a folder-with-plus (`FolderPlus`) icon.
3. **Live session-title sync** — renaming a session from the chat header didn't update the sidebar row until a manual refresh. `PATCH /api/sessions/<id>` now broadcasts a `session.activity` event (`event: "updated"`, with the new `title`), and the sidebar subscribes and patches the cached session row in place. Decoupled via SSE so it doesn't reintroduce per-render churn.

## Scenario IDs

No `tests/scenarios/*` catalog entries added or changed — this is a Web UI polish + a small SSE broadcast on an existing route.

## Evidence layers

- **Unit**: `ruff check` clean on `vibe/ui_server.py`.
- **Contract**: `npm run build` passes (TS typecheck across the changed sidebar/context).
- **Scenario**: n/a (no catalog change).
- **Residual manual checks**: recommend verifying in the Docker regression env — expand/collapse folder icon, add-project button icon, and renaming a session from the chat header reflecting in the sidebar live.