### PR TITLE
fix(ui): stop workbench list+detail grid from overflowing the viewport

### DIFF
--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -273,10 +273,12 @@ export const AgentsPage: React.FC = () => {
       <div
         className={clsx(
           'grid gap-5',
-          selected ? 'grid-cols-1 lg:grid-cols-[1fr_420px]' : 'grid-cols-1',
+          // `minmax(0,1fr)` + `min-w-0` keep the list column shrinkable; bare
+          // `1fr` would let a long agent row push the fixed detail card off-screen.
+          selected ? 'grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]' : 'grid-cols-1',
         )}
       >
-        <div className="flex flex-col gap-4">
+        <div className="flex min-w-0 flex-col gap-4">
           {BACKEND_ORDER.map((backend) => {
             const items = grouped[backend];
             if (!items || items.length === 0) return null;

--- a/ui/src/components/workbench/SkillsPage.tsx
+++ b/ui/src/components/workbench/SkillsPage.tsx
@@ -333,8 +333,12 @@ export const SkillsPage: React.FC = () => {
           </Button>
         </div>
       ) : (
-        <div className={clsx('grid gap-5', selected ? 'lg:grid-cols-[1fr_400px]' : 'grid-cols-1')}>
-          <div className="flex flex-col gap-4">
+        // `minmax(0,1fr)` (not bare `1fr`) lets the list column shrink below its
+        // content's intrinsic width; otherwise a long row keeps the column from
+        // shrinking and pushes the fixed detail card past the viewport edge. The
+        // list column itself also needs `min-w-0` for the same reason.
+        <div className={clsx('grid gap-5', selected ? 'lg:grid-cols-[minmax(0,1fr)_400px]' : 'grid-cols-1')}>
+          <div className="flex min-w-0 flex-col gap-4">
             {scope === 'global' ? (
               <div className="flex flex-col gap-2">{renderRows(filtered)}</div>
             ) : (


### PR DESCRIPTION
## Capability

Web UI **Workbench** layout: the *list + fixed-width detail panel* grid on the **Skills** and **Agents** pages no longer overflows the right edge of the viewport when a row is selected.

Reported on `/skills` (viewport 1664×1363): selecting a skill made the detail card run off-screen to the right (`.mx-auto > .mx-auto > .grid > .flex`).

## Root cause

Both pages used `grid-cols-[1fr_Npx]` for the two-column "list + detail" body. Bare **`1fr` is `minmax(auto, 1fr)`** — its `auto` minimum is the track's *min-content* width, so the flexible list track **refuses to shrink below its content's intrinsic width**. A long skill/agent row (name, source path, chips) then keeps the list column wide and pushes the fixed `Npx` detail card past the viewport edge. Row-level `truncate` never engages because the column is never forced to shrink.

This is a known footgun and was **already fixed elsewhere** in the same codebase:
- `HarnessPage` → `lg:grid-cols-[minmax(0,1fr)_440px]` (+ `min-w-0` list column, with an explanatory comment describing this exact bug)
- `ShowPagesPage` → `lg:grid-cols-[minmax(0,1fr)_300px]`

`SkillsPage` and `AgentsPage` were simply missed in that earlier sweep.

## Fix

For both pages: `1fr` → **`minmax(0, 1fr)`** on the grid track, and add **`min-w-0`** to the list column so it can shrink and its rows truncate as designed. This aligns all four list+detail grids to one consistent, correct pattern.

| Page | Before | After |
| --- | --- | --- |
| SkillsPage | `lg:grid-cols-[1fr_400px]` | `lg:grid-cols-[minmax(0,1fr)_400px]` ✅ |
| AgentsPage | `lg:grid-cols-[1fr_420px]` | `lg:grid-cols-[minmax(0,1fr)_420px]` ✅ |
| HarnessPage | `minmax(0,1fr)_440px` | unchanged (already correct) |
| ShowPagesPage | `minmax(0,1fr)_300px` | unchanged (already correct) |

### Class audit (other `1fr` grids reviewed, intentionally left unchanged)
- `RemoteAccess` `md:grid-cols-[1fr_auto]` — different pattern (form row: input + buttons); `1fr` holds a self-shrinking input, no fixed-px sibling to push off-screen. Not at risk.
- `ChannelList` `md:grid-cols-[minmax(220px,280px)_1fr]` — different pattern (select pickers); the `1fr` is the trailing track holding self-managing `<select>`s. Lower-risk; can be hardened separately if desired.

## Evidence layers

- **Unit / contract / scenario:** N/A — pure CSS/layout change; the repo has no UI-layout test framework and no scenario catalog covers Workbench grid sizing. Not introducing a new framework for this.
- **Build:** `npm run build` (tsc -b + vite) passes. Emitted CSS verified to contain `grid-template-columns:minmax(0,1fr) 400px` and `…420px`, with **zero** remaining bare-`1fr` detail grids — confirms the arbitrary-value utilities resolve and the whole class is consistent.
- **Code parity:** identical to the already-shipped `HarnessPage`/`ShowPagesPage` pattern.
- **Residual manual check:** a live before/after browser screenshot was **not** captured (no headless browser available in this environment). Recommend a quick visual confirm of `/skills` and `/agents` (select a row) in the regression UI.