### PR TITLE
feat(workbench): markdown in user chat bubbles + a queue-send button

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -31,6 +31,7 @@
         "react-i18next": "^16.5.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.12.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.2.0",
         "tailwind-merge": "^3.4.0",
@@ -2546,7 +2547,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4812,6 +4812,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -5956,6 +5970,21 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "react-i18next": "^16.5.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.12.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.2.0",
     "tailwind-merge": "^3.4.0",

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 
 import { ChatImage, LinkedImageProvider } from '@/components/ui/chat-image';
 import { FileCard } from '@/components/ui/file-card';
@@ -18,14 +19,21 @@ import { cn } from '@/lib/utils';
 // that live inside a clickable row/button (e.g. inbox previews): links render as
 // plain text so a nested <a> can't become invalid interactive content or steal
 // the row's click.
-export const Markdown: React.FC<{ content: string; className?: string; interactive?: boolean }> = ({
-  content,
-  className,
-  interactive = true,
-}) => (
+// ``softBreaks`` (default false) turns a single newline into a hard <br> via
+// remark-breaks — CommonMark otherwise collapses a soft break to a space. Enable
+// it for as-typed text (the user's own chat messages) so a multi-line prompt
+// echoes with its line breaks intact while still formatting explicit markdown;
+// leave it off for authored markdown (agent replies) where wrapped lines must
+// not sprout stray hard breaks.
+export const Markdown: React.FC<{
+  content: string;
+  className?: string;
+  interactive?: boolean;
+  softBreaks?: boolean;
+}> = ({ content, className, interactive = true, softBreaks = false }) => (
   <div className={cn('vr-markdown', className)}>
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={softBreaks ? [remarkGfm, remarkBreaks] : [remarkGfm]}
       components={{
         // Markdown here is untrusted (agent replies, user-authored prompts) and
         // can embed images. The default <img> renderer would auto-fetch any URL

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1250,13 +1250,15 @@ const MessageRow: React.FC<{
       />
     ) : null;
 
-  // Agent / system replies are markdown; the user's own and harness-triggered
-  // prompts are shown verbatim as typed/sent.
+  // Agent / system replies AND the user's own messages render as markdown (users
+  // routinely type lists / code / **emphasis** and expect it formatted). Only
+  // harness-triggered prompts (scheduled task / watch / webhook) stay verbatim —
+  // that row is a collapsed technical preview where the raw text is the point.
   const bodyNode = message.text ? (
-    isAgent || isSystem ? (
-      <Markdown content={message.text} />
-    ) : (
+    isHarness ? (
       <div className="whitespace-pre-wrap break-words text-[13px] text-foreground">{message.text}</div>
+    ) : (
+      <Markdown content={message.text} />
     )
   ) : messageAttachments.length === 0 ? (
     <div className="text-[13px] text-muted">—</div>
@@ -1289,7 +1291,7 @@ const MessageRow: React.FC<{
     return (
       <div className="flex w-full justify-end">
         <div className="flex max-w-[min(92%,860px)] flex-col items-end gap-1">
-          <div className="w-fit min-w-0 max-w-full rounded-2xl rounded-tr-md border border-border-strong bg-foreground/[0.06] px-3.5 py-2.5 text-[13px] leading-relaxed">
+          <div className="w-fit min-w-0 max-w-full rounded-2xl rounded-tr-md border border-border-strong bg-foreground/[0.06] px-3.5 py-2.5 text-[13px] leading-relaxed [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_table]:w-full">
             {bodyNode}
             {attachmentsNode}
           </div>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1258,7 +1258,9 @@ const MessageRow: React.FC<{
     isHarness ? (
       <div className="whitespace-pre-wrap break-words text-[13px] text-foreground">{message.text}</div>
     ) : (
-      <Markdown content={message.text} />
+      // Keep the user's own newlines visible (soft-break → <br>); agent/system
+      // replies are authored markdown and must not get stray hard breaks.
+      <Markdown content={message.text} softBreaks={isUser} />
     )
   ) : messageAttachments.length === 0 ? (
     <div className="text-[13px] text-muted">—</div>

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, Mic, Paperclip, Plus, Send, Square, Trash2, X } from 'lucide-react';
+import { Clock, Loader2, Mic, Paperclip, Plus, Send, Square, Trash2, X } from 'lucide-react';
 import clsx from 'clsx';
 
 import { apiFetch } from '../../lib/apiFetch';
@@ -457,19 +457,45 @@ export const Composer: React.FC<ComposerProps> = ({
             <Trash2 className="size-4" />
           </Button>
         )}
-        {/* 36px (size-9) icon button: pink-soft Stop while a turn runs, else a
+        {/* 36px (size-9) icon buttons: pink-soft Stop while a turn runs, else a
             flat mint Send — design-system variants, not a glowy brand CTA. */}
         {busy ? (
-          <Button
-            type="button"
-            variant="destructive-soft"
-            size="icon"
-            onClick={onStop}
-            aria-label={t('chat.compose.stop')}
-            className="size-9 shrink-0"
-          >
-            <Square className="size-4" />
-          </Button>
+          <>
+            {/* Sending while a turn runs is allowed — the backend enqueues it
+                (202) instead of refusing (Enter does this too). Surface a visible
+                affordance for it, but only when there's something to send: a cyan
+                "queue" button left of Stop. Paper-plane + a small clock badge
+                reads as "send, but later / into the queue". */}
+            {canSubmit && (
+              <Button
+                type="button"
+                variant="accent"
+                size="icon"
+                onClick={submit}
+                aria-label={t('chat.compose.queueSend')}
+                title={t('chat.compose.queueSend')}
+                className="size-9 shrink-0"
+              >
+                <span className="relative inline-flex">
+                  <Send className="size-4" />
+                  <Clock
+                    className="absolute -bottom-1 -right-1 size-2.5 rounded-full bg-surface-2"
+                    strokeWidth={2.5}
+                  />
+                </span>
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="destructive-soft"
+              size="icon"
+              onClick={onStop}
+              aria-label={t('chat.compose.stop')}
+              className="size-9 shrink-0"
+            >
+              <Square className="size-4" />
+            </Button>
+          </>
         ) : (
           <Button
             type="button"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1702,6 +1702,7 @@
       "placeholderBusy": "Type to queue while the agent works…",
       "hint": "Enter to send",
       "send": "Send",
+      "queueSend": "Send to queue",
       "sending": "Sending…",
       "stop": "Stop",
       "attach": "Attach files",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1701,6 +1701,7 @@
       "placeholderBusy": "Agent 处理中，输入将排队…",
       "hint": "Enter 发送",
       "send": "发送",
+      "queueSend": "排队发送",
       "sending": "发送中…",
       "stop": "停止",
       "attach": "添加附件",


### PR DESCRIPTION
## Summary

- capability: User chat bubbles render markdown; the send-while-busy queue gets a visible button in the composer.
- user-visible change:
  - The user's own messages now format markdown (lists / code / tables / **emphasis** / links), matching agent replies. Harness (scheduled-task / watch) preview rows stay verbatim.
  - While the agent is working **and** the input box has content, a cyan "queue" button (paper-plane + clock badge) appears to the left of Stop. Clicking it enqueues the message (shows in the queue strip above the composer). With an empty box, only Stop shows — unchanged.
- motivation: Direct user feedback. (1) Typed markdown should render in the user's own bubble. (2) The send-while-busy queue already worked end-to-end (backend returns 202 + `QueueStrip`; **Enter already enqueued**) but had no discoverable button.

## Scenario Coverage

- scenario IDs: n/a (presentational UI change)
- unit / contract coverage: none added — reuses the existing `Markdown` renderer and the existing send-while-busy queue path (no new logic/branches in data flow).
- scenario coverage: manual
- residual manual checks: queue button shows only when `busy && canSubmit`; click enqueues; empty-box-while-busy shows only Stop; user bubble renders markdown; harness preview stays raw; long code block / table in a user bubble scrolls instead of overflowing.

## Validation

- commands run (in `ui/`): `npx tsc -b`, `npm run validate:theme`, `npm run build`
- result: all green. Final appearance verified with a production-accurate render (real `accent` variant + badge classes).

## Risks / Follow-ups

- risk: low / presentational. Behavior change worth noting: user-typed text is now interpreted as markdown (e.g. a literal `# `/`* ` formats). It goes through the **same** untrusted-markdown renderer already used for agent replies — inline images only for our own same-origin media proxy, every other link is click-through — so no new fetch/XSS surface.
- follow-up: none.
