### PR TITLE
test(upgrade): expect 600s runtime-prepare timeout

### DIFF
--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -418,7 +418,7 @@ def test_do_upgrade_without_auto_restart_prepares_runtime(monkeypatch):
     assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
     assert calls["runtime_prepare_kwargs"]["capture_output"] is True
     assert calls["runtime_prepare_kwargs"]["text"] is True
-    assert calls["runtime_prepare_kwargs"]["timeout"] == 300
+    assert calls["runtime_prepare_kwargs"]["timeout"] == 600  # prepare now budgets for Show Runtime + askill
     assert calls["runtime_prepare_kwargs"]["cwd"] == calls["upgrade_kwargs"]["cwd"]
 
 
@@ -459,7 +459,7 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
     assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
     assert calls["runtime_prepare_kwargs"]["capture_output"] is True
     assert calls["runtime_prepare_kwargs"]["text"] is True
-    assert calls["runtime_prepare_kwargs"]["timeout"] == 300
+    assert calls["runtime_prepare_kwargs"]["timeout"] == 600  # prepare now budgets for Show Runtime + askill
 
 
 def test_cmd_upgrade_skips_install_when_already_latest(monkeypatch):


### PR DESCRIPTION
## Capability

Fix the red `install-upgrade-regression` CI job on master. PR #365 intentionally bumped the post-install/upgrade `vibe runtime prepare --strict` subprocess timeout **300s → 600s** (it now nests two installers — the Show Page runtime **and** askill — in one call), but two assertions in `tests/test_upgrade_flow.py` still pinned `timeout == 300`, so `assert 600 == 300` failed after the merge. This aligns the assertions with the intended budget.

## Evidence layers
- **Unit/regression**: `pytest tests/test_upgrade_flow.py tests/test_local_deps.py tests/test_install_script.py` → **55 pass** locally (the install-upgrade-regression group); `ruff` clean.
- Test-only change; no behavior change (the 600s budget shipped in #365).

## Notes
Follow-up to #365. The merge slipped through because the feature PR's local validation ran only the new `test_local_deps.py`, not the broader install/upgrade suite the CI job covers.