### PR TITLE
ci(tests): gate the unit suite per-file + fix the red tests it surfaced

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,35 @@ jobs:
           pip install pre-commit
           pre-commit run --all-files
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package-lock.json
+
+      # hatchling force-includes ui/dist into the (editable) install, so it must
+      # exist before `pip install -e .`.
+      - name: Build UI assets
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test deps
+        run: pip install -e . pytest
+
+      - name: Run unit tests (one file per process)
+        run: bash scripts/ci_unit_tests.sh
+
   npm-wrapper:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/ci_unit_tests.sh
+++ b/scripts/ci_unit_tests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Gate the unit test suite by running each test file in its OWN process.
+#
+# Why per-file: several test modules install module-level ``sys.modules`` stubs
+# for optional platform deps (slack_sdk, aiohttp, modules.agents.*, core.*) that
+# never tear down. Collecting the whole ``tests/`` tree in a single process
+# therefore fails at import time as those stubs shadow real packages for later
+# modules. Running each file in its own interpreter sidesteps that cross-file
+# pollution. Making the stubs fixture-scoped so a single ``pytest tests/`` works
+# is tracked separately; until then this is how the unit suite is CI-gated.
+#
+# Excludes ``tests/e2e`` (Docker) and the ``integration`` marker (Docker +
+# platform tokens) — those run in dedicated jobs. ``-p no:randomly`` keeps a
+# deterministic order if pytest-randomly happens to be installed (no-op when it
+# is not), and ``-o addopts=""`` ignores any ambient addopts.
+set -uo pipefail
+
+PYTEST=(python -m pytest)
+
+failed=""
+empty=""
+total=0
+while IFS= read -r f; do
+  total=$((total + 1))
+  "${PYTEST[@]}" "$f" -m "not integration" -p no:randomly -o addopts="" -q
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    :
+  elif [ "$rc" -eq 5 ]; then
+    # exit 5 = no tests collected (e.g. a file that is entirely integration-marked)
+    empty="$empty $f"
+  else
+    failed="$failed $f"
+  fi
+done < <(find tests -name 'test_*.py' -not -path 'tests/e2e/*' | sort)
+
+echo "========================================"
+echo "Ran ${total} unit test file(s), one process each."
+if [ -n "$empty" ]; then
+  echo "No unit tests collected (skipped):"
+  for f in $empty; do echo "  $f"; done
+fi
+if [ -n "$failed" ]; then
+  echo "FAILED files:"
+  for f in $failed; do echo "  $f"; done
+  exit 1
+fi
+echo "All unit test files passed."

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -119,6 +119,14 @@ _STUBBED_MODULES = {
     "modules.agents.codex.transport": _transport_module,
     "modules.agents.codex.turn_state": _turn_state_module,
 }
+# Prime the real ``modules.agents.catalog`` before installing the bare (no
+# ``__path__``) ``modules.agents`` stub below. Loading agent.py pulls in
+# core.show_pages -> config.v2_config -> ``from modules.agents.catalog import``;
+# without the real submodule cached first, the stub shadows it and standalone
+# collection fails with "modules.agents is not a package". Sibling test modules
+# import core.controller (which primes this), so a group run masks the issue.
+import modules.agents.catalog  # noqa: E402,F401
+
 _saved_modules = {name: sys.modules.get(name) for name in _STUBBED_MODULES}
 
 for name, module in _STUBBED_MODULES.items():

--- a/tests/test_codex_process_match.py
+++ b/tests/test_codex_process_match.py
@@ -61,9 +61,14 @@ def test_rejects_unrelated_node_process(tmp_path: Path) -> None:
 
 
 def test_rejects_different_codex_install(tmp_path: Path) -> None:
-    """Another codex install elsewhere on the system is not ours to kill."""
+    """A binary with a *different basename* is not ours to kill.
+
+    A same-basename ``codex`` elsewhere is now intentionally treated as a match
+    (api._process_matches_codex_binary basename fallback), so the rejection case
+    must use a distinct basename to stay meaningful.
+    """
     _, codex_path = _make_paths(tmp_path)
-    elsewhere = tmp_path / "other" / "codex"
+    elsewhere = tmp_path / "other" / "codex-canary"
     elsewhere.parent.mkdir(parents=True, exist_ok=True)
     elsewhere.write_text("#!/usr/bin/env node\n")
     cmdline = [str(elsewhere), "app-server"]

--- a/tests/test_native_session_providers.py
+++ b/tests/test_native_session_providers.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from types import SimpleNamespace
 import json
 
+import pytest
+
 from modules.agents.native_sessions.base import build_resume_preview, build_tail_preview
 from modules.agents.native_sessions import claude as claude_module
 from modules.agents.native_sessions.claude import ClaudeNativeSessionProvider, encode_project_path
@@ -291,6 +293,16 @@ def test_native_session_service_loads_default_providers_lazily(monkeypatch) -> N
     assert calls == ["modules.agents.native_sessions.claude"]
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "core.show_pages imports the storage/migration (sqlite) layer at module load, and "
+        "handler-path modules import it for lightweight constants/helpers (core.system_prompt_injection, "
+        "core.handlers.session_handler), so the lightweight import path transitively pulls in sqlite. "
+        "Fixing it cleanly means splitting ShowPageStore out of core.show_pages' constants module "
+        "(tracked separately). strict=True => remove this marker once that lands, or CI fails on XPASS."
+    ),
+)
 def test_native_session_lightweight_imports_do_not_require_sqlite() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     env = dict(os.environ)

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -185,15 +185,30 @@ def test_run_ui_server_reconciles_remote_access_after_binding(monkeypatch):
     fake_uvicorn.Server = DummyServer
     monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
 
+    import time
+
+    from core.services import settings as settings_service
+
     reconcile_calls = []
     config = _config()
 
     monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
-    monkeypatch.setattr(ui_server.V2Config, "load", lambda *args, **kwargs: config)
+    # run_ui_server loads config via settings_service.load_config (PR #340), not
+    # V2Config.load — patch the real seam, otherwise config is None and the
+    # reconcile thread early-returns.
+    monkeypatch.setattr(settings_service, "load_config", lambda *args, **kwargs: config)
     monkeypatch.setattr(ui_server, "init_sentry", lambda *args, **kwargs: None)
+    # With a non-None config the start path also kicks the status heartbeat; keep it inert.
+    monkeypatch.setattr(remote_access, "start_status_heartbeat", lambda *args, **kwargs: None)
     monkeypatch.setattr(remote_access, "reconcile", lambda next_config=None: reconcile_calls.append(next_config) or {"ok": True})
 
     ui_server.run_ui_server("127.0.0.1", 0)
+
+    # Reconcile runs on a daemon thread spawned after binding; poll briefly.
+    for _ in range(200):
+        if reconcile_calls:
+            break
+        time.sleep(0.01)
 
     assert reconcile_calls == [config]
 

--- a/tests/test_service_logging_handlers.py
+++ b/tests/test_service_logging_handlers.py
@@ -34,21 +34,24 @@ def test_start_service_disables_stdout_logging_for_background_process(monkeypatc
     monkeypatch.setattr(runtime.paths, "get_runtime_pid_path", lambda: pid_path)
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: False)
     monkeypatch.setattr(runtime, "get_service_main_path", lambda: Path("/tmp/main.py"))
+    monkeypatch.setattr(runtime, "service_instance_lock_available", lambda: (True, 0))
+    # Stub the real spawn (start_service calls spawn_service_background, not
+    # spawn_background) so we never fork a real vibe service, and short-circuit the
+    # post-spawn lock wait. This captures the env start_service would launch with.
+    monkeypatch.setattr(runtime, "wait_for_service_pid", lambda pid, *args, **kwargs: True)
 
-    def fake_spawn_background(args, pid_path_arg, stdout_name, stderr_name, env=None):
+    def fake_spawn_service_background(args, stdout_name, stderr_name, env=None):
         captured["args"] = args
-        captured["pid_path"] = pid_path_arg
         captured["stdout_name"] = stdout_name
         captured["stderr_name"] = stderr_name
         captured["env"] = env
         return 12345
 
-    monkeypatch.setattr(runtime, "spawn_background", fake_spawn_background)
+    monkeypatch.setattr(runtime, "spawn_service_background", fake_spawn_service_background)
 
     pid = runtime.start_service()
 
     assert pid == 12345
-    assert captured["pid_path"] == pid_path
     assert captured["stdout_name"] == "service_stdout.log"
     assert captured["stderr_name"] == "service_stderr.log"
     assert isinstance(captured["env"], dict)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from config import paths
@@ -14,6 +16,17 @@ from modules.agents.native_sessions import NativeResumeSession
 from modules.im import MessageContext
 from modules.im.telegram import TelegramBot
 from config.v2_config import TelegramConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_chat_discovery_cache():
+    """chat_discovery keeps process-global debounce/migration caches keyed on
+    (platform, chat_id) — not on the DB path — so a chat remembered by one test
+    short-circuits remember_chat in a later test that points get_vibe_remote_dir at
+    a fresh tmp dir. Clear them between tests for isolation."""
+    chat_discovery._debounce_cache.clear()
+    chat_discovery._migrated_db_paths.clear()
+    yield
 
 
 def test_normalize_command_text_strips_bot_mention() -> None:
@@ -290,7 +303,7 @@ def test_run_dispatches_telegram_updates_concurrently() -> None:
     second_started = asyncio.Event()
     poll_calls = 0
 
-    async def fake_get_updates(_token: str, _offset=None):
+    async def fake_get_updates(_token: str, _offset=None, proxy_url=None):
         nonlocal poll_calls
         poll_calls += 1
         if poll_calls == 1:
@@ -568,7 +581,7 @@ def test_add_reaction_uses_telegram_message_reactions() -> None:
         result = asyncio.run(bot.add_reaction(context, "77", ":eyes:"))
 
     assert result is True
-    reaction_mock.assert_awaited_once_with("123456:test-token", "-100123", "77", "👀")
+    reaction_mock.assert_awaited_once_with("123456:test-token", "-100123", "77", "👀", proxy_url=None)
 
 
 def test_remove_reaction_clears_telegram_message_reactions() -> None:
@@ -582,7 +595,7 @@ def test_remove_reaction_clears_telegram_message_reactions() -> None:
         result = asyncio.run(bot.remove_reaction(context, "77", ":eyes:"))
 
     assert result is True
-    reaction_mock.assert_awaited_once_with("123456:test-token", "-100123", "77")
+    reaction_mock.assert_awaited_once_with("123456:test-token", "-100123", "77", proxy_url=None)
 
 
 def test_resume_menu_uses_short_callback_ids() -> None:

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -253,7 +253,23 @@ def test_detect_cli_supports_explicit_path(monkeypatch, tmp_path):
     assert result["path"] == str(binary_path)
 
 
-def test_detect_cli_finds_npm_in_nvm(monkeypatch, tmp_path):
+@pytest.fixture
+def only_tmp_binaries(monkeypatch, tmp_path):
+    """Make CLI discovery hermetic: only executables under ``tmp_path`` count as
+    installed, so the runner's real ``/usr/local/bin/{npm,codex}`` (or a dev box's
+    homebrew/nvm binaries) can't leak into detection. ``api._candidate_cli_paths``
+    scans hardcoded common bin dirs (``/usr/local/bin``, ``/opt/homebrew/bin``)
+    that these tests cannot otherwise neutralize; without this they pass locally
+    but fail on a CI runner that has a real npm installed."""
+    real_is_exec = api._is_executable_file
+    monkeypatch.setattr(
+        api,
+        "_is_executable_file",
+        lambda p: str(p).startswith(str(tmp_path)) and real_is_exec(p),
+    )
+
+
+def test_detect_cli_finds_npm_in_nvm(monkeypatch, tmp_path, only_tmp_binaries):
     npm_path = tmp_path / ".nvm" / "versions" / "node" / "v22.18.0" / "bin" / "npm"
     npm_path.parent.mkdir(parents=True, exist_ok=True)
     npm_path.write_text("#!/bin/sh\n")
@@ -268,7 +284,7 @@ def test_detect_cli_finds_npm_in_nvm(monkeypatch, tmp_path):
     assert result["path"] == str(npm_path)
 
 
-def test_detect_cli_skips_non_version_entries_in_nvm(monkeypatch, tmp_path):
+def test_detect_cli_skips_non_version_entries_in_nvm(monkeypatch, tmp_path, only_tmp_binaries):
     # Real-world nvm dir on macOS can contain a .DS_Store file (Finder/iCloud)
     # and a "system" alias dir, alongside real vX.Y.Z version directories.
     # Mixed-type sort keys used to crash with TypeError; this regression test
@@ -296,7 +312,7 @@ def test_detect_cli_skips_non_version_entries_in_nvm(monkeypatch, tmp_path):
     assert result["path"] == str(newer_npm)
 
 
-def test_detect_cli_prefers_released_over_prerelease_in_nvm(monkeypatch, tmp_path):
+def test_detect_cli_prefers_released_over_prerelease_in_nvm(monkeypatch, tmp_path, only_tmp_binaries):
     # When both a released and a pre-release of the same major.minor.patch exist,
     # the released version must win. Locks in the released > prerelease ranking
     # in _nvm_version_sort_key (released maps to is_released=True).
@@ -320,7 +336,7 @@ def test_detect_cli_prefers_released_over_prerelease_in_nvm(monkeypatch, tmp_pat
     assert result["path"] == str(released_npm)
 
 
-def test_detect_cli_sorts_prerelease_numerically_in_nvm(monkeypatch, tmp_path):
+def test_detect_cli_sorts_prerelease_numerically_in_nvm(monkeypatch, tmp_path, only_tmp_binaries):
     # "-rc.10" > "-rc.2" numerically, but lexicographic string comparison
     # would put "-rc.10" before "-rc.2" (because "1" < "2"). Locks in that
     # suffix tokens are split and the numeric segment compares as int.
@@ -584,7 +600,7 @@ def test_install_codex_prefers_homebrew_when_npm_shares_prefix(monkeypatch, tmp_
     assert [str(npm_path), "install", "-g", "@openai/codex"] not in commands
 
 
-def test_install_codex_unknown_install_falls_back_to_cli_update(monkeypatch, tmp_path):
+def test_install_codex_unknown_install_falls_back_to_cli_update(monkeypatch, tmp_path, only_tmp_binaries):
     codex_path = tmp_path / "bin" / "codex"
     codex_path.parent.mkdir(parents=True)
     codex_path.write_text("#!/bin/sh\n")
@@ -689,7 +705,7 @@ def test_discord_list_channels_rejects_empty_guild_id(monkeypatch):
     assert result["error"] == "Discord guild_id is required"
 
 
-def test_install_codex_detects_existing_install_via_npm_prefix_and_upgrades_with_npm(monkeypatch, tmp_path):
+def test_install_codex_detects_existing_install_via_npm_prefix_and_upgrades_with_npm(monkeypatch, tmp_path, only_tmp_binaries):
     # Codex already installed under the npm global prefix; resolve_cli_path
     # must discover it (via `npm config get prefix`) and install_agent must
     # still upgrade by rerunning npm install -g @openai/codex.

--- a/tests/test_v2_config_platform_registry.py
+++ b/tests/test_v2_config_platform_registry.py
@@ -79,6 +79,7 @@ def test_config_payload_includes_platform_catalog_and_setup_state() -> None:
         "telegram",
         "lark",
         "wechat",
+        "avibe",
     ]
     assert [backend["id"] for backend in payload["agent_backend_catalog"]] == [
         "opencode",

--- a/tests/test_v2_sessions.py
+++ b/tests/test_v2_sessions.py
@@ -196,10 +196,12 @@ def test_migrate_session_mappings_moves_old_key_to_prefixed(tmp_path, monkeypatc
 
     # Old raw key should be gone
     assert "C0A6U2GH6P5" not in reloaded.state.session_mappings
-    # New prefixed key should have the entries
+    # New prefixed key should have the entries. The ``:/tmp/work`` cwd suffix in the
+    # seed is stripped on save (#368: anchors no longer carry the working path; it
+    # lives on the ``workdir`` column), so the round-tripped thread keys are bare.
     prefixed = reloaded.state.session_mappings.get("slack::C0A6U2GH6P5", {})
-    assert prefixed["opencode"]["slack_123.456:/tmp/work"] == "ses_old_abc"
-    assert prefixed["opencode"]["slack_789.012:/tmp/work"] == "ses_old_def"
+    assert prefixed["opencode"]["slack_123.456"] == "ses_old_abc"
+    assert prefixed["opencode"]["slack_789.012"] == "ses_old_def"
 
 
 def test_migrate_session_mappings_merges_without_overwriting(tmp_path, monkeypatch):
@@ -230,10 +232,11 @@ def test_migrate_session_mappings_merges_without_overwriting(tmp_path, monkeypat
 
     assert "C123" not in reloaded.state.session_mappings
     oc = reloaded.state.session_mappings["slack::C123"]["opencode"]
-    # Thread A keeps the fresh value (not overwritten by stale)
-    assert oc["slack_threadA:/work"] == "ses_fresh"
+    # Thread A keeps the fresh value (not overwritten by stale). Keys are bare:
+    # the ``:/work`` cwd suffix is stripped on save (#368).
+    assert oc["slack_threadA"] == "ses_fresh"
     # Thread B is carried over from old key
-    assert oc["slack_threadB:/work"] == "ses_old_B"
+    assert oc["slack_threadB"] == "ses_old_B"
 
 
 def test_migrate_session_mappings_cleans_empty_keys(tmp_path, monkeypatch):
@@ -299,7 +302,7 @@ def test_migrate_session_mappings_infers_platform_from_thread_ids(tmp_path, monk
     assert "D456" not in reloaded.state.session_mappings
     assert "slack::D456" not in reloaded.state.session_mappings
     prefixed = reloaded.state.session_mappings.get("discord::D456", {})
-    assert prefixed["opencode"]["discord_1485641561998889093:/work"] == "ses_discord_1"
+    assert prefixed["opencode"]["discord_1485641561998889093"] == "ses_discord_1"
 
 
 def test_migrate_session_mappings_is_idempotent(tmp_path, monkeypatch):
@@ -323,4 +326,4 @@ def test_migrate_session_mappings_is_idempotent(tmp_path, monkeypatch):
     store2.load()
 
     assert set(store2.state.session_mappings.keys()) == {"slack::C123"}
-    assert store2.state.session_mappings["slack::C123"]["opencode"]["slack_123.456:/work"] == "ses_abc"
+    assert store2.state.session_mappings["slack::C123"]["opencode"]["slack_123.456"] == "ses_abc"

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -210,7 +210,9 @@ def test_managed_watch_service_once_success_enqueues_hook_and_disables(tmp_path:
     saved = store.get_watch(watch.id)
 
     assert len(pending) == 1
-    assert pending[0].request_type == "hook_send"
+    # ManagedWatchService enqueues with the dedicated "watch" run_type (core/watches.py),
+    # which scheduled_tasks dispatches like a hook_send but tags as trigger_kind="watch".
+    assert pending[0].request_type == "watch"
     assert pending[0].prompt == "The waiter finished.\n\nwaiter output"
     assert saved is not None
     assert saved.enabled is False


### PR DESCRIPTION
## What

Gate the **unit pytest suite** in CI and fix the red tests that turning the gate on surfaced.

Today CI (`lint.yml`) runs only ruff, the npm wrapper, and a narrow install/upgrade/e2e pytest subset — **the unit suite (`tests/test_*.py`) has never run in CI**. That's how red tests merged undetected (e.g. #383 fixed a `test_dispatcher_stream_chunk` that had been red on master since #367).

## Why per-file

A single `pytest tests/` collection currently **fails at import time**: ~7 test modules install module-level `sys.modules` stubs (for optional platform deps / `core.*` / `modules.agents.*`) that never tear down, so they shadow real packages for later-collected modules (13 collection errors). The new `unit-tests` job runs **each test file in its own process** via `scripts/ci_unit_tests.sh`, which structurally sidesteps that cross-file pollution with zero changes to the polluting tests. Making those stubs fixture-scoped so a single `pytest tests/` works is left as tracked debt.

`tests/e2e` (Docker) and the `integration` marker (Docker + platform tokens) are excluded — they run in dedicated jobs.

## Red tests fixed (9 files)

All were **stale tests or test self-containment gaps — no production regressions**, except one real layering issue (xfailed + tracked):

| Test | Verdict | Fix |
| --- | --- | --- |
| `test_v2_config_platform_registry` | stale | `avibe` is now a first-class platform — add to expected catalog |
| `test_v2_sessions` (×4) | stale | #368 strips the `:cwd` anchor suffix — assert bare round-tripped keys |
| `test_watches` | stale | `ManagedWatchService` enqueues `run_type="watch"`, not `"hook_send"` |
| `test_sentry_integration` | stale | `run_ui_server` loads via `settings_service.load_config` (PR #340), not `V2Config.load` — patch the real seam + poll the reconcile daemon |
| `test_codex_process_match` | stale | same-basename `codex` is now intentionally matched — distinct basename for the rejection case |
| `test_telegram_bot` (×4) | stale + self-containment | `get_updates`/reactions take `proxy_url` now; + autouse fixture clearing `chat_discovery`'s process-global debounce cache |
| `test_codex_agent` | self-containment | prime the real `modules.agents.catalog` before the bare `modules.agents` stub so standalone collection resolves it |
| `test_service_logging_handlers` | stale + safety | retarget the stub to `spawn_service_background` (the real call) so the test **no longer forks a real vibe service**; also stub `wait_for_service_pid` |
| `test_native_session_providers` | **real layering issue** | `xfail(strict)` the lightweight-import contract — `core.show_pages` imports the storage/sqlite layer at module load and handler-path modules import it for constants, so the handler import path pulls in sqlite. Clean fix (split `ShowPageStore` out of `show_pages`) tracked separately. |

## Evidence layers

- **Unit**: `scripts/ci_unit_tests.sh` runs green across **all 145 unit files** (0 failures, 1 expected xfail); the new CI job runs it on this PR. `ruff check` clean.
- **Contract/scenario**: no scenario catalog touched; the per-file runner *is* the new contract for the unit layer.
- **Residual manual**: confirmed async tests execute for real via the `anyio` pytest plugin (injected a failing assert into an `async def test_` → it failed), so the gate is meaningful and not false-green. The service-spawning test was verified to no longer launch a real process.

## Not in this PR (tracked)

- Make the module-level `sys.modules` stubs fixture-scoped so a single-process `pytest tests/` collects cleanly.
- Decouple `ShowPageStore` from `core.show_pages`' lightweight constants so the handler import path stays DB-layer-free (removes the one `xfail`).

No production code is changed in this PR.
