### PR TITLE
fix(projects): archive works for folder-less projects

### DIFF
--- a/storage/projects_service.py
+++ b/storage/projects_service.py
@@ -257,11 +257,30 @@ def archive_project(conn: Connection, project_id: str) -> dict[str, Any]:
         raise LookupError(f"Project not found: {project_id}")
 
     now = _utc_now_iso()
-    conn.execute(
-        update(scope_settings)
-        .where(scope_settings.c.scope_id == scope_id)
-        .values(enabled=0, updated_at=now)
-    )
+    has_settings = conn.execute(
+        select(scope_settings.c.scope_id).where(scope_settings.c.scope_id == scope_id)
+    ).scalar_one_or_none()
+    if has_settings is None:
+        # Folder-less legacy projects never got a scope_settings row, so a plain
+        # UPDATE would archive nothing (0 rows) and the project would stay
+        # visible. Insert a disabled row so it drops out of the default list
+        # like any other archived project.
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=0,
+                settings_version=1,
+                settings_json=json.dumps({}),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    else:
+        conn.execute(
+            update(scope_settings)
+            .where(scope_settings.c.scope_id == scope_id)
+            .values(enabled=0, updated_at=now)
+        )
     conn.execute(
         update(scopes)
         .where(scopes.c.id == scope_id)

--- a/tests/test_projects_service.py
+++ b/tests/test_projects_service.py
@@ -136,6 +136,51 @@ def test_path_lookup_ignores_non_project_scopes(engine, tmp_path):
     assert proj["scope_id"].startswith("avibe::project::")
 
 
+def test_archive_folderless_project_hides_it(engine):
+    """A legacy project scope with no scope_settings row must still archive.
+
+    Such projects (created before the folder was mandatory) have no settings
+    row, so the old UPDATE-only archive was a no-op and they stayed visible.
+    archive_project now inserts a disabled row so they drop out of the list.
+    """
+    ts = "2026-01-01T00:00:00Z"
+    scope_id = "avibe::project::proj_folderless"
+    with engine.begin() as conn:
+        conn.execute(
+            scopes.insert().values(
+                id=scope_id,
+                platform="avibe",
+                scope_type="project",
+                native_id="proj_folderless",
+                parent_scope_id=None,
+                display_name="legacy",
+                native_type="project",
+                is_private=1,
+                supports_threads=1,
+                metadata_json="{}",
+                first_seen_at=ts,
+                last_seen_at=ts,
+                updated_at=ts,
+            )
+        )
+
+    # No scope_settings row → shown in the default list (treated as active).
+    with engine.connect() as conn:
+        assert any(p["id"] == "proj_folderless" for p in projects_service.list_projects(conn))
+
+    with engine.begin() as conn:
+        result = projects_service.archive_project(conn, "proj_folderless")
+    assert result["archived"] is True
+
+    # Now hidden by default, but still present when archived are included.
+    with engine.connect() as conn:
+        assert all(p["id"] != "proj_folderless" for p in projects_service.list_projects(conn))
+        assert any(
+            p["id"] == "proj_folderless"
+            for p in projects_service.list_projects(conn, include_archived=True)
+        )
+
+
 def test_duplicate_path_pick_prefers_active_then_recent(engine, tmp_path):
     """Legacy duplicates for one path resolve deterministically: active first."""
     folder = tmp_path / "dup"


### PR DESCRIPTION
## What & why
`archive_project` only ran `UPDATE scope_settings SET enabled=0`, which affects **0 rows** for a legacy project that has no `scope_settings` row (created before a folder was mandatory). Those projects could never be archived from the UI — the Archive action silently did nothing and they stayed in the sidebar. Now, when no settings row exists, archive **inserts a disabled one** so the project drops out of the default list like any other archived project.

## Scope
- `storage/projects_service.py::archive_project` — insert-if-missing; the UPDATE path is unchanged for normal projects.
- No API/UI change; the existing `DELETE /api/projects/<id>` (archive) now works for these projects too.

## Evidence layers
- **Unit**: `tests/test_projects_service.py::test_archive_folderless_project_hides_it` — seeds a project scope with no settings row, archives it, asserts it leaves the default list and remains under `include_archived`. Existing foldered-archive test still passes. 6/6 pass.
- **Contract / scenario**: n/a (single-service behaviour).
- **Residual manual checks**: `ruff` clean on the changed files.