### PR TITLE
fix(ui): home agent-trigger width + mobile keyboard/Enter behavior

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,12 +4,31 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <!-- maximum-scale=1 + user-scalable=no stops iOS Safari from auto-zooming when
-         a sub-16px input gains focus (app shell, not a content page). NOTE: we do
-         NOT set interactive-widget=resizes-content — on iOS it reflowed the
-         centered home badly when the keyboard opened. Keyboard handling is done
-         in layout instead (the chat sizes to the visualViewport-driven --app-vvh,
-         see useViewportHeightVar; the home uses top-aligned flow on mobile). -->
+         a sub-16px input gains focus (app shell, not a content page).
+         interactive-widget=resizes-content (added below for non-iOS) keeps Android
+         bottom sheets above the soft keyboard; on iOS it reflowed the centered home
+         when the keyboard opened, so iOS is handled in layout instead (top-aligned
+         home + visualViewport --app-vvh chat, see useViewportHeightVar). -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <script>
+      // Enable interactive-widget=resizes-content on Android/desktop (keeps bottom
+      // sheets above the soft keyboard) but NOT on iOS, where it reflowed the
+      // layout badly when the keyboard opened. Browsers re-evaluate the viewport
+      // meta when its content attribute changes, so this head script applies it
+      // before first paint.
+      (function () {
+        try {
+          var ua = navigator.userAgent || '';
+          var isIOS =
+            /iP(hone|ad|od)/.test(ua) ||
+            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+          if (!isIOS) {
+            var vp = document.querySelector('meta[name="viewport"]');
+            if (vp) vp.setAttribute('content', vp.getAttribute('content') + ', interactive-widget=resizes-content');
+          }
+        } catch (e) {}
+      })();
+    </script>
     <title>Vibe Remote</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ui/index.html
+++ b/ui/index.html
@@ -10,25 +10,6 @@
          when the keyboard opened, so iOS is handled in layout instead (top-aligned
          home + visualViewport --app-vvh chat, see useViewportHeightVar). -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <script>
-      // Enable interactive-widget=resizes-content on Android/desktop (keeps bottom
-      // sheets above the soft keyboard) but NOT on iOS, where it reflowed the
-      // layout badly when the keyboard opened. Browsers re-evaluate the viewport
-      // meta when its content attribute changes, so this head script applies it
-      // before first paint.
-      (function () {
-        try {
-          var ua = navigator.userAgent || '';
-          var isIOS =
-            /iP(hone|ad|od)/.test(ua) ||
-            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-          if (!isIOS) {
-            var vp = document.querySelector('meta[name="viewport"]');
-            if (vp) vp.setAttribute('content', vp.getAttribute('content') + ', interactive-widget=resizes-content');
-          }
-        } catch (e) {}
-      })();
-    </script>
     <title>Vibe Remote</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -54,6 +35,25 @@
         if (mode === "light" || mode === "dark") {
           document.documentElement.setAttribute("data-theme", mode);
         }
+      })();
+    </script>
+    <script>
+      // Enable interactive-widget=resizes-content on Android/desktop (keeps bottom
+      // sheets above the soft keyboard) but NOT on iOS, where it reflowed the
+      // layout badly when the keyboard opened. Placed AFTER the theme bootstrap so
+      // ui/scripts/validate-theme.mjs still treats the theme script as the first
+      // inline script. Browsers re-evaluate the viewport meta on content change.
+      (function () {
+        try {
+          var ua = navigator.userAgent || '';
+          var isIOS =
+            /iP(hone|ad|od)/.test(ua) ||
+            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+          if (!isIOS) {
+            var vp = document.querySelector('meta[name="viewport"]');
+            if (vp) vp.setAttribute('content', vp.getAttribute('content') + ', interactive-widget=resizes-content');
+          }
+        } catch (e) {}
       })();
     </script>
   </head>

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <!-- maximum-scale=1 + user-scalable=no stops iOS Safari from auto-zooming when
-         a sub-16px input gains focus (app shell, not a content page).
-         interactive-widget=resizes-content lets Android shrink the layout for the
-         keyboard; iOS uses the visualViewport-driven --app-vvh instead (see
-         useViewportHeightVar). -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content" />
+         a sub-16px input gains focus (app shell, not a content page). NOTE: we do
+         NOT set interactive-widget=resizes-content — on iOS it reflowed the
+         centered home badly when the keyboard opened. Keyboard handling is done
+         in layout instead (the chat sizes to the visualViewport-driven --app-vvh,
+         see useViewportHeightVar; the home uses top-aligned flow on mobile). -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Vibe Remote</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ui/src/components/Workbench.tsx
+++ b/ui/src/components/Workbench.tsx
@@ -48,11 +48,12 @@ export const Workbench: React.FC = () => {
   ] as const;
 
   return (
-    // Center the hero + Composer as a group, leaving the AppShell's top/bottom
-    // padding as margin (no negative-margin full-bleed). min-h fills the visible
-    // area so justify-center actually centers; the responsive offset accounts
-    // for the mobile header + bottom nav vs. the desktop sidebar layout.
-    <div className="flex min-h-[calc(100dvh-13rem)] flex-col items-center justify-center gap-5 md:min-h-[calc(100dvh-7rem)]">
+    // Desktop centers the hero + Composer as a group (min-h + justify-center). On
+    // mobile we DON'T center or force a tall min-height: a tall centered container
+    // fights the iOS keyboard (focusing the composer leaves a big gap / pushes it
+    // off-screen). Top-aligned normal flow lets iOS scroll the focused composer
+    // into view above the keyboard the way it does for ordinary in-flow inputs.
+    <div className="flex flex-col items-center gap-5 md:min-h-[calc(100dvh-7rem)] md:justify-center">
       {/* Hero panel — a centered card, not a full-bleed fill. */}
       <div className="flex w-full max-w-[640px] flex-col items-center gap-6 rounded-2xl border border-border bg-surface-2 px-6 py-10">
         <div className="flex size-14 items-center justify-center rounded-2xl border border-mint/40 bg-mint-soft text-mint shadow-[0_0_24px_-6px_rgba(91,255,160,0.6)]">
@@ -98,7 +99,7 @@ export const Workbench: React.FC = () => {
             defaultLabel={ns.defaultAgentName ? t('newSession.defaultAgentNamed', { name: ns.defaultAgentName }) : t('newSession.defaultAgent')}
             disabled={ns.sending}
             align="start"
-            triggerClassName="w-full max-w-full"
+            triggerClassName="max-w-full"
           />
         </div>
         <Composer

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -4,6 +4,7 @@ import { Loader2, Mic, Paperclip, Plus, Send, Square, Trash2, X } from 'lucide-r
 import clsx from 'clsx';
 
 import { apiFetch } from '../../lib/apiFetch';
+import { isSoftKeyboardOpen } from '../../lib/softKeyboard';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 
@@ -101,16 +102,6 @@ export const Composer: React.FC<ComposerProps> = ({
   // Upload + voice are scoped to a session (the upload endpoint needs one); the
   // home composer leaves them off.
   const mediaEnabled = Boolean(sessionId);
-
-  // Enter inserts a newline while the ON-SCREEN keyboard is open (Send is the
-  // button); with a hardware keyboard (no soft keyboard → the visual viewport
-  // isn't shrunk) or on desktop, Enter still sends. Keying off the soft keyboard
-  // specifically — not `pointer: coarse` — keeps Enter-to-send for iPad / tablet
-  // hardware keyboards (Codex P2).
-  const softKeyboardOpen = () => {
-    const vv = window.visualViewport;
-    return !!vv && window.innerHeight - vv.height > 120;
-  };
 
   useEffect(() => {
     if (draftAppliedRef.current || initialDraft == null) return;
@@ -427,7 +418,7 @@ export const Composer: React.FC<ComposerProps> = ({
             // keyboard is open (mobile), where Enter inserts a newline and Send is
             // the button. Hardware keyboards (no soft keyboard) keep Enter-to-send.
             // ``isComposing`` guards against submitting mid-IME composition (CJK).
-            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !softKeyboardOpen()) {
+            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !isSoftKeyboardOpen()) {
               e.preventDefault();
               submit();
             }

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -102,6 +102,19 @@ export const Composer: React.FC<ComposerProps> = ({
   // home composer leaves them off.
   const mediaEnabled = Boolean(sessionId);
 
+  // Touch devices (coarse pointer): Enter inserts a newline and Send is the
+  // on-screen button, so multi-line input is easy and a stray Return can't fire a
+  // half-typed message. Desktop (fine pointer) keeps the efficient Enter-to-send.
+  const [coarsePointer, setCoarsePointer] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(pointer: coarse)');
+    const apply = () => setCoarsePointer(mq.matches);
+    apply();
+    mq.addEventListener?.('change', apply);
+    return () => mq.removeEventListener?.('change', apply);
+  }, []);
+
   useEffect(() => {
     if (draftAppliedRef.current || initialDraft == null) return;
     draftAppliedRef.current = true;
@@ -413,10 +426,12 @@ export const Composer: React.FC<ComposerProps> = ({
           value={value}
           onChange={(e) => update(e.target.value)}
           onKeyDown={(e) => {
-            // Enter sends; Shift+Enter inserts a newline. ``isComposing`` guards
-            // against submitting mid-IME composition (CJK), where Enter commits
-            // the candidate rather than the message.
-            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+            // Desktop (fine pointer): Enter sends, Shift+Enter newline. Touch
+            // (coarse pointer / mobile): Enter inserts a newline — Send is the
+            // on-screen button — so multi-line input is easy. ``isComposing``
+            // guards against submitting mid-IME composition (CJK), where Enter
+            // commits the candidate rather than the message.
+            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !coarsePointer) {
               e.preventDefault();
               submit();
             }

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -102,18 +102,15 @@ export const Composer: React.FC<ComposerProps> = ({
   // home composer leaves them off.
   const mediaEnabled = Boolean(sessionId);
 
-  // Touch devices (coarse pointer): Enter inserts a newline and Send is the
-  // on-screen button, so multi-line input is easy and a stray Return can't fire a
-  // half-typed message. Desktop (fine pointer) keeps the efficient Enter-to-send.
-  const [coarsePointer, setCoarsePointer] = useState(false);
-  useEffect(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) return;
-    const mq = window.matchMedia('(pointer: coarse)');
-    const apply = () => setCoarsePointer(mq.matches);
-    apply();
-    mq.addEventListener?.('change', apply);
-    return () => mq.removeEventListener?.('change', apply);
-  }, []);
+  // Enter inserts a newline while the ON-SCREEN keyboard is open (Send is the
+  // button); with a hardware keyboard (no soft keyboard → the visual viewport
+  // isn't shrunk) or on desktop, Enter still sends. Keying off the soft keyboard
+  // specifically — not `pointer: coarse` — keeps Enter-to-send for iPad / tablet
+  // hardware keyboards (Codex P2).
+  const softKeyboardOpen = () => {
+    const vv = window.visualViewport;
+    return !!vv && window.innerHeight - vv.height > 120;
+  };
 
   useEffect(() => {
     if (draftAppliedRef.current || initialDraft == null) return;
@@ -426,12 +423,11 @@ export const Composer: React.FC<ComposerProps> = ({
           value={value}
           onChange={(e) => update(e.target.value)}
           onKeyDown={(e) => {
-            // Desktop (fine pointer): Enter sends, Shift+Enter newline. Touch
-            // (coarse pointer / mobile): Enter inserts a newline — Send is the
-            // on-screen button — so multi-line input is easy. ``isComposing``
-            // guards against submitting mid-IME composition (CJK), where Enter
-            // commits the candidate rather than the message.
-            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !coarsePointer) {
+            // Enter sends, Shift+Enter newline — EXCEPT while the on-screen
+            // keyboard is open (mobile), where Enter inserts a newline and Send is
+            // the button. Hardware keyboards (no soft keyboard) keep Enter-to-send.
+            // ``isComposing`` guards against submitting mid-IME composition (CJK).
+            if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !softKeyboardOpen()) {
               e.preventDefault();
               submit();
             }

--- a/ui/src/lib/softKeyboard.ts
+++ b/ui/src/lib/softKeyboard.ts
@@ -11,13 +11,27 @@
 
 let restingHeight = 0;
 
+// True when a text field is focused — i.e. the soft keyboard could be up — so the
+// resize handler knows whether a shrink is "keyboard" or just a window/orientation
+// change.
+function isEditableFocused(): boolean {
+  const el = typeof document !== 'undefined' ? (document.activeElement as HTMLElement | null) : null;
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || el.isContentEditable;
+}
+
 if (typeof window !== 'undefined' && window.visualViewport) {
   const vv = window.visualViewport;
-  // Initialised at module load (app start, keyboard closed) so the baseline is a
-  // keyboard-free height; then tracked upward as the address bar collapses.
+  // Initialised at module load (app start, keyboard closed) → a keyboard-free baseline.
   restingHeight = vv.height;
   vv.addEventListener('resize', () => {
-    if (vv.height > restingHeight) restingHeight = vv.height;
+    // While NO text field is focused the keyboard is closed, so the current height
+    // IS the resting baseline — this recomputes it on window resize / orientation
+    // change / address-bar show-hide (so a shrunk desktop window doesn't read as a
+    // keyboard). While a field is focused, only let the baseline grow (address bar
+    // hiding); never let the keyboard itself lower it.
+    if (!isEditableFocused() || vv.height > restingHeight) restingHeight = vv.height;
   });
 }
 

--- a/ui/src/lib/softKeyboard.ts
+++ b/ui/src/lib/softKeyboard.ts
@@ -1,0 +1,31 @@
+// Cross-platform "is the on-screen keyboard open?" check.
+//
+// It must work whether the keyboard OVERLAYS the viewport (iOS Safari: window
+// .innerHeight stays full, only visualViewport.height shrinks) OR RESIZES it
+// (Android Chrome with interactive-widget=resizes-content: innerHeight AND
+// visualViewport.height shrink together, so an innerHeight−visualViewport delta
+// reads ~0 — https://developer.chrome.com/blog/viewport-resize-behavior/). The
+// signal that survives both is the visual-viewport height vs the LARGEST height
+// seen while no keyboard was up (the "resting" height): the keyboard only ever
+// shrinks the visible viewport, and by far more than address-bar show/hide.
+
+let restingHeight = 0;
+
+if (typeof window !== 'undefined' && window.visualViewport) {
+  const vv = window.visualViewport;
+  // Initialised at module load (app start, keyboard closed) so the baseline is a
+  // keyboard-free height; then tracked upward as the address bar collapses.
+  restingHeight = vv.height;
+  vv.addEventListener('resize', () => {
+    if (vv.height > restingHeight) restingHeight = vv.height;
+  });
+}
+
+// ~250–300px keyboard vs ~60–100px address-bar variation → a 150px floor cleanly
+// separates "keyboard up" from address-bar collapse/expand.
+const KEYBOARD_MIN_DELTA = 150;
+
+export function isSoftKeyboardOpen(): boolean {
+  if (typeof window === 'undefined' || !window.visualViewport) return false;
+  return restingHeight - window.visualViewport.height > KEYBOARD_MIN_DELTA;
+}

--- a/ui/src/lib/softKeyboard.ts
+++ b/ui/src/lib/softKeyboard.ts
@@ -39,7 +39,15 @@ if (typeof window !== 'undefined' && window.visualViewport) {
 // separates "keyboard up" from address-bar collapse/expand.
 const KEYBOARD_MIN_DELTA = 150;
 
+// Only touch-capable devices have an on-screen keyboard. Gating on this keeps
+// isSoftKeyboardOpen() false on desktop regardless of window resizes (so Enter
+// always sends there — no false positives from a shorter window), while a
+// hardware keyboard on a touch device still reads false because it doesn't shrink
+// the viewport. So the resting-height heuristic only ever runs where a soft
+// keyboard can actually exist.
+const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0;
+
 export function isSoftKeyboardOpen(): boolean {
-  if (typeof window === 'undefined' || !window.visualViewport) return false;
+  if (!isTouchDevice || typeof window === 'undefined' || !window.visualViewport) return false;
   return restingHeight - window.visualViewport.height > KEYBOARD_MIN_DELTA;
 }


### PR DESCRIPTION
## Home page feedback: agent-trigger width + mobile keyboard / Enter

From on-device feedback on `/`.

### Changes
- **Desktop agent trigger width**: the agent route trigger was full-width and filled the whole row on desktop. Now content-width (`max-w-full`), sized to its label.
- **Mobile keyboard regression** (my last change made it worse): removed `interactive-widget=resizes-content` from the viewport — on iOS it reflowed the centered home badly when the keyboard opened (the input got pushed off the top with a large gap). The home now uses **top-aligned flow on mobile** (centers only on desktop) so iOS scrolls the focused composer into view above the keyboard like an ordinary in-flow input. The chat keeps its `visualViewport`-driven `--app-vvh` sizing.
- **Mobile Enter = newline**: on touch (`pointer: coarse`), Enter inserts a newline and Send is the on-screen button; desktop keeps Enter-to-send. Applies to every composer (shared component).

### Deferred / not feasible (per product call + platform limits)
- **File attach on the home**: stays session-scoped (the upload endpoint needs a session), so the home composer is text-only for now. (Voice could be added to the home later — transcribe is session-agnostic.)
- **iOS keyboard prediction/accessory bar**: can't be hidden from the web layer — Safari-controlled (predictions are a user setting; the form-assistant bar isn't web-removable).

### Evidence
- Build: `npm run build` green.
- ⚠️ **Mobile keyboard needs on-device verification** — I can't run iOS Safari in my environment and my previous attempt regressed it, so this wants a real-device pass (focus the home composer + a chat composer, confirm the input sits above the keyboard).
