### PR TITLE
fix(release): use current macOS Intel runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
             artifact: linux-x64
           - os: ubuntu-24.04-arm
             artifact: linux-arm64
-          - os: macos-13
+          - os: macos-15-intel
             artifact: darwin-x64
           - os: macos-14
             artifact: darwin-arm64

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -36,7 +36,7 @@ jobs:
             artifact: linux-x64
           - os: ubuntu-24.04-arm
             artifact: linux-arm64
-          - os: macos-13
+          - os: macos-15-intel
             artifact: darwin-x64
           - os: macos-14
             artifact: darwin-arm64


### PR DESCRIPTION
## Summary
- move the darwin-x64 Show Runtime bundle job from the old `macos-13` runner label to `macos-15-intel`
- apply the same runner fix to both GitHub release and PyPI publish workflows

## Test
- parsed both workflow YAML files with PyYAML
- asserted the Show Runtime bundle matrix uses `macos-15-intel` for `darwin-x64` and no longer uses `macos-13`

## Context
- `gh-v2.3.6rc4` was cancelled because the `macos-13` darwin-x64 job stayed queued while the other five platform bundle jobs completed.
