### PR TITLE
fix(ui): lock mobile app shell to visual viewport (iOS keyboard off-top fix)

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -189,7 +189,10 @@ export const AppShell: React.FC = () => {
   const showBottomNav = !location.pathname.startsWith('/chat/') && location.pathname !== '/setup';
 
   return (
-    <div className="min-h-screen min-h-[100dvh] bg-background text-foreground">
+    // Mobile: a LOCKED, --app-vvh-sized flex column (overflow-hidden) so the
+    // document never scrolls — iOS can't then fling a focused input off the top —
+    // and <main> scrolls internally. Desktop: normal document flow.
+    <div className="flex h-[var(--app-vvh)] flex-col overflow-hidden bg-background text-foreground md:block md:h-auto md:min-h-screen md:overflow-visible">
       <aside className="fixed inset-y-0 left-0 z-30 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
         <div className="flex h-full flex-col justify-between gap-6 px-4 py-5">
           {/* Top: Brand + Workspace label + Nav list */}
@@ -287,7 +290,7 @@ export const AppShell: React.FC = () => {
         </div>
       </aside>
 
-      <header className="sticky top-0 z-40 flex h-[calc(4rem+env(safe-area-inset-top))] items-center justify-between gap-2 border-b border-border bg-background/92 px-4 pt-[env(safe-area-inset-top)] backdrop-blur md:hidden">
+      <header className="sticky top-0 z-40 flex h-[calc(4rem+env(safe-area-inset-top))] shrink-0 items-center justify-between gap-2 border-b border-border bg-background/92 px-4 pt-[env(safe-area-inset-top)] backdrop-blur md:hidden">
         <div className="flex min-w-0 items-center gap-2">
           <img
             src={logoImg}
@@ -303,7 +306,10 @@ export const AppShell: React.FC = () => {
 
       <main
         className={clsx(
-          'min-h-screen md:ml-[240px] md:pb-0',
+          // Mobile: the internal scroll area of the locked flex-column shell, so
+          // the document itself never scrolls. Desktop: normal flow (min-h-screen
+          // + sidebar offset).
+          'flex-1 min-h-0 overflow-y-auto md:ml-[240px] md:min-h-screen md:flex-none md:overflow-visible md:pb-0',
           showBottomNav ? 'pb-[calc(5.5rem+env(safe-area-inset-bottom))]' : 'pb-0',
           location.pathname.startsWith('/admin/settings') ? 'page-glow-settings' : 'page-glow-console'
         )}

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -707,7 +707,11 @@ export const ChatPage: React.FC = () => {
     // and left a 4rem dead gap below the compose bar. On mobile the sticky
     // ``h-16`` header occupies 4rem at the top, so subtract that instead.
     <ImageViewerProvider images={sessionImages}>
-      <div className="-mx-4 -my-5 flex h-[calc(var(--app-vvh)_-_4rem)] flex-col md:-mx-10 md:-my-8 md:h-[var(--app-vvh)]">
+      {/* Mobile: fill <main> exactly. <main> is app-vvh minus the header, and the
+          header is 4rem + the top safe-area, so subtract BOTH — otherwise the chat
+          is taller than main and main double-scrolls, hiding the compose bar on
+          notched iPhones. Desktop has no mobile header → full app-vvh. */}
+      <div className="-mx-4 -my-5 flex h-[calc(var(--app-vvh)_-_4rem_-_env(safe-area-inset-top))] flex-col md:-mx-10 md:-my-8 md:h-[var(--app-vvh)]">
         <ChatHeaderBar session={session} agents={agents} onPatch={patch} onBack={goBack} />
 
       {error && (

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -350,6 +350,23 @@ body {
   min-height: 100vh;
 }
 
+/* iOS Safari keyboard fix: on mobile, lock the document so it can't scroll.
+   Otherwise focusing an input makes Safari scroll the (slightly-taller-than-
+   viewport) page to "reveal" it and overshoots, flinging the input off the top
+   of the screen. The AppShell instead is a fixed, --app-vvh-sized flex column
+   whose <main> scrolls internally. Desktop keeps normal document scrolling. */
+@media (max-width: 767px) {
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+  #root {
+    height: 100%;
+  }
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Lock the mobile app shell to the visual viewport (iOS keyboard)

On-device follow-up: the chat/home composer still flew **off the top of the screen** when focused on iOS Safari (my earlier layout-only changes didn't fix it).

### Root cause
The page is slightly taller than the screen (the mobile header sits on top of a `min-h-screen` `main`), so the document **can scroll**. iOS then scrolls the whole document to "reveal" the focused input and overshoots, pushing it above the viewport. Removing `interactive-widget` / top-aligning the home didn't help because the document could still scroll.

### Fix (Telegram / PWA-shell pattern)
On **mobile only**: lock the document (`html,body { overflow:hidden; height:100% }`) and make `AppShell` a fixed, `--app-vvh`-sized flex column — `header` (`shrink-0`) + `main` (`flex-1 overflow-y-auto`) that scrolls **internally**. With nowhere for the document to scroll, iOS can't fling the input off the top; and because the shell is sized to the visual viewport (via `useViewportHeightVar`), it shrinks with the keyboard so the composer stays flush above it. **Desktop is unchanged** (`md:` keeps `min-h-screen` + normal document flow).

### Evidence
- Build green; `npm run validate:theme` passes.
- ⚠️ **Must be verified on a real iOS device** — I can't run iOS Safari in my environment, and this is a layout-level change. Please test: home `/` + a chat, focus the input → it should sit above the keyboard, not jump off the top; and confirm admin/settings long pages still scroll and desktop is unaffected.

### Risk / blast radius
This changes the mobile scroll model (document → internal `main` scroll). Desktop is gated behind `md:`. Long mobile pages (admin/settings) now scroll within `main`. Possible follow-up: a minor safe-area-top scroll on notch devices in the chat (the chat keeps its `--app-vvh - 4rem` height).
