### PR TITLE
fix(workbench): compact 8-session sidebar pages + scrollable project list

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -206,7 +206,7 @@ export const AppShell: React.FC = () => {
       <aside className="fixed inset-y-0 left-0 z-30 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
         <div className="flex h-full flex-col justify-between gap-6 px-4 py-5">
           {/* Top: Brand + Workspace label + Nav list */}
-          <div className="flex flex-col gap-6">
+          <div className="flex min-h-0 flex-1 flex-col gap-6">
             <div className="flex items-center gap-2.5 px-1 py-2">
               <img
                 src={logoImg}

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -630,8 +630,11 @@ export const WorkbenchSidebar: React.FC = () => {
     return totalUnread > 99 ? '99+' : String(totalUnread);
   }, [totalUnread]);
 
+  // Fill the sidebar column and cap its height so the project list (and only the
+  // project list) scrolls; Inbox + Capabilities stay pinned. The Inbox hover
+  // popover stays OUT of any overflow box below, so it is never clipped.
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
       {/* Inbox entry — hover opens the floating popover. */}
       <div
         className="relative"
@@ -709,7 +712,7 @@ export const WorkbenchSidebar: React.FC = () => {
       {/* Projects section — design.pen b8wX2. Header row carries the
           "Projects" label on the left (matching the Capabilities label
           style) and the 22x22 add button on the right. */}
-      <div className="flex flex-col gap-1.5">
+      <div className="flex min-h-0 flex-1 flex-col gap-1.5">
         <div className="flex items-center justify-between px-1">
           <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
             {t('workbench.projectsLabel')}
@@ -728,7 +731,7 @@ export const WorkbenchSidebar: React.FC = () => {
           </Button>
         </div>
 
-        <div className="flex flex-col gap-0.5">
+        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto pr-0.5">
           {projects === null && !projectsError && (
             <div className="flex items-center gap-2 rounded-md border border-dashed border-border px-3 py-3 text-[11px] text-muted">
               <Loader2 className="size-3 animate-spin" />

--- a/ui/src/context/WorkbenchProjectsContext.tsx
+++ b/ui/src/context/WorkbenchProjectsContext.tsx
@@ -7,10 +7,11 @@ import type { ProjectDefaultAgent, WorkbenchProject, WorkbenchSession, Workbench
 // How many sessions to load per page under a project. The server clamps the
 // /api/sessions limit (to 200) and returns a cursor (next_before_id); both the
 // desktop sidebar and the mobile Projects page append the next page via a
-// "Load more" control rather than loading every session up front. 20 is a
-// middle ground between the desktop sidebar's old 10 (compact rail) and the
-// mobile page's old 50 (full-screen list) now that one provider serves both.
-const SESSIONS_PAGE_SIZE = 20;
+// "Load more" control rather than loading every session up front. Kept small (8)
+// to keep the compact desktop sidebar rail short — long histories stay one click
+// away behind "Load more". Both surfaces share a single per-project cache, so the
+// page size has to be one shared value (it can't differ per surface).
+const SESSIONS_PAGE_SIZE = 8;
 
 export interface ProjectSessionsState {
   /** null = not loaded yet. [] = loaded-but-empty (or a first-page failure, with `error`). */


### PR DESCRIPTION
## Capability changed

Desktop **workbench sidebar** — two related compactness fixes:

1. **Per-project session page size 20 → 8.** Each project now shows 8 sessions before the existing **"Load more"** control; older sessions stay one click away. The desktop sidebar and the mobile Projects page share a single per-project session cache (unified in #406), so the page size is necessarily one shared value — this also tightens the mobile list to 8/page.
2. **Sidebar project list now scrolls when it overflows.** The fixed-height sidebar previously let a long project/session tree overflow without scrolling. `flex-1 + min-h-0` is plumbed from the shell column (`AppShell`) down through the sidebar to the project list, and **only the project list** gets `overflow-y-auto`.

### Why scrolling is scoped to the project list

The Inbox row's hover popover is an `absolute left-full` element that extends ~360px **outside** the 240px rail. Putting `overflow-y-auto` on a shared ancestor would force `overflow-x` to clip and cut the popover off. Scoping the scroll container to the project list keeps Inbox + Capabilities pinned and the popover unclipped.

## Affected scenario IDs

None — no scenario catalog entry covers the sidebar layout / pagination constant.

## Evidence layers

- **Unit / contract / scenario:** not updated — change is a UI layout (Tailwind flex classes) + one frontend constant; no existing test asserts `SESSIONS_PAGE_SIZE` or the sidebar DOM structure.
- **Build:** `npm run build` (tsc -b + vite) passes.
- **Lint:** `eslint` on the 3 changed files introduces no new errors (pre-existing `no-explicit-any` / `react-refresh` warnings on untouched lines remain).
- **Residual manual checks (pending):** visual confirmation in the Docker regression env — expand the `home` project (24 active sessions) to verify the 8-row page + "Load more", and that the project list scrolls while the Inbox hover popover renders unclipped. Will run on request.