### PR TITLE
fix(ui): workbench home reuses chat Composer, centers panel, drops v1 placeholder

### DIFF
--- a/ui/src/components/Workbench.tsx
+++ b/ui/src/components/Workbench.tsx
@@ -48,13 +48,16 @@ export const Workbench: React.FC = () => {
   const targetProject = sortedProjects[0] || null;
   const hasProjects = !!targetProject;
 
+  // Returns whether the send actually started, so the Composer only clears the
+  // box on a real start — a no-project nudge or a transient create error keeps
+  // the typed prompt for retry (Codex P2).
   const send = useCallback(
-    async (text: string) => {
+    async (text: string): Promise<boolean> => {
       const trimmed = text.trim();
-      if (!trimmed || sending) return;
+      if (!trimmed || sending) return false;
       if (!targetProject) {
         setNewProjectOpen(true);
-        return;
+        return false;
       }
       setSending(true);
       setError(null);
@@ -67,9 +70,11 @@ export const Workbench: React.FC = () => {
         navigate(`/chat/${encodeURIComponent(session.id)}`, {
           state: { initialMessage: trimmed },
         });
+        return true;
       } catch (err: any) {
         setError(err?.message ?? String(err));
         setSending(false);
+        return false;
       }
     },
     [api, navigate, sending, targetProject],
@@ -120,12 +125,9 @@ export const Workbench: React.FC = () => {
           disabled={sending}
           className="max-w-[640px]"
         />
-        <div className="flex items-center justify-between px-2 text-[10.5px] text-muted">
-          <span>{t('workbench.canvas.inputHint')}</span>
-          {projects !== null && !hasProjects && (
-            <span className="text-gold">{t('workbench.canvas.noProjectForChat')}</span>
-          )}
-        </div>
+        {projects !== null && !hasProjects && (
+          <div className="px-2 text-[10.5px] text-gold">{t('workbench.canvas.noProjectForChat')}</div>
+        )}
         {error && (
           <div className="mt-1 rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
             {error}

--- a/ui/src/components/Workbench.tsx
+++ b/ui/src/components/Workbench.tsx
@@ -1,33 +1,30 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { Activity, ArrowUp, Bot, FolderPlus, Loader2, Plus, Sparkles } from 'lucide-react';
+import { Activity, Bot, FolderPlus, Sparkles } from 'lucide-react';
 
 import { useApi } from '../context/ApiContext';
 import type { WorkbenchProject } from '../context/ApiContext';
-import { Badge } from './ui/badge';
-import { Button } from './ui/button';
 import { NewProjectDialog } from './workbench/NewProjectDialog';
+import { Composer } from './workbench/Composer';
 
-// Mirrors design.pen DnkGJ "Workbench" canvas. Hero card on a surface-2
-// rounded backdrop + suggestion chips + bottom InputBar. The InputBar
-// is wired to create a new session under the most-recently-active
-// project using the default backend, then routes to /chat/<id> with the
-// typed message pre-seeded. No project? The button surfaces the
-// NewProjectDialog so the user gets unstuck without bouncing pages.
+// Mirrors design.pen DnkGJ "Workbench" canvas: a centered hero panel +
+// suggestion chips with the shared chat Composer below it. The Composer is
+// wired to create a new session under the most-recently-active project using
+// the default backend, then routes to /chat/<id> with the typed message
+// pre-seeded. No project? The send surfaces the NewProjectDialog so the user
+// gets unstuck without bouncing pages.
 export const Workbench: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const api = useApi();
   const [projects, setProjects] = useState<WorkbenchProject[] | null>(null);
-  const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // Load projects so we know whether the InputBar can fire directly or
-  // needs to nudge the user to create one first.
+  // Load projects so we know whether the Composer can fire directly or needs
+  // to nudge the user to create one first.
   useEffect(() => {
     let cancelled = false;
     api
@@ -51,71 +48,54 @@ export const Workbench: React.FC = () => {
   const targetProject = sortedProjects[0] || null;
   const hasProjects = !!targetProject;
 
-  const send = useCallback(async () => {
-    const text = draft.trim();
-    if (!text || sending) return;
-    if (!targetProject) {
-      setNewProjectOpen(true);
-      return;
-    }
-    setSending(true);
-    setError(null);
-    try {
-      // Omit agent_backend so the server routes the new chat through the
-      // configured agents.default_backend rather than a hard-coded one.
-      const session = await api.createSession({ project_id: targetProject.id });
-      // Hand the typed message to ChatPage as router state. ChatPage replays it
-      // through its fire-and-forget compose path (plain POST → dispatch_async),
-      // so the agent turn actually starts and the reply arrives over the
-      // session stream — instead of persisting a user message here that no
-      // dispatch would ever pick up.
-      navigate(`/chat/${encodeURIComponent(session.id)}`, {
-        state: { initialMessage: text },
-      });
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
-      setSending(false);
-    }
-  }, [api, draft, navigate, sending, targetProject]);
+  const send = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || sending) return;
+      if (!targetProject) {
+        setNewProjectOpen(true);
+        return;
+      }
+      setSending(true);
+      setError(null);
+      try {
+        // Omit agent_backend so the server routes the new chat through the
+        // configured agents.default_backend rather than a hard-coded one.
+        const session = await api.createSession({ project_id: targetProject.id });
+        // Hand the typed message to ChatPage as router state; it replays it
+        // through the fire-and-forget compose path so the agent turn starts.
+        navigate(`/chat/${encodeURIComponent(session.id)}`, {
+          state: { initialMessage: trimmed },
+        });
+      } catch (err: any) {
+        setError(err?.message ?? String(err));
+        setSending(false);
+      }
+    },
+    [api, navigate, sending, targetProject],
+  );
 
-  // Quick chips at the bottom of the canvas — three of the most common
-  // first moves. Click routes to the existing surface for that flow.
+  // Quick chips under the hero — three of the most common first moves.
   const suggestions = [
-    {
-      key: 'newProject',
-      icon: FolderPlus,
-      onClick: () => setNewProjectOpen(true),
-    },
-    {
-      key: 'openAgents',
-      icon: Bot,
-      onClick: () => navigate('/agents'),
-    },
-    {
-      key: 'openHarness',
-      icon: Activity,
-      onClick: () => navigate('/harness'),
-    },
+    { key: 'newProject', icon: FolderPlus, onClick: () => setNewProjectOpen(true) },
+    { key: 'openAgents', icon: Bot, onClick: () => navigate('/agents') },
+    { key: 'openHarness', icon: Activity, onClick: () => navigate('/harness') },
   ] as const;
 
   return (
-    <div className="-my-5 flex h-[calc(100dvh-2.5rem)] flex-col gap-4 md:-my-8 md:h-[calc(100dvh-4rem)]">
-      {/* Canvas card — flex-1 so it eats all the space between the
-          (absent for now) breadcrumb and the InputBar. */}
-      <div className="flex flex-1 flex-col items-center justify-center gap-6 overflow-hidden rounded-2xl border border-border bg-surface-2 px-6 py-10">
+    // Center the hero + Composer as a group, leaving the AppShell's top/bottom
+    // padding as margin (no negative-margin full-bleed). min-h fills the visible
+    // area so justify-center actually centers; the responsive offset accounts
+    // for the mobile header + bottom nav vs. the desktop sidebar layout.
+    <div className="flex min-h-[calc(100dvh-13rem)] flex-col items-center justify-center gap-5 md:min-h-[calc(100dvh-7rem)]">
+      {/* Hero panel — a centered card, not a full-bleed fill. */}
+      <div className="flex w-full max-w-[640px] flex-col items-center gap-6 rounded-2xl border border-border bg-surface-2 px-6 py-10">
         <div className="flex size-14 items-center justify-center rounded-2xl border border-mint/40 bg-mint-soft text-mint shadow-[0_0_24px_-6px_rgba(91,255,160,0.6)]">
           <Sparkles className="size-6" />
         </div>
-        <div className="flex max-w-[560px] flex-col items-center gap-3 text-center">
-          <h1 className="text-[22px] font-semibold text-foreground">
-            {t('workbench.canvas.heroTitle')}
-          </h1>
-          <p className="text-[13px] leading-[1.55] text-muted">
-            {t('workbench.canvas.heroBody')}
-          </p>
-          <Badge variant="warning" className="font-mono text-[10px]">
-            {t('workbench.canvas.v1Hint')}
-          </Badge>
+        <div className="flex max-w-[520px] flex-col items-center gap-3 text-center">
+          <h1 className="text-[22px] font-semibold text-foreground">{t('workbench.canvas.heroTitle')}</h1>
+          <p className="text-[13px] leading-[1.55] text-muted">{t('workbench.canvas.heroBody')}</p>
         </div>
         <div className="flex flex-wrap items-center justify-center gap-2">
           {suggestions.map(({ key, icon: Icon, onClick }) => (
@@ -132,45 +112,14 @@ export const Workbench: React.FC = () => {
         </div>
       </div>
 
-      {/* InputBar — design.pen s6tin3. Plus icon (+ new project shortcut),
-          textarea-sized input, mint Send button. Enter sends; Shift+Enter
-          inserts a newline. */}
-      <div className="flex flex-col gap-1">
-        <div className="flex items-end gap-2 rounded-2xl border border-border-strong bg-surface-2 p-3">
-          <button
-            type="button"
-            onClick={() => setNewProjectOpen(true)}
-            aria-label={t('workbench.canvas.suggestions.newProject')}
-            className="flex size-9 shrink-0 items-center justify-center rounded-md text-muted transition hover:bg-foreground/[0.04] hover:text-foreground"
-          >
-            <Plus className="size-4" />
-          </button>
-          <textarea
-            ref={textareaRef}
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-                e.preventDefault();
-                send();
-              }
-            }}
-            placeholder={t('workbench.canvas.inputPlaceholder')}
-            rows={1}
-            className="flex-1 resize-none bg-transparent py-2 text-[13px] text-foreground outline-none placeholder:text-muted"
-          />
-          <Button
-            type="button"
-            variant="brand"
-            size="xs"
-            onClick={send}
-            disabled={!draft.trim() || sending}
-            className="shrink-0"
-          >
-            {sending ? <Loader2 className="size-3.5 animate-spin" /> : <ArrowUp className="size-3.5" />}
-            {t('workbench.canvas.send')}
-          </Button>
-        </div>
+      {/* Input — the shared chat Composer, width-matched to the hero. */}
+      <div className="flex w-full max-w-[640px] flex-col gap-1">
+        <Composer
+          onSend={send}
+          placeholder={t('workbench.canvas.inputPlaceholder')}
+          disabled={sending}
+          className="max-w-[640px]"
+        />
         <div className="flex items-center justify-between px-2 text-[10.5px] text-muted">
           <span>{t('workbench.canvas.inputHint')}</span>
           {projects !== null && !hasProjects && (
@@ -190,9 +139,9 @@ export const Workbench: React.FC = () => {
           onCreated={(project) => {
             setNewProjectOpen(false);
             // create_project is find-or-create by path: this may return an
-            // already-tracked project, refreshed (revived / last_active_at
-            // bumped). Drop any stale copy and hoist the fresh one to the top so
-            // the canvas "most recent" target reflects the folder just opened.
+            // already-tracked project, refreshed. Drop any stale copy and hoist
+            // the fresh one to the top so the "most recent" target reflects the
+            // folder just opened.
             setProjects((prev) => {
               if (!prev) return [project];
               return [project, ...prev.filter((p) => p.id !== project.id)];

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Bot, ChevronDown, Clock, Loader2, MessageSquare, Pencil, Plus, Send, Square, X } from 'lucide-react';
+import { ArrowLeft, Bot, ChevronDown, Clock, Loader2, MessageSquare, Pencil, Plus, X } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -15,6 +15,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Markdown } from '../ui/markdown';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Composer } from './Composer';
 
 // Last-resort failsafe for a LOST ``turn.end`` event. The controller is the
 // authority on turn end (``turn.start`` / ``turn.end`` over the bus) and its own
@@ -698,99 +699,24 @@ interface ComposeProps {
   onDraftChange: (text: string) => void;
 }
 
-const Compose: React.FC<ComposeProps> = ({ onSend, onStop, busy, initialDraft, onDraftChange }) => {
-  const { t } = useTranslation();
-  const [value, setValue] = useState('');
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  // Seed the composer with the saved draft once it loads — but only if the box
-  // is still untouched, so a late-arriving draft can't clobber live typing.
-  const draftAppliedRef = useRef(false);
-  useEffect(() => {
-    if (draftAppliedRef.current || initialDraft == null) return;
-    draftAppliedRef.current = true;
-    if (initialDraft) setValue((cur) => (cur ? cur : initialDraft));
-  }, [initialDraft]);
-
-  const trimmed = value.trim();
-  // Enter always sends when there's text — sending WHILE a turn runs queues it
-  // (the queue feature), so the composer stays usable during a turn.
-  const canSubmit = trimmed.length > 0;
-
-  const update = (next: string) => {
-    setValue(next);
-    onDraftChange(next);
-  };
-
-  const submit = () => {
-    if (!canSubmit) return;
-    onSend(trimmed);
-    setValue('');
-    onDraftChange('');
-  };
-
-  // shrink-0 keeps the compose bar pinned at the bottom of the
-  // fixed-height chat container; the transcript above scrolls instead. The
-  // bar background fades from the page colour up to transparent (no opaque
-  // "white bar" band, no hard top border) so the transcript scrolls cleanly
-  // behind it and the input sits close to the very bottom edge (feedback #3).
-  return (
-    <div
-      className="shrink-0 px-4 pb-4 pt-3 md:px-8"
-      style={{ background: 'linear-gradient(to top, var(--background) 65%, transparent)' }}
-    >
-      {/* Input and send/stop button share one row (regression feedback #6):
-          the textarea grows, the icon-only button sits flush right and swaps
-          between Send (idle) and Stop (generating). No helper hint line. */}
-      <div className="mx-auto flex w-full max-w-[1080px] items-end gap-2 rounded-2xl border border-border-strong bg-surface-2 py-2 pl-3.5 pr-2 shadow-[0_-4px_24px_-12px_rgba(0,0,0,0.5)]">
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => update(e.target.value)}
-          onKeyDown={(e) => {
-            // Enter sends; Shift+Enter inserts a newline. ``isComposing``
-            // guards against submitting mid-IME composition (Chinese /
-            // Japanese / Korean), where Enter only commits the candidate.
-            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-              e.preventDefault();
-              submit();
-            }
-          }}
-          rows={1}
-          placeholder={busy ? t('chat.compose.placeholderBusy') : t('chat.compose.placeholder')}
-          className="max-h-40 flex-1 resize-none bg-transparent py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted"
-        />
-        {/* design.pen kxEkn compose bar: a 36px (size-9) icon button with a
-            16px glyph. While generating it becomes a pink-soft Stop (the
-            ``destructive-soft`` design-system variant), otherwise a flat mint
-            Send — matching Icon Button/Default rather than the glowy brand CTA. */}
-        {busy ? (
-          <Button
-            type="button"
-            variant="destructive-soft"
-            size="icon"
-            onClick={onStop}
-            aria-label={t('chat.compose.stop')}
-            className="size-9 shrink-0"
-          >
-            <Square className="size-4" />
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            variant="default"
-            size="icon"
-            onClick={submit}
-            disabled={!canSubmit}
-            aria-label={t('chat.compose.send')}
-            className="size-9 shrink-0"
-          >
-            <Send className="size-4" />
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-};
+const Compose: React.FC<ComposeProps> = ({ onSend, onStop, busy, initialDraft, onDraftChange }) => (
+  // shrink-0 pins the bar at the bottom of the fixed-height chat container; the
+  // gradient fades the transcript out behind it (no opaque band / hard border)
+  // so the input sits close to the bottom edge. The input row is the shared
+  // <Composer>, also used by the Workbench home.
+  <div
+    className="shrink-0 px-4 pb-4 pt-3 md:px-8"
+    style={{ background: 'linear-gradient(to top, var(--background) 65%, transparent)' }}
+  >
+    <Composer
+      onSend={onSend}
+      onStop={onStop}
+      busy={busy}
+      initialDraft={initialDraft}
+      onDraftChange={onDraftChange}
+    />
+  </div>
+);
 
 interface ChatHeaderBarProps {
   session: WorkbenchSession;

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Send, Square } from 'lucide-react';
+
+import { cn } from '../../lib/utils';
+import { Button } from '../ui/button';
+
+export interface ComposerProps {
+  /** Fired with the trimmed text when the user sends. */
+  onSend: (text: string) => void;
+  /** A turn is running — the send button becomes a Stop button. */
+  busy?: boolean;
+  /** Pressed while busy. */
+  onStop?: () => void;
+  /** Seed the box once from a saved draft (chat sessions). */
+  initialDraft?: string | null;
+  /** Persist draft changes (chat sessions). */
+  onDraftChange?: (text: string) => void;
+  /** Idle placeholder override; while busy the chat "working" placeholder wins. */
+  placeholder?: string;
+  /** Disable sending (e.g. while the caller creates a session + navigates). */
+  disabled?: boolean;
+  /** Override the row container — e.g. a narrower max-width on the home canvas. */
+  className?: string;
+}
+
+// The chat-style input row: an auto-growing textarea + a Send/Stop icon button.
+// Shared by the chat view (ChatPage) and the Workbench home so both use one
+// input component instead of each hand-rolling its own. Owns its draft value;
+// callers react via onSend / onDraftChange. design.pen kxEkn.
+export const Composer: React.FC<ComposerProps> = ({
+  onSend,
+  busy = false,
+  onStop,
+  initialDraft = null,
+  onDraftChange,
+  placeholder,
+  disabled = false,
+  className,
+}) => {
+  const { t } = useTranslation();
+  const [value, setValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // Seed once from a saved draft, but only while the box is untouched so a
+  // late-arriving draft can't clobber live typing.
+  const draftAppliedRef = useRef(false);
+  useEffect(() => {
+    if (draftAppliedRef.current || initialDraft == null) return;
+    draftAppliedRef.current = true;
+    if (initialDraft) setValue((cur) => (cur ? cur : initialDraft));
+  }, [initialDraft]);
+
+  const trimmed = value.trim();
+  const canSubmit = trimmed.length > 0 && !disabled;
+
+  const update = (next: string) => {
+    setValue(next);
+    onDraftChange?.(next);
+  };
+
+  const submit = () => {
+    if (!canSubmit) return;
+    onSend(trimmed);
+    setValue('');
+    onDraftChange?.('');
+  };
+
+  return (
+    <div
+      className={cn(
+        'mx-auto flex w-full max-w-[1080px] items-end gap-2 rounded-2xl border border-border-strong bg-surface-2 py-2 pl-3.5 pr-2 shadow-[0_-4px_24px_-12px_rgba(0,0,0,0.5)]',
+        className,
+      )}
+    >
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => update(e.target.value)}
+        onKeyDown={(e) => {
+          // Enter sends; Shift+Enter inserts a newline. ``isComposing`` guards
+          // against submitting mid-IME composition (CJK), where Enter commits
+          // the candidate rather than the message.
+          if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+            e.preventDefault();
+            submit();
+          }
+        }}
+        rows={1}
+        placeholder={busy ? t('chat.compose.placeholderBusy') : placeholder ?? t('chat.compose.placeholder')}
+        className="max-h-40 flex-1 resize-none bg-transparent py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted"
+      />
+      {/* 36px (size-9) icon button: pink-soft Stop while a turn runs, else a
+          flat mint Send — design-system variants, not a glowy brand CTA. */}
+      {busy ? (
+        <Button
+          type="button"
+          variant="destructive-soft"
+          size="icon"
+          onClick={onStop}
+          aria-label={t('chat.compose.stop')}
+          className="size-9 shrink-0"
+        >
+          <Square className="size-4" />
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="default"
+          size="icon"
+          onClick={submit}
+          disabled={!canSubmit}
+          aria-label={t('chat.compose.send')}
+          className="size-9 shrink-0"
+        >
+          <Send className="size-4" />
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -45,6 +45,8 @@ export const Composer: React.FC<ComposerProps> = ({
   // Seed once from a saved draft, but only while the box is untouched so a
   // late-arriving draft can't clobber live typing.
   const draftAppliedRef = useRef(false);
+  // Blocks a same-tick double-submit before the optimistic clear re-renders.
+  const pendingRef = useRef(false);
   useEffect(() => {
     if (draftAppliedRef.current || initialDraft == null) return;
     draftAppliedRef.current = true;
@@ -60,14 +62,22 @@ export const Composer: React.FC<ComposerProps> = ({
   };
 
   const submit = async () => {
-    if (!canSubmit) return;
-    // Clear only once the caller confirms the send started. The home composer
-    // resolves false when it can't (no project yet, or a create-session error),
-    // so the typed prompt is preserved for retry instead of vanishing.
-    const started = await onSend(trimmed);
-    if (started === false) return;
+    if (!canSubmit || pendingRef.current) return;
+    const submitted = trimmed;
+    pendingRef.current = true;
+    // Clear optimistically so the box can't be re-submitted (canSubmit goes
+    // false) and a slow send can't wipe text typed in the meantime.
     setValue('');
     onDraftChange?.('');
+    try {
+      // If the caller reports the send couldn't start (the home composer's
+      // no-project nudge / create-session error), restore the prompt for retry
+      // — but only if the user hasn't already typed something new.
+      const started = await onSend(submitted);
+      if (started === false) setValue((cur) => (cur ? cur : submitted));
+    } finally {
+      pendingRef.current = false;
+    }
   };
 
   return (

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -6,8 +6,9 @@ import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 
 export interface ComposerProps {
-  /** Fired with the trimmed text when the user sends. */
-  onSend: (text: string) => void;
+  /** Fired with the trimmed text when the user sends. Return (or resolve to)
+   *  ``false`` to signal the send couldn't start, so the box keeps the text. */
+  onSend: (text: string) => boolean | void | Promise<boolean | void>;
   /** A turn is running — the send button becomes a Stop button. */
   busy?: boolean;
   /** Pressed while busy. */
@@ -58,9 +59,13 @@ export const Composer: React.FC<ComposerProps> = ({
     onDraftChange?.(next);
   };
 
-  const submit = () => {
+  const submit = async () => {
     if (!canSubmit) return;
-    onSend(trimmed);
+    // Clear only once the caller confirms the send started. The home composer
+    // resolves false when it can't (no project yet, or a create-session error),
+    // so the typed prompt is preserved for retry instead of vanishing.
+    const started = await onSend(trimmed);
+    if (started === false) return;
     setValue('');
     onDraftChange?.('');
   };

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -452,8 +452,6 @@
         "openHarnessHint": "Have an agent write the cron / watch"
       },
       "inputPlaceholder": "Tell the agent what you want…",
-      "inputHint": "Enter to send",
-      "send": "Send",
       "noProjectForChat": "No projects yet — add one before starting a chat"
     },
     "openControlPanel": "Open Control Panel",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -443,7 +443,6 @@
     "canvas": {
       "heroTitle": "What should we build today?",
       "heroBody": "Describe what you want and an agent will run it. Or start with one of the suggestions below.",
-      "v1Hint": "v1 placeholder · canvas-anchored iteration lands next",
       "suggestions": {
         "newProject": "Open project",
         "newProjectHint": "Pick a folder; sessions default to it",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -443,7 +443,6 @@
     "canvas": {
       "heroTitle": "今天想搭点什么?",
       "heroBody": "在下面输入想做的事,Agent 会按你的描述执行。你也可以从下面的建议开始。",
-      "v1Hint": "v1 占位 · 后续会做画布标注 + 多轮迭代",
       "suggestions": {
         "newProject": "打开项目",
         "newProjectHint": "选个目录开个项目,会话默认会落在里面",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -452,8 +452,6 @@
         "openHarnessHint": "让 Agent 帮你写 cron / watch"
       },
       "inputPlaceholder": "和 Agent 聊点什么…",
-      "inputHint": "Enter 发送",
-      "send": "发送",
       "noProjectForChat": "还没有项目 — 先新建一个,再来这里聊"
     },
     "openControlPanel": "进入控制面板",


### PR DESCRIPTION
## Capability
Workbench home (`/`) feedback: reuse the chat input component, center the hero panel, and drop the v1 placeholder text.

## Changes
1. **Shared Composer.** Extracted ChatPage's local compose input row into `ui/src/components/workbench/Composer.tsx` (auto-growing textarea + Send/Stop icon button, draft seeding). ChatPage's `Compose` is now a thin gradient wrapper around it, and the Workbench home uses the **same** `<Composer>` instead of its own hand-rolled input bar — one input component across the app. `busy`/`onStop`/`initialDraft`/`onDraftChange` are optional; added `placeholder` / `className` / `disabled` props for the home's create-and-navigate flow.
2. **Centered hero panel.** Dropped the `-my-5`/`-my-8` negative margins that cancelled the AppShell padding and made the canvas full-bleed (flush to the top, awkward bottom spacing). The hero + Composer now center as a group with the AppShell's top/bottom padding as margin; the hero is a contained `max-w-[640px]` card rather than a full-width fill.
3. **Removed** the `v1 placeholder · …` badge and its i18n keys.

## Scenarios
No scenario catalog covers the Workbench home; no scenario IDs apply.

## Evidence layers
- **Unit:** none (no UI unit harness).
- **Contract:** n/a — no API change; chat compose behavior is unchanged (same component + props, just relocated).
- **Scenario:** n/a.
- **Residual manual checks:** UI build (tsc -b + vite) passes; rendered the new home layout with the REAL shared `Composer` inside an AppShell-shaped viewport (centered panel with top margin, chat-style input, no v1 badge). Full in-app render pending regression deploy.