### PR TITLE
fix(inbox): persistent 'awaiting agent' replied badge + Markdown preview

### DIFF
--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -476,6 +476,7 @@ def list_inbox_sessions(
             m.c.content_text.label("preview_text"),
             m.c.content_json.label("preview_json"),
             m.c.created_at.label("preview_at"),
+            m.c.id.label("preview_id"),
             func.row_number()
             .over(partition_by=m.c.session_id, order_by=(m.c.created_at.desc(), m.c.id.desc()))
             .label("rn"),
@@ -499,6 +500,7 @@ def list_inbox_sessions(
         select(
             m.c.session_id.label("session_id"),
             m.c.created_at.label("last_user_at"),
+            m.c.id.label("last_user_id"),
             func.row_number()
             .over(partition_by=m.c.session_id, order_by=(m.c.created_at.desc(), m.c.id.desc()))
             .label("rn"),
@@ -538,7 +540,9 @@ def list_inbox_sessions(
             scopes.c.native_id.label("project_id"),
             scopes.c.display_name.label("project_name"),
             unread_count_col.label("unread_count"),
+            latest_agent.c.preview_id,
             latest_user.c.last_user_at,
+            latest_user.c.last_user_id,
         )
         .select_from(
             latest_agent.join(latest_any, latest_any.c.session_id == latest_agent.c.session_id)
@@ -581,13 +585,23 @@ def list_inbox_sessions(
                 preview = ""
         unread = int(row["unread_count"] or 0)
         # Awaiting the agent: the user's latest message is newer than the agent's
-        # latest reply (``preview_at``). Persistent across a reload and stays set
-        # for the whole agent turn, unlike a "last author == user" check. ``>`` is
-        # strict so a same-second tie counts as already-replied (the agent reply
-        # is conceptually after the user's send).
+        # latest reply. Persistent across a reload and stays set for the whole
+        # agent turn, unlike a "last author == user" check. ``created_at`` is
+        # second-resolution, so compare ``(created_at, id)`` tuples — the message
+        # id carries a microsecond-clock prefix (see ``_new_message_id``), giving
+        # the right order for a follow-up sent in the same second as the prior
+        # reply.
         last_user_at = row["last_user_at"]
+        last_user_id = row["last_user_id"]
+        preview_at = row["preview_at"]
+        preview_id = row["preview_id"]
         awaiting_reply = bool(
-            last_user_at is not None and row["preview_at"] is not None and last_user_at > row["preview_at"]
+            last_user_at is not None
+            and preview_at is not None
+            and (
+                last_user_at > preview_at
+                or (last_user_at == preview_at and (last_user_id or "") > (preview_id or ""))
+            )
         )
         sessions.append(
             {

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -430,8 +430,10 @@ def list_inbox_sessions(
     One row per session that has at least one agent reply. Sorted by the
     session's most recent message of *any* author (the activity clock),
     descending. The preview text is the session's latest *agent* reply
-    (distinct from the sort key). ``replied`` is True when the most recent
-    message is the user's (they've responded, awaiting the agent).
+    (distinct from the sort key). ``replied`` is True when the session is
+    *awaiting the agent* — the user's latest message is newer than the agent's
+    latest reply — so it stays set for the whole time the agent is working and
+    survives a reload, clearing only once the agent replies.
 
     Keyset pagination via ``before`` (an opaque ``"<last_activity_at>|<session_id>"``
     cursor returned as ``next_cursor``).
@@ -486,6 +488,30 @@ def list_inbox_sessions(
     agent_ranked = agent_ranked.subquery()
     latest_agent = select(agent_ranked).where(agent_ranked.c.rn == 1).subquery()
 
+    # Latest *user* message per session (real sends only — exclude the ephemeral
+    # draft/queue/pending rows). Drives the persistent "awaiting the agent" badge:
+    # a session is awaiting a reply when the user's latest message is newer than
+    # the agent's latest reply. That stays true for the whole time the agent is
+    # working (not just the instant before it starts streaming) and survives a
+    # reload — unlike a "who literally spoke last" check that the agent's mid-turn
+    # streaming rows would immediately flip off.
+    user_ranked = (
+        select(
+            m.c.session_id.label("session_id"),
+            m.c.created_at.label("last_user_at"),
+            func.row_number()
+            .over(partition_by=m.c.session_id, order_by=(m.c.created_at.desc(), m.c.id.desc()))
+            .label("rn"),
+        )
+        .where(m.c.session_id.is_not(None))
+        .where(m.c.author == "user")
+        .where(m.c.type.notin_(NON_CONVERSATION_TYPES))
+    )
+    if platform is not None:
+        user_ranked = user_ranked.where(m.c.platform == platform)
+    user_ranked = user_ranked.subquery()
+    latest_user = select(user_ranked).where(user_ranked.c.rn == 1).subquery()
+
     # Unread agent messages per session.
     unread_q = (
         select(m.c.session_id.label("session_id"), func.count().label("unread_count"))
@@ -512,12 +538,14 @@ def list_inbox_sessions(
             scopes.c.native_id.label("project_id"),
             scopes.c.display_name.label("project_name"),
             unread_count_col.label("unread_count"),
+            latest_user.c.last_user_at,
         )
         .select_from(
             latest_agent.join(latest_any, latest_any.c.session_id == latest_agent.c.session_id)
             .join(agent_sessions, agent_sessions.c.id == latest_agent.c.session_id)
             .join(scopes, scopes.c.id == agent_sessions.c.scope_id, isouter=True)
             .join(unread_sub, unread_sub.c.session_id == latest_agent.c.session_id, isouter=True)
+            .join(latest_user, latest_user.c.session_id == latest_agent.c.session_id, isouter=True)
         )
     )
     if unread_only:
@@ -552,6 +580,15 @@ def list_inbox_sessions(
             except json.JSONDecodeError:
                 preview = ""
         unread = int(row["unread_count"] or 0)
+        # Awaiting the agent: the user's latest message is newer than the agent's
+        # latest reply (``preview_at``). Persistent across a reload and stays set
+        # for the whole agent turn, unlike a "last author == user" check. ``>`` is
+        # strict so a same-second tie counts as already-replied (the agent reply
+        # is conceptually after the user's send).
+        last_user_at = row["last_user_at"]
+        awaiting_reply = bool(
+            last_user_at is not None and row["preview_at"] is not None and last_user_at > row["preview_at"]
+        )
         sessions.append(
             {
                 "session_id": row["session_id"],
@@ -561,7 +598,7 @@ def list_inbox_sessions(
                 "title": row["title"],
                 "last_activity_at": row["last_activity_at"],
                 "last_message_author": row["last_author"],
-                "replied": row["last_author"] == "user",
+                "replied": awaiting_reply,
                 "preview_text": preview or "",
                 "preview_at": row["preview_at"],
                 "unread_count": unread,

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -369,17 +369,18 @@ def _seed_titled_session(conn, scope_id: str, session_id: str, title: str) -> No
     )
 
 
-def _insert_msg(conn, scope_id, session_id, author, text, created_at, *, read=True, msg_type=None):
+def _insert_msg(conn, scope_id, session_id, author, text, created_at, *, read=True, msg_type=None, msg_id=None):
     """Direct insert so the test controls created_at (second-resolution) + read_at.
 
     Agent rows default to type='result' (the user-facing reply the inbox
     previews); pass ``msg_type`` to insert an intermediate type (assistant /
-    tool_call) that must NOT drive the inbox preview.
+    tool_call) that must NOT drive the inbox preview. Pass ``msg_id`` to control
+    the (time-sortable) id when a test needs a deterministic same-second order.
     """
     resolved_type = msg_type or ("user" if author == "user" else "result")
     conn.execute(
         messages.insert().values(
-            id=f"msg_{session_id}_{created_at[-9:]}_{author}_{resolved_type}",
+            id=msg_id or f"msg_{session_id}_{created_at[-9:]}_{author}_{resolved_type}",
             scope_id=scope_id,
             session_id=session_id,
             platform="avibe",
@@ -517,6 +518,36 @@ def test_list_inbox_sessions_awaiting_reply_persists_through_agent_stream(isolat
         row2 = messages_service.list_inbox_sessions(conn, platform="avibe")["sessions"][0]
     assert row2["replied"] is False
     assert row2["preview_text"] == "R2"
+
+
+def test_list_inbox_sessions_same_second_followup_uses_id_tiebreaker(isolated_state):
+    """``created_at`` is second-resolution, so a follow-up sent in the SAME second
+    as the prior agent reply ties on time; the time-sortable message id breaks the
+    tie (real ids carry a microsecond-clock prefix). A later user id ⇒ still
+    awaiting the agent; a later agent-reply id ⇒ already replied. A plain
+    timestamp ``>`` would miss the awaiting case."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        # ses_wait_tie: agent reply, then the user's same-second follow-up (later id).
+        _seed_titled_session(conn, scope_id, "ses_wait_tie", "WaitTie")
+        _insert_msg(conn, scope_id, "ses_wait_tie", "agent", "R", "2026-05-30T10:00:00Z", msg_id="msg_00000001")
+        _insert_msg(conn, scope_id, "ses_wait_tie", "user", "again", "2026-05-30T10:00:00Z", msg_id="msg_00000002")
+        # ses_done_tie: user asks, then the agent's same-second reply (later id).
+        _seed_titled_session(conn, scope_id, "ses_done_tie", "DoneTie")
+        _insert_msg(conn, scope_id, "ses_done_tie", "user", "ask", "2026-05-30T10:00:00Z", msg_id="msg_00000003")
+        _insert_msg(conn, scope_id, "ses_done_tie", "agent", "R", "2026-05-30T10:00:00Z", msg_id="msg_00000004")
+
+    with engine.connect() as conn:
+        rows = {
+            r["session_id"]: r
+            for r in messages_service.list_inbox_sessions(conn, platform="avibe")["sessions"]
+        }
+
+    # Same second, user's message has the later id → still awaiting the agent.
+    assert rows["ses_wait_tie"]["replied"] is True
+    # Same second, the agent reply has the later id → already replied.
+    assert rows["ses_done_tie"]["replied"] is False
 
 
 def test_list_inbox_sessions_pagination(isolated_state):

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -397,7 +397,8 @@ def _insert_msg(conn, scope_id, session_id, author, text, created_at, *, read=Tr
 
 def test_list_inbox_sessions_per_session_feed(isolated_state):
     """One card per session, sorted by last activity (any author) desc, preview =
-    latest agent reply, replied = last message is the user's, with unread counts."""
+    latest agent reply, replied = awaiting the agent (the user's latest message is
+    newer than the agent's latest reply), with unread counts."""
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         scope_id = _seed_scope(conn)
@@ -405,7 +406,8 @@ def test_list_inbox_sessions_per_session_feed(isolated_state):
         _seed_titled_session(conn, scope_id, "ses_a", "Alpha")
         _seed_titled_session(conn, scope_id, "ses_b", "Beta")
         _seed_titled_session(conn, scope_id, "ses_c", "Gamma")
-        # ses_a: agent reply (read), then the user replied last → replied, no unread.
+        # ses_a: agent reply (read), then a newer user message → awaiting the
+        # agent (replied=True), no unread.
         _insert_msg(conn, scope_id, "ses_a", "agent", "A1", "2026-05-30T10:00:00Z")
         _insert_msg(conn, scope_id, "ses_a", "user", "AU", "2026-05-30T10:05:00Z")
         # ses_b: two result replies, the second unread → most recent activity, unread=1.
@@ -430,10 +432,10 @@ def test_list_inbox_sessions_per_session_feed(isolated_state):
     b, a = rows[0], rows[1]
     assert b["title"] == "Beta" and b["project_name"] == "My Project" and b["project_id"] == "proj_test"
     assert b["preview_text"] == "B2" and b["unread_count"] == 1 and b["unread"] is True
-    assert b["replied"] is False  # last message is the agent's
+    assert b["replied"] is False  # agent replied last → not awaiting
     # ses_a: preview is the latest AGENT reply (A1), not the user's last message.
     assert a["preview_text"] == "A1" and a["unread_count"] == 0
-    assert a["replied"] is True  # last message is the user's
+    assert a["replied"] is True  # user's message is newer than the agent's reply → awaiting
 
     # Unread filter drops the fully-read ses_a.
     with engine.connect() as conn:
@@ -471,8 +473,50 @@ def test_list_inbox_sessions_includes_notify_only_failed_turn(isolated_state):
     row = rows[0]
     # Preview is the failure notify so the user sees WHY the turn ended.
     assert row["preview_text"] == "❌ Claude error: boom"
-    # ``replied`` reflects who spoke last (the agent's notify), not the user.
+    # The agent's notify reply (10:00:05) is newer than the user's message
+    # (10:00:00) → the agent has responded, so the session is not awaiting.
     assert row["replied"] is False
+
+
+def test_list_inbox_sessions_awaiting_reply_persists_through_agent_stream(isolated_state):
+    """``replied`` is the persistent "awaiting the agent" flag: it stays True for
+    the whole agent turn — even after the agent starts streaming intermediate
+    ``assistant`` / ``tool_call`` rows — and clears only when an agent *reply*
+    (result / notify) lands after the user's latest message. A "who literally
+    spoke last" check would wrongly flip to False the instant streaming begins."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        _seed_titled_session(conn, scope_id, "ses_wait", "Waiting")
+        # turn 1: user asks, agent replies (read).
+        _insert_msg(conn, scope_id, "ses_wait", "user", "first", "2026-05-30T10:00:00Z")
+        _insert_msg(conn, scope_id, "ses_wait", "agent", "R1", "2026-05-30T10:01:00Z")
+        # turn 2: user follows up; the agent is mid-stream (assistant chunk) but
+        # has NOT produced a new result yet.
+        _insert_msg(conn, scope_id, "ses_wait", "user", "second", "2026-05-30T10:05:00Z")
+        _insert_msg(
+            conn, scope_id, "ses_wait", "agent", "thinking…", "2026-05-30T10:06:00Z",
+            read=False, msg_type="assistant",
+        )
+
+    with engine.connect() as conn:
+        row = messages_service.list_inbox_sessions(conn, platform="avibe")["sessions"][0]
+
+    # Awaiting the agent: the user's latest message (10:05) is newer than the
+    # agent's latest *reply* (R1 @10:01) — the streaming chunk doesn't count.
+    assert row["replied"] is True
+    # …even though the agent's streaming row is literally the last message,
+    assert row["last_message_author"] == "agent"
+    # …and the preview is still the last completed reply, not the stream chunk.
+    assert row["preview_text"] == "R1"
+
+    # Once the agent's new result lands after the user's message, it clears.
+    with engine.begin() as conn:
+        _insert_msg(conn, scope_id, "ses_wait", "agent", "R2", "2026-05-30T10:07:00Z", read=False)
+    with engine.connect() as conn:
+        row2 = messages_service.list_inbox_sessions(conn, platform="avibe")["sessions"][0]
+    assert row2["replied"] is False
+    assert row2["preview_text"] == "R2"
 
 
 def test_list_inbox_sessions_pagination(isolated_state):

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -43,7 +43,15 @@ export const Markdown: React.FC<{ content: string; className?: string; interacti
         },
         ...(interactive
           ? {}
-          : { a: ({ children }: { children?: React.ReactNode }) => <span>{children}</span> }),
+          : {
+              a: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+              // GFM task lists render a checkbox <input>; even disabled, an
+              // <input> nested in the sidebar row <button> is invalid interactive
+              // content, so show the state as a plain glyph instead.
+              input: ({ checked }: { checked?: boolean }) => (
+                <span aria-hidden="true">{checked ? '☑ ' : '☐ '}</span>
+              ),
+            }),
       }}
     >
       {content}

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -10,7 +10,16 @@ import { cn } from '@/lib/utils';
 // plugin. Promoted out of ChatPage once a second caller (the agent-config
 // editor preview) needed the same renderer — one home for "render markdown the
 // Vibe Remote way", so the security-conscious <img> handling is shared too.
-export const Markdown: React.FC<{ content: string; className?: string }> = ({ content, className }) => (
+// ``interactive`` (default true) keeps the normal chat/editor rendering where
+// links and image-links are clickable. Pass ``interactive={false}`` for snippets
+// that live inside a clickable row/button (e.g. inbox previews): links render as
+// plain text so a nested <a> can't become invalid interactive content or steal
+// the row's click.
+export const Markdown: React.FC<{ content: string; className?: string; interactive?: boolean }> = ({
+  content,
+  className,
+  interactive = true,
+}) => (
   <div className={cn('vr-markdown', className)}>
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
@@ -20,13 +29,21 @@ export const Markdown: React.FC<{ content: string; className?: string }> = ({ co
         // the moment the view opens (``![](http://attacker/x)``), leaking the
         // viewer's IP / network metadata to an attacker-chosen host. Render
         // images as click-through links instead so nothing is fetched without
-        // an explicit user action.
-        img: ({ src, alt }) =>
-          src ? (
+        // an explicit user action — or as plain text when non-interactive.
+        img: ({ src, alt }) => {
+          if (!src) return null;
+          const label = `🖼 ${alt || String(src)}`;
+          return interactive ? (
             <a href={String(src)} target="_blank" rel="noopener noreferrer nofollow">
-              {`🖼 ${alt || String(src)}`}
+              {label}
             </a>
-          ) : null,
+          ) : (
+            <span>{label}</span>
+          );
+        },
+        ...(interactive
+          ? {}
+          : { a: ({ children }: { children?: React.ReactNode }) => <span>{children}</span> }),
       }}
     >
       {content}

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -189,13 +189,14 @@ export const InboxPage: React.FC = () => {
                     {t('workbench.inbox.agent')}
                   </div>
                   {s.preview_text ? (
-                    <Markdown
-                      content={s.preview_text}
+                    <div
                       className={clsx(
-                        'vr-markdown--preview line-clamp-3 text-[13px] leading-relaxed',
+                        'line-clamp-3 text-[13px] leading-relaxed',
                         unread > 0 ? 'text-foreground' : 'text-muted',
                       )}
-                    />
+                    >
+                      <Markdown content={s.preview_text} interactive={false} className="vr-markdown--preview" />
+                    </div>
                   ) : (
                     <p className="text-[13px] leading-relaxed text-muted">—</p>
                   )}

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { InboxSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
+import { Markdown } from '../ui/markdown';
 
 type FilterMode = 'unread' | 'all';
 
@@ -187,9 +188,17 @@ export const InboxPage: React.FC = () => {
                   <div className="text-[10px] font-bold uppercase tracking-wider text-mint">
                     {t('workbench.inbox.agent')}
                   </div>
-                  <p className={clsx('line-clamp-3 text-[13px] leading-relaxed', unread > 0 ? 'text-foreground' : 'text-muted')}>
-                    {s.preview_text || '—'}
-                  </p>
+                  {s.preview_text ? (
+                    <Markdown
+                      content={s.preview_text}
+                      className={clsx(
+                        'vr-markdown--preview line-clamp-3 text-[13px] leading-relaxed',
+                        unread > 0 ? 'text-foreground' : 'text-muted',
+                      )}
+                    />
+                  ) : (
+                    <p className="text-[13px] leading-relaxed text-muted">—</p>
+                  )}
                 </div>
 
                 <div className="flex items-center gap-2">

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -146,13 +146,14 @@ const InboxHoverPopover: React.FC<{
                   <span className="font-mono text-muted">{formatRelativeTime(s.last_activity_at, t)}</span>
                 </div>
                 {s.preview_text ? (
-                  <Markdown
-                    content={s.preview_text}
+                  <div
                     className={clsx(
-                      'vr-markdown--preview line-clamp-2 text-[11.5px] leading-relaxed',
+                      'line-clamp-2 text-[11.5px] leading-relaxed',
                       unread > 0 ? 'text-foreground' : 'text-muted',
                     )}
-                  />
+                  >
+                    <Markdown content={s.preview_text} interactive={false} className="vr-markdown--preview" />
+                  </div>
                 ) : (
                   <div className="text-[11.5px] leading-relaxed text-muted">—</div>
                 )}

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -29,6 +29,7 @@ import { formatRelativeTime } from '../../lib/relativeTime';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { Markdown } from '../ui/markdown';
 import { NewProjectDialog } from './NewProjectDialog';
 
 interface CapabilityNavItem {
@@ -144,14 +145,17 @@ const InboxHoverPopover: React.FC<{
                   )}
                   <span className="font-mono text-muted">{formatRelativeTime(s.last_activity_at, t)}</span>
                 </div>
-                <div
-                  className={clsx(
-                    'line-clamp-2 text-[11.5px] leading-relaxed',
-                    unread > 0 ? 'text-foreground' : 'text-muted',
-                  )}
-                >
-                  {s.preview_text || '—'}
-                </div>
+                {s.preview_text ? (
+                  <Markdown
+                    content={s.preview_text}
+                    className={clsx(
+                      'vr-markdown--preview line-clamp-2 text-[11.5px] leading-relaxed',
+                      unread > 0 ? 'text-foreground' : 'text-muted',
+                    )}
+                  />
+                ) : (
+                  <div className="text-[11.5px] leading-relaxed text-muted">—</div>
+                )}
               </button>
             );
           })}

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -404,7 +404,10 @@ export type WorkbenchMessage = {
 // Aggregated per session at query time: ``preview_text`` is the session's latest
 // agent ``result`` (aligned with the avibe chat, which only shows results),
 // ``last_activity_at`` is the most recent message of *any* author (the sort
-// key), and ``replied`` is true when that most recent message is the user's.
+// key), and ``replied`` is true when the session is awaiting the agent — the
+// user's latest message is newer than the agent's latest reply, so it stays set
+// for the whole agent turn (even mid-stream) and clears only once the agent
+// replies.
 export type InboxSession = {
   session_id: string;
   scope_id: string | null;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -473,17 +473,13 @@ pre,
 
 /* Compact inline-ish markdown for inbox previews: inherit the host row's small
    font-size + color, collapse block spacing, and tame headings / code blocks so
-   a clamped 2–3 line snippet stays tidy instead of rendering full-size blocks. */
+   a clamped 2–3 line snippet stays tidy instead of rendering full-size blocks.
+   The block rules are scoped under the doubled ``.vr-markdown.vr-markdown--preview``
+   class so they outrank the base ``.vr-markdown <el>`` rules on specificity,
+   regardless of source order. */
 .vr-markdown--preview { font-size: inherit; line-height: inherit; color: inherit; }
-.vr-markdown--preview > * { margin: 0; }
-.vr-markdown--preview > * + * { margin-top: 0.15em; }
-.vr-markdown--preview h1,
-.vr-markdown--preview h2,
-.vr-markdown--preview h3,
-.vr-markdown--preview h4 { font-size: inherit; margin: 0; }
-.vr-markdown--preview ul,
-.vr-markdown--preview ol { margin: 0; padding-left: 1.1em; }
-.vr-markdown--preview pre { margin: 0; padding: 4px 8px; border-radius: 6px; }
-.vr-markdown--preview blockquote { margin: 0; padding: 0 0 0 0.7em; }
-.vr-markdown--preview hr { margin: 0.3em 0; }
-.vr-markdown--preview table { margin: 0; }
+.vr-markdown.vr-markdown--preview :is(p, h1, h2, h3, h4, ul, ol, pre, blockquote, table, hr) { margin: 0; }
+.vr-markdown.vr-markdown--preview :is(h1, h2, h3, h4) { font-size: inherit; }
+.vr-markdown.vr-markdown--preview :is(ul, ol) { padding-left: 1.1em; }
+.vr-markdown.vr-markdown--preview pre { padding: 4px 8px; border-radius: 6px; }
+.vr-markdown.vr-markdown--preview blockquote { padding: 0 0 0 0.7em; }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -470,3 +470,20 @@ pre,
 .vr-markdown th { background: var(--surface-2); font-weight: 600; }
 .vr-markdown img { max-width: 100%; border-radius: 8px; }
 .vr-markdown strong { font-weight: 700; }
+
+/* Compact inline-ish markdown for inbox previews: inherit the host row's small
+   font-size + color, collapse block spacing, and tame headings / code blocks so
+   a clamped 2–3 line snippet stays tidy instead of rendering full-size blocks. */
+.vr-markdown--preview { font-size: inherit; line-height: inherit; color: inherit; }
+.vr-markdown--preview > * { margin: 0; }
+.vr-markdown--preview > * + * { margin-top: 0.15em; }
+.vr-markdown--preview h1,
+.vr-markdown--preview h2,
+.vr-markdown--preview h3,
+.vr-markdown--preview h4 { font-size: inherit; margin: 0; }
+.vr-markdown--preview ul,
+.vr-markdown--preview ol { margin: 0; padding-left: 1.1em; }
+.vr-markdown--preview pre { margin: 0; padding: 4px 8px; border-radius: 6px; }
+.vr-markdown--preview blockquote { margin: 0; padding: 0 0 0 0.7em; }
+.vr-markdown--preview hr { margin: 0.3em 0; }
+.vr-markdown--preview table { margin: 0; }


### PR DESCRIPTION
## What

Two inbox fixes (one branch, two commits).

**1. The `已回复` / Replied badge now actually shows.** It was defined as "the last
conversational message author is the user" — a transient state the agent's reply
(and even its mid-stream `assistant`/`tool_call` rows) immediately overwrote, so on a
normal inbox load it was false on every session (verified against the regression DB:
all avibe sessions currently end with an agent message → the badge never rendered).
Recomputed as a persistent **"awaiting the agent"** flag: the session's latest USER
message is newer than its latest AGENT reply (`result`/`notify`). It now stays set for
the whole agent turn and survives a reload, clearing only once the agent replies.

**2. Inbox preview renders Markdown.** The preview showed raw text, so markdown read
as messy syntax. It now goes through the same `Markdown` component the chat uses
(react-markdown + remark-gfm), via a compact `.vr-markdown--preview` variant that
inherits the row's small size/color and collapses block spacing for the clamped
2–3 line snippet. Applied in `InboxPage` and the sidebar inbox popover.

No API shape change; `replied` stays a boolean on the existing `/api/inbox` payload.

## Affected scenarios

No scenario catalog applies to this surface.

## Evidence layers

- **Unit:** `tests/test_messages_service.py` — updated the inbox-feed assertions to the
  new semantics and added `test_list_inbox_sessions_awaiting_reply_persists_through_agent_stream`
  (user → agent reply, then a user follow-up while the agent is mid-stream → `replied`
  stays True; clears once the new result lands). Confirmed it fails under the old logic.
  Ran the messages/inbox/mirror group (`test_messages_service`, `test_message_mirror`,
  `test_inbox_events`) — all pass. `ruff` clean.
- **Contract:** `replied` is computed in `list_inbox_sessions`; `get_inbox_session` and the
  realtime `inbox.session.updated` publish inherit it. No route/payload change.
- **UI build:** `npm run build` (`tsc -b` + vite) passes.
- **Residual manual:** regression-env check — send a follow-up to a long-running agent and
  confirm `已回复` stays until it replies; confirm a markdown-heavy reply previews cleanly.
