### PR TITLE
feat(ui): responsive / mobile Web UI

### DIFF
--- a/docs/plans/mobile-responsive-webui.md
+++ b/docs/plans/mobile-responsive-webui.md
@@ -1,0 +1,39 @@
+# Mobile / responsive Web UI
+
+## Background
+The avibe Web UI has two shells (see `AppShell.tsx`):
+- **Workbench** (`/`): agent-centric — Inbox, Projects tree, Capabilities (Agents/Skills/Harness/Vaults), Chat. All of this lives in `WorkbenchSidebar`, which is inside the `md:flex hidden` desktop aside.
+- **Control Panel / admin** (`/admin/*`): Dashboard, Channels, Users, Show Pages, Settings (multi-page), Logs.
+
+**Core gap:** on mobile the desktop sidebar is hidden and the bottom nav only renders for `admin` (`mobileItems = []` in workbench). So the **Workbench is unnavigable on mobile**. Admin has a basic 5-item bottom nav but pages (esp. ChannelList master+detail) and dialogs aren't mobile-optimized.
+
+Design model approved by Alex (2026-06-02). Reference: design.pen Workbench mobile frames + Show Page
+`https://alex-app.avibe.bot/show/ses4xvk2m932f/`. design.pen IDs: TabBar `ONBGv`; screens Inbox `FnsGz`, Projects `FW7cI`, Chat `p6dhFi`, New-session sheet `KSXXB`, Capabilities·Agents `wdtCs`, More `Nxnja`.
+
+## Approved interaction model
+- **Two shells, each with its own bottom tab bar + a prominent center button** (mirrors desktop Workbench⇄Control-Panel switch):
+  - Workbench tabs: `收件箱 Inbox · 项目 Projects · [＋ center] · 能力 Capabilities · 更多 More`. Center ＋ = new session.
+  - Control Panel tabs: section nav + **center button = 工作台 (jump back to Workbench)** — Alex's explicit request (symmetry with the workbench ＋).
+- **List → detail = full-page drill-down** (tap row → push screen + back), replacing desktop side-by-side master/detail.
+- **Desktop popovers / dialogs → bottom sheets** on mobile (agent/model/effort picker, new-agent, run, add-skill, create-via-chat, new-project, context menus, visibility).
+- Chat (`/chat/:id`) is a full-screen detail: **no bottom tab bar**, composer pinned at bottom.
+
+### Alex's two tweaks (2026-06-02)
+1. **More** screen: NO service start/stop control — read-only status only; service control stays in the Control Panel.
+2. **Control Panel bottom Tab bar**: add a centered **工作台** entry button (back to Workbench).
+
+## Build order (single branch `feature/mobile-responsive-webui`, atomic commits, one PR)
+1. **Nav foundation** (this commit): `AppShell` mobile bottom tab bars for BOTH shells with center buttons; hide nav on `/chat` + `/setup`. New routes `/projects` + `/more`. `MorePage` (read-only status, control-panel link, theme/lang/account, host/version). `ProjectsPage` (projects → sessions drill-down, reuse `useApi` + `useWorkbenchInbox`). Capabilities tab → `/agents` (active across agents/skills/harness/vaults).
+2. **Capability pages responsive + sub-tabs**: Agents/Skills/Harness mobile (single-column, drill-down detail, sub-tab strip Agents/Skills/Harness/Vaults). Dialogs → bottom sheets.
+3. **Chat mobile**: transcript word-break/responsive, composer, agent/model/effort picker → bottom sheet, header back.
+4. **New-session sheet** for the ＋ (project picker + compose + quick-starts).
+5. **Admin pages responsive**: Dashboard, Channels (master+detail → drill-down), Users, Show Pages, Settings hub + sub-pages, Logs.
+6. **Setup wizard mobile**.
+7. **Dialog/Popover → Sheet** primitive (shared) + Light theme pass if requested.
+
+## Conventions
+- Reuse `ui/src/components/ui/*` primitives (Button/Badge/Card/...); extend variants, never re-roll (AGENTS.md §6).
+- Match design.pen pixel values; map to tokens in `index.css`.
+- Tailwind breakpoint `md` (768px) is the desktop/mobile split already in use.
+- i18n: every string via `ui/src/i18n/{en,zh}.json` (`nav.*`, new `more.*`, `projects.*`).
+- Verify each commit with `npm run build` in `ui/`.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,8 @@ import { SkillsPage } from './components/workbench/SkillsPage';
 import { HarnessPage } from './components/workbench/HarnessPage';
 import { VaultsPage } from './components/workbench/VaultsPage';
 import { ChatPage } from './components/workbench/ChatPage';
+import { ProjectsPage } from './components/workbench/ProjectsPage';
+import { MorePage } from './components/workbench/MorePage';
 import { Dashboard } from './components/Dashboard';
 import { ChannelList } from './components/steps/ChannelList';
 import { UserList } from './components/steps/UserList';
@@ -226,6 +228,8 @@ function AppRoutes() {
         <Route path="/skills" element={<SkillsPage />} />
         <Route path="/harness" element={<HarnessPage />} />
         <Route path="/vaults" element={<VaultsPage />} />
+        <Route path="/projects" element={<ProjectsPage />} />
+        <Route path="/more" element={<MorePage />} />
         <Route path="/chat/:sessionId" element={<ChatPage />} />
 
         {/* Control Panel mode — existing pages moved under /admin/* */}

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { useApi } from '../context/ApiContext';
 import { useStatus } from '../context/StatusContext';
+import { useWorkbenchInbox } from '../context/WorkbenchInboxContext';
 import { AccountMenu } from './AccountMenu';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { ThemeToggle } from './ThemeToggle';
@@ -19,6 +20,7 @@ type ShellNavItem = {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   match?: (pathname: string) => boolean;
+  badge?: number;
 };
 
 // Mirrors design.pen kSWgv (VR/Sidebar): 240px width, fill --surface,
@@ -57,7 +59,14 @@ const MobileNavLink: React.FC<{ item: ShellNavItem }> = ({ item }) => {
         active ? 'bg-mint/[0.08] text-mint' : 'text-muted'
       )}
     >
-      <Icon className="size-4" />
+      <span className="relative">
+        <Icon className="size-4" />
+        {item.badge ? (
+          <span className="absolute -right-2 -top-1.5 min-w-[14px] rounded-full bg-mint px-1 text-center font-mono text-[9px] font-bold leading-[14px] text-background">
+            {item.badge > 99 ? '99+' : item.badge}
+          </span>
+        ) : null}
+      </span>
       <span className="max-w-full truncate">{item.label}</span>
     </NavLink>
   );
@@ -96,6 +105,7 @@ const MobileTabBar: React.FC<{ items: ShellNavItem[]; center: CenterButton }> = 
 export const AppShell: React.FC = () => {
   const { t } = useTranslation();
   const { status } = useStatus();
+  const { totalUnread } = useWorkbenchInbox();
   const api = useApi();
   const location = useLocation();
   const [enabledPlatforms, setEnabledPlatforms] = useState<string[]>([]);
@@ -143,7 +153,7 @@ export const AppShell: React.FC = () => {
   // ＋ that opens the workbench canvas (new session). Capabilities routes to
   // Agents and stays active across the four capability pages.
   const workbenchTabs: ShellNavItem[] = [
-    { to: '/inbox', label: t('nav.inbox'), icon: Inbox },
+    { to: '/inbox', label: t('nav.inbox'), icon: Inbox, badge: totalUnread },
     { to: '/projects', label: t('nav.projects'), icon: FolderTree },
     {
       to: '/agents',

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -75,7 +75,7 @@ const MobileTabBar: React.FC<{ items: ShellNavItem[]; center: CenterButton }> = 
   const right = items.slice(half);
   const CenterIcon = center.icon;
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-surface/96 px-2 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur md:hidden">
+    <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface/96 px-2 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur md:hidden">
       <div className="flex items-end justify-between gap-1">
         {left.map((item) => <MobileNavLink key={item.to} item={item} />)}
         <div className="flex flex-1 justify-center">

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
-import { ArrowLeft, ArrowRight, Hash, LayoutDashboard, MonitorPlay, Settings, SlidersHorizontal, Users } from 'lucide-react';
+import { ArrowLeft, ArrowRight, FolderTree, Hash, Inbox, LayoutDashboard, LayoutGrid, Menu, MonitorPlay, Plus, Settings, SlidersHorizontal, Sparkles, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -63,6 +63,36 @@ const MobileNavLink: React.FC<{ item: ShellNavItem }> = ({ item }) => {
   );
 };
 
+type CenterButton = { to: string; label: string; icon: React.ComponentType<{ className?: string }> };
+
+// Mobile bottom tab bar shared by both shells. Section tabs flank a raised
+// center FAB. Workbench: center = ＋ (new session). Control Panel: center =
+// Workbench (jump back) — the symmetric counterpart Alex asked for, so each
+// shell can reach the other from the tab bar.
+const MobileTabBar: React.FC<{ items: ShellNavItem[]; center: CenterButton }> = ({ items, center }) => {
+  const half = Math.ceil(items.length / 2);
+  const left = items.slice(0, half);
+  const right = items.slice(half);
+  const CenterIcon = center.icon;
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-surface/96 px-2 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur md:hidden">
+      <div className="flex items-end justify-between gap-1">
+        {left.map((item) => <MobileNavLink key={item.to} item={item} />)}
+        <div className="flex flex-1 justify-center">
+          <Link
+            to={center.to}
+            aria-label={center.label}
+            className="grid size-12 -translate-y-1 place-items-center rounded-full bg-mint text-background shadow-[0_8px_20px_-4px_rgba(91,255,160,0.6)] transition active:scale-95"
+          >
+            <CenterIcon className="size-6" />
+          </Link>
+        </div>
+        {right.map((item) => <MobileNavLink key={item.to} item={item} />)}
+      </div>
+    </nav>
+  );
+};
+
 export const AppShell: React.FC = () => {
   const { t } = useTranslation();
   const { status } = useStatus();
@@ -108,9 +138,25 @@ export const AppShell: React.FC = () => {
 
   const items: ShellNavItem[] = shellMode === 'admin' ? adminItems : [];
 
-  // Mobile nav uses the same routes as desktop; diagnostics lives under
-  // the Settings tab so we don't promote it to its own bottom-nav slot.
-  const mobileItems = items;
+  // Workbench mobile tabs flatten the (desktop-only) WorkbenchSidebar into a
+  // bottom tab bar: Inbox / Projects / Capabilities / More, around a center
+  // ＋ that opens the workbench canvas (new session). Capabilities routes to
+  // Agents and stays active across the four capability pages.
+  const workbenchTabs: ShellNavItem[] = [
+    { to: '/inbox', label: t('nav.inbox'), icon: Inbox },
+    { to: '/projects', label: t('nav.projects'), icon: FolderTree },
+    {
+      to: '/agents',
+      label: t('nav.capabilities'),
+      icon: LayoutGrid,
+      match: (p) => ['/agents', '/skills', '/harness', '/vaults'].some((x) => p.startsWith(x)),
+    },
+    { to: '/more', label: t('nav.more'), icon: Menu, match: (p) => p.startsWith('/more') },
+  ];
+
+  // Chat is a full-screen detail (own composer); the wizard owns the whole
+  // viewport. Hide the bottom tab bar on both.
+  const showBottomNav = !location.pathname.startsWith('/chat/') && location.pathname !== '/setup';
 
   return (
     <div className="min-h-screen min-h-[100dvh] bg-background text-foreground">
@@ -230,7 +276,8 @@ export const AppShell: React.FC = () => {
 
       <main
         className={clsx(
-          'min-h-screen pb-[calc(5.5rem+env(safe-area-inset-bottom))] md:ml-[240px] md:pb-0',
+          'min-h-screen md:ml-[240px] md:pb-0',
+          showBottomNav ? 'pb-[calc(5.5rem+env(safe-area-inset-bottom))]' : 'pb-0',
           location.pathname.startsWith('/admin/settings') ? 'page-glow-settings' : 'page-glow-console'
         )}
       >
@@ -239,12 +286,18 @@ export const AppShell: React.FC = () => {
         </div>
       </main>
 
-      {mobileItems.length > 0 && (
-        <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-surface/96 px-2 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur md:hidden">
-          <div className="flex gap-1">
-            {mobileItems.map((item) => <MobileNavLink key={item.to} item={item} />)}
-          </div>
-        </nav>
+      {showBottomNav && (
+        shellMode === 'admin' ? (
+          <MobileTabBar
+            items={adminItems}
+            center={{ to: '/', label: t('appShell.backToWorkbench'), icon: Sparkles }}
+          />
+        ) : (
+          <MobileTabBar
+            items={workbenchTabs}
+            center={{ to: '/', label: t('appShell.newSession'), icon: Plus }}
+          />
+        )
       )}
     </div>
   );

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -341,7 +341,7 @@ export function ShowPagesPage() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t('showPages.searchPlaceholder')}
-            className="w-[280px]"
+            className="w-full sm:w-[280px]"
           />
           <Button
             type="button"

--- a/ui/src/components/settings/SettingsPageShell.tsx
+++ b/ui/src/components/settings/SettingsPageShell.tsx
@@ -61,7 +61,7 @@ export const SettingsPageShell: React.FC<SettingsPageShellProps> = ({
       </div>
 
       <div className="border-b border-border">
-        <nav className="-mb-px flex flex-wrap gap-1" aria-label="Settings sections">
+        <nav className="-mb-px flex gap-1 overflow-x-auto pb-px" aria-label="Settings sections">
           {TABS.map((tab) => {
             const Icon = tab.icon;
             const active = tab.key === activeTab;
@@ -70,7 +70,7 @@ export const SettingsPageShell: React.FC<SettingsPageShellProps> = ({
                 key={tab.key}
                 to={tab.href}
                 className={clsx(
-                  'inline-flex items-center gap-2 border-b-2 px-4 py-2.5 text-[13px] transition-colors',
+                  'inline-flex shrink-0 items-center gap-2 whitespace-nowrap border-b-2 px-4 py-2.5 text-[13px] transition-colors',
                   active
                     ? 'border-mint font-semibold text-foreground'
                     : 'border-transparent font-medium text-muted hover:border-border-strong hover:text-foreground'

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -1066,7 +1066,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder={t('channelList.filterPlaceholder')}
-                className="w-[240px]"
+                className="w-full sm:w-[240px]"
               />
               <Button
                 type="button"
@@ -1085,12 +1085,12 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
           </div>
 
           {/* Platform Tabs — design.pen O2hb2M */}
-          <div className="flex flex-wrap items-end gap-1 border-b border-border">
+          <div className="flex items-end gap-1 overflow-x-auto border-b border-border">
             <button
               type="button"
               onClick={() => setPageTab('all')}
               className={clsx(
-                '-mb-px flex items-center gap-2 border-b-2 px-3 pb-2.5 pt-2 text-[13px] font-medium transition-colors',
+                '-mb-px flex shrink-0 items-center gap-2 border-b-2 px-3 pb-2.5 pt-2 text-[13px] font-medium transition-colors',
                 pageTab === 'all'
                   ? 'border-mint text-foreground'
                   : 'border-transparent text-muted hover:text-foreground'
@@ -1116,7 +1116,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                   type="button"
                   onClick={() => setPageTab(p)}
                   className={clsx(
-                    '-mb-px flex items-center gap-2 border-b-2 px-3 pb-2.5 pt-2 text-[13px] font-medium transition-colors',
+                    '-mb-px flex shrink-0 items-center gap-2 border-b-2 px-3 pb-2.5 pt-2 text-[13px] font-medium transition-colors',
                     active
                       ? 'border-mint text-foreground'
                       : 'border-transparent text-muted hover:text-foreground'

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -693,7 +693,7 @@ export const UserList: React.FC = () => {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder={t('userList.filterPlaceholder')}
-              className="w-[280px]"
+              className="w-full sm:w-[280px]"
             />
             <Button
               type="button"

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -33,7 +33,10 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-card p-6 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        // Mobile: keep a small gutter (w-calc) and cap height so a tall dialog
+        // scrolls inside the viewport instead of overflowing off the top/bottom
+        // of a short phone screen. sm+ restores the full-width-capped centered card.
+        'fixed left-1/2 top-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-1.5rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl border border-border bg-card p-6 shadow-xl sm:w-full data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
         className
       )}
       {...props}

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -35,6 +35,7 @@ import { estimateTokens } from '../../lib/tokenEstimate';
 import { fetchBackendModels } from '../../lib/backendModels';
 import { resolveEffortOptions } from '../../lib/effortOptions';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
+import { CapabilityTabs } from './CapabilityTabs';
 // Backend order / labels / accent classes live in lib/backendAccent, shared
 // with the Skills surface (BACKEND_TEXT is this page's old BACKEND_ICON_CLASS).
 import {
@@ -224,6 +225,7 @@ export const AgentsPage: React.FC = () => {
 
   return (
     <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 py-2">
+      <CapabilityTabs />
       {/* Header — shared WorkbenchPageHeader (design.pen: 40px mint icon + title + subtitle). */}
       <WorkbenchPageHeader
         icon={<Bot className="size-5" />}

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -241,7 +241,7 @@ export const AgentsPage: React.FC = () => {
 
       {/* Toolbar — design.pen Imduv: search + backend filter + spacer + Import + 新建 Agent */}
       <div className="flex flex-wrap items-center gap-2.5">
-        <div className="flex h-9 w-[320px] items-center gap-2 rounded-md border border-input bg-background px-3 transition-colors focus-within:border-ring focus-within:ring-2 focus-within:ring-ring">
+        <div className="flex h-9 w-full items-center gap-2 rounded-md border border-input bg-background px-3 transition-colors focus-within:border-ring focus-within:ring-2 focus-within:ring-ring sm:w-[320px]">
           <Search className="size-3.5 shrink-0 text-muted" />
           <input
             value={search}

--- a/ui/src/components/workbench/CapabilityTabs.tsx
+++ b/ui/src/components/workbench/CapabilityTabs.tsx
@@ -1,0 +1,40 @@
+import { NavLink, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Activity, Bot, KeyRound, WandSparkles } from 'lucide-react';
+import clsx from 'clsx';
+
+const TABS = [
+  { to: '/agents', icon: Bot, key: 'workbench.modules.agents.title' },
+  { to: '/skills', icon: WandSparkles, key: 'workbench.modules.skills.title' },
+  { to: '/harness', icon: Activity, key: 'workbench.modules.harness.title' },
+  { to: '/vaults', icon: KeyRound, key: 'workbench.modules.vaults.title' },
+] as const;
+
+// Mobile-only capability sub-tab strip. On desktop these capabilities live in
+// the WorkbenchSidebar; on mobile the 能力 (Capabilities) bottom tab lands on
+// a capability page and this strip switches between Agents / Skills / Harness /
+// Vaults. Design: design.pen `wdtCs` sub-tabs.
+export const CapabilityTabs: React.FC = () => {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  return (
+    <div className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-0.5 md:hidden">
+      {TABS.map(({ to, icon: Icon, key }) => {
+        const active = pathname.startsWith(to);
+        return (
+          <NavLink
+            key={to}
+            to={to}
+            className={clsx(
+              'flex shrink-0 items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-[12.5px] font-medium transition',
+              active ? 'border-mint/40 bg-mint-soft text-mint' : 'border-border-strong text-muted',
+            )}
+          >
+            <Icon className="size-3.5" />
+            <span>{t(key)}</span>
+          </NavLink>
+        );
+      })}
+    </div>
+  );
+};

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1030,8 +1030,11 @@ const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({ session, agents, on
           <ChevronDown className="size-3 shrink-0 text-muted" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-[620px] max-w-[92vw] overflow-hidden p-0">
-        <div className="grid grid-cols-3 divide-x divide-border">
+      <PopoverContent align="end" className="max-h-[70vh] w-[620px] max-w-[92vw] overflow-y-auto p-0">
+        {/* On phones the three columns stack into one scrollable list (the
+            popover anchors near the bottom like a sheet); sm+ keeps the
+            side-by-side cascading menu. */}
+        <div className="grid grid-cols-1 divide-y divide-border sm:grid-cols-3 sm:divide-x sm:divide-y-0">
           {/* Column 1 — Agent */}
           <RouteColumn title={t('chat.picker.agent')}>
             {agents.length === 0 && (
@@ -1146,7 +1149,7 @@ const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({ session, agents, on
 };
 
 const RouteColumn: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
-  <div className="flex max-h-[320px] min-w-0 flex-col overflow-y-auto p-1.5">
+  <div className="flex min-w-0 flex-col overflow-y-auto p-1.5 sm:max-h-[320px]">
     <div className="px-2 pb-1 pt-0.5 text-[10px] font-bold uppercase tracking-[0.1em] text-muted">{title}</div>
     {children}
   </div>

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -31,6 +31,7 @@ import type {
 import { formatRelativeTime } from '../../lib/relativeTime';
 import { CreateViaChatDialog } from './CreateViaChatDialog';
 import type { CreateViaChatKind } from './CreateViaChatDialog';
+import { CapabilityTabs } from './CapabilityTabs';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
@@ -297,6 +298,7 @@ export const HarnessPage: React.FC = () => {
 
   return (
     <div className="mx-auto flex w-full max-w-[1180px] flex-col gap-5 py-2">
+      <CapabilityTabs />
       {/* Header */}
       <div className="flex items-center gap-4">
         <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-violet/30 bg-violet/[0.08] text-violet shadow-[0_0_24px_-6px_rgba(124,91,255,0.5)]">

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -369,7 +369,7 @@ export const HarnessPage: React.FC = () => {
           runs tab has its own server-side query in /api/harness/runs. */}
       {showSearchBar && (
         <div className="flex flex-wrap items-center gap-2.5">
-          <div className="flex h-9 w-[320px] items-center gap-2 rounded-md border border-input bg-background px-3 transition-colors focus-within:border-ring focus-within:ring-2 focus-within:ring-ring">
+          <div className="flex h-9 w-full items-center gap-2 rounded-md border border-input bg-background px-3 transition-colors focus-within:border-ring focus-within:ring-2 focus-within:ring-ring sm:w-[320px]">
             <Search className="size-3.5 shrink-0 text-muted" />
             <input
               value={search}

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -326,7 +326,7 @@ export const HarnessPage: React.FC = () => {
       </div>
 
       {/* Tab row */}
-      <div className="flex items-center gap-0 border-b border-border">
+      <div className="flex items-center gap-0 overflow-x-auto border-b border-border">
         {TAB_ORDER.map((key) => {
           const active = tab === key;
           const count = counts[key];
@@ -339,7 +339,7 @@ export const HarnessPage: React.FC = () => {
                 setSelection(null);
               }}
               className={clsx(
-                'flex items-center gap-2 px-4 py-3 text-[13px] transition',
+                'flex shrink-0 items-center gap-2 whitespace-nowrap px-4 py-3 text-[13px] transition',
                 active ? 'border-b-2 border-violet font-bold text-violet' : 'font-medium text-muted hover:text-foreground',
               )}
             >

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowRight, Globe, Info, Link as LinkIcon, SlidersHorizontal } from 'lucide-react';
+import clsx from 'clsx';
+
+import { useApi } from '../../context/ApiContext';
+import { useStatus } from '../../context/StatusContext';
+import { AccountMenu } from '../AccountMenu';
+import { LanguageSwitcher } from '../LanguageSwitcher';
+import { ThemeToggle } from '../ThemeToggle';
+import { VersionBadge } from '../VersionBadge';
+
+// Mobile-only "More" tab (workbench). The bridge to the Control Panel plus
+// appearance / connection / account. Per product decision the service
+// start/stop control lives ONLY in the Control Panel, so this screen shows a
+// read-only status line. Design: design.pen `Nxnja`.
+export const MorePage: React.FC = () => {
+  const { t } = useTranslation();
+  const { status } = useStatus();
+  const api = useApi();
+  const [config, setConfig] = useState<any>(null);
+
+  useEffect(() => {
+    api.getConfig().then(setConfig).catch(() => {});
+  }, [api]);
+
+  const isRunning = status.state === 'running';
+  const hostname = config?.runtime?.hostname as string | undefined;
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      <h1 className="text-xl font-bold">{t('more.title')}</h1>
+
+      {/* Read-only service status — control lives in the Control Panel. */}
+      <div
+        className={clsx(
+          'flex items-center gap-2.5 rounded-xl border px-4 py-3.5',
+          isRunning ? 'border-mint/30 bg-mint/[0.08]' : 'border-border bg-surface'
+        )}
+      >
+        <span
+          className={clsx(
+            'size-2.5 shrink-0 rounded-full',
+            isRunning ? 'bg-mint shadow-[0_0_9px_rgba(91,255,160,0.9)]' : 'bg-muted'
+          )}
+        />
+        <span className="flex-1 text-sm font-semibold">
+          {isRunning ? t('common.running') : t('common.stopped')}
+        </span>
+        <VersionBadge />
+      </div>
+
+      {/* Bridge to the Control Panel (admin shell). */}
+      <Link
+        to="/admin/dashboard"
+        className="flex items-center gap-3 rounded-xl border border-cyan/35 bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
+      >
+        <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-cyan/[0.14]">
+          <SlidersHorizontal className="size-[18px] text-cyan" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[15px] font-semibold">{t('more.controlPanel')}</span>
+          <span className="block truncate text-[11.5px] text-muted">{t('more.controlPanelDesc')}</span>
+        </span>
+        <ArrowRight className="size-[18px] shrink-0 text-cyan" />
+      </Link>
+
+      {/* Appearance — reuse the existing toggles as touch rows. */}
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <span className="flex-1 text-sm font-medium">{t('more.appearance')}</span>
+          <ThemeToggle />
+          <LanguageSwitcher />
+        </div>
+      </div>
+
+      {/* Connection */}
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        {hostname && (
+          <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+            <LinkIcon className="size-4 text-muted" />
+            <span className="flex-1 text-sm font-medium">{t('more.host')}</span>
+            <span className="font-mono text-[12px] text-muted">{hostname}</span>
+          </div>
+        )}
+        <div className="flex items-center gap-3 px-4 py-3">
+          <Globe className="size-4 text-muted" />
+          <span className="flex-1 text-sm font-medium">{t('more.connection')}</span>
+          <AccountMenu />
+        </div>
+        <div className="flex items-center gap-3 border-t border-border px-4 py-3">
+          <Info className="size-4 text-muted" />
+          <span className="flex-1 text-sm font-medium">{t('more.version')}</span>
+          <VersionBadge />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -67,7 +67,7 @@ export const MorePage: React.FC = () => {
       </Link>
 
       {/* Appearance — reuse the existing toggles as touch rows. */}
-      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="rounded-xl border border-border bg-surface">
         <div className="flex items-center gap-3 px-4 py-3">
           <span className="flex-1 text-sm font-medium">{t('more.appearance')}</span>
           <ThemeToggle />
@@ -76,7 +76,7 @@ export const MorePage: React.FC = () => {
       </div>
 
       {/* Connection */}
-      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="rounded-xl border border-border bg-surface">
         {hostname && (
           <div className="flex items-center gap-3 border-b border-border px-4 py-3">
             <LinkIcon className="size-4 text-muted" />
@@ -87,7 +87,7 @@ export const MorePage: React.FC = () => {
         <div className="flex items-center gap-3 px-4 py-3">
           <Globe className="size-4 text-muted" />
           <span className="flex-1 text-sm font-medium">{t('more.connection')}</span>
-          <AccountMenu />
+          <AccountMenu openUpward />
         </div>
         <div className="flex items-center gap-3 border-t border-border px-4 py-3">
           <Info className="size-4 text-muted" />

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, Globe, Info, Link as LinkIcon, SlidersHorizontal } from 'lucide-react';
+import { ArrowRight, Info, Link as LinkIcon, SlidersHorizontal } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
 import { useStatus } from '../../context/StatusContext';
-import { AccountMenu } from '../AccountMenu';
 import { LanguageSwitcher } from '../LanguageSwitcher';
 import { ThemeToggle } from '../ThemeToggle';
 import { VersionBadge } from '../VersionBadge';
@@ -78,18 +77,13 @@ export const MorePage: React.FC = () => {
       {/* Connection */}
       <div className="rounded-xl border border-border bg-surface">
         {hostname && (
-          <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+          <div className="flex items-center gap-3 px-4 py-3">
             <LinkIcon className="size-4 text-muted" />
             <span className="flex-1 text-sm font-medium">{t('more.host')}</span>
             <span className="font-mono text-[12px] text-muted">{hostname}</span>
           </div>
         )}
-        <div className="flex items-center gap-3 px-4 py-3">
-          <Globe className="size-4 text-muted" />
-          <span className="flex-1 text-sm font-medium">{t('more.connection')}</span>
-          <AccountMenu openUpward />
-        </div>
-        <div className="flex items-center gap-3 border-t border-border px-4 py-3">
+        <div className={clsx('flex items-center gap-3 px-4 py-3', hostname && 'border-t border-border')}>
           <Info className="size-4 text-muted" />
           <span className="flex-1 text-sm font-medium">{t('more.version')}</span>
           <VersionBadge />

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight, Folder, FolderOpen, FolderPlus, Loader2, RotateCw } from 'lucide-react';
@@ -39,6 +39,7 @@ export const ProjectsPage: React.FC = () => {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [sessions, setSessions] = useState<Record<string, SessionState>>({});
   const [showNewProject, setShowNewProject] = useState(false);
+  const expandedRef = useRef<Set<string>>(new Set());
 
   const fetchProjects = useCallback(async () => {
     try {
@@ -74,9 +75,13 @@ export const ProjectsPage: React.FC = () => {
         const res = await api.listSessions({ projectId, status: 'active', limit: PAGE_SIZE, beforeId });
         setSessions((prev) => {
           const existing = beforeId ? prev[projectId]?.sessions ?? [] : [];
+          // Dedupe against already-loaded ids: a page can overlap if a session's
+          // last_active_at shifts between requests or Load more is double-tapped.
+          const seen = new Set(existing.map((s) => s.id));
+          const merged = [...existing, ...res.sessions.filter((s) => !seen.has(s.id))];
           return {
             ...prev,
-            [projectId]: { status: 'loaded', sessions: [...existing, ...res.sessions], nextBeforeId: res.next_before_id },
+            [projectId]: { status: 'loaded', sessions: merged, nextBeforeId: res.next_before_id },
           };
         });
       } catch {
@@ -116,6 +121,41 @@ export const ProjectsPage: React.FC = () => {
     },
     [markRead, navigate],
   );
+
+  useEffect(() => {
+    expandedRef.current = expanded;
+  }, [expanded]);
+
+  // Keep /projects live: patch a row's status dot from session.status events and
+  // re-pull expanded projects on SSE reconnect, so dots don't go stale like a
+  // one-shot listSessions would (mirrors the desktop WorkbenchSidebar).
+  useEffect(() => {
+    const disconnect = api.connectWorkbenchEvents({
+      onSessionStatus: ({ session_id, agent_status }) => {
+        setSessions((prev) => {
+          let changed = false;
+          const next: Record<string, SessionState> = {};
+          for (const [pid, st] of Object.entries(prev)) {
+            let rowChanged = false;
+            const updated = st.sessions.map((s) => {
+              if (s.id === session_id && s.agent_status !== agent_status) {
+                rowChanged = true;
+                return { ...s, agent_status };
+              }
+              return s;
+            });
+            next[pid] = rowChanged ? { ...st, sessions: updated } : st;
+            if (rowChanged) changed = true;
+          }
+          return changed ? next : prev;
+        });
+      },
+      onConnected: () => {
+        for (const pid of expandedRef.current) void loadSessions(pid);
+      },
+    });
+    return disconnect;
+  }, [api, loadSessions]);
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-3">

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -34,7 +34,7 @@ export const ProjectsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
   const navigate = useNavigate();
-  const { markRead } = useWorkbenchInbox();
+  const { markRead, unreadBySession } = useWorkbenchInbox();
   const [projects, setProjects] = useState<WorkbenchProject[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [sessions, setSessions] = useState<Record<string, SessionState>>({});
@@ -283,22 +283,31 @@ export const ProjectsPage: React.FC = () => {
                 {state?.status === 'loaded' && state.sessions.length === 0 && (
                   <div className="px-3 py-3 text-center text-[13px] text-muted">{t('projects.noSessions')}</div>
                 )}
-                {state?.sessions.map((session) => (
-                  <button
-                    key={session.id}
-                    type="button"
-                    onClick={() => openSession(session.id)}
-                    className="flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition hover:bg-foreground/[0.04]"
-                  >
-                    <span className={clsx('size-1.5 shrink-0 rounded-full', DOT[session.agent_status] ?? DOT.idle)} />
-                    <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
-                      {session.title || `#${session.id.slice(-6)}`}
-                    </span>
-                    <span className="shrink-0 text-[10.5px] text-muted">
-                      {formatRelativeTime(session.last_active_at ?? session.updated_at, t)}
-                    </span>
-                  </button>
-                ))}
+                {state?.sessions.map((session) => {
+                  const unread = unreadBySession[session.id] ?? 0;
+                  return (
+                    <button
+                      key={session.id}
+                      type="button"
+                      onClick={() => openSession(session.id)}
+                      className="flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition hover:bg-foreground/[0.04]"
+                    >
+                      <span className={clsx('size-1.5 shrink-0 rounded-full', DOT[session.agent_status] ?? DOT.idle)} />
+                      <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
+                        {session.title || `#${session.id.slice(-6)}`}
+                      </span>
+                      {unread > 0 ? (
+                        <span className="shrink-0 rounded-full bg-mint px-1.5 py-0.5 font-mono text-[10px] font-bold text-background">
+                          {unread > 99 ? '99+' : unread}
+                        </span>
+                      ) : (
+                        <span className="shrink-0 text-[10.5px] text-muted">
+                          {formatRelativeTime(session.last_active_at ?? session.updated_at, t)}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
                 {state?.nextBeforeId && (
                   <button
                     type="button"

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronRight, Folder, FolderOpen, FolderPlus } from 'lucide-react';
+import clsx from 'clsx';
+
+import { useApi } from '../../context/ApiContext';
+import type { WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
+import { formatRelativeTime } from '../../lib/relativeTime';
+import { NewProjectDialog } from './NewProjectDialog';
+
+const DOT: Record<string, string> = {
+  running: 'bg-mint shadow-[0_0_7px_rgba(91,255,160,0.9)]',
+  failed: 'bg-destructive',
+  idle: 'bg-muted',
+};
+
+// Mobile-only "Projects" tab (workbench). The desktop projects tree
+// (WorkbenchSidebar) flattened into a full-page accordion: tap a project to
+// expand its sessions, tap a session to open the chat. Design: design.pen `FW7cI`.
+export const ProjectsPage: React.FC = () => {
+  const { t } = useTranslation();
+  const api = useApi();
+  const navigate = useNavigate();
+  const [projects, setProjects] = useState<WorkbenchProject[]>([]);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [sessions, setSessions] = useState<Record<string, WorkbenchSession[]>>({});
+  const [showNewProject, setShowNewProject] = useState(false);
+
+  const fetchProjects = useCallback(async () => {
+    try {
+      const res = await api.listProjects();
+      setProjects(res.projects);
+    } catch {
+      /* surfaced elsewhere */
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void fetchProjects();
+  }, [fetchProjects]);
+
+  const toggle = useCallback(
+    async (projectId: string) => {
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        next.has(projectId) ? next.delete(projectId) : next.add(projectId);
+        return next;
+      });
+      if (!sessions[projectId]) {
+        try {
+          const res = await api.listSessions({ projectId, status: 'active' });
+          setSessions((prev) => ({ ...prev, [projectId]: res.sessions }));
+        } catch {
+          setSessions((prev) => ({ ...prev, [projectId]: [] }));
+        }
+      }
+    },
+    [api, sessions]
+  );
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">{t('projects.title')}</h1>
+        <button
+          type="button"
+          onClick={() => setShowNewProject(true)}
+          className="grid size-9 place-items-center rounded-lg border border-mint/35 bg-mint/[0.08] text-mint transition hover:bg-mint/[0.14]"
+          aria-label={t('projects.newProject')}
+        >
+          <FolderPlus className="size-4" />
+        </button>
+      </div>
+
+      {projects.length === 0 && (
+        <div className="rounded-xl border border-border bg-surface px-4 py-10 text-center text-sm text-muted">
+          {t('projects.empty')}
+        </div>
+      )}
+
+      {projects.map((project) => {
+        const open = expanded.has(project.id);
+        const projectSessions = sessions[project.id];
+        return (
+          <div key={project.id} className="overflow-hidden rounded-xl border border-border bg-surface">
+            <button
+              type="button"
+              onClick={() => void toggle(project.id)}
+              className="flex w-full items-center gap-2.5 px-4 py-3.5 text-left"
+            >
+              {open ? <FolderOpen className="size-4 shrink-0 text-cyan" /> : <Folder className="size-4 shrink-0 text-muted" />}
+              <span className="min-w-0 flex-1 truncate text-sm font-semibold">{project.display_name}</span>
+              {projectSessions && (
+                <span className="rounded-full bg-foreground/[0.06] px-2 py-0.5 font-mono text-[10px] text-muted">
+                  {projectSessions.length}
+                </span>
+              )}
+              {open ? <ChevronDown className="size-4 shrink-0 text-muted" /> : <ChevronRight className="size-4 shrink-0 text-muted" />}
+            </button>
+
+            {open && (
+              <div className="flex flex-col gap-0.5 border-t border-border px-2 py-2">
+                {projectSessions && projectSessions.length === 0 && (
+                  <div className="px-3 py-3 text-center text-[13px] text-muted">{t('projects.noSessions')}</div>
+                )}
+                {projectSessions?.map((session) => (
+                  <button
+                    key={session.id}
+                    type="button"
+                    onClick={() => navigate(`/chat/${session.id}`)}
+                    className="flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition hover:bg-foreground/[0.04]"
+                  >
+                    <span className={clsx('size-1.5 shrink-0 rounded-full', DOT[session.agent_status] ?? DOT.idle)} />
+                    <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
+                      {session.title || `#${session.id.slice(-6)}`}
+                    </span>
+                    <span className="shrink-0 text-[10.5px] text-muted">
+                      {formatRelativeTime(session.last_active_at ?? session.updated_at, t)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {showNewProject && (
+        <NewProjectDialog
+          onClose={() => setShowNewProject(false)}
+          onCreated={() => {
+            setShowNewProject(false);
+            void fetchProjects();
+          }}
+        />
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -40,13 +40,18 @@ export const ProjectsPage: React.FC = () => {
   const [sessions, setSessions] = useState<Record<string, SessionState>>({});
   const [showNewProject, setShowNewProject] = useState(false);
   const expandedRef = useRef<Set<string>>(new Set());
+  const sessionsRef = useRef<Record<string, SessionState>>({});
+  const [projectsError, setProjectsError] = useState(false);
 
   const fetchProjects = useCallback(async () => {
+    setProjectsError(false);
     try {
       const res = await api.listProjects();
       setProjects(res.projects);
     } catch {
-      /* surfaced elsewhere */
+      // Don't strand the user on an empty-state for a transient failure —
+      // surface a retry instead of a false "No projects yet".
+      setProjectsError(true);
     }
   }, [api]);
 
@@ -126,6 +131,27 @@ export const ProjectsPage: React.FC = () => {
     expandedRef.current = expanded;
   }, [expanded]);
 
+  useEffect(() => {
+    sessionsRef.current = sessions;
+  }, [sessions]);
+
+  // Refetch a project's already-loaded window (not just page 1) so a reconnect
+  // preserves paged-in rows instead of collapsing back to the first page.
+  const reconcileSessions = useCallback(
+    async (projectId: string, limit: number) => {
+      try {
+        const res = await api.listSessions({ projectId, status: 'active', limit });
+        setSessions((prev) => ({
+          ...prev,
+          [projectId]: { status: 'loaded', sessions: res.sessions, nextBeforeId: res.next_before_id },
+        }));
+      } catch {
+        /* keep the current window on a failed reconcile */
+      }
+    },
+    [api],
+  );
+
   // Keep /projects live: patch a row's status dot from session.status events and
   // re-pull expanded projects on SSE reconnect, so dots don't go stale like a
   // one-shot listSessions would (mirrors the desktop WorkbenchSidebar).
@@ -151,11 +177,16 @@ export const ProjectsPage: React.FC = () => {
         });
       },
       onConnected: () => {
-        for (const pid of expandedRef.current) void loadSessions(pid);
+        // Refetch the already-loaded window per expanded project (not page 1),
+        // so paged-in rows survive a reconnect.
+        for (const pid of expandedRef.current) {
+          const loaded = sessionsRef.current[pid]?.sessions.length ?? 0;
+          void reconcileSessions(pid, Math.max(PAGE_SIZE, loaded));
+        }
       },
     });
     return disconnect;
-  }, [api, loadSessions]);
+  }, [api, reconcileSessions]);
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-3">
@@ -171,7 +202,17 @@ export const ProjectsPage: React.FC = () => {
         </button>
       </div>
 
-      {projects.length === 0 && (
+      {projects.length === 0 && projectsError && (
+        <button
+          type="button"
+          onClick={() => void fetchProjects()}
+          className="flex items-center justify-center gap-2 rounded-xl border border-border bg-surface px-4 py-10 text-sm text-muted transition hover:text-foreground"
+        >
+          <RotateCw className="size-4" />
+          {t('projects.loadFailed')}
+        </button>
+      )}
+      {projects.length === 0 && !projectsError && (
         <div className="rounded-xl border border-border bg-surface px-4 py-10 text-center text-sm text-muted">
           {t('projects.empty')}
         </div>

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ChevronRight, Folder, FolderOpen, FolderPlus } from 'lucide-react';
+import { ChevronDown, ChevronRight, Folder, FolderOpen, FolderPlus, Loader2, RotateCw } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
 import type { WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
+import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
 import { NewProjectDialog } from './NewProjectDialog';
 
@@ -15,6 +16,17 @@ const DOT: Record<string, string> = {
   idle: 'bg-muted',
 };
 
+const PAGE_SIZE = 50;
+
+// Per-project session list: tracks paging cursor + load status so a transient
+// failure can be retried (not cached as an empty list) and projects with >50
+// active sessions can page in the rest — mirroring the desktop sidebar.
+type SessionState = {
+  status: 'loading' | 'loaded' | 'error';
+  sessions: WorkbenchSession[];
+  nextBeforeId: string | null;
+};
+
 // Mobile-only "Projects" tab (workbench). The desktop projects tree
 // (WorkbenchSidebar) flattened into a full-page accordion: tap a project to
 // expand its sessions, tap a session to open the chat. Design: design.pen `FW7cI`.
@@ -22,9 +34,10 @@ export const ProjectsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
   const navigate = useNavigate();
+  const { markRead } = useWorkbenchInbox();
   const [projects, setProjects] = useState<WorkbenchProject[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const [sessions, setSessions] = useState<Record<string, WorkbenchSession[]>>({});
+  const [sessions, setSessions] = useState<Record<string, SessionState>>({});
   const [showNewProject, setShowNewProject] = useState(false);
 
   const fetchProjects = useCallback(async () => {
@@ -40,23 +53,68 @@ export const ProjectsPage: React.FC = () => {
     void fetchProjects();
   }, [fetchProjects]);
 
+  // Load (or page) a project's sessions. `beforeId` appends the next page;
+  // omitting it loads the first page. On failure we store status:'error' WITHOUT
+  // an empty list so the user can retry (re-expand or the Retry button) instead
+  // of being stuck on a permanent "No sessions".
+  const loadSessions = useCallback(
+    async (projectId: string, beforeId?: string) => {
+      setSessions((prev) => {
+        const cur = prev[projectId];
+        return {
+          ...prev,
+          [projectId]: {
+            status: 'loading',
+            sessions: cur?.sessions ?? [],
+            nextBeforeId: cur?.nextBeforeId ?? null,
+          },
+        };
+      });
+      try {
+        const res = await api.listSessions({ projectId, status: 'active', limit: PAGE_SIZE, beforeId });
+        setSessions((prev) => {
+          const existing = beforeId ? prev[projectId]?.sessions ?? [] : [];
+          return {
+            ...prev,
+            [projectId]: { status: 'loaded', sessions: [...existing, ...res.sessions], nextBeforeId: res.next_before_id },
+          };
+        });
+      } catch {
+        setSessions((prev) => ({
+          ...prev,
+          [projectId]: {
+            status: 'error',
+            sessions: prev[projectId]?.sessions ?? [],
+            nextBeforeId: prev[projectId]?.nextBeforeId ?? null,
+          },
+        }));
+      }
+    },
+    [api],
+  );
+
   const toggle = useCallback(
-    async (projectId: string) => {
+    (projectId: string) => {
       setExpanded((prev) => {
         const next = new Set(prev);
         next.has(projectId) ? next.delete(projectId) : next.add(projectId);
         return next;
       });
-      if (!sessions[projectId]) {
-        try {
-          const res = await api.listSessions({ projectId, status: 'active' });
-          setSessions((prev) => ({ ...prev, [projectId]: res.sessions }));
-        } catch {
-          setSessions((prev) => ({ ...prev, [projectId]: [] }));
-        }
-      }
+      // Fetch on first expand or after a prior failure; a successful load is cached.
+      const cur = sessions[projectId];
+      if (!cur || cur.status === 'error') void loadSessions(projectId);
     },
-    [api, sessions]
+    [sessions, loadSessions],
+  );
+
+  const openSession = useCallback(
+    (sessionId: string) => {
+      // Opening a chat marks it read everywhere (matches the desktop tree + Inbox),
+      // so unread badges/counts don't linger after a mobile drill-in.
+      void markRead(sessionId);
+      navigate(`/chat/${sessionId}`);
+    },
+    [markRead, navigate],
   );
 
   return (
@@ -81,19 +139,20 @@ export const ProjectsPage: React.FC = () => {
 
       {projects.map((project) => {
         const open = expanded.has(project.id);
-        const projectSessions = sessions[project.id];
+        const state = sessions[project.id];
         return (
           <div key={project.id} className="overflow-hidden rounded-xl border border-border bg-surface">
             <button
               type="button"
-              onClick={() => void toggle(project.id)}
+              onClick={() => toggle(project.id)}
               className="flex w-full items-center gap-2.5 px-4 py-3.5 text-left"
             >
               {open ? <FolderOpen className="size-4 shrink-0 text-cyan" /> : <Folder className="size-4 shrink-0 text-muted" />}
               <span className="min-w-0 flex-1 truncate text-sm font-semibold">{project.display_name}</span>
-              {projectSessions && (
+              {state?.status === 'loaded' && (
                 <span className="rounded-full bg-foreground/[0.06] px-2 py-0.5 font-mono text-[10px] text-muted">
-                  {projectSessions.length}
+                  {state.sessions.length}
+                  {state.nextBeforeId ? '+' : ''}
                 </span>
               )}
               {open ? <ChevronDown className="size-4 shrink-0 text-muted" /> : <ChevronRight className="size-4 shrink-0 text-muted" />}
@@ -101,14 +160,30 @@ export const ProjectsPage: React.FC = () => {
 
             {open && (
               <div className="flex flex-col gap-0.5 border-t border-border px-2 py-2">
-                {projectSessions && projectSessions.length === 0 && (
+                {state?.status === 'loading' && state.sessions.length === 0 && (
+                  <div className="flex items-center justify-center gap-2 px-3 py-3 text-[13px] text-muted">
+                    <Loader2 className="size-3.5 animate-spin" />
+                    {t('common.loading')}
+                  </div>
+                )}
+                {state?.status === 'error' && state.sessions.length === 0 && (
+                  <button
+                    type="button"
+                    onClick={() => void loadSessions(project.id)}
+                    className="flex items-center justify-center gap-2 rounded-lg px-3 py-3 text-[13px] text-muted transition hover:text-foreground"
+                  >
+                    <RotateCw className="size-3.5" />
+                    {t('projects.loadFailed')}
+                  </button>
+                )}
+                {state?.status === 'loaded' && state.sessions.length === 0 && (
                   <div className="px-3 py-3 text-center text-[13px] text-muted">{t('projects.noSessions')}</div>
                 )}
-                {projectSessions?.map((session) => (
+                {state?.sessions.map((session) => (
                   <button
                     key={session.id}
                     type="button"
-                    onClick={() => navigate(`/chat/${session.id}`)}
+                    onClick={() => openSession(session.id)}
                     className="flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-left transition hover:bg-foreground/[0.04]"
                   >
                     <span className={clsx('size-1.5 shrink-0 rounded-full', DOT[session.agent_status] ?? DOT.idle)} />
@@ -120,6 +195,17 @@ export const ProjectsPage: React.FC = () => {
                     </span>
                   </button>
                 ))}
+                {state?.nextBeforeId && (
+                  <button
+                    type="button"
+                    onClick={() => void loadSessions(project.id, state.nextBeforeId!)}
+                    disabled={state.status === 'loading'}
+                    className="flex items-center justify-center gap-2 rounded-lg px-3 py-2.5 text-[12px] font-medium text-cyan transition hover:bg-cyan/[0.06] disabled:opacity-50"
+                  >
+                    {state.status === 'loading' ? <Loader2 className="size-3.5 animate-spin" /> : <ChevronDown className="size-3.5" />}
+                    {t('projects.loadMore')}
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -8,6 +8,8 @@ import { useApi } from '../../context/ApiContext';
 import type { WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
 import { NewProjectDialog } from './NewProjectDialog';
 
 const DOT: Record<string, string> = {
@@ -138,12 +140,29 @@ export const ProjectsPage: React.FC = () => {
   // Refetch a project's already-loaded window (not just page 1) so a reconnect
   // preserves paged-in rows instead of collapsing back to the first page.
   const reconcileSessions = useCallback(
-    async (projectId: string, limit: number) => {
+    async (projectId: string, targetCount: number) => {
       try {
-        const res = await api.listSessions({ projectId, status: 'active', limit });
+        // Page in PAGE_SIZE chunks until the previously-loaded window is rebuilt.
+        // The server clamps /api/sessions limit to 200, so a single large
+        // request would silently truncate windows >200 rows on reconnect.
+        const acc: WorkbenchSession[] = [];
+        const seen = new Set<string>();
+        let before: string | undefined;
+        let nextBeforeId: string | null = null;
+        do {
+          const res = await api.listSessions({ projectId, status: 'active', limit: PAGE_SIZE, beforeId: before });
+          for (const s of res.sessions) {
+            if (!seen.has(s.id)) {
+              seen.add(s.id);
+              acc.push(s);
+            }
+          }
+          nextBeforeId = res.next_before_id;
+          before = res.next_before_id ?? undefined;
+        } while (before && acc.length < targetCount);
         setSessions((prev) => ({
           ...prev,
-          [projectId]: { status: 'loaded', sessions: res.sessions, nextBeforeId: res.next_before_id },
+          [projectId]: { status: 'loaded', sessions: acc, nextBeforeId },
         }));
       } catch {
         /* keep the current window on a failed reconcile */
@@ -215,14 +234,16 @@ export const ProjectsPage: React.FC = () => {
     <div className="mx-auto flex max-w-xl flex-col gap-3">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">{t('projects.title')}</h1>
-        <button
+        <Button
           type="button"
+          variant="outline"
+          size="icon"
           onClick={() => setShowNewProject(true)}
-          className="grid size-9 place-items-center rounded-lg border border-mint/35 bg-mint/[0.08] text-mint transition hover:bg-mint/[0.14]"
           aria-label={t('projects.newProject')}
+          className="border-mint/35 bg-mint/[0.08] text-mint hover:bg-mint/[0.14]"
         >
           <FolderPlus className="size-4" />
-        </button>
+        </Button>
       </div>
 
       {projects.length === 0 && projectsError && (
@@ -254,10 +275,10 @@ export const ProjectsPage: React.FC = () => {
               {open ? <FolderOpen className="size-4 shrink-0 text-cyan" /> : <Folder className="size-4 shrink-0 text-muted" />}
               <span className="min-w-0 flex-1 truncate text-sm font-semibold">{project.display_name}</span>
               {state?.status === 'loaded' && (
-                <span className="rounded-full bg-foreground/[0.06] px-2 py-0.5 font-mono text-[10px] text-muted">
+                <Badge variant="secondary" className="font-mono text-[10px]">
                   {state.sessions.length}
                   {state.nextBeforeId ? '+' : ''}
-                </span>
+                </Badge>
               )}
               {open ? <ChevronDown className="size-4 shrink-0 text-muted" /> : <ChevronRight className="size-4 shrink-0 text-muted" />}
             </button>

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -176,6 +176,29 @@ export const ProjectsPage: React.FC = () => {
           return changed ? next : prev;
         });
       },
+      onSessionActivity: (data) => {
+        // A rename broadcasts session.activity {event:'updated', title}; patch the
+        // cached row so the list doesn't show a stale title until remount.
+        if (data.event !== 'updated' || !Object.prototype.hasOwnProperty.call(data, 'title')) return;
+        const nextTitle = data.title ?? null;
+        setSessions((prev) => {
+          let changed = false;
+          const next: Record<string, SessionState> = {};
+          for (const [pid, st] of Object.entries(prev)) {
+            let rowChanged = false;
+            const updated = st.sessions.map((s) => {
+              if (s.id === data.session_id && s.title !== nextTitle) {
+                rowChanged = true;
+                return { ...s, title: nextTitle };
+              }
+              return s;
+            });
+            next[pid] = rowChanged ? { ...st, sessions: updated } : st;
+            if (rowChanged) changed = true;
+          }
+          return changed ? next : prev;
+        });
+      },
       onConnected: () => {
         // Refetch the already-loaded window per expanded project (not page 1),
         // so paged-in rows survive a reconnect.

--- a/ui/src/components/workbench/SkillsPage.tsx
+++ b/ui/src/components/workbench/SkillsPage.tsx
@@ -11,6 +11,7 @@ import { Button } from '../ui/button';
 import { SegmentedRadio } from '../ui/segmented';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
+import { CapabilityTabs } from './CapabilityTabs';
 import { SkillRow } from './skills/SkillRow';
 import { SkillDetailPanel } from './skills/SkillDetailPanel';
 import { ProjectPicker } from './skills/ProjectPicker';
@@ -238,6 +239,7 @@ export const SkillsPage: React.FC = () => {
 
   return (
     <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 py-2">
+      <CapabilityTabs />
       <WorkbenchPageHeader
         icon={<WandSparkles className="size-5" />}
         title={t('skills.title')}

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -1,6 +1,10 @@
 import { KeyRound } from 'lucide-react';
 import { WorkbenchModulePlaceholder } from './WorkbenchModulePlaceholder';
+import { CapabilityTabs } from './CapabilityTabs';
 
 export const VaultsPage: React.FC = () => (
-  <WorkbenchModulePlaceholder icon={<KeyRound className="size-6" />} i18nPrefix="workbench.modules.vaults" />
+  <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-5 py-2">
+    <CapabilityTabs />
+    <WorkbenchModulePlaceholder icon={<KeyRound className="size-6" />} i18nPrefix="workbench.modules.vaults" />
+  </div>
 );

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -74,7 +74,28 @@
     "showPages": "Show Pages",
     "settings": "Settings",
     "remoteAccess": "Remote Access",
-    "doctor": "Doctor"
+    "doctor": "Doctor",
+    "inbox": "Inbox",
+    "projects": "Projects",
+    "capabilities": "Capabilities",
+    "more": "More",
+    "workbench": "Workbench"
+  },
+  "more": {
+    "title": "More",
+    "controlPanel": "Control Panel",
+    "controlPanelDesc": "Channels · Users · Show Pages · Settings · Logs",
+    "appearance": "Appearance",
+    "connection": "Connection",
+    "host": "Local address",
+    "version": "Version"
+  },
+  "projects": {
+    "title": "Projects",
+    "empty": "No projects yet",
+    "newProject": "New project",
+    "noSessions": "No sessions",
+    "sessions": "{{count}} sessions"
   },
   "showPages": {
     "title": "Show Pages",
@@ -458,6 +479,7 @@
     "workspaceLabel": "Workspace",
     "openControlPanel": "Control Panel",
     "backToWorkbench": "Back to Workbench",
+    "newSession": "New",
     "navigationLabel": "Console",
     "statusLabel": "Service status",
     "versionLabel": "Version",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -95,7 +95,9 @@
     "empty": "No projects yet",
     "newProject": "New project",
     "noSessions": "No sessions",
-    "sessions": "{{count}} sessions"
+    "sessions": "{{count}} sessions",
+    "loadMore": "Load more",
+    "loadFailed": "Couldn't load — tap to retry"
   },
   "showPages": {
     "title": "Show Pages",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -74,7 +74,28 @@
     "showPages": "展示页面",
     "settings": "设置",
     "remoteAccess": "远程访问",
-    "doctor": "诊断"
+    "doctor": "诊断",
+    "inbox": "收件箱",
+    "projects": "项目",
+    "capabilities": "能力",
+    "more": "更多",
+    "workbench": "工作台"
+  },
+  "more": {
+    "title": "更多",
+    "controlPanel": "控制面板",
+    "controlPanelDesc": "频道 · 用户 · 展示页面 · 设置 · 日志",
+    "appearance": "外观",
+    "connection": "连接",
+    "host": "本机地址",
+    "version": "版本"
+  },
+  "projects": {
+    "title": "项目",
+    "empty": "还没有项目",
+    "newProject": "新建项目",
+    "noSessions": "暂无会话",
+    "sessions": "{{count}} 个会话"
   },
   "showPages": {
     "title": "展示页面",
@@ -458,6 +479,7 @@
     "workspaceLabel": "工作区",
     "openControlPanel": "控制面板",
     "backToWorkbench": "返回工作台",
+    "newSession": "新建",
     "navigationLabel": "控制台",
     "statusLabel": "服务状态",
     "versionLabel": "版本",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -95,7 +95,9 @@
     "empty": "还没有项目",
     "newProject": "新建项目",
     "noSessions": "暂无会话",
-    "sessions": "{{count}} 个会话"
+    "sessions": "{{count}} 个会话",
+    "loadMore": "加载更多",
+    "loadFailed": "加载失败，点击重试"
   },
   "showPages": {
     "title": "展示页面",


### PR DESCRIPTION
## What
Make the avibe Web UI usable on mobile (≤390px). Both shells get a bottom tab bar with a center button; pages collapse to a single column; dialogs and the chat picker fit small viewports.

## Why
The **Workbench was unreachable on mobile** — its navigation (Inbox / Projects tree / Capabilities) lived in the desktop-only `md:flex hidden` sidebar, and the mobile bottom nav only rendered for `/admin`. This implements the mobile interaction model approved with the team (design.pen Workbench mobile frames).

## Changes
- **Nav foundation** (`AppShell`): a shared `MobileTabBar` with a raised center FAB.
  - Workbench tabs: Inbox · Projects · **＋** (new session → `/`) · Capabilities · More.
  - Control Panel tabs: section nav + **center 工作台 button** (jump back to Workbench) — the symmetric switch.
  - Hidden on `/chat` (full-screen detail) and `/setup`.
  - New mobile pages: `ProjectsPage` (projects → sessions drill-down) and `MorePage` (read-only service status, Control Panel bridge, appearance / connection / account).
- **`CapabilityTabs`**: a `md:hidden` sub-tab strip (Agents / Skills / Harness / Vaults) so the Capabilities tab can switch between them without the sidebar.
- **Chat**: the agent / model / effort picker stacks into one scrollable column on mobile (was a 3-column popover crammed into 92vw).
- **Dialogs**: shared `DialogContent` gains a mobile side gutter + `max-h` + `overflow-y-auto` — every dialog inherits it.
- **Toolbars**: fixed-width search fields → `w-full sm:w-[…]`; ChannelList platform tabs + the Settings section nav → horizontal scroll instead of a cramped wrap.

Two review tweaks are baked in: **More has no service start/stop** (that control stays in the Control Panel), and the **Control Panel tab bar has the center Workbench button**.

## Scope notes
- Most pages already used `md:` grids that collapse below `md`, so much of this was verify + targeted toolbar fixes rather than layout rewrites.
- New components use semantic tokens (`bg-surface` / `text-muted` / …), so **Light theme works automatically**.
- Capability master/detail currently stacks on mobile (functional); a full master→detail drill-down and a dedicated ＋ new-session sheet are noted follow-up polish.

## Affected scenarios
No scenario catalog covers Web UI layout/responsiveness; no scenario IDs apply.

## Evidence layers
- **Unit / contract / scenario:** none added — this is layout/responsive (Tailwind) work with no logic branches to assert.
- **Build:** `npm run build` (tsc -b + vite) green after every commit.
- **Residual manual checks:** in-browser visual QA on a phone viewport is still TODO — deferred to the Docker regression env / `npm run dev`, because the agent sandbox can't launch a headless browser and the local `vibe` service serves packaged UI assets, not this worktree's `ui/dist`.

Plan: `docs/plans/mobile-responsive-webui.md`.
