### PR TITLE
feat(workbench): right-click context menus for sidebar projects and sessions

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -369,6 +369,13 @@ export const ChatPage: React.FC = () => {
         // The send-while-busy queue changed (enqueue / flush / per-item delete).
         if (data.session_id === sessionIdRef.current) void refreshQueue();
       },
+      onSessionActivity: (data) => {
+        // A rename (from the sidebar or elsewhere) broadcasts the new title;
+        // keep this chat's header in sync without a reload. Match the CURRENT
+        // route via sessionIdRef like the handlers above.
+        if (data.session_id !== sessionIdRef.current || data.event !== 'updated') return;
+        setSession((prev) => (prev ? { ...prev, title: data.title ?? null } : prev));
+      },
       onConnected: () => {
         // Every (re)connect recovers any state missed while the socket was down:
         // dropped message rows, the queue, and whether a turn is still running.

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -996,21 +996,12 @@ export const WorkbenchSidebar: React.FC = () => {
                 onRename={(next) => renameProject(project.id, next)}
                 onArchive={() => archiveProject(project.id)}
                 onRenameSession={async (sessionId, title) => {
-                  const nextTitle = title || null;
-                  // Reflect immediately (optimistic) so the row updates the
-                  // instant the user commits; the session.activity 'updated'
-                  // event then confirms the same value from the server.
-                  setSessionsByProject((prev) => {
-                    const list = prev[project.id];
-                    if (!list) return prev;
-                    return {
-                      ...prev,
-                      [project.id]: list.map((s) =>
-                        s.id === sessionId ? { ...s, title: nextTitle } : s,
-                      ),
-                    };
-                  });
-                  await api.updateSession(sessionId, { title: nextTitle });
+                  // Send the trimmed name; an empty string clears to "untitled"
+                  // server-side (a null title means "unchanged"). The resulting
+                  // session.activity 'updated' broadcast patches this list
+                  // (onSessionActivity) and any open chat header — so there's no
+                  // optimistic local state to reconcile or roll back here.
+                  await api.updateSession(sessionId, { title });
                 }}
               />
             ))}

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -205,12 +205,18 @@ const SessionRow: React.FC<{
   const [renaming, setRenaming] = useState(false);
   const [draft, setDraft] = useState(session.title ?? '');
   const inputRef = useRef<HTMLInputElement | null>(null);
+  // Guards a double commit: Enter (or click-away) commits, then the input
+  // unmounts and its onBlur would fire commitRename again; Escape cancels and
+  // must NOT let that trailing blur commit the stale draft (Codex P2).
+  const handledRef = useRef(false);
 
   useEffect(() => {
     if (renaming) inputRef.current?.focus();
   }, [renaming]);
 
   const commitRename = async () => {
+    if (handledRef.current) return;
+    handledRef.current = true;
     const trimmed = draft.trim();
     setRenaming(false);
     // No-op when unchanged; an empty name clears to "untitled" like the header.
@@ -220,6 +226,11 @@ const SessionRow: React.FC<{
     } catch {
       // The shared apiFetch layer already surfaced the error toast.
     }
+  };
+
+  const cancelRename = () => {
+    handledRef.current = true; // suppress the input's trailing onBlur commit
+    setRenaming(false);
   };
 
   if (renaming) {
@@ -238,10 +249,7 @@ const SessionRow: React.FC<{
           onBlur={commitRename}
           onKeyDown={(e) => {
             if (e.key === 'Enter') commitRename();
-            if (e.key === 'Escape') {
-              setDraft(session.title ?? '');
-              setRenaming(false);
-            }
+            if (e.key === 'Escape') cancelRename();
           }}
           placeholder={t('workbench.sessionRenamePlaceholder')}
           className="h-7 flex-1 px-1.5 text-[12px]"
@@ -299,6 +307,7 @@ const SessionRow: React.FC<{
           onClick={() => {
             setMenuOpen(false);
             setDraft(session.title ?? '');
+            handledRef.current = false;
             setRenaming(true);
           }}
           className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
@@ -996,12 +1005,23 @@ export const WorkbenchSidebar: React.FC = () => {
                 onRename={(next) => renameProject(project.id, next)}
                 onArchive={() => archiveProject(project.id)}
                 onRenameSession={async (sessionId, title) => {
-                  // Send the trimmed name; an empty string clears to "untitled"
-                  // server-side (a null title means "unchanged"). The resulting
-                  // session.activity 'updated' broadcast patches this list
-                  // (onSessionActivity) and any open chat header — so there's no
-                  // optimistic local state to reconcile or roll back here.
-                  await api.updateSession(sessionId, { title });
+                  // Empty string clears to "untitled" server-side; null means
+                  // "unchanged". Patch from the REST response so the row updates
+                  // even if the session.activity SSE drops; the broadcast then
+                  // reconciles the same value (and any open chat header). Only
+                  // patches on success — a failed rename throws and leaves the
+                  // old title untouched.
+                  const updated = await api.updateSession(sessionId, { title });
+                  setSessionsByProject((prev) => {
+                    const list = prev[project.id];
+                    if (!list) return prev;
+                    return {
+                      ...prev,
+                      [project.id]: list.map((s) =>
+                        s.id === sessionId ? { ...s, title: updated.title } : s,
+                      ),
+                    };
+                  });
                 }}
               />
             ))}

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -27,7 +27,7 @@ import { useApi } from '../../context/ApiContext';
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
-import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Markdown } from '../ui/markdown';
@@ -186,6 +186,131 @@ const STATUS_DOT_CLASS: Record<string, string> = {
   idle: 'bg-muted',
 };
 
+// One session row under a project. Left-click opens the chat; right-click opens
+// a small menu whose action is Rename — an inline edit equivalent to the chat
+// header's title field. Rename calls api.updateSession({ title }); the live
+// session.activity 'updated' event then patches the title in this list (see the
+// onSessionActivity handler in WorkbenchSidebar), so no manual local patch here.
+const SessionRow: React.FC<{
+  session: WorkbenchSession;
+  unread: number;
+  onSessionMarkRead: (sessionId: string) => void;
+  onRenameSession: (sessionId: string, title: string) => Promise<void>;
+}> = ({ session, unread, onSessionMarkRead, onRenameSession }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const active = location.pathname === `/chat/${session.id}`;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState(session.title ?? '');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (renaming) inputRef.current?.focus();
+  }, [renaming]);
+
+  const commitRename = async () => {
+    const trimmed = draft.trim();
+    setRenaming(false);
+    // No-op when unchanged; an empty name clears to "untitled" like the header.
+    if (trimmed === (session.title ?? '').trim()) return;
+    try {
+      await onRenameSession(session.id, trimmed);
+    } catch {
+      // The shared apiFetch layer already surfaced the error toast.
+    }
+  };
+
+  if (renaming) {
+    return (
+      <div className="flex items-center gap-2 py-1.5 pl-[30px] pr-2.5">
+        <span
+          className={clsx(
+            'size-[5px] shrink-0 rounded-full',
+            STATUS_DOT_CLASS[session.agent_status] ?? STATUS_DOT_CLASS.idle,
+          )}
+        />
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitRename}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commitRename();
+            if (e.key === 'Escape') {
+              setDraft(session.title ?? '');
+              setRenaming(false);
+            }
+          }}
+          placeholder={t('workbench.sessionRenamePlaceholder')}
+          className="h-7 flex-1 px-1.5 text-[12px]"
+        />
+      </div>
+    );
+  }
+
+  const displayName = session.title?.trim() || t('workbench.untitledSession');
+  return (
+    <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+      <PopoverAnchor asChild>
+        <button
+          type="button"
+          onClick={() => {
+            navigate(`/chat/${encodeURIComponent(session.id)}`);
+            if (unread > 0) onSessionMarkRead(session.id);
+          }}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setMenuOpen(true);
+          }}
+          className={clsx(
+            'group/sess flex items-center gap-2 rounded-md py-1.5 pl-[30px] pr-2.5 text-left transition',
+            active
+              ? 'border-l-2 border-mint bg-mint-soft pl-[28px] font-semibold text-foreground'
+              : 'hover:bg-foreground/[0.04]',
+          )}
+        >
+          <span
+            title={t(`workbench.sessionStatus.${session.agent_status}`)}
+            className={clsx(
+              'size-[5px] shrink-0 rounded-full',
+              STATUS_DOT_CLASS[session.agent_status] ?? STATUS_DOT_CLASS.idle,
+            )}
+          />
+          <span
+            className={clsx(
+              'flex-1 truncate text-[12px]',
+              active ? 'font-semibold text-foreground' : 'font-medium text-foreground',
+            )}
+          >
+            {displayName}
+          </span>
+          {unread > 0 && (
+            <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-[#080812]">
+              {unread > 99 ? '99+' : unread}
+            </span>
+          )}
+        </button>
+      </PopoverAnchor>
+      <PopoverContent align="start" className="w-[160px] p-1">
+        <button
+          type="button"
+          onClick={() => {
+            setMenuOpen(false);
+            setDraft(session.title ?? '');
+            setRenaming(true);
+          }}
+          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
+        >
+          <Pencil className="size-3 text-muted" />
+          {t('workbench.sessionRename')}
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
 // One project row + (when expanded) the session list under it. Mirrors
 // design.pen N96dsm/C68Ul (project row) and C7clY/R2C8U (session row).
 const ProjectRow: React.FC<{
@@ -203,6 +328,7 @@ const ProjectRow: React.FC<{
   onSessionMarkRead: (sessionId: string) => void;
   onRename: (next: string) => Promise<void>;
   onArchive: () => Promise<void>;
+  onRenameSession: (sessionId: string, title: string) => Promise<void>;
 }> = ({
   project,
   expanded,
@@ -218,10 +344,9 @@ const ProjectRow: React.FC<{
   onSessionMarkRead,
   onRename,
   onArchive,
+  onRenameSession,
 }) => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const location = useLocation();
   const Chevron = expanded ? ChevronDown : ChevronRight;
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState(project.display_name);
@@ -249,6 +374,12 @@ const ProjectRow: React.FC<{
       <div
         className="group flex items-center gap-1.5 rounded-md px-2 py-1.5 transition hover:bg-foreground/[0.04]"
         title={project.folder_path}
+        onContextMenu={(e) => {
+          // Right-click opens the same menu as the ⋯ button (anchored to it).
+          if (renaming) return;
+          e.preventDefault();
+          setMenuOpen(true);
+        }}
       >
         {renaming ? (
           <div className="flex flex-1 items-center gap-1.5">
@@ -374,48 +505,15 @@ const ProjectRow: React.FC<{
             <div className="px-3 py-2 pl-[30px] text-[11px] italic text-muted">{t('workbench.sessionsEmpty')}</div>
           )}
           {sessions !== null &&
-            sessions.map((session) => {
-              const active = location.pathname === `/chat/${session.id}`;
-              const unread = unreadBySession[session.id] || 0;
-              const displayName = session.title?.trim() || t('workbench.untitledSession');
-              return (
-                <button
-                  key={session.id}
-                  type="button"
-                  onClick={() => {
-                    navigate(`/chat/${encodeURIComponent(session.id)}`);
-                    if (unread > 0) onSessionMarkRead(session.id);
-                  }}
-                  className={clsx(
-                    'group/sess flex items-center gap-2 rounded-md py-1.5 pl-[30px] pr-2.5 text-left transition',
-                    active
-                      ? 'border-l-2 border-mint bg-mint-soft pl-[28px] font-semibold text-foreground'
-                      : 'hover:bg-foreground/[0.04]',
-                  )}
-                >
-                  <span
-                    title={t(`workbench.sessionStatus.${session.agent_status}`)}
-                    className={clsx(
-                      'size-[5px] shrink-0 rounded-full',
-                      STATUS_DOT_CLASS[session.agent_status] ?? STATUS_DOT_CLASS.idle,
-                    )}
-                  />
-                  <span
-                    className={clsx(
-                      'flex-1 truncate text-[12px]',
-                      active ? 'font-semibold text-foreground' : 'font-medium text-foreground',
-                    )}
-                  >
-                    {displayName}
-                  </span>
-                  {unread > 0 && (
-                    <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-[#080812]">
-                      {unread > 99 ? '99+' : unread}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
+            sessions.map((session) => (
+              <SessionRow
+                key={session.id}
+                session={session}
+                unread={unreadBySession[session.id] || 0}
+                onSessionMarkRead={onSessionMarkRead}
+                onRenameSession={onRenameSession}
+              />
+            ))}
           {hasMore && (
             <button
               type="button"
@@ -897,6 +995,23 @@ export const WorkbenchSidebar: React.FC = () => {
                 onSessionMarkRead={onSessionMarkRead}
                 onRename={(next) => renameProject(project.id, next)}
                 onArchive={() => archiveProject(project.id)}
+                onRenameSession={async (sessionId, title) => {
+                  const nextTitle = title || null;
+                  // Reflect immediately (optimistic) so the row updates the
+                  // instant the user commits; the session.activity 'updated'
+                  // event then confirms the same value from the server.
+                  setSessionsByProject((prev) => {
+                    const list = prev[project.id];
+                    if (!list) return prev;
+                    return {
+                      ...prev,
+                      [project.id]: list.map((s) =>
+                        s.id === sessionId ? { ...s, title: nextTitle } : s,
+                      ),
+                    };
+                  });
+                  await api.updateSession(sessionId, { title: nextTitle });
+                }}
               />
             ))}
         </div>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -495,6 +495,8 @@
     "projectArchive": "Archive",
     "projectArchiveConfirm": "Archive project \"{{name}}\"? Session history is preserved; it just stops showing in the sidebar.",
     "projectRenamePlaceholder": "New name",
+    "sessionRename": "Rename",
+    "sessionRenamePlaceholder": "Session name",
     "projectsEmpty": "No projects yet — add one to start a session.",
     "projectsLoading": "Loading projects…",
     "projectsLoadError": "Couldn't load projects.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -495,6 +495,8 @@
     "projectArchive": "归档",
     "projectArchiveConfirm": "确定归档项目「{{name}}」?会话历史会保留,侧栏不再显示。",
     "projectRenamePlaceholder": "新名字",
+    "sessionRename": "重命名",
+    "sessionRenamePlaceholder": "会话名称",
     "projectsEmpty": "还没有项目 — 添加一个就能开始会话。",
     "projectsLoading": "加载项目中…",
     "projectsLoadError": "项目加载失败。",


### PR DESCRIPTION
## Capability

Right-click context menus in the workbench sidebar.

- **Projects** — right-clicking a project row opens the **same** menu as the ⋯ button (Rename / Edit AGENTS.md / Archive), anchored to the ⋯ trigger. No menu duplication.
- **Sessions** — right-clicking a session row opens a menu whose action is **Rename**. Rename is an inline edit in the sidebar, equivalent to the chat header's title field: it calls `api.updateSession(id, { title })`, with the title patched optimistically and then confirmed by the live `session.activity` `updated` event the sidebar already listens to.

## Implementation

- Project row: added `onContextMenu` that opens the existing controlled Popover (`setMenuOpen(true)`); the menu markup is untouched, so it stays in sync with the ⋯ button by construction.
- Extracted a `SessionRow` component: left-click navigates; right-click opens a Popover anchored to the row via `PopoverAnchor` (no extra trigger button); Rename switches the row to an inline `Input` (commit on Enter / blur, Esc cancels). `useNavigate` / `useLocation` moved from `ProjectRow` into `SessionRow`.
- New `onRenameSession` callback threaded `WorkbenchSidebar` → `ProjectRow` → `SessionRow`: optimistic local patch of `sessionsByProject` + `updateSession`. Empty name clears to "untitled", matching the chat header.
- i18n: `workbench.sessionRename`, `workbench.sessionRenamePlaceholder` (zh + en).

## Evidence layers

- **Unit / contract / scenario**: n/a — sidebar interaction only, no backend change.
- **Residual manual checks**: `npm run build` clean (tsc + vite); i18n JSON validated. Reuses the established `ProjectRow` menu/rename pattern and the existing `session.activity` title-patch path, so behavior matches the chat-header rename.
