### PR TITLE
fix(ui): truncate long project names in workbench sidebar

### DIFF
--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -379,7 +379,7 @@ const ProjectRow: React.FC<{
   return (
     <div className="flex flex-col gap-0.5">
       <div
-        className="group flex items-center gap-1.5 rounded-md px-2 py-1.5 transition hover:bg-foreground/[0.04]"
+        className="group flex items-center gap-1.5 rounded-md py-1.5 pl-1 pr-2 transition hover:bg-foreground/[0.04]"
         title={project.folder_path}
         onContextMenu={(e) => {
           // Right-click opens the same menu as the ⋯ button (anchored to it).
@@ -415,7 +415,7 @@ const ProjectRow: React.FC<{
           <button
             type="button"
             onClick={onToggle}
-            className="flex flex-1 items-center gap-1.5 text-left"
+            className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
           >
             <Chevron className="size-3 shrink-0 text-muted" />
             {expanded ? (


### PR DESCRIPTION
## Problem
A long project name in the workbench sidebar (e.g. `vibe-remote-project123123`) pushes the `⋯` / `+` action buttons out of the row, so they are clipped / not fully visible. Reported via in-app feedback.

## Root cause
Classic flexbox `min-width: auto` trap. The project-name toggle button is `flex-1` but — like every flex item — defaults to `min-width: auto`, so it refuses to shrink below its content width. A long name expands the button past its share, pushing the `shrink-0` action buttons out of the row, and the name span's existing `truncate` never engages (its flex parent can't shrink).

## Fix
`ui/src/components/workbench/WorkbenchSidebar.tsx` (`ProjectRow`):
- Add `min-w-0` to the toggle button → it can shrink, the `flex-1 truncate` name span truncates with an ellipsis, and the `⋯` / `+` buttons stay visible.
- Trim the row's left padding `px-2` → `pl-1 pr-2` → reclaims the empty gutter left of the folder icon (2nd point of the report), giving the name more room.

## Testing
- Reproduced the layout with the exact Tailwind classes; verified **before** (buttons pushed out, no ellipsis) vs **after** (`vibe-remote-pr…`, buttons visible, icon closer to the left edge).
- `tsc -b`: no new type errors — `WorkbenchSidebar.tsx` is clean. The pre-existing missing-dependency errors in `file-viewer-modal.tsx` / `highlighter.ts` are unrelated to this change.