### PR TITLE
fix(ui): shorten sidebar capabilities label to 能力

### DIFF
--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -455,7 +455,7 @@
       "noProjectForChat": "还没有项目 — 先新建一个,再来这里聊"
     },
     "openControlPanel": "进入控制面板",
-    "capabilitiesLabel": "能力模块",
+    "capabilitiesLabel": "能力",
     "projectsLabel": "项目",
     "addProject": "打开项目",
     "addSession": "在该项目新建会话",


### PR DESCRIPTION
## What & why
The workbench sidebar section label read **能力模块** ("Capability Module") in Chinese, while the English label is already the concise **Capabilities**. Per user feedback, drop the redundant "模块" so the zh label is simply **能力**.

## Scope
- zh-only display copy: value of `nav`-adjacent key `capabilitiesLabel` in `ui/src/i18n/zh.json` (能力模块 → 能力).
- English ("Capabilities") already omits "Module" — left unchanged.
- The i18n key, routes, and config are untouched.

## Evidence layers
- Unit / contract / scenario: none — display copy only.
- Residual manual checks: `npm run build` passes; JSON validated.