### PR TITLE
fix(regression): stabilize Show Runtime state

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,7 @@ htmlcov/
 
 # Project
 _tmp/
+.runtime/
 tmp/
 logs/
 .vibe_remote/

--- a/.env.three-regression.example
+++ b/.env.three-regression.example
@@ -37,12 +37,23 @@ THREE_REGRESSION_OPENCODE_ANTHROPIC_API_KEY=
 # -----------------------------------------------------------------------------
 # Shared regression defaults
 # -----------------------------------------------------------------------------
+# Keep empty to use the canonical repo-level runtime state root:
+# `.runtime/three-regression` under the primary checkout. Set this only when
+# intentionally running an isolated regression state.
+THREE_REGRESSION_STATE_ROOT=
 THREE_REGRESSION_UI_HOST=127.0.0.1
 THREE_REGRESSION_PORT=15130
 THREE_REGRESSION_DEFAULT_CWD=/data/vibe_remote/workdir
 THREE_REGRESSION_DEFAULT_BACKEND=opencode
 THREE_REGRESSION_LOG_LEVEL=INFO
 THREE_REGRESSION_LANGUAGE=en
+
+# Master/worktree regression does not necessarily carry a packaged release
+# manifest, so the regression script prepares Show Runtime from source by
+# default. Release/pre-release installs should use the packaged manifest path.
+THREE_REGRESSION_SHOW_RUNTIME_SOURCE=github-source
+THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REPO=https://github.com/avibe-bot/vibe-show-runtime.git
+THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REF=main
 
 # -----------------------------------------------------------------------------
 # Slack

--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ cython_debug/
 claude_proxy.log
 demolog.log
 _tmp/
+.runtime/
 .DS_Store
 logs/
 .vibe_remote/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Decision checklist before writing code:
 - logs: `~/.vibe_remote/logs/vibe_remote.log`
 - persisted state: `~/.vibe_remote/state/`
 - default agent working directory: `_tmp/`
-- generated regression data: `_tmp/three-regression/`
+- generated regression data: `.runtime/three-regression/` in the primary checkout
 
 ## 3. Runtime Environments
 
@@ -107,14 +107,19 @@ Rules:
 - do **not** use `--no-build` when code changes must take effect; it is only for restarting with the existing image
 - after running the script, verify the service is healthy before handing back to the user
 - prefer Docker regression over local `vibe` whenever validating cross-platform behavior, setup wizard behavior, or user-facing IM flows
+- always use `./scripts/run_three_regression.sh`; do not run `docker compose -f docker-compose.three-regression.yml ...` directly because the script owns the canonical state root and runtime readiness checks
+- the script stores persistent regression state under the primary checkout's `.runtime/three-regression/` by default, even when invoked from a task worktree
+- the script reads `.env.three-regression` from the current worktree first, then falls back to the primary checkout
+- override `THREE_REGRESSION_STATE_ROOT` only when intentionally creating an isolated regression state
+- the script must prepare and verify Show Runtime before reporting success; if Show Runtime cannot be installed or executed, treat the regression update as failed
+- for branch/master regression, `THREE_REGRESSION_SHOW_RUNTIME_SOURCE` defaults to `github-source` because source checkouts do not necessarily include a packaged release manifest; release/pre-release installs should use the packaged manifest path
 
-Worktree gotcha — `_tmp/three-regression/vibe/` is per-worktree:
+Worktree behavior:
 
-- the regression container bind-mounts `${PWD}/_tmp/three-regression/vibe` to `/data/vibe_remote`, so the volume points at whichever worktree ran the script most recently
-- running `./scripts/run_three_regression.sh` from a different worktree silently swaps the bound volume — the new container sees a fresh/empty state, losing pairing (`remote_access` config), agent CLI binaries, sessions, etc.
-- symptom: `test-app.avibe.bot` (or any paired `vibe_cloud` URL) returns Cloudflare **1033** because cloudflared never starts inside the new container — no `tunnel_token` in `config.json`
-- before switching worktrees for regression, either sync the state directory (`cp -a` from old to new worktree's `_tmp/three-regression/`) or copy at minimum the `remote_access` block in `config/config.json`, then `docker exec ... vibe remote start` to re-spawn cloudflared
-- the simplest discipline: always run regression from the same worktree until the user explicitly says to move
+- code is built from the worktree where the script is invoked
+- runtime state is shared from the primary checkout's `.runtime/three-regression/`
+- this keeps pairing (`remote_access` config), agent CLI homes, sessions, Show Page workspaces, and Show Runtime cache stable while still allowing any worktree to update the regression image
+- if an older container was started with per-worktree `_tmp/three-regression/` state, the script imports `/data/vibe_remote` from the running container before recreating it
 
 ## 4. Configuration and Routing Model
 
@@ -266,7 +271,7 @@ Testing guidance:
 
 - keep `AGENT_DEFAULT_CWD` scoped to `_tmp/` or another sanitized directory
 - logs may contain sensitive context; scrub before sharing them back
-- be careful with persisted state under `~/.vibe_remote/` and `_tmp/three-regression/`
+- be careful with persisted state under `~/.vibe_remote/` and `.runtime/three-regression/`
 - do not reset or wipe regression data unless the user explicitly asks for it
 
 ## 9. Release Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Rules:
 - override `THREE_REGRESSION_STATE_ROOT` only when intentionally creating an isolated regression state
 - the script must prepare and verify Show Runtime before reporting success; if Show Runtime cannot be installed or executed, treat the regression update as failed
 - for branch/master regression, `THREE_REGRESSION_SHOW_RUNTIME_SOURCE` defaults to `github-source` because source checkouts do not necessarily include a packaged release manifest; release/pre-release installs should use the packaged manifest path
+- the script serializes `up` and `down` operations with `.runtime/three-regression/.run.lock`; do not remove the lock unless the recorded PID is gone and the run is clearly stale
 
 Worktree behavior:
 

--- a/docker-compose.three-regression.yml
+++ b/docker-compose.three-regression.yml
@@ -12,6 +12,9 @@ services:
       VIBE_UI_PORT: 5123
       VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS: "1"
       VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST: "${THREE_REGRESSION_PORT_BIND_HOST:-127.0.0.1}"
+      VIBE_SHOW_RUNTIME_SOURCE: "${THREE_REGRESSION_SHOW_RUNTIME_SOURCE:-github-source}"
+      VIBE_SHOW_RUNTIME_GITHUB_REPO: "${THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REPO:-https://github.com/avibe-bot/vibe-show-runtime.git}"
+      VIBE_SHOW_RUNTIME_GITHUB_REF: "${THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REF:-main}"
       PYTHONUNBUFFERED: "1"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
@@ -27,9 +30,9 @@ services:
     ports:
       - "${THREE_REGRESSION_PORT_BIND_HOST:-127.0.0.1}:${THREE_REGRESSION_PORT:-15130}:5123"
     volumes:
-      - ./_tmp/three-regression/vibe:/data/vibe_remote
-      - ./_tmp/three-regression/shared-home/.claude:/root/.claude
-      - ./_tmp/three-regression/shared-home/.claude.json:/root/.claude.json
-      - ./_tmp/three-regression/shared-home/.codex:/root/.codex
-      - ./_tmp/three-regression/shared-home/.config/opencode:/root/.config/opencode
-      - ./_tmp/three-regression/shared-home/.local/share/opencode:/root/.local/share/opencode
+      - ${THREE_REGRESSION_STATE_ROOT:?set by scripts/run_three_regression.sh}/vibe:/data/vibe_remote
+      - ${THREE_REGRESSION_STATE_ROOT:?set by scripts/run_three_regression.sh}/shared-home/.claude:/root/.claude
+      - ${THREE_REGRESSION_STATE_ROOT:?set by scripts/run_three_regression.sh}/shared-home/.claude.json:/root/.claude.json
+      - ${THREE_REGRESSION_STATE_ROOT:?set by scripts/run_three_regression.sh}/shared-home/.codex:/root/.codex
+      - ${THREE_REGRESSION_STATE_ROOT:?set by scripts/run_three_regression.sh}/shared-home/.config/opencode:/root/.config/opencode
+      - ${THREE_REGRESSION_STATE_ROOT:?set by scripts/run_three_regression.sh}/shared-home/.local/share/opencode:/root/.local/share/opencode

--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -2,7 +2,7 @@
 
 `回归测试` is the manual regression workflow for this repository. It starts a single unified container with all four IM platforms (Slack, Discord, Feishu, WeChat) running simultaneously, each with per-channel backend routing pre-configured.
 
-The container state is persistent by default. Changes you make through the UI or inside the running service, such as channel routing and other saved settings, stay under `_tmp/three-regression/` across normal restarts.
+The container state is persistent by default. Changes you make through the UI or inside the running service, such as channel routing and other saved settings, stay under `.runtime/three-regression/` in the primary checkout across normal restarts.
 
 It complements the existing automated `E2E` flow instead of replacing it:
 
@@ -45,7 +45,7 @@ Channel IDs are optional. If you leave them empty, the container still starts an
 3. Keep these local-only files out of git:
 
 - `.env.three-regression`
-- `_tmp/three-regression/`
+- `.runtime/three-regression/`
 
 ## Usage
 
@@ -97,13 +97,13 @@ Unified regression environment is ready:
 
 If you set `THREE_REGRESSION_UI_HOST=192.168.2.3`, the printed URL and generated UI config will use that host instead.
 
-On first startup, or when you run with `--reset-config` / `--reset-all`, the runner seeds these files under `_tmp/three-regression/vibe/`:
+On first startup, or when you run with `--reset-config` / `--reset-all`, the runner seeds these files under `.runtime/three-regression/vibe/` in the primary checkout:
 
 - `config/config.json`
 - `state/settings.json`
 - `state/sessions.json`
 
-The generated state lives under `_tmp/three-regression/`, which keeps the regression environment isolated while preserving your later modifications by default.
+The generated state lives under `.runtime/three-regression/`, which keeps the regression environment isolated while preserving your later modifications by default. Task worktrees share this primary-checkout state root unless `THREE_REGRESSION_STATE_ROOT` is explicitly set for an isolated run.
 
 Persistence rules:
 
@@ -118,8 +118,8 @@ The unified container leverages the multi-platform IM support to run all four pl
 - **Config**: A single `config.json` with `platforms.enabled: ["slack", "discord", "lark", "wechat"]` and all four platform credential blocks populated.
 - **Routing**: Per-channel backend routing via `settings.json` scoped by platform, so each platform's test channel resolves to its designated backend.
 - **Agents**: All three backend agents (OpenCode, Claude, Codex) are enabled and installed in the container image.
-- **State**: A single `_tmp/three-regression/vibe/` directory holds config, state, logs, and the agent workdir.
-- **Shared agent home configs**: Generated under `_tmp/three-regression/shared-home/` and mounted read-only into the container.
+- **State**: A single `.runtime/three-regression/vibe/` directory holds config, state, logs, and the agent workdir.
+- **Shared agent home configs**: Generated under `.runtime/three-regression/shared-home/` and mounted read-only into the container.
 
 ## Configuration Rules
 
@@ -127,11 +127,11 @@ The unified container leverages the multi-platform IM support to run all four pl
 - The `platforms.primary` is set to `slack` by default (controls fallback behavior).
 - `THREE_REGRESSION_DEFAULT_BACKEND` sets the global default backend (default: `opencode`).
 - Per-platform backend vars (`THREE_REGRESSION_SLACK_BACKEND`, etc.) control per-channel routing in `settings.json`.
-- All three agent CLIs receive shared credentials via `_tmp/three-regression/shared-home/`.
+- All three agent CLIs receive shared credentials via `.runtime/three-regression/shared-home/`.
 - The default working directory is `/data/vibe_remote/workdir`, a writable sandbox under the generated state.
 
 ## Secret Safety
 
 - Never commit `.env.three-regression`.
-- Never commit generated files under `_tmp/three-regression/`.
+- Never commit generated files under `.runtime/three-regression/`.
 - Share `.env.three-regression.example` if you only need to show the structure.

--- a/scripts/prepare_three_regression.py
+++ b/scripts/prepare_three_regression.py
@@ -523,7 +523,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--output-root",
-        default=str(Path("_tmp") / "three-regression"),
+        default=str(Path(".runtime") / "three-regression"),
         help="Directory that will hold generated state",
     )
     parser.add_argument(

--- a/scripts/run_three_regression.sh
+++ b/scripts/run_three_regression.sh
@@ -6,10 +6,39 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/docker-compose.three-regression.yml"
 PROJECT_NAME="vibe-three-regression"
-ENV_FILE="$REPO_ROOT/.env.three-regression"
-OUTPUT_ROOT="$REPO_ROOT/_tmp/three-regression"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 DOCKER_BIN="${DOCKER_BIN:-}"
+
+resolve_git_common_repo_root() {
+    local common_dir
+    common_dir="$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null || true)"
+    if [ -z "$common_dir" ]; then
+        echo "$REPO_ROOT"
+        return 0
+    fi
+    case "$common_dir" in
+        /*) ;;
+        *) common_dir="$REPO_ROOT/$common_dir" ;;
+    esac
+    (cd "$common_dir/.." && pwd)
+}
+
+absolute_from_repo_root() {
+    local path="$1"
+    case "$path" in
+        /*) echo "$path" ;;
+        *) echo "$REPO_ROOT/$path" ;;
+    esac
+}
+
+CANONICAL_REPO_ROOT="$(resolve_git_common_repo_root)"
+DEFAULT_OUTPUT_ROOT="$CANONICAL_REPO_ROOT/.runtime/three-regression"
+OUTPUT_ROOT="${THREE_REGRESSION_STATE_ROOT:-$DEFAULT_OUTPUT_ROOT}"
+if [ -f "$REPO_ROOT/.env.three-regression" ]; then
+    ENV_FILE="$REPO_ROOT/.env.three-regression"
+else
+    ENV_FILE="$CANONICAL_REPO_ROOT/.env.three-regression"
+fi
 
 if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
     PYTHON_BIN="python"
@@ -55,6 +84,12 @@ Usage:
   ./scripts/run_three_regression.sh --status
   ./scripts/run_three_regression.sh --logs
   ./scripts/run_three_regression.sh --env-file /path/to/.env.three-regression
+
+Environment:
+  THREE_REGRESSION_STATE_ROOT       Override the persistent state root.
+  THREE_REGRESSION_SHOW_RUNTIME_SOURCE
+                                    Show Runtime provider for regression.
+                                    Defaults to github-source.
 EOF
 }
 
@@ -125,9 +160,16 @@ if load_env_file; then
     ENV_LOADED=true
 elif [ "$MODE" = "up" ]; then
     echo "Missing env file: $ENV_FILE" >&2
-    echo "Copy $REPO_ROOT/.env.three-regression.example to .env.three-regression first." >&2
+    echo "Copy .env.three-regression.example to .env.three-regression in either this worktree or the primary checkout first." >&2
     exit 1
 fi
+
+OUTPUT_ROOT="${THREE_REGRESSION_STATE_ROOT:-$DEFAULT_OUTPUT_ROOT}"
+OUTPUT_ROOT="$(absolute_from_repo_root "$OUTPUT_ROOT")"
+export THREE_REGRESSION_STATE_ROOT="$OUTPUT_ROOT"
+export THREE_REGRESSION_SHOW_RUNTIME_SOURCE="${THREE_REGRESSION_SHOW_RUNTIME_SOURCE:-github-source}"
+export THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REPO="${THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REPO:-https://github.com/avibe-bot/vibe-show-runtime.git}"
+export THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REF="${THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REF:-main}"
 
 print_summary() {
     local port="${THREE_REGRESSION_PORT:-15130}"
@@ -135,6 +177,11 @@ print_summary() {
     local ui_host="${THREE_REGRESSION_ACCESS_HOST:-${THREE_REGRESSION_UI_HOST:-$bind_host}}"
     local default_backend="${THREE_REGRESSION_DEFAULT_BACKEND:-opencode}"
     local config_path="$OUTPUT_ROOT/vibe/config/config.json"
+    local display_root
+    display_root="$OUTPUT_ROOT"
+    case "$display_root" in
+        "$CANONICAL_REPO_ROOT"/*) display_root="${display_root#"$CANONICAL_REPO_ROOT/"}" ;;
+    esac
 
     if [ -f "$config_path" ]; then
         default_backend="$("$PYTHON_BIN" - "$config_path" "$default_backend" <<'PY'
@@ -166,6 +213,8 @@ PY
 Unified regression environment is ready:
   URL: http://${ui_host}:${port}
   Default backend: ${default_backend}
+  State root: ${display_root}
+  Show Runtime source: ${THREE_REGRESSION_SHOW_RUNTIME_SOURCE}
 
   Platform routing:
   - Slack:   channel=${slack_channel}  backend=${THREE_REGRESSION_SLACK_BACKEND:-${default_backend}}
@@ -216,6 +265,99 @@ snapshot_agent_runtime_state() {
     snapshot_container_path "/root/.local/share/opencode" "$shared_root/.local/share" "opencode"
 }
 
+snapshot_vibe_remote_state() {
+    if [ "$RESET_MODE" = "all" ]; then
+        return 0
+    fi
+
+    if ! container_exists; then
+        return 0
+    fi
+
+    local cid
+    cid="$("$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" ps -q vibe 2>/dev/null || true)"
+    if [ -z "$cid" ]; then
+        return 0
+    fi
+
+    local target="$OUTPUT_ROOT/vibe"
+    if [ -f "$target/config/config.json" ]; then
+        return 0
+    fi
+
+    mkdir -p "$target"
+    echo "Importing Vibe Remote state from the existing regression container..."
+    "$DOCKER_BIN" cp "$cid:/data/vibe_remote/." "$target" >/dev/null 2>&1 || true
+}
+
+write_regression_metadata() {
+    mkdir -p "$OUTPUT_ROOT"
+    "$PYTHON_BIN" - "$OUTPUT_ROOT" "$REPO_ROOT" "$CANONICAL_REPO_ROOT" <<'PY'
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+output_root = Path(sys.argv[1])
+repo_root = Path(sys.argv[2])
+canonical_repo_root = Path(sys.argv[3])
+
+def git_value(*args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+payload = {
+    "schema_version": 1,
+    "updated_at": datetime.now(timezone.utc).isoformat(),
+    "state_root": str(output_root),
+    "repo_root": str(repo_root),
+    "canonical_repo_root": str(canonical_repo_root),
+    "branch": git_value("branch", "--show-current"),
+    "commit": git_value("rev-parse", "HEAD"),
+}
+(output_root / "metadata.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+prepare_show_runtime() {
+    echo "Preparing Show Runtime inside the regression container..."
+    if ! "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T vibe vibe runtime prepare --strict; then
+        echo "Show Runtime preparation failed inside the regression container." >&2
+        "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T vibe vibe runtime status --json >&2 || true
+        return 1
+    fi
+
+    local status_json
+    status_json="$("$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T vibe vibe runtime status --json)"
+    STATUS_JSON="$status_json" "$PYTHON_BIN" - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["STATUS_JSON"])
+if not payload.get("command"):
+    reason = payload.get("reason") or "runtime_command_missing"
+    raise SystemExit(f"Show Runtime is not executable after prepare: {reason}")
+print(
+    "Show Runtime ready: "
+    f"provider={payload.get('provider')} "
+    f"platform={payload.get('platform')} "
+    f"installed={payload.get('installed')}"
+)
+PY
+}
+
 wait_for_service() {
     for _ in $(seq 1 60); do
         if "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" exec -T vibe python - <<'PY' >/dev/null 2>&1; then
@@ -242,6 +384,7 @@ PY
 
 case "$MODE" in
     down)
+        snapshot_vibe_remote_state
         snapshot_agent_runtime_state
         "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" down --remove-orphans
         exit 0
@@ -259,6 +402,7 @@ case "$MODE" in
         ;;
 esac
 
+snapshot_vibe_remote_state
 snapshot_agent_runtime_state
 
 echo "Stopping previous regression container..."
@@ -268,6 +412,7 @@ echo "Preparing generated config and state..."
 PREPARE_ARGS=(--output-root "$OUTPUT_ROOT")
 PREPARE_ARGS+=(--reset-mode "$RESET_MODE")
 "$PYTHON_BIN" "$REPO_ROOT/scripts/prepare_three_regression.py" "${PREPARE_ARGS[@]}"
+write_regression_metadata
 
 echo "Starting unified regression container..."
 if [ -n "$BUILD_FLAG" ]; then
@@ -278,5 +423,6 @@ fi
 
 echo "Waiting for service to become healthy..."
 wait_for_service "${THREE_REGRESSION_PORT:-15130}"
+prepare_show_runtime
 
 print_summary

--- a/scripts/run_three_regression.sh
+++ b/scripts/run_three_regression.sh
@@ -171,6 +171,59 @@ export THREE_REGRESSION_SHOW_RUNTIME_SOURCE="${THREE_REGRESSION_SHOW_RUNTIME_SOU
 export THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REPO="${THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REPO:-https://github.com/avibe-bot/vibe-show-runtime.git}"
 export THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REF="${THREE_REGRESSION_SHOW_RUNTIME_GITHUB_REF:-main}"
 
+LOCK_DIR=""
+LOCK_HELD=false
+
+release_run_lock() {
+    if [ "$LOCK_HELD" != true ] || [ -z "$LOCK_DIR" ] || [ ! -d "$LOCK_DIR" ]; then
+        return 0
+    fi
+
+    local lock_pid
+    lock_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [ "$lock_pid" = "$$" ]; then
+        rm -rf "$LOCK_DIR"
+    fi
+}
+
+acquire_run_lock() {
+    mkdir -p "$OUTPUT_ROOT"
+    LOCK_DIR="$OUTPUT_ROOT/.run.lock"
+
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        LOCK_HELD=true
+    else
+        local existing_pid=""
+        existing_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+        if [[ "$existing_pid" =~ ^[0-9]+$ ]] && kill -0 "$existing_pid" 2>/dev/null; then
+            echo "Another three-regression update is already running." >&2
+            echo "Lock: $LOCK_DIR" >&2
+            echo "PID: $existing_pid" >&2
+            echo "Repo: $(cat "$LOCK_DIR/repo_root" 2>/dev/null || echo unknown)" >&2
+            exit 1
+        fi
+
+        echo "Removing stale three-regression lock: $LOCK_DIR" >&2
+        rm -rf "$LOCK_DIR"
+        if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+            echo "Failed to acquire three-regression lock: $LOCK_DIR" >&2
+            exit 1
+        fi
+        LOCK_HELD=true
+    fi
+
+    printf '%s\n' "$$" > "$LOCK_DIR/pid"
+    printf '%s\n' "$REPO_ROOT" > "$LOCK_DIR/repo_root"
+    date -u +"%Y-%m-%dT%H:%M:%SZ" > "$LOCK_DIR/started_at"
+    trap 'release_run_lock' EXIT
+    trap 'release_run_lock; exit 130' INT
+    trap 'release_run_lock; exit 143' TERM
+}
+
+if [ "$MODE" = "up" ] || [ "$MODE" = "down" ]; then
+    acquire_run_lock
+fi
+
 print_summary() {
     local port="${THREE_REGRESSION_PORT:-15130}"
     local bind_host="${THREE_REGRESSION_PORT_BIND_HOST:-127.0.0.1}"

--- a/tests/test_three_regression_script.py
+++ b/tests/test_three_regression_script.py
@@ -21,3 +21,10 @@ def test_three_regression_compose_uses_canonical_state_root_env() -> None:
     assert "${THREE_REGRESSION_STATE_ROOT:" in compose
     assert "./_tmp/three-regression" not in compose
     assert "VIBE_SHOW_RUNTIME_SOURCE" in compose
+
+
+def test_three_regression_script_serializes_state_updates() -> None:
+    script = (REPO_ROOT / "scripts" / "run_three_regression.sh").read_text(encoding="utf-8")
+
+    assert "$OUTPUT_ROOT/.run.lock" in script
+    assert "Another three-regression update is already running." in script

--- a/tests/test_three_regression_script.py
+++ b/tests/test_three_regression_script.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_three_regression_script_has_valid_shell_syntax() -> None:
+    subprocess.run(
+        ["bash", "-n", str(REPO_ROOT / "scripts" / "run_three_regression.sh")],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_three_regression_compose_uses_canonical_state_root_env() -> None:
+    compose = (REPO_ROOT / "docker-compose.three-regression.yml").read_text(encoding="utf-8")
+
+    assert "${THREE_REGRESSION_STATE_ROOT:" in compose
+    assert "./_tmp/three-regression" not in compose
+    assert "VIBE_SHOW_RUNTIME_SOURCE" in compose


### PR DESCRIPTION
## Summary
- move three-regression persistent state to the primary checkout's `.runtime/three-regression` root instead of per-worktree `_tmp`
- make the regression compose file consume an explicit `THREE_REGRESSION_STATE_ROOT` and Show Runtime source env from the runner script
- prepare and verify Show Runtime inside the regression container before reporting the environment ready
- document the fixed regression workflow in `AGENTS.md` and add smoke tests for the script/compose contract

## Why
The regression environment could be recreated from whichever worktree ran `run_three_regression.sh`, silently swapping `/data/vibe_remote` and losing Show Page runtime cache/config. Source checkouts also do not always contain a packaged Show Runtime manifest, so regression updates could appear healthy while Show Pages fell back to the static Ready page.

## Validation
- `bash -n scripts/run_three_regression.sh`
- `THREE_REGRESSION_STATE_ROOT=/tmp/vibe-three-regression-state docker compose -p vibe-three-regression -f docker-compose.three-regression.yml config`
- `pytest tests/test_prepare_three_regression.py tests/test_three_regression_script.py`
- `ruff check scripts/prepare_three_regression.py tests/test_three_regression_script.py`
- `git diff --check`

## Manual checks not run
- Did not update, restart, or deploy the live regression environment in this PR.
