### PR TITLE
fix(ui): drop redundant version row from mobile More page

### DIFF
--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, Info, Link as LinkIcon, LogOut, SlidersHorizontal } from 'lucide-react';
+import { ArrowRight, Link as LinkIcon, LogOut, SlidersHorizontal } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -101,21 +101,17 @@ export const MorePage: React.FC = () => {
         </div>
       )}
 
-      {/* Connection */}
-      <div className="rounded-xl border border-border bg-surface">
-        {hostname && (
+      {/* Connection — host only. The version badge already lives in the status
+          card above, so a second version row here would be redundant. */}
+      {hostname && (
+        <div className="rounded-xl border border-border bg-surface">
           <div className="flex items-center gap-3 px-4 py-3">
             <LinkIcon className="size-4 text-muted" />
             <span className="flex-1 text-sm font-medium">{t('more.host')}</span>
             <span className="font-mono text-[12px] text-muted">{hostname}</span>
           </div>
-        )}
-        <div className={clsx('flex items-center gap-3 px-4 py-3', hostname && 'border-t border-border')}>
-          <Info className="size-4 text-muted" />
-          <span className="flex-1 text-sm font-medium">{t('more.version')}</span>
-          <VersionBadge />
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -95,8 +95,7 @@
     "controlPanelDesc": "Channels · Users · Show Pages · Settings · Logs",
     "appearance": "Appearance",
     "connection": "Connection",
-    "host": "Local address",
-    "version": "Version"
+    "host": "Local address"
   },
   "projects": {
     "title": "Projects",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -95,8 +95,7 @@
     "controlPanelDesc": "频道 · 用户 · 展示页面 · 设置 · 日志",
     "appearance": "外观",
     "connection": "连接",
-    "host": "本机地址",
-    "version": "版本"
+    "host": "本机地址"
   },
   "projects": {
     "title": "项目",


### PR DESCRIPTION
## Capability

Mobile **More** page (`/more`) showed the version badge twice: once in the top read-only status card, and again as a redundant "Version" row in the Connection card below. Remove the lower row (page-feedback from device review).

### What changed
- Drop the duplicate `more.version` row from `MorePage.tsx`; the version badge in the status card is the single source.
- The Connection card now renders **only when a hostname exists** (its sole remaining content), avoiding an empty bordered card.
- Remove the now-unused `Info` icon import and the `more.version` i18n key (en + zh).

## Evidence layers
- **Unit / contract**: `npm run build` (tsc) green — confirms no dangling references to the removed import/key.
- **Scenario**: n/a.
- **Manual / residual**: visual confirmation on a phone viewport pending via the Docker regression env (sandbox can't run a browser); change is a pure row removal, low risk.
