### PR TITLE
fix(skills): vacuous-install success + folderless-project handling

### DIFF
--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -243,7 +243,27 @@ async def add_skill(
     if copy:
         args.append("--copy")
     args.append("-y")
-    return await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    result = await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    # askill returns ok=True even when a `@name` selector (or empty source)
+    # matched no skill — it just installs nothing (results/summary null). Surface
+    # that as a failure so the UI never reports success for a skill that never
+    # landed (e.g. ``gh:owner/repo@does-not-exist``).
+    if result.get("ok") and result.get("action") == "install":
+        summary = result.get("summary")
+        installed = (
+            summary.get("skills")
+            if isinstance(summary, dict) and isinstance(summary.get("skills"), int)
+            else sum(1 for r in (result.get("results") or []) if isinstance(r, dict) and r.get("success"))
+        )
+        if not installed:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "nothing_installed",
+                    "message": "No matching skill was found in this source — nothing was installed.",
+                },
+            }
+    return result
 
 
 async def remove_skill(

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -55,6 +55,23 @@ def test_add_global_all(monkeypatch):
     monkeypatch.setattr(skills, "_run_askill", rec)
     _run(skills.add_skill("askill", "gh:o/r", scope="global", backends=["opencode"], all_skills=True))
     assert rec.calls[0]["args"] == ["add", "gh:o/r", "-g", "-a", "opencode", "--all", "-y"]
+
+
+def test_add_reports_nothing_installed_when_no_skill_matched(monkeypatch):
+    # askill returns ok=True with null results when a @name selector matches
+    # nothing (e.g. gh:o/r@does-not-exist); add_skill must surface that as a
+    # failure, not a silent success that the UI shows as "installed".
+    rec = _Recorder({"ok": True, "action": "install", "results": None, "summary": None, "skills": []})
+    monkeypatch.setattr(skills, "_run_askill", rec)
+    out = _run(skills.add_skill("askill", "gh:o/r@nope", scope="global"))
+    assert out["ok"] is False and out["error"]["code"] == "nothing_installed"
+
+
+def test_add_succeeds_when_a_skill_was_installed(monkeypatch):
+    rec = _Recorder({"ok": True, "action": "install", "summary": {"skills": 1}, "results": [{"skill": "x", "success": True}]})
+    monkeypatch.setattr(skills, "_run_askill", rec)
+    out = _run(skills.add_skill("askill", "gh:o/r@x", scope="global"))
+    assert out["ok"] is True
     assert rec.calls[0]["cwd"] is None
 
 

--- a/tests/test_ui_server_skills_routes.py
+++ b/tests/test_ui_server_skills_routes.py
@@ -1,0 +1,105 @@
+"""Route-level coverage for the Skills API's folderless-project handling.
+
+A workbench project whose ``folder_path`` is blank can't hold project-scoped
+skills (askill needs a real cwd). ``_resolve_project_dir`` raises
+``_ProjectNoFolder`` for it, and every skills route that takes a ``project_id``
+must degrade gracefully rather than 500: reads fall back (list → global,
+check → empty), the project-independent zip unpack drops the cwd, and the
+project-scoped mutations return a clear ``project_no_folder`` error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vibe import api, ui_server
+from vibe.ui_server import app
+
+from tests.ui_server_test_helpers import csrf_headers
+
+NO_FOLDER = "proj_nofolder"
+
+
+@pytest.fixture
+def folderless(monkeypatch):
+    def fake_resolve(project_id):
+        if project_id == NO_FOLDER:
+            raise ui_server._ProjectNoFolder(project_id)
+        return None
+
+    monkeypatch.setattr(ui_server, "_resolve_project_dir", fake_resolve)
+    return monkeypatch
+
+
+def _boom(*_args, **_kwargs):
+    raise AssertionError("askill must not be reached for a folderless project")
+
+
+def test_list_degrades_to_global_with_flag(folderless, monkeypatch):
+    async def fake_list(*, scope, project_dir=None, backends=None):
+        assert scope == "global"
+        assert project_dir is None
+        return {"ok": True, "skills": [{"name": "demo", "scope": "global"}]}
+
+    monkeypatch.setattr(api, "list_skills", fake_list)
+
+    res = app.test_client().get(f"/api/skills?scope=all&project_id={NO_FOLDER}")
+    body = res.get_json()
+
+    assert res.status_code == 200
+    assert body["ok"] is True
+    assert body["project_no_folder"] is True
+    assert body["skills"][0]["scope"] == "global"
+
+
+def test_check_returns_empty(folderless, monkeypatch):
+    monkeypatch.setattr(api, "check_skills", _boom)
+
+    res = app.test_client().get(f"/api/skills/check?scope=project&project_id={NO_FOLDER}")
+
+    assert res.status_code == 200
+    assert res.get_json() == {"ok": True, "skills": []}
+
+
+def test_upload_drops_project_cwd(folderless, monkeypatch):
+    seen = {}
+
+    async def fake_upload(payload, *, project_dir=None):
+        seen["project_dir"] = project_dir
+        return {"ok": True, "skills": [], "dir": "/tmp/askill-upload-x"}
+
+    monkeypatch.setattr(api, "upload_skill_zip", fake_upload)
+
+    client = app.test_client()
+    res = client.post(
+        "/api/skills/upload",
+        json={"content_base64": "", "project_id": NO_FOLDER},
+        headers=csrf_headers(client),
+    )
+
+    assert res.status_code == 200
+    assert res.get_json()["ok"] is True
+    assert seen["project_dir"] is None  # the project cwd was dropped, not errored
+
+
+@pytest.mark.parametrize(
+    "method,path,attr,payload",
+    [
+        ("post", "/api/skills", "add_skill", {"source": "gh:owner/repo", "scope": "project"}),
+        ("delete", "/api/skills/demo?scope=project", "remove_skill", None),
+        ("post", "/api/skills/update", "update_skill", {"name": "demo", "scope": "project"}),
+    ],
+)
+def test_mutations_return_clear_error(folderless, monkeypatch, method, path, attr, payload):
+    monkeypatch.setattr(api, attr, _boom)
+
+    client = app.test_client()
+    headers = csrf_headers(client)
+    if method == "delete":
+        sep = "&" if "?" in path else "?"
+        res = client.delete(f"{path}{sep}project_id={NO_FOLDER}", headers=headers)
+    else:
+        res = client.post(path, json={**(payload or {}), "project_id": NO_FOLDER}, headers=headers)
+
+    assert res.status_code == 400
+    assert res.get_json()["error"]["code"] == "project_no_folder"

--- a/ui/src/components/workbench/SkillsPage.tsx
+++ b/ui/src/components/workbench/SkillsPage.tsx
@@ -43,6 +43,13 @@ export const SkillsPage: React.FC = () => {
   const [updating, setUpdating] = useState(false);
 
   const activeProject = projects.find((p) => p.id === projectId) ?? null;
+  // A folderless project can't hold project-scoped skills (askill needs a real
+  // cwd), so the add/browse flows treat it as global-only: the add dialog drops
+  // the project-scope option, and browse installs land in global.
+  const projectHasFolder = Boolean(activeProject?.folder_path);
+  const addDialogProjectId = projectHasFolder ? activeProject?.id : undefined;
+  const browseScope: SkillScope = scope === 'project' && projectHasFolder ? 'project' : 'global';
+  const browseProjectId = browseScope === 'project' ? activeProject?.id : undefined;
 
   useEffect(() => {
     api
@@ -388,16 +395,16 @@ export const SkillsPage: React.FC = () => {
       {showAdd ? (
         <AddSkillDialog
           defaultScope={scope}
-          projectId={projectId ?? undefined}
-          projectName={activeProject?.display_name}
+          projectId={addDialogProjectId}
+          projectName={addDialogProjectId ? activeProject?.display_name : undefined}
           onClose={() => setShowAdd(false)}
           onInstalled={afterDialog}
         />
       ) : null}
       {showBrowse ? (
         <BrowseRegistryDialog
-          scope={scope}
-          projectId={scope === 'project' ? projectId ?? undefined : undefined}
+          scope={browseScope}
+          projectId={browseProjectId}
           installedNames={installedNames}
           onClose={() => setShowBrowse(false)}
           onInstalled={afterDialog}

--- a/ui/src/components/workbench/SkillsPage.tsx
+++ b/ui/src/components/workbench/SkillsPage.tsx
@@ -32,6 +32,7 @@ export const SkillsPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [notInstalled, setNotInstalled] = useState(false);
   const [installingAskill, setInstallingAskill] = useState(false);
+  const [projectNoFolder, setProjectNoFolder] = useState(false);
   const [search, setSearch] = useState('');
   const [backendFilter, setBackendFilter] = useState<Backend | 'all'>('all');
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
@@ -67,6 +68,7 @@ export const SkillsPage: React.FC = () => {
     setLoading(true);
     setError(null);
     setNotInstalled(false);
+    setProjectNoFolder(false);
     try {
       const res = await api.listSkills(
         scope === 'global' ? { scope: 'global' } : { scope: 'all', projectId: projectId ?? undefined },
@@ -74,6 +76,7 @@ export const SkillsPage: React.FC = () => {
       if (reqId !== listReq.current) return; // superseded by a newer refresh
       if (res.ok) {
         setSkills(res.skills ?? []);
+        setProjectNoFolder(Boolean(res.project_no_folder));
       } else if (res.error?.code === 'askill_not_found') {
         setNotInstalled(true);
         setSkills([]);
@@ -276,7 +279,7 @@ export const SkillsPage: React.FC = () => {
         </Button>
       </div>
 
-      {scope === 'project' && activeProject ? (
+      {scope === 'project' && activeProject?.folder_path ? (
         <div className="flex items-center gap-2 rounded-[10px] border border-border-strong bg-surface-2 px-3.5 py-2.5">
           <span className="truncate font-mono text-[10.5px] text-muted">{activeProject.folder_path}/.agents/skills</span>
           <div className="flex-1" />
@@ -327,6 +330,11 @@ export const SkillsPage: React.FC = () => {
               <div className="flex flex-col gap-2">{renderRows(filtered)}</div>
             ) : (
               <>
+                {projectNoFolder ? (
+                  <div className="rounded-xl border border-gold/30 bg-gold/[0.06] px-4 py-3 text-[12px] text-muted">
+                    {t('skills.projectNoFolder')}
+                  </div>
+                ) : null}
                 <div className="flex flex-col gap-2">
                   {sectionLabel(
                     <WandSparkles className="size-3.5 text-mint" />,

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -267,6 +267,9 @@ export type SkillsListResult = {
   filters?: { scope: string; agents: AskillAgentRef[] };
   summary?: { global: number; project: number };
   skills?: SkillBrief[];
+  /** Set when the selected project has no folder configured: the backend
+   *  returned global skills only (project-scoped skills aren't possible). */
+  project_no_folder?: boolean;
 };
 export type SkillAiBreakdown = { key: string; label: string; score: number };
 export type SkillSearchItem = {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1358,6 +1358,7 @@
     "installAskill": "Install askill",
     "installing": "Installing…",
     "installFailed": "Could not install askill.",
+    "projectNoFolder": "This project has no folder configured, so it has no project-scoped skills — showing global skills only.",
     "removeConfirm": "Remove skill \"{{name}}\"? This unlinks it from the selected scope.",
     "removeSuccess": "Removed {{name}}.",
     "addSuccess": "Installed {{count}} skill(s).",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1357,6 +1357,7 @@
     "installAskill": "安装 askill",
     "installing": "安装中…",
     "installFailed": "安装 askill 失败。",
+    "projectNoFolder": "此项目未配置文件夹，没有项目级技能——仅显示全局技能。",
     "removeConfirm": "移除技能 \"{{name}}\"？这会从当前范围解除链接。",
     "removeSuccess": "已移除 {{name}}。",
     "addSuccess": "已安装 {{count}} 个技能。",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2870,6 +2870,9 @@ async def skills_check():
         project_dir = _resolve_project_dir(request.args.get("project_id"))
     except LookupError as err:
         return _project_not_found(err)
+    except _ProjectNoFolder:
+        # Folderless project has no project-local skills, so nothing to check.
+        return jsonify({"ok": True, "skills": []})
     return jsonify(await api.check_skills(scope=scope, project_dir=project_dir))
 
 
@@ -2882,6 +2885,8 @@ async def skills_update():
         project_dir = _resolve_project_dir(payload.get("project_id"))
     except LookupError as err:
         return _project_not_found(err)
+    except _ProjectNoFolder:
+        return _project_no_folder_error()
     return jsonify(
         await api.update_skill(
             str(payload.get("name") or ""),
@@ -2900,6 +2905,10 @@ async def skills_upload():
         project_dir = _resolve_project_dir(payload.get("project_id"))
     except LookupError as err:
         return _project_not_found(err)
+    except _ProjectNoFolder:
+        # The zip is unpacked to a temp dir (project-independent); the install
+        # step picks the scope. Drop the cwd like preview rather than erroring.
+        project_dir = None
     return jsonify(await api.upload_skill_zip(payload, project_dir=project_dir))
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2726,11 +2726,19 @@ def projects_archive(project_id: str):
     return jsonify(project)
 
 
+class _ProjectNoFolder(Exception):
+    """A project exists but has no folder configured. Project-scoped skills are
+    impossible (askill needs a real cwd), so routes degrade to global or return
+    a clear error instead of feeding an empty cwd into the CLI."""
+
+
 def _resolve_project_dir(project_id):
     """Map a workbench project id to its folder path for project-scoped skills.
 
-    Returns None when no project is given (global / all scope). Raises
-    LookupError for an unknown id, which each skills route turns into a 404.
+    Returns None when no project is given (global scope). Raises LookupError for
+    an unknown id (→ 404) and _ProjectNoFolder when the project's folder is
+    unset/blank, so callers can degrade gracefully rather than passing an empty
+    cwd to askill (which would surface as a raw ``project folder not found:``).
     """
     if not project_id:
         return None
@@ -2739,11 +2747,29 @@ def _resolve_project_dir(project_id):
     engine = _projects_engine()
     with engine.connect() as conn:
         project = projects_service.get_project(conn, project_id)
-    return project.get("folder_path")
+    folder = (project.get("folder_path") or "").strip()
+    if not folder:
+        raise _ProjectNoFolder(project_id)
+    return folder
 
 
 def _project_not_found(err):
     return jsonify({"ok": False, "error": {"code": "project_not_found", "message": str(err)}}), 404
+
+
+def _project_no_folder_error():
+    return (
+        jsonify(
+            {
+                "ok": False,
+                "error": {
+                    "code": "project_no_folder",
+                    "message": "This project has no folder configured, so it has no project-scoped skills.",
+                },
+            }
+        ),
+        400,
+    )
 
 
 # Agent Skills — thin shells over api.* (which wraps the askill CLI). Pure
@@ -2759,6 +2785,13 @@ async def skills_list():
         project_dir = _resolve_project_dir(request.args.get("project_id"))
     except LookupError as err:
         return _project_not_found(err)
+    except _ProjectNoFolder:
+        # Folderless project: no project-scoped skills are possible — show
+        # global skills (with a flag) instead of erroring the whole page.
+        result = await api.list_skills(scope="global", backends=backends or None)
+        if isinstance(result, dict) and result.get("ok"):
+            result = {**result, "project_no_folder": True}
+        return jsonify(result)
     return jsonify(await api.list_skills(scope=scope, project_dir=project_dir, backends=backends or None))
 
 
@@ -2771,6 +2804,8 @@ async def skills_preview():
         project_dir = _resolve_project_dir(payload.get("project_id"))
     except LookupError as err:
         return _project_not_found(err)
+    except _ProjectNoFolder:
+        project_dir = None  # preview doesn't need the project folder (gh/zip sources)
     return jsonify(await api.preview_skill_source(str(payload.get("source") or ""), project_dir=project_dir))
 
 
@@ -2783,6 +2818,8 @@ async def skills_add():
         project_dir = _resolve_project_dir(payload.get("project_id"))
     except LookupError as err:
         return _project_not_found(err)
+    except _ProjectNoFolder:
+        return _project_no_folder_error()
     return jsonify(
         await api.add_skill(
             str(payload.get("source") or ""),
@@ -2805,6 +2842,8 @@ async def skills_remove(name):
         project_dir = _resolve_project_dir(request.args.get("project_id"))
     except LookupError as err:
         return _project_not_found(err)
+    except _ProjectNoFolder:
+        return _project_no_folder_error()
     return jsonify(
         await api.remove_skill(
             name,


### PR DESCRIPTION
## Capability

Two Skills-page bug fixes, both reproduced live in the three-regression environment:

1. **A "successful" install that installs nothing.** Installing a slug whose `@name` selector matches no skill (e.g. `gh:openclaw/openclaw@tavily` — that repo has 96 skills but no `tavily`) made `askill add` return `ok:true` while installing nothing (`results`/`summary` null). The UI reported "installed" but the skill never appeared in the list. `core/services/skills.py::add_skill` now detects a zero-skill install (`summary.skills`, else successful `results`) and returns a clear `nothing_installed` error instead of a vacuous success.

2. **A folderless project broke the Skills page.** A workbench project whose `folder_path` is empty (routing scopes surfaced as projects with no `workdir`) fed an empty cwd to askill, surfacing as a raw `project folder not found:` error. `vibe/ui_server.py::_resolve_project_dir` now raises `_ProjectNoFolder` for a blank folder, and the routes handle it: **list** degrades to global skills (with a `project_no_folder` flag + a localized UI note), **preview** drops the cwd, **add/remove** return a clear `project_no_folder` error. The project path banner is also hidden when there is no folder (it previously rendered a bare `/.agents/skills`).

## Scenarios

No scenario catalog for the Skills surface — none referenced.

## Evidence layers

- **Unit** — `tests/test_skills_service.py`: +2 (zero-install → `nothing_installed`; real install with results → success). **19 pass**.
- **Contract** — verified against the askill **v0.1.13** `add --json` envelope (upstream `src/cli.ts`): `summary.skills` = distinct successful main-skill count; `results[].success`; the vacuous path emits `ok:true, skills:[]` with no summary. The detection has no false positives (real installs keep `ok`) or reachable false negatives.
- **Build / type / lint** — `tsc --noEmit` clean, `vite build` ✓, `ruff` clean.
- **Review** — adversarial pre-PR reviewer: no blockers/majors (both fixes verified against upstream askill). Fixed the path-banner glitch it flagged.
- **Residual / manual** — both bugs were reproduced + root-caused in the live three-regression container (the `@tavily` preview returns 0 skills; projects `proj_890721e64fc8` / `proj_d64afca183ec` have empty `workdir`). Deferred: localizing the two new backend error messages (`nothing_installed`, `project_no_folder`) — consistent with the existing pattern where all askill error messages surface in English; warrants a dedicated i18n pass rather than localizing 2 of N codes here. The primary user-facing path (the folderless-project note) IS localized (en+zh).
