### PR TITLE
fix(ui): mobile workbench UX fixes (viewport, project/agent pickers, header→More, chat back)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- maximum-scale=1 + user-scalable=no stops iOS Safari from auto-zooming
+         when a sub-16px input gains focus; this is an app shell, not a content
+         page, so pinch-zoom isn't expected. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Vibe Remote</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ui/src/components/AccountMenu.tsx
+++ b/ui/src/components/AccountMenu.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { LogOut } from 'lucide-react';
 import clsx from 'clsx';
 
-import { useApi } from '../context/ApiContext';
+import { useAuthAccount } from '../lib/useAuthAccount';
 
 const initialFor = (email: string): string => {
   const local = email.split('@')[0] || email;
@@ -13,30 +13,9 @@ const initialFor = (email: string): string => {
 
 export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = false }) => {
   const { t } = useTranslation();
-  const { getAuthSession, signOut } = useApi();
-  const [email, setEmail] = useState<string | null>(null);
+  const { email, signingOut, signOut: handleSignOut } = useAuthAccount();
   const [isOpen, setIsOpen] = useState(false);
-  const [signingOut, setSigningOut] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    getAuthSession()
-      .then((session) => {
-        if (cancelled) return;
-        if (session.remote && session.authenticated) {
-          setEmail(session.email);
-        } else {
-          setEmail(null);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setEmail(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [getAuthSession]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -58,21 +37,6 @@ export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = f
   }, [isOpen]);
 
   if (email === null) return null;
-
-  const handleSignOut = async () => {
-    if (signingOut) return;
-    setSigningOut(true);
-    // Always navigate to "/" — even on transient errors. The cookie may already
-    // be expired (in which case the request would 401), so leaving the user
-    // stuck in the dropdown would be worse than letting the OIDC redirect
-    // handle whatever state remains.
-    try {
-      await signOut();
-    } catch {
-      // swallow — we still reload below
-    }
-    window.location.assign('/');
-  };
 
   const accountLabel = t('appShell.accountMenuLabel', { email });
 

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -293,12 +293,9 @@ export const AppShell: React.FC = () => {
           />
           <span className="truncate text-[13px] font-semibold">{t('appShell.title')}</span>
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <VersionBadge />
-          <LanguageSwitcher />
-          <ThemeToggle />
-          <AccountMenu />
-        </div>
+        {/* Version / language / theme / account moved into the More tab — the
+            mobile header stays just brand. (Desktop keeps them in the admin
+            sidebar bottom.) */}
       </header>
 
       <main

--- a/ui/src/components/Workbench.tsx
+++ b/ui/src/components/Workbench.tsx
@@ -6,6 +6,8 @@ import { Activity, Bot, FolderPlus, Sparkles } from 'lucide-react';
 import { useNewSession } from '../lib/useNewSession';
 import { NewProjectDialog } from './workbench/NewProjectDialog';
 import { Composer } from './workbench/Composer';
+import { ProjectPicker } from './workbench/ProjectPicker';
+import { AgentPicker } from './workbench/AgentPicker';
 
 // Mirrors design.pen DnkGJ "Workbench" canvas: a centered hero panel +
 // suggestion chips with the shared chat Composer below it. The Composer is
@@ -75,8 +77,25 @@ export const Workbench: React.FC = () => {
         </div>
       </div>
 
-      {/* Input — the shared chat Composer, width-matched to the hero. */}
-      <div className="flex w-full max-w-[640px] flex-col gap-1">
+      {/* Input — project + agent pickers above the shared chat Composer so the
+          user can see/choose where the session lands and which agent runs it. */}
+      <div className="flex w-full max-w-[640px] flex-col gap-3">
+        {ns.projects.length > 0 && (
+          <ProjectPicker
+            projects={ns.projects}
+            targetId={ns.target?.id}
+            onSelect={ns.setSelected}
+            onNewProject={() => setNewProjectOpen(true)}
+            disabled={ns.sending}
+          />
+        )}
+        <AgentPicker
+          agents={ns.agents}
+          defaultAgentName={ns.defaultAgentName}
+          value={ns.selectedAgent}
+          onChange={ns.setSelectedAgent}
+          disabled={ns.sending}
+        />
         <Composer
           onSend={send}
           placeholder={t('workbench.canvas.inputPlaceholder')}

--- a/ui/src/components/workbench/AgentPicker.tsx
+++ b/ui/src/components/workbench/AgentPicker.tsx
@@ -1,0 +1,67 @@
+import { useTranslation } from 'react-i18next';
+import { Bot, Sparkles } from 'lucide-react';
+import clsx from 'clsx';
+
+import type { VibeAgentBrief } from '../../context/ApiContext';
+import { Button } from '../ui/button';
+
+interface AgentPickerProps {
+  agents: VibeAgentBrief[];
+  defaultAgentName: string | null;
+  /** Selected agent, or null for the server default (agents.default_backend). */
+  value: VibeAgentBrief | null;
+  onChange: (id: string | null) => void;
+  disabled?: boolean;
+}
+
+// Shared agent (backend) picker for the create surfaces. A horizontal scroll
+// row: a Default chip (null → the server's default backend, labelled with the
+// resolved agent when known) followed by every enabled Vibe Agent, each tagged
+// with its backend. Hidden entirely when no agents are loaded (the create then
+// just uses the default).
+export const AgentPicker: React.FC<AgentPickerProps> = ({ agents, defaultAgentName, value, onChange, disabled }) => {
+  const { t } = useTranslation();
+  if (agents.length === 0) return null;
+  const chipClass = (active: boolean) =>
+    clsx(
+      'h-auto shrink-0 gap-1.5 rounded-full px-3 py-1.5 text-[12.5px] font-medium',
+      active ? 'border-cyan/40 bg-cyan/[0.08] text-cyan hover:bg-cyan/[0.08] hover:text-cyan' : 'text-foreground',
+    );
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-muted">
+        {t('newSession.agent')}
+      </div>
+      <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onChange(null)}
+          disabled={disabled}
+          className={chipClass(value === null)}
+        >
+          <Sparkles className="size-3.5" />
+          <span className="max-w-[160px] truncate">
+            {defaultAgentName ? t('newSession.defaultAgentNamed', { name: defaultAgentName }) : t('newSession.defaultAgent')}
+          </span>
+        </Button>
+        {agents.map((agent) => (
+          <Button
+            key={agent.id}
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onChange(agent.id)}
+            disabled={disabled}
+            className={chipClass(value?.id === agent.id)}
+          >
+            <Bot className="size-3.5" />
+            <span className="max-w-[140px] truncate">{agent.name}</span>
+            <span className="rounded bg-foreground/[0.06] px-1 font-mono text-[9px] uppercase text-muted">{agent.backend}</span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -87,6 +87,15 @@ export const ChatPage: React.FC = () => {
   const location = useLocation();
   const api = useApi();
   const { unreadBySession, markRead: markInboxRead } = useWorkbenchInbox();
+
+  // Back returns to the page the user came from, not a hardcoded inbox.
+  // location.key === 'default' means /chat was the first history entry (deep
+  // link / refresh) with nothing to pop back to — fall back to the inbox then.
+  const goBack = useCallback(() => {
+    if (location.key !== 'default') navigate(-1);
+    else navigate('/inbox');
+  }, [location.key, navigate]);
+
   const [session, setSession] = useState<WorkbenchSession | null>(null);
   const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
   const [messages, setMessages] = useState<WorkbenchMessage[]>([]);
@@ -655,7 +664,7 @@ export const ChatPage: React.FC = () => {
   }, [messages]);
 
   if (!sessionId) {
-    return <ChatMissing onBack={() => navigate('/inbox')} />;
+    return <ChatMissing onBack={goBack} />;
   }
 
   if (loading && !session) {
@@ -672,11 +681,11 @@ export const ChatPage: React.FC = () => {
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 py-8">
         <button
           type="button"
-          onClick={() => navigate('/inbox')}
+          onClick={goBack}
           className="inline-flex items-center gap-1.5 text-[12px] text-cyan hover:underline"
         >
           <ArrowLeft className="size-3.5" />
-          {t('chat.backToInbox')}
+          {t('chat.back')}
         </button>
         <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
           {error ?? t('chat.notFound')}
@@ -701,7 +710,7 @@ export const ChatPage: React.FC = () => {
     // ``h-16`` header occupies 4rem at the top, so subtract that instead.
     <ImageViewerProvider images={sessionImages}>
       <div className="-mx-4 -my-5 flex h-[calc(100dvh-4rem)] flex-col md:-mx-10 md:-my-8 md:h-[100dvh]">
-        <ChatHeaderBar session={session} agents={agents} onPatch={patch} onBack={() => navigate('/inbox')} />
+        <ChatHeaderBar session={session} agents={agents} onPatch={patch} onBack={goBack} />
 
       {error && (
         <div className="mx-auto mt-3 w-full max-w-[1080px] rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
@@ -823,7 +832,7 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, onPatch,
           variant="outline"
           size="icon"
           onClick={onBack}
-          aria-label={t('chat.backToInbox')}
+          aria-label={t('chat.back')}
           className="size-7 shrink-0"
         >
           <ArrowLeft className="size-3.5" />
@@ -1438,7 +1447,7 @@ const ChatMissing: React.FC<{ onBack: () => void }> = ({ onBack }) => {
         className="inline-flex items-center gap-1.5 text-[12px] text-cyan hover:underline"
       >
         <ArrowLeft className="size-3.5" />
-        {t('chat.backToInbox')}
+        {t('chat.back')}
       </button>
       <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
         {t('chat.missingSessionId')}

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, Info, Link as LinkIcon, SlidersHorizontal } from 'lucide-react';
+import { ArrowRight, Info, Link as LinkIcon, LogOut, SlidersHorizontal } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
 import { useStatus } from '../../context/StatusContext';
+import { useAuthAccount } from '../../lib/useAuthAccount';
 import { LanguageSwitcher } from '../LanguageSwitcher';
 import { ThemeToggle } from '../ThemeToggle';
 import { VersionBadge } from '../VersionBadge';
@@ -18,6 +19,7 @@ export const MorePage: React.FC = () => {
   const { t } = useTranslation();
   const { status } = useStatus();
   const api = useApi();
+  const { email, signingOut, signOut } = useAuthAccount();
   const [config, setConfig] = useState<any>(null);
 
   useEffect(() => {
@@ -73,6 +75,31 @@ export const MorePage: React.FC = () => {
           <LanguageSwitcher />
         </div>
       </div>
+
+      {/* Account — moved here from the mobile header. Only shown for an
+          authenticated remote session (local setups have no sign-out). */}
+      {email && (
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <div className="flex items-center gap-3 px-4 py-3">
+            <span className="grid size-9 shrink-0 place-items-center rounded-full border border-cyan/35 bg-cyan/[0.08] text-[13px] font-semibold text-cyan">
+              {(email.split('@')[0]?.[0] ?? '?').toUpperCase()}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-muted">{t('appShell.signedInAs')}</div>
+              <div className="truncate text-sm font-medium">{email}</div>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={signOut}
+            disabled={signingOut}
+            className="flex w-full items-center gap-2 border-t border-border px-4 py-3 text-left text-sm font-medium text-destructive transition hover:bg-destructive/[0.06] disabled:opacity-60"
+          >
+            <LogOut className="size-4" />
+            {signingOut ? t('appShell.signingOut') : t('appShell.signOut')}
+          </button>
+        </div>
+      )}
 
       {/* Connection */}
       <div className="rounded-xl border border-border bg-surface">

--- a/ui/src/components/workbench/NewSessionSheet.tsx
+++ b/ui/src/components/workbench/NewSessionSheet.tsx
@@ -1,14 +1,13 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Folder, FolderOpen, FolderPlus } from 'lucide-react';
-import clsx from 'clsx';
 
 import { useNewSession } from '../../lib/useNewSession';
 import { Dialog, DialogContent, DialogTitle } from '../ui/dialog';
-import { Button } from '../ui/button';
 import { Composer } from './Composer';
 import { NewProjectDialog } from './NewProjectDialog';
+import { ProjectPicker } from './ProjectPicker';
+import { AgentPicker } from './AgentPicker';
 
 interface NewSessionSheetProps {
   open: boolean;
@@ -73,44 +72,20 @@ export const NewSessionSheet: React.FC<NewSessionSheetProps> = ({ open, onClose,
         <DialogContent className="gap-5" onOpenAutoFocus={(e) => e.preventDefault()}>
           <DialogTitle className="text-lg font-bold">{t('newSession.title')}</DialogTitle>
 
-          <div className="flex flex-col gap-2">
-            <div className="font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-muted">
-              {t('newSession.project')}
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {ns.projects.slice(0, 6).map((project) => {
-                const active = project.id === ns.target?.id;
-                return (
-                  <Button
-                    key={project.id}
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => ns.setSelected(project.id)}
-                    disabled={ns.sending}
-                    className={clsx(
-                      'h-auto gap-1.5 rounded-full px-3 py-1.5 text-[12.5px] font-medium',
-                      active ? 'border-mint/40 bg-mint-soft text-mint hover:bg-mint-soft hover:text-mint' : 'text-foreground',
-                    )}
-                  >
-                    {active ? <FolderOpen className="size-3.5" /> : <Folder className="size-3.5" />}
-                    <span className="max-w-[140px] truncate">{project.display_name}</span>
-                  </Button>
-                );
-              })}
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={openNewProject}
-                disabled={ns.sending}
-                className="h-auto gap-1.5 rounded-full px-3 py-1.5 text-[12.5px] font-medium text-muted"
-              >
-                <FolderPlus className="size-3.5" />
-                {t('newSession.newProject')}
-              </Button>
-            </div>
-          </div>
+          <ProjectPicker
+            projects={ns.projects}
+            targetId={ns.target?.id}
+            onSelect={ns.setSelected}
+            onNewProject={openNewProject}
+            disabled={ns.sending}
+          />
+          <AgentPicker
+            agents={ns.agents}
+            defaultAgentName={ns.defaultAgentName}
+            value={ns.selectedAgent}
+            onChange={ns.setSelectedAgent}
+            disabled={ns.sending}
+          />
 
           {ns.error && (
             <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">

--- a/ui/src/components/workbench/ProjectPicker.tsx
+++ b/ui/src/components/workbench/ProjectPicker.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next';
+import { Folder, FolderOpen, FolderPlus } from 'lucide-react';
+import clsx from 'clsx';
+
+import type { WorkbenchProject } from '../../context/ApiContext';
+import { Button } from '../ui/button';
+
+interface ProjectPickerProps {
+  projects: WorkbenchProject[];
+  /** The resolved create target's id — the chip to highlight. */
+  targetId: string | undefined;
+  onSelect: (id: string) => void;
+  onNewProject: () => void;
+  disabled?: boolean;
+}
+
+// Shared project chip picker for the create surfaces (Workbench home +
+// NewSessionSheet) so the user can see + choose where a new session lands. A
+// horizontal scroll row of EVERY project (a target beyond the first few stays
+// reachable) plus a New Project chip; the active chip is the resolved target.
+export const ProjectPicker: React.FC<ProjectPickerProps> = ({ projects, targetId, onSelect, onNewProject, disabled }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-muted">
+        {t('newSession.project')}
+      </div>
+      <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+        {projects.map((project) => {
+          const active = project.id === targetId;
+          return (
+            <Button
+              key={project.id}
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onSelect(project.id)}
+              disabled={disabled}
+              className={clsx(
+                'h-auto shrink-0 gap-1.5 rounded-full px-3 py-1.5 text-[12.5px] font-medium',
+                active ? 'border-mint/40 bg-mint-soft text-mint hover:bg-mint-soft hover:text-mint' : 'text-foreground',
+              )}
+            >
+              {active ? <FolderOpen className="size-3.5" /> : <Folder className="size-3.5" />}
+              <span className="max-w-[140px] truncate">{project.display_name}</span>
+            </Button>
+          );
+        })}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onNewProject}
+          disabled={disabled}
+          className="h-auto shrink-0 gap-1.5 rounded-full px-3 py-1.5 text-[12.5px] font-medium text-muted"
+        >
+          <FolderPlus className="size-3.5" />
+          {t('newSession.newProject')}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/context/WorkbenchProjectsContext.tsx
+++ b/ui/src/context/WorkbenchProjectsContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import type { ReactNode } from 'react';
 
 import { useApi } from './ApiContext';
-import type { WorkbenchProject, WorkbenchSession } from './ApiContext';
+import type { WorkbenchProject, WorkbenchSession, WorkbenchSessionCreate } from './ApiContext';
 
 // How many sessions to load per page under a project. The server clamps the
 // /api/sessions limit (to 200) and returns a cursor (next_before_id); both the
@@ -48,8 +48,9 @@ export interface WorkbenchProjectsTree {
 
   creatingSession: (projectId: string) => boolean;
   /** Creates a session under a project (optimistic prepend + expand) and RETURNS it;
-   *  the caller navigates (this provider is mounted outside the router). null on failure. */
-  createSessionForProject: (projectId: string) => Promise<WorkbenchSession | null>;
+   *  the caller navigates (this provider is mounted outside the router). null on failure.
+   *  `overrides` lets the create surfaces pin an agent/backend; omit for the server default. */
+  createSessionForProject: (projectId: string, overrides?: Partial<WorkbenchSessionCreate>) => Promise<WorkbenchSession | null>;
   renameProject: (projectId: string, name: string) => Promise<void>;
   archiveProject: (projectId: string) => Promise<void>;
   /** Throws on failure so the row's inline editor can fall back; patches title on success. */
@@ -266,15 +267,15 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   );
 
   const createSessionForProject = useCallback(
-    async (projectId: string): Promise<WorkbenchSession | null> => {
+    async (projectId: string, overrides?: Partial<WorkbenchSessionCreate>): Promise<WorkbenchSession | null> => {
       setCreating((prev) => new Set(prev).add(projectId));
       // Whether this project's list is already cached. If not, we must NOT seed a
       // partial cache: toggleExpanded treats any loaded entry as "already loaded"
       // and would never fetch the project's existing sessions, hiding them.
       const alreadyLoaded = sessionsRef.current[projectId]?.sessions != null;
       try {
-        // Omit agent_backend so the server defers to agents.default_backend.
-        const session = await api.createSession({ project_id: projectId });
+        // No overrides → omit agent fields so the server defers to agents.default_backend.
+        const session = await api.createSession({ project_id: projectId, ...overrides });
         if (alreadyLoaded) {
           setSessions((prev) => {
             const cur = prev[projectId] ?? EMPTY_SESSIONS;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -105,7 +105,10 @@
     "newProject": "New",
     "placeholder": "Describe what you want the agent to do…",
     "loadError": "Couldn't load projects — close and reopen to retry.",
-    "createFailed": "Couldn't start the session. Please try again."
+    "createFailed": "Couldn't start the session. Please try again.",
+    "agent": "Agent",
+    "defaultAgent": "Default agent",
+    "defaultAgentNamed": "Default · {{name}}"
   },
   "showPages": {
     "title": "Show Pages",
@@ -1608,7 +1611,7 @@
     }
   },
   "chat": {
-    "backToInbox": "Back to inbox",
+    "back": "Back",
     "untitled": "Untitled session",
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -105,7 +105,10 @@
     "newProject": "新项目",
     "placeholder": "描述你想让 agent 做什么…",
     "loadError": "项目加载失败，关掉重开可重试。",
-    "createFailed": "会话创建失败，请重试。"
+    "createFailed": "会话创建失败，请重试。",
+    "agent": "选择 Agent",
+    "defaultAgent": "默认 Agent",
+    "defaultAgentNamed": "默认 · {{name}}"
   },
   "showPages": {
     "title": "展示页面",
@@ -1607,7 +1610,7 @@
     }
   },
   "chat": {
-    "backToInbox": "返回收件箱",
+    "back": "返回",
     "untitled": "未命名会话",
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",

--- a/ui/src/lib/useAuthAccount.ts
+++ b/ui/src/lib/useAuthAccount.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useApi } from '../context/ApiContext';
+
+// Shared remote-auth account state: the signed-in email + a sign-out action.
+// Consumed by the desktop AccountMenu dropdown and the mobile More page so the
+// auth fetch + sign-out flow lives in one place. email is null when this isn't a
+// remote/authenticated session (e.g. local setups) — callers hide the account UI.
+export function useAuthAccount() {
+  const { getAuthSession, signOut } = useApi();
+  const [email, setEmail] = useState<string | null>(null);
+  const [signingOut, setSigningOut] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAuthSession()
+      .then((session) => {
+        if (cancelled) return;
+        setEmail(session.remote && session.authenticated ? session.email : null);
+      })
+      .catch(() => {
+        if (!cancelled) setEmail(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [getAuthSession]);
+
+  const handleSignOut = useCallback(async () => {
+    if (signingOut) return;
+    setSigningOut(true);
+    // Always navigate to "/" even on error: the cookie may already be expired
+    // (the request would 401), so leaving the user stuck would be worse — let
+    // the OIDC redirect handle whatever state remains.
+    try {
+      await signOut();
+    } catch {
+      // swallow — we still reload below
+    }
+    window.location.assign('/');
+  }, [signingOut, signOut]);
+
+  return { email, signingOut, signOut: handleSignOut };
+}

--- a/ui/src/lib/useNewSession.ts
+++ b/ui/src/lib/useNewSession.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useApi } from '../context/ApiContext';
 import { useWorkbenchProjectsTree } from '../context/WorkbenchProjectsContext';
-import type { WorkbenchProject } from '../context/ApiContext';
+import type { VibeAgentBrief, WorkbenchProject } from '../context/ApiContext';
 
 interface UseNewSessionOptions {
   /** Re-run the per-open reset on the rising edge — sheets pass their `open`. Default true. */
@@ -20,9 +21,14 @@ export interface NewSessionState {
   setSelected: (id: string) => void;
   target: WorkbenchProject | null;
   needsProject: boolean;
-  /** Creates a session under `target` and returns the nav target; null if it couldn't start
-   *  (empty / in-flight / not loaded / no project / error). The hook never navigates — the
-   *  caller does, since the projects provider is mounted outside the router. */
+  // Agent (backend) selection — null = the server default (agents.default_backend).
+  agents: VibeAgentBrief[];
+  defaultAgentName: string | null;
+  selectedAgent: VibeAgentBrief | null;
+  setSelectedAgent: (id: string | null) => void;
+  /** Creates a session under `target` (with the picked agent, if any) and returns the nav
+   *  target; null if it couldn't start (empty / in-flight / not loaded / no project / error).
+   *  The hook never navigates — the caller does, since the provider is mounted outside the router. */
   send: (text: string) => Promise<{ sessionId: string; initialMessage: string } | null>;
   upsertSelectProject: (project: WorkbenchProject) => void;
 }
@@ -33,20 +39,46 @@ const sortByRecent = (list: WorkbenchProject[]) =>
     .sort((a, b) => (b.last_active_at || b.created_at).localeCompare(a.last_active_at || a.created_at));
 
 // Shared new-session create flow for the desktop Workbench home (`Workbench.tsx`)
-// and the mobile NewSessionSheet. It's a thin layer over the shared projects
-// provider — the project LIST and the create itself come from there, so a
-// project/session created here shows up in the sidebar + Projects tree without a
-// separate fetch (one source of truth). The hook only adds the picker selection,
-// the transient sending/error state, and the most-recent target resolution.
-// Navigation + draft handling + the sheet's open/close lifecycle stay in the consumer.
+// and the mobile NewSessionSheet. A thin layer over the shared projects provider
+// (the project LIST + the create itself come from there, so a project/session
+// created here shows up in the sidebar + Projects tree). It adds the picker
+// selections (project + agent), the transient sending/error state, and target
+// resolution. Navigation + draft + the sheet's open/close lifecycle stay in the consumer.
 export function useNewSession({ active = true, loadErrorText, createFailedText }: UseNewSessionOptions): NewSessionState {
+  const api = useApi();
   const { projects: rawProjects, projectsError, createSessionForProject, upsertProjectToTop } = useWorkbenchProjectsTree();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
+  const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
+  const [defaultAgentName, setDefaultAgentName] = useState<string | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 
   const projects = useMemo(() => (rawProjects ? sortByRecent(rawProjects) : []), [rawProjects]);
   const loaded = rawProjects !== null;
+
+  // Agents rarely change → fetch once per mount (not per sheet-open). Lets the
+  // user pick which Vibe Agent (backend) runs the session instead of always
+  // falling back to the server default.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listVibeAgents({ includeDisabled: false })
+      .then((res) => {
+        if (cancelled) return;
+        setAgents(res.agents);
+        setDefaultAgentName(res.default_agent_name);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAgents([]);
+          setDefaultAgentName(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
 
   // Clear transient state when the sheet (re)opens so a prior submit / error
   // doesn't leak into the next open. The home passes active=true (runs once).
@@ -60,6 +92,7 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
   // null or now-hidden selection still resolves a sane target.
   const target = projects.find((p) => p.id === selectedId) ?? projects[0] ?? null;
   const needsProject = loaded && !target;
+  const selectedAgent = useMemo(() => agents.find((a) => a.id === selectedAgentId) ?? null, [agents, selectedAgentId]);
 
   const send = useCallback(
     async (text: string): Promise<{ sessionId: string; initialMessage: string } | null> => {
@@ -68,7 +101,20 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
       if (!trimmed || sending || !loaded || !target) return null;
       setSending(true);
       setError(null);
-      const session = await createSessionForProject(target.id);
+      // null selectedAgent → omit agent fields so the server uses its default.
+      const overrides = selectedAgent
+        ? {
+            agent_id: selectedAgent.id,
+            agent_name: selectedAgent.name,
+            agent_backend: selectedAgent.backend,
+            // Match agent_variant to the backend so the session can resume its
+            // native thread (mirrors the chat AgentRoutePicker).
+            agent_variant: selectedAgent.backend,
+            model: selectedAgent.model ?? undefined,
+            reasoning_effort: selectedAgent.reasoning_effort ?? undefined,
+          }
+        : undefined;
+      const session = await createSessionForProject(target.id, overrides);
       setSending(false);
       if (!session) {
         setError(createFailedText);
@@ -76,7 +122,7 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
       }
       return { sessionId: session.id, initialMessage: trimmed };
     },
-    [sending, loaded, target, createSessionForProject, createFailedText],
+    [sending, loaded, target, selectedAgent, createSessionForProject, createFailedText],
   );
 
   const upsertSelectProject = useCallback(
@@ -100,6 +146,10 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
     setSelected: setSelectedId,
     target,
     needsProject,
+    agents,
+    defaultAgentName,
+    selectedAgent,
+    setSelectedAgent: setSelectedAgentId,
     send,
     upsertSelectProject,
   };


### PR DESCRIPTION
## Mobile workbench UX fixes (from on-device testing)

Five issues found testing the (just-merged #406) mobile workbench on a phone.

### Changes
1. **Input focus zoom** — iOS zoomed the page when an input focused. Added `maximum-scale=1, user-scalable=no` to the viewport (this is an app shell, not a content page).
2. **Home composer had no project picker** — the user couldn't see/choose where a session would land. Added a shared `ProjectPicker` above the home composer.
3. **Couldn't pick the agent on create** — the ＋ new-session sheet (and the home) always used the default agent. Added a shared `AgentPicker`; `useNewSession` now carries the selected agent and `createSessionForProject(projectId, overrides?)` threads it into `createSession`. A null pick keeps the server default; a specific pick passes `agent_id/name/backend/variant/model/effort` (mirrors the chat picker, so the session resumes its native thread).
4. **Mobile header clutter** — removed version / language / theme / account from the mobile header; account (email + sign out) now lives on the **More** page (theme/language/version were already there). Extracted a shared `useAuthAccount` hook so `AccountMenu` (desktop) and More don't duplicate the auth logic.
5. **Chat back always went to inbox** — now returns to the actual previous page (`navigate(-1)`, with an inbox fallback for deep links / refresh).

`ProjectPicker` + `AgentPicker` are shared chip-row components reused by the desktop home **and** the mobile sheet — one source of truth for the create surfaces (continues the #406 single-source refactor).

### Capability
Create-session surfaces (home + new-session sheet) gain project + agent selection; mobile chrome consolidation; chat navigation.

### Evidence
- **Unit/contract**: no automated UI tests exist for these components (pre-existing gap).
- **Build**: `npm run build` (tsc + vite) green.
- **Review**: adversarial self-review of the diff found no P1/P2 regressions; confirmed `agent_variant=backend` is the resumable-correct path, no unused imports, `useAuthAccount` matches the old inline behavior, `goBack` uses the right v7 `location.key` signal.
- **Manual**: needs an on-device pass via the Docker regression env (the original report source).

### Known tradeoffs (deliberate)
- Mobile **admin** users reach sign-out via the center FAB → Workbench → More (the More tab is workbench-only). Reachable, one extra hop; account control was intentionally consolidated into More.
- `user-scalable=no` blocks pinch-zoom (WCAG 1.4.4) — accepted for an app shell per the report; the alternative (≥16px inputs) would change the type scale.
