### PR TITLE
feat(show): align annotation event payloads

### DIFF
--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -36,6 +36,14 @@ ANNOTATION_EVENT_TYPES = {
     "human.annotation.resolved",
     "human.annotation.dismissed",
 }
+ANNOTATION_PRIMARY_ANCHORS = {
+    "mark",
+    "element",
+    "text-range",
+    "element-group",
+    "area",
+    "screenshot",
+}
 
 
 class ShowSessionEventError(ValueError):
@@ -64,7 +72,7 @@ class ShowSessionEventStore:
         event_type = _validate_event_type(payload.get("type"))
         actor = _actor_for_event(event_type)
         event_payload = _normalize_event_payload(event_type, payload)
-        anchor = _normalize_json_object(payload.get("anchor") or event_payload.get("anchor"))
+        anchor = _event_anchor(event_type, payload, event_payload)
         scope = _event_scope(event_type, event_payload)
         transcript_text = _format_transcript_text(event_type, event_payload, anchor)
         event_id = _event_id(payload, event_payload)
@@ -204,6 +212,12 @@ def _normalize_event_payload(event_type: str, payload: dict[str, Any]) -> dict[s
         normalized = dict(annotation)
         normalized.setdefault("id", _new_id("annotation"))
         normalized["scope"] = _text_or_none(normalized.get("scope")) or DEFAULT_MARK_SCOPE
+        primary_anchor = _infer_annotation_primary_anchor(
+            normalized,
+            default="element" if event_type in {"human.annotation.created", "human.annotation.updated"} else None,
+        )
+        if primary_anchor:
+            normalized["primaryAnchor"] = primary_anchor
         normalized["status"] = _annotation_status_for_event(event_type, _text_or_none(normalized.get("status")))
         normalized["createdAt"] = created_at
         normalized["updatedAt"] = _text_or_none(normalized.get("updatedAt")) or created_at
@@ -221,6 +235,28 @@ def _normalize_event_payload(event_type: str, payload: dict[str, Any]) -> dict[s
 
 def _normalize_json_object(raw: Any) -> dict[str, Any]:
     return raw if isinstance(raw, dict) else {}
+
+
+def _json_object_list(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _event_anchor(event_type: str, payload: dict[str, Any], event_payload: dict[str, Any]) -> dict[str, Any]:
+    anchor = _normalize_json_object(payload.get("anchor") or event_payload.get("anchor"))
+    if anchor or event_type not in ANNOTATION_EVENT_TYPES:
+        return anchor
+
+    anchors = _json_object_list(event_payload.get("anchors"))
+    if anchors:
+        return anchors[0]
+
+    matched_elements = _json_object_list(event_payload.get("matchedElements"))
+    if matched_elements:
+        return matched_elements[0]
+
+    return {}
 
 
 def _event_scope(event_type: str, payload: dict[str, Any]) -> str:
@@ -261,6 +297,47 @@ def _format_transcript_text(event_type: str, payload: dict[str, Any], anchor: di
         lines = [f"[show-annotation:{payload.get('scope') or DEFAULT_MARK_SCOPE}:{action}] {label}"]
         if text:
             lines.extend(["", text])
+        primary_anchor = _normalize_annotation_primary_anchor(payload.get("primaryAnchor"))
+        if primary_anchor:
+            lines.extend(["", f"Anchor kind: {primary_anchor}"])
+        screenshot = _normalize_json_object(payload.get("screenshot"))
+        if screenshot:
+            screenshot_ref = _text_or_none(
+                screenshot.get("attachmentId")
+                or screenshot.get("assetId")
+                or screenshot.get("id")
+                or screenshot.get("url")
+                or screenshot.get("src")
+            )
+            lines.append(f"Screenshot: {screenshot_ref or 'captured region'}")
+            screenshot_region = _format_rect(screenshot.get("region") or screenshot.get("rect"))
+            if screenshot_region:
+                lines.append(f"Screenshot region: {screenshot_region}")
+            screenshot_items = _json_object_list(screenshot.get("items"))
+            if screenshot_items:
+                lines.append("Screenshot comments:")
+                for index, item in enumerate(screenshot_items, start=1):
+                    item_label = _text_or_none(item.get("label")) or str(index)
+                    item_text = _text_or_none(item.get("comment") or item.get("text") or item.get("body"))
+                    line = f"{item_label}. {item_text or 'comment'}"
+                    item_region = _format_rect(item.get("region") or item.get("rect"))
+                    item_point = _format_point(item.get("point"))
+                    if item_region:
+                        line += f" ({item_region})"
+                    elif item_point:
+                        line += f" ({item_point})"
+                    lines.append(line)
+        region = _format_rect(payload.get("userRegion") or payload.get("region"))
+        if region:
+            lines.append(f"Region: {region}")
+        classification = _format_classification(payload.get("classification"))
+        if classification:
+            lines.append(f"Selection: {classification}")
+        matched_elements = _json_object_list(payload.get("matchedElements"))
+        anchor_list = _json_object_list(payload.get("anchors"))
+        matched_count = len(matched_elements) or (len(anchor_list) if primary_anchor == "element-group" else 0)
+        if matched_count:
+            lines.append(f"Matched elements: {matched_count}")
         quote = _text_or_none(anchor.get("textQuote") or anchor.get("text"))
         if quote:
             lines.extend(["", f"Quote: {quote}"])
@@ -310,6 +387,101 @@ def _text_or_none(raw: Any) -> str | None:
         return None
     value = str(raw).strip()
     return value or None
+
+
+def _normalize_annotation_primary_anchor(raw: Any) -> str | None:
+    value = _text_or_none(raw)
+    if value == "group":
+        return "element-group"
+    if value in ANNOTATION_PRIMARY_ANCHORS:
+        return value
+    return None
+
+
+def _infer_annotation_primary_anchor(annotation: dict[str, Any], *, default: str | None = None) -> str | None:
+    explicit = _normalize_annotation_primary_anchor(annotation.get("primaryAnchor"))
+    if explicit:
+        return explicit
+
+    if _normalize_json_object(annotation.get("screenshot")):
+        return "screenshot"
+
+    classification = _normalize_annotation_primary_anchor(_format_classification(annotation.get("classification")))
+    if classification:
+        return classification
+
+    anchors = _json_object_list(annotation.get("anchors"))
+    matched_elements = _json_object_list(annotation.get("matchedElements"))
+    if len(anchors) > 1 or len(matched_elements) > 1:
+        return "element-group"
+
+    anchor = _normalize_json_object(annotation.get("anchor"))
+    anchor_kind = _normalize_annotation_primary_anchor(anchor.get("kind"))
+    if anchor_kind:
+        return anchor_kind
+
+    if len(anchors) == 1:
+        single_anchor_kind = _normalize_annotation_primary_anchor(anchors[0].get("kind"))
+        if single_anchor_kind:
+            return single_anchor_kind
+
+    if len(matched_elements) == 1:
+        single_match_kind = _normalize_annotation_primary_anchor(matched_elements[0].get("kind"))
+        return single_match_kind or "element"
+
+    if _normalize_json_object(annotation.get("userRegion") or annotation.get("region")):
+        return "area"
+
+    return default
+
+
+def _first_present(mapping: dict[str, Any], keys: tuple[str, ...]) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] is not None:
+            return mapping[key]
+    return None
+
+
+def _format_scalar(raw: Any) -> str | None:
+    if isinstance(raw, bool):
+        return _text_or_none(raw)
+    if isinstance(raw, int):
+        return str(raw)
+    if isinstance(raw, float):
+        if raw.is_integer():
+            return str(int(raw))
+        return f"{raw:.2f}".rstrip("0").rstrip(".")
+    return _text_or_none(raw)
+
+
+def _format_rect(raw: Any) -> str | None:
+    rect = _normalize_json_object(raw)
+    if not rect:
+        return None
+    x = _first_present(rect, ("x", "left"))
+    y = _first_present(rect, ("y", "top"))
+    width = _first_present(rect, ("width", "w"))
+    height = _first_present(rect, ("height", "h"))
+    if x is None or y is None or width is None or height is None:
+        return None
+    return f"x:{_format_scalar(x)}, y:{_format_scalar(y)}, {_format_scalar(width)}x{_format_scalar(height)}"
+
+
+def _format_point(raw: Any) -> str | None:
+    point = _normalize_json_object(raw)
+    if not point:
+        return None
+    x = _first_present(point, ("x", "left"))
+    y = _first_present(point, ("y", "top"))
+    if x is None or y is None:
+        return None
+    return f"x:{_format_scalar(x)}, y:{_format_scalar(y)}"
+
+
+def _format_classification(raw: Any) -> str | None:
+    if isinstance(raw, dict):
+        return _text_or_none(raw.get("mode") or raw.get("kind") or raw.get("type"))
+    return _text_or_none(raw)
 
 
 def _annotation_status_for_event(event_type: str, requested: str | None) -> str:

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -143,6 +143,92 @@ def test_show_event_store_records_human_annotation_with_anchor_context(isolated_
     assert message_row["author"] == "user"
 
 
+def test_show_event_store_records_element_group_annotation_context(isolated_state):
+    _seed_session()
+
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_mark",
+            {
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "change",
+                    "comment": "Align these cards.",
+                    "userRegion": {"x": 10, "y": 20, "width": 300, "height": 120},
+                    "classification": {"mode": "element-group", "confidence": 0.82},
+                    "matchedElements": [
+                        {
+                            "kind": "element",
+                            "selector": "[data-card='summary']",
+                            "text": "Summary",
+                        },
+                        {
+                            "kind": "element",
+                            "selector": "[data-card='details']",
+                            "text": "Details",
+                        },
+                    ],
+                },
+            },
+        )
+    finally:
+        store.close()
+
+    assert event["payload"]["primaryAnchor"] == "element-group"
+    assert event["payload"]["userRegion"]["width"] == 300
+    assert len(event["payload"]["matchedElements"]) == 2
+    assert event["anchor"]["selector"] == "[data-card='summary']"
+    assert "Anchor kind: element-group" in event["transcript_text"]
+    assert "Region: x:10, y:20, 300x120" in event["transcript_text"]
+    assert "Selection: element-group" in event["transcript_text"]
+    assert "Matched elements: 2" in event["transcript_text"]
+
+
+def test_show_event_store_records_screenshot_annotation_batch(isolated_state):
+    _seed_session()
+
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_mark",
+            {
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "review",
+                    "comment": "Review the captured area.",
+                    "screenshot": {
+                        "attachmentId": "show_asset_screenshot_1",
+                        "region": {"x": 24, "y": 32, "width": 640, "height": 360},
+                        "items": [
+                            {
+                                "label": "1",
+                                "comment": "This counter looks stale.",
+                                "point": {"x": 120, "y": 80},
+                            },
+                            {
+                                "label": "2",
+                                "comment": "Crop this empty area.",
+                                "region": {"x": 420, "y": 240, "width": 160, "height": 72},
+                            },
+                        ],
+                    },
+                },
+            },
+        )
+    finally:
+        store.close()
+
+    assert event["payload"]["primaryAnchor"] == "screenshot"
+    assert event["payload"]["screenshot"]["attachmentId"] == "show_asset_screenshot_1"
+    assert len(event["payload"]["screenshot"]["items"]) == 2
+    assert "Anchor kind: screenshot" in event["transcript_text"]
+    assert "Screenshot: show_asset_screenshot_1" in event["transcript_text"]
+    assert "Screenshot region: x:24, y:32, 640x360" in event["transcript_text"]
+    assert "1. This counter looks stale. (x:120, y:80)" in event["transcript_text"]
+    assert "2. Crop this empty area. (x:420, y:240, 160x72)" in event["transcript_text"]
+
+
 def test_show_event_store_records_annotation_resolution(isolated_state):
     _seed_session()
 

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -357,6 +357,70 @@ def test_private_show_page_dispatches_human_show_event(monkeypatch, tmp_path):
     assert "show.dispatch" in [event_type for event_type, _data in published]
 
 
+def test_private_show_page_dispatches_screenshot_annotation_batch(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+    dispatches = []
+    dispatch_done = asyncio.Event()
+
+    async def fake_stream_dispatch(payload, **kwargs):
+        dispatches.append(payload)
+        dispatch_done.set()
+        yield "turn.start", {"session_id": payload["session_id"]}
+        yield "turn.end", {"session_id": payload["session_id"]}
+
+    with patch("vibe.internal_client.stream_dispatch", fake_stream_dispatch):
+        response = app.test_client().post(
+            "/show/ses123/__show/events",
+            base_url="http://127.0.0.1:5123",
+            headers={
+                "Origin": "http://127.0.0.1:5123",
+                "Content-Type": "application/json",
+                "X-Vibe-Show-Token": token,
+            },
+            json={
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "review",
+                    "comment": "Review this screenshot batch.",
+                    "dispatch": True,
+                    "screenshot": {
+                        "attachmentId": "show_asset_screenshot_1",
+                        "region": {"x": 24, "y": 32, "width": 640, "height": 360},
+                        "items": [
+                            {
+                                "label": "1",
+                                "comment": "This counter looks stale.",
+                                "point": {"x": 120, "y": 80},
+                            },
+                            {
+                                "label": "2",
+                                "comment": "Crop this empty area.",
+                                "region": {"x": 420, "y": 240, "width": 160, "height": 72},
+                            },
+                        ],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["event"]["payload"]["primaryAnchor"] == "screenshot"
+    asyncio.run(asyncio.wait_for(dispatch_done.wait(), timeout=1))
+    assert dispatches
+    transcript = dispatches[0]["text"]
+    assert "Anchor kind: screenshot" in transcript
+    assert "Screenshot: show_asset_screenshot_1" in transcript
+    assert "Screenshot region: x:24, y:32, 640x360" in transcript
+    assert "1. This counter looks stale. (x:120, y:80)" in transcript
+    assert "2. Crop this empty area. (x:420, y:240, 160x72)" in transcript
+
+
 def test_private_show_page_rejects_show_event_without_write_token(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)


### PR DESCRIPTION
## Summary

- align Show Page human annotation events with the richer annotation payload contract
- infer `primaryAnchor` for element groups, areas, screenshots, and legacy group anchors
- include screenshot batches, selected regions, selection classification, and matched element counts in the transcript sent to the agent

## Evidence layers

- Unit: updated Show session event store tests for element-group and screenshot annotation payloads
- Contract: added private Show Page route coverage for dispatching one screenshot annotation with multiple numbered comments
- Scenario: covers smart non-text area selection and screenshot batch comment submission
- Residual manual checks: frontend annotation UI is not part of this slice

## Validation

- `uv run --no-sync pytest tests/test_show_session_events.py tests/test_ui_show_pages.py::test_private_show_page_records_show_event tests/test_ui_show_pages.py::test_private_show_page_dispatches_human_show_event tests/test_ui_show_pages.py::test_private_show_page_dispatches_screenshot_annotation_batch tests/test_ui_show_pages.py::test_private_show_page_rejects_show_event_without_write_token tests/test_ui_show_pages.py::test_show_events_stream_replays_all_persisted_pages_before_live tests/test_ui_show_pages.py::test_show_events_stream_forwards_live_dispatch_events -q`
- `uv run --no-sync ruff check core/show_session_events.py tests/test_show_session_events.py tests/test_ui_show_pages.py`
- `git diff --check`
