### PR TITLE
fix(workbench): show inherited default agent in chat picker

### DIFF
--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -401,6 +401,7 @@ class SessionsStore:
         workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
+        vibe_agent_backend: str | None = None,
     ) -> Optional[str]:
         self._ensure_service()
         bound_id = self._service.bind_agent_session_by_id(
@@ -409,6 +410,7 @@ class SessionsStore:
             workdir=workdir,
             vibe_agent_id=vibe_agent_id,
             vibe_agent_name=vibe_agent_name,
+            vibe_agent_backend=vibe_agent_backend,
         )
         if bound_id:
             self.load()

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -373,6 +373,15 @@ class MessageHandler(BaseHandler):
 
             message = self._append_attachment_errors(message, attachment_errors)
 
+            if vibe_agent:
+                spec = dict(context.platform_specific or {})
+                spec["resolved_vibe_agent"] = {
+                    "id": vibe_agent.id,
+                    "name": vibe_agent.name,
+                    "backend": vibe_agent.backend,
+                }
+                context.platform_specific = spec
+
             request = self._build_agent_request(
                 context=context,
                 message=message,

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -193,6 +193,9 @@ class BaseAgent(ABC):
         native_session_id: Any,
         *,
         working_path: Optional[str] = None,
+        vibe_agent_id: Optional[str] = None,
+        vibe_agent_name: Optional[str] = None,
+        vibe_agent_backend: Optional[str] = None,
     ) -> Optional[str]:
         """Bind the backend-native id to the RESERVED workbench session row, by id.
 
@@ -207,6 +210,12 @@ class BaseAgent(ABC):
         reserved_id = self._reserved_agent_session_id(context)
         if not reserved_id:
             return None
+        payload = getattr(context, "platform_specific", None) or {}
+        resolved = payload.get("resolved_vibe_agent")
+        if isinstance(resolved, dict):
+            vibe_agent_id = vibe_agent_id if vibe_agent_id is not None else resolved.get("id")
+            vibe_agent_name = vibe_agent_name if vibe_agent_name is not None else resolved.get("name")
+            vibe_agent_backend = vibe_agent_backend if vibe_agent_backend is not None else resolved.get("backend")
         sessions = getattr(self, "sessions", None)
         bind_by_id = getattr(sessions, "bind_agent_session_by_id", None)
         bound: Optional[str] = None
@@ -216,7 +225,14 @@ class BaseAgent(ABC):
                 # binds by a positional ``agent_session_id``, NOT a keyword, so a
                 # ``session_id=`` call would TypeError and silently skip recording
                 # the native id (Codex P2). Mirrors the OpenCode call.
-                bound = bind_by_id(reserved_id, native_session_id, workdir=working_path)
+                bound = bind_by_id(
+                    reserved_id,
+                    native_session_id,
+                    workdir=working_path,
+                    vibe_agent_id=vibe_agent_id,
+                    vibe_agent_name=vibe_agent_name,
+                    vibe_agent_backend=vibe_agent_backend,
+                )
             except Exception:
                 logger.debug("bind_agent_session_by_id failed; keeping reserved id", exc_info=True)
         # Pin ``agent_session_id`` to the reserved row even if the by-id bind
@@ -306,7 +322,12 @@ class BaseAgent(ABC):
         # avibe: bind to the reserved workbench row by id (mirrors OpenCode) so the
         # reply publishes under the open Chat session, not a new hidden row (P1).
         reserved = self._bind_reserved_workbench_session(
-            request.context, native_session_id, working_path=getattr(request, "working_path", None)
+            request.context,
+            native_session_id,
+            working_path=getattr(request, "working_path", None),
+            vibe_agent_id=getattr(request, "vibe_agent_id", None),
+            vibe_agent_name=getattr(request, "vibe_agent_name", None),
+            vibe_agent_backend=getattr(request, "vibe_agent_backend", None),
         )
         if reserved:
             return reserved

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -125,6 +125,7 @@ class OpenCodeSessionManager:
                     workdir=request.working_path,
                     vibe_agent_id=request.vibe_agent_id,
                     vibe_agent_name=request.vibe_agent_name,
+                    vibe_agent_backend=request.vibe_agent_backend,
                 )
                 if agent_session_id:
                     self._set_request_agent_session_id(request, agent_session_id)

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -129,6 +129,7 @@ class SessionsFacade:
         workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
+        vibe_agent_backend: str | None = None,
     ) -> Optional[str]:
         binder = getattr(self.sessions_store, "bind_agent_session_by_id", None)
         if not callable(binder):
@@ -139,6 +140,7 @@ class SessionsFacade:
             workdir=workdir,
             vibe_agent_id=vibe_agent_id,
             vibe_agent_name=vibe_agent_name,
+            vibe_agent_backend=vibe_agent_backend,
         )
 
     def clear_agent_session_mapping(

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -315,6 +315,7 @@ class SQLiteSessionsService:
         workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
+        vibe_agent_backend: str | None = None,
     ) -> str | None:
         """Bind a backend-native session id to an already-reserved Vibe session row."""
         now = _utc_now_iso()
@@ -330,6 +331,11 @@ class SQLiteSessionsService:
             values["agent_id"] = vibe_agent_id
         if vibe_agent_name is not None:
             values["agent_name"] = vibe_agent_name
+        if vibe_agent_backend is not None:
+            values["agent_backend"] = vibe_agent_backend or ""
+            values["agent_variant"] = vibe_agent_backend or "default"
+        elif vibe_agent_name is not None:
+            values["agent_variant"] = vibe_agent_name or "default"
         with self.engine.begin() as conn:
             # WRITE-ONCE: bind the native only if the row has none yet; never let a
             # recapture / fork / subagent overwrite an existing native (see

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -267,10 +267,10 @@ def update_session(
     session_id: str,
     *,
     title: Any = _UNSET,
-    agent_id: Optional[str] = None,
-    agent_name: Optional[str] = None,
-    agent_backend: Optional[str] = None,
-    agent_variant: Optional[str] = None,
+    agent_id: Any = _UNSET,
+    agent_name: Any = _UNSET,
+    agent_backend: Any = _UNSET,
+    agent_variant: Any = _UNSET,
     model: Any = _UNSET,
     reasoning_effort: Any = _UNSET,
 ) -> dict[str, Any]:
@@ -295,7 +295,7 @@ def update_session(
     # away from a concrete backend (Codex P2: otherwise the chat can't pick an
     # agent/model after its first reply).
     if (
-        agent_backend is not None
+        agent_backend is not _UNSET
         and existing.native_session_id
         and str(existing.agent_backend or "")
         and str(agent_backend) != str(existing.agent_backend or "")
@@ -314,14 +314,14 @@ def update_session(
         metadata["title_source"] = "user"
         metadata["title_user_modified_at"] = values["updated_at"]
         values["metadata_json"] = _dumps_metadata(metadata)
-    if agent_id is not None:
+    if agent_id is not _UNSET:
         values["agent_id"] = agent_id or None
-    if agent_name is not None:
+    if agent_name is not _UNSET:
         values["agent_name"] = agent_name or None
-    if agent_backend is not None:
-        values["agent_backend"] = agent_backend
-    if agent_variant is not None:
-        values["agent_variant"] = str(agent_variant)
+    if agent_backend is not _UNSET:
+        values["agent_backend"] = agent_backend or ""
+    if agent_variant is not _UNSET:
+        values["agent_variant"] = str(agent_variant or "default")
     # ``model`` / ``reasoning_effort`` use a sentinel default so a PRESENT
     # ``None`` clears the column (switching to an agent whose default model /
     # effort is empty must drop the previous agent's override), while an omitted

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -954,16 +954,41 @@ class BindReservedWorkbenchSessionTests(unittest.TestCase):
         # SessionsFacade.bind_agent_session_by_id takes (agent_session_id,
         # native_session_id) POSITIONALLY — a session_id= keyword call would
         # TypeError and silently skip recording the native id (Codex P2).
-        def bind_by_id(agent_session_id, native_session_id, workdir=None):
-            calls.update(session_id=agent_session_id, native=native_session_id, workdir=workdir)
+        def bind_by_id(
+            agent_session_id,
+            native_session_id,
+            workdir=None,
+            vibe_agent_id=None,
+            vibe_agent_name=None,
+            vibe_agent_backend=None,
+        ):
+            calls.update(
+                session_id=agent_session_id,
+                native=native_session_id,
+                workdir=workdir,
+                vibe_agent_id=vibe_agent_id,
+                vibe_agent_name=vibe_agent_name,
+                vibe_agent_backend=vibe_agent_backend,
+            )
             return agent_session_id  # the reserved row exists → rowcount 1
 
         agent = _FakeBaseAgent(SimpleNamespace(bind_agent_session_by_id=bind_by_id))
         ctx = self._ctx("ses_workbench")
+        ctx.platform_specific["resolved_vibe_agent"] = {"id": "agent-codex", "name": "codex", "backend": "codex"}
         ret = agent._bind_reserved_workbench_session(ctx, "claude-native-123", working_path="/tmp/x")
         self.assertEqual(ret, "ses_workbench")
         self.assertEqual(ctx.platform_specific["agent_session_id"], "ses_workbench")
-        self.assertEqual(calls, {"session_id": "ses_workbench", "native": "claude-native-123", "workdir": "/tmp/x"})
+        self.assertEqual(
+            calls,
+            {
+                "session_id": "ses_workbench",
+                "native": "claude-native-123",
+                "workdir": "/tmp/x",
+                "vibe_agent_id": "agent-codex",
+                "vibe_agent_name": "codex",
+                "vibe_agent_backend": "codex",
+            },
+        )
 
     def test_im_turn_without_target_falls_through(self):
         agent = _FakeBaseAgent(SimpleNamespace(bind_agent_session_by_id=lambda *a, **k: None))

--- a/tests/test_core_services_sessions.py
+++ b/tests/test_core_services_sessions.py
@@ -190,6 +190,42 @@ def test_update_session_present_null_clears_model_and_effort(isolated_state):
     assert kept["title"] == "renamed"
 
 
+def test_update_session_present_null_clears_agent_route(isolated_state):
+    """The Chat header's "Default" item sends present nulls; update_session must
+    clear the route fields instead of treating null as "field omitted"."""
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_avibe_scope(conn)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="codex",
+            agent_name="codex",
+            agent_id="agent-1",
+            agent_variant="codex",
+            model="gpt-5.5",
+            reasoning_effort="high",
+        )
+        cleared = sessions_service.update_session(
+            conn,
+            session["id"],
+            agent_id=None,
+            agent_name=None,
+            agent_backend=None,
+            agent_variant=None,
+            model=None,
+            reasoning_effort=None,
+        )
+
+    assert cleared["agent_id"] is None
+    assert cleared["agent_name"] is None
+    assert cleared["agent_backend"] == ""
+    assert cleared["agent_variant"] == "default"
+    assert cleared["model"] is None
+    assert cleared["reasoning_effort"] is None
+
+
 def test_update_session_marks_user_title_ownership(isolated_state):
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -375,3 +411,32 @@ def test_update_session_blank_backend_takes_first_concrete_pin(isolated_state):
         # Now pinned: a different backend is rejected.
         with pytest.raises(sessions_service.SessionBackendLockedError):
             sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude")
+
+
+def test_update_session_bound_session_cannot_clear_backend_to_default(isolated_state):
+    """Once a native thread exists, clearing back to inherited default could let a
+    future global default switch route the old native through another backend."""
+
+    from sqlalchemy import update as sa_update
+
+    from storage.models import agent_sessions
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_avibe_scope(conn)
+        sid = sessions_service.create_session(
+            conn, scope_id=scope_id, agent_backend="codex", agent_name="codex"
+        )["id"]
+        conn.execute(sa_update(agent_sessions).where(agent_sessions.c.id == sid).values(native_session_id="nat-codex"))
+
+        with pytest.raises(sessions_service.SessionBackendLockedError):
+            sessions_service.update_session(
+                conn,
+                sid,
+                agent_backend=None,
+                agent_name=None,
+                agent_id=None,
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+            )

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -312,6 +312,10 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.vibe_agent_model, "gpt-5.4")
         self.assertEqual(request.vibe_agent_reasoning_effort, "high")
         self.assertEqual(request.vibe_agent_system_prompt, "Default prompt")
+        self.assertEqual(
+            request.context.platform_specific["resolved_vibe_agent"],
+            {"id": "agent-default", "name": "default", "backend": "codex"},
+        )
 
     async def test_scope_model_and_reasoning_override_vibe_agent_defaults(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -95,6 +95,7 @@ def test_opencode_reserved_agent_session_id_is_not_replaced() -> None:
         workdir="/repo",
         vibe_agent_id=None,
         vibe_agent_name=None,
+        vibe_agent_backend=None,
     )
 
 
@@ -133,6 +134,7 @@ def test_opencode_resumes_reserved_native_session_id() -> None:
         workdir="/repo",
         vibe_agent_id=None,
         vibe_agent_name=None,
+        vibe_agent_backend=None,
     )
 
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -248,6 +248,9 @@ def test_sqlite_sessions_service_binds_reserved_agent_session_by_id(tmp_path: Pa
             session_id=reserved_id,
             native_session_id="oc-session-1",
             workdir="/repo",
+            vibe_agent_id="agent-codex",
+            vibe_agent_name="codex",
+            vibe_agent_backend="codex",
         )
 
         assert bound_id == reserved_id
@@ -255,6 +258,10 @@ def test_sqlite_sessions_service_binds_reserved_agent_session_by_id(tmp_path: Pa
         assert row is not None
         assert row["native_session_id"] == "oc-session-1"
         assert row["workdir"] == "/repo"
+        assert row["agent_id"] == "agent-codex"
+        assert row["agent_name"] == "codex"
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "codex"
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -393,6 +393,35 @@ def test_sessions_store_lifecycle_updates_in_memory_state(tmp_path: Path) -> Non
         store.close()
 
 
+def test_sessions_store_bind_by_id_accepts_vibe_agent_backend(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    try:
+        reserved_id = store.ensure_agent_session_id("slack::C123", "opencode", "slack_171717.123")
+        assert reserved_id is not None
+
+        bound_id = store.bind_agent_session_by_id(
+            reserved_id,
+            "oc-session-1",
+            workdir="/repo",
+            vibe_agent_id="agent-codex",
+            vibe_agent_name="codex",
+            vibe_agent_backend="codex",
+        )
+
+        assert bound_id == reserved_id
+        with create_sqlite_engine(db_path=tmp_path / "vibe.sqlite").connect() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == reserved_id)).mappings().one()
+        assert row["native_session_id"] == "oc-session-1"
+        assert row["workdir"] == "/repo"
+        assert row["agent_id"] == "agent-codex"
+        assert row["agent_name"] == "codex"
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "codex"
+    finally:
+        store.close()
+
+
 def test_sessions_store_lifecycle_survives_followup_save(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     store = SessionsStore(sessions_path)

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -17,6 +17,7 @@ export interface AgentRouteValue {
   agent_backend?: string | null;
   agent_name?: string | null;
   agent_id?: string | null;
+  agent_variant?: string | null;
   model?: string | null;
   reasoning_effort?: string | null;
 }
@@ -33,10 +34,16 @@ interface AgentRoutePickerProps {
   onChange: (patch: AgentRoutePatch) => void | Promise<void>;
   /** Trigger label when no agent is selected — the create flow shows "默认 · …". */
   defaultLabel?: string;
+  /** Concrete route to display while `value` is inheriting a project/global default. */
+  defaultRoute?: AgentRouteValue;
+  /** True when the displayed route is inherited, not persisted on this session/project yet. */
+  isDefaultRoute?: boolean;
   disabled?: boolean;
   align?: 'start' | 'end';
   /** Override the trigger width (chat caps at 62%; the create surfaces go full width). */
   triggerClassName?: string;
+  /** On mobile chat headers, keep the closed trigger to the agent label only. */
+  compactMobile?: boolean;
   /** Make the popover a modal layer — required when nested in a modal Dialog (the
    *  new-session sheet) so its content isn't aria-hidden/inert by the dialog. */
   modal?: boolean;
@@ -57,9 +64,12 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   agents,
   onChange,
   defaultLabel,
+  defaultRoute,
+  isDefaultRoute,
   disabled,
   align = 'end',
   triggerClassName,
+  compactMobile,
   modal,
   onNavigateAway,
 }) => {
@@ -75,6 +85,10 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   const [loadingModels, setLoadingModels] = useState(false);
   const [patching, setPatching] = useState(false);
 
+  const hasExplicitRoute = Boolean(value.agent_name || value.agent_backend);
+  const routeIsDefault = isDefaultRoute ?? !hasExplicitRoute;
+  const displayValue = routeIsDefault ? (defaultRoute ?? value) : value;
+
   // Serialize patches: an agent pick carries its default model/effort, so if it
   // resolves AFTER a later model/effort pick the later choice would be rolled
   // back. One patch at a time, items disabled while it's in flight.
@@ -83,18 +97,39 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
       if (patching) return;
       setPatching(true);
       try {
-        await onChange(changes);
+        const patchPinsDisplayedDefault =
+          routeIsDefault &&
+          Boolean(displayValue.agent_name || displayValue.agent_backend) &&
+          !('agent_name' in changes) &&
+          !('agent_backend' in changes) &&
+          !('agent_id' in changes) &&
+          !('agent_variant' in changes);
+        await onChange(
+          patchPinsDisplayedDefault
+            ? {
+                agent_name: displayValue.agent_name ?? null,
+                agent_id: displayValue.agent_id ?? null,
+                agent_backend: displayValue.agent_backend ?? null,
+                agent_variant: displayValue.agent_variant ?? displayValue.agent_backend ?? null,
+                model: displayValue.model ?? null,
+                reasoning_effort: displayValue.reasoning_effort ?? null,
+                ...changes,
+              }
+            : changes,
+        );
       } finally {
         setPatching(false);
       }
     },
-    [patching, onChange],
+    [displayValue, patching, onChange, routeIsDefault],
   );
 
-  const backend = value.agent_backend || '';
-  const currentAgent = value.agent_name;
-  const currentModel = value.model;
-  const currentEffort = value.reasoning_effort;
+  const backend = displayValue.agent_backend || '';
+  const currentAgent = displayValue.agent_name;
+  const currentModel = displayValue.model;
+  const currentEffort = displayValue.reasoning_effort;
+  const triggerLabel = (routeIsDefault && defaultLabel) || currentAgent || defaultLabel || t('chat.pickAgent');
+  const compactTriggerLabel = currentAgent || defaultLabel || t('chat.pickAgent');
 
   const grouped = useMemo(() => {
     const groups: Record<string, VibeAgentBrief[]> = {};
@@ -147,24 +182,38 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
           )}
         >
           {backend && (
-            <span className="inline-flex shrink-0 items-center gap-1 rounded border border-cyan/30 bg-cyan/[0.08] px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase text-cyan">
+            <span
+              className={clsx(
+                'shrink-0 items-center gap-1 rounded border border-cyan/30 bg-cyan/[0.08] px-1.5 py-0.5 font-mono text-[9px] font-bold uppercase text-cyan',
+                compactMobile ? 'hidden md:inline-flex' : 'inline-flex',
+              )}
+            >
               <Bot className="size-3" />
               {backend}
             </span>
           )}
-          <span className="truncate font-semibold text-foreground">{currentAgent || defaultLabel || t('chat.pickAgent')}</span>
+          {compactMobile ? (
+            <>
+              <span className="truncate font-semibold text-foreground md:hidden">{compactTriggerLabel}</span>
+              <span className="hidden truncate font-semibold text-foreground md:inline">{triggerLabel}</span>
+            </>
+          ) : (
+            <span className="truncate font-semibold text-foreground">{triggerLabel}</span>
+          )}
           {currentModel && (
             <>
-              <span className="text-muted">·</span>
-              <span className="truncate font-mono text-[10px] text-muted">{currentModel}</span>
+              <span className={clsx('text-muted', compactMobile && 'hidden md:inline')}>·</span>
+              <span className={clsx('truncate font-mono text-[10px] text-muted', compactMobile && 'hidden md:inline')}>
+                {currentModel}
+              </span>
             </>
           )}
           {currentEffort && (
             <>
-              <span className="text-muted">·</span>
+              <span className={clsx('text-muted', compactMobile && 'hidden md:inline')}>·</span>
               {/* Localize via the same key the column uses so the closed trigger
                   doesn't show raw low/max in zh builds; unknown falls back to raw. */}
-              <span className="shrink-0 text-[10px] capitalize text-muted">
+              <span className={clsx('shrink-0 text-[10px] capitalize text-muted', compactMobile && 'hidden md:inline')}>
                 {t(`chat.picker.effortOptions.${currentEffort}`, { defaultValue: currentEffort })}
               </span>
             </>
@@ -178,12 +227,11 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
         <div className="grid grid-cols-1 divide-y divide-border sm:grid-cols-3 sm:divide-x sm:divide-y-0">
           {/* Column 1 — Agent */}
           <RouteColumn title={t('chat.picker.agent')}>
-            {/* Default option (create surfaces only — they pass defaultLabel): clears
-                the draft route back to {} so the user can return to the server
-                default after picking an agent, without a page refresh. */}
+            {/* Default option: clears the route back to inherited defaults after
+                picking an explicit agent, without a page refresh. */}
             {defaultLabel && (
               <RouteItem
-                active={!currentAgent}
+                active={routeIsDefault}
                 disabled={patching}
                 onClick={() =>
                   void applyPatch({
@@ -209,7 +257,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
                 {list.map((agent) => (
                   <RouteItem
                     key={agent.id}
-                    active={agent.name === currentAgent}
+                    active={!routeIsDefault && agent.name === currentAgent}
                     disabled={patching}
                     onClick={() =>
                       void applyPatch({

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -104,6 +104,7 @@ export const ChatPage: React.FC = () => {
 
   const [session, setSession] = useState<WorkbenchSession | null>(null);
   const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
+  const [defaultAgentName, setDefaultAgentName] = useState<string | null>(null);
   const [messages, setMessages] = useState<WorkbenchMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -305,6 +306,7 @@ export const ChatPage: React.FC = () => {
       if (sessionId !== sessionIdRef.current) return;
       setSession(fetched);
       setAgents(agentList.agents);
+      setDefaultAgentName(agentList.default_agent_name);
       // Merge (not replace) so a row that arrived over the stream during the
       // load isn't clobbered; the session-change reset keeps prior sessions out.
       setMessages((prev) => mergeById(msgs.messages, prev));
@@ -757,7 +759,13 @@ export const ChatPage: React.FC = () => {
         ref={chatSurfaceRef}
         className="fixed inset-0 z-40 flex flex-col bg-background pt-[env(safe-area-inset-top)] md:static md:inset-auto md:z-auto md:-mx-10 md:-my-8 md:h-[var(--app-vvh)] md:bg-transparent md:pt-0"
       >
-        <ChatHeaderBar session={session} agents={agents} onPatch={patch} onBack={goBack} />
+        <ChatHeaderBar
+          session={session}
+          agents={agents}
+          defaultAgentName={defaultAgentName}
+          onPatch={patch}
+          onBack={goBack}
+        />
 
       {error && (
         <div className="mx-auto mt-3 w-full max-w-[1080px] rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
@@ -860,12 +868,25 @@ const Compose: React.FC<ComposeProps> = ({ onSend, onStop, busy, sessionId, init
 interface ChatHeaderBarProps {
   session: WorkbenchSession;
   agents: VibeAgentBrief[];
+  defaultAgentName: string | null;
   onPatch: (changes: Partial<WorkbenchSession>) => Promise<void>;
   onBack: () => void;
 }
 
-const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, onPatch, onBack }) => {
+const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack }) => {
   const { t } = useTranslation();
+  const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
+  const defaultRoute = defaultAgent
+    ? {
+        agent_name: defaultAgent.name,
+        agent_id: defaultAgent.id,
+        agent_backend: defaultAgent.backend,
+        agent_variant: defaultAgent.backend,
+        model: defaultAgent.model,
+        reasoning_effort: defaultAgent.reasoning_effort,
+      }
+    : undefined;
+  const inheritsDefault = !session.agent_name && !session.agent_backend;
   return (
     // A single compact row (design.pen IDQ5n): back button + click-to-edit
     // title on the left, the agent/model/effort picker on the right. The bar
@@ -886,7 +907,15 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, onPatch,
           <ArrowLeft className="size-3.5" />
         </Button>
         <TitleField key={session.id} title={session.title} onCommit={(title) => onPatch({ title })} />
-        <AgentRoutePicker value={session} agents={agents} onChange={onPatch} />
+        <AgentRoutePicker
+          value={session}
+          agents={agents}
+          onChange={onPatch}
+          defaultLabel={defaultAgent ? t('newSession.defaultAgentNamed', { name: defaultAgent.name }) : t('newSession.defaultAgent')}
+          defaultRoute={defaultRoute}
+          isDefaultRoute={inheritsDefault}
+          compactMobile
+        />
         {/* Chat hides the brand header, so mount the install nudge here too —
             IM-launched users often land straight in a chat. Renders only on iOS
             Safari + not-installed; null otherwise. */}

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -876,6 +876,7 @@ interface ChatHeaderBarProps {
 const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack }) => {
   const { t } = useTranslation();
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
+  const canClearToDefault = !session.native_session_id;
   const defaultRoute = defaultAgent
     ? {
         agent_name: defaultAgent.name,
@@ -911,7 +912,13 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
           value={session}
           agents={agents}
           onChange={onPatch}
-          defaultLabel={defaultAgent ? t('newSession.defaultAgentNamed', { name: defaultAgent.name }) : t('newSession.defaultAgent')}
+          defaultLabel={
+            canClearToDefault
+              ? defaultAgent
+                ? t('newSession.defaultAgentNamed', { name: defaultAgent.name })
+                : t('newSession.defaultAgent')
+              : undefined
+          }
           defaultRoute={defaultRoute}
           isDefaultRoute={inheritsDefault}
           compactMobile


### PR DESCRIPTION
## What
- Show the resolved global default agent in chat header pickers when a project/session inherits defaults.
- Keep inherited routes editable: changing model/effort pins the displayed default route before applying the override.
- Pin the resolved Vibe Agent/backend onto the reserved session row when the first native session is bound, preventing later global-default changes from rerouting an existing chat.
- On mobile chat headers, show only the agent label in the closed picker; desktop keeps backend/model/effort details.

## Why
Project chats created with default agent set to "follow global" intentionally store empty route fields. The message dispatch path resolves the default at send time, but the chat header only rendered the stored session fields, so it showed an empty "Pick Agent" state instead of the inherited global default.

## Test
- `npm run build`
- `uv run pytest -q tests/test_core_services_sessions.py tests/test_workbench_session_defaults.py tests/test_ui_session_stream.py::test_create_session_without_backend_defers_to_default_agent tests/test_sqlite_sessions_store.py::test_sqlite_sessions_service_binds_reserved_agent_session_by_id tests/test_claude_agent_sessions.py::BindReservedWorkbenchSessionTests tests/test_opencode_session_manager.py::test_opencode_reserved_agent_session_id_is_not_replaced tests/test_opencode_session_manager.py::test_opencode_resumes_reserved_native_session_id tests/test_message_handler_typing.py::MessageHandlerTypingTests::test_regular_message_passes_default_vibe_agent_metadata`
