### PR TITLE
fix(workbench): resolve agent run targets from sessions

### DIFF
--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -342,6 +342,7 @@ class SessionsStore:
         agent_name: str,
         thread_id: str,
         *,
+        workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
     ) -> Optional[str]:
@@ -350,6 +351,7 @@ class SessionsStore:
             scope_key=user_id,
             agent_name=agent_name,
             session_anchor=thread_id,
+            workdir=workdir,
             vibe_agent_id=vibe_agent_id,
             vibe_agent_name=vibe_agent_name,
         )
@@ -373,6 +375,7 @@ class SessionsStore:
         thread_id: str,
         session_id: Any,
         *,
+        workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
     ) -> Optional[str]:
@@ -382,6 +385,7 @@ class SessionsStore:
             agent_name=agent_name,
             session_anchor=thread_id,
             native_session_id=session_id,
+            workdir=workdir,
             vibe_agent_id=vibe_agent_id,
             vibe_agent_name=vibe_agent_name,
         )

--- a/core/controller.py
+++ b/core/controller.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import os
 import logging
 import threading
 from typing import Optional, Dict, Any
@@ -34,6 +33,27 @@ from core.vibe_agents import VibeAgent, VibeAgentStore
 from vibe.i18n import get_supported_languages, t as i18n_t
 
 logger = logging.getLogger(__name__)
+
+
+def _optional_target_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _target_agent_variant(value: Any, backend: Any = None, agent_name: Any = None) -> Optional[str]:
+    variant = _optional_target_str(value)
+    if variant is None:
+        return None
+    sentinel_values = {"default", "claude", "codex", "opencode"}
+    backend_text = _optional_target_str(backend)
+    if backend_text:
+        sentinel_values.add(backend_text)
+    agent_name_text = _optional_target_str(agent_name)
+    if agent_name_text:
+        sentinel_values.add(agent_name_text)
+    return None if variant in sentinel_values else variant
 
 
 class Controller:
@@ -520,36 +540,29 @@ class Controller:
     # Utility methods used by handlers
 
     def get_cwd(self, context: MessageContext) -> str:
-        """Get working directory based on context (channel/chat)
-        This is the SINGLE source of truth for CWD
-        """
-        # Get the settings key based on context
-        settings_key = self._get_settings_key(context)
+        """Get the current cwd without creating an Agent Session row."""
+        payload = context.platform_specific or {}
+        source = str(payload.get("turn_source") or "human")
+        return self.resolve_agent_run_target(context, source=source, create_session=False).workdir
 
-        # Get custom CWD from settings
-        settings_manager = self.get_settings_manager_for_context(context)
-        custom_cwd = settings_manager.get_custom_cwd(settings_key)
+    def resolve_agent_run_target(
+        self,
+        context: MessageContext,
+        *,
+        base_session_id: Optional[str] = None,
+        source: str = "human",
+        create_session: bool = True,
+    ):
+        """Resolve the shared execution target for one agent turn."""
+        from core.services.agent_run_target import resolve_agent_run_target
 
-        # Use custom CWD if available, otherwise use default from config
-        if custom_cwd:
-            abs_path = os.path.abspath(os.path.expanduser(custom_cwd))
-            if os.path.exists(abs_path):
-                return abs_path
-            # Try to create it
-            try:
-                os.makedirs(abs_path, exist_ok=True)
-                logger.info(f"Created custom CWD: {abs_path}")
-                return abs_path
-            except OSError as e:
-                logger.warning(f"Failed to create custom CWD '{abs_path}': {e}, using default")
-
-        # Fall back to default from config.json
-        default_cwd = self.config.claude.cwd
-        if default_cwd:
-            return os.path.abspath(os.path.expanduser(default_cwd))
-
-        # Last resort: current directory
-        return os.getcwd()
+        return resolve_agent_run_target(
+            context,
+            controller=self,
+            base_session_id=base_session_id,
+            source=source,
+            create_session=create_session,
+        )
 
     def _get_settings_key(self, context: MessageContext) -> str:
         """Get settings key based on context.
@@ -708,6 +721,20 @@ class Controller:
         4. AgentRouter platform default (configured in code)
         5. AgentService.default_agent ("claude")
         """
+        target = self._agent_run_target_payload(context)
+        target_agent_name = target.get("agent_name") if target else None
+        target_backend = target.get("agent_backend") if target else None
+        if target_agent_name:
+            vibe_agent = self.resolve_vibe_agent_for_context(
+                context,
+                override_agent_name=str(target_agent_name),
+                required=False,
+            )
+            if vibe_agent and vibe_agent.backend in self.agent_service.agents:
+                return vibe_agent.backend
+        if target_backend and str(target_backend) in self.agent_service.agents:
+            return str(target_backend)
+
         settings_key = self._get_settings_key(context)
         settings_manager = self.get_settings_manager_for_context(context)
         routing = settings_manager.get_channel_routing(settings_key)
@@ -738,14 +765,23 @@ class Controller:
         override_agent_name: Optional[str] = None,
         required: bool = True,
     ) -> Optional[VibeAgent]:
-        settings_key = self._get_settings_key(context)
-        settings_manager = self.get_settings_manager_for_context(context)
-        routing = settings_manager.get_channel_routing(settings_key)
-        agent_name = override_agent_name or (routing.agent_name if routing else None)
+        target = self._agent_run_target_payload(context)
+        platform = context.platform or (context.platform_specific or {}).get("platform") or self.primary_platform
+        if platform == "avibe" and target:
+            routing = None
+        else:
+            settings_key = self._get_settings_key(context)
+            settings_manager = self.get_settings_manager_for_context(context)
+            routing = settings_manager.get_channel_routing(settings_key)
+        agent_name = override_agent_name or (target.get("agent_name") if target else None) or (
+            routing.agent_name if routing else None
+        )
         try:
             if agent_name:
                 return self.vibe_agent_store.require_enabled(agent_name)
-            legacy_backend = routing.agent_backend if routing else None
+            legacy_backend = (target.get("agent_backend") if target else None) or (
+                routing.agent_backend if routing else None
+            )
             if legacy_backend:
                 agent = self.vibe_agent_store.get_builtin_default_agent_for_backend(legacy_backend)
                 if agent is not None:
@@ -762,6 +798,12 @@ class Controller:
             logger.warning("Scope references Vibe Agent '%s' but it cannot be resolved: %s", agent_name or "default", exc)
             return None
 
+    @staticmethod
+    def _agent_run_target_payload(context: MessageContext) -> dict[str, Any]:
+        payload = context.platform_specific or {}
+        target = payload.get("agent_run_target")
+        return target if isinstance(target, dict) else {}
+
     def get_opencode_overrides(self, context: MessageContext) -> tuple[Optional[str], Optional[str], Optional[str]]:
         """Get OpenCode agent, model, and reasoning effort overrides for this channel.
 
@@ -769,6 +811,18 @@ class Controller:
             Tuple of (opencode_agent, opencode_model, opencode_reasoning_effort)
             or (None, None, None) if no overrides.
         """
+        target = self._agent_run_target_payload(context)
+        platform = context.platform or (context.platform_specific or {}).get("platform") or self.primary_platform
+        if platform == "avibe" and target:
+            return (
+                _target_agent_variant(
+                    target.get("agent_variant"),
+                    target.get("agent_backend"),
+                    target.get("agent_name"),
+                ),
+                _optional_target_str(target.get("model")),
+                _optional_target_str(target.get("reasoning_effort")),
+            )
         settings_key = self._get_settings_key(context)
         settings_manager = self.get_settings_manager_for_context(context)
         routing = settings_manager.get_channel_routing(settings_key)
@@ -784,6 +838,18 @@ class Controller:
 
     def get_codex_overrides(self, context: MessageContext) -> tuple[Optional[str], Optional[str], Optional[str]]:
         """Get Codex agent, model, and reasoning effort overrides for this channel."""
+        target = self._agent_run_target_payload(context)
+        platform = context.platform or (context.platform_specific or {}).get("platform") or self.primary_platform
+        if platform == "avibe" and target:
+            return (
+                _target_agent_variant(
+                    target.get("agent_variant"),
+                    target.get("agent_backend"),
+                    target.get("agent_name"),
+                ),
+                _optional_target_str(target.get("model")),
+                _optional_target_str(target.get("reasoning_effort")),
+            )
         settings_key = self._get_settings_key(context)
         settings_manager = self.get_settings_manager_for_context(context)
         routing = settings_manager.get_channel_routing(settings_key)

--- a/core/handlers/command_handlers.py
+++ b/core/handlers/command_handlers.py
@@ -937,6 +937,13 @@ class CommandHandlers(BaseHandler):
             im_client = self._get_im_client(context)
             session_handler = self.controller.session_handler
             base_session_id, working_path, composite_key = session_handler.get_session_info(context)
+            payload = context.platform_specific or {}
+            backend_base_session_id = str(payload.get("backend_base_session_id") or "").strip()
+            backend_composite_session_id = str(payload.get("backend_composite_session_id") or "").strip()
+            if backend_base_session_id:
+                base_session_id = backend_base_session_id
+            if backend_composite_session_id:
+                composite_key = backend_composite_session_id
             session_key = self._get_session_key(context)
             # Stop the backend the turn actually ran on. The web Chat cancel path
             # hands in the turn's captured context, which carries the session's
@@ -947,7 +954,7 @@ class CommandHandlers(BaseHandler):
             # real turn keeps running. IM ``/stop`` carries no
             # ``agent_session_target`` and falls back to the generic resolver, so
             # its behavior is unchanged.
-            session_target = (context.platform_specific or {}).get("agent_session_target")
+            session_target = payload.get("agent_session_target")
             session_agent_backend = (
                 str(session_target["agent_backend"])
                 if isinstance(session_target, dict) and session_target.get("agent_backend")

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -23,6 +23,20 @@ logger = logging.getLogger(__name__)
 SUBAGENT_REACTION_EMOJI = "🤖"
 
 
+def _target_agent_variant(value: Any, backend: Optional[str], agent_name: Optional[str] = None) -> Optional[str]:
+    if value is None:
+        return None
+    variant = str(value).strip()
+    if not variant:
+        return None
+    sentinel_values = {"default", "claude", "codex", "opencode"}
+    if backend:
+        sentinel_values.add(str(backend).strip())
+    if agent_name:
+        sentinel_values.add(str(agent_name).strip())
+    return None if variant in sentinel_values else variant
+
+
 class MessageHandler(BaseHandler):
     """Handles message routing and Claude communication"""
 
@@ -175,16 +189,27 @@ class MessageHandler(BaseHandler):
             self.controller.update_thread_message_id(context)
 
             platform_payload = context.platform_specific or {}
-            routing = self._get_settings_manager(context).get_channel_routing(settings_key)
+            resolved_target = platform_payload.get("agent_run_target")
+            resolved_target = resolved_target if isinstance(resolved_target, dict) else {}
+            platform_name = context.platform or platform_payload.get("platform")
+            routing = (
+                None
+                if platform_name == "avibe" and resolved_target
+                else self._get_settings_manager(context).get_channel_routing(settings_key)
+            )
             requested_vibe_agent = platform_payload.get("vibe_agent_name")
             session_target = platform_payload.get("agent_session_target")
             if not requested_vibe_agent and isinstance(session_target, dict):
                 requested_vibe_agent = session_target.get("agent_name")
+            if not requested_vibe_agent:
+                requested_vibe_agent = resolved_target.get("agent_name")
             session_agent_backend = (
                 str(session_target["agent_backend"])
                 if isinstance(session_target, dict) and session_target.get("agent_backend")
                 else None
             )
+            if not session_agent_backend and resolved_target.get("agent_backend"):
+                session_agent_backend = str(resolved_target["agent_backend"])
             # Pin an EXISTING thread to its OWN backend. avibe carries the session
             # row in ``agent_session_target``; IM/CLI turns don't, so look up the
             # thread's (scope, anchor) row and adopt its agent/backend. A thread
@@ -232,6 +257,12 @@ class MessageHandler(BaseHandler):
                     routing_agent = getattr(routing, "claude_agent", None)
                 elif agent_name == "codex":
                     routing_agent = getattr(routing, "codex_agent", None)
+            if not routing_agent and agent_name in {"opencode", "claude", "codex"}:
+                routing_agent = _target_agent_variant(
+                    resolved_target.get("agent_variant"),
+                    agent_name,
+                    resolved_target.get("agent_name"),
+                )
 
             from config.v2_settings import routing_model_for_backend, routing_reasoning_effort_for_backend
 
@@ -248,10 +279,10 @@ class MessageHandler(BaseHandler):
             # actually routed to the backend.
             session_target_model = (
                 session_target.get("model") if isinstance(session_target, dict) else None
-            )
+            ) or resolved_target.get("model")
             session_target_reasoning = (
                 session_target.get("reasoning_effort") if isinstance(session_target, dict) else None
-            )
+            ) or resolved_target.get("reasoning_effort")
 
             matched_prefix = None
             subagent_message = None
@@ -329,6 +360,7 @@ class MessageHandler(BaseHandler):
                 # Update session IDs for routing-based agent to match SessionHandler
                 base_session_id = f"{base_session_id}:{routing_agent}"
                 composite_key = f"{base_session_id}:{working_path}"
+                subagent_name = routing_agent
                 # Flag the routing-default subagent so the backends' reserved-native
                 # resume shortcut treats it like an explicit subagent: this namespaced
                 # base has its OWN thread, so resuming the MAIN session's reserved
@@ -336,6 +368,12 @@ class MessageHandler(BaseHandler):
                 # subagent on the first turn after the subagent is enabled (Codex P2).
                 spec = dict(context.platform_specific or {})
                 spec["routing_subagent"] = routing_agent
+                context.platform_specific = spec
+
+            if agent_name in {"claude", "codex"} and subagent_name:
+                spec = dict(context.platform_specific or {})
+                spec["backend_base_session_id"] = base_session_id
+                spec["backend_composite_session_id"] = composite_key
                 context.platform_specific = spec
 
             if is_human:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -338,7 +338,12 @@ class SessionHandler(BaseHandler):
     def get_session_info(self, context: MessageContext, source: str = "human") -> Tuple[str, str, str]:
         """Get session info: base_session_id, working_path, and composite_key"""
         base_session_id = self.get_base_session_id(context, source=source)
-        working_path = self.get_working_path(context)  # Pass context to get user's custom_cwd
+        resolve_target = getattr(self.controller, "resolve_agent_run_target", None)
+        if callable(resolve_target):
+            target = resolve_target(context, base_session_id=base_session_id, source=source)
+            working_path = target.workdir
+        else:
+            working_path = self.get_working_path(context)
         # Create composite key for internal storage
         composite_key = f"{base_session_id}:{working_path}"
         return base_session_id, working_path, composite_key
@@ -1110,13 +1115,21 @@ class SessionHandler(BaseHandler):
                 self._get_formatter(context).format_error(self._t("error.sessionGeneric", error=error_msg)),
             )
 
-    def capture_session_id(self, base_session_id: str, claude_session_id: str, session_key: str):
+    def capture_session_id(
+        self,
+        base_session_id: str,
+        claude_session_id: str,
+        session_key: str,
+        *,
+        working_path: Optional[str] = None,
+    ):
         """Capture and store Claude session ID mapping"""
         agent_session_id = self.bind_agent_session_id(
             session_key=session_key,
             agent_name="claude",
             session_anchor=base_session_id,
             native_session_id=claude_session_id,
+            working_path=working_path,
         )
         logger.info(f"Captured Claude session_id: {claude_session_id} for {base_session_id}")
         return agent_session_id
@@ -1161,10 +1174,17 @@ class SessionHandler(BaseHandler):
         agent_name: str,
         session_anchor: str,
         native_session_id: str,
+        working_path: Optional[str] = None,
     ) -> Optional[str]:
         binder = getattr(self.sessions, "bind_agent_session", None)
         if callable(binder):
-            return binder(session_key, agent_name, session_anchor, native_session_id)
+            return binder(
+                session_key,
+                agent_name,
+                session_anchor,
+                native_session_id,
+                workdir=working_path,
+            )
         self.sessions.set_agent_session_mapping(session_key, agent_name, session_anchor, native_session_id)
         getter = getattr(self.sessions, "get_agent_session_row_id", None)
         return getter(session_key, session_anchor, agent_name) if callable(getter) else None

--- a/core/services/agent_run_target.py
+++ b/core/services/agent_run_target.py
@@ -1,0 +1,620 @@
+"""Resolve the concrete execution target for an agent turn.
+
+This module is the shared boundary between product surfaces (IM, Workbench,
+scheduled follow-ups) and backend agents.  The key rule is that an existing
+``agent_sessions`` row owns its execution cwd; scope settings only seed new
+sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from sqlalchemy import Engine, select
+
+from modules.im import MessageContext
+from storage.agent_session_rows import create_agent_session_row
+from storage.models import agent_sessions, scope_settings, scopes
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentRunTarget:
+    platform: str
+    settings_key: str
+    session_key: str
+    session_anchor: str
+    workdir: str
+    source: str
+    scope_id: Optional[str] = None
+    scope_type: Optional[str] = None
+    agent_session_id: Optional[str] = None
+    agent_id: Optional[str] = None
+    agent_name: Optional[str] = None
+    agent_backend: Optional[str] = None
+    agent_variant: Optional[str] = None
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    native_session_id: Optional[str] = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "platform": self.platform,
+            "settings_key": self.settings_key,
+            "session_key": self.session_key,
+            "session_anchor": self.session_anchor,
+            "workdir": self.workdir,
+            "source": self.source,
+            "scope_id": self.scope_id,
+            "scope_type": self.scope_type,
+            "agent_session_id": self.agent_session_id,
+            "agent_id": self.agent_id,
+            "agent_name": self.agent_name,
+            "agent_backend": self.agent_backend,
+            "agent_variant": self.agent_variant,
+            "model": self.model,
+            "reasoning_effort": self.reasoning_effort,
+            "native_session_id": self.native_session_id,
+        }
+
+
+def resolve_agent_run_target(
+    context: MessageContext,
+    *,
+    controller: Any,
+    base_session_id: Optional[str] = None,
+    source: str = "human",
+    create_session: bool = True,
+) -> AgentRunTarget:
+    """Resolve cwd/session/scope metadata for one agent turn.
+
+    Resolution order:
+    1. Reserved/explicit ``agent_sessions`` row carried by the context.
+    2. Existing IM-style row for ``(scope, anchor)``.
+    3. Current scope defaults.
+    4. Global/process cwd fallback with a warning.
+    """
+
+    cached = _cached_target(
+        context,
+        base_session_id=base_session_id,
+        source=source,
+        create_session=create_session,
+    )
+    if cached is not None:
+        return cached
+
+    platform = _platform_for(context, controller)
+    settings_key = _settings_key_for(context)
+    session_key = f"{platform}::{settings_key}"
+    anchor = str(base_session_id or _fallback_anchor(context, platform))
+    engine = _engine_for(controller)
+
+    with engine.begin() as conn:
+        target_payload = _target_payload(context)
+        target_id = _target_id(context, target_payload)
+        if target_id:
+            row = conn.execute(
+                select(
+                    agent_sessions,
+                    scopes.c.scope_type.label("_scope_type"),
+                )
+                .select_from(agent_sessions.outerjoin(scopes, scopes.c.id == agent_sessions.c.scope_id))
+                .where(agent_sessions.c.id == target_id)
+            ).mappings().first()
+            if row is not None:
+                return _cache_target(
+                    context,
+                    _target_from_session_row(
+                        row,
+                        platform=platform,
+                        settings_key=settings_key,
+                        session_key=session_key,
+                        fallback_anchor=anchor,
+                        workdir=_authoritative_session_workdir(
+                            conn,
+                            row,
+                            controller=controller,
+                            platform=platform,
+                            settings_key=settings_key,
+                            session_key=session_key,
+                            fallback_anchor=anchor,
+                            source="agent_session",
+                        ),
+                        source=source,
+                    ),
+                )
+            raise LookupError(f"agent session target does not exist: {target_id}")
+
+        scope_row = _scope_for_context(conn, context, platform, settings_key)
+        scope_id = scope_row.get("scope_id") if scope_row else None
+
+        if scope_id:
+            existing = conn.execute(
+                select(
+                    agent_sessions,
+                    scopes.c.scope_type.label("_scope_type"),
+                )
+                .select_from(agent_sessions.outerjoin(scopes, scopes.c.id == agent_sessions.c.scope_id))
+                .where(agent_sessions.c.scope_id == scope_id)
+                .where(agent_sessions.c.session_anchor == anchor)
+                .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
+                .limit(1)
+            ).mappings().first()
+            if existing is not None:
+                return _cache_target(
+                    context,
+                    _target_from_session_row(
+                        existing,
+                        platform=platform,
+                        settings_key=settings_key,
+                        session_key=session_key,
+                        fallback_anchor=anchor,
+                        workdir=_authoritative_session_workdir(
+                            conn,
+                            existing,
+                            controller=controller,
+                            platform=platform,
+                            settings_key=settings_key,
+                            session_key=session_key,
+                            fallback_anchor=anchor,
+                            source="existing_session",
+                        ),
+                        source=source,
+                    ),
+                )
+
+        if not scope_id:
+            return _cache_target(
+                context,
+                _unpersisted_target(
+                    None,
+                    controller=controller,
+                    platform=platform,
+                    settings_key=settings_key,
+                    session_key=session_key,
+                    anchor=anchor,
+                    source=source,
+                    workdir_source="no_scope",
+                ),
+            )
+
+        resolved_new_workdir = _resolve_workdir(
+            _normalize_workdir(scope_row.get("workdir")) if scope_row else None,
+            controller=controller,
+            platform=platform,
+            settings_key=settings_key,
+            session_key=session_key,
+            source="new_session",
+        )
+        if not create_session:
+            return _cache_target(
+                context,
+                _unpersisted_target(
+                    scope_row,
+                    controller=controller,
+                    platform=platform,
+                    settings_key=settings_key,
+                    session_key=session_key,
+                    anchor=anchor,
+                    source=source,
+                    workdir=resolved_new_workdir,
+                    workdir_source="scope_read",
+                ),
+            )
+
+        new_session_id = create_agent_session_row(
+            conn,
+            scope_id=str(scope_id),
+            session_anchor=anchor,
+            agent_backend=_optional_str(scope_row.get("agent_backend")) if scope_row else "",
+            agent_variant=_optional_str(scope_row.get("agent_variant")) if scope_row else None,
+            agent_name=_optional_str(scope_row.get("agent_name")) if scope_row else None,
+            model=_optional_str(scope_row.get("model")) if scope_row else None,
+            reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
+            workdir=resolved_new_workdir,
+            metadata={"created_via": "agent_run_target", "source": source},
+        )
+        created = conn.execute(
+            select(
+                agent_sessions,
+                scopes.c.scope_type.label("_scope_type"),
+            )
+            .select_from(agent_sessions.outerjoin(scopes, scopes.c.id == agent_sessions.c.scope_id))
+            .where(agent_sessions.c.id == new_session_id)
+        ).mappings().one()
+        return _cache_target(
+            context,
+            _target_from_session_row(
+                created,
+                platform=platform,
+                settings_key=settings_key,
+                session_key=session_key,
+                fallback_anchor=anchor,
+                workdir=resolved_new_workdir,
+                source=source,
+            ),
+        )
+
+
+def _cached_target(
+    context: MessageContext,
+    *,
+    base_session_id: Optional[str],
+    source: str,
+    create_session: bool,
+) -> Optional[AgentRunTarget]:
+    payload = context.platform_specific or {}
+    cached = payload.get("agent_run_target")
+    if not isinstance(cached, dict):
+        return None
+    if base_session_id and cached.get("session_anchor") != base_session_id:
+        return None
+    if cached.get("source") != source:
+        return None
+    if create_session and cached.get("scope_id") and not cached.get("agent_session_id"):
+        return None
+    workdir = _normalize_workdir(cached.get("workdir"))
+    if not workdir:
+        return None
+    return AgentRunTarget(
+        platform=str(cached.get("platform") or ""),
+        settings_key=str(cached.get("settings_key") or ""),
+        session_key=str(cached.get("session_key") or ""),
+        session_anchor=str(cached.get("session_anchor") or base_session_id or ""),
+        workdir=workdir,
+        source=str(cached.get("source") or source),
+        scope_id=_optional_str(cached.get("scope_id")),
+        scope_type=_optional_str(cached.get("scope_type")),
+        agent_session_id=_optional_str(cached.get("agent_session_id")),
+        agent_id=_optional_str(cached.get("agent_id")),
+        agent_name=_optional_str(cached.get("agent_name")),
+        agent_backend=_optional_str(cached.get("agent_backend")),
+        agent_variant=_optional_str(cached.get("agent_variant")),
+        model=_optional_str(cached.get("model")),
+        reasoning_effort=_optional_str(cached.get("reasoning_effort")),
+        native_session_id=_optional_str(cached.get("native_session_id")),
+    )
+
+
+def _cache_target(context: MessageContext, target: AgentRunTarget) -> AgentRunTarget:
+    payload = dict(context.platform_specific or {})
+    payload["agent_run_target"] = target.to_payload()
+    context.platform_specific = payload
+    return target
+
+
+def _engine_for(controller: Any) -> Engine:
+    engine = getattr(controller, "sqlite_engine", None)
+    if engine is not None:
+        return engine
+    from storage.db import create_sqlite_engine
+
+    engine = create_sqlite_engine()
+    try:
+        setattr(controller, "sqlite_engine", engine)
+    except Exception:
+        pass
+    return engine
+
+
+def _platform_for(context: MessageContext, controller: Any) -> str:
+    return (
+        context.platform
+        or (context.platform_specific or {}).get("platform")
+        or getattr(controller, "primary_platform", None)
+        or getattr(getattr(controller, "config", None), "platform", None)
+        or "slack"
+    )
+
+
+def _settings_key_for(context: MessageContext) -> str:
+    payload = context.platform_specific or {}
+    return str(context.user_id if payload.get("is_dm", False) else context.channel_id)
+
+
+def _fallback_anchor(context: MessageContext, platform: str) -> str:
+    payload = context.platform_specific or {}
+    target = payload.get("agent_session_target")
+    if isinstance(target, dict) and target.get("session_anchor"):
+        return str(target["session_anchor"])
+    return f"{platform}_{context.thread_id or context.message_id or context.channel_id or context.user_id}"
+
+
+def _target_payload(context: MessageContext) -> dict[str, Any]:
+    payload = context.platform_specific or {}
+    target = payload.get("agent_session_target")
+    return target if isinstance(target, dict) else {}
+
+
+def _target_id(context: MessageContext, target_payload: dict[str, Any]) -> Optional[str]:
+    payload = context.platform_specific or {}
+    value = target_payload.get("id") or payload.get("agent_session_id") or payload.get("workbench_session_id")
+    return _optional_str(value)
+
+
+def _scope_for_context(conn, context: MessageContext, platform: str, settings_key: str) -> Optional[dict[str, Any]]:
+    payload = context.platform_specific or {}
+    target = payload.get("agent_session_target")
+    if isinstance(target, dict) and target.get("scope_id"):
+        row = _scope_row(conn, str(target["scope_id"]))
+        if row is not None:
+            return row
+
+    project_id = payload.get("project_id")
+    if platform == "avibe" and project_id:
+        row = _scope_row(conn, f"avibe::project::{project_id}")
+        if row is not None:
+            return row
+
+    candidates: list[tuple[str, str, str]] = []
+    if (payload.get("is_dm", False)):
+        candidates.append((platform, "user", str(context.user_id)))
+    else:
+        candidates.append((platform, "channel", str(settings_key)))
+        candidates.append((platform, "user", str(settings_key)))
+    if platform == "avibe":
+        candidates.append(("avibe", "project", str(settings_key)))
+
+    for candidate_platform, scope_type, native_id in candidates:
+        scope_id = f"{candidate_platform}::{scope_type}::{native_id}"
+        row = _scope_row(conn, scope_id)
+        if row is not None:
+            return row
+    return None
+
+
+def _scope_row(conn, scope_id: str) -> Optional[dict[str, Any]]:
+    row = conn.execute(
+        select(
+            scopes.c.id.label("scope_id"),
+            scopes.c.scope_type,
+            scopes.c.platform,
+            scopes.c.native_id,
+            scope_settings.c.workdir,
+            scope_settings.c.agent_name,
+            scope_settings.c.agent_backend,
+            scope_settings.c.agent_variant,
+            scope_settings.c.model,
+            scope_settings.c.reasoning_effort,
+        )
+        .select_from(scopes.outerjoin(scope_settings, scope_settings.c.scope_id == scopes.c.id))
+        .where(scopes.c.id == scope_id)
+    ).mappings().first()
+    return dict(row) if row is not None else None
+
+
+def _scope_workdir(conn, scope_id: Any) -> Optional[str]:
+    if not scope_id:
+        return None
+    value = conn.execute(
+        select(scope_settings.c.workdir).where(scope_settings.c.scope_id == str(scope_id))
+    ).scalar_one_or_none()
+    return _normalize_workdir(value)
+
+
+def _authoritative_session_workdir(
+    conn,
+    row: dict[str, Any],
+    *,
+    controller: Any,
+    platform: str,
+    settings_key: str,
+    session_key: str,
+    fallback_anchor: str,
+    source: str,
+) -> str:
+    """Return ``agent_sessions.workdir`` and repair legacy blanks once.
+
+    New sessions must be created with a workdir snapshot. This function exists
+    for old rows only: if the stored workdir is missing or is a legacy
+    anchor-derived placeholder, choose a migration value and write it back.
+    """
+
+    session_id = _optional_str(row.get("id"))
+    stored = _session_row_workdir(row, fallback_anchor=fallback_anchor)
+    if stored:
+        return _resolve_workdir(
+            stored,
+            controller=controller,
+            platform=platform,
+            settings_key=settings_key,
+            session_key=session_key,
+            source=source,
+        )
+
+    repaired = _resolve_workdir(
+        _scope_workdir(conn, row.get("scope_id")),
+        controller=controller,
+        platform=platform,
+        settings_key=settings_key,
+        session_key=session_key,
+        source=f"{source}_legacy_repair",
+    )
+    if session_id:
+        conn.execute(
+            agent_sessions.update()
+            .where(agent_sessions.c.id == session_id)
+            .values(workdir=repaired)
+        )
+        logger.warning("Repaired legacy agent session workdir session_id=%s workdir=%s", session_id, repaired)
+    return repaired
+
+
+def _target_from_session_row(
+    row: dict[str, Any],
+    *,
+    platform: str,
+    settings_key: str,
+    session_key: str,
+    fallback_anchor: str,
+    workdir: str,
+    source: str,
+) -> AgentRunTarget:
+    return AgentRunTarget(
+        platform=platform,
+        settings_key=settings_key,
+        session_key=session_key,
+        session_anchor=str(row.get("session_anchor") or fallback_anchor),
+        workdir=workdir,
+        source=source,
+        scope_id=_optional_str(row.get("scope_id")),
+        scope_type=_optional_str(row.get("_scope_type")),
+        agent_session_id=_optional_str(row.get("id")),
+        agent_id=_optional_str(row.get("agent_id")),
+        agent_name=_optional_str(row.get("agent_name")),
+        agent_backend=_optional_str(row.get("agent_backend")),
+        agent_variant=_optional_str(row.get("agent_variant")),
+        model=_optional_str(row.get("model")),
+        reasoning_effort=_optional_str(row.get("reasoning_effort")),
+        native_session_id=_optional_str(row.get("native_session_id")),
+    )
+
+
+def _unpersisted_target(
+    scope_row: Optional[dict[str, Any]],
+    *,
+    controller: Any,
+    platform: str,
+    settings_key: str,
+    session_key: str,
+    anchor: str,
+    source: str,
+    workdir_source: str,
+    workdir: Optional[str] = None,
+) -> AgentRunTarget:
+    resolved_workdir = workdir or _resolve_workdir(
+        _normalize_workdir(scope_row.get("workdir")) if scope_row else None,
+        controller=controller,
+        platform=platform,
+        settings_key=settings_key,
+        session_key=session_key,
+        source=workdir_source,
+    )
+    return AgentRunTarget(
+        platform=platform,
+        settings_key=settings_key,
+        session_key=session_key,
+        session_anchor=anchor,
+        workdir=resolved_workdir,
+        source=source,
+        scope_id=_optional_str(scope_row.get("scope_id")) if scope_row else None,
+        scope_type=_optional_str(scope_row.get("scope_type")) if scope_row else None,
+        agent_name=_optional_str(scope_row.get("agent_name")) if scope_row else None,
+        agent_backend=_optional_str(scope_row.get("agent_backend")) if scope_row else None,
+        agent_variant=_optional_str(scope_row.get("agent_variant")) if scope_row else None,
+        model=_optional_str(scope_row.get("model")) if scope_row else None,
+        reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
+    )
+
+
+def _session_row_workdir(row: dict[str, Any], *, fallback_anchor: str) -> Optional[str]:
+    workdir = _normalize_workdir(row.get("workdir"))
+    if not workdir:
+        return None
+    native_session_id = _optional_str(row.get("native_session_id"))
+    anchor = str(row.get("session_anchor") or fallback_anchor)
+    placeholder = _normalize_workdir(_workdir_from_anchor(anchor))
+    if not native_session_id and placeholder and workdir == placeholder:
+        return None
+    return workdir
+
+
+def _workdir_from_anchor(anchor: str) -> Optional[str]:
+    if ":" not in anchor:
+        return None
+    suffix = anchor.rsplit(":", 1)[1]
+    return suffix or None
+
+
+def _normalize_workdir(value: Any) -> Optional[str]:
+    text = _optional_str(value)
+    if not text:
+        return None
+    return os.path.abspath(os.path.expanduser(text))
+
+
+def _resolve_workdir(
+    candidate: Optional[str],
+    *,
+    controller: Any,
+    platform: str,
+    settings_key: str,
+    session_key: str,
+    source: str,
+) -> str:
+    if candidate:
+        ensured_candidate = _ensure_workdir(
+            candidate,
+            platform=platform,
+            settings_key=settings_key,
+            session_key=session_key,
+            source=source,
+        )
+        if ensured_candidate:
+            return ensured_candidate
+    config = getattr(controller, "config", None)
+    default_cwd = getattr(getattr(config, "claude", None), "cwd", None)
+    if default_cwd:
+        resolved_default = os.path.abspath(os.path.expanduser(str(default_cwd)))
+        ensured_default = _ensure_workdir(
+            resolved_default,
+            platform=platform,
+            settings_key=settings_key,
+            session_key=session_key,
+            source="config_default",
+        )
+        if ensured_default:
+            return ensured_default
+    fallback = str(Path.cwd())
+    logger.warning(
+        "Agent run target missing workdir; falling back to process cwd=%s platform=%s settings_key=%s session_key=%s source=%s",
+        fallback,
+        platform,
+        settings_key,
+        session_key,
+        source,
+    )
+    return _ensure_workdir(
+        fallback,
+        platform=platform,
+        settings_key=settings_key,
+        session_key=session_key,
+        source=source,
+    )
+
+
+def _ensure_workdir(
+    path: str,
+    *,
+    platform: str,
+    settings_key: str,
+    session_key: str,
+    source: str,
+) -> Optional[str]:
+    try:
+        os.makedirs(path, exist_ok=True)
+    except OSError as exc:
+        logger.warning(
+            "Failed to create agent run target workdir=%s platform=%s settings_key=%s session_key=%s source=%s error=%s",
+            path,
+            platform,
+            settings_key,
+            session_key,
+            source,
+            exc,
+        )
+        return None
+    return path
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/docs/plans/agent-run-target-resolver.md
+++ b/docs/plans/agent-run-target-resolver.md
@@ -1,0 +1,318 @@
+# Agent Run Target Resolver
+
+## Status
+
+Draft. This plan captures the root fix for Workbench sessions starting agents
+from the wrong directory, and generalizes it into a shared execution-target
+model for every platform.
+
+## Problem
+
+Vibe Remote stores working directories in a shared table, but runtime resolution
+is not shared.
+
+Current behavior:
+
+- IM channel and DM scopes store their cwd in `scope_settings.workdir`, then
+  load it through the runtime `SettingsManager` as `custom_cwd`.
+- Workbench projects also store their folder in `scope_settings.workdir`.
+- Workbench sessions snapshot the project folder into `agent_sessions.workdir`.
+- Workbench dispatch injects the session row into
+  `platform_specific["agent_session_target"]`, including its `workdir`.
+- `Controller.get_cwd(context)` ignores `agent_session_target.workdir` and only
+  asks the IM settings facade for `custom_cwd`.
+
+That leaves Avibe/Web UI contexts with no matching IM custom cwd. When there is
+no global default cwd, `get_cwd()` falls back to the Vibe Remote process cwd.
+If the service was launched from `/tmp/test`, a Workbench session can start its
+agent from `/tmp/test` even though the selected project is
+`/Users/cyh/vibe-remote-project`.
+
+Some backends then bind their native session id back into the reserved
+`agent_sessions` row with `request.working_path`, which can persist the wrong
+cwd onto the Workbench session.
+
+## Goal
+
+Create one shared runtime resolver for "where and how this agent turn should
+run".
+
+After this plan lands:
+
+- Every agent turn uses the same resolver for cwd, scope, session anchor,
+  session row, agent, backend, model, and reasoning effort.
+- Adding a new platform does not require remembering platform-specific cwd
+  fallbacks in agent handlers.
+- `scope_settings.workdir` remains the source of default scope cwd.
+- `agent_sessions.workdir` becomes the source of truth for an existing session's
+  actual bound cwd.
+- `Controller.get_cwd(context)` becomes a compatibility wrapper over the shared
+  resolver instead of a separate policy engine.
+
+## Non-Goals
+
+- Do not change the database schema unless implementation finds a missing
+  constraint. The existing `scopes`, `scope_settings`, and `agent_sessions`
+  tables are enough for the target model.
+- Do not merge Workbench and IM UX concepts. Workbench projects and IM channels
+  can remain different product surfaces; only execution target resolution is
+  unified.
+- Do not silently move existing native sessions to a new cwd. Existing sessions
+  should resume from their persisted `agent_sessions.workdir`.
+
+## Target Model
+
+### Scope default
+
+`scope_settings.workdir` means:
+
+> The default working directory for new sessions created in this scope.
+
+Examples:
+
+- `slack::channel::C09KX3GN118`
+- `slack::user::U0E0FM3QT`
+- `lark::channel::oc_...`
+- `avibe::project::proj_272e944ca452`
+
+This is not the resume source of truth once a concrete `agent_sessions` row
+exists.
+
+### Session binding
+
+`agent_sessions.workdir` means:
+
+> The working directory snapshot bound to this concrete agent session.
+
+That value must be stable for resume. If a project or channel's default cwd
+changes later, existing sessions keep their original cwd unless an explicit
+session-level move feature is designed.
+
+### Execution target
+
+Introduce a value object, for example:
+
+```python
+@dataclass(frozen=True)
+class AgentRunTarget:
+    platform: str
+    scope_id: str | None
+    scope_type: str | None
+    settings_key: str
+    session_key: str
+    agent_session_id: str | None
+    session_anchor: str
+    workdir: str
+    agent_name: str | None
+    agent_backend: str | None
+    model: str | None
+    reasoning_effort: str | None
+    source: str
+```
+
+The exact fields can be adjusted during implementation, but the resolver must
+return one object that all agent-start paths consume.
+
+## Resolution Rules
+
+### 1. Existing reserved session wins
+
+If the context carries an agent-session target:
+
+- Read by `agent_session_target.id` or `platform_specific["agent_session_id"]`.
+- Use `agent_sessions.scope_id`, `session_anchor`, `workdir`, and pinned agent
+  fields from that row.
+- If the target payload is present but incomplete, reload the row from storage
+  instead of falling back to process cwd.
+
+This is the Workbench path, but the rule is deliberately generic so scheduled
+tasks and watches can also resume by session id.
+
+### 2. Existing IM thread session wins
+
+If this is an IM turn and a row already exists for `(scope_id, session_anchor)`:
+
+- Use the existing `agent_sessions` row.
+- Use `agent_sessions.workdir` for cwd.
+- Use the session's pinned agent/backend values.
+
+This keeps existing IM threads stable when a channel default changes.
+
+### 3. New session seeds from scope
+
+If no existing session row is bound:
+
+- Resolve the scope from context:
+  - IM channel: platform + channel id.
+  - IM DM: platform + user id.
+  - Workbench project: project scope id.
+  - Scheduled/watch: explicit target session if present, otherwise explicit
+    target scope.
+- Read default cwd and routing from `scope_settings`.
+- Create or reserve the session row with `agent_sessions.workdir =
+  scope_settings.workdir`.
+
+### 4. Fallbacks are explicit and noisy
+
+Only after the resolver has proved there is no session cwd and no scope cwd:
+
+1. Use configured global default cwd, if any.
+2. Use process cwd as last resort.
+3. Log a warning that includes platform, settings key, session key, and whether
+   an agent session id was present.
+
+The process cwd fallback should be a diagnosable escape hatch, not normal
+Workbench behavior.
+
+## Implementation Plan
+
+### Phase 1: Resolver service
+
+Add a shared service under `core/services/`, for example
+`core/services/agent_run_target.py`.
+
+Responsibilities:
+
+- Normalize platform, settings key, session key, and session anchor.
+- Resolve a concrete `agent_sessions` row when possible.
+- Resolve the current scope row when no session exists.
+- Return an `AgentRunTarget`.
+- Validate and normalize `workdir`.
+- Avoid creating hidden sessions unless the caller explicitly asks for
+  reservation.
+
+The first version can be read-only plus an explicit `ensure_session=True` option
+for paths that need to reserve a row before prompt injection.
+
+### Phase 2: Wire cwd callers
+
+Change these callers to use the resolver:
+
+- `Controller.get_cwd(context)`
+- `SessionHandler.get_session_info(context)`
+- `MessageHandler` when constructing `AgentRequest`
+- Claude, Codex, and OpenCode preflight paths that currently re-read cwd
+- command paths such as `/cwd` and `/set_cwd`
+
+`get_cwd()` should remain as a public compatibility method, but its body should
+become resolver-backed.
+
+### Phase 3: Wire routing callers
+
+Move agent/backend/model/effort resolution onto the same target object.
+
+Replace split reads from:
+
+- `settings_manager.get_channel_routing(settings_key)`
+- `agent_session_target`
+- Workbench header overrides
+- global default agent
+
+with a single resolver result consumed by `MessageHandler` and backend agents.
+
+This prevents the cwd fix from leaving routing with the same split-brain
+problem.
+
+### Phase 4: Bind without cwd pollution
+
+Update native-session binding helpers so reserved-session bind does not blindly
+overwrite a valid `agent_sessions.workdir` with `request.working_path` unless
+that request path came from the resolver.
+
+Acceptable behavior:
+
+- If the row has no workdir, set it from the resolver target.
+- If the row has the same workdir, keep it.
+- If the row has a different workdir, do not overwrite silently. Log and fail
+  loud for resume-sensitive paths, or require an explicit migration operation.
+
+### Phase 5: Cleanup compatibility names
+
+Keep API compatibility for `custom_cwd`, but stop treating it as a separate
+runtime concept.
+
+Suggested direction:
+
+- Public IM settings can still expose `custom_cwd`.
+- Internal services should use `workdir`.
+- `SettingsManager.get_custom_cwd()` can become a thin compatibility wrapper
+  over the scope resolver or scope settings reader.
+
+## Data Repair
+
+After the code-level fix, repair already polluted Workbench sessions separately.
+
+Safe repair rule:
+
+- Only target `agent_sessions` rows whose `scope_id` points to an
+  `avibe::project::*` scope.
+- Only repair rows whose `workdir` equals a known fallback such as `/tmp/test`.
+- Replace with the owning project scope's `scope_settings.workdir`.
+- Do not modify rows where `native_session_id` is non-empty unless we confirm
+  the backend native session can still resume under the project cwd.
+
+The last condition matters: changing `agent_sessions.workdir` for an already
+native-bound session may make Claude/Codex resume look in a different project
+state location.
+
+## Test Plan
+
+### Unit tests
+
+- Workbench dispatch with `agent_session_target.workdir` resolves that workdir.
+- Workbench dispatch with incomplete target reloads `agent_sessions` by id.
+- IM channel turn resolves channel `scope_settings.workdir`.
+- IM DM turn resolves user `scope_settings.workdir`.
+- Existing IM thread resolves `agent_sessions.workdir` even after the channel
+  scope cwd changes.
+- Missing scope cwd falls back to global cwd and logs a warning.
+- Process cwd fallback is covered but treated as last resort.
+
+### Integration tests
+
+- Create an Avibe project with cwd `/repo`.
+- Create a Workbench session in that project.
+- Start a Codex turn while the Vibe Remote process cwd is `/tmp/test`.
+- Assert the Codex request/transport cwd is `/repo`.
+- Assert `agent_sessions.workdir` remains `/repo` after native bind.
+
+Repeat the same shape for Claude and OpenCode.
+
+### Regression tests
+
+- Existing Slack/Lark channel cwd behavior remains unchanged.
+- `/set_cwd` updates the correct channel/user scope row.
+- Workbench project folder update affects new sessions, not existing sessions.
+- Scheduled task/watch follow-up into an existing session uses that session's
+  `agent_sessions.workdir`.
+
+## Risks
+
+- Cwd, routing, and session pinning are central to all platforms. This needs
+  broad tests before merging.
+- Existing code uses `settings_key` for both settings lookup and session
+  grouping in several places. The resolver must keep `settings_key` and
+  `session_key` explicit to avoid reintroducing cross-platform collisions.
+- Backends differ in when native session ids become available. The resolver
+  should not assume native id exists before prompt injection.
+- Data repair can strand native sessions if it changes cwd for already-bound
+  sessions. Repair must be conservative.
+
+## Rollout Plan
+
+1. Land resolver and tests with `get_cwd()` still exposing the old method name.
+2. Move cwd consumers onto resolver-backed `get_cwd()`.
+3. Move routing consumers onto the target object.
+4. Add a read-only diagnostic command or debug log to print the resolved target
+   for a turn.
+5. Repair polluted Workbench rows after validating native resume behavior.
+
+## Open Questions
+
+- Should Workbench allow a session-level cwd override distinct from project cwd,
+  or should cwd always be immutable after session creation?
+- Should `/set_cwd` on IM scopes affect only new sessions, or should it offer an
+  explicit "move current thread" operation?
+- Should `agent_sessions.workdir` be nullable long-term, or should new session
+  creation require a resolved cwd?
+- Should process cwd fallback eventually become an error for Workbench contexts?

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -111,6 +111,9 @@ class BaseAgent(ABC):
         ensure = getattr(sessions, "ensure_agent_session_id", None)
         if callable(ensure):
             kwargs = {}
+            resolved_target = (request.context.platform_specific or {}).get("agent_run_target")
+            if isinstance(resolved_target, dict) and resolved_target.get("workdir"):
+                kwargs["workdir"] = str(resolved_target["workdir"])
             if request.vibe_agent_id is not None:
                 kwargs["vibe_agent_id"] = request.vibe_agent_id
             if request.vibe_agent_name is not None:
@@ -187,6 +190,17 @@ class BaseAgent(ABC):
         payload["agent_session_id"] = agent_session_id
         context.platform_specific = payload
 
+    @staticmethod
+    def _uses_namespaced_backend_session(
+        context: Any,
+        *,
+        subagent_name: Optional[str] = None,
+    ) -> bool:
+        if subagent_name:
+            return True
+        payload = getattr(context, "platform_specific", None) or {}
+        return bool(payload.get("routing_subagent"))
+
     def _bind_reserved_workbench_session(
         self,
         context: Any,
@@ -207,6 +221,8 @@ class BaseAgent(ABC):
         open Chat page (Codex P1). Returns the reserved id when this is an avibe
         turn (so the caller skips its normal binder), else ``None``.
         """
+        if self._uses_namespaced_backend_session(context):
+            return None
         reserved_id = self._reserved_agent_session_id(context)
         if not reserved_id:
             return None
@@ -221,6 +237,12 @@ class BaseAgent(ABC):
         bound: Optional[str] = None
         if callable(bind_by_id):
             try:
+                resolved_target = payload.get("agent_run_target")
+                resolved_workdir = (
+                    resolved_target.get("workdir")
+                    if isinstance(resolved_target, dict)
+                    else None
+                )
                 # Positional (session_id, native_session_id) — the SessionsFacade
                 # binds by a positional ``agent_session_id``, NOT a keyword, so a
                 # ``session_id=`` call would TypeError and silently skip recording
@@ -228,7 +250,7 @@ class BaseAgent(ABC):
                 bound = bind_by_id(
                     reserved_id,
                     native_session_id,
-                    workdir=working_path,
+                    workdir=resolved_workdir or working_path,
                     vibe_agent_id=vibe_agent_id,
                     vibe_agent_name=vibe_agent_name,
                     vibe_agent_backend=vibe_agent_backend,
@@ -319,22 +341,34 @@ class BaseAgent(ABC):
     ) -> Optional[str]:
         """Bind a backend-native session id to the existing Vibe session row."""
         anchor = session_anchor or request.base_session_id
-        # avibe: bind to the reserved workbench row by id (mirrors OpenCode) so the
-        # reply publishes under the open Chat session, not a new hidden row (P1).
-        reserved = self._bind_reserved_workbench_session(
+        reserved_id = self._reserved_agent_session_id(request.context)
+        use_backend_anchor = self._uses_namespaced_backend_session(
             request.context,
-            native_session_id,
-            working_path=getattr(request, "working_path", None),
-            vibe_agent_id=getattr(request, "vibe_agent_id", None),
-            vibe_agent_name=getattr(request, "vibe_agent_name", None),
-            vibe_agent_backend=getattr(request, "vibe_agent_backend", None),
+            subagent_name=getattr(request, "subagent_name", None),
         )
-        if reserved:
-            return reserved
+        if not use_backend_anchor:
+            # avibe: bind to the reserved workbench row by id (mirrors OpenCode) so
+            # the reply publishes under the open Chat session, not a new hidden row
+            # (P1). Namespaced backend subagents are the exception: their native
+            # threads must be stored under their own anchor, while the publish
+            # target remains the open Chat row.
+            reserved = self._bind_reserved_workbench_session(
+                request.context,
+                native_session_id,
+                working_path=getattr(request, "working_path", None),
+                vibe_agent_id=getattr(request, "vibe_agent_id", None),
+                vibe_agent_name=getattr(request, "vibe_agent_name", None),
+                vibe_agent_backend=getattr(request, "vibe_agent_backend", None),
+            )
+            if reserved:
+                return reserved
         sessions = getattr(self, "sessions", None)
         binder = getattr(sessions, "bind_agent_session", None)
         if callable(binder):
             kwargs = {}
+            resolved_target = (request.context.platform_specific or {}).get("agent_run_target")
+            if isinstance(resolved_target, dict) and resolved_target.get("workdir"):
+                kwargs["workdir"] = str(resolved_target["workdir"])
             if request.vibe_agent_id is not None:
                 kwargs["vibe_agent_id"] = request.vibe_agent_id
             if request.vibe_agent_name is not None:
@@ -353,10 +387,13 @@ class BaseAgent(ABC):
             agent_session_id = None
         if agent_session_id:
             payload = dict(request.context.platform_specific or {})
-            payload["agent_session_id"] = agent_session_id
+            payload["agent_session_id"] = reserved_id if use_backend_anchor and reserved_id else agent_session_id
             request.context.platform_specific = payload
             return agent_session_id
-        return self.ensure_agent_session_id(request, session_anchor=anchor)
+        ensured_id = self.ensure_agent_session_id(request, session_anchor=anchor)
+        if use_backend_anchor and reserved_id:
+            self._pin_agent_session_id(request.context, reserved_id)
+        return ensured_id
 
     async def _remove_ack_reaction(self, request: AgentRequest) -> None:
         """Remove the acknowledgement reaction / typing indicator.

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -390,7 +390,13 @@ class ClaudeAgent(BaseAgent):
                     touch_session_activity = getattr(self.session_handler, "touch_session_activity", None)
                     if callable(touch_session_activity):
                         touch_session_activity(composite_key)
-                    claude_session_id = self._maybe_capture_session_id(message, base_session_id, session_key, context)
+                    claude_session_id = self._maybe_capture_session_id(
+                        message,
+                        base_session_id,
+                        session_key,
+                        context,
+                        working_path=working_path,
+                    )
                     if claude_session_id:
                         self._native_session_ids[composite_key] = claude_session_id
                         logger.info(f"Captured Claude session id {claude_session_id} for {base_session_id}")
@@ -841,6 +847,8 @@ class ClaudeAgent(BaseAgent):
         base_session_id: str,
         session_key: str,
         context: MessageContext,
+        *,
+        working_path: Optional[str] = None,
     ) -> Optional[str]:
         """Capture session id from system init messages."""
         if (
@@ -853,8 +861,11 @@ class ClaudeAgent(BaseAgent):
             if session_id:
                 # avibe: bind the native id to the RESERVED workbench session row so
                 # the reply publishes under the open Chat session, not a freshly
-                # minted hidden row (Codex P1). Mirrors OpenCode / the Codex base
-                # path; falls through to the normal binder for IM turns.
+                # minted hidden row (Codex P1). Target subagents are the exception:
+                # their native id is persisted under the namespaced anchor, then the
+                # publish target is pinned back to the open Chat session.
+                reserved_id = self._reserved_agent_session_id(context)
+                uses_backend_anchor = self._uses_namespaced_backend_session(context)
                 reserved = self._bind_reserved_workbench_session(context, session_id)
                 if reserved:
                     return session_id
@@ -865,12 +876,20 @@ class ClaudeAgent(BaseAgent):
                         agent_name=self.name,
                         session_anchor=base_session_id,
                         native_session_id=session_id,
+                        working_path=working_path,
                     )
                 else:
-                    agent_session_id = self.session_handler.capture_session_id(base_session_id, session_id, session_key)
+                    agent_session_id = self.session_handler.capture_session_id(
+                        base_session_id,
+                        session_id,
+                        session_key,
+                        working_path=working_path,
+                    )
                 if agent_session_id:
                     payload = dict(context.platform_specific or {})
-                    payload["agent_session_id"] = agent_session_id
+                    payload["agent_session_id"] = (
+                        reserved_id if uses_backend_anchor and reserved_id else agent_session_id
+                    )
                     context.platform_specific = payload
                 return session_id
         return None

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -90,10 +90,11 @@ class OpenCodeSessionManager:
         return None
 
     def ensure_agent_session_id(self, request: AgentRequest, session_anchor: str) -> Optional[str]:
-        reserved_id = self._reserved_agent_session_id(request)
-        if reserved_id:
-            self._set_request_agent_session_id(request, reserved_id)
-            return reserved_id
+        reserved_target_id = self._reserved_agent_session_id(request)
+        use_backend_anchor = BaseAgent._uses_namespaced_backend_session(request.context)
+        if reserved_target_id and not use_backend_anchor:
+            self._set_request_agent_session_id(request, reserved_target_id)
+            return reserved_target_id
         sessions = getattr(self._settings_manager, "sessions", self._settings_manager)
         ensure = getattr(sessions, "ensure_agent_session_id", None)
         if callable(ensure):
@@ -105,7 +106,10 @@ class OpenCodeSessionManager:
                 if callable(getter)
                 else None
             )
-        self._set_request_agent_session_id(request, agent_session_id)
+        self._set_request_agent_session_id(
+            request,
+            reserved_target_id if use_backend_anchor and reserved_target_id else agent_session_id,
+        )
         return agent_session_id
 
     def bind_agent_session_id(
@@ -116,7 +120,8 @@ class OpenCodeSessionManager:
     ) -> Optional[str]:
         sessions = getattr(self._settings_manager, "sessions", self._settings_manager)
         reserved_id = self._reserved_agent_session_id(request)
-        if reserved_id:
+        use_backend_anchor = BaseAgent._uses_namespaced_backend_session(request.context)
+        if reserved_id and not use_backend_anchor:
             bind_by_id = getattr(sessions, "bind_agent_session_by_id", None)
             if callable(bind_by_id):
                 agent_session_id = bind_by_id(
@@ -139,6 +144,7 @@ class OpenCodeSessionManager:
                 self._agent_name,
                 session_anchor,
                 opencode_session_id,
+                workdir=request.working_path,
             )
         else:
             sessions.set_agent_session_mapping(
@@ -151,7 +157,10 @@ class OpenCodeSessionManager:
         if not agent_session_id:
             agent_session_id = self.ensure_agent_session_id(request, session_anchor)
         else:
-            self._set_request_agent_session_id(request, agent_session_id)
+            self._set_request_agent_session_id(
+                request,
+                reserved_id if use_backend_anchor and reserved_id else agent_session_id,
+            )
         return agent_session_id
 
     def mark_initialized(self, opencode_session_id: str) -> bool:
@@ -229,7 +238,10 @@ class OpenCodeSessionManager:
         # session after a restart (context loss). IM/CLI turns (no reserved target)
         # fall back to the (scope, anchor) projection. The server-validation below
         # still handles a reserved native the server no longer knows.
-        session_id = BaseAgent._reserved_native_session_id(request.context, self._agent_name) or sessions.get_agent_session_id(
+        use_backend_anchor = BaseAgent._uses_namespaced_backend_session(request.context)
+        session_id = (
+            None if use_backend_anchor else BaseAgent._reserved_native_session_id(request.context, self._agent_name)
+        ) or sessions.get_agent_session_id(
             request.session_key,
             anchor,
             agent_name=self._agent_name,

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -86,6 +86,7 @@ class SessionsFacade:
         agent_name: str,
         thread_id: str,
         *,
+        workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
     ) -> Optional[str]:
@@ -96,6 +97,7 @@ class SessionsFacade:
                 user_key,
                 agent_name,
                 thread_id,
+                workdir=workdir,
                 vibe_agent_id=vibe_agent_id,
                 vibe_agent_name=vibe_agent_name,
             )
@@ -108,6 +110,7 @@ class SessionsFacade:
         thread_id: str,
         session_id: Any,
         *,
+        workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
     ) -> Optional[str]:
@@ -117,6 +120,7 @@ class SessionsFacade:
             agent_name,
             thread_id,
             session_id,
+            workdir=workdir,
             vibe_agent_id=vibe_agent_id,
             vibe_agent_name=vibe_agent_name,
         )

--- a/storage/agent_session_rows.py
+++ b/storage/agent_session_rows.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import Connection, select
+
+from storage.models import agent_sessions, scope_settings
+
+SESSION_ID_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
+JSON_VALUE_PREFIX = "__json__:"
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def encode_session_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return JSON_VALUE_PREFIX + json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def decode_session_value(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    if not value.startswith(JSON_VALUE_PREFIX):
+        return value
+    try:
+        return json.loads(value[len(JSON_VALUE_PREFIX) :])
+    except (TypeError, ValueError):
+        return value
+
+
+def snapshot_scope_workdir(conn: Connection, scope_id: str | None) -> str | None:
+    if not scope_id:
+        return None
+    value = conn.execute(
+        select(scope_settings.c.workdir).where(scope_settings.c.scope_id == str(scope_id))
+    ).scalar_one_or_none()
+    return normalize_workdir(value)
+
+
+def normalize_workdir(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    return os.path.abspath(os.path.expanduser(text))
+
+
+def new_session_id(conn: Connection) -> str:
+    used = {str(value) for value in conn.execute(select(agent_sessions.c.id)).scalars()}
+    while True:
+        candidate = "ses" + "".join(secrets.choice(SESSION_ID_ALPHABET) for _ in range(10))
+        if candidate not in used:
+            return candidate
+
+
+def create_agent_session_row(
+    conn: Connection,
+    *,
+    scope_id: str | None,
+    session_anchor: str | None,
+    agent_backend: str,
+    agent_variant: str | None = None,
+    agent_id: str | None = None,
+    agent_name: str | None = None,
+    model: str | None = None,
+    reasoning_effort: str | None = None,
+    workdir: str | None = None,
+    native_session_id: Any = "",
+    title: str | None = None,
+    status: str = "active",
+    agent_status: str = "idle",
+    metadata: dict[str, Any] | None = None,
+    now: str | None = None,
+    require_workdir: bool = True,
+) -> str:
+    """Create the one public Session row used by every platform.
+
+    A Session owns its cwd. Scope settings are only consulted at creation time
+    to snapshot the initial workdir; later Agent turns must read the stored
+    ``agent_sessions.workdir`` and never re-resolve cwd from Scope.
+    """
+
+    resolved_workdir = normalize_workdir(workdir) or snapshot_scope_workdir(conn, scope_id)
+    if require_workdir and not resolved_workdir:
+        raise ValueError(f"cannot create agent session without workdir for scope_id={scope_id!r}")
+
+    row_id = new_session_id(conn)
+    anchor = str(session_anchor) if session_anchor is not None else row_id
+    now_value = now or utc_now_iso()
+    backend = str(agent_backend or "")
+    variant = str(agent_variant or backend or "default")
+    title_value = title.strip() if (title or "").strip() else None
+    conn.execute(
+        agent_sessions.insert().values(
+            id=row_id,
+            scope_id=scope_id,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            agent_backend=backend,
+            agent_variant=variant,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            session_anchor=anchor,
+            workdir=resolved_workdir,
+            native_session_id=encode_session_value(native_session_id),
+            title=title_value,
+            status=status,
+            agent_status=agent_status,
+            metadata_json=json.dumps(dict(metadata or {}), separators=(",", ":"), ensure_ascii=False),
+            created_at=now_value,
+            updated_at=now_value,
+            last_active_at=now_value,
+        )
+    )
+    return row_id

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import Connection, select
+from sqlalchemy import Connection, case, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 
@@ -16,11 +16,15 @@ from config import paths
 from config.v2_sessions import ActivePollInfo, SessionState
 from config.v2_settings import _split_scoped_key
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
+from storage.agent_session_rows import (
+    create_agent_session_row,
+    decode_session_value,
+    encode_session_value,
+)
 from storage.models import agent_sessions, metadata, runtime_records, scopes, state_meta
 from storage.settings_service import make_scope_id, upsert_scope
 
 SESSIONS_LAST_ACTIVITY_KEY = "sessions_last_activity"
-JSON_VALUE_PREFIX = "__json__:"
 SESSION_ID_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
 
 logger = logging.getLogger(__name__)
@@ -155,18 +159,20 @@ class SQLiteSessionsService:
             scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
             if scope_id is None:
                 return None
-            return _insert_agent_session_row(
+            return create_agent_session_row(
                 conn,
                 scope_id=scope_id,
-                scope_key=str(scope_key),
-                agent_name=backend,
+                agent_backend=_agent_backend(backend),
+                agent_variant=backend,
                 session_anchor=session_anchor,
                 native_session_id="",
-                vibe_agent_id=agent_id,
-                vibe_agent_name=agent_name,
+                agent_id=agent_id,
+                agent_name=agent_name,
                 model=model,
                 reasoning_effort=reasoning_effort,
+                metadata={"legacy_scope_key": str(scope_key)},
                 now=now,
+                require_workdir=False,
             )
 
     def reserve_private_agent_session(
@@ -199,19 +205,20 @@ class SQLiteSessionsService:
                 metadata=metadata_payload,
                 now=now,
             )
-            return _insert_agent_session_row(
+            return create_agent_session_row(
                 conn,
                 scope_id=scope_id,
-                scope_key=scope_key,
-                agent_name=backend,
+                agent_backend=_agent_backend(backend),
+                agent_variant=backend,
                 session_anchor=session_anchor,
                 native_session_id="",
-                vibe_agent_id=agent_id,
-                vibe_agent_name=agent_name,
+                agent_id=agent_id,
+                agent_name=agent_name,
                 model=model,
                 reasoning_effort=reasoning_effort,
-                session_metadata=metadata_payload,
+                metadata={"legacy_scope_key": scope_key, **metadata_payload},
                 now=now,
+                require_workdir=False,
             )
 
     def ensure_agent_session_id(
@@ -220,6 +227,7 @@ class SQLiteSessionsService:
         scope_key: str,
         agent_name: str,
         session_anchor: str,
+        workdir: str | None = None,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
     ) -> str | None:
@@ -237,18 +245,21 @@ class SQLiteSessionsService:
             )
             if row_id:
                 return row_id
-            return _insert_agent_session_row(
+            return create_agent_session_row(
                 conn,
                 scope_id=scope_id,
-                scope_key=str(scope_key),
-                agent_name=agent_name,
+                agent_backend=_agent_backend(str(agent_name)),
+                agent_variant=str(agent_name) or "default",
                 session_anchor=session_anchor,
                 native_session_id="",
-                vibe_agent_id=vibe_agent_id,
-                vibe_agent_name=vibe_agent_name,
+                workdir=workdir,
+                agent_id=vibe_agent_id,
+                agent_name=vibe_agent_name,
                 model=None,
                 reasoning_effort=None,
+                metadata={"legacy_scope_key": str(scope_key)},
                 now=now,
+                require_workdir=False,
             )
 
     def bind_agent_session(
@@ -260,6 +271,7 @@ class SQLiteSessionsService:
         native_session_id: Any,
         vibe_agent_id: str | None = None,
         vibe_agent_name: str | None = None,
+        workdir: str | None = None,
     ) -> str | None:
         """Bind a backend-native session id to the stable Vibe session row."""
         now = _utc_now_iso()
@@ -274,26 +286,40 @@ class SQLiteSessionsService:
                 session_anchor=session_anchor,
             )
             encoded_session_id = encode_session_value(native_session_id)
+            requested_workdir = str(workdir) if workdir is not None else None
             if not row_id:
-                return _insert_agent_session_row(
+                return create_agent_session_row(
                     conn,
                     scope_id=scope_id,
-                    scope_key=str(scope_key),
-                    agent_name=agent_name,
+                    agent_backend=_agent_backend(str(agent_name)),
+                    agent_variant=str(agent_name) or "default",
                     session_anchor=session_anchor,
                     native_session_id=encoded_session_id,
-                    vibe_agent_id=vibe_agent_id,
-                    vibe_agent_name=vibe_agent_name,
+                    workdir=requested_workdir,
+                    agent_id=vibe_agent_id,
+                    agent_name=vibe_agent_name,
                     model=None,
                     reasoning_effort=None,
+                    metadata={"legacy_scope_key": str(scope_key)},
                     now=now,
+                    require_workdir=False,
                 )
             values = {
-                "workdir": _workdir_from_anchor(str(session_anchor)),
                 "status": "active",
                 "updated_at": now,
                 "last_active_at": now,
             }
+            if requested_workdir:
+                current_workdir = conn.execute(
+                    select(agent_sessions.c.workdir).where(agent_sessions.c.id == row_id)
+                ).scalar_one_or_none()
+                if current_workdir and str(current_workdir) != str(requested_workdir):
+                    logger.warning(
+                        "Ignoring native bind workdir override; session workdir is authoritative session_id=%s current=%s requested=%s",
+                        row_id,
+                        current_workdir,
+                        requested_workdir,
+                    )
             # WRITE-ONCE: a row's native_session_id is bound exactly once and never
             # changed. Set it only when the row has none yet; never let a recapture,
             # fork, subagent, or any fallback overwrite an existing native (product
@@ -325,8 +351,6 @@ class SQLiteSessionsService:
             "updated_at": now,
             "last_active_at": now,
         }
-        if workdir is not None:
-            values["workdir"] = str(workdir) or None
         if vibe_agent_id is not None:
             values["agent_id"] = vibe_agent_id
         if vibe_agent_name is not None:
@@ -334,9 +358,21 @@ class SQLiteSessionsService:
         if vibe_agent_backend is not None:
             values["agent_backend"] = vibe_agent_backend or ""
             values["agent_variant"] = vibe_agent_backend or "default"
-        elif vibe_agent_name is not None:
-            values["agent_variant"] = vibe_agent_name or "default"
         with self.engine.begin() as conn:
+            if workdir is not None:
+                requested_workdir = str(workdir) or None
+                current = conn.execute(
+                    select(agent_sessions.c.workdir, agent_sessions.c.session_anchor)
+                    .where(agent_sessions.c.id == str(session_id))
+                ).mappings().first()
+                current_workdir = current.get("workdir") if current else None
+                if current_workdir and str(current_workdir) != str(requested_workdir):
+                    logger.warning(
+                        "Ignoring native bind workdir override; session workdir is authoritative session_id=%s current=%s requested=%s",
+                        session_id,
+                        current_workdir,
+                        requested_workdir,
+                    )
             # WRITE-ONCE: bind the native only if the row has none yet; never let a
             # recapture / fork / subagent overwrite an existing native (see
             # ``_set_native_once`` + bind_agent_session).
@@ -945,23 +981,6 @@ def resolve_scope_from_legacy_key(conn: Connection, scope_key: str, *, now: str)
     return upsert_scope(conn, platform, _infer_scope_type(platform, native_id), native_id, now=now)
 
 
-def encode_session_value(value: Any) -> str:
-    if isinstance(value, str):
-        return value
-    return JSON_VALUE_PREFIX + _json_dumps(value)
-
-
-def decode_session_value(value: Any) -> Any:
-    if not isinstance(value, str):
-        return value
-    if not value.startswith(JSON_VALUE_PREFIX):
-        return value
-    try:
-        return json.loads(value[len(JSON_VALUE_PREFIX) :])
-    except (TypeError, ValueError):
-        return value
-
-
 def _merge_processed_message_maps(
     primary: dict[str, dict[str, Any]],
     secondary: dict[str, dict[str, list[str]]],
@@ -1015,8 +1034,12 @@ def _infer_scope_type(platform: str, native_id: str) -> str:
     return "channel"
 
 
+_BACKEND_AGENT_NAMES = {"codex", "claude", "opencode"}
+_ROUTING_SENTINEL_VARIANTS = {"", "default", *_BACKEND_AGENT_NAMES}
+
+
 def _agent_backend(agent_name: str) -> str:
-    return agent_name if agent_name in {"codex", "claude", "opencode"} else "unknown"
+    return agent_name if agent_name in _BACKEND_AGENT_NAMES else "unknown"
 
 
 def _new_session_id(used: set[str]) -> str:
@@ -1034,12 +1057,28 @@ def _find_agent_session_row_id(
     agent_name: str,
     session_anchor: str,
 ) -> str | None:
-    return conn.execute(
+    requested = str(agent_name) or "default"
+    backend = _agent_backend(requested)
+    base_query = (
         select(agent_sessions.c.id)
         .where(agent_sessions.c.scope_id == scope_id)
-        .where(agent_sessions.c.agent_variant == (str(agent_name) or "default"))
         .where(agent_sessions.c.session_anchor == str(session_anchor))
-        .limit(1)
+    )
+    if backend != "unknown":
+        return conn.execute(
+            base_query.where(agent_sessions.c.agent_backend == backend)
+            .order_by(
+                case(
+                    (agent_sessions.c.agent_variant.notin_(sorted(_ROUTING_SENTINEL_VARIANTS)), 0),
+                    else_=1,
+                ),
+                agent_sessions.c.last_active_at.desc(),
+                agent_sessions.c.id.desc(),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+    return conn.execute(
+        base_query.where(agent_sessions.c.agent_variant == requested).limit(1)
     ).scalar_one_or_none()
 
 
@@ -1063,55 +1102,6 @@ def _find_row_id_for_scope_anchor(
         .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
         .limit(1)
     ).scalar_one_or_none()
-
-
-def _insert_agent_session_row(
-    conn: Connection,
-    *,
-    scope_id: str | None,
-    scope_key: str,
-    agent_name: str,
-    session_anchor: str,
-    native_session_id: Any,
-    vibe_agent_id: str | None = None,
-    vibe_agent_name: str | None = None,
-    model: str | None = None,
-    reasoning_effort: str | None = None,
-    session_metadata: dict[str, Any] | None = None,
-    now: str,
-) -> str:
-    used_session_ids = {
-        str(existing_id)
-        for existing_id in conn.execute(select(agent_sessions.c.id)).scalars()
-    }
-    row_id = _new_session_id(used_session_ids)
-    agent_variant = str(agent_name) or "default"
-    anchor = str(session_anchor)
-    metadata_payload = {"legacy_scope_key": scope_key}
-    if session_metadata:
-        metadata_payload.update(session_metadata)
-    conn.execute(
-        agent_sessions.insert().values(
-            id=row_id,
-            scope_id=scope_id,
-            agent_id=vibe_agent_id,
-            agent_name=vibe_agent_name,
-            agent_backend=_agent_backend(agent_variant),
-            agent_variant=agent_variant,
-            model=model,
-            reasoning_effort=reasoning_effort,
-            session_anchor=anchor,
-            workdir=_workdir_from_anchor(anchor),
-            native_session_id=encode_session_value(native_session_id),
-            title=None,
-            status="active",
-            metadata_json=_json_dumps(metadata_payload),
-            created_at=now,
-            updated_at=now,
-            last_active_at=now,
-        )
-    )
-    return row_id
 
 
 def _runtime_record_values(

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -15,13 +15,14 @@ Avibe scope_ids look like ``avibe::project::proj_<hex12>`` — see
 from __future__ import annotations
 
 import json
-import secrets
+import os
 from datetime import datetime, timezone
 from typing import Any, Optional
 
 from sqlalchemy import func, select, update
 from sqlalchemy.engine import Connection
 
+from storage.agent_session_rows import create_agent_session_row
 from storage.models import agent_sessions, scope_settings, scopes
 
 
@@ -35,14 +36,6 @@ _UNSET: Any = object()
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _new_session_id(conn: Connection) -> str:
-    used = {str(value) for value in conn.execute(select(agent_sessions.c.id)).scalars()}
-    while True:
-        candidate = "ses" + "".join(secrets.choice(SESSION_ID_ALPHABET) for _ in range(10))
-        if candidate not in used:
-            return candidate
 
 
 def _row_to_payload(row: dict[str, Any]) -> dict[str, Any]:
@@ -194,8 +187,6 @@ def create_session(
         raise LookupError(f"Scope not found: {scope_id}")
     if scope_row.get("enabled") == 0:
         raise PermissionError(f"Scope is archived: {scope_id}")
-    workdir = scope_row.get("workdir")
-
     # Inherit the project's default Agent when the caller didn't pin a backend.
     # The default lives in ``scope_settings`` (set via Project Settings); adopting
     # it at creation pins the backend from the first turn (a session's backend is
@@ -214,33 +205,26 @@ def create_session(
             reasoning_effort = scope_row.get("reasoning_effort")
 
     now = _utc_now_iso()
-    session_id = _new_session_id(conn)
-    variant = agent_variant or agent_name or "default"
+    variant = agent_variant or agent_backend or "default"
     metadata_payload = {"created_via": "workbench"}
     if metadata:
         metadata_payload.update(metadata)
 
-    conn.execute(
-        agent_sessions.insert().values(
-            id=session_id,
-            scope_id=scope_id,
-            agent_id=agent_id,
-            agent_name=agent_name,
-            agent_backend=agent_backend,
-            agent_variant=str(variant),
-            model=model,
-            reasoning_effort=reasoning_effort,
-            session_anchor=session_id,  # workbench sessions self-anchor; IM platforms use the parent message ts
-            workdir=workdir,
-            native_session_id="",
-            title=title.strip() if (title or "").strip() else None,
-            status="active",
-            agent_status="idle",
-            metadata_json=json.dumps(metadata_payload),
-            created_at=now,
-            updated_at=now,
-            last_active_at=now,
-        )
+    session_id = create_agent_session_row(
+        conn,
+        scope_id=scope_id,
+        agent_id=agent_id,
+        agent_name=agent_name,
+        agent_backend=agent_backend,
+        agent_variant=str(variant),
+        model=model,
+        reasoning_effort=reasoning_effort,
+        # Workbench sessions self-anchor; IM platforms use the parent message ts.
+        session_anchor=None,
+        workdir=scope_row.get("workdir") or os.getcwd(),
+        title=title,
+        metadata=metadata_payload,
+        now=now,
     )
     return get_session(conn, session_id)
 

--- a/tests/test_agent_run_target.py
+++ b/tests/test_agent_run_target.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from core.services import sessions as sessions_service
+from core.services.agent_run_target import resolve_agent_run_target
+from modules.im import MessageContext
+from storage.db import create_sqlite_engine
+from storage.importer import ensure_sqlite_state
+from storage.models import scope_settings
+from storage.sessions_service import SQLiteSessionsService
+from storage.settings_service import upsert_scope
+
+
+def _controller(tmp_path):
+    ensure_sqlite_state()
+    return SimpleNamespace(
+        sqlite_engine=create_sqlite_engine(),
+        primary_platform="slack",
+        config=SimpleNamespace(platform="slack", claude=SimpleNamespace(cwd=None)),
+    )
+
+
+def _seed_scope_settings(
+    conn,
+    scope_id: str,
+    *,
+    workdir: str,
+    agent_name: str | None = None,
+    agent_backend: str | None = None,
+    agent_variant: str | None = None,
+) -> None:
+    conn.execute(
+        scope_settings.insert().values(
+            scope_id=scope_id,
+            enabled=1,
+            role=None,
+            workdir=workdir,
+            agent_name=agent_name,
+            agent_backend=agent_backend,
+            agent_variant=agent_variant,
+            model=None,
+            reasoning_effort=None,
+            require_mention=None,
+            settings_version=1,
+            settings_json="{}",
+            created_at="2026-06-04T05:00:00Z",
+            updated_at="2026-06-04T05:00:00Z",
+        )
+    )
+
+
+def test_workbench_reserved_session_workdir_wins_over_process_cwd(tmp_path, monkeypatch):
+    project_workdir = tmp_path / "vibe-remote-project"
+    monkeypatch.chdir(tmp_path)
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_vibe_remote",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(project_workdir))
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="codex",
+            agent_name="codex",
+        )
+
+    ctx = MessageContext(
+        user_id="workbench",
+        channel_id=session["id"],
+        platform="avibe",
+        platform_specific={
+            "agent_session_id": session["id"],
+            "agent_session_target": {
+                "id": session["id"],
+                "workdir": session["workdir"],
+                "session_anchor": session["session_anchor"],
+            },
+        },
+    )
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id=session["id"],
+    )
+
+    assert target.workdir == str(project_workdir)
+    assert target.agent_session_id == session["id"]
+    assert ctx.platform_specific["agent_run_target"]["workdir"] == str(project_workdir)
+
+
+def test_im_channel_scope_workdir_creates_session_snapshot(tmp_path):
+    workdir = tmp_path / "channel"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(workdir))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.scope_id == "slack::channel::C123"
+    assert target.workdir == str(workdir)
+    assert target.session_anchor == "slack_171717.123"
+    assert target.agent_session_id
+    with controller.sqlite_engine.connect() as conn:
+        session = sessions_service.get_session(conn, target.agent_session_id)
+    assert session["workdir"] == str(workdir)
+
+
+def test_new_im_session_without_scope_settings_snapshots_default_cwd(tmp_path):
+    default_cwd = tmp_path / "default"
+    controller = _controller(tmp_path)
+    controller.config.claude.cwd = str(default_cwd)
+    with controller.sqlite_engine.begin() as conn:
+        upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.scope_id == "slack::channel::C123"
+    assert target.workdir == str(default_cwd)
+    assert target.agent_session_id
+    with controller.sqlite_engine.connect() as conn:
+        session = sessions_service.get_session(conn, target.agent_session_id)
+    assert session["workdir"] == str(default_cwd)
+    assert default_cwd.is_dir()
+
+
+def test_opencode_bind_reuses_scoped_agent_variant_session(tmp_path):
+    workdir = tmp_path / "channel"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(
+            conn,
+            scope_id,
+            workdir=str(workdir),
+            agent_name="Code Reviewer",
+            agent_backend="opencode",
+            agent_variant="reviewer",
+        )
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.agent_session_id is not None
+    assert target.agent_backend == "opencode"
+    assert target.agent_variant == "reviewer"
+
+    service = SQLiteSessionsService(Path(controller.sqlite_engine.url.database))
+    try:
+        bound_id = service.bind_agent_session(
+            scope_key="slack::channel::C123",
+            agent_name="opencode",
+            session_anchor="slack_171717.123",
+            native_session_id="oc-native",
+            workdir=str(workdir),
+        )
+    finally:
+        service.close()
+
+    assert bound_id == target.agent_session_id
+    with controller.sqlite_engine.connect() as conn:
+        rows = conn.exec_driver_sql(
+            "select agent_backend, agent_variant, native_session_id from agent_sessions"
+        ).all()
+    assert rows == [("opencode", "reviewer", "oc-native")]
+
+
+def test_readonly_cwd_lookup_does_not_create_session(tmp_path):
+    workdir = tmp_path / "channel"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(workdir))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    readonly = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+        create_session=False,
+    )
+
+    assert readonly.workdir == str(workdir)
+    assert readonly.agent_session_id is None
+    with controller.sqlite_engine.connect() as conn:
+        count = conn.exec_driver_sql("select count(*) from agent_sessions").scalar_one()
+    assert count == 0
+
+    persisted = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+    assert persisted.agent_session_id
+    with controller.sqlite_engine.connect() as conn:
+        count = conn.exec_driver_sql("select count(*) from agent_sessions").scalar_one()
+    assert count == 1
+
+
+def test_scope_workdir_is_created_before_return(tmp_path):
+    missing = tmp_path / "new-project"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(missing))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.workdir == str(missing)
+    assert missing.is_dir()
+
+
+def test_missing_explicit_session_target_is_rejected(tmp_path):
+    controller = _controller(tmp_path)
+    ctx = MessageContext(
+        user_id="U1",
+        channel_id="C123",
+        platform="slack",
+        platform_specific={
+            "agent_session_id": "ses_missing",
+            "agent_session_target": {
+                "id": "ses_missing",
+                "session_anchor": "slack_payload",
+                "workdir": str(tmp_path / "payload-project"),
+            },
+        },
+    )
+
+    import pytest
+
+    with pytest.raises(LookupError):
+        resolve_agent_run_target(
+            ctx,
+            controller=controller,
+            base_session_id="slack_payload",
+        )
+
+def test_uncreatable_scope_workdir_falls_back_to_config_default(tmp_path):
+    blocked_parent = tmp_path / "not-a-dir"
+    blocked_parent.write_text("blocked", encoding="utf-8")
+    default_cwd = tmp_path / "default-cwd"
+    controller = _controller(tmp_path)
+    controller.config.claude.cwd = str(default_cwd)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(blocked_parent / "child"))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.workdir == str(default_cwd)
+    assert default_cwd.is_dir()
+
+
+def test_existing_im_session_workdir_wins_over_scope_change(tmp_path):
+    original_workdir = tmp_path / "original"
+    changed_workdir = tmp_path / "changed"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(original_workdir))
+    service = SQLiteSessionsService(Path(controller.sqlite_engine.url.database))
+    try:
+        session_id = service.reserve_agent_session(
+            scope_key="slack::channel::C123",
+            agent_backend="codex",
+            session_anchor="slack_171717.123",
+            agent_name="codex",
+        )
+        assert session_id is not None
+        with controller.sqlite_engine.begin() as conn:
+            conn.execute(
+                scope_settings.update()
+                .where(scope_settings.c.scope_id == scope_id)
+                .values(workdir=str(changed_workdir))
+            )
+        service.bind_agent_session_by_id(session_id=session_id, native_session_id="codex-native")
+    finally:
+        service.close()
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.agent_session_id == session_id
+    assert target.workdir == str(original_workdir)
+
+
+def test_reserved_session_placeholder_workdir_falls_back_to_scope(tmp_path):
+    workdir = tmp_path / "channel"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(workdir))
+    service = SQLiteSessionsService(Path(controller.sqlite_engine.url.database))
+    try:
+        session_id = service.reserve_agent_session(
+            scope_key="slack::channel::C123",
+            agent_backend="codex",
+            session_anchor="slack_scheduled:/tmp/test",
+            agent_name="codex",
+        )
+        assert session_id is not None
+    finally:
+        service.close()
+
+    ctx = MessageContext(
+        user_id="U1",
+        channel_id="C123",
+        platform="slack",
+        platform_specific={
+            "agent_session_id": session_id,
+            "agent_session_target": {
+                "id": session_id,
+                "session_anchor": "slack_scheduled:/tmp/test",
+            },
+        },
+    )
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_scheduled:/tmp/test",
+    )
+
+    assert target.agent_session_id == session_id
+    assert target.session_anchor == "slack_scheduled:/tmp/test"
+    assert target.workdir == str(workdir)
+
+
+def test_new_im_session_bind_snapshots_scope_workdir(tmp_path):
+    original_workdir = tmp_path / "original"
+    changed_workdir = tmp_path / "changed"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(original_workdir))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+    first = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+    assert first.workdir == str(original_workdir)
+
+    session_id = first.agent_session_id
+    assert session_id is not None
+
+    with controller.sqlite_engine.begin() as conn:
+        conn.execute(
+            scope_settings.update()
+            .where(scope_settings.c.scope_id == scope_id)
+            .values(workdir=str(changed_workdir))
+        )
+
+    next_ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+    second = resolve_agent_run_target(
+        next_ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert second.agent_session_id == session_id
+    assert second.workdir == str(original_workdir)
+
+
+def test_native_bind_does_not_change_session_workdir(tmp_path):
+    original_workdir = tmp_path / "original"
+    requested_workdir = tmp_path / "requested"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(original_workdir))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+    target = resolve_agent_run_target(ctx, controller=controller, base_session_id="slack_171717.123")
+    assert target.agent_session_id is not None
+
+    service = SQLiteSessionsService(Path(controller.sqlite_engine.url.database))
+    try:
+        service.bind_agent_session_by_id(
+            session_id=target.agent_session_id,
+            native_session_id="native-1",
+            workdir=str(requested_workdir),
+        )
+    finally:
+        service.close()
+
+    with controller.sqlite_engine.connect() as conn:
+        session = sessions_service.get_session(conn, target.agent_session_id)
+    assert session["workdir"] == str(original_workdir)

--- a/tests/test_agent_silent_result.py
+++ b/tests/test_agent_silent_result.py
@@ -65,7 +65,7 @@ class AgentSessionIdContextTests(unittest.TestCase):
     def test_bind_agent_session_id_attaches_returned_public_session_id(self):
         controller = _StubController()
         controller.sessions = SimpleNamespace(
-            bind_agent_session=lambda session_key, agent_name, anchor, native_id: "sesk8m4q2p7x"
+            bind_agent_session=lambda session_key, agent_name, anchor, native_id, **kwargs: "sesk8m4q2p7x"
         )
         agent = _StubAgent(controller)
         context = MessageContext(
@@ -87,6 +87,90 @@ class AgentSessionIdContextTests(unittest.TestCase):
 
         self.assertEqual(session_id, "sesk8m4q2p7x")
         self.assertEqual(request.context.platform_specific["agent_session_id"], "sesk8m4q2p7x")
+
+    def test_bind_agent_session_id_passes_resolved_target_workdir(self):
+        calls = {}
+
+        def bind_agent_session(session_key, agent_name, anchor, native_id, **kwargs):
+            calls.update(
+                session_key=session_key,
+                agent_name=agent_name,
+                anchor=anchor,
+                native_id=native_id,
+                kwargs=kwargs,
+            )
+            return "sesk8m4q2p7x"
+
+        controller = _StubController()
+        controller.sessions = SimpleNamespace(bind_agent_session=bind_agent_session)
+        agent = _StubAgent(controller)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={
+                "platform": "slack",
+                "agent_run_target": {"workdir": "/repo/original"},
+            },
+        )
+        request = AgentRequest(
+            context=context,
+            message="hello",
+            working_path="/tmp/test",
+            base_session_id="slack_171717.123",
+            composite_session_id="slack_171717.123:/repo/original",
+            session_key="slack::C1",
+        )
+
+        session_id = agent.bind_agent_session_id(request, "thread-native-1")
+
+        self.assertEqual(session_id, "sesk8m4q2p7x")
+        self.assertEqual(calls["kwargs"]["workdir"], "/repo/original")
+
+    def test_target_subagent_native_is_stored_under_namespaced_anchor(self):
+        calls = {}
+
+        def bind_agent_session(session_key, agent_name, anchor, native_id, **kwargs):
+            calls.update(
+                session_key=session_key,
+                agent_name=agent_name,
+                anchor=anchor,
+                native_id=native_id,
+                kwargs=kwargs,
+            )
+            return "ses_subagent"
+
+        controller = _StubController()
+        controller.sessions = SimpleNamespace(
+            bind_agent_session=bind_agent_session,
+            bind_agent_session_by_id=lambda *a, **k: "ses_main",
+        )
+        agent = _StubAgent(controller)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="avibe",
+            platform_specific={
+                "agent_session_target": {"id": "ses_main"},
+                "routing_subagent": "reviewer",
+            },
+        )
+        request = AgentRequest(
+            context=context,
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="chat-1:reviewer",
+            composite_session_id="chat-1:reviewer:/tmp/work",
+            session_key="avibe::project::p1",
+            subagent_name="reviewer",
+        )
+
+        session_id = agent.bind_agent_session_id(request, "thread-native-reviewer")
+
+        self.assertEqual(session_id, "ses_subagent")
+        self.assertEqual(calls["anchor"], "chat-1:reviewer")
+        self.assertEqual(calls["native_id"], "thread-native-reviewer")
+        self.assertEqual(request.context.platform_specific["agent_session_id"], "ses_main")
 
 
 if __name__ == "__main__":

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -685,6 +685,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             "session-1",
             "slack::channel::C1",
             context,
+            working_path="/tmp/work",
         )
 
         self.assertEqual(session_id, "session-sdk")
@@ -697,6 +698,49 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
                     "agent_name": "claude",
                     "session_anchor": "session-1",
                     "native_session_id": "session-sdk",
+                    "working_path": "/tmp/work",
+                }
+            ],
+        )
+
+    async def test_init_message_persists_routing_subagent_native_under_namespaced_anchor(self):
+        controller = _StubController()
+        binds = []
+        controller.session_handler = SimpleNamespace(
+            bind_agent_session_id=lambda **kwargs: binds.append(kwargs) or "ses_subagent"
+        )
+        agent = ClaudeAgent(controller)
+        context = SimpleNamespace(
+            platform_specific={
+                "agent_session_target": {"id": "ses_main"},
+                "routing_subagent": "reviewer",
+            }
+        )
+        init_message = type(
+            "SystemMessage",
+            (),
+            {"subtype": "init", "data": {"session_id": "session-sdk-reviewer"}},
+        )()
+
+        session_id = agent._maybe_capture_session_id(
+            init_message,
+            "session-1:reviewer",
+            "avibe::project::p1",
+            context,
+            working_path="/tmp/work",
+        )
+
+        self.assertEqual(session_id, "session-sdk-reviewer")
+        self.assertEqual(context.platform_specific["agent_session_id"], "ses_main")
+        self.assertEqual(
+            binds,
+            [
+                {
+                    "session_key": "avibe::project::p1",
+                    "agent_name": "claude",
+                    "session_anchor": "session-1:reviewer",
+                    "native_session_id": "session-sdk-reviewer",
+                    "working_path": "/tmp/work",
                 }
             ],
         )
@@ -989,6 +1033,34 @@ class BindReservedWorkbenchSessionTests(unittest.TestCase):
                 "vibe_agent_backend": "codex",
             },
         )
+
+    def test_reserved_bind_uses_resolved_target_workdir(self):
+        calls = {}
+
+        def bind_by_id(agent_session_id, native_session_id, workdir=None, **kwargs):
+            calls.update(session_id=agent_session_id, native=native_session_id, workdir=workdir)
+            return agent_session_id
+
+        agent = _FakeBaseAgent(SimpleNamespace(bind_agent_session_by_id=bind_by_id))
+        ctx = self._ctx("ses_workbench")
+        ctx.platform_specific["agent_run_target"] = {
+            "workdir": "/Users/cyh/vibe-remote-project",
+        }
+
+        ret = agent._bind_reserved_workbench_session(ctx, "native-123", working_path="/tmp/test")
+
+        self.assertEqual(ret, "ses_workbench")
+        self.assertEqual(calls["workdir"], "/Users/cyh/vibe-remote-project")
+
+    def test_routing_subagent_does_not_bind_native_to_reserved_row(self):
+        agent = _FakeBaseAgent(SimpleNamespace(bind_agent_session_by_id=lambda *a, **k: "ses_wb"))
+        ctx = self._ctx("ses_wb")
+        ctx.platform_specific["routing_subagent"] = "reviewer"
+
+        ret = agent._bind_reserved_workbench_session(ctx, "native-subagent")
+
+        self.assertIsNone(ret)
+        self.assertEqual(ctx.platform_specific["agent_session_id"], "from_build")
 
     def test_im_turn_without_target_falls_through(self):
         agent = _FakeBaseAgent(SimpleNamespace(bind_agent_session_by_id=lambda *a, **k: None))

--- a/tests/test_controller_vibe_agent_routing.py
+++ b/tests/test_controller_vibe_agent_routing.py
@@ -88,3 +88,107 @@ def test_codex_overrides_prefer_scope_level_model_and_reasoning() -> None:
     )
 
     assert controller.get_codex_overrides(_context()) == (None, "gpt-5.5", "xhigh")
+
+
+def test_avibe_run_target_agent_does_not_read_im_routing() -> None:
+    controller = _StubController()
+    reviewer = SimpleNamespace(name="reviewer", backend="codex")
+    controller.primary_platform = "slack"
+    controller._get_settings_key = lambda context: context.channel_id
+    controller.agent_service = SimpleNamespace(agents={"codex": object(), "claude": object()})
+    controller.vibe_agent_store = SimpleNamespace(
+        require_enabled=lambda name: reviewer if name == "reviewer" else None,
+        get_builtin_default_agent_for_backend=lambda backend: None,
+        get_default_agent=lambda: SimpleNamespace(name="default", backend="claude"),
+    )
+    controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
+        get_channel_routing=lambda settings_key: (_ for _ in ()).throw(AssertionError("routing should not be read"))
+    )
+
+    ctx = MessageContext(
+        user_id="user-1",
+        channel_id="ses-1",
+        platform="avibe",
+        platform_specific={"agent_run_target": {"agent_name": "reviewer", "agent_backend": "codex"}},
+    )
+
+    assert controller.resolve_vibe_agent_for_context(ctx, required=False) is reviewer
+    assert controller.resolve_agent_for_context(ctx) == "codex"
+
+
+def test_avibe_run_target_overrides_do_not_read_im_routing() -> None:
+    controller = _StubController()
+    controller.primary_platform = "slack"
+    controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
+        get_channel_routing=lambda settings_key: (_ for _ in ()).throw(AssertionError("routing should not be read"))
+    )
+
+    ctx = MessageContext(
+        user_id="user-1",
+        channel_id="ses-1",
+        platform="avibe",
+        platform_specific={
+            "agent_run_target": {
+                "agent_backend": "codex",
+                "agent_variant": "reviewer",
+                "model": "gpt-5.5",
+                "reasoning_effort": "xhigh",
+            }
+        },
+    )
+
+    assert controller.get_codex_overrides(ctx) == ("reviewer", "gpt-5.5", "xhigh")
+    assert controller.get_opencode_overrides(ctx) == ("reviewer", "gpt-5.5", "xhigh")
+
+
+def test_avibe_run_target_overrides_ignore_backend_and_default_variants() -> None:
+    controller = _StubController()
+    controller.primary_platform = "slack"
+    controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
+        get_channel_routing=lambda settings_key: (_ for _ in ()).throw(AssertionError("routing should not be read"))
+    )
+
+    codex_ctx = MessageContext(
+        user_id="user-1",
+        channel_id="ses-1",
+        platform="avibe",
+        platform_specific={
+            "agent_run_target": {
+                "agent_backend": "codex",
+                "agent_variant": "codex",
+                "model": "gpt-5.5",
+                "reasoning_effort": "xhigh",
+            }
+        },
+    )
+    default_ctx = MessageContext(
+        user_id="user-1",
+        channel_id="ses-2",
+        platform="avibe",
+        platform_specific={
+            "agent_run_target": {
+                "agent_backend": "opencode",
+                "agent_variant": "default",
+                "model": "gpt-5.5",
+                "reasoning_effort": "xhigh",
+            }
+        },
+    )
+    agent_name_ctx = MessageContext(
+        user_id="user-1",
+        channel_id="ses-3",
+        platform="avibe",
+        platform_specific={
+            "agent_run_target": {
+                "agent_name": "contract-bot",
+                "agent_backend": "codex",
+                "agent_variant": "contract-bot",
+                "model": "gpt-5.5",
+                "reasoning_effort": "xhigh",
+            }
+        },
+    )
+
+    assert controller.get_codex_overrides(codex_ctx) == (None, "gpt-5.5", "xhigh")
+    assert controller.get_opencode_overrides(default_ctx) == (None, "gpt-5.5", "xhigh")
+    assert controller.get_codex_overrides(agent_name_ctx) == (None, "gpt-5.5", "xhigh")

--- a/tests/test_core_services_sessions.py
+++ b/tests/test_core_services_sessions.py
@@ -19,6 +19,7 @@ from core.services import sessions as sessions_service
 from storage import workbench_sessions_service as storage_sessions
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
+from storage.models import scope_settings
 from storage.settings_service import upsert_scope
 
 
@@ -29,14 +30,33 @@ def isolated_state(monkeypatch, tmp_path):
     yield tmp_path
 
 
-def _seed_avibe_scope(conn) -> str:
-    return upsert_scope(
+def _seed_avibe_scope(conn, workdir: str | None = None) -> str:
+    scope_id = upsert_scope(
         conn,
         platform="avibe",
         scope_type="project",
         native_id="proj_contract",
         now="2026-05-26T13:00:00Z",
     )
+    conn.execute(
+        scope_settings.insert().values(
+            scope_id=scope_id,
+            enabled=1,
+            role=None,
+            workdir=workdir or "/tmp/vibe-remote-contract-project",
+            agent_name=None,
+            agent_backend=None,
+            agent_variant=None,
+            model=None,
+            reasoning_effort=None,
+            require_mention=None,
+            settings_version=1,
+            settings_json="{}",
+            created_at="2026-05-26T13:00:00Z",
+            updated_at="2026-05-26T13:00:00Z",
+        )
+    )
+    return scope_id
 
 
 # --- Public surface ---------------------------------------------------
@@ -102,11 +122,13 @@ def test_create_and_get_round_trip(isolated_state):
     assert created["scope_id"] == scope_id
     assert created["agent_backend"] == "claude"
     assert created["agent_name"] == "contract-bot"
+    assert created["agent_variant"] == "claude"
 
     with engine.connect() as conn:
         fetched = sessions_service.get_session(conn, created["id"])
     assert fetched["id"] == created["id"]
     assert fetched["agent_name"] == "contract-bot"
+    assert fetched["agent_variant"] == "claude"
 
 
 def test_create_session_without_title_persists_null(isolated_state):

--- a/tests/test_harness_payload_enrichment.py
+++ b/tests/test_harness_payload_enrichment.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from storage import workbench_sessions_service
 from storage.background import SQLiteBackgroundTaskStore, compute_next_run_at
 from storage.db import create_sqlite_engine
-from storage.models import agent_sessions
+from storage.models import agent_sessions, scope_settings
 from storage.sessions_service import SQLiteSessionsService
 from storage.settings_service import upsert_scope
 
@@ -30,6 +30,27 @@ def _build_schema(db_path: Path) -> None:
     # SQLiteSessionsService builds + migrates the core schema (scopes,
     # agent_sessions, ...); the background store later adds run_definitions.
     SQLiteSessionsService(db_path).close()
+
+
+def _seed_project_workdir(conn, scope_id: str, workdir: Path) -> None:
+    conn.execute(
+        scope_settings.insert().values(
+            scope_id=scope_id,
+            enabled=1,
+            role=None,
+            workdir=str(workdir),
+            agent_name=None,
+            agent_backend=None,
+            agent_variant=None,
+            model=None,
+            reasoning_effort=None,
+            require_mention=None,
+            settings_version=1,
+            settings_json="{}",
+            created_at=NOW,
+            updated_at=NOW,
+        )
+    )
 
 
 def test_compute_next_run_at_handles_cron_disabled_and_past() -> None:
@@ -59,6 +80,7 @@ def test_scheduled_task_payload_resolves_workbench_session(tmp_path: Path) -> No
             scope_id = upsert_scope(
                 conn, platform="avibe", scope_type="project", native_id="proj_test", now=NOW
             )
+            _seed_project_workdir(conn, scope_id, tmp_path)
             session = workbench_sessions_service.create_session(
                 conn, scope_id=scope_id, agent_backend="claude", agent_name="default"
             )

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -37,6 +37,29 @@ from modules.im import MessageContext
 # ---------------------------------------------------------------------
 
 
+def _seed_project_workdir(conn, scope_id: str, workdir: Path, *, now: str = "2026-05-31T00:00:00Z") -> None:
+    from storage.models import scope_settings
+
+    conn.execute(
+        scope_settings.insert().values(
+            scope_id=scope_id,
+            enabled=1,
+            role=None,
+            workdir=str(workdir),
+            agent_name=None,
+            agent_backend=None,
+            agent_variant=None,
+            model=None,
+            reasoning_effort=None,
+            require_mention=None,
+            settings_version=1,
+            settings_json="{}",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+
 def _build_controller_double(handler=None):
     """A MagicMock controller whose ``message_handler.handle_user_message``
     can be patched to emit chunks via the real ``_stream_chunk`` hook.
@@ -256,6 +279,7 @@ def test_dispatch_forwards_session_routing_into_platform_specific(monkeypatch, t
             native_id="proj_routing",
             now="2026-05-26T13:00:00Z",
         )
+        _seed_project_workdir(conn, scope_id, tmp_path, now="2026-05-26T13:00:00Z")
         session = sessions_service.create_session(
             conn,
             scope_id=scope_id,
@@ -436,6 +460,7 @@ def test_dispatch_async_enqueues_during_busy_turn(monkeypatch, tmp_path):
         scope_id = upsert_scope(
             conn, platform="avibe", scope_type="project", native_id="proj_enq", now="2026-05-31T00:00:00Z"
         )
+        _seed_project_workdir(conn, scope_id, tmp_path)
         session = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="worker"
         )
@@ -511,6 +536,7 @@ def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):
         scope_id = upsert_scope(
             conn, platform="avibe", scope_type="project", native_id="proj_flush", now="2026-05-31T00:00:00Z"
         )
+        _seed_project_workdir(conn, scope_id, tmp_path)
         session = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="worker"
         )
@@ -568,6 +594,7 @@ def test_cancel_does_not_flush_queue(monkeypatch, tmp_path):
         scope_id = upsert_scope(
             conn, platform="avibe", scope_type="project", native_id="proj_noflush", now="2026-05-31T00:00:00Z"
         )
+        _seed_project_workdir(conn, scope_id, tmp_path)
         session = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="worker"
         )
@@ -766,6 +793,7 @@ def test_scheduled_gate_busy_enqueues_and_leaves_chat_turn_untouched(monkeypatch
         scope_id = upsert_scope(
             conn, platform="avibe", scope_type="project", native_id="proj_sched_busy", now="2026-05-31T00:00:00Z"
         )
+        _seed_project_workdir(conn, scope_id, tmp_path)
         session = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="worker"
         )
@@ -828,6 +856,7 @@ def test_scheduled_gate_cancel_stops_scheduled_run(monkeypatch, tmp_path):
         scope_id = upsert_scope(
             conn, platform="avibe", scope_type="project", native_id="proj_sched_cancel", now="2026-05-31T00:00:00Z"
         )
+        _seed_project_workdir(conn, scope_id, tmp_path)
         session = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="worker"
         )
@@ -887,6 +916,7 @@ def _seed_avibe_session_with_queue(queued):
         scope_id = upsert_scope(
             conn, platform="avibe", scope_type="project", native_id="proj_q84", now="2026-05-31T00:00:00Z"
         )
+        _seed_project_workdir(conn, scope_id, Path.cwd())
         session = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="worker"
         )

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -385,6 +385,135 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.vibe_agent_reasoning_effort, "max")
         self.assertEqual(request.vibe_agent_system_prompt, "Claude prompt")
 
+    async def test_avibe_target_variant_applies_to_claude_request(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+
+        def _resolve_claude_agent(context, override_agent_name=None, required=False):
+            return type(
+                "VibeAgent",
+                (),
+                {
+                    "id": "agent-claude",
+                    "name": "claude",
+                    "backend": "claude",
+                    "model": None,
+                    "reasoning_effort": None,
+                    "system_prompt": None,
+                },
+            )()
+
+        controller.resolve_vibe_agent_for_context = _resolve_claude_agent
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="workbench",
+            channel_id="ses-1",
+            message_id="m1",
+            platform="avibe",
+            platform_specific={
+                "agent_run_target": {
+                    "agent_backend": "claude",
+                    "agent_variant": "reviewer",
+                    "workdir": "/repo/work",
+                    "model": "claude-opus-4-8",
+                    "reasoning_effort": "max",
+                }
+            },
+        )
+
+        with patch("modules.agents.subagent_router.load_claude_subagent", return_value=None):
+            await handler.handle_user_message(context, "hello")
+
+        agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(agent_name, "claude")
+        self.assertEqual(request.subagent_name, "reviewer")
+        self.assertEqual(request.base_session_id, "base-session:reviewer")
+        self.assertEqual(request.vibe_agent_model, "claude-opus-4-8")
+        self.assertEqual(request.vibe_agent_reasoning_effort, "max")
+
+    async def test_avibe_backend_variant_does_not_namespace_normal_claude_session(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+
+        def _resolve_claude_agent(context, override_agent_name=None, required=False):
+            return type(
+                "VibeAgent",
+                (),
+                {
+                    "id": "agent-claude",
+                    "name": "claude",
+                    "backend": "claude",
+                    "model": None,
+                    "reasoning_effort": None,
+                    "system_prompt": None,
+                },
+            )()
+
+        controller.resolve_vibe_agent_for_context = _resolve_claude_agent
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="workbench",
+            channel_id="ses-1",
+            message_id="m1",
+            platform="avibe",
+            platform_specific={
+                "agent_run_target": {
+                    "agent_backend": "claude",
+                    "agent_variant": "claude",
+                    "workdir": "/repo/work",
+                }
+            },
+        )
+
+        await handler.handle_user_message(context, "hello")
+
+        agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(agent_name, "claude")
+        self.assertIsNone(request.subagent_name)
+        self.assertEqual(request.base_session_id, "base-session")
+
+    async def test_avibe_agent_name_variant_does_not_namespace_normal_claude_session(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+
+        def _resolve_claude_agent(context, override_agent_name=None, required=False):
+            return type(
+                "VibeAgent",
+                (),
+                {
+                    "id": "agent-claude-contract",
+                    "name": "contract-bot",
+                    "backend": "claude",
+                    "model": None,
+                    "reasoning_effort": None,
+                    "system_prompt": None,
+                },
+            )()
+
+        controller.resolve_vibe_agent_for_context = _resolve_claude_agent
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="workbench",
+            channel_id="ses-1",
+            message_id="m1",
+            platform="avibe",
+            platform_specific={
+                "agent_run_target": {
+                    "agent_name": "contract-bot",
+                    "agent_backend": "claude",
+                    "agent_variant": "contract-bot",
+                    "workdir": "/repo/work",
+                }
+            },
+        )
+
+        await handler.handle_user_message(context, "hello")
+
+        agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(agent_name, "claude")
+        self.assertIsNone(request.subagent_name)
+        self.assertEqual(request.base_session_id, "base-session")
+
     async def test_reply_anchor_alias_keeps_original_anchor_mapping(self):
         controller = _StubController(platform="discord", ack_mode="reaction", typing_result=True)
         handler = MessageHandler(controller)
@@ -596,6 +725,59 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(controller.agent_service.stop_requests), 1)
         self.assertEqual(controller.agent_service.requests, [])
+
+    async def test_target_routing_subagent_preserves_backend_runtime_key_for_stop(self):
+        from core.handlers.command_handlers import CommandHandlers
+
+        controller = _StubController(platform="avibe", ack_mode="reaction", typing_result=True)
+        controller.command_handler = CommandHandlers(controller)
+        handler = MessageHandler(controller)
+        session_handler = _StubSessionHandler()
+        controller.session_handler = session_handler
+        handler.set_session_handler(session_handler)
+        context = MessageContext(
+            user_id="workbench",
+            channel_id="ses_main",
+            message_id="m1",
+            platform="avibe",
+            platform_specific={
+                "agent_run_target": {
+                    "platform": "avibe",
+                    "settings_key": "ses_main",
+                    "session_key": "avibe::ses_main",
+                    "session_anchor": "ses_main",
+                    "workdir": "/tmp",
+                    "source": "human",
+                    "scope_id": "avibe::project::proj",
+                    "scope_type": "project",
+                    "agent_session_id": "ses_main",
+                    "agent_name": "reviewer-agent",
+                    "agent_backend": "claude",
+                    "agent_variant": "reviewer",
+                },
+                "agent_session_target": {
+                    "id": "ses_main",
+                    "session_anchor": "ses_main",
+                    "agent_name": "reviewer-agent",
+                    "agent_backend": "claude",
+                    "agent_variant": "reviewer",
+                },
+            },
+        )
+
+        await handler.handle_user_message(context, "hello")
+
+        agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(agent_name, "claude")
+        self.assertEqual(request.base_session_id, "base-session:reviewer")
+        self.assertEqual(context.platform_specific["backend_base_session_id"], "base-session:reviewer")
+
+        await controller.command_handler.handle_stop(context)
+
+        stop_agent, stop_request = controller.agent_service.stop_requests[0]
+        self.assertEqual(stop_agent, "claude")
+        self.assertEqual(stop_request.base_session_id, "base-session:reviewer")
+        self.assertEqual(stop_request.composite_session_id, "base-session:reviewer:/tmp")
 
     async def test_empty_fallback_uses_agent_message_not_control_text(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -49,6 +49,7 @@ def test_opencode_reused_session_attaches_agent_session_id() -> None:
         "opencode",
         "base-1",
         "oc-session-1",
+        workdir="/repo",
     )
 
 
@@ -136,6 +137,43 @@ def test_opencode_resumes_reserved_native_session_id() -> None:
         vibe_agent_name=None,
         vibe_agent_backend=None,
     )
+
+
+def test_opencode_subagent_uses_reserved_native_session_id() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value="oc-subagent"),
+        ensure_agent_session_id=Mock(return_value="ses-subagent"),
+        bind_agent_session=Mock(return_value="ses-subagent"),
+        bind_agent_session_by_id=Mock(return_value="ses-reserved"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(get_session=AsyncMock(return_value={"id": "oc-subagent"}))
+    request = _request()
+    request.subagent_name = "reviewer"
+    request.context.platform_specific = {
+        "agent_session_id": "ses-reserved",
+        "agent_session_target": {
+            "id": "ses-reserved",
+            "native_session_id": "oc-main",
+            "agent_backend": "opencode",
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-main"
+    sessions.get_agent_session_id.assert_not_called()
+    server.get_session.assert_awaited_once_with("oc-main", "/repo", raise_on_error=True)
+    sessions.bind_agent_session.assert_not_called()
+    sessions.bind_agent_session_by_id.assert_called_once_with(
+        "ses-reserved",
+        "oc-main",
+        workdir="/repo",
+        vibe_agent_id=None,
+        vibe_agent_name=None,
+        vibe_agent_backend=None,
+    )
+    assert request.context.platform_specific["agent_session_id"] == "ses-reserved"
 
 
 def test_opencode_fails_loud_when_existing_session_invalid() -> None:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -120,6 +120,7 @@ def test_resolve_session_id_target_accepts_avibe_project_session(tmp_path: Path)
     to the session via ``agent_session_target``); rejecting the project scope made
     scheduled tasks unusable on the workbench."""
     from storage.db import create_sqlite_engine
+    from storage.models import scope_settings
     from storage.sessions_service import SQLiteSessionsService
     from storage.settings_service import upsert_scope
     from storage import workbench_sessions_service
@@ -132,6 +133,24 @@ def test_resolve_session_id_target_accepts_avibe_project_session(tmp_path: Path)
         with engine.begin() as conn:
             scope_id = upsert_scope(
                 conn, platform="avibe", scope_type="project", native_id="proj_test", now="2026-05-31T00:00:00Z"
+            )
+            conn.execute(
+                scope_settings.insert().values(
+                    scope_id=scope_id,
+                    enabled=1,
+                    role=None,
+                    workdir=str(tmp_path),
+                    agent_name=None,
+                    agent_backend=None,
+                    agent_variant=None,
+                    model=None,
+                    reasoning_effort=None,
+                    require_mention=None,
+                    settings_version=1,
+                    settings_json="{}",
+                    created_at="2026-05-31T00:00:00Z",
+                    updated_at="2026-05-31T00:00:00Z",
+                )
             )
             session = workbench_sessions_service.create_session(
                 conn, scope_id=scope_id, agent_backend="claude", agent_name="default"
@@ -1606,6 +1625,7 @@ def _make_avibe_session(monkeypatch, tmp_path) -> str:
     from core.services import sessions as sessions_service
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
     from storage.settings_service import upsert_scope
 
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
@@ -1614,6 +1634,24 @@ def _make_avibe_session(monkeypatch, tmp_path) -> str:
     with engine.begin() as conn:
         scope_id = upsert_scope(
             conn, platform="avibe", scope_type="project", native_id="proj_gate_exec", now="2026-05-31T00:00:00Z"
+        )
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=str(tmp_path),
+                agent_name=None,
+                agent_backend=None,
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json="{}",
+                created_at="2026-05-31T00:00:00Z",
+                updated_at="2026-05-31T00:00:00Z",
+            )
         )
         session = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="worker"

--- a/tests/test_session_titles.py
+++ b/tests/test_session_titles.py
@@ -11,6 +11,7 @@ from core.services import sessions as sessions_service
 from storage import messages_service
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
+from storage.models import scope_settings
 from storage.settings_service import upsert_scope
 
 
@@ -28,6 +29,24 @@ def test_backfill_agent_session_title_uses_first_user_message_for_claude(monkeyp
             scope_type="project",
             native_id="proj_titles",
             now="2026-06-02T08:00:00Z",
+        )
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=str(tmp_path),
+                agent_name=None,
+                agent_backend=None,
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json="{}",
+                created_at="2026-06-02T08:00:00Z",
+                updated_at="2026-06-02T08:00:00Z",
+            )
         )
         session = sessions_service.create_session(conn, scope_id=scope_id, agent_backend="claude")
         messages_service.append(

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -11,6 +11,7 @@ from modules.sessions_facade import SessionsFacade
 from storage.db import create_sqlite_engine
 from storage.models import agent_sessions
 from storage.sessions_service import SQLiteSessionsService
+from storage.settings_service import upsert_scope
 
 
 def test_sessions_store_uses_sqlite_without_rewriting_legacy_json(tmp_path: Path) -> None:
@@ -206,16 +207,38 @@ def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: 
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
     try:
+        from storage.models import scope_settings
+
+        with service.engine.begin() as conn:
+            scope_id = upsert_scope(conn, "slack", "channel", "C123", now="2026-06-04T05:00:00Z")
+            conn.execute(
+                scope_settings.insert().values(
+                    scope_id=scope_id,
+                    enabled=1,
+                    role=None,
+                    workdir=str(tmp_path / "repo"),
+                    agent_name=None,
+                    agent_backend=None,
+                    agent_variant=None,
+                    model=None,
+                    reasoning_effort=None,
+                    require_mention=None,
+                    settings_version=1,
+                    settings_json="{}",
+                    created_at="2026-06-04T05:00:00Z",
+                    updated_at="2026-06-04T05:00:00Z",
+                )
+            )
         reserved_id = service.ensure_agent_session_id(
-            scope_key="slack::C123",
+            scope_key="slack::channel::C123",
             agent_name="codex",
             session_anchor="slack_171717.123",
         )
         assert reserved_id is not None
-        assert service.load_state().session_mappings["slack::C123"]["codex"]["slack_171717.123"] == ""
+        assert service.load_state().session_mappings["slack::channel::C123"]["codex"]["slack_171717.123"] == ""
 
         bound_id = service.bind_agent_session(
-            scope_key="slack::C123",
+            scope_key="slack::channel::C123",
             agent_name="codex",
             session_anchor="slack_171717.123",
             native_session_id="thread-native-1",
@@ -223,11 +246,14 @@ def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: 
 
         assert bound_id == reserved_id
         assert service.get_agent_session_row_id(
-            scope_key="slack::C123",
+            scope_key="slack::channel::C123",
             agent_name="codex",
             session_anchor="slack_171717.123",
         ) == reserved_id
-        assert service.load_state().session_mappings["slack::C123"]["codex"]["slack_171717.123"] == "thread-native-1"
+        assert (
+            service.load_state().session_mappings["slack::channel::C123"]["codex"]["slack_171717.123"]
+            == "thread-native-1"
+        )
     finally:
         service.close()
 
@@ -257,11 +283,133 @@ def test_sqlite_sessions_service_binds_reserved_agent_session_by_id(tmp_path: Pa
         row = service.get_agent_session_by_id(reserved_id)
         assert row is not None
         assert row["native_session_id"] == "oc-session-1"
-        assert row["workdir"] == "/repo"
+        assert row["workdir"] is None
         assert row["agent_id"] == "agent-codex"
         assert row["agent_name"] == "codex"
         assert row["agent_backend"] == "codex"
         assert row["agent_variant"] == "codex"
+    finally:
+        service.close()
+
+
+def test_bind_agent_session_by_id_does_not_overwrite_existing_workdir(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        reserved_id = service.reserve_agent_session(
+            scope_key="slack::channel::C123",
+            agent_backend="codex",
+            session_anchor="slack_private-agent",
+            agent_name="codex",
+        )
+        assert reserved_id is not None
+        with service.engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == reserved_id)
+                .values(workdir="/repo/right")
+            )
+        service.bind_agent_session_by_id(
+            session_id=reserved_id,
+            native_session_id="codex-native-1",
+            workdir="/repo/right",
+        )
+
+        service.bind_agent_session_by_id(
+            session_id=reserved_id,
+            native_session_id="codex-native-1",
+            workdir="/tmp/test",
+        )
+
+        row = service.get_agent_session_by_id(reserved_id)
+        assert row is not None
+        assert row["workdir"] == "/repo/right"
+    finally:
+        service.close()
+
+
+def test_bind_agent_session_by_id_does_not_use_anchor_suffix_as_workdir(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        reserved_id = service.reserve_agent_session(
+            scope_key="slack::channel::C123",
+            agent_backend="codex",
+            session_anchor="slack_scheduled:/tmp/test",
+            agent_name="codex",
+        )
+        assert reserved_id is not None
+        row = service.get_agent_session_by_id(reserved_id)
+        assert row is not None
+        assert row["workdir"] is None
+
+        service.bind_agent_session_by_id(
+            session_id=reserved_id,
+            native_session_id="codex-native-1",
+            workdir="/repo/right",
+        )
+
+        row = service.get_agent_session_by_id(reserved_id)
+        assert row is not None
+        assert row["workdir"] is None
+    finally:
+        service.close()
+
+
+def test_bind_agent_session_by_id_does_not_derive_variant_from_vibe_agent_name(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        reserved_id = service.reserve_agent_session(
+            scope_key="slack::channel::C123",
+            agent_backend="claude",
+            session_anchor="slack_private-agent",
+            agent_name="claude",
+        )
+        assert reserved_id is not None
+
+        service.bind_agent_session_by_id(
+            session_id=reserved_id,
+            native_session_id="native-1",
+            vibe_agent_name="contract-bot",
+        )
+
+        row = service.get_agent_session_by_id(reserved_id)
+        assert row is not None
+        assert row["agent_name"] == "contract-bot"
+        assert row["agent_backend"] == "claude"
+        assert row["agent_variant"] == "claude"
+    finally:
+        service.close()
+
+
+def test_bind_agent_session_snapshots_workdir_without_anchor_suffix(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        session_id = service.bind_agent_session(
+            scope_key="slack::channel::C123",
+            agent_name="codex",
+            session_anchor="slack_171717.123",
+            native_session_id="codex-native-1",
+            workdir="/repo/original",
+        )
+        assert session_id is not None
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["workdir"] == "/repo/original"
+
+        service.bind_agent_session(
+            scope_key="slack::channel::C123",
+            agent_name="codex",
+            session_anchor="slack_171717.123",
+            native_session_id="codex-native-1",
+            workdir="/repo/changed",
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["workdir"] == "/repo/original"
     finally:
         service.close()
 
@@ -393,6 +541,52 @@ def test_sessions_store_lifecycle_updates_in_memory_state(tmp_path: Path) -> Non
         store.close()
 
 
+def test_sessions_store_ensure_snapshots_workdir(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    try:
+        reserved_id = store.ensure_agent_session_id(
+            "slack::C123",
+            "codex",
+            "slack_171717.123",
+            workdir="/repo/original",
+        )
+        assert reserved_id is not None
+        with create_sqlite_engine(db_path=tmp_path / "vibe.sqlite").connect() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == reserved_id)).mappings().one()
+        assert row["workdir"] == "/repo/original"
+    finally:
+        store.close()
+
+
+def test_bind_agent_session_does_not_use_anchor_suffix_as_workdir(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        reserved_id = service.ensure_agent_session_id(
+            scope_key="slack::channel::C123",
+            agent_name="codex",
+            session_anchor="slack_171717.123:/tmp/test",
+        )
+        assert reserved_id is not None
+        assert service.get_agent_session_by_id(reserved_id)["workdir"] is None
+
+        bound_id = service.bind_agent_session(
+            scope_key="slack::channel::C123",
+            agent_name="codex",
+            session_anchor="slack_171717.123:/tmp/test",
+            native_session_id="codex-native-1",
+            workdir="/repo/original",
+        )
+
+        assert bound_id == reserved_id
+        row = service.get_agent_session_by_id(reserved_id)
+        assert row is not None
+        assert row["workdir"] is None
+    finally:
+        service.close()
+
+
 def test_sessions_store_bind_by_id_accepts_vibe_agent_backend(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     store = SessionsStore(sessions_path)
@@ -413,7 +607,7 @@ def test_sessions_store_bind_by_id_accepts_vibe_agent_backend(tmp_path: Path) ->
         with create_sqlite_engine(db_path=tmp_path / "vibe.sqlite").connect() as conn:
             row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == reserved_id)).mappings().one()
         assert row["native_session_id"] == "oc-session-1"
-        assert row["workdir"] == "/repo"
+        assert row["workdir"] is None
         assert row["agent_id"] == "agent-codex"
         assert row["agent_name"] == "codex"
         assert row["agent_backend"] == "codex"

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import pytest
 
 from storage.importer import ensure_sqlite_state
+from storage.models import scope_settings
 from storage.settings_service import upsert_scope
 from tests.ui_server_test_helpers import csrf_headers
 
@@ -46,6 +47,24 @@ def _make_session(tmp_path: Path) -> tuple[str, str]:
             scope_type="project",
             native_id="proj_stream",
             now="2026-05-26T13:00:00Z",
+        )
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=str(tmp_path),
+                agent_name=None,
+                agent_backend=None,
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json="{}",
+                created_at="2026-05-26T13:00:00Z",
+                updated_at="2026-05-26T13:00:00Z",
+            )
         )
         session = sessions_service.create_session(
             conn,

--- a/tests/test_workbench_session_defaults.py
+++ b/tests/test_workbench_session_defaults.py
@@ -13,6 +13,7 @@ import pytest
 from storage import projects_service, workbench_sessions_service
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
+from storage.settings_service import upsert_scope
 
 
 @pytest.fixture
@@ -86,3 +87,22 @@ def test_session_without_project_default_stays_agentless(engine, tmp_path):
     assert (session["agent_backend"] or "") == ""
     assert session["model"] is None
     assert session["reasoning_effort"] is None
+
+
+def test_folderless_project_session_snapshots_process_cwd(engine, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_folderless",
+            now="2026-06-04T05:00:00Z",
+        )
+        session = workbench_sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="",
+        )
+
+    assert session["workdir"] == str(tmp_path)


### PR DESCRIPTION
## Summary

- add a shared `AgentRunTarget` resolver for agent cwd/session/scope metadata
- make Workbench sessions resolve cwd, agent, backend, model, and reasoning from the bound `agent_sessions` row instead of IM channel settings
- prevent native-session binding from silently overwriting an existing session workdir
- document the target model and add regression coverage for Workbench and IM cwd resolution

## Root cause

Workbench dispatch already carried the selected project/session workdir, but `Controller.get_cwd()` ignored that runtime target and fell back through the legacy IM settings path. For Avibe contexts this could miss the project scope entirely and use the Vibe Remote process cwd, such as `/tmp/test`. Some backend bind paths then persisted that wrong `request.working_path` back onto the reserved session.

## Validation

- `PYTHONPATH=. python3 -m pytest tests/test_agent_run_target.py tests/test_sqlite_sessions_store.py tests/test_claude_agent_sessions.py::BindReservedWorkbenchSessionTests tests/test_controller_vibe_agent_routing.py tests/test_message_handler_typing.py tests/test_session_handler_base_id.py tests/test_opencode_session_manager.py -q`
- `python3 -m py_compile core/services/agent_run_target.py core/controller.py core/handlers/session_handler.py core/handlers/message_handler.py modules/agents/base.py storage/sessions_service.py`
- `git diff --check`
