### PR TITLE
fix(cli): resolve legacy scope routing through agents

### DIFF
--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -9,7 +9,7 @@ import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NamedTuple, Optional
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
@@ -27,6 +27,11 @@ from storage.models import agent_sessions, scope_settings, scopes
 from storage.pagination import PageRequest, PageResult, page_sequence
 
 logger = logging.getLogger(__name__)
+
+
+class _ScopeAgentTarget(NamedTuple):
+    agent_name: Optional[str]
+    agent_backend: Optional[str]
 
 
 def _utc_now_iso() -> str:
@@ -1430,7 +1435,13 @@ class ScheduledTaskService:
         ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(config_paths.get_state_dir()))
         agent_store = VibeAgentStore()
         try:
-            resolved_agent_name = agent_name or self._resolve_scope_agent_name(deliver_key)
+            scope_target = self._resolve_scope_agent_target(deliver_key) if not agent_name else _ScopeAgentTarget(None, None)
+            resolved_agent_name = agent_name or scope_target.agent_name
+            if not resolved_agent_name and scope_target.agent_backend:
+                raise ValueError(
+                    "scope routing still references a legacy backend without an Agent; "
+                    "choose an Agent before creating sessions for this Scope"
+                )
             agent = agent_store.require_enabled(resolved_agent_name) if resolved_agent_name else None
         finally:
             agent_store.close()
@@ -1452,11 +1463,11 @@ class ScheduledTaskService:
             raise ValueError("failed to reserve runtime session")
         return session_id
 
-    def _resolve_scope_agent_name(self, deliver_key: str) -> Optional[str]:
+    def _resolve_scope_agent_target(self, deliver_key: str) -> "_ScopeAgentTarget":
         try:
             target = parse_session_key(deliver_key)
         except ValueError:
-            return None
+            return _ScopeAgentTarget(None, None)
         from config import paths as config_paths
         from storage.settings_service import make_scope_id
 
@@ -1465,13 +1476,17 @@ class ScheduledTaskService:
         try:
             with engine.connect() as conn:
                 value = conn.execute(
-                    select(scope_settings.c.agent_name)
+                    select(scope_settings.c.agent_name, scope_settings.c.agent_backend)
                     .where(scope_settings.c.scope_id == scope_id)
                     .limit(1)
-                ).scalar_one_or_none()
+                ).first()
         finally:
             engine.dispose()
-        return str(value).strip() if value else None
+        if value is None:
+            return _ScopeAgentTarget(None, None)
+        agent_name = str(value.agent_name).strip() if value.agent_name else None
+        agent_backend = str(value.agent_backend).strip() if value.agent_backend else None
+        return _ScopeAgentTarget(agent_name, agent_backend)
 
     async def _execute_request(
         self,

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1430,10 +1430,11 @@ class ScheduledTaskService:
         ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(config_paths.get_state_dir()))
         agent_store = VibeAgentStore()
         try:
-            agent = agent_store.require_enabled(agent_name) if agent_name else None
+            resolved_agent_name = agent_name or self._resolve_scope_agent_name(deliver_key)
+            agent = agent_store.require_enabled(resolved_agent_name) if resolved_agent_name else None
         finally:
             agent_store.close()
-        agent_backend = agent.backend if agent else self._resolve_scope_agent_backend(deliver_key)
+        agent_backend = agent.backend if agent else self.controller.agent_router.global_default
         service = SQLiteSessionsService(config_paths.get_sqlite_state_path())
         try:
             session_id = service.reserve_agent_session(
@@ -1451,11 +1452,11 @@ class ScheduledTaskService:
             raise ValueError("failed to reserve runtime session")
         return session_id
 
-    def _resolve_scope_agent_backend(self, deliver_key: str) -> str:
+    def _resolve_scope_agent_name(self, deliver_key: str) -> Optional[str]:
         try:
             target = parse_session_key(deliver_key)
         except ValueError:
-            return self.controller.agent_router.global_default
+            return None
         from config import paths as config_paths
         from storage.settings_service import make_scope_id
 
@@ -1464,14 +1465,13 @@ class ScheduledTaskService:
         try:
             with engine.connect() as conn:
                 value = conn.execute(
-                    select(scope_settings.c.agent_backend)
+                    select(scope_settings.c.agent_name)
                     .where(scope_settings.c.scope_id == scope_id)
                     .limit(1)
                 ).scalar_one_or_none()
         finally:
             engine.dispose()
-        return str(value).strip() if value else self.controller.agent_router.global_default
-
+        return str(value).strip() if value else None
 
     async def _execute_request(
         self,

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -316,7 +316,7 @@ class VibeAgentStore:
         return self.create(
             name=agent_name,
             backend=backend,
-            description=f"Default {agent_name} agent.",
+            description=f"Default Agent for the {backend} backend.",
             source="builtin",
             metadata=metadata,
             enabled=True,

--- a/storage/alembic/versions/20260529_0007_backfill_scope_agent_names.py
+++ b/storage/alembic/versions/20260529_0007_backfill_scope_agent_names.py
@@ -88,7 +88,7 @@ def _ensure_backend_default_agent(bind, backend: str, now: str) -> str | None:
             uuid.uuid4().hex[:12],
             backend,
             backend,
-            f"Default {backend} agent.",
+            f"Default Agent for the {backend} backend.",
             backend,
             _json_dumps(metadata),
             now,

--- a/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
+++ b/storage/alembic/versions/20260530_0008_remove_legacy_default_agent.py
@@ -153,7 +153,7 @@ def _insert_backend_default_agent(bind, backend: str, *, enabled: bool) -> dict[
             agent_id,
             backend,
             backend,
-            f"Default {backend} agent.",
+            f"Default Agent for the {backend} backend.",
             backend,
             1 if enabled else 0,
             _json_dumps(metadata),

--- a/storage/importer.py
+++ b/storage/importer.py
@@ -547,7 +547,7 @@ def _ensure_backend_default_agent(conn: Connection, backend: str, now: str) -> s
             uuid.uuid4().hex[:12],
             backend,
             backend,
-            f"Default {backend} agent.",
+            f"Default Agent for the {backend} backend.",
             backend,
             _json_dumps(metadata),
             now,

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -1275,6 +1275,53 @@ def test_reserve_definition_session_uses_canonicalized_scope_agent(tmp_path: Pat
     assert target.agent_id
 
 
+def test_reserve_definition_session_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    agent_store.ensure_default_agent(backend="claude")
+    agent_store.create(name="codex", backend="opencode")
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with cli.create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-05-22T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=None,
+                agent_backend="codex",
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps({"routing": {"agent_backend": "codex"}}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+        pytest.raises(cli.TaskCliError) as exc,
+    ):
+        cli._reserve_definition_session(
+            agent_name=None,
+            deliver_key="slack::channel::C123",
+            help_command="vibe task add --help",
+        )
+
+    assert exc.value.code == "legacy_scope_backend_unresolved"
+    assert exc.value.details == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
+
+
 def test_task_add_rejects_deprecated_prompt_argument() -> None:
     args = _parse_task_add(
         [

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -785,6 +785,56 @@ def test_hook_send_enqueues_request(tmp_path: Path, capsys) -> None:
     assert (request_root / "pending" / f"{payload['execution_id']}.json").exists()
 
 
+def test_hook_send_allows_unresolved_legacy_scope_backend(tmp_path: Path, capsys) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    default_agent = agent_store.ensure_default_agent(backend="claude")
+    agent_store.create(name="codex", backend="opencode")
+    agent_store.close()
+    request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with cli.create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-05-22T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=None,
+                agent_backend="codex",
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps({"routing": {"agent_backend": "codex"}}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    args = _parse_hook_send(["--session-key", "slack::channel::C123", "--message", "hello"])
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._task_request_store", return_value=request_store),
+    ):
+        result = cli.cmd_hook_send(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    queued = json.loads((request_store.pending_dir / f"{payload['run_id']}.json").read_text())
+    assert queued["session_key"] == "slack::channel::C123"
+    assert queued["agent_name"] == default_agent.name
+
+
 def test_hook_send_returns_reachability_warning_for_unbound_lark_dm(tmp_path: Path, capsys) -> None:
     args = _parse_hook_send(
         [
@@ -1229,7 +1279,59 @@ def test_resolve_agent_for_target_canonicalizes_legacy_scope_backend_to_agent(tm
     assert json.loads(row[2])["routing"]["agent_name"] == "codex"
 
 
-def test_resolve_agent_for_target_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+def test_resolve_agent_for_target_allows_unresolved_legacy_scope_backend_without_session_creation(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    default_agent = agent_store.ensure_default_agent(backend="claude")
+    agent_store.create(name="codex", backend="opencode")
+    agent_store.close()
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with cli.create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-05-22T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=None,
+                agent_backend="codex",
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps({"routing": {"agent_backend": "codex"}}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+    ):
+        agent = cli._resolve_agent_for_target(
+            agent_name=None,
+            session_id=None,
+            session_key="slack::channel::C123",
+            help_command="vibe task add --help",
+        )
+
+    assert agent is not None
+    assert agent.name == default_agent.name
+
+
+def test_resolve_agent_for_target_rejects_unresolved_legacy_scope_backend_for_session_creation(
+    tmp_path: Path,
+) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = cli.VibeAgentStore(db_path)
     agent_store.ensure_default_agent(backend="claude")
@@ -1272,6 +1374,7 @@ def test_resolve_agent_for_target_rejects_unresolved_legacy_scope_backend(tmp_pa
             session_id=None,
             session_key="slack::channel::C123",
             help_command="vibe task add --help",
+            reject_unresolved_legacy_scope_backend=True,
         )
 
     assert exc.value.code == "legacy_scope_backend_unresolved"

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -1229,6 +1229,55 @@ def test_resolve_agent_for_target_canonicalizes_legacy_scope_backend_to_agent(tm
     assert json.loads(row[2])["routing"]["agent_name"] == "codex"
 
 
+def test_resolve_agent_for_target_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    agent_store.ensure_default_agent(backend="claude")
+    agent_store.create(name="codex", backend="opencode")
+    agent_store.close()
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with cli.create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-05-22T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=None,
+                agent_backend="codex",
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps({"routing": {"agent_backend": "codex"}}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+        pytest.raises(cli.TaskCliError) as exc,
+    ):
+        cli._resolve_agent_for_target(
+            agent_name=None,
+            session_id=None,
+            session_key="slack::channel::C123",
+            help_command="vibe task add --help",
+        )
+
+    assert exc.value.code == "legacy_scope_backend_unresolved"
+    assert exc.value.details == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
+
+
 def test_reserve_definition_session_uses_canonicalized_scope_agent(tmp_path: Path) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     cli.VibeAgentStore(db_path).ensure_default_agent(backend="claude")
@@ -1320,6 +1369,62 @@ def test_reserve_definition_session_rejects_unresolved_legacy_scope_backend(tmp_
 
     assert exc.value.code == "legacy_scope_backend_unresolved"
     assert exc.value.details == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
+
+
+def test_task_add_create_per_run_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    agent_store.ensure_default_agent(backend="claude")
+    agent_store.create(name="codex", backend="opencode")
+    agent_store.close()
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with cli.create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-05-22T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=None,
+                agent_backend="codex",
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps({"routing": {"agent_backend": "codex"}}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    args = _parse_task_add(
+        [
+            "--create-session-per-run",
+            "--deliver-key",
+            "slack::channel::C123",
+            "--cron",
+            "0 * * * *",
+            "--message",
+            "hello",
+        ]
+    )
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+    ):
+        result, payload = _capture_stderr_json(cli.cmd_task_add, args)
+
+    assert result == 1
+    assert payload["code"] == "legacy_scope_backend_unresolved"
+    assert payload["details"] == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
 
 
 def test_task_add_rejects_deprecated_prompt_argument() -> None:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -1172,7 +1172,7 @@ def test_resolve_agent_for_target_bootstraps_sqlite_before_scope_lookup(tmp_path
         assert conn.execute("select count(*) from scope_settings").fetchone()[0] == 0
 
 
-def test_resolve_agent_for_target_keeps_legacy_scope_backend_from_default_agent(tmp_path: Path) -> None:
+def test_resolve_agent_for_target_canonicalizes_legacy_scope_backend_to_agent(tmp_path: Path) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     cli.VibeAgentStore(db_path).ensure_default_agent(backend="claude")
     from storage.importer import ensure_sqlite_state
@@ -1214,10 +1214,22 @@ def test_resolve_agent_for_target_keeps_legacy_scope_backend_from_default_agent(
             help_command="vibe task add --help",
         )
 
-    assert agent is None
+    assert agent is not None
+    assert agent.name == "codex"
+    assert agent.backend == "codex"
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "select agent_name, agent_backend, settings_json from scope_settings where scope_id = ?",
+            ("slack::channel::C123",),
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "codex"
+    assert row[1] == "codex"
+    assert json.loads(row[2])["routing"]["agent_name"] == "codex"
 
 
-def test_reserve_definition_session_uses_legacy_scope_backend(tmp_path: Path) -> None:
+def test_reserve_definition_session_uses_canonicalized_scope_agent(tmp_path: Path) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     cli.VibeAgentStore(db_path).ensure_default_agent(backend="claude")
     from storage.importer import ensure_sqlite_state
@@ -1259,7 +1271,8 @@ def test_reserve_definition_session_uses_legacy_scope_backend(tmp_path: Path) ->
         target = cli.resolve_session_id_target(session_id, db_path=db_path)
 
     assert target.agent_backend == "codex"
-    assert target.agent_name is None
+    assert target.agent_name == "codex"
+    assert target.agent_id
 
 
 def test_task_add_rejects_deprecated_prompt_argument() -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import sqlite3
 import sys
 from contextlib import redirect_stderr
 from datetime import datetime, timedelta, timezone
@@ -154,6 +155,62 @@ def test_watch_add_rejects_missing_cwd() -> None:
 
     assert result == 1
     assert payload["code"] == "invalid_watch_cwd"
+
+
+def test_watch_add_create_per_run_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    agent_store.ensure_default_agent(backend="claude")
+    agent_store.create(name="codex", backend="opencode")
+    agent_store.close()
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with cli.create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-05-22T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=None,
+                agent_backend="codex",
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps({"routing": {"agent_backend": "codex"}}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    args = _parse_watch_add(
+        [
+            "--create-session-per-run",
+            "--deliver-key",
+            "slack::channel::C123",
+            "--shell",
+            "echo done",
+        ]
+    )
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+    ):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert payload["code"] == "legacy_scope_backend_unresolved"
+    assert payload["details"] == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("select count(*) from agent_sessions").fetchone()[0] == 0
 
 
 def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from config import paths
@@ -806,6 +808,60 @@ def test_runtime_session_reservation_uses_canonicalized_scope_agent(tmp_path: Pa
     assert target.agent_backend == "codex"
     assert target.agent_name == "codex"
     assert target.agent_id
+
+
+def test_runtime_session_reservation_rejects_unresolved_legacy_scope_backend(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    monkeypatch.setattr(paths, "get_state_dir", lambda: db_path.parent)
+    monkeypatch.setattr(paths, "get_sqlite_state_path", lambda: db_path)
+
+    from core.vibe_agents import VibeAgentStore
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    agent_store = VibeAgentStore(db_path)
+    try:
+        agent_store.ensure_default_agent(backend="claude")
+        agent_store.create(name="codex", backend="opencode")
+    finally:
+        agent_store.close()
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-05-22T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=None,
+                agent_backend="codex",
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps({"routing": {"agent_backend": "codex"}}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    controller = SimpleNamespace(agent_router=SimpleNamespace(global_default="claude"))
+    service = ScheduledTaskService(
+        controller=controller,
+        store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=TaskExecutionStore(tmp_path / "task_requests"),
+    )
+
+    with pytest.raises(ValueError, match="legacy backend without an Agent"):
+        service._reserve_runtime_session(agent_name=None, deliver_key="slack::channel::C123")
 
 
 def test_request_store_constructor_does_not_requeue_processing_files(tmp_path: Path) -> None:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -761,7 +761,7 @@ def test_sqlite_run_query_filter_treats_like_wildcards_as_literals(tmp_path: Pat
         sqlite.close()
 
 
-def test_runtime_session_reservation_uses_legacy_scope_backend(tmp_path: Path, monkeypatch) -> None:
+def test_runtime_session_reservation_uses_canonicalized_scope_agent(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     monkeypatch.setattr(paths, "get_state_dir", lambda: db_path.parent)
     monkeypatch.setattr(paths, "get_sqlite_state_path", lambda: db_path)
@@ -804,7 +804,8 @@ def test_runtime_session_reservation_uses_legacy_scope_backend(tmp_path: Path, m
     target = resolve_session_id_target(session_id, db_path=db_path)
 
     assert target.agent_backend == "codex"
-    assert target.agent_name is None
+    assert target.agent_name == "codex"
+    assert target.agent_id
 
 
 def test_request_store_constructor_does_not_requeue_processing_files(tmp_path: Path) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -393,7 +393,7 @@ def test_run_migrations_removes_legacy_builtin_default_agent(tmp_path: Path) -> 
                     null, null, null, 1, 'builtin', null, '{"builtin":true}', 'now', 'now'
                 ),
                 (
-                    'agent-opencode', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    'agent-opencode', 'opencode', 'opencode', 'Default Agent for the opencode backend.', 'opencode',
                     null, null, null, 1, 'builtin', null,
                     '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
                     'now', 'now'
@@ -578,7 +578,7 @@ def test_run_migrations_removes_unreferenced_disabled_legacy_default_with_existi
                     null, null, null, 0, 'builtin', null, '{"builtin":true}', 'now', 'now'
                 ),
                 (
-                    'agent-opencode', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    'agent-opencode', 'opencode', 'opencode', 'Default Agent for the opencode backend.', 'opencode',
                     null, null, null, 1, 'builtin', null,
                     '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
                     'now', 'now'
@@ -621,7 +621,7 @@ def test_run_migrations_skips_disabled_legacy_default_with_existing_backend_targ
                     null, null, null, 0, 'builtin', null, '{"builtin":true}', 'now', 'now'
                 ),
                 (
-                    'agent-opencode', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    'agent-opencode', 'opencode', 'opencode', 'Default Agent for the opencode backend.', 'opencode',
                     null, null, null, 1, 'builtin', null,
                     '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
                     'now', 'now'
@@ -792,7 +792,7 @@ def test_run_migrations_skips_legacy_default_when_backend_target_is_disabled(tmp
                     null, null, null, 1, 'builtin', null, '{"builtin":true}', 'now', 'now'
                 ),
                 (
-                    'agent-opencode-disabled', 'opencode', 'opencode', 'Default opencode agent.', 'opencode',
+                    'agent-opencode-disabled', 'opencode', 'opencode', 'Default Agent for the opencode backend.', 'opencode',
                     null, null, null, 0, 'builtin', null,
                     '{"builtin":true,"builtin_default":true,"lock_delete":true,"backend":"opencode","backend_enabled":true}',
                     'now', 'now'
@@ -828,7 +828,7 @@ def test_run_migrations_backfills_scope_agent_names_from_legacy_backend(tmp_path
                 id, name, normalized_name, description, backend, model, reasoning_effort,
                 system_prompt, enabled, source, source_ref, metadata_json, created_at, updated_at
             ) values (
-                'agent-claude', 'claude', 'claude', 'Default claude agent.', 'claude', null, null,
+                'agent-claude', 'claude', 'claude', 'Default Agent for the claude backend.', 'claude', null, null,
                 null, 1, 'builtin', null, '{}', 'now', 'now'
             );
             insert into scopes (

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1415,6 +1415,7 @@ def _resolve_agent_for_target(
     session_id: Optional[str],
     session_key: str,
     help_command: str,
+    reject_unresolved_legacy_scope_backend: bool = False,
 ):
     store = _agent_store()
     try:
@@ -1446,7 +1447,7 @@ def _resolve_agent_for_target(
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
                 return store.require_enabled(scope_target.agent_name)
-            if scope_target.agent_backend:
+            if scope_target.agent_backend and reject_unresolved_legacy_scope_backend:
                 _raise_unresolved_legacy_scope_backend(
                     scope_target=scope_target,
                     deliver_key=session_key,
@@ -1704,6 +1705,7 @@ def cmd_task_add(args):
             session_id=session_id,
             session_key=session_key or getattr(args, "deliver_key", None) or "",
             help_command="vibe task add --help",
+            reject_unresolved_legacy_scope_backend=session_policy != "existing",
         )
         agent_name = agent.name if agent else None
         if session_policy == "create_once":
@@ -2032,6 +2034,7 @@ def cmd_task_update(args):
                 session_id=None,
                 session_key=deliver_key or "",
                 help_command="vibe task update --help",
+                reject_unresolved_legacy_scope_backend=True,
             )
             agent_name = agent.name if agent else None
         elif agent_name is not None or session_id or session_key:
@@ -2884,6 +2887,7 @@ def cmd_watch_add(args):
             session_id=session_id,
             session_key=session_key or getattr(args, "deliver_key", None) or "",
             help_command="vibe watch add --help",
+            reject_unresolved_legacy_scope_backend=session_policy != "existing",
         )
         agent_name = agent.name if agent else None
         if session_policy == "create_once":
@@ -3161,6 +3165,7 @@ def cmd_watch_update(args):
                 session_id=None,
                 session_key=deliver_key or "",
                 help_command="vibe watch update --help",
+                reject_unresolved_legacy_scope_backend=True,
             )
             agent_name = agent.name if agent else None
         elif agent_name is not None or session_id or session_key:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1394,6 +1394,21 @@ def _resolve_scope_agent_name(session_key: str) -> Optional[str]:
     return _resolve_scope_routing_target(session_key).agent_name
 
 
+def _raise_unresolved_legacy_scope_backend(
+    *,
+    scope_target: _ScopeRoutingTarget,
+    deliver_key: str,
+    help_command: str,
+) -> None:
+    raise TaskCliError(
+        "scope routing still references a legacy backend without an Agent",
+        code="legacy_scope_backend_unresolved",
+        hint="Open the Scope routing settings and choose an Agent before creating sessions for this Scope.",
+        help_command=help_command,
+        details={"deliver_key": deliver_key, "agent_backend": scope_target.agent_backend},
+    )
+
+
 def _resolve_agent_for_target(
     *,
     agent_name: Optional[str],
@@ -1431,6 +1446,12 @@ def _resolve_agent_for_target(
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
                 return store.require_enabled(scope_target.agent_name)
+            if scope_target.agent_backend:
+                _raise_unresolved_legacy_scope_backend(
+                    scope_target=scope_target,
+                    deliver_key=session_key,
+                    help_command=help_command,
+                )
 
         return store.get_default_agent()
     finally:
@@ -1450,12 +1471,10 @@ def _resolve_agent_for_session_reservation(
         resolved_agent_name = scope_target.agent_name
     if not resolved_agent_name:
         if scope_target.agent_backend:
-            raise TaskCliError(
-                "scope routing still references a legacy backend without an Agent",
-                code="legacy_scope_backend_unresolved",
-                hint="Open the Scope routing settings and choose an Agent before creating sessions for this Scope.",
+            _raise_unresolved_legacy_scope_backend(
+                scope_target=scope_target,
+                deliver_key=deliver_key,
                 help_command=help_command,
-                details={"deliver_key": deliver_key, "agent_backend": scope_target.agent_backend},
             )
         return None
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -42,7 +42,7 @@ from core.scheduled_tasks import (
     resolve_session_id_target,
     session_anchor_for_target,
 )
-from core.vibe_agents import VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
+from core.vibe_agents import VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
 from core.watches import (
     DEFAULT_RETRY_EXIT_CODE,
     WATCH_RECONCILE_INTERVAL_SECONDS,
@@ -1431,8 +1431,6 @@ def _resolve_agent_for_target(
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
                 return store.require_enabled(scope_target.agent_name)
-            if scope_target.agent_backend:
-                return None
 
         return store.get_default_agent()
     finally:
@@ -1440,16 +1438,25 @@ def _resolve_agent_for_target(
 
 
 def _resolve_agent_backend_for_session_reservation(*, agent_name: Optional[str], deliver_key: str) -> str:
-    if agent_name:
-        store = _agent_store()
-        try:
-            return store.require_enabled(agent_name).backend
-        finally:
-            store.close()
-    scope_target = _resolve_scope_routing_target(deliver_key)
-    if scope_target.agent_backend:
-        return scope_target.agent_backend
+    agent = _resolve_agent_for_session_reservation(agent_name=agent_name, deliver_key=deliver_key)
+    if agent:
+        return agent.backend
     return _ensure_config().agents.default_backend
+
+
+def _resolve_agent_for_session_reservation(*, agent_name: Optional[str], deliver_key: str) -> Optional[VibeAgent]:
+    resolved_agent_name = agent_name
+    if not resolved_agent_name:
+        scope_target = _resolve_scope_routing_target(deliver_key)
+        resolved_agent_name = scope_target.agent_name
+    if not resolved_agent_name:
+        return None
+
+    store = _agent_store()
+    try:
+        return store.require_enabled(resolved_agent_name)
+    finally:
+        store.close()
 
 
 def _resolve_watch_command(args, *, help_command: str) -> tuple[list[str], Optional[str]]:
@@ -2589,7 +2596,7 @@ def _reserve_definition_session(*, agent_name: Optional[str], deliver_key: str, 
     from core.services import sessions as sessions_service
 
     target = _parse_validated_session_key(deliver_key, help_command=help_command)
-    agent = _agent_store().require_enabled(agent_name) if agent_name else None
+    agent = _resolve_agent_for_session_reservation(agent_name=agent_name, deliver_key=deliver_key)
     agent_backend = (
         agent.backend
         if agent

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1437,19 +1437,26 @@ def _resolve_agent_for_target(
         store.close()
 
 
-def _resolve_agent_backend_for_session_reservation(*, agent_name: Optional[str], deliver_key: str) -> str:
-    agent = _resolve_agent_for_session_reservation(agent_name=agent_name, deliver_key=deliver_key)
-    if agent:
-        return agent.backend
-    return _ensure_config().agents.default_backend
-
-
-def _resolve_agent_for_session_reservation(*, agent_name: Optional[str], deliver_key: str) -> Optional[VibeAgent]:
+def _resolve_agent_for_session_reservation(
+    *,
+    agent_name: Optional[str],
+    deliver_key: str,
+    help_command: str,
+) -> Optional[VibeAgent]:
     resolved_agent_name = agent_name
+    scope_target = _ScopeRoutingTarget(None, None)
     if not resolved_agent_name:
         scope_target = _resolve_scope_routing_target(deliver_key)
         resolved_agent_name = scope_target.agent_name
     if not resolved_agent_name:
+        if scope_target.agent_backend:
+            raise TaskCliError(
+                "scope routing still references a legacy backend without an Agent",
+                code="legacy_scope_backend_unresolved",
+                hint="Open the Scope routing settings and choose an Agent before creating sessions for this Scope.",
+                help_command=help_command,
+                details={"deliver_key": deliver_key, "agent_backend": scope_target.agent_backend},
+            )
         return None
 
     store = _agent_store()
@@ -2596,12 +2603,12 @@ def _reserve_definition_session(*, agent_name: Optional[str], deliver_key: str, 
     from core.services import sessions as sessions_service
 
     target = _parse_validated_session_key(deliver_key, help_command=help_command)
-    agent = _resolve_agent_for_session_reservation(agent_name=agent_name, deliver_key=deliver_key)
-    agent_backend = (
-        agent.backend
-        if agent
-        else _resolve_agent_backend_for_session_reservation(agent_name=None, deliver_key=deliver_key)
+    agent = _resolve_agent_for_session_reservation(
+        agent_name=agent_name,
+        deliver_key=deliver_key,
+        help_command=help_command,
     )
+    agent_backend = agent.backend if agent else _ensure_config().agents.default_backend
     session_anchor = session_anchor_for_target(target)
     session_id = sessions_service.reserve_agent_session(
         scope_key=target.session_scope,


### PR DESCRIPTION
## Summary

This PR corrects the Scope routing follow-up after the Agent-only model change:

- treats legacy `scope_settings.agent_backend` as migration input, not as a live backend-only Scope override
- resolves CLI-created task/watch sessions through the canonicalized Scope Agent name
- resolves runtime-created task/watch sessions through the canonicalized Scope Agent name as well
- updates regressions so legacy `agent_backend=codex` rows produce `agent_name=codex` sessions after migration

## Evidence

- Unit/contract: `tests/test_cli_task_command.py`, `tests/test_scheduled_tasks.py`, `tests/test_sqlite_state_migration.py`
- Scenario: legacy Scope backend row is canonicalized to a backend-named built-in Agent and new sessions retain `agent_name` / `agent_id`
- Residual manual checks: not needed; this is covered by CLI/runtime session reservation tests

## Validation

- `python -m pytest tests/test_cli_task_command.py tests/test_scheduled_tasks.py tests/test_sqlite_state_migration.py -q` -> 146 passed
- `ruff check vibe/cli.py core/scheduled_tasks.py tests/test_cli_task_command.py tests/test_scheduled_tasks.py`
