### PR TITLE
feat(workbench): open chat at latest message + jump-to-latest button

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1187,7 +1187,15 @@ interface TranscriptProps {
 
 const Transcript: React.FC<TranscriptProps> = ({ messages, session, working }) => {
   const { t } = useTranslation();
-  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // ``true`` while the viewport is pinned to (or near) the bottom — drives both
+  // the auto-follow of new content and the jump button. A ref, not state, so the
+  // scroll handler and ResizeObserver read it without stale closures or renders.
+  const atBottomRef = useRef(true);
+  const lastSessionRef = useRef<string | null>(null);
+  const [showJump, setShowJump] = useState(false);
+
   // The reply arrives atomically as a persisted ``result`` row (no streaming
   // card), so the thinking bubble shows for the whole gap between send and
   // reply. Hide it the moment the last row is a fresh agent terminal — a
@@ -1197,14 +1205,61 @@ const Transcript: React.FC<TranscriptProps> = ({ messages, session, working }) =
     messages[messages.length - 1].author === 'agent' &&
     (messages[messages.length - 1].type === 'result' || messages[messages.length - 1].type === 'error');
   const showThinking = working && !lastIsAgentResult;
-  // Auto-scroll to the bottom whenever a new message arrives or the thinking
-  // bubble toggles — mirrors how every other chat client behaves and saves the
-  // user from chasing the reply.
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-  }, [messages.length, showThinking]);
+  const empty = messages.length === 0 && !working;
 
-  if (messages.length === 0 && !working) {
+  // Instant, not smooth: a smooth animation emits intermediate scroll events
+  // that flip ``atBottomRef`` back off mid-flight (re-showing the button), and
+  // if content grows during the glide the pin is skipped so it lands short of
+  // the true bottom. A direct jump matches the ResizeObserver pin below and is
+  // the conventional "jump to latest" behavior.
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    atBottomRef.current = true;
+    setShowJump(false);
+  }, []);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    // Small tolerance keeps us "stuck" through sub-pixel rounding; the jump
+    // button only appears once the user has scrolled up a clear distance.
+    atBottomRef.current = distance < 80;
+    setShowJump(distance > 240);
+  };
+
+  // Open each session pinned to the latest message (instant, no animation) —
+  // opening from the inbox should land on what just arrived.
+  useEffect(() => {
+    if (lastSessionRef.current === session.id) return;
+    lastSessionRef.current = session.id;
+    atBottomRef.current = true;
+    setShowJump(false);
+    const id = requestAnimationFrame(() => scrollToBottom());
+    return () => cancelAnimationFrame(id);
+  }, [session.id, scrollToBottom]);
+
+  // While the user is at the bottom, follow content growth (new messages, the
+  // thinking bubble, late-loading images) so the latest stays in view; if they
+  // scrolled up to read history, leave their position alone. Instant pin avoids
+  // animating on rapid growth — and on image loads that would otherwise shift
+  // the bottom out from under a just-opened transcript. ``empty`` is in the deps
+  // so the observer (re)attaches when the scroll container mounts after an empty
+  // state; ResizeObserver fires once on observe, pinning the freshly shown list.
+  useEffect(() => {
+    const el = scrollRef.current;
+    const content = contentRef.current;
+    if (!el || !content) return;
+    const ro = new ResizeObserver(() => {
+      if (atBottomRef.current) el.scrollTop = el.scrollHeight;
+    });
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [empty]);
+
+  if (empty) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center text-muted">
         <MessageSquare className="size-8 opacity-60" />
@@ -1213,14 +1268,29 @@ const Transcript: React.FC<TranscriptProps> = ({ messages, session, working }) =
     );
   }
   return (
-    <div className="flex-1 overflow-y-auto px-4 py-5 md:px-8">
-      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-3">
-        {messages.map((message) => (
-          <MessageRow key={message.id} message={message} session={session} />
-        ))}
-        {showThinking && <ThinkingBubble session={session} />}
-        <div ref={bottomRef} />
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div ref={scrollRef} onScroll={handleScroll} className="min-h-0 flex-1 overflow-y-auto px-4 py-5 md:px-8">
+        <div ref={contentRef} className="mx-auto flex w-full max-w-[1080px] flex-col gap-3">
+          {messages.map((message) => (
+            <MessageRow key={message.id} message={message} session={session} />
+          ))}
+          {showThinking && <ThinkingBubble session={session} />}
+        </div>
       </div>
+      {/* Jump-to-latest: appears after scrolling up a clear distance, returns to
+          the bottom on click. Centered just above the compose bar. */}
+      {showJump && (
+        <Button
+          type="button"
+          variant="secondary"
+          size="icon"
+          onClick={() => scrollToBottom()}
+          aria-label={t('chat.scrollToBottom')}
+          className="absolute bottom-3 left-1/2 size-9 -translate-x-1/2 rounded-full border-border-strong shadow-lg"
+        >
+          <ChevronDown className="size-4" />
+        </Button>
+      )}
     </div>
   );
 };

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1596,6 +1596,7 @@
     "notFound": "Session not found.",
     "missingSessionId": "Missing session id in the URL.",
     "transcriptEmpty": "Type a message below to start the conversation",
+    "scrollToBottom": "Scroll to latest",
     "streaming": "Streaming",
     "thinking": "Thinking…",
     "notifyLabel": "Notify",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1595,6 +1595,7 @@
     "notFound": "未找到该会话。",
     "missingSessionId": "URL 缺少 session id。",
     "transcriptEmpty": "在下方输入消息开始对话",
+    "scrollToBottom": "回到最新",
     "streaming": "实时输出中",
     "thinking": "思考中…",
     "notifyLabel": "通知",


### PR DESCRIPTION
## Capability

Three chat-scroll interaction improvements (Alex's request) in the `/chat/:sessionId` transcript:

1. **Open at the latest message.** Every session now opens pinned to the bottom (instant), so entering from the inbox lands on the newest message instead of the top.
2. **Jump-to-latest button.** After the user scrolls **up** a clear distance, a centered down-arrow button appears just above the composer.
3. **Click → back to bottom.** Clicking it returns the transcript to the bottom.

## How it works

- A `ResizeObserver` on the transcript content keeps it pinned to the bottom as rows render and **images load late** — but only while `atBottomRef` is true, so a user who scrolled up to read history is **never yanked back down** by a new message.
- `handleScroll` tracks distance-from-bottom with two thresholds: `< 80px` = "at bottom" (stick), `> 240px` = show the jump button.
- Open-at-bottom uses an instant `rAF` jump per session (with `cancelAnimationFrame` cleanup); the `ResizeObserver` (which fires once on `observe`) re-attaches via an `empty` dep so it pins correctly when the scroll container mounts after the empty state.
- The jump itself is **instant**, not smooth: a smooth glide emits intermediate scroll events that flip the at-bottom flag mid-animation (re-flickering the button) and can land short if content grows during the glide — the conventional snap is also what Slack/Discord do.

## Reuse / review

- Jump button is the shared `Button` primitive (`secondary` / `size="icon"`, rounded-full).
- Removed the old `bottomRef` sentinel (scrolling now targets the container directly).
- Pre-PR reviewer pass: fixed the smooth-scroll-fights-handler bug and added rAF cleanup before opening.

## Evidence layers

- **Unit / contract:** none — presentational/interaction-only.
- **Build:** `npm run build` green; i18n JSON validated.
- **Residual manual (regression):** open from inbox lands at bottom; scroll up → button appears; click → snaps to bottom; new reply while scrolled up does NOT yank; new reply while at bottom follows.

No Python touched (UI-only); no scenario catalog applies.