### PR TITLE
refactor(workbench): fold avibe turn execution state into one Turn dataclass (#85)

### DIFF
--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -73,8 +73,8 @@ def create_app(controller: "Controller") -> FastAPI:
         openapi_url=None,
     )
 
-    # In-flight ``dispatch_turn`` tasks per session, each stored together with
-    # the routing ``MessageContext`` the turn STARTED under. The cancel
+    # In-flight ``dispatch_turn`` tasks per session, each a ``Turn`` holding the
+    # task + the routing ``MessageContext`` the turn STARTED under. The cancel
     # endpoint looks the task up here so the UI can stop a runaway turn without
     # waiting for the agent to settle, and reuses the stored context so it
     # interrupts the backend the turn actually started on — even if the Chat
@@ -84,9 +84,9 @@ def create_app(controller: "Controller") -> FastAPI:
     # The turn owner (FSM) is created in Controller.__init__ so it exists for boot
     # stale-reset + OpenCode restore; reuse it here and bind the routing-context
     # builder now that the gate (which owns _build_session_context) is built. A fake
-    # controller in tests may lack one — create it then. The containers bound below
-    # are the SAME objects the closures + ``controller.session_turn_gate`` use.
-    from core.session_turns import SessionTurnManager
+    # controller in tests may lack one — create it then. The registry bound below
+    # is the SAME object the closures + ``controller.session_turn_gate`` use.
+    from core.session_turns import SessionTurnManager, Turn
 
     manager = getattr(controller, "session_turns", None)
     if not isinstance(manager, SessionTurnManager):
@@ -96,21 +96,12 @@ def create_app(controller: "Controller") -> FastAPI:
         controller.session_turns = manager
     manager.bind_context(_build_session_context)
 
+    # The turn registry (``session_id -> Turn``) is owned by the manager; the legacy
+    # streaming ``/internal/dispatch`` (Show-page) endpoint below shares it directly,
+    # and tests inspect it via ``app.state``. The flush intents live ON each ``Turn``
+    # (set by ``manager.cancel`` / ``manager.send_now``), not in side sets here.
     in_flight = manager.in_flight
     app.state.in_flight_dispatches = in_flight
-
-    # Sessions whose current turn should flush its send-while-busy queue EVEN
-    # though it's ending via cancellation. A plain Stop cancels without flushing
-    # (the user asked to keep the queue — "不清空队列"); ``send-now`` cancels the
-    # running turn but sets this so the queue runs immediately afterwards.
-    flush_on_cancel = manager.flush_on_cancel
-    app.state.flush_on_cancel = flush_on_cancel
-
-    # Sessions whose current turn is being stopped by a plain Stop and must NOT
-    # flush, even if the backend interrupt lets the turn settle NORMALLY (no
-    # CancelledError) during the awaited stop — a Stop keeps the queue ("不清空").
-    # Recorded before awaiting the interrupt so the race is covered.
-    stop_no_flush = manager.stop_no_flush
 
     async def _flush_queue(session_id: str) -> bool:
         """Thin delegation to ``SessionTurnManager.flush_queue`` (FSM, Phase 1b):
@@ -194,7 +185,7 @@ def create_app(controller: "Controller") -> FastAPI:
         # interrupt, so the Stop button would silently no-op.
         if isinstance(session_id, str) and session_id:
             existing = in_flight.get(session_id)
-            if existing is not None and not existing[0].done():
+            if existing is not None and not existing.task.done():
                 async def _busy_stream():
                     yield _sse_event("turn.start", {"session_id": session_id})
                     yield _sse_event(
@@ -240,7 +231,7 @@ def create_app(controller: "Controller") -> FastAPI:
 
         task = asyncio.create_task(_runner(), name="internal-dispatch")
         if isinstance(session_id, str) and session_id:
-            in_flight[session_id] = (task, context)
+            in_flight[session_id] = Turn(task=task, context=context)
 
         async def _stream():
             saw_cancel = False

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from core.services.dispatch import SOURCE_HUMAN, SOURCE_SCHEDULED, dispatch_turn
@@ -89,22 +90,49 @@ def emit_matches_active_turn(sink: dict, context: "MessageContext") -> bool:
     return not (sink_token is not None and ctx_token != sink_token)
 
 
+@dataclass
+class Turn:
+    """The one active turn for an avibe session — the EXECUTION half of the FSM
+    state, keyed by ``session_id`` in ``SessionTurnManager.in_flight``.
+
+    - ``task`` / ``context``: the running dispatch task + the ``MessageContext`` the
+      turn STARTED under (so Stop interrupts the backend it actually ran on, even if
+      the Chat header later swapped agent/model). ``task`` is the Stop target
+      (``/internal/cancel``) and the ``/turn-state`` source.
+    - ``flush_on_cancel``: drain the send-while-busy queue even though the turn ends
+      via cancellation — ``send-now`` cancels the running turn but wants the queue to
+      run right after. A plain Stop keeps the queue ("不清空队列").
+    - ``stop_no_flush``: a plain Stop is interrupting this turn and it must NOT flush,
+      even if the backend interrupt lets the turn settle normally (no
+      ``CancelledError``) during the awaited stop.
+
+    The two intents live HERE rather than in parallel ``set``s so they retire with
+    the turn: ``cancel`` / ``send_now`` set them on this object and ``_run`` reads
+    them off the SAME object when it pops it — no separate ``.discard()`` to leak.
+
+    The streaming SINK is deliberately NOT held here: it is keyed by ``session_key``
+    (platform-prefixed ``avibe::<id>``) not ``session_id``, is registered from the
+    dispatcher on the emit path, and is platform-agnostic (a future IM stream has a
+    sink but no avibe ``session_id``). See ``SessionTurnManager.active_turn_sinks``.
+    """
+
+    task: asyncio.Task
+    context: "MessageContext"
+    flush_on_cancel: bool = False
+    stop_no_flush: bool = False
+
+
 class SessionTurnManager:
     """Owns the live per-session turn state + lifecycle for avibe sessions.
 
-    Containers (the same shapes the gate used inline):
+    State (a session has at most one active turn):
 
-    - ``in_flight``: ``session_id -> (task, context)`` for the active turn. It is
-      the Stop target (``/internal/cancel``), the ``/turn-state`` source, and the
-      trigger for draining the send-while-busy queue. The stored ``MessageContext``
-      is the one the turn STARTED under, so Stop interrupts the backend the turn
-      actually ran on even if the Chat header later changed agent/model.
-    - ``flush_on_cancel``: sessions whose queue should flush even though the turn is
-      ending via cancellation — ``send-now`` cancels the running turn but wants the
-      queue to run immediately after. A plain Stop keeps the queue ("不清空队列").
-    - ``stop_no_flush``: sessions being stopped by a plain Stop that must NOT flush,
-      even if the backend interrupt lets the turn settle normally (no
-      ``CancelledError``) during the awaited stop.
+    - ``in_flight``: ``session_id -> Turn`` for the active turn — the Stop target
+      (``/internal/cancel``), the ``/turn-state`` source, the trigger for draining
+      the send-while-busy queue, and the carrier of the two end-of-turn flush
+      intents (``Turn.flush_on_cancel`` / ``Turn.stop_no_flush``).
+    - ``active_turn_sinks``: the live streaming sink per ``session_key`` — the
+      streaming half, kept separate on purpose (see ``Turn``).
 
     ``controller`` reaches the backends + the outbound chokepoint
     (``emit_agent_message``); ``build_context`` rebuilds a session's routing
@@ -120,9 +148,7 @@ class SessionTurnManager:
     ) -> None:
         self.controller = controller
         self._build_context = build_context
-        self.in_flight: dict[str, tuple[asyncio.Task, "MessageContext"]] = {}
-        self.flush_on_cancel: set[str] = set()
-        self.stop_no_flush: set[str] = set()
+        self.in_flight: dict[str, Turn] = {}
         # The live streaming turn sink per SESSION KEY (avibe/web-Chat only; IM/CLI
         # turns register none). Each is ``{on_chunk, done_event, turn_token}`` — the
         # turn's stream callback + completion event + correlation token. Keyed by
@@ -174,7 +200,7 @@ class SessionTurnManager:
         from storage.db import create_sqlite_engine
 
         entry = self.in_flight.get(session_id)
-        busy = entry is not None and not entry[0].done()
+        busy = entry is not None and not entry.task.done()
         # Enqueue when a turn is running OR a prior Stop left queued rows behind — the
         # new message must run AFTER them, not jump ahead (Codex P2).
         if busy:
@@ -266,7 +292,7 @@ class SessionTurnManager:
                     # user stopped it, or dispatch raised before any backend turn.
                     # NO turn-duration timeout: the slot is freed only by a real
                     # terminal signal here (Phase 1a — STUCK/sentinel removed).
-                    self.in_flight.pop(session_id, None)
+                    turn = self.in_flight.pop(session_id, None)
                     bus.publish("turn.end", {"session_id": session_id})
                     # Converge the no-terminal-result outcome onto the OUTBOUND status
                     # chokepoint. The normal path already emitted a terminal result;
@@ -275,20 +301,20 @@ class SessionTurnManager:
                     # → dot red. This is a real terminal FAILURE, not a timeout.
                     if failed:
                         await self.controller.emit_agent_message(context, "result", "", is_error=True)
-                    # Don't flush after a Stop (keep the queue) or a terminal failure.
-                    # send-now still forces a flush via flush_on_cancel.
+                    # Flush intents ride on the popped Turn (set by cancel / send_now),
+                    # so they retire with it — no parallel set to discard. Don't flush
+                    # after a plain Stop (keep the queue) or a terminal failure; send-now
+                    # still forces a flush via flush_on_cancel.
                     should_flush = (
-                        (not cancelled and not failed and session_id not in self.stop_no_flush)
-                        or (session_id in self.flush_on_cancel)
+                        (not cancelled and not failed and not (turn is not None and turn.stop_no_flush))
+                        or (turn is not None and turn.flush_on_cancel)
                     )
-                    self.flush_on_cancel.discard(session_id)
-                    self.stop_no_flush.discard(session_id)
                     if should_flush:
                         await self.flush_queue(session_id)
 
         task = asyncio.create_task(_runner(), name="internal-dispatch-async")
         if isinstance(session_id, str) and session_id:
-            self.in_flight[session_id] = (task, context)
+            self.in_flight[session_id] = Turn(task=task, context=context)
             bus.publish("turn.start", {"session_id": session_id})
 
     async def flush_queue(self, session_id: str) -> bool:
@@ -401,7 +427,7 @@ class SessionTurnManager:
         dispatch survives browser disconnects, so a freshly loaded / reconnected
         Chat page asks this to restore its working / Stop state (Codex P2)."""
         entry = self.in_flight.get(session_id)
-        active = entry is not None and not entry[0].done()
+        active = entry is not None and not entry.task.done()
         return {"ok": True, "session_id": session_id, "in_flight": active}
 
     async def cancel(self, session_id: str) -> dict:
@@ -411,22 +437,21 @@ class SessionTurnManager:
         ("不清空"). Returns a result dict; ``code`` is ``not_in_flight`` /
         ``stop_failed`` for the HTTP adapter to map to 404 / 409, else a 200 status.
         """
-        entry = self.in_flight.get(session_id)
-        if entry is None:
+        turn = self.in_flight.get(session_id)
+        if turn is None:
             return {"ok": False, "code": "not_in_flight", "session_id": session_id}
-        task, turn_context = entry
-        if task.done():
+        if turn.task.done():
             return {"ok": True, "session_id": session_id, "status": "already_finished"}
         # Record the no-flush intent BEFORE awaiting the interrupt: if the backend
         # stop lets the turn settle normally during the await (no CancelledError),
-        # submit()'s finally would otherwise treat it as a natural completion and
+        # _run's finally would otherwise treat it as a natural completion and
         # flush — but a plain Stop keeps the queue (Codex P2). We pass the context the
         # turn STARTED under so the right backend is interrupted even if the Chat
         # header swapped the session's agent / model mid-turn.
-        self.stop_no_flush.add(session_id)
+        turn.stop_no_flush = True
         stopped = False
         try:
-            stopped = bool(await self.controller.command_handler.handle_stop(turn_context))
+            stopped = bool(await self.controller.command_handler.handle_stop(turn.context))
         except Exception:
             logger.exception("internal cancel: backend stop failed for session=%s", session_id)
         if not stopped:
@@ -435,9 +460,9 @@ class SessionTurnManager:
             # Don't cancel the waiter — that would fire a false ``turn.end``, hide
             # Stop, and let follow-up work start while the turn still produces output
             # (Codex P2).
-            self.stop_no_flush.discard(session_id)
+            turn.stop_no_flush = False
             return {"ok": False, "code": "stop_failed", "session_id": session_id}
-        task.cancel()
+        turn.task.cancel()
         return {"ok": True, "session_id": session_id, "status": "cancel_requested"}
 
     async def send_now(self, session_id: str) -> dict:
@@ -452,8 +477,8 @@ class SessionTurnManager:
         from storage import messages_service
         from storage.db import create_sqlite_engine
 
-        entry = self.in_flight.get(session_id)
-        if entry is not None and not entry[0].done():
+        turn = self.in_flight.get(session_id)
+        if turn is not None and not turn.task.done():
             # Don't interrupt a live turn unless there is actually something queued to
             # cut in with — a stale queue item already flushed by another tab would
             # otherwise make send-now an unintended Stop (Codex P2).
@@ -462,20 +487,19 @@ class SessionTurnManager:
                 has_queue = bool(messages_service.list_queued(conn, session_id))
             if not has_queue:
                 return {"ok": True, "session_id": session_id, "status": "empty"}
-            _task, turn_context = entry
             # Record the flush intent BEFORE awaiting the interrupt (same race as
             # cancel, opposite intent: send-now WANTS the queue to run). Drop it on a
             # refused stop and leave the turn + queue untouched (Codex P2).
-            self.flush_on_cancel.add(session_id)
+            turn.flush_on_cancel = True
             stopped = False
             try:
-                stopped = bool(await self.controller.command_handler.handle_stop(turn_context))
+                stopped = bool(await self.controller.command_handler.handle_stop(turn.context))
             except Exception:
                 logger.exception("internal send-now: backend stop failed for session=%s", session_id)
             if not stopped:
-                self.flush_on_cancel.discard(session_id)
+                turn.flush_on_cancel = False
                 return {"ok": False, "code": "stop_failed", "session_id": session_id}
-            _task.cancel()
+            turn.task.cancel()
             return {"ok": True, "session_id": session_id, "status": "interrupted"}
         # No running turn — flush the queue directly as a new turn (rebuilds routing
         # from the current session row internally). ``empty`` when nothing flushed.

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -376,7 +376,7 @@ def test_dispatch_async_no_terminal_result_keeps_session_in_flight(monkeypatch, 
             # is STILL held — no timer auto-freed it.
             await asyncio.sleep(0.1)
             entry = app.state.in_flight_dispatches.get("ses_long")
-            captured["held"] = entry is not None and not entry[0].done()
+            captured["held"] = entry is not None and not entry.task.done()
             # Only a real cancel frees the slot — clean up so the loop tears down.
             resp_cancel = await client.post("/internal/cancel/ses_long")
             captured["cancel_status"] = resp_cancel.status_code
@@ -432,9 +432,9 @@ def test_dispatch_async_enqueues_during_busy_turn(monkeypatch, tmp_path):
             await asyncio.sleep(60)
 
         task = asyncio.create_task(_busy())
-        app.state.in_flight_dispatches[session_id] = (
-            task,
-            MessageContext(user_id="U", channel_id="C", platform="avibe"),
+        app.state.in_flight_dispatches[session_id] = session_turns.Turn(
+            task=task,
+            context=MessageContext(user_id="U", channel_id="C", platform="avibe"),
         )
         sub_id, events = bus.subscribe()
         try:
@@ -590,9 +590,9 @@ def test_turn_state_reflects_in_flight():
             idle = (await client.get("/internal/turn-state/ses_ts")).json()
             # Simulate an in-flight turn.
             task = asyncio.create_task(asyncio.sleep(60))
-            app.state.in_flight_dispatches["ses_ts"] = (
-                task,
-                MessageContext(user_id="U", channel_id="C", platform="avibe"),
+            app.state.in_flight_dispatches["ses_ts"] = session_turns.Turn(
+                task=task,
+                context=MessageContext(user_id="U", channel_id="C", platform="avibe"),
             )
             busy = (await client.get("/internal/turn-state/ses_ts")).json()
             task.cancel()
@@ -762,13 +762,13 @@ def test_scheduled_gate_busy_enqueues_and_leaves_chat_turn_untouched(monkeypatch
 
         chat_task = asyncio.create_task(_busy())
         chat_ctx = MessageContext(user_id="U", channel_id="C", platform="avibe")
-        app.state.in_flight_dispatches[session_id] = (chat_task, chat_ctx)
+        app.state.in_flight_dispatches[session_id] = session_turns.Turn(task=chat_task, context=chat_ctx)
         try:
             await controller.session_turn_gate.submit_scheduled(session_id, ctx, "scheduled while busy")
         finally:
             entry = app.state.in_flight_dispatches.get(session_id)
             # The in-flight Chat turn is undisturbed: same task object, not cancelled.
-            assert entry is not None and entry[0] is chat_task and not chat_task.done()
+            assert entry is not None and entry.task is chat_task and not chat_task.done()
             chat_task.cancel()
         return chat_ctx
 


### PR DESCRIPTION
## Capability

Collapses the avibe turn owner's **execution-half** state — previously three parallel `session_id`-keyed containers (`in_flight` = task+context, `flush_on_cancel`, `stop_no_flush`) — into **one `Turn` dataclass** held in `in_flight: dict[str, Turn]`. This is the deferred single-object refinement from the #85 turn-lifecycle FSM: the turn becomes a real object, not state smeared across a dict + two sets.

No user-visible behavior change, with one intentional bug fix (below).

## What changed

- **`core/session_turns.py`**: new `@dataclass Turn(task, context, flush_on_cancel=False, stop_no_flush=False)`. `cancel` / `send_now` set the intent **on the Turn**; `_run` reads it off the **same** object when it pops the turn — the side `set`s and their hand-managed `.discard()` bookkeeping are gone.
- **Latent leak fixed**: cancelling a Show-page `/internal/dispatch` turn used to `add()` `session_id` to the `stop_no_flush` *set* and never remove it (that path doesn't run `_run`'s `finally`), which would suppress the send-while-busy flush on a *later* Chat turn of the same session. On the `Turn`, the flag retires with the turn.
- **`core/internal_server.py`**: the legacy Show-page `/internal/dispatch` stores `Turn(task, context)` and reads `existing.task.done()`; removed the dead `flush_on_cancel`/`stop_no_flush` `app.state` aliases (leftovers from before `cancel`/`send_now` moved onto the manager — nothing read them).

## Deliberately NOT merged: the streaming sink

The sink registry (`active_turn_sinks`) stays separate. Evidence, not preference: it is keyed by `session_key` (platform-prefixed `avibe::<id>`, **not** `session_id`), registered from the dispatcher on the emit path, and platform-agnostic (a future IM stream has a sink but no avibe `session_id`). Folding it into a `session_id`-keyed avibe `Turn` would couple a transport detail to avibe identity and require a back-mapping index — complexity for zero correctness gain. So "one Turn object" = the execution half; the sink remains the documented streaming half.

## Evidence layers

- **Unit**: full per-file unit suite green (146 files, one process each via `scripts/ci_unit_tests.sh`); `ruff` clean. The turn-lifecycle guarantees are locked by the **unchanged** `test_internal_server.py` suite — `test_cancel_does_not_flush_queue`, `test_async_dispatch_flushes_queue_on_turn_end`, send-now, and the scheduled-gate idle/busy/cancel tests — which still pass against the new representation. Seeds/reads of `in_flight` updated to `session_turns.Turn`.
- **Contract**: dispatcher ↔ sink contract untouched (sink left as-is).
- **Scenario**: regression catalog in `docs/plans/avibe-turn-lifecycle-fsm.md` Part 4 (turn lifecycle / Stop-no-flush / send-now / flush-on-end) covered by the unit suite above.
- **Residual manual**: none required — internal representation change, behavior-preserving.

Part of #85.