### PR TITLE
fix(ui): populate OpenCode model dropdown across agent surfaces

### DIFF
--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -32,6 +32,7 @@ import { Textarea } from '../ui/textarea';
 import { EditorDialog } from '../ui/editor-dialog';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { estimateTokens } from '../../lib/tokenEstimate';
+import { fetchBackendModels } from '../../lib/backendModels';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
 // Backend order / labels / accent classes live in lib/backendAccent, shared
 // with the Skills surface (BACKEND_TEXT is this page's old BACKEND_ICON_CLASS).
@@ -512,14 +513,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
     let cancelled = false;
     async function loadModels() {
       try {
-        let models: string[] = [];
-        if (agent.backend === 'claude') {
-          const result = await api.claudeModels();
-          if (result.ok && result.models) models = result.models;
-        } else if (agent.backend === 'codex') {
-          const result = await api.codexModels();
-          if (result.ok && result.models) models = result.models;
-        }
+        const { models } = await fetchBackendModels(api, agent.backend);
         if (!cancelled) setModelOptions(models.map((m) => ({ value: m, label: m })));
       } catch {
         if (!cancelled) setModelOptions([]);

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -9,6 +9,7 @@ import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { formatLocalDateTime } from '../../lib/relativeTime';
+import { fetchBackendModels } from '../../lib/backendModels';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Markdown } from '../ui/markdown';
@@ -965,27 +966,16 @@ const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({ session, agents, on
     setLoadingModels(true);
     (async () => {
       try {
-        let models: string[] = [];
-        if (backend === 'claude') {
-          const res = await api.claudeModels();
-          models = res.models ?? [];
-          // Capture the per-model effort sets so Column 3 can offer xhigh/max
-          // only for the models that actually support them.
-          if (!cancelled && res.reasoning_options) setClaudeReasoning(res.reasoning_options);
-        } else if (backend === 'codex') models = (await api.codexModels()).models ?? [];
-        else if (backend === 'opencode')
-          // The providers endpoint returns RAW model ids per provider (never
-          // provider-prefixed), and the OpenCode adapter resolves the override
-          // by splitting the selected value on the FIRST "/" into
-          // {providerID, modelID}. So ALWAYS prepend the provider id — even
-          // when the raw id itself contains "/" (e.g. OpenRouter's
-          // ``anthropic/claude-*`` must become ``openrouter/anthropic/claude-*``,
-          // not be misread as provider ``anthropic``). The first-slash split
-          // keeps the remainder (``anthropic/claude-*``) intact as the model.
-          models = ((await api.getOpencodeProviders()).providers ?? []).flatMap((p) =>
-            (p.models ?? []).map((m) => `${p.id}/${m}`),
-          );
-        if (!cancelled) setModelsByBackend((prev) => ({ ...prev, [backend]: models }));
+        // Shared resolver (lib/backendModels) — OpenCode's provider-prefixing
+        // and the per-backend fetch live there so every model picker stays
+        // consistent (Agents detail panel, New Agent dialog, this menu).
+        const { models, reasoningOptions } = await fetchBackendModels(api, backend);
+        if (!cancelled) {
+          // Claude returns per-model effort sets so Column 3 can offer
+          // xhigh/max only for the models that actually support them.
+          if (reasoningOptions) setClaudeReasoning(reasoningOptions);
+          setModelsByBackend((prev) => ({ ...prev, [backend]: models }));
+        }
       } catch {
         if (!cancelled) setModelsByBackend((prev) => ({ ...prev, [backend]: [] }));
       } finally {

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
 import type { VibeAgentFull } from '../../context/ApiContext';
+import { fetchBackendModels } from '../../lib/backendModels';
 import { Combobox } from '../ui/combobox';
 import type { ComboboxOption } from '../ui/combobox';
 import { Input } from '../ui/input';
@@ -74,14 +75,7 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
     let cancelled = false;
     async function loadModels() {
       try {
-        let models: string[] = [];
-        if (backend === 'claude') {
-          const result = await api.claudeModels();
-          if (result.ok && result.models) models = result.models;
-        } else if (backend === 'codex') {
-          const result = await api.codexModels();
-          if (result.ok && result.models) models = result.models;
-        }
+        const { models } = await fetchBackendModels(api, backend);
         if (!cancelled) {
           setModelOptions(models.map((m) => ({ value: m, label: m })));
           // Clear model when the backend changes if the previous choice

--- a/ui/src/lib/backendModels.ts
+++ b/ui/src/lib/backendModels.ts
@@ -1,0 +1,46 @@
+import type { ApiContextType } from '../context/ApiContext';
+
+export interface BackendModels {
+  /** Selectable model identifiers for the backend. */
+  models: string[];
+  /** Per-model reasoning-effort option sets (Claude only); undefined elsewhere. */
+  reasoningOptions?: Record<string, { value: string; label: string }[]>;
+}
+
+// Single source of truth for "list the selectable models for a backend",
+// shared by ChatPage, the Agents detail panel, and the New Agent dialog so a
+// new backend (or a fix like OpenCode's provider-prefixing) lands in one place.
+//
+// claude / codex expose flat model arrays. OpenCode's catalog is per-provider
+// and the provider endpoint returns RAW model ids (never provider-prefixed), so
+// we flatten it into ``providerId/modelId`` keys — ALWAYS provider-prefixed,
+// even when the raw id itself contains "/" (e.g. OpenRouter's
+// ``anthropic/claude-*`` must become ``openrouter/anthropic/claude-*``). The
+// OpenCode adapter resolves the override by splitting on the FIRST "/" into
+// {providerID, modelID}, so the prefix is required for the selection to bind to
+// the right provider. Callers keep ``allowCustomValue`` so a model the catalog
+// doesn't know yet can still be typed.
+export async function fetchBackendModels(
+  api: ApiContextType,
+  backend: string,
+): Promise<BackendModels> {
+  if (backend === 'claude') {
+    const res = await api.claudeModels();
+    return {
+      models: res.ok && res.models ? res.models : [],
+      reasoningOptions: res.reasoning_options,
+    };
+  }
+  if (backend === 'codex') {
+    const res = await api.codexModels();
+    return { models: res.ok && res.models ? res.models : [] };
+  }
+  if (backend === 'opencode') {
+    const res = await api.getOpencodeProviders();
+    const models = (res.providers ?? []).flatMap((p) =>
+      (p.models ?? []).map((m) => `${p.id}/${m}`),
+    );
+    return { models };
+  }
+  return { models: [] };
+}


### PR DESCRIPTION
## Capability
Fix the empty OpenCode model dropdown on the **Agents** page (detail panel) and in the **New Agent** dialog, and unify per-backend model loading behind one helper.

## Root cause
`AgentDetailPanel` and `NewAgentDialog`'s `loadModels` only branched on `claude` / `codex`. An OpenCode agent fell through both branches, leaving `modelOptions = []` — so the Combobox showed only the "backend default" sentinel ("only one option"). ChatPage already had the correct OpenCode path (`getOpencodeProviders()` → flatten to `providerId/modelId`), but it lived inline in that one component, so the other two surfaces never got it.

## Change
- New `ui/src/lib/backendModels.ts` → `fetchBackendModels(api, backend)`: the single source of truth for "list selectable models for a backend" (claude flat list + reasoning options, codex flat list, OpenCode provider-prefixed catalog). The provider-prefix rule (split on the FIRST `/` into `{providerID, modelID}`) now lives in one place.
- Retrofit all three callers to use it: `ChatPage`, `AgentsPage` (detail panel), `NewAgentDialog`. Net **-37 / +61** lines; the three feature components shrink, the logic consolidates.

OpenCode now populates everywhere, and a future surface (or a 4th backend) inherits the behavior for free.

## Scenarios
No scenario catalog covers the Workbench Agents model picker; no scenario IDs apply.

## Evidence layers
- **Unit:** none (no existing UI unit harness for these components).
- **Contract:** n/a — no API/route change; reuses the existing `getOpencodeProviders` / `claudeModels` / `codexModels` methods.
- **Scenario:** n/a — no catalog for this surface.
- **Residual manual checks:** `npm run build` (tsc -b + vite build) passes; the OpenCode branch is a verbatim reuse of ChatPage's already-working logic. Live dropdown confirmation requires the real web UI (the data-plane `remote_access` host guard rejects out-of-band curl probes) — to be confirmed on a regression deploy of this branch.