### PR TITLE
fix(ui): pin chat composer to the iOS keyboard (visual-viewport correction)

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -190,7 +190,8 @@ export const AppShell: React.FC = () => {
 
   // Chat is a full-screen detail (own composer); the wizard owns the whole
   // viewport. Hide the bottom tab bar on both.
-  const showBottomNav = !location.pathname.startsWith('/chat/') && location.pathname !== '/setup';
+  const isChat = location.pathname.startsWith('/chat/');
+  const showBottomNav = !isChat && location.pathname !== '/setup';
 
   return (
     // Mobile: a LOCKED, full-viewport flex column (overflow-hidden) so the
@@ -299,19 +300,23 @@ export const AppShell: React.FC = () => {
         </div>
       </aside>
 
-      <header className="sticky top-0 z-40 flex h-[calc(4rem+env(safe-area-inset-top))] shrink-0 items-center justify-between gap-2 border-b border-border bg-background/92 px-4 pt-[env(safe-area-inset-top)] backdrop-blur md:hidden">
-        <div className="flex min-w-0 items-center gap-2">
-          <img
-            src={logoImg}
-            alt="Vibe Remote Logo"
-            className="size-6 shrink-0 rounded-md border border-mint/30 bg-mint/[0.08] object-cover"
-          />
-          <span className="truncate text-[13px] font-semibold">{t('appShell.title')}</span>
-        </div>
-        {/* Version / language / theme / account moved into the More tab — the
-            mobile header stays just brand. (Desktop keeps them in the admin
-            sidebar bottom.) */}
-      </header>
+      {/* Chat is a fixed full-screen surface with its own header bar, so the
+          brand header is hidden there (otherwise it would sit behind the chat). */}
+      {!isChat && (
+        <header className="sticky top-0 z-40 flex h-[calc(4rem+env(safe-area-inset-top))] shrink-0 items-center justify-between gap-2 border-b border-border bg-background/92 px-4 pt-[env(safe-area-inset-top)] backdrop-blur md:hidden">
+          <div className="flex min-w-0 items-center gap-2">
+            <img
+              src={logoImg}
+              alt="Vibe Remote Logo"
+              className="size-6 shrink-0 rounded-md border border-mint/30 bg-mint/[0.08] object-cover"
+            />
+            <span className="truncate text-[13px] font-semibold">{t('appShell.title')}</span>
+          </div>
+          {/* Version / language / theme / account moved into the More tab — the
+              mobile header stays just brand. (Desktop keeps them in the admin
+              sidebar bottom.) */}
+        </header>
+      )}
 
       <main
         className={clsx(

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -8,6 +8,7 @@ import { useApi } from '../../context/ApiContext';
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import type { VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
+import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { formatLocalDateTime } from '../../lib/relativeTime';
 import { AgentRoutePicker } from './AgentRoutePicker';
@@ -85,6 +86,10 @@ export const ChatPage: React.FC = () => {
   const location = useLocation();
   const api = useApi();
   const { unreadBySession, markRead: markInboxRead } = useWorkbenchInbox();
+  // The mobile chat surface is a fixed full-screen flex column; this keeps the
+  // composer glued to the iOS keyboard (settle-then-correct; see the hook).
+  const chatSurfaceRef = useRef<HTMLDivElement>(null);
+  useIosKeyboardInset(chatSurfaceRef);
 
   // Back returns to the page the user came from, not a hardcoded inbox.
   // location.key === 'default' means /chat was the first history entry (deep
@@ -707,13 +712,17 @@ export const ChatPage: React.FC = () => {
     // and left a 4rem dead gap below the compose bar. On mobile the sticky
     // ``h-16`` header occupies 4rem at the top, so subtract that instead.
     <ImageViewerProvider images={sessionImages}>
-      {/* Mobile: fill <main> exactly — --app-shell-h minus the header (4rem + top
-          safe-area), statically (dvh, 100vh fallback for old iOS): the mobile
-          body-lock makes iOS pan the locked page to lift the composer above the
-          keyboard, so no JS sizing is needed. md+ (iPad / phone-landscape) uses the
-          desktop layout (no body-lock), so size to the visual-viewport height
-          (--app-vvh) to keep the composer above the soft keyboard there. */}
-      <div className="-mx-4 -my-5 flex h-[calc(var(--app-shell-h)_-_4rem_-_env(safe-area-inset-top))] flex-col md:-mx-10 md:-my-8 md:h-[var(--app-vvh)]">
+      {/* Mobile: a FIXED full-screen flex column (the AppShell brand header is
+          hidden on chat) so the composer has NO scrollable ancestor — that is what
+          let iOS fling it off the top. useIosKeyboardInset then sizes this surface
+          to the visible area above the keyboard once it settles, so the composer
+          stays glued to the keyboard. Desktop/iPad: revert to the in-flow layout
+          sized to --app-vvh (the visual-viewport var handles the soft keyboard
+          there). */}
+      <div
+        ref={chatSurfaceRef}
+        className="fixed inset-0 z-40 flex flex-col bg-background pt-[env(safe-area-inset-top)] md:static md:inset-auto md:z-auto md:-mx-10 md:-my-8 md:h-[var(--app-vvh)] md:bg-transparent md:pt-0"
+      >
         <ChatHeaderBar session={session} agents={agents} onPatch={patch} onBack={goBack} />
 
       {error && (
@@ -799,7 +808,7 @@ const Compose: React.FC<ComposeProps> = ({ onSend, onStop, busy, sessionId, init
   // so the input sits close to the bottom edge. The input row is the shared
   // <Composer>, also used by the Workbench home.
   <div
-    className="shrink-0 px-4 pb-4 pt-3 md:px-8"
+    className="shrink-0 px-4 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-3 md:px-8 md:pb-4"
     style={{ background: 'linear-gradient(to top, var(--background) 65%, transparent)' }}
   >
     <Composer

--- a/ui/src/lib/useIosKeyboardInset.ts
+++ b/ui/src/lib/useIosKeyboardInset.ts
@@ -1,0 +1,70 @@
+import { type RefObject, useEffect } from 'react';
+
+// Keep a bottom-pinned composer glued to the on-screen keyboard on mobile iOS
+// Safari (incl. the iOS 26 regression where `position: fixed` stops being
+// honored, `dvh` under-resolves, and `visualViewport` values are
+// self-contradictory — so the composer either flies off the top on focus or
+// floats above the keyboard).
+//
+// Approach (validated on-device): do NOT fight the keyboard's open animation —
+// reacting to every visualViewport frame over-corrects and flings the input even
+// farther. Instead, let iOS do its natural pan, then ONCE the viewport SETTLES
+// (debounced) apply a single gentle correction:
+//   • size the fixed full-screen surface to the TRUE visible bottom
+//     (visualViewport.offsetTop + visualViewport.height) — 100dvh under-resolves
+//     with the keyboard open, which is why the composer stops short of the bottom;
+//   • pull the focused field into view (scrollIntoView) as a backstop.
+// On blur, restore full height and nudge the scroll to work around the iOS 26 bug
+// where visualViewport.offsetTop fails to revert after the keyboard closes.
+//
+// Mobile only — `containerRef` is a `position: fixed` surface that exists solely
+// on the mobile layout; desktop/iPad keep their normal document flow.
+export function useIosKeyboardInset(containerRef: RefObject<HTMLDivElement | null>): void {
+  useEffect(() => {
+    // The fixed full-screen surface + document body-lock only exist on mobile.
+    if (!window.matchMedia('(max-width: 767px)').matches) return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    let settle = 0;
+    const correct = () => {
+      const el = containerRef.current;
+      // True bottom of the visible area, in layout coords (see header comment).
+      if (el) el.style.height = `${Math.round(vv.offsetTop + vv.height)}px`;
+      const active = document.activeElement as HTMLElement | null;
+      if (active && (active.tagName === 'TEXTAREA' || active.tagName === 'INPUT')) {
+        active.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }
+    };
+    // Debounce: nothing moves DURING the open/close animation; correct once the
+    // visual viewport stops changing.
+    const onViewport = () => {
+      window.clearTimeout(settle);
+      settle = window.setTimeout(correct, 140);
+    };
+    vv.addEventListener('resize', onViewport);
+    vv.addEventListener('scroll', onViewport);
+
+    const onFocusOut = () => {
+      window.setTimeout(() => {
+        const el = containerRef.current;
+        if (el) el.style.height = '';
+        // iOS 26: offsetTop can stay > 0 after dismiss; a 1px scroll forces recalc.
+        if (window.visualViewport && window.visualViewport.offsetTop > 0) {
+          window.scrollBy(0, -1);
+          window.scrollBy(0, 1);
+        }
+      }, 120);
+    };
+    document.addEventListener('focusout', onFocusOut);
+
+    return () => {
+      window.clearTimeout(settle);
+      vv.removeEventListener('resize', onViewport);
+      vv.removeEventListener('scroll', onViewport);
+      document.removeEventListener('focusout', onFocusOut);
+      const el = containerRef.current;
+      if (el) el.style.height = '';
+    };
+  }, [containerRef]);
+}

--- a/ui/src/lib/useIosKeyboardInset.ts
+++ b/ui/src/lib/useIosKeyboardInset.ts
@@ -17,23 +17,29 @@ import { type RefObject, useEffect } from 'react';
 // On blur, restore full height and nudge the scroll to work around the iOS 26 bug
 // where visualViewport.offsetTop fails to revert after the keyboard closes.
 //
-// Mobile only — `containerRef` is a `position: fixed` surface that exists solely
-// on the mobile layout; desktop/iPad keep their normal document flow.
+// `containerRef` is a `position: fixed` surface that exists only on the mobile
+// layout, so the correction is gated to the mobile breakpoint — and re-evaluated
+// live (the chat page stays mounted across orientation changes, so a rotate into
+// the desktop/`md` layout must release the listeners AND clear any stale inline
+// height that would otherwise override `md:h-[var(--app-vvh)]`).
 export function useIosKeyboardInset(containerRef: RefObject<HTMLDivElement | null>): void {
   useEffect(() => {
-    // The fixed full-screen surface + document body-lock only exist on mobile.
-    if (!window.matchMedia('(max-width: 767px)').matches) return;
     const vv = window.visualViewport;
     if (!vv) return;
+    const mql = window.matchMedia('(max-width: 767px)');
 
     let settle = 0;
+    let active = false;
+
+    const isEditable = (el: Element | null): boolean =>
+      !!el && (el.tagName === 'TEXTAREA' || el.tagName === 'INPUT');
+
     const correct = () => {
       const el = containerRef.current;
       // True bottom of the visible area, in layout coords (see header comment).
       if (el) el.style.height = `${Math.round(vv.offsetTop + vv.height)}px`;
-      const active = document.activeElement as HTMLElement | null;
-      if (active && (active.tagName === 'TEXTAREA' || active.tagName === 'INPUT')) {
-        active.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      if (isEditable(document.activeElement)) {
+        (document.activeElement as HTMLElement).scrollIntoView({ block: 'end', behavior: 'smooth' });
       }
     };
     // Debounce: nothing moves DURING the open/close animation; correct once the
@@ -42,11 +48,12 @@ export function useIosKeyboardInset(containerRef: RefObject<HTMLDivElement | nul
       window.clearTimeout(settle);
       settle = window.setTimeout(correct, 140);
     };
-    vv.addEventListener('resize', onViewport);
-    vv.addEventListener('scroll', onViewport);
-
     const onFocusOut = () => {
       window.setTimeout(() => {
+        // Focus moved to ANOTHER field (e.g. title → composer) with the keyboard
+        // still up — keep the inset; resetting here would expand the surface back
+        // behind the keyboard and obscure the composer until the next vv event.
+        if (isEditable(document.activeElement)) return;
         const el = containerRef.current;
         if (el) el.style.height = '';
         // iOS 26: offsetTop can stay > 0 after dismiss; a 1px scroll forces recalc.
@@ -56,15 +63,34 @@ export function useIosKeyboardInset(containerRef: RefObject<HTMLDivElement | nul
         }
       }, 120);
     };
-    document.addEventListener('focusout', onFocusOut);
 
-    return () => {
+    const activate = () => {
+      if (active) return;
+      active = true;
+      vv.addEventListener('resize', onViewport);
+      vv.addEventListener('scroll', onViewport);
+      document.addEventListener('focusout', onFocusOut);
+    };
+    const deactivate = () => {
+      if (!active) return;
+      active = false;
       window.clearTimeout(settle);
       vv.removeEventListener('resize', onViewport);
       vv.removeEventListener('scroll', onViewport);
       document.removeEventListener('focusout', onFocusOut);
+      // Clear any stale inline height so the desktop/md layout takes over.
       const el = containerRef.current;
       if (el) el.style.height = '';
+    };
+
+    // Sync to the breakpoint now and whenever it changes (orientation/resize).
+    const sync = () => (mql.matches ? activate() : deactivate());
+    sync();
+    mql.addEventListener('change', sync);
+
+    return () => {
+      mql.removeEventListener('change', sync);
+      deactivate();
     };
   }, [containerRef]);
 }


### PR DESCRIPTION
## Capability

Mobile **chat composer stays pinned to the iOS keyboard** — focusing the chat input must not fling it off the top of the screen (blank page), and it should sit flush above the keyboard.

## Why #420 didn't actually fix it

#420 shipped a static locked shell, but on mobile the chat composer still lived **inside the scrollable `<main>`** — so iOS scrolled that ancestor on focus and flung the input off the top. On top of that, **iOS 26** has an active Safari regression: `position: fixed` stops being honored with the keyboard up, `dvh` under-resolves, and `visualViewport` reports self-contradictory values (`innerHeight == visualViewport.height` while `offsetTop` is large). No static/CSS layout holds the composer in place there. (Confirmed on the reporter's device — `scale: 1`, so it is not a zoom artifact.)

## Fix (validated on-device first)

Built a Show Page test bench, iterated with the reporter until the behavior was right, then ported that exact structure:

- The mobile chat is now a **fixed full-screen flex column** (the AppShell brand header is hidden on chat, which already has its own header bar). The composer is a `shrink-0` sibling of the scrolling transcript, so it has **no scrollable ancestor** → iOS can't scroll-to-reveal it off the top.
- New `useIosKeyboardInset` hook (mobile-only): does **nothing during the keyboard open animation** (reacting per-frame over-corrects and makes the input fly *farther*); once the visual viewport **settles** (debounced ~140ms), it sizes the surface to the true visible bottom (`visualViewport.offsetTop + visualViewport.height`) and pulls the focused field into view. A `focusout` 1px scroll-nudge works around the iOS 26 dismiss-misalignment.
- Composer gains `safe-area-inset-bottom` clearance for the home indicator when the keyboard is closed.

Desktop / iPad are untouched: `md:` reverts the chat to the in-flow `--app-vvh` layout, and the hook early-returns above the `767px` breakpoint.

## Evidence

- **Unit / contract**: n/a — CSS/layout + a small DOM-effect hook.
- **Scenario**: none — no scenario catalog covers UI layout.
- **Build**: `tsc -b && vite build` clean.
- **Manual**: the fix structure + the settle-then-correct timing were validated on the reporter's iPhone (iOS Safari) via the test bench before this port; final on-device verification of the real app to follow after the regression refresh. (This bug class can't be reproduced in-sandbox.)

## Follow-ups (not in this PR)

The **home** composer and the **new-session bottom sheet** input share the same root cause (composer inside a scrollable container). They'll adopt `useIosKeyboardInset` + the no-scrollable-ancestor structure in a follow-up.
