### PR TITLE
fix(ui): handle folder-less projects in AGENTS.md editor + robust API error rendering

### DIFF
--- a/ui/src/components/workbench/ProjectAgentsMdDialog.tsx
+++ b/ui/src/components/workbench/ProjectAgentsMdDialog.tsx
@@ -69,7 +69,7 @@ export const ProjectAgentsMdDialog: React.FC<{
   if (!data) {
     return (
       <Dialog open onOpenChange={(next) => !next && onClose()}>
-        <DialogContent className="flex max-w-sm items-center gap-3">
+        <DialogContent className="flex max-w-sm items-center gap-3" aria-describedby={undefined}>
           <DialogTitle className="sr-only">{t('agentsMd.title')}</DialogTitle>
           <Loader2 className="size-4 animate-spin text-muted" />
           <span className="text-[13px] text-muted">{t('agentsMd.loading')}</span>

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -319,17 +319,19 @@ const ProjectRow: React.FC<{
                   <Pencil className="size-3 text-muted" />
                   {t('workbench.projectRename')}
                 </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setMenuOpen(false);
-                    setAgentsMdOpen(true);
-                  }}
-                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
-                >
-                  <FileText className="size-3 text-muted" />
-                  {t('workbench.projectEditAgents')}
-                </button>
+                {project.folder_path && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      setAgentsMdOpen(true);
+                    }}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
+                  >
+                    <FileText className="size-3 text-muted" />
+                    {t('workbench.projectEditAgents')}
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={async () => {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -907,8 +907,17 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     try {
       const data = await res.json();
       if (data.error) {
-        errorCode = typeof data.error === 'string' ? data.error : null;
-        errorMessage = t(`errors.${data.error}`, { defaultValue: data.error });
+        // ``error`` may be a plain string (an errors.<key> code) or a
+        // structured ``{ code, message }`` object (project-scoped routes).
+        // Localize by code, falling back to the server-provided message so we
+        // never render a key like ``errors.[object Object]``.
+        const code = typeof data.error === 'string' ? data.error : data.error?.code;
+        const fallback =
+          typeof data.error === 'string'
+            ? data.error
+            : data.error?.message ?? data.error?.code ?? errorMessage;
+        errorCode = typeof code === 'string' ? code : null;
+        errorMessage = errorCode ? t(`errors.${errorCode}`, { defaultValue: fallback }) : fallback;
       }
     } catch {
       // Response is not JSON, use status text

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -432,6 +432,8 @@
     "retry": "Retry"
   },
   "errors": {
+    "project_no_folder": "This project has no local folder configured, so AGENTS.md can't be edited.",
+    "project_not_found": "Project not found.",
     "remote_access_host_mismatch": "This address can't open the Vibe Remote control panel. Open it from your https://<your-slug>.avibe.bot link, or http://127.0.0.1:5123 on the machine running Vibe Remote.",
     "remote_access_config_unavailable": "Vibe Remote couldn't read its configuration. Check that the service is healthy and try again.",
     "remote_access_public_url_invalid": "Remote access is misconfigured (the public URL is invalid). Re-pair this device or fix the remote-access settings.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -432,7 +432,7 @@
     "retry": "Retry"
   },
   "errors": {
-    "project_no_folder": "This project has no local folder configured, so AGENTS.md can't be edited.",
+    "project_no_folder": "This project has no local folder configured.",
     "project_not_found": "Project not found.",
     "remote_access_host_mismatch": "This address can't open the Vibe Remote control panel. Open it from your https://<your-slug>.avibe.bot link, or http://127.0.0.1:5123 on the machine running Vibe Remote.",
     "remote_access_config_unavailable": "Vibe Remote couldn't read its configuration. Check that the service is healthy and try again.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -432,7 +432,7 @@
     "retry": "重试"
   },
   "errors": {
-    "project_no_folder": "这个项目没有配置本地文件夹，无法编辑 AGENTS.md。",
+    "project_no_folder": "这个项目没有配置本地文件夹。",
     "project_not_found": "找不到这个项目。",
     "remote_access_host_mismatch": "这个地址无法打开 Vibe Remote 控制台。请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Vibe Remote 的机器上访问 http://127.0.0.1:5123。",
     "remote_access_config_unavailable": "Vibe Remote 无法读取配置。请确认服务运行正常后重试。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -432,6 +432,8 @@
     "retry": "重试"
   },
   "errors": {
+    "project_no_folder": "这个项目没有配置本地文件夹，无法编辑 AGENTS.md。",
+    "project_not_found": "找不到这个项目。",
     "remote_access_host_mismatch": "这个地址无法打开 Vibe Remote 控制台。请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Vibe Remote 的机器上访问 http://127.0.0.1:5123。",
     "remote_access_config_unavailable": "Vibe Remote 无法读取配置。请确认服务运行正常后重试。",
     "remote_access_public_url_invalid": "远程访问配置有误（公网地址无效）。请重新配对此设备或修正远程访问设置。",


### PR DESCRIPTION
## What & why

Regression testing surfaced three issues when opening the **Edit AGENTS.md** dialog on a project that has **no configured folder** (common for IM-channel-derived projects):

1. **Broken error toast** — the GET returned the structured `{ ok: false, error: { code, message } }` shape (the project-scoped convention), but `handleApiError` only handled a plain-string `error`, so `` t(`errors.${data.error}`) `` produced the key `errors.[object Object]` → *"returned an object instead of string."* Now it handles **both** shapes: localize by `code`, fall back to the server `message`. This also fixes the skills routes, which return the same shape.
2. **Action offered where it can't work** — gate the "Edit AGENTS.md" menu item on `project.folder_path`; a folder-less project has no directory to read/write, so the item is now hidden rather than failing on click.
3. **Radix a11y warning** — the brief loading dialog had no description; added `aria-describedby={undefined}` (the documented opt-out) to silence *"Missing `Description` … for {DialogContent}."*

## Scope
- Frontend only: `WorkbenchSidebar.tsx` (gate), `context/ApiContext.tsx` (`handleApiError`, shared), `ProjectAgentsMdDialog.tsx` (a11y), `i18n/{zh,en}.json` (two `errors.*` codes). No backend/route change.

## Evidence layers
- **Unit / contract / scenario:** n/a — UI error-handling + display gating; no backend logic changed.
- **Residual manual checks:** `npm run build` clean (tsc + vite); i18n JSON validated. Reproduced against the regression report: folder-less project → menu item hidden; if reached, the GET error now renders a localized message; no Radix description warning.
