### PR TITLE
fix(ui): label IM private-chat section as "私聊" / "Direct Messages"

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -70,7 +70,7 @@
   "nav": {
     "dashboard": "Dashboard",
     "channels": "Groups",
-    "users": "Users",
+    "users": "Direct Messages",
     "settings": "Settings",
     "remoteAccess": "Remote Access",
     "doctor": "Doctor"
@@ -1204,7 +1204,7 @@
     "manageUserSettings": "Manage User Settings"
   },
   "userList": {
-    "title": "Users",
+    "title": "Direct Messages",
     "subtitle": "Bound users from each IM platform · per-user routing & admin rights.",
     "noUsers": "No bound users yet. Create a bind code and share it with users.",
     "filterPlaceholder": "Filter users…",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -70,7 +70,7 @@
   "nav": {
     "dashboard": "仪表盘",
     "channels": "群组",
-    "users": "用户",
+    "users": "私聊",
     "settings": "设置",
     "remoteAccess": "远程访问",
     "doctor": "诊断"
@@ -1204,7 +1204,7 @@
     "manageUserSettings": "管理用户设置"
   },
   "userList": {
-    "title": "用户",
+    "title": "私聊",
     "subtitle": "来自各 IM 平台的已绑定用户 · 单独路由 & 管理员权限。",
     "noUsers": "暂无绑定用户。创建绑定码并分享给用户。",
     "filterPlaceholder": "搜索用户…",


### PR DESCRIPTION
## What & why
The `/admin/users` section is really the per-DM-channel settings for the IM users who have bound to this Vibe Remote instance — but the sidebar nav item and the page header only said **用户 / Users**, which users found ambiguous (feedback: many users do not know what 用户 means here).

This renames the **section label** to **私聊 / Direct Messages** in both locales:
- sidebar nav item (value of `nav.users`)
- page header (value of `userList.title`)

## Scope / non-goals
- Underlying i18n keys, the `/admin/users` route, and all config/variables are **unchanged** — display copy only.
- In-page strings that refer to an **individual person** ("搜索用户", "邀请新用户", "移除此用户") and the Dashboard "已绑定用户" count card are intentionally left as-is: there "用户" correctly means a person, and the page subtitle ("来自各 IM 平台的已绑定用户") already explains what 私聊 is.

## Evidence layers
- **Unit / contract / scenario:** none — change is display copy only; no scenario catalog applies.
- **Residual manual checks:** `npm run build` passes; verified the built bundle contains 私聊 and Direct Messages for both the nav and the page title; diff is exactly 4 string values across `en.json` / `zh.json`.