### PR TITLE
fix(release): bundle show runtime in GitHub prereleases

### DIFF
--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -4,10 +4,11 @@ on:
   push:
     tags:
       - "v*"
+      - "gh-v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g., v1.0.0 or v1.0.1rc1)"
+        description: "Tag to release (e.g., v1.0.0, v1.0.1rc1, or gh-v1.0.1rc1)"
         required: true
         type: string
       model:
@@ -26,7 +27,125 @@ permissions:
   pull-requests: read
 
 jobs:
+  show-runtime-bundles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: linux-x64
+          - os: ubuntu-24.04-arm
+            artifact: linux-arm64
+          - os: macos-13
+            artifact: darwin-x64
+          - os: macos-14
+            artifact: darwin-arm64
+          - os: windows-latest
+            artifact: win32-x64
+          - os: windows-11-arm
+            artifact: win32-arm64
+    steps:
+      - name: Checkout Show Runtime
+        uses: actions/checkout@v5
+        with:
+          repository: avibe-bot/vibe-show-runtime
+          ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22.14.0"
+          cache: "npm"
+      - name: Build Show Runtime bundle
+        run: |
+          npm ci
+          npm run build
+          npm run bundle:vibe-remote
+      - name: Upload Show Runtime bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: show-runtime-${{ matrix.artifact }}
+          path: dist/vibe-show-runtime-node-*.tgz
+
+  build-assets:
+    needs: show-runtime-bundles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Build UI
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+
+      - name: Download Show Runtime bundles
+        uses: actions/download-artifact@v6
+        with:
+          pattern: show-runtime-*
+          path: vibe/show_runtime
+          merge-multiple: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build Python package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Verify bundled Show Runtime archives
+        run: |
+          python - <<'PY'
+          import sys
+          import zipfile
+          from pathlib import Path
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"Expected exactly one wheel, found {len(wheels)}")
+
+          with zipfile.ZipFile(wheels[0]) as wheel:
+              archives = {
+                  name for name in wheel.namelist()
+                  if name.startswith("vibe/show_runtime/vibe-show-runtime-node-")
+                  and name.endswith(".tgz")
+              }
+
+          expected = {
+              "vibe/show_runtime/vibe-show-runtime-node-darwin-arm64.tgz",
+              "vibe/show_runtime/vibe-show-runtime-node-darwin-x64.tgz",
+              "vibe/show_runtime/vibe-show-runtime-node-linux-arm64.tgz",
+              "vibe/show_runtime/vibe-show-runtime-node-linux-x64.tgz",
+              "vibe/show_runtime/vibe-show-runtime-node-win32-arm64.tgz",
+              "vibe/show_runtime/vibe-show-runtime-node-win32-x64.tgz",
+          }
+          missing = sorted(expected - archives)
+          if missing:
+              raise SystemExit("Wheel is missing bundled Show Runtime archives:\n" + "\n".join(missing))
+
+          print("\n".join(sorted(archives)))
+          PY
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-dist
+          path: dist/
+
   release:
+    needs: build-assets
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -71,6 +190,17 @@ jobs:
         shell: bash
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
+
+          if [[ "$TAG" == gh-v* ]]; then
+            if ! git rev-parse --verify "$TAG^{commit}" >/dev/null 2>&1; then
+              echo "Current tag '$TAG' not found in git tags" >&2
+              git tag -l '*v*' --sort=v:refname | tail -n 50 >&2
+              exit 1
+            fi
+            PREV=$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)
+            echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Find the previous semantic version tag (v*) before current tag.
           # This assumes tags follow semver-like ordering.
@@ -291,12 +421,20 @@ jobs:
             mv release.md.tmp release.md
           fi
 
+      - name: Download release artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: release-dist
+          path: dist/
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
           body_path: release.md
+          files: dist/*
+          fail_on_unmatched_files: true
           draft: false
           prerelease: ${{ steps.release_type.outputs.prerelease == 'true' }}
           make_latest: ${{ github.event_name == 'push' && steps.release_type.outputs.prerelease != 'true' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,5 +260,5 @@ Testing guidance:
 - tags follow the latest version number +1 (for example `v1.0.1` -> `v1.0.2`)
 - before publishing a release, explicitly decide whether the version should notify users; add `<!-- vibe-remote:update-notification=none -->` to the GitHub Release body when update and post-update notifications should be suppressed while automatic update behavior remains enabled
 - GitHub-only pre-releases should use the `gh-vX.Y.ZrcN` format (for example `gh-v2.2.8rc2`) so they stay distinct from PyPI-triggering `v*` tags
-- GitHub-only pre-releases must include installable artifacts (at minimum a wheel built with `ui/dist`) in the GitHub release assets
+- GitHub-only pre-releases must include installable artifacts in the GitHub release assets: a wheel built with `ui/dist` and bundled `vibe/show_runtime/*.tgz`, plus the sdist
 - releases are published automatically by workflow after tagging/push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ packages = ["vibe", "config", "core", "modules", "storage"]
 [tool.hatch.build.targets.wheel.force-include]
 "main.py" = "vibe/service_main.py"
 "ui/dist" = "vibe/ui/dist"
-"vibe/show_runtime" = "vibe/show_runtime"
 
 [tool.hatch.build.targets.sdist]
 # Include ui/dist for source distribution


### PR DESCRIPTION
## Summary
- make GitHub-only `gh-v*` prereleases run the same asset build path as publish releases
- build and attach Show Runtime archives to release wheels so installed prereleases can run Show Pages without falling back to static recovery HTML
- verify the wheel contains all six runtime platform archives and avoid duplicate wheel entries from `force-include`

## Test
- `npm ci && npm run build` in `ui/`
- `uv run --with build python -m build --wheel` with six generated runtime archives staged under `vibe/show_runtime/`
- inspected the built wheel and confirmed exactly six `vibe/show_runtime/vibe-show-runtime-node-*.tgz` entries

## Related
- depends on avibe-bot/vibe-show-runtime#2, merged with green Linux/macOS/Windows CI
