### PR TITLE
fix(session): clean up Claude buffer error sessions

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -14,6 +14,7 @@ from modules.claude_sdk_compat import (
     ClaudeAgentOptions,
     ClaudeSDKClient,
     PermissionResultAllow,
+    is_claude_sdk_buffer_error,
 )
 from modules.agents.native_sessions.base import build_resume_preview
 from core.avibe_cloud import avibe_cloud_url_available
@@ -1085,9 +1086,12 @@ class SessionHandler(BaseHandler):
                 context,
                 self._get_formatter(context).format_error(self._t("error.sessionReset")),
             )
-        # TODO: Consider treating Claude SDK oversized JSON buffer failures as
-        # broken sessions once the recovery behavior is validated in production.
-        elif "Session is broken" in error_msg or "Connection closed" in error_msg or "Connection lost" in error_msg:
+        elif (
+            "Session is broken" in error_msg
+            or "Connection closed" in error_msg
+            or "Connection lost" in error_msg
+            or is_claude_sdk_buffer_error(error)
+        ):
             logger.error(f"Session {composite_key} is broken - cleaning up")
             await self.cleanup_session(composite_key, current_receiver_task=asyncio.current_task())
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -4,7 +4,7 @@ import os
 from typing import Callable, Optional
 
 from core.agent_auth_service import classify_auth_error
-from modules.claude_sdk_compat import TextBlock, ToolUseBlock
+from modules.claude_sdk_compat import TextBlock, ToolUseBlock, is_claude_sdk_buffer_error
 
 from modules.agents.base import AgentRequest, BaseAgent
 
@@ -49,6 +49,18 @@ class ClaudeAgent(BaseAgent):
         #     settings_manager=controller.settings_manager,
         # )
         self._question_handler = None
+
+    def _format_error_notify(self, error: Exception) -> str:
+        """Return the durable notify text for Claude terminal errors."""
+        if is_claude_sdk_buffer_error(error):
+            translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)
+            if callable(translator):
+                try:
+                    return f"❌ {translator('error.sessionConnectionLost')}"
+                except Exception:
+                    logger.debug("claude: failed to translate buffer-error notify", exc_info=True)
+            return "❌ Connection to Claude was lost. Please try your message again."
+        return f"❌ Claude error: {error}"
 
     async def handle_message(self, request: AgentRequest) -> None:
         context = request.context
@@ -115,10 +127,11 @@ class ClaudeAgent(BaseAgent):
             self._remove_pending_request(runtime_session_key, request)
             self._mark_session_idle_if_no_pending_requests(runtime_session_key)
             await self._remove_ack_reaction(request)
+            error_notify = self._format_error_notify(e)
             handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                 context,
                 "claude",
-                f"❌ Claude error: {e}",
+                error_notify,
             )
             if not handled:
                 await self.session_handler.handle_session_error(runtime_session_key, context, e)
@@ -131,7 +144,7 @@ class ClaudeAgent(BaseAgent):
                 try:
                     from core.message_mirror import persist_agent_message
 
-                    persist_agent_message(context, "notify", f"❌ Claude error: {e}")
+                    persist_agent_message(context, "notify", error_notify)
                 except Exception:
                     logger.debug("claude: failed to persist terminal error row", exc_info=True)
             # Synchronous failure (query/setup raised), no async receiver result
@@ -602,10 +615,11 @@ class ClaudeAgent(BaseAgent):
             # Clean up all pending reactions for this session on error —
             # the receiver is dead and won't process any more results.
             await self._clear_pending_reactions(composite_key, context)
+            error_notify = self._format_error_notify(e)
             handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                 context,
                 "claude",
-                f"❌ Claude error: {e}",
+                error_notify,
             )
             if not handled:
                 await self.session_handler.handle_session_error(composite_key, context, e)
@@ -616,7 +630,7 @@ class ClaudeAgent(BaseAgent):
                 try:
                     from core.message_mirror import persist_agent_message
 
-                    persist_agent_message(context, "notify", f"❌ Claude error: {e}")
+                    persist_agent_message(context, "notify", error_notify)
                 except Exception:
                     logger.debug("claude: failed to persist terminal receiver-error row", exc_info=True)
                 # A dead receiver is terminal. The HANDLED (auth) branch already

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -566,6 +566,48 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
         persist.assert_called_once()
         self.assertEqual(persist.call_args.args[1], "notify")
+        self.assertEqual(persist.call_args.args[2], "❌ Claude error: Connection lost")
+
+    async def test_receiver_buffer_error_persists_connection_lost_notify(self):
+        controller = _StubController()
+        controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=False)
+        controller.emit_agent_message = AsyncMock()
+        controller._get_session_key = lambda context: "telegram::user::U1"
+        agent = ClaudeAgent(controller)
+        agent.session_handler = SimpleNamespace(
+            handle_session_error=AsyncMock(),
+            _t=lambda key: "Connection to Claude was lost. Please try your message again."
+            if key == "error.sessionConnectionLost"
+            else key,
+        )
+        agent._clear_pending_reactions = AsyncMock()
+        context = SimpleNamespace()
+
+        class _FailingClient:
+            def receive_messages(self):
+                async def _iterate():
+                    raise RuntimeError(
+                        "Failed to decode JSON: JSON message exceeded maximum buffer size of 1048576 bytes"
+                    )
+                    yield  # pragma: no cover
+
+                return _iterate()
+
+        with patch("core.message_mirror.persist_agent_message") as persist:
+            await agent._receive_messages(_FailingClient(), "session-1", "/tmp/work", context)
+
+        agent.session_handler.handle_session_error.assert_awaited_once()
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once_with(
+            context,
+            "claude",
+            "❌ Connection to Claude was lost. Please try your message again.",
+        )
+        persist.assert_called_once_with(
+            context,
+            "notify",
+            "❌ Connection to Claude was lost. Please try your message again.",
+        )
 
     async def test_result_auth_error_prefers_oauth_recovery_message(self):
         controller = _StubController()

--- a/tests/test_session_handler_base_id.py
+++ b/tests/test_session_handler_base_id.py
@@ -347,14 +347,14 @@ def test_claude_session_not_found_error_is_reported_without_cleanup() -> None:
     assert "/tmp/other" in message
 
 
-def test_claude_sdk_buffer_error_is_reported_without_cleanup_for_now() -> None:
+def test_claude_sdk_buffer_error_cleans_up_broken_session() -> None:
     controller = _Controller(platform="slack", dm_threads=False)
     controller.im_client = _FakeIM()
     handler = SessionHandler(controller)
     cleanup_calls = []
 
-    async def _cleanup_session(composite_key: str) -> None:
-        cleanup_calls.append(composite_key)
+    async def _cleanup_session(composite_key: str, *, current_receiver_task=None) -> None:
+        cleanup_calls.append((composite_key, current_receiver_task))
 
     handler.cleanup_session = _cleanup_session
     context = MessageContext(user_id="U123", channel_id="C123", platform="slack")
@@ -367,7 +367,10 @@ def test_claude_sdk_buffer_error_is_reported_without_cleanup_for_now() -> None:
         )
     )
 
-    assert cleanup_calls == []
+    assert len(cleanup_calls) == 1
+    cleanup_key, cleanup_task = cleanup_calls[0]
+    assert cleanup_key == "slack_C123:/tmp/workdir"
+    assert cleanup_task is not None
     assert len(controller.im_client.sent_messages) == 1
     _, message = controller.im_client.sent_messages[0]
-    assert "JSON message exceeded maximum buffer size" in message
+    assert message == "ERR:Connection to Claude was lost. Please try your message again."


### PR DESCRIPTION
## Summary

- Treat Claude SDK oversized JSON buffer failures as broken sessions so Vibe Remote cleans up the half-dead SDK client and rebuilds on the next turn.
- Reuse the existing Claude SDK buffer-error helper instead of matching the broader JSON decode prefix directly.
- Persist the same normalized connection-lost notice for avibe/web Chat durable rows when the Claude receiver hits the buffer fatal.
- Update regression coverage for both session cleanup and receiver durable notify behavior.

## Related

- Incorporates the useful fix direction from #396 and adds the missing test coverage.
- Addresses the Codex review finding about persisting the normalized buffer-error message for web Chat.

## Evidence

- Unit: `uv run pytest tests/test_session_handler_base_id.py::test_claude_sdk_buffer_error_cleans_up_broken_session -q`
- Unit: `uv run pytest tests/test_session_handler_base_id.py -q`
- Unit: `uv run pytest tests/test_claude_agent_sessions.py::ClaudeAgentSessionTests::test_receiver_non_auth_error_settles_dot_and_persists tests/test_claude_agent_sessions.py::ClaudeAgentSessionTests::test_receiver_buffer_error_persists_connection_lost_notify tests/test_session_handler_base_id.py::test_claude_sdk_buffer_error_cleans_up_broken_session -q`
- Unit: `uv run pytest tests/test_claude_agent_sessions.py -q`
- Unit: `uv run pytest tests/test_claude_agent_sessions.py::ClaudeAgentSessionTests::test_receiver_non_auth_error_settles_dot_and_persists tests/test_claude_cli_path.py::test_cleanup_session_swallows_receiver_task_failure tests/test_claude_cli_path.py::test_cleanup_session_defers_disconnect_for_current_receiver -q`
- Lint: `uv run ruff check modules/agents/claude_agent.py core/handlers/session_handler.py tests/test_session_handler_base_id.py tests/test_claude_agent_sessions.py`
- Build prerequisite: `npm run build` in `ui/` so Python editable build could include `ui/dist`.

## Scenario IDs

- No matching scenario catalog entry for `handle_session_error`; this is covered by unit-level session handler and Claude receiver evidence.
