### PR TITLE
refactor(show-pages): move avibe-cloud URL helpers off the lightweight import path (#87)

### DIFF
--- a/core/avibe_cloud.py
+++ b/core/avibe_cloud.py
@@ -1,0 +1,48 @@
+"""Avibe Cloud public-URL availability — the lightweight, storage-free slice the
+handler / agent / system-prompt paths need WITHOUT dragging the show-page storage
+layer (and sqlite) into their import path.
+
+``core.show_pages`` imports ``storage.db`` / SQLAlchemy at module load to back
+``ShowPageStore``. Lightweight callers (``core.handlers.session_handler``,
+``core.system_prompt_injection``, the Codex / OpenCode agent backends) only ever
+needed "is the avibe.bot public URL configured, and the connect guidance if not"
+— so importing ``core.show_pages`` for that one helper transitively pulled sqlite
+onto the agent-setup / command-handler import path. These primitives are derived
+purely from ``V2Config`` (no storage), so they live here; ``core.show_pages``
+builds the show-page URLs + ``ShowPageStore`` on top of ``base_public_url``.
+
+Guarded by ``tests/test_native_session_providers.py::
+test_native_session_lightweight_imports_do_not_require_sqlite``.
+"""
+
+from __future__ import annotations
+
+from config.v2_config import V2Config
+
+AVIBE_CLOUD_CONNECT_GUIDANCE = (
+    "⚠️ Avibe Cloud is not connected, so this page cannot be accessed from the public internet "
+    "through your domain. To fully use Show Pages, register an avibe.bot account, claim your dedicated "
+    "domain and pairing key, then run `vibe remote pair`."
+)
+
+
+def base_public_url(config: V2Config | None = None) -> str | None:
+    """The configured avibe.bot public base URL (trailing slash stripped), or
+    ``None`` when Avibe Cloud is disabled / unconfigured / unreadable."""
+    try:
+        cfg = config or V2Config.load()
+    except Exception:
+        return None
+    cloud = getattr(getattr(cfg, "remote_access", None), "vibe_cloud", None)
+    if not cloud or not getattr(cloud, "enabled", False):
+        return None
+    public_url = (getattr(cloud, "public_url", "") or "").strip()
+    return public_url.rstrip("/") if public_url else None
+
+
+def avibe_cloud_url_available(config: V2Config | None = None) -> bool:
+    return bool(base_public_url(config))
+
+
+def avibe_cloud_connect_guidance(config: V2Config | None = None) -> str | None:
+    return None if avibe_cloud_url_available(config) else AVIBE_CLOUD_CONNECT_GUIDANCE

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -16,7 +16,7 @@ from modules.claude_sdk_compat import (
     PermissionResultAllow,
 )
 from modules.agents.native_sessions.base import build_resume_preview
-from core.show_pages import avibe_cloud_url_available
+from core.avibe_cloud import avibe_cloud_url_available
 from core.system_prompt_injection import build_system_prompt_injection
 
 from .base import BaseHandler

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -14,6 +14,7 @@ from sqlalchemy import insert, or_, select, update
 
 from config import paths
 from config.v2_config import V2Config
+from core.avibe_cloud import avibe_cloud_connect_guidance, base_public_url
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
 from storage.models import show_pages
@@ -29,11 +30,6 @@ SHOW_EVENT_WRITE_TOKEN_HEADER = "X-Vibe-Show-Token"
 SHOW_CLI_EVENT_TOKEN_HEADER = "X-Vibe-Show-Cli-Token"
 _SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 _LIKE_ESCAPE = "\\"
-AVIBE_CLOUD_CONNECT_GUIDANCE = (
-    "⚠️ Avibe Cloud is not connected, so this page cannot be accessed from the public internet "
-    "through your domain. To fully use Show Pages, register an avibe.bot account, claim your dedicated "
-    "domain and pairing key, then run `vibe remote pair`."
-)
 
 
 class ShowPageError(ValueError):
@@ -134,28 +130,8 @@ def _like_pattern(value: str, *, prefix: bool = False, contains: bool = False) -
     return escaped
 
 
-def _base_public_url(config: V2Config | None = None) -> str | None:
-    try:
-        cfg = config or V2Config.load()
-    except Exception:
-        return None
-    cloud = getattr(getattr(cfg, "remote_access", None), "vibe_cloud", None)
-    if not cloud or not getattr(cloud, "enabled", False):
-        return None
-    public_url = (getattr(cloud, "public_url", "") or "").strip()
-    return public_url.rstrip("/") if public_url else None
-
-
-def avibe_cloud_url_available(config: V2Config | None = None) -> bool:
-    return bool(_base_public_url(config))
-
-
-def avibe_cloud_connect_guidance(config: V2Config | None = None) -> str | None:
-    return None if avibe_cloud_url_available(config) else AVIBE_CLOUD_CONNECT_GUIDANCE
-
-
 def private_url(session_id: str, *, config: V2Config | None = None) -> str | None:
-    base = _base_public_url(config)
+    base = base_public_url(config)
     if not base:
         return None
     return urljoin(base + "/", f"show/{validate_session_id(session_id)}/")
@@ -164,7 +140,7 @@ def private_url(session_id: str, *, config: V2Config | None = None) -> str | Non
 def public_url(share_id: str | None, *, config: V2Config | None = None) -> str | None:
     if not share_id:
         return None
-    base = _base_public_url(config)
+    base = base_public_url(config)
     if not base:
         return None
     return urljoin(base + "/", f"p/{share_id}/")

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -8,7 +8,7 @@ from string import Template
 from typing import Optional
 
 from config import paths
-from core.show_pages import AVIBE_CLOUD_CONNECT_GUIDANCE
+from core.avibe_cloud import AVIBE_CLOUD_CONNECT_GUIDANCE
 from modules.im import MessageContext
 
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from core.show_pages import avibe_cloud_url_available
+from core.avibe_cloud import avibe_cloud_url_available
 from core.system_prompt_injection import build_system_prompt_injection
 from modules.agents.base import AgentRequest, BaseAgent
 from modules.agents.subagent_router import SubagentDefinition, load_codex_subagent

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -13,7 +13,7 @@ import logging
 import time
 from typing import Dict, Optional
 
-from core.show_pages import avibe_cloud_url_available
+from core.avibe_cloud import avibe_cloud_url_available
 from core.system_prompt_injection import build_system_prompt_injection
 from modules.agents.base import AgentRequest, BaseAgent
 

--- a/tests/test_native_session_providers.py
+++ b/tests/test_native_session_providers.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from types import SimpleNamespace
 import json
 
-import pytest
-
 from modules.agents.native_sessions.base import build_resume_preview, build_tail_preview
 from modules.agents.native_sessions import claude as claude_module
 from modules.agents.native_sessions.claude import ClaudeNativeSessionProvider, encode_project_path
@@ -293,17 +291,11 @@ def test_native_session_service_loads_default_providers_lazily(monkeypatch) -> N
     assert calls == ["modules.agents.native_sessions.claude"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "core.show_pages imports the storage/migration (sqlite) layer at module load, and "
-        "handler-path modules import it for lightweight constants/helpers (core.system_prompt_injection, "
-        "core.handlers.session_handler), so the lightweight import path transitively pulls in sqlite. "
-        "Fixing it cleanly means splitting ShowPageStore out of core.show_pages' constants module "
-        "(tracked separately). strict=True => remove this marker once that lands, or CI fails on XPASS."
-    ),
-)
 def test_native_session_lightweight_imports_do_not_require_sqlite() -> None:
+    """The agent-setup / command-handler / session-handler import path must NOT
+    transitively pull in sqlite: those modules only need the avibe-cloud URL
+    availability helpers, which now live in the storage-free ``core.avibe_cloud``
+    (not ``core.show_pages``, which imports ``storage.db`` to back ``ShowPageStore``)."""
     repo_root = Path(__file__).resolve().parents[1]
     env = dict(os.environ)
     env["PYTHONPATH"] = str(repo_root) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -768,12 +768,9 @@ def list_show_pages() -> dict:
     and joins ``agent_sessions.title`` so the UI can label rows by title and
     fall back to the session id when no title is set.
     """
-    from core.show_pages import (
-        ShowPageStore,
-        avibe_cloud_connect_guidance,
-        avibe_cloud_url_available,
-        show_page_payload,
-    )
+    from core.avibe_cloud import avibe_cloud_connect_guidance, avibe_cloud_url_available
+    from core.show_pages import ShowPageStore, show_page_payload
+
     config = V2Config.load()
     store = ShowPageStore()
     try:


### PR DESCRIPTION
## Capability

Decouples the **lightweight agent-setup import path** from the show-page **storage** layer. `core.show_pages` imports `storage.db` (SQLAlchemy → sqlite) at module load to back `ShowPageStore`; but `core.handlers.session_handler`, `core.system_prompt_injection`, and the Codex / OpenCode agent backends imported it **only** for the "is the avibe.bot public URL configured, and the connect-guidance if not" helper — dragging sqlite transitively onto a path that must not require a database. An `xfail(strict)` in `test_native_session_providers` documented exactly this.

## What changed

- **New `core/avibe_cloud.py`** (storage-free; imports only `config.v2_config`): `AVIBE_CLOUD_CONNECT_GUIDANCE`, `base_public_url`, `avibe_cloud_url_available`, `avibe_cloud_connect_guidance`.
- **Repointed the 4 module-level lightweight importers** — `modules/agents/codex/agent.py`, `modules/agents/opencode/agent.py`, `core/handlers/session_handler.py`, `core/system_prompt_injection.py` — to `core.avibe_cloud`. Their import graph no longer touches storage. (All four also import `build_system_prompt_injection`, so `system_prompt_injection` had to be repointed too, or the chain would survive through it.)
- **`core/show_pages.py`** keeps `ShowPageStore` + the storage imports + the show-page URL builders, now built on `base_public_url` (re-imports the two helpers it uses internally).
- **`vibe/api.py`** list route imports the two cloud helpers from `core.avibe_cloud` directly (it's a lazy, call-time import in the heavy `vibe/` layer, but pointing it at the true source keeps the call site honest).
- **Removed the `xfail(strict)` marker** — the lightweight-imports test now passes for real (strict means an unexpected XPASS would fail CI, so the marker *must* go with the fix).

## Scope note

The visibility / token constants (`VISIBILITY_*`, `SHOW_*_TOKEN_*`) **stay** in `core.show_pages` — they're on no lightweight import path, so relocating them would be churn without benefit. The fix targets exactly the surface that was dragging sqlite.

## Evidence layers

- **Unit**: `tests/test_native_session_providers.py::test_native_session_lightweight_imports_do_not_require_sqlite` now **passes** (was xfail) — it spawns a subprocess that blocks `sqlite3` imports and imports `modules.agents.native_sessions`, `core.handlers.command_handlers`, `core.handlers.session_handler`. Full per-file unit suite green (146 files, one process each); `ruff` clean.
- **Regression caught + fixed in-PR**: a first cut removed `avibe_cloud_url_available` from `core.show_pages`, breaking a lazy import in `vibe/api.py` (`/api/show-pages` → 500). Caught by `test_show_pages_admin_api`, confirmed against clean master, fixed by repointing that import. Both tests green again.
- **Contract / scenario**: `ShowPageStore` + `show_page_payload` behavior unchanged; show-page admin/list/CLI tests green.
- **Residual manual**: none.

Closes #87.