### PR TITLE
fix(ui): default the harness status filter to enabled

### DIFF
--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -95,7 +95,11 @@ export const HarnessPage: React.FC = () => {
   // for tasks and watches; reset between tab switches happens via
   // setSelection(null) below.
   const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<'all' | 'enabled' | 'disabled'>('all');
+  // Default to enabled-only: the Harness landing view should surface the
+  // active tasks/watches first, not bury them among disabled leftovers. The
+  // user can still switch to "all"/"disabled"; the filtered-count hint makes
+  // the active filter obvious.
+  const [statusFilter, setStatusFilter] = useState<'all' | 'enabled' | 'disabled'>('enabled');
 
   const refresh = useCallback(async () => {
     setLoading(true);


### PR DESCRIPTION
## What & why
Page feedback on `/harness`: the status filter opened on **All**, so the tasks/watches lists landed with active items buried among disabled leftovers. Default the (shared) status filter to **Enabled** so the landing view surfaces active items first.

The single `statusFilter` drives both the Tasks and Watches tabs (the Runs tab uses a server-side query and has no client status filter). The segmented control still offers All / Enabled / Disabled, and the filtered-count hint makes the active filter obvious — discoverability is preserved.

## Scope
Workbench-only `HarnessPage` default state change; no API/contract change.

## Scenario IDs
N/A — no scenario catalog covers the Harness page.

## Evidence
- **Unit/Contract/Scenario:** unchanged (pure client default; no server or contract surface touched).
- **Build:** `npm run build` (tsc -b + vite) passes.
- **Independent review:** `codex review --base master` (xhigh) — PASS, no regression.
- **Residual manual checks:** live confirmation on the `/harness` page in the regression UI (offered to the reporter).
