### PR TITLE
feat(workbench): polish chat media — capped image previews, lightbox, voice controls

### DIFF
--- a/ui/src/components/ui/chat-image.tsx
+++ b/ui/src/components/ui/chat-image.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Download } from 'lucide-react';
+
+import { useImageViewer } from '@/components/ui/image-viewer';
+import { cn } from '@/lib/utils';
+
+// One inline chat image — used by both the Markdown renderer (agent replies) and
+// the user-attachment renderer (ChatPage). Capped to a preview width and shown
+// at its natural aspect (never stretched / full-width); click to open the
+// lightbox; hover reveals a download button. The width cap is an inline style so
+// it beats the ``.vr-markdown img { max-width: 100% }`` descendant rule.
+export const ChatImage: React.FC<{ src: string; alt?: string; className?: string }> = ({ src, alt, className }) => {
+  const viewer = useImageViewer();
+  return (
+    <span className={cn('group relative my-1 inline-block max-w-full align-bottom', className)}>
+      <img
+        src={src}
+        alt={alt || ''}
+        loading="lazy"
+        onClick={() => viewer?.open(src)}
+        style={{ maxWidth: 'min(22rem, 100%)', maxHeight: '15rem' }}
+        className={cn(
+          'block h-auto w-auto rounded-lg border border-border object-contain',
+          viewer ? 'cursor-zoom-in' : '',
+        )}
+      />
+      <a
+        href={`${src}?download=1`}
+        download
+        onClick={(e) => e.stopPropagation()}
+        aria-label="Download image"
+        // Inline color/decoration override: this <a> can render inside
+        // ``.vr-markdown`` whose ``a`` rule would otherwise tint it cyan + underline.
+        style={{ color: '#fff', textDecoration: 'none' }}
+        className="absolute right-2 top-2 grid size-7 place-items-center rounded-md bg-black/55 opacity-0 backdrop-blur-sm transition group-hover:opacity-100"
+      >
+        <Download className="size-4" />
+      </a>
+    </span>
+  );
+};

--- a/ui/src/components/ui/chat-image.tsx
+++ b/ui/src/components/ui/chat-image.tsx
@@ -1,16 +1,44 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Download } from 'lucide-react';
 
+import { Button } from '@/components/ui/button';
 import { useImageViewer } from '@/components/ui/image-viewer';
 import { cn } from '@/lib/utils';
+
+// When a markdown image is wrapped in a link (``[![](media)](href)``),
+// react-markdown nests the image inside the outer <a>. The Markdown ``a`` handler
+// wraps such children in this provider so the ChatImage inside renders WITHOUT
+// its own download <a> (nested anchors are invalid HTML) and without the
+// lightbox click (the surrounding link is the intended action) — just the
+// capped <img>.
+const LinkedImageContext = React.createContext(false);
+export const LinkedImageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <LinkedImageContext.Provider value={true}>{children}</LinkedImageContext.Provider>
+);
+
+// The width cap is an inline style so it beats the ``.vr-markdown img {
+// max-width: 100% }`` descendant rule.
+const IMG_BOX: React.CSSProperties = { maxWidth: 'min(22rem, 100%)', maxHeight: '15rem' };
+const IMG_CLASS = 'block h-auto w-auto rounded-lg border border-border object-contain';
 
 // One inline chat image — used by both the Markdown renderer (agent replies) and
 // the user-attachment renderer (ChatPage). Capped to a preview width and shown
 // at its natural aspect (never stretched / full-width); click to open the
-// lightbox; hover reveals a download button. The width cap is an inline style so
-// it beats the ``.vr-markdown img { max-width: 100% }`` descendant rule.
+// lightbox; hover reveals a download button.
 export const ChatImage: React.FC<{ src: string; alt?: string; className?: string }> = ({ src, alt, className }) => {
+  const { t } = useTranslation();
   const viewer = useImageViewer();
+  const linked = React.useContext(LinkedImageContext);
+
+  // Inside a markdown link: a bare capped image — no nested download anchor and
+  // no lightbox click stealing the link.
+  if (linked) {
+    return (
+      <img src={src} alt={alt || ''} loading="lazy" style={IMG_BOX} className={cn('my-1 align-bottom', IMG_CLASS, className)} />
+    );
+  }
+
   return (
     <span className={cn('group relative my-1 inline-block max-w-full align-bottom', className)}>
       <img
@@ -18,24 +46,29 @@ export const ChatImage: React.FC<{ src: string; alt?: string; className?: string
         alt={alt || ''}
         loading="lazy"
         onClick={() => viewer?.open(src)}
-        style={{ maxWidth: 'min(22rem, 100%)', maxHeight: '15rem' }}
-        className={cn(
-          'block h-auto w-auto rounded-lg border border-border object-contain',
-          viewer ? 'cursor-zoom-in' : '',
-        )}
+        style={IMG_BOX}
+        className={cn(IMG_CLASS, viewer ? 'cursor-zoom-in' : '')}
       />
-      <a
-        href={`${src}?download=1`}
-        download
-        onClick={(e) => e.stopPropagation()}
-        aria-label="Download image"
-        // Inline color/decoration override: this <a> can render inside
-        // ``.vr-markdown`` whose ``a`` rule would otherwise tint it cyan + underline.
-        style={{ color: '#fff', textDecoration: 'none' }}
-        className="absolute right-2 top-2 grid size-7 place-items-center rounded-md bg-black/55 opacity-0 backdrop-blur-sm transition group-hover:opacity-100"
+      <Button
+        asChild
+        variant="ghost"
+        size="icon"
+        // Overlay badge on the image corner: smaller than a standard icon button,
+        // dark translucent, revealed on hover. Inline color/decoration override
+        // because this <a> can render inside ``.vr-markdown`` whose ``a`` rule
+        // would otherwise tint it cyan + underline.
+        className="absolute right-2 top-2 size-7 rounded-md bg-black/55 text-white opacity-0 backdrop-blur-sm transition hover:bg-black/70 hover:text-white group-hover:opacity-100"
       >
-        <Download className="size-4" />
-      </a>
+        <a
+          href={`${src}?download=1`}
+          download
+          onClick={(e) => e.stopPropagation()}
+          aria-label={t('chat.media.download')}
+          style={{ color: '#fff', textDecoration: 'none' }}
+        >
+          <Download className="size-4" />
+        </a>
+      </Button>
     </span>
   );
 };

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { ChevronLeft, ChevronRight, Download, X } from 'lucide-react';
+
+// A session-scoped image lightbox. ChatPage computes the ordered list of media-
+// proxy image URLs in the transcript and wraps the page in a provider; any chat
+// image (markdown inline image or a user attachment) opens it via ``open(src)``,
+// and the lightbox pages left/right through the whole session's images. Used
+// through the optional context so the shared Markdown renderer keeps working
+// (no-op) where there's no provider (e.g. the agent-config editor preview).
+
+type ImageViewerContextValue = { open: (src: string) => void };
+
+const ImageViewerContext = React.createContext<ImageViewerContextValue | null>(null);
+
+export function useImageViewer(): ImageViewerContextValue | null {
+  return React.useContext(ImageViewerContext);
+}
+
+export const ImageViewerProvider: React.FC<{ images: string[]; children: React.ReactNode }> = ({
+  images,
+  children,
+}) => {
+  // Track the *displayed URL*, not an index. ``images`` is recomputed on every
+  // streamed message, so a stored index would drift; and keeping the context
+  // value (``open``) free of any ``images`` dependency means it stays stable, so
+  // chat images don't re-render on every streaming tick. A clicked src that
+  // isn't in the list (shouldn't happen for our own clean proxy URLs, but be
+  // safe) still shows exactly what was clicked — paging just turns off for it.
+  const [src, setSrc] = React.useState<string | null>(null);
+
+  const open = React.useCallback((next: string) => setSrc(next), []);
+  const close = React.useCallback(() => setSrc(null), []);
+
+  const index = src ? images.indexOf(src) : -1;
+  const pageable = index >= 0 && images.length > 1;
+  const step = React.useCallback(
+    (delta: number) => {
+      if (index < 0 || images.length === 0) return;
+      setSrc(images[(index + delta + images.length) % images.length]);
+    },
+    [index, images],
+  );
+
+  React.useEffect(() => {
+    if (src === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+      else if (e.key === 'ArrowLeft') step(-1);
+      else if (e.key === 'ArrowRight') step(1);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [src, close, step]);
+
+  const ctx = React.useMemo(() => ({ open }), [open]);
+
+  return (
+    <ImageViewerContext.Provider value={ctx}>
+      {children}
+      {src && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6 backdrop-blur-sm"
+          onClick={close}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="absolute right-4 top-4 flex items-center gap-2">
+            <a
+              href={`${src}?download=1`}
+              download
+              onClick={(e) => e.stopPropagation()}
+              aria-label="Download"
+              className="grid size-9 place-items-center rounded-lg bg-white/10 text-white transition hover:bg-white/20"
+            >
+              <Download className="size-4" />
+            </a>
+            <button
+              type="button"
+              onClick={close}
+              aria-label="Close"
+              className="grid size-9 place-items-center rounded-lg bg-white/10 text-white transition hover:bg-white/20"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+          {pageable && (
+            <>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  step(-1);
+                }}
+                aria-label="Previous"
+                className="absolute left-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20"
+              >
+                <ChevronLeft className="size-5" />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  step(1);
+                }}
+                aria-label="Next"
+                className="absolute right-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20"
+              >
+                <ChevronRight className="size-5" />
+              </button>
+            </>
+          )}
+          <img
+            src={src}
+            alt=""
+            onClick={(e) => e.stopPropagation()}
+            className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
+          />
+          {pageable && (
+            <span className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 font-mono text-[11px] text-white">
+              {index + 1} / {images.length}
+            </span>
+          )}
+        </div>
+      )}
+    </ImageViewerContext.Provider>
+  );
+};

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, Download, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
 
 // A session-scoped image lightbox. ChatPage computes the ordered list of media-
 // proxy image URLs in the transcript and wraps the page in a provider; any chat
@@ -16,10 +19,17 @@ export function useImageViewer(): ImageViewerContextValue | null {
   return React.useContext(ImageViewerContext);
 }
 
+// Overlay controls sit on a dark backdrop, so the shared Button's themed
+// foreground/hover (tuned for app surfaces) would be invisible here — override
+// to white-on-translucent while still inheriting Button's sizing/focus/disabled
+// behavior instead of hand-rolling a <button>.
+const OVERLAY_BTN = 'bg-white/10 text-white hover:bg-white/20 hover:text-white';
+
 export const ImageViewerProvider: React.FC<{ images: string[]; children: React.ReactNode }> = ({
   images,
   children,
 }) => {
+  const { t } = useTranslation();
   // Track the *displayed URL*, not an index. ``images`` is recomputed on every
   // streamed message, so a stored index would drift; and keeping the context
   // value (``open``) free of any ``images`` dependency means it stays stable, so
@@ -65,48 +75,57 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
           aria-modal="true"
         >
           <div className="absolute right-4 top-4 flex items-center gap-2">
-            <a
-              href={`${src}?download=1`}
-              download
-              onClick={(e) => e.stopPropagation()}
-              aria-label="Download"
-              className="grid size-9 place-items-center rounded-lg bg-white/10 text-white transition hover:bg-white/20"
+            <Button
+              asChild
+              variant="ghost"
+              size="icon"
+              className={OVERLAY_BTN}
             >
-              <Download className="size-4" />
-            </a>
-            <button
-              type="button"
+              <a
+                href={`${src}?download=1`}
+                download
+                onClick={(e) => e.stopPropagation()}
+                aria-label={t('chat.media.download')}
+              >
+                <Download className="size-4" />
+              </a>
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={close}
-              aria-label="Close"
-              className="grid size-9 place-items-center rounded-lg bg-white/10 text-white transition hover:bg-white/20"
+              aria-label={t('chat.viewer.close')}
+              className={OVERLAY_BTN}
             >
               <X className="size-4" />
-            </button>
+            </Button>
           </div>
           {pageable && (
             <>
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={(e) => {
                   e.stopPropagation();
                   step(-1);
                 }}
-                aria-label="Previous"
-                className="absolute left-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20"
+                aria-label={t('chat.viewer.previous')}
+                className={`absolute left-4 top-1/2 -translate-y-1/2 rounded-full ${OVERLAY_BTN}`}
               >
                 <ChevronLeft className="size-5" />
-              </button>
-              <button
-                type="button"
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={(e) => {
                   e.stopPropagation();
                   step(1);
                 }}
-                aria-label="Next"
-                className="absolute right-4 top-1/2 grid size-10 -translate-y-1/2 place-items-center rounded-full bg-white/10 text-white transition hover:bg-white/20"
+                aria-label={t('chat.viewer.next')}
+                className={`absolute right-4 top-1/2 -translate-y-1/2 rounded-full ${OVERLAY_BTN}`}
               >
                 <ChevronRight className="size-5" />
-              </button>
+              </Button>
             </>
           )}
           <img

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -53,13 +53,26 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
 
   React.useEffect(() => {
     if (src === null) return;
+    // The lightbox is a modal: while open it OWNS Escape / arrows. Listen in the
+    // capture phase and stop immediate propagation on the keys we handle so a
+    // lower global handler (notably the Composer's "Escape aborts recording")
+    // can't also fire — Escape here must only close the viewer, not discard an
+    // in-progress voice recording. Capture runs before any bubble-phase window
+    // listener regardless of registration order, so ownership is deterministic.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
-      else if (e.key === 'ArrowLeft') step(-1);
-      else if (e.key === 'ArrowRight') step(1);
+      if (e.key === 'Escape') {
+        e.stopImmediatePropagation();
+        close();
+      } else if (e.key === 'ArrowLeft') {
+        e.stopImmediatePropagation();
+        step(-1);
+      } else if (e.key === 'ArrowRight') {
+        e.stopImmediatePropagation();
+        step(1);
+      }
     };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
   }, [src, close, step]);
 
   const ctx = React.useMemo(() => ({ open }), [open]);

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import { ChatImage } from '@/components/ui/chat-image';
 import { FileCard } from '@/components/ui/file-card';
 import { isProxyMediaUrl } from '@/lib/mediaProxy';
 import { cn } from '@/lib/utils';
@@ -37,7 +38,7 @@ export const Markdown: React.FC<{ content: string; className?: string; interacti
           if (!src) return null;
           const url = String(src);
           if (interactive && isProxyMediaUrl(url)) {
-            return <img src={url} alt={alt || ''} loading="lazy" />;
+            return <ChatImage src={url} alt={alt || ''} />;
           }
           const label = `🖼 ${alt || url}`;
           return interactive ? (

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-import { ChatImage } from '@/components/ui/chat-image';
+import { ChatImage, LinkedImageProvider } from '@/components/ui/chat-image';
 import { FileCard } from '@/components/ui/file-card';
 import { isProxyMediaUrl } from '@/lib/mediaProxy';
 import { cn } from '@/lib/utils';
@@ -59,9 +59,11 @@ export const Markdown: React.FC<{ content: string; className?: string; interacti
             return <FileCard href={url}>{children}</FileCard>;
           }
           if (!interactive) return <span>{children}</span>;
+          // Wrap children so a nested ChatImage (``[![](media)](href)``) renders
+          // bare — without its own download anchor inside this one.
           return (
             <a href={url} target="_blank" rel="noopener noreferrer nofollow">
-              {children}
+              <LinkedImageProvider>{children}</LinkedImageProvider>
             </a>
           );
         },

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -13,7 +13,9 @@ import { formatLocalDateTime } from '../../lib/relativeTime';
 import { fetchBackendModels } from '../../lib/backendModels';
 import { resolveEffortOptions } from '../../lib/effortOptions';
 import { Button } from '../ui/button';
+import { ChatImage } from '../ui/chat-image';
 import { FileCard } from '../ui/file-card';
+import { ImageViewerProvider } from '../ui/image-viewer';
 import { Input } from '../ui/input';
 import { Markdown } from '../ui/markdown';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
@@ -624,6 +626,34 @@ export const ChatPage: React.FC = () => {
     [api, session],
   );
 
+  // Ordered media-proxy image URLs across the whole session — feeds the lightbox
+  // so it pages left/right through every image, in render order (each message's
+  // attachments first, then any inline images in its text).
+  const sessionImages = useMemo(() => {
+    const urls: string[] = [];
+    const seen = new Set<string>();
+    const push = (u: string) => {
+      if (u && isProxyMediaUrl(u) && !seen.has(u)) {
+        seen.add(u);
+        urls.push(u);
+      }
+    };
+    for (const m of messages) {
+      const atts = (m.content as { attachments?: Array<Record<string, unknown>> })?.attachments;
+      if (Array.isArray(atts)) {
+        for (const a of atts) {
+          if (a?.kind === 'image' || String(a?.mime || '').startsWith('image/')) push(String(a?.url || ''));
+        }
+      }
+      if (m.text) {
+        const re = /!\[[^\]]*\]\((\/api\/sessions\/[^)\s]+\/media\/[^)\s]+)\)/g;
+        let match: RegExpExecArray | null;
+        while ((match = re.exec(m.text)) !== null) push(match[1]);
+      }
+    }
+    return urls;
+  }, [messages]);
+
   if (!sessionId) {
     return <ChatMissing onBack={() => navigate('/inbox')} />;
   }
@@ -669,8 +699,9 @@ export const ChatPage: React.FC = () => {
     // ``calc(100dvh-4rem)`` double-subtracted the (already-cancelled) padding
     // and left a 4rem dead gap below the compose bar. On mobile the sticky
     // ``h-16`` header occupies 4rem at the top, so subtract that instead.
-    <div className="-mx-4 -my-5 flex h-[calc(100dvh-4rem)] flex-col md:-mx-10 md:-my-8 md:h-[100dvh]">
-      <ChatHeaderBar session={session} agents={agents} onPatch={patch} onBack={() => navigate('/inbox')} />
+    <ImageViewerProvider images={sessionImages}>
+      <div className="-mx-4 -my-5 flex h-[calc(100dvh-4rem)] flex-col md:-mx-10 md:-my-8 md:h-[100dvh]">
+        <ChatHeaderBar session={session} agents={agents} onPatch={patch} onBack={() => navigate('/inbox')} />
 
       {error && (
         <div className="mx-auto mt-3 w-full max-w-[1080px] rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
@@ -691,7 +722,8 @@ export const ChatPage: React.FC = () => {
         initialDraft={initialDraft}
         onDraftChange={onDraftChange}
       />
-    </div>
+      </div>
+    </ImageViewerProvider>
   );
 };
 
@@ -827,7 +859,7 @@ const TitleField: React.FC<TitleFieldProps> = ({ title, onCommit }) => {
       <button
         type="button"
         onClick={() => setEditing(true)}
-        className="group inline-flex flex-1 items-center gap-2 truncate text-left text-[16px] font-bold text-foreground hover:text-foreground"
+        className="group inline-flex min-w-0 items-center gap-2 truncate text-left text-[16px] font-bold text-foreground hover:text-foreground"
       >
         <span className="truncate">{title || t('chat.untitled')}</span>
         <Pencil className="size-3.5 shrink-0 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
@@ -969,7 +1001,7 @@ const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({ session, agents, on
         <Button
           type="button"
           variant="outline"
-          className="ml-auto inline-flex h-auto max-w-[62%] items-center justify-start gap-1.5 rounded-lg border-cyan/40 bg-surface-2 px-2.5 py-1.5 text-[12px] font-normal hover:bg-cyan/[0.06]"
+          className="inline-flex h-auto max-w-[62%] items-center justify-start gap-1.5 rounded-lg border-cyan/40 bg-surface-2 px-2.5 py-1.5 text-[12px] font-normal hover:bg-cyan/[0.06]"
         >
           {backend && (
             <span className="inline-flex shrink-0 items-center gap-1 rounded border border-cyan/30 bg-cyan/[0.08] px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase text-cyan">
@@ -1310,13 +1342,7 @@ const MessageRow: React.FC<{ message: WorkbenchMessage; session: WorkbenchSessio
             const isImage =
               (att?.kind === 'image' || String(att?.mime || '').startsWith('image/')) && isProxyMediaUrl(url);
             return isImage ? (
-              <img
-                key={i}
-                src={url}
-                alt={typeof att?.name === 'string' ? att.name : ''}
-                loading="lazy"
-                className="max-h-60 max-w-full rounded-lg border border-border"
-              />
+              <ChatImage key={i} src={url} alt={typeof att?.name === 'string' ? att.name : ''} />
             ) : (
               <FileCard key={i} href={url}>
                 {typeof att?.name === 'string' ? att.name : 'file'}

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -95,6 +95,8 @@ export const Composer: React.FC<ComposerProps> = ({
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
   const unmountedRef = useRef(false);
+  // Set just before stopping to mean "discard, don't transcribe" (ESC / unmount).
+  const abortedRef = useRef(false);
 
   // Upload + voice are scoped to a session (the upload endpoint needs one); the
   // home composer leaves them off.
@@ -209,8 +211,12 @@ export const Composer: React.FC<ComposerProps> = ({
       recorder.onstop = async () => {
         stream.getTracks().forEach((track) => track.stop());
         streamRef.current = null;
+        const aborted = abortedRef.current;
+        abortedRef.current = false;
         if (unmountedRef.current) return;
         setRecording(false);
+        // ESC (or unmount) aborted the recording → mic released above, discard it.
+        if (aborted) return;
         const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' });
         if (!blob.size) return;
         setTranscribing(true);
@@ -232,6 +238,7 @@ export const Composer: React.FC<ComposerProps> = ({
           if (!unmountedRef.current) setTranscribing(false);
         }
       };
+      abortedRef.current = false;
       recorderRef.current = recorder;
       recorder.start();
       setRecording(true);
@@ -244,17 +251,37 @@ export const Composer: React.FC<ComposerProps> = ({
     }
   };
 
+  const stopRecording = () => recorderRef.current?.stop(); // stop → transcribe
+  const abortRecording = () => {
+    abortedRef.current = true;
+    recorderRef.current?.stop(); // stop → discard (onstop honors the abort flag)
+  };
   const toggleRecording = () => {
-    if (recording) recorderRef.current?.stop();
+    if (recording) stopRecording();
     else void startRecording();
   };
+
+  // ESC aborts an in-progress recording (discard, no transcribe).
+  useEffect(() => {
+    if (!recording) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        abortRecording();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [recording]);
 
   const trimmed = value.trim();
   const readyAttachments = attachments.filter((a) => a.status === 'ready');
   const uploading = attachments.some((a) => a.status === 'uploading');
   // Send on text OR a ready attachment (attachment-only runs a turn so the agent
-  // reads the files); blocked while an upload is still in flight.
-  const canSubmit = (trimmed.length > 0 || readyAttachments.length > 0) && !uploading && !disabled;
+  // reads the files); blocked while an upload is still in flight, and while
+  // recording so neither the Send button nor the Enter key can fire mid-record.
+  const canSubmit =
+    (trimmed.length > 0 || readyAttachments.length > 0) && !uploading && !disabled && !recording;
 
   const update = (next: string) => {
     setValue(next);
@@ -328,7 +355,7 @@ export const Composer: React.FC<ComposerProps> = ({
         )}
       >
         {mediaEnabled && (
-          <>
+          <div className="flex items-end gap-0.5">
             <input
               ref={fileInputRef}
               type="file"
@@ -362,7 +389,7 @@ export const Composer: React.FC<ComposerProps> = ({
                 {transcribing ? <Loader2 className="size-4 animate-spin" /> : <Mic className="size-4" />}
               </Button>
             )}
-          </>
+          </div>
         )}
         <textarea
           ref={textareaRef}
@@ -381,6 +408,21 @@ export const Composer: React.FC<ComposerProps> = ({
           placeholder={busy ? t('chat.compose.placeholderBusy') : placeholder ?? t('chat.compose.placeholder')}
           className="max-h-40 min-h-9 flex-1 resize-none bg-transparent py-2 text-[13px] leading-5 text-foreground outline-none placeholder:text-muted"
         />
+        {/* While recording, a stop-voice button sits just left of Send (which is
+            greyed out): click it to finish + transcribe; ESC aborts/discards. */}
+        {recording && (
+          <Button
+            type="button"
+            variant="destructive-soft"
+            size="icon"
+            onClick={stopRecording}
+            disabled={transcribing}
+            aria-label={t('chat.compose.stopRecording')}
+            className="size-9 shrink-0 animate-pulse"
+          >
+            <Square className="size-4" />
+          </Button>
+        )}
         {/* 36px (size-9) icon button: pink-soft Stop while a turn runs, else a
             flat mint Send — design-system variants, not a glowy brand CTA. */}
         {busy ? (

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1614,6 +1614,11 @@
       "preview": "Preview",
       "download": "Download"
     },
+    "viewer": {
+      "close": "Close",
+      "previous": "Previous",
+      "next": "Next"
+    },
     "queue": {
       "title": "Queued · {{count}}",
       "sendNow": "Send now",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1613,6 +1613,11 @@
       "preview": "预览",
       "download": "下载"
     },
+    "viewer": {
+      "close": "关闭",
+      "previous": "上一张",
+      "next": "下一张"
+    },
     "queue": {
       "title": "排队中 · {{count}}",
       "sendNow": "立即发送",


### PR DESCRIPTION
## Capability

Follow-up UI polish on the chat media feature (#393), addressing 7 pieces of feedback on the `/chat/:sessionId` workbench:

1. **Image preview width** — inline images were rendering full-width; now capped to a `22rem × 15rem` preview box.
2. **No stretch** — images render at their natural aspect (`object-contain`, `w-auto h-auto`), never distorted.
3. **Lightbox** — click any chat image to open a full-screen viewer that pages left/right (ESC / ← / →) through *every* image in the session.
4. **Hover download** — hovering an image reveals a top-right download button; the lightbox has one too.
5. **Voice controls** — ESC aborts an in-progress recording (discard, no transcribe); a Stop button sits just left of Send while recording; Send is disabled (button **and** Enter) until recording stops.
6. **Spacing** — tightened the gap between the attach and mic buttons.
7. **Header** — moved the agent-route picker to sit next to the chat title instead of the far right.

## Design / reuse notes

- New shared `ChatImage` primitive is used by **both** the markdown renderer (agent replies) and the user-attachment renderer in `ChatPage` — one home for "an inline chat image".
- `ImageViewerProvider` exposes an **optional** context (`useImageViewer()` returns `null` with no provider), so the shared `Markdown` renderer keeps working unchanged in non-chat callers (e.g. the agent-config editor preview).
- The viewer tracks the **displayed URL**, not an array index, so paging stays correct as the transcript streams (the image list is recomputed each message) and the context value stays stable (chat images don't re-render per streamed token).
- The width cap is an inline style so it beats the `.vr-markdown img { max-width: 100% }` descendant rule.

## Evidence layers

- **Unit / contract:** none added — this is a presentational/interaction-only change with no backend or schema surface.
- **Build:** `npm run build` green.
- **Visual:** standalone render of the capped image verified against the original full-width screenshot (cap + aspect + hover download confirmed).
- **Pre-merge reviewer:** ran a focused review pass; fixed 3 findings before opening — (1) Enter key could still send while recording, (2) lightbox could land on the wrong image for non-canonical URLs, (3) context-value churn re-rendering chat images each streamed token. All folded into the commit.
- **Residual manual (regression):** lightbox paging, voice ESC/Stop interaction, and header layout to confirm in the Docker regression env.

No Python touched (UI-only); no scenario catalog applies.