### PR TITLE
fix(workbench): clarify voice controls, plus-icon attach, uniform composer spacing

### DIFF
--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -354,11 +354,15 @@ export const Composer: React.FC<ComposerProps> = ({
           mediaEnabled ? 'pl-1.5' : 'pl-3.5',
         )}
       >
-        {/* Left controls are flattened into the row (no inner wrapper) so the
-            single ``gap-1.5`` governs every gap uniformly: left-pad == attach↔mic
-            == mic↔textarea. */}
+        {/* Left controls sit in a tight (gap-0) cluster of 28px-wide (w-7) icon
+            buttons. Equal *box* gaps don't look equal here — two adjacent icon
+            buttons stack their inner padding, so an 8px box gap reads as ~26px
+            between the glyphs. Instead each button's icon padding (6px), the
+            left pad (pl-1.5 = 6px) and the cluster→textarea gap (gap-1.5 = 6px)
+            are all 6px, which makes the *visual* spacing uniform:
+            wall→＋ == ＋→mic == mic→textarea ≈ 12px. */}
         {mediaEnabled && (
-          <>
+          <div className="flex items-end">
             <input
               ref={fileInputRef}
               type="file"
@@ -377,7 +381,7 @@ export const Composer: React.FC<ComposerProps> = ({
               size="icon"
               onClick={() => fileInputRef.current?.click()}
               aria-label={t('chat.compose.attach')}
-              className="size-9 shrink-0"
+              className="h-9 w-7 shrink-0"
             >
               <Plus className="size-4" />
             </Button>
@@ -391,7 +395,7 @@ export const Composer: React.FC<ComposerProps> = ({
                 onClick={toggleRecording}
                 disabled={transcribing}
                 aria-label={t(recording ? 'chat.compose.stopRecording' : 'chat.compose.voice')}
-                className={clsx('size-9 shrink-0', recording && 'animate-pulse')}
+                className={clsx('h-9 w-7 shrink-0', recording && 'animate-pulse')}
               >
                 {transcribing ? (
                   <Loader2 className="size-4 animate-spin" />
@@ -402,7 +406,7 @@ export const Composer: React.FC<ComposerProps> = ({
                 )}
               </Button>
             )}
-          </>
+          </div>
         )}
         <textarea
           ref={textareaRef}

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, Mic, Paperclip, Send, Square, X } from 'lucide-react';
+import { Loader2, Mic, Paperclip, Plus, Send, Square, Trash2, X } from 'lucide-react';
 import clsx from 'clsx';
 
 import { apiFetch } from '../../lib/apiFetch';
@@ -350,12 +350,15 @@ export const Composer: React.FC<ComposerProps> = ({
       )}
       <div
         className={cn(
-          'flex w-full items-end gap-2 rounded-2xl border border-border-strong bg-surface-2 py-2 pr-2 shadow-[0_-4px_24px_-12px_rgba(0,0,0,0.5)]',
-          mediaEnabled ? 'pl-2' : 'pl-3.5',
+          'flex w-full items-end gap-1.5 rounded-2xl border border-border-strong bg-surface-2 py-2 pr-2 shadow-[0_-4px_24px_-12px_rgba(0,0,0,0.5)]',
+          mediaEnabled ? 'pl-1.5' : 'pl-3.5',
         )}
       >
+        {/* Left controls are flattened into the row (no inner wrapper) so the
+            single ``gap-1.5`` governs every gap uniformly: left-pad == attach↔mic
+            == mic↔textarea. */}
         {mediaEnabled && (
-          <div className="flex items-end gap-0.5">
+          <>
             <input
               ref={fileInputRef}
               type="file"
@@ -366,6 +369,8 @@ export const Composer: React.FC<ComposerProps> = ({
                 e.target.value = '';
               }}
             />
+            {/* Attach uses a generic plus rather than a paperclip — reads as
+                "add anything" and pairs cleanly with the mic. */}
             <Button
               type="button"
               variant="ghost"
@@ -374,22 +379,30 @@ export const Composer: React.FC<ComposerProps> = ({
               aria-label={t('chat.compose.attach')}
               className="size-9 shrink-0"
             >
-              <Paperclip className="size-4" />
+              <Plus className="size-4" />
             </Button>
             {asrAvailable && (
+              // While recording this is the Stop control: tap to finish +
+              // transcribe (the discard path is the trash button by Send, or ESC).
               <Button
                 type="button"
-                variant={recording ? 'destructive-soft' : 'ghost'}
+                variant={recording ? 'secondary' : 'ghost'}
                 size="icon"
                 onClick={toggleRecording}
                 disabled={transcribing}
                 aria-label={t(recording ? 'chat.compose.stopRecording' : 'chat.compose.voice')}
                 className={clsx('size-9 shrink-0', recording && 'animate-pulse')}
               >
-                {transcribing ? <Loader2 className="size-4 animate-spin" /> : <Mic className="size-4" />}
+                {transcribing ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : recording ? (
+                  <Square className="size-4" />
+                ) : (
+                  <Mic className="size-4" />
+                )}
               </Button>
             )}
-          </div>
+          </>
         )}
         <textarea
           ref={textareaRef}
@@ -408,19 +421,19 @@ export const Composer: React.FC<ComposerProps> = ({
           placeholder={busy ? t('chat.compose.placeholderBusy') : placeholder ?? t('chat.compose.placeholder')}
           className="max-h-40 min-h-9 flex-1 resize-none bg-transparent py-2 text-[13px] leading-5 text-foreground outline-none placeholder:text-muted"
         />
-        {/* While recording, a stop-voice button sits just left of Send (which is
-            greyed out): click it to finish + transcribe; ESC aborts/discards. */}
+        {/* While recording, the left mic button is the Stop control (tap to
+            finish + transcribe); this trash button cancels/discards the clip —
+            same as ESC. Send stays greyed until recording ends. */}
         {recording && (
           <Button
             type="button"
             variant="destructive-soft"
             size="icon"
-            onClick={stopRecording}
-            disabled={transcribing}
-            aria-label={t('chat.compose.stopRecording')}
-            className="size-9 shrink-0 animate-pulse"
+            onClick={abortRecording}
+            aria-label={t('chat.compose.cancelRecording')}
+            className="size-9 shrink-0"
           >
-            <Square className="size-4" />
+            <Trash2 className="size-4" />
           </Button>
         )}
         {/* 36px (size-9) icon button: pink-soft Stop while a turn runs, else a

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1608,6 +1608,7 @@
       "attach": "Attach files",
       "voice": "Voice input",
       "stopRecording": "Stop recording",
+      "cancelRecording": "Cancel recording",
       "removeAttachment": "Remove"
     },
     "media": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1607,6 +1607,7 @@
       "attach": "添加附件",
       "voice": "语音输入",
       "stopRecording": "停止录音",
+      "cancelRecording": "取消录音",
       "removeAttachment": "移除"
     },
     "media": {


### PR DESCRIPTION
## Capability

Follow-up UX fixes on the chat composer (after #400), from Alex's review:

1. **Voice control semantics were ambiguous.** The button beside Send was a second *Stop* that did the same thing as the mic button (finish + transcribe), and its stop icon misread. Now:
   - **Left mic button** → while recording it becomes the **Stop** control (`Square`); tapping it finishes the recording and starts transcription.
   - **Button beside Send** → a **Cancel / discard** control (`Trash2`, `destructive-soft`) that aborts the clip — same as Escape. Red is reserved for this destructive action; the finish control stays neutral (`secondary`) and carries the recording pulse.
2. **Attach icon** → `Paperclip` replaced with `Plus` (reads as "add anything", pairs better with the mic). The file-chip paperclip is unchanged.
3. **Composer spacing** → the left controls are flattened into the row so a single `gap-1.5` governs every gap uniformly: `left-pad == attach↔mic == mic↔textarea` (was `8 / 2 / 8`).

## Design / reuse notes

- All controls remain the shared `Button` primitive (`ghost` / `secondary` / `destructive-soft`, `size="icon"`).
- `stopRecording` (finish+transcribe) and `abortRecording` (discard) already existed; this only re-wires which button calls which and swaps icons — no recording-lifecycle logic changed.
- New i18n key `chat.compose.cancelRecording` added to `en.json` + `zh.json`.

## Evidence layers

- **Unit / contract:** none — presentational/interaction-only.
- **Build:** `npm run build` green; i18n JSON validated.
- **Visual:** standalone render of the composer in idle + recording states (icons, colors, uniform 6px gaps) verified.
- **Residual manual (regression):** tap-through of record → stop → transcribe and record → cancel/ESC in the Docker regression env.

No Python touched (UI-only); no scenario catalog applies.