### PR TITLE
fix(ui): agents page feedback — delete button, badge, description, prompt editor

### DIFF
--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-semibold tracking-wide transition-colors focus:outline-none',
+  'inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-0.5 text-[11px] font-semibold tracking-wide transition-colors focus:outline-none',
   {
     variants: {
       variant: {

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -30,11 +30,17 @@ const buttonVariants = cva(
           'gap-1.5 border border-cyan/40 bg-cyan/[0.06] text-cyan hover:bg-cyan/[0.10]',
         ghost: 'gap-1.5 text-foreground hover:bg-surface-2',
         destructive: 'gap-1.5 bg-destructive text-destructive-foreground hover:opacity-90',
-        // Pink-soft destructive — design.pen T09T8Z. Pink-tinted fill +
-        // border + text, used for in-panel delete CTAs where a full
-        // destructive shouts too loud.
+        // Pink-soft destructive — design.pen T09T8Z. Pink fill + pink border
+        // + pink text/icon, used for in-panel delete CTAs where a full
+        // destructive shouts too loud. Drives the --pink / --pink-soft tokens
+        // (see index.css); the old bg-[#FF5B8A14] one-off plus an unresolved
+        // `pink` token left the border falling back to currentColor (black in
+        // light, white in dark) and the fill near-invisible.
+        // Fill is pink/15 (not the 10% --pink-soft token) so it carries the
+        // same visual weight as the mint-soft "Run" button it usually sits next
+        // to — a balanced soft pair rather than a near-invisible wash.
         'destructive-soft':
-          'gap-1.5 border border-pink/40 bg-[#FF5B8A14] text-pink hover:bg-pink/[0.14]',
+          'gap-1.5 border border-pink/45 bg-pink/15 text-pink hover:border-pink/60 hover:bg-pink/[0.22]',
         link: 'text-primary underline-offset-4 hover:underline',
         accent: 'gap-1.5 border border-cyan/40 bg-cyan-soft text-cyan hover:bg-cyan/15',
       },

--- a/ui/src/components/ui/editor-dialog.tsx
+++ b/ui/src/components/ui/editor-dialog.tsx
@@ -1,0 +1,150 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from './dialog';
+import { SegmentedRadio } from './segmented';
+import { Button } from './button';
+import { Textarea } from './textarea';
+import { Markdown } from './markdown';
+
+type EditorMode = 'edit' | 'preview';
+
+export interface EditorDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Heading shown at the top-left of the modal. */
+  title: string;
+  /** Optional one-line subtitle under the title. */
+  description?: string;
+  /** Current text; the modal edits a private draft seeded from this on open. */
+  value: string;
+  /** Commit the edited text. Called on Save, just before the modal closes. */
+  onSave: (value: string) => void;
+  placeholder?: string;
+  /** Show the Edit/Preview toggle + Markdown preview (default true). */
+  markdownPreview?: boolean;
+  /** Optional left-aligned footer node derived from the live draft (e.g. a
+   *  token/char count). */
+  footerHint?: (draft: string) => React.ReactNode;
+}
+
+// Generic full-size text editor in a modal: a large monospace textarea with an
+// optional Edit/Preview Markdown toggle, reusing the shared <Markdown> renderer
+// and the .vr-markdown styling. Built for agent system prompts first, but kept
+// field-agnostic (title / value / onSave) so any long-text field can adopt it
+// and grow here later toward a real editor — syntax highlighting, code, docs.
+export const EditorDialog: React.FC<EditorDialogProps> = ({
+  open,
+  onClose,
+  title,
+  description,
+  value,
+  onSave,
+  placeholder,
+  markdownPreview = true,
+  footerHint,
+}) => {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState(value);
+  const [mode, setMode] = useState<EditorMode>('edit');
+
+  // Reseed the draft (and reset to edit mode) each time the modal opens, so a
+  // cancelled edit never leaks into the next open and an external change to
+  // ``value`` between opens is picked up.
+  useEffect(() => {
+    if (open) {
+      setDraft(value);
+      setMode('edit');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const handleSave = () => {
+    onSave(draft);
+    onClose();
+  };
+
+  const showPreview = markdownPreview && mode === 'preview';
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent className="flex h-[82vh] w-[92vw] max-w-[920px] flex-col gap-0 overflow-hidden p-0">
+        {/* Header — title + optional subtitle. pr-12 leaves room for the
+            Dialog's built-in close X (absolute, top-right). */}
+        <div className="flex flex-col gap-1 border-b border-border px-5 py-4 pr-12">
+          <DialogTitle className="text-[15px] font-bold text-foreground">{title}</DialogTitle>
+          {description && (
+            <DialogDescription className="text-[12px] leading-relaxed text-muted">
+              {description}
+            </DialogDescription>
+          )}
+        </div>
+
+        {/* Toolbar — Edit/Preview toggle + Markdown hint (preview-capable only). */}
+        {markdownPreview && (
+          <div className="flex items-center justify-between gap-3 border-b border-border px-5 py-2.5">
+            <div className="w-[200px]">
+              <SegmentedRadio<EditorMode>
+                value={mode}
+                onChange={setMode}
+                ariaLabel={t('editor.modeLabel')}
+                options={[
+                  { id: 'edit', label: t('editor.edit') },
+                  { id: 'preview', label: t('editor.preview') },
+                ]}
+              />
+            </div>
+            <span className="font-mono text-[10px] text-muted">{t('editor.markdownHint')}</span>
+          </div>
+        )}
+
+        {/* Body — editor or preview, fills the remaining height. */}
+        <div className="min-h-0 flex-1 overflow-hidden p-5">
+          {showPreview ? (
+            <div className="h-full overflow-auto rounded-lg border border-border bg-surface-2 px-4 py-3">
+              {draft.trim() ? (
+                <Markdown content={draft} />
+              ) : (
+                <span className="text-[12px] text-muted">{t('editor.previewEmpty')}</span>
+              )}
+            </div>
+          ) : (
+            <Textarea
+              autoFocus
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                // Cmd/Ctrl+Enter saves from anywhere in the textarea.
+                if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                  e.preventDefault();
+                  handleSave();
+                }
+              }}
+              placeholder={placeholder}
+              className="h-full resize-none font-mono text-[13px] leading-relaxed"
+            />
+          )}
+        </div>
+
+        {/* Footer — optional draft-derived hint + actions. */}
+        <div className="flex items-center justify-between gap-3 border-t border-border px-5 py-3">
+          <span className="text-[11px] text-muted">{footerHint?.(draft)}</span>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={onClose}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="button" variant="brand" size="sm" onClick={handleSave}>
+              {t('common.save')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import { cn } from '@/lib/utils';
+
+// Shared markdown renderer. react-markdown + remark-gfm (tables, strikethrough,
+// task lists, autolinks); the element styling lives in index.css under
+// ``.vr-markdown`` because the project doesn't ship the Tailwind typography
+// plugin. Promoted out of ChatPage once a second caller (the agent-config
+// editor preview) needed the same renderer — one home for "render markdown the
+// Vibe Remote way", so the security-conscious <img> handling is shared too.
+export const Markdown: React.FC<{ content: string; className?: string }> = ({ content, className }) => (
+  <div className={cn('vr-markdown', className)}>
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        // Markdown here is untrusted (agent replies, user-authored prompts) and
+        // can embed images. The default <img> renderer would auto-fetch any URL
+        // the moment the view opens (``![](http://attacker/x)``), leaking the
+        // viewer's IP / network metadata to an attacker-chosen host. Render
+        // images as click-through links instead so nothing is fetched without
+        // an explicit user action.
+        img: ({ src, alt }) =>
+          src ? (
+            <a href={String(src)} target="_blank" rel="noopener noreferrer nofollow">
+              {`🖼 ${alt || String(src)}`}
+            </a>
+          ) : null,
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  </div>
+);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   Funnel,
   Loader2,
+  Maximize2,
   Pencil,
   Play,
   Plus,
@@ -28,6 +29,7 @@ import { Switch } from '../ui/switch';
 import { Combobox } from '../ui/combobox';
 import type { ComboboxOption } from '../ui/combobox';
 import { Textarea } from '../ui/textarea';
+import { EditorDialog } from '../ui/editor-dialog';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { estimateTokens } from '../../lib/tokenEstimate';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
@@ -484,19 +486,23 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
   const [name, setName] = useState(agent.name);
   const [renaming, setRenaming] = useState(false);
   const [settingDefault, setSettingDefault] = useState(false);
+  const [description, setDescription] = useState(agent.description ?? '');
   const [model, setModel] = useState(agent.model ?? '');
   const [effort, setEffort] = useState(agent.reasoning_effort ?? 'medium');
   const [systemPrompt, setSystemPrompt] = useState(agent.system_prompt ?? '');
   const [systemPromptOpen, setSystemPromptOpen] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
   const [modelOptions, setModelOptions] = useState<ComboboxOption[]>([]);
   const [running, setRunning] = useState(false);
 
   useEffect(() => {
     setName(agent.name);
+    setDescription(agent.description ?? '');
     setModel(agent.model ?? '');
     setEffort(agent.reasoning_effort ?? 'medium');
     setSystemPrompt(agent.system_prompt ?? '');
     setSystemPromptOpen(false);
+    setEditorOpen(false);
   }, [agent.id]);
 
   // Load model catalog for the agent's backend so the Combobox can offer
@@ -691,6 +697,24 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
         </div>
       </Field>
 
+      {/* Description — free-text summary of what the agent is for. Feeds the
+          list-row subtitle (model · effort · description). Editable for every
+          agent, system ones included: it's metadata, not an identity field. */}
+      <Field label={t('agents.detail.description')}>
+        <Textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onBlur={() => {
+            if (description !== (agent.description ?? '')) {
+              onChange({ description: description.trim() || null });
+            }
+          }}
+          rows={2}
+          placeholder={t('agents.detail.descriptionPlaceholder')}
+          className="text-[13px]"
+        />
+      </Field>
+
       {/* Backend (read-only) — design.pen JUopp. "creation-time only ·
           locked" hint sits inside the value chip on the right so users
           don't mistake it for a note about the field above (the name). */}
@@ -756,24 +780,39 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
           textarea-level hint was deleted because the field label + the
           chevron row already tell the user what this is. */}
       <div className="flex flex-col gap-2">
-        <button
-          type="button"
-          onClick={() => setSystemPromptOpen((prev) => !prev)}
-          className="flex items-center gap-2.5 rounded-lg border border-border bg-foreground/[0.015] px-3 py-2.5 text-left transition hover:bg-foreground/[0.04]"
-        >
-          <ChevronRight
-            className={clsx(
-              'size-3 shrink-0 text-muted transition-transform',
-              systemPromptOpen && 'rotate-90',
-            )}
-          />
-          <span className="flex-1 text-[12px] font-semibold text-foreground">
-            {t('agents.detail.systemPrompt')}
-          </span>
-          <span className="font-mono text-[10px] text-muted">
-            {t('agents.detail.systemPromptCount', { count: systemPromptTokens })}
-          </span>
-        </button>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => setSystemPromptOpen((prev) => !prev)}
+            className="flex flex-1 items-center gap-2.5 rounded-lg border border-border bg-foreground/[0.015] px-3 py-2.5 text-left transition hover:bg-foreground/[0.04]"
+          >
+            <ChevronRight
+              className={clsx(
+                'size-3 shrink-0 text-muted transition-transform',
+                systemPromptOpen && 'rotate-90',
+              )}
+            />
+            <span className="flex-1 text-[12px] font-semibold text-foreground">
+              {t('agents.detail.systemPrompt')}
+            </span>
+            <span className="font-mono text-[10px] text-muted">
+              {t('agents.detail.systemPromptCount', { count: systemPromptTokens })}
+            </span>
+          </button>
+          {/* Expand into the full editor modal (large input + Markdown
+              edit/preview) — the shared EditorDialog primitive. */}
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-9 shrink-0 text-muted hover:text-foreground"
+            onClick={() => setEditorOpen(true)}
+            aria-label={t('agents.detail.systemPromptExpand')}
+            title={t('agents.detail.systemPromptExpand')}
+          >
+            <Maximize2 className="size-3.5" />
+          </Button>
+        </div>
         {systemPromptOpen && (
           <Textarea
             value={systemPrompt}
@@ -821,6 +860,24 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
       </div>
 
       {running && <RunAgentDialog agent={agent} onClose={() => setRunning(false)} />}
+
+      {/* Full-screen system-prompt editor — large input + Markdown preview.
+          Opening from collapsed or expanded both jump straight here. */}
+      <EditorDialog
+        open={editorOpen}
+        onClose={() => setEditorOpen(false)}
+        title={t('agents.detail.systemPrompt')}
+        description={t('agents.detail.systemPromptEditorHint')}
+        value={systemPrompt}
+        placeholder={t('agents.create.systemPromptPlaceholder')}
+        footerHint={(draft) => t('agents.detail.systemPromptCount', { count: estimateTokens(draft) })}
+        onSave={(next) => {
+          setSystemPrompt(next);
+          if (next !== (agent.system_prompt ?? '')) {
+            onChange({ system_prompt: next.trim() || null });
+          }
+        }}
+      />
     </div>
   );
 };

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, Bot, ChevronDown, Clock, Loader2, MessageSquare, Pencil, Plus, Send, Square, X } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -13,6 +11,7 @@ import { apiFetch } from '../../lib/apiFetch';
 import { formatLocalDateTime } from '../../lib/relativeTime';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { Markdown } from '../ui/markdown';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 
 // Reasoning-effort options are backend-specific (mirrors the backend's own
@@ -1240,32 +1239,6 @@ const Transcript: React.FC<TranscriptProps> = ({ messages, session, working }) =
   );
 };
 
-// Shared markdown renderer for agent replies. react-markdown + remark-gfm
-// (tables, strikethrough, task lists, autolinks); the element styling lives in
-// index.css under ``.vr-markdown`` because the project doesn't ship the
-// Tailwind typography plugin.
-const Markdown: React.FC<{ content: string }> = ({ content }) => (
-  <div className="vr-markdown">
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
-      components={{
-        // Agent replies are untrusted markdown. The default <img> renderer would
-        // auto-fetch any URL the agent writes (``![](http://attacker/x)``) the
-        // moment the chat opens, leaking the viewer's IP / network metadata to an
-        // attacker-chosen host (Codex P2 / privacy). Render images as click-through
-        // links instead so nothing is fetched without an explicit user action.
-        img: ({ src, alt }) =>
-          src ? (
-            <a href={String(src)} target="_blank" rel="noopener noreferrer nofollow">
-              {`🖼 ${alt || String(src)}`}
-            </a>
-          ) : null,
-      }}
-    >
-      {content}
-    </ReactMarkdown>
-  </div>
-);
 
 // Shown while a turn is in flight but the reply hasn't landed yet — an
 // agent-styled bubble with three dots that fade in sequence

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -45,6 +45,7 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
   const api = useApi();
   const [backend, setBackend] = useState<BackendKey>('claude');
   const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
   const [model, setModel] = useState('');
   const [effort, setEffort] = useState<string>('medium');
   const [systemPrompt, setSystemPrompt] = useState('');
@@ -55,6 +56,7 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
   useEffect(() => {
     if (!open) {
       setName('');
+      setDescription('');
       setModel('');
       setEffort('medium');
       setSystemPrompt('');
@@ -120,6 +122,7 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
       const result = await api.createVibeAgent({
         name: name.trim(),
         backend,
+        description: description.trim() || null,
         model: model.trim() || null,
         reasoning_effort: effort,
         system_prompt: systemPrompt.trim() || null,
@@ -210,6 +213,20 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
             }}
             placeholder="reviewer"
             className="font-mono text-[13px]"
+          />
+        </div>
+
+        {/* Description — optional free-text summary, mirrors the detail panel. */}
+        <div className="flex flex-col gap-1.5">
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+            {t('agents.create.description')}
+          </div>
+          <Textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            placeholder={t('agents.create.descriptionPlaceholder')}
+            className="text-[12px]"
           />
         </div>
 

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -27,6 +27,7 @@ import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { NewProjectDialog } from './NewProjectDialog';
 
@@ -693,14 +694,18 @@ export const WorkbenchSidebar: React.FC = () => {
           <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
             {t('workbench.projectsLabel')}
           </span>
-          <button
+          {/* Borderless ghost icon button (design-system Button) — bumped from
+              a 22px bordered box to a roomier 28px tap target. */}
+          <Button
             type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0 text-muted hover:text-foreground"
             aria-label={t('workbench.addProject')}
             onClick={() => setShowNewProject(true)}
-            className="flex size-[22px] items-center justify-center rounded-md border border-border-strong text-foreground transition hover:bg-foreground/[0.04]"
           >
-            <FolderPlus className="size-3" />
-          </button>
+            <FolderPlus className="size-4" />
+          </Button>
         </div>
 
         <div className="flex flex-col gap-0.5">

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1304,6 +1304,8 @@
       "defaultNeedsEnabled": "Enable the agent before making it the default.",
       "defaultSet": "{{name}} is now the default agent.",
       "name": "Name",
+      "description": "Description",
+      "descriptionPlaceholder": "What this agent is for…",
       "backend": "Backend",
       "backendLocked": "creation-time only · locked",
       "model": "Model",
@@ -1313,6 +1315,8 @@
       "effort": "Reasoning effort",
       "systemPrompt": "System prompt",
       "systemPromptCount": "~{{count}} tokens",
+      "systemPromptExpand": "Expand editor",
+      "systemPromptEditorHint": "Write the full system prompt with live Markdown preview.",
       "systemLocked": "System agents cannot be deleted. You can still adjust model, effort, and system prompt.",
       "run": "Run",
       "nameLocked": "Used as the reference id · locked after create"
@@ -1331,6 +1335,8 @@
       "body": "Pick a backend, name the agent, and fine-tune model and effort. Backend cannot be changed after creation.",
       "backend": "Backend",
       "name": "Name",
+      "description": "Description",
+      "descriptionPlaceholder": "What this agent is for…",
       "model": "Model",
       "modelPlaceholder": "e.g. claude-sonnet-4-6",
       "effort": "Effort",
@@ -1339,6 +1345,13 @@
       "systemPromptPlaceholder": "Optional. Prepended to every conversation that uses this agent.",
       "submit": "Create agent"
     }
+  },
+  "editor": {
+    "modeLabel": "Editor mode",
+    "edit": "Edit",
+    "preview": "Preview",
+    "markdownHint": "Markdown supported",
+    "previewEmpty": "Nothing to preview yet."
   },
   "skills": {
     "title": "Skills",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1303,6 +1303,8 @@
       "defaultNeedsEnabled": "请先启用该 Agent 再设为默认。",
       "defaultSet": "{{name}} 已设为默认 Agent。",
       "name": "名称",
+      "description": "描述",
+      "descriptionPlaceholder": "这个 Agent 用来做什么…",
       "backend": "后端",
       "backendLocked": "创建时确定 · 不可改",
       "model": "模型",
@@ -1312,6 +1314,8 @@
       "effort": "推理强度",
       "systemPrompt": "系统提示词",
       "systemPromptCount": "~{{count}} tokens",
+      "systemPromptExpand": "展开编辑器",
+      "systemPromptEditorHint": "在更大的编辑器里编写系统提示词，并实时预览 Markdown。",
       "systemLocked": "系统 Agent 不可删除,仍可调整模型、Effort 与系统提示词。",
       "run": "运行",
       "nameLocked": "用作引用 ID,创建后不可改"
@@ -1330,6 +1334,8 @@
       "body": "选择后端,命名 Agent,微调模型与 Effort。后端在创建后不可更改。",
       "backend": "后端",
       "name": "名称",
+      "description": "描述",
+      "descriptionPlaceholder": "这个 Agent 用来做什么…",
       "model": "模型",
       "modelPlaceholder": "例如 claude-sonnet-4-6",
       "effort": "Effort",
@@ -1338,6 +1344,13 @@
       "systemPromptPlaceholder": "可选。会拼接到使用本 Agent 的每一段对话前。",
       "submit": "创建 Agent"
     }
+  },
+  "editor": {
+    "modeLabel": "编辑器模式",
+    "edit": "编辑",
+    "preview": "预览",
+    "markdownHint": "支持 Markdown",
+    "previewEmpty": "暂无可预览内容。"
   },
   "skills": {
     "title": "技能",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -33,6 +33,8 @@
   --color-violet-soft: var(--violet-soft);
   --color-gold: var(--gold);
   --color-gold-foreground: var(--gold-foreground);
+  --color-pink: var(--pink);
+  --color-pink-soft: var(--pink-soft);
 
   /* Compatibility aliases for current UI during migration. */
   --color-bg: var(--background);
@@ -100,6 +102,8 @@
   --violet-soft: rgba(124, 91, 255, 0.16);
   --gold: #ffc857;
   --gold-foreground: #080812;
+  --pink: #ff5b8a;
+  --pink-soft: rgba(255, 91, 138, 0.10);
 
   /* Page-family gradients (mirror design.pen 1:1). Layers ordered top-most first. */
   --gradient-console:
@@ -172,6 +176,8 @@
     --violet-soft: rgba(124, 58, 237, 0.14);
     --gold: #d97706;
     --gold-foreground: #ffffff;
+    --pink: #dc2659;
+    --pink-soft: rgba(220, 38, 89, 0.10);
 
     /* Light-theme page gradients (softer alphas over light base). */
     --gradient-console:
@@ -247,6 +253,8 @@
   --violet-soft: rgba(124, 58, 237, 0.14);
   --gold: #d97706;
   --gold-foreground: #ffffff;
+  --pink: #dc2659;
+  --pink-soft: rgba(220, 38, 89, 0.10);
 
   /* Light-theme page gradients (softer alphas over light base). */
   --gradient-console:


### PR DESCRIPTION
## Capability
Polish the Workbench **Agents** page per five points of page feedback — including one real design↔code token-drift bug — and add a reusable Markdown editor modal.

## Changes
1. **Default-routing badge no longer stacks CJK text vertically** — `whitespace-nowrap` on the `Badge` primitive (a squeezed pill's min-content was one CJK char wide, so "默认" wrapped to two stacked glyphs). Fixes every badge.
2. **Sidebar "Add project" button** — drop the border + grow the tap target: replaced a hand-rolled 22px bordered `<button>` with the design-system `Button` (`variant=ghost size=icon`, 28px / 16px glyph).
3. **Soft-destructive delete button (root-cause fix)** — `design.pen` defines `--pink` / `--pink-soft`, but `index.css` never ported them, so `destructive-soft`'s `border-pink` / `text-pink` / `bg-pink` classes silently no-opped → the border fell back to `currentColor` (black in light, white in dark) and the fill was near-invisible. Ported the tokens and rewrote the variant to a real pink border + pink text/icon + `pink/15` fill (balanced with the mint-soft Run button it sits beside). **Every delete/stop CTA reusing the variant inherits the fix** — AgentsPage delete, SkillDetailPanel remove, ChatPage stop.
4. **Agent Description field** — added below Name in the detail panel and in the create dialog; commits on blur.
5. **System-prompt expand editor** — new reusable `EditorDialog` (`ui/`): large textarea + Edit/Preview Markdown toggle, built on the `Dialog` primitive and a newly-shared `Markdown` renderer (promoted out of ChatPage so the click-through `<img>` privacy handling lives in one home).

## Scenarios
No scenario catalog covers the Workbench Agents UI surface; no scenario IDs apply.

## Evidence layers
- **Unit:** none (no existing UI unit harness for these components).
- **Contract:** n/a — no API/route shape change; `description` was already on the create/update payload types.
- **Scenario:** n/a — no catalog for this surface.
- **Residual manual checks:** `npm run build` (tsc -b + vite build) passes clean; rendered all five surfaces in an isolated harness across **light + dark** — default badge (no wrap), delete button (pink border/text/fill), add-project button (borderless), description field, and the editor modal in both Edit and Markdown-preview modes.