### PR TITLE
fix(workbench): resync inbox + chat SSE streams on resume (mobile PWA)

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -114,6 +114,10 @@ export const ChatPage: React.FC = () => {
   // ``working`` = a turn is in flight for this session (from our send, or any
   // other origin we observe). Drives the thinking bubble + the Send→Stop swap.
   const [working, setWorking] = useState(false);
+  // Bumped on resume (tab visible again / network back) to force the transcript
+  // subscription effect to reopen a possibly-dead SSE stream — see the
+  // visibility effect below.
+  const [connectionEpoch, setConnectionEpoch] = useState(0);
   // Lifecycle guards for ``syncTurnState``'s clear-on-idle (Codex P2):
   //  - ``turnEpochRef`` bumps every time a turn STARTS (local send / send-now /
   //    observed ``turn.start``). syncTurnState captures it before its request and
@@ -418,7 +422,7 @@ export const ChatPage: React.FC = () => {
       },
     });
     return disconnect;
-  }, [api, sessionId, appendMessage, reconcile, refreshQueue, syncTurnState, markWorking]);
+  }, [api, sessionId, appendMessage, reconcile, refreshQueue, syncTurnState, markWorking, connectionEpoch]);
 
   // Mobile tabs (the common case for IM users) get backgrounded mid-turn; the
   // SSE feed can be suspended without a clean reconnect, dropping the reply.
@@ -433,9 +437,26 @@ export const ChatPage: React.FC = () => {
       void reconcile();
       void refreshQueue();
       void syncTurnState();
+      // The immediate reconcile above only catches up to NOW; if the socket
+      // itself is dead (iOS can leave EventSource in a zombie OPEN state that
+      // never auto-reconnects), it would be the last update until the next
+      // resume. Reopen the stream so live events keep flowing while the page
+      // stays foregrounded — the reopen's onConnected re-runs reconcile
+      // (idempotent).
+      setConnectionEpoch((e) => e + 1);
     };
     document.addEventListener('visibilitychange', onVisible);
-    return () => document.removeEventListener('visibilitychange', onVisible);
+    // Network flaps (mobile handoff, sleep/wake) can kill the stream without a
+    // visibility change; reopen it on ``online`` too (only while foregrounded —
+    // a background resume is handled by visibilitychange).
+    const onOnline = () => {
+      if (document.visibilityState === 'visible') setConnectionEpoch((e) => e + 1);
+    };
+    window.addEventListener('online', onOnline);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('online', onOnline);
+    };
   }, [sessionId, reconcile, refreshQueue, syncTurnState]);
 
   // Reconcile (don't kill) while a turn is in flight: there is no turn-duration

--- a/ui/src/context/WorkbenchInboxContext.tsx
+++ b/ui/src/context/WorkbenchInboxContext.tsx
@@ -83,6 +83,12 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // window without depending on (and re-identifying with) ``inboxSessions``.
   const inboxSessionsRef = useRef<InboxSession[]>([]);
   inboxSessionsRef.current = inboxSessions;
+  // Only the very first mount does the destructive first-page refresh; every
+  // later effect rerun — an ``api`` identity change (e.g. a locale switch, which
+  // ApiProvider documents as rebuilding the value) or a resume-driven
+  // connectionEpoch bump — reconciles the loaded window instead, so a non-resume
+  // rerun never collapses a multi-page feed back to page one.
+  const initialFetched = useRef(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -128,9 +134,9 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // visibility/online resume can fire after the user has loaded several pages;
   // a plain first-page refresh() would drop every row past page 1 and reset the
   // cursor. Re-read enough rows to cover what's loaded (capped at the API's
-  // 100-row max), merge in place so existing rows update and any sessions that
-  // arrived during the gap surface at top, and leave nextCursor untouched. No
-  // loading flag — the user already has content; this is a silent catch-up.
+  // 100-row max) and merge in place so existing rows update and any sessions
+  // that arrived during the gap surface at top. No loading flag — the user
+  // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
     const limit = Math.min(Math.max(inboxSessionsRef.current.length, PAGE_SIZE), 100);
     try {
@@ -145,19 +151,31 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       });
       // Whole-account unread map (not paginated) — always authoritative.
       setUnreadBySession(result.unread_by_session ?? {});
+      // Cursor: keep the existing one when it's non-null (we only re-read the
+      // already-loaded window, we didn't advance pagination). But if the feed
+      // was previously exhausted (null cursor) and the gap pushed it past the
+      // reconciled window, adopt the new cursor so "Load more" reappears for the
+      // overflow rows instead of staying hidden.
+      setNextCursor((prev) => prev ?? result.next_cursor);
     } catch (err) {
       console.error('[inbox] reconcile failed', err);
     }
   }, [api]);
 
   useEffect(() => {
-    // Mount (epoch 0) does a full first-page load; every resume-driven reconnect
-    // (the connectionEpoch bump) reconciles the already-loaded window instead —
-    // see reconcile. The broker fans events out live with no replay (sse_broker
-    // .py ``/api/events``), so anything published while the socket was down is
-    // gone from the stream and must be re-read. Plain HTTP, independent of
-    // whether the SSE stream itself comes back up.
-    void (connectionEpoch === 0 ? refresh() : reconcile());
+    // First mount loads page one; every later rerun reconciles the loaded window
+    // instead — whether the rerun is a resume-driven connectionEpoch bump or just
+    // an ``api`` identity change (e.g. a locale switch rebuilding the value) — so
+    // a non-resume rerun never collapses a multi-page feed back to page one. The
+    // broker fans events out live with no replay (sse_broker.py ``/api/events``),
+    // so anything missed while the socket was down must be re-read; plain HTTP,
+    // independent of whether the SSE stream itself comes back up.
+    if (!initialFetched.current) {
+      initialFetched.current = true;
+      void refresh();
+    } else {
+      void reconcile();
+    }
     const disconnect = api.connectWorkbenchEvents({
       onInboxSessionUpdated: (row) => {
         setInboxSessions((prev) => upsertSession(prev, row));

--- a/ui/src/context/WorkbenchInboxContext.tsx
+++ b/ui/src/context/WorkbenchInboxContext.tsx
@@ -151,12 +151,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       });
       // Whole-account unread map (not paginated) — always authoritative.
       setUnreadBySession(result.unread_by_session ?? {});
-      // Cursor: keep the existing one when it's non-null (we only re-read the
-      // already-loaded window, we didn't advance pagination). But if the feed
-      // was previously exhausted (null cursor) and the gap pushed it past the
-      // reconciled window, adopt the new cursor so "Load more" reappears for the
-      // overflow rows instead of staying hidden.
-      setNextCursor((prev) => prev ?? result.next_cursor);
+      // Deliberately DON'T touch nextCursor. Gap arrivals carry the newest
+      // activity, so they come back at the TOP of this read and merge into the
+      // feed above — never "beyond" the cursor. The cursor marks the oldest-
+      // loaded boundary, which re-reading the loaded window doesn't advance.
+      // Adopting result.next_cursor would misfire on keyset's "len == limit ⇒
+      // maybe more" signal (and always misfires once loaded > the 100-row cap),
+      // resurrecting a "Load more" that just refetches already-loaded pages.
     } catch (err) {
       console.error('[inbox] reconcile failed', err);
     }

--- a/ui/src/context/WorkbenchInboxContext.tsx
+++ b/ui/src/context/WorkbenchInboxContext.tsx
@@ -138,7 +138,10 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
-    const limit = Math.min(Math.max(inboxSessionsRef.current.length, PAGE_SIZE), 100);
+    // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
+    // afterward whether the read overlapped what we already had (cursor note).
+    const loadedIds = new Set(inboxSessionsRef.current.map((s) => s.session_id));
+    const limit = Math.min(Math.max(loadedIds.size, PAGE_SIZE), 100);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit });
       setInboxSessions((prev) => {
@@ -151,13 +154,17 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       });
       // Whole-account unread map (not paginated) — always authoritative.
       setUnreadBySession(result.unread_by_session ?? {});
-      // Deliberately DON'T touch nextCursor. Gap arrivals carry the newest
-      // activity, so they come back at the TOP of this read and merge into the
-      // feed above — never "beyond" the cursor. The cursor marks the oldest-
-      // loaded boundary, which re-reading the loaded window doesn't advance.
-      // Adopting result.next_cursor would misfire on keyset's "len == limit ⇒
-      // maybe more" signal (and always misfires once loaded > the 100-row cap),
-      // resurrecting a "Load more" that just refetches already-loaded pages.
+      // Cursor: the loaded feed is always a contiguous run from the top, and
+      // this reads the newest `limit` rows. If the read shares ANY row with what
+      // we had (overlap), the two runs are contiguous — no gap below the read —
+      // so the existing cursor still marks the boundary; leave it untouched
+      // (this is what stops a >100-row exhausted feed from resurrecting a
+      // duplicate-page "Load more"). If the read is ENTIRELY new rows (no
+      // overlap), gap arrivals outnumbered the window and there are unseen rows
+      // between this read and the old feed — adopt result.next_cursor so "Load
+      // more" can page through them (loadMore dedupes the overlap).
+      const overlap = result.sessions.some((s) => loadedIds.has(s.session_id));
+      if (!overlap) setNextCursor(result.next_cursor);
     } catch (err) {
       console.error('[inbox] reconcile failed', err);
     }

--- a/ui/src/context/WorkbenchInboxContext.tsx
+++ b/ui/src/context/WorkbenchInboxContext.tsx
@@ -56,10 +56,12 @@ const appendPage = (prev: InboxSession[], page: InboxSession[]): InboxSession[] 
 
 /** Provider that owns the Inbox state shared across WorkbenchSidebar + InboxPage.
  *
- *  Connects to ``/api/events`` once on mount and updates the per-session feed in
- *  place: ``inbox.session.updated`` upserts + re-sorts a card (the realtime
- *  "bump to top"), ``inbox.unread.changed`` refreshes the unread map after a
- *  mark-read elsewhere. The provider value is memoized per
+ *  Connects to ``/api/events`` (reopening the stream on resume — see the resync
+ *  effect) and updates the per-session feed in place: ``inbox.session.updated``
+ *  upserts + re-sorts a card (the realtime "bump to top"), ``inbox.unread.changed``
+ *  refreshes the unread map after a mark-read elsewhere. Each (re)connect also
+ *  does a full ``refresh()`` so events missed while the socket was down (the
+ *  broker has no replay) are recovered. The provider value is memoized per
  *  [[feedback_react_context_value_memoize]] so consumer ``useEffect`` hooks that
  *  depend on context functions don't re-fire on every parent render. */
 export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) => {
@@ -69,12 +71,18 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  // Avoid duplicate refresh-on-first-mount during StrictMode double-invoke.
-  const initialFetched = useRef(false);
+  // Bumped on resume (tab visible again / network back) to force the SSE
+  // connection effect to tear down the (possibly dead) stream and reopen it.
+  // See the resync effect below for why a frozen mobile PWA needs this.
+  const [connectionEpoch, setConnectionEpoch] = useState(0);
   // Mirror the cursor into a ref so ``loadMore`` can read the latest value
   // without re-creating its identity (and the context value) on every page.
   const cursorRef = useRef<string | null>(null);
   cursorRef.current = nextCursor;
+  // Mirror the loaded feed so ``reconcile`` can size its re-read to the current
+  // window without depending on (and re-identifying with) ``inboxSessions``.
+  const inboxSessionsRef = useRef<InboxSession[]>([]);
+  inboxSessionsRef.current = inboxSessions;
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -116,11 +124,40 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     [api],
   );
 
-  useEffect(() => {
-    if (!initialFetched.current) {
-      initialFetched.current = true;
-      refresh();
+  // Resume reconcile: re-read the feed WITHOUT collapsing pagination. A
+  // visibility/online resume can fire after the user has loaded several pages;
+  // a plain first-page refresh() would drop every row past page 1 and reset the
+  // cursor. Re-read enough rows to cover what's loaded (capped at the API's
+  // 100-row max), merge in place so existing rows update and any sessions that
+  // arrived during the gap surface at top, and leave nextCursor untouched. No
+  // loading flag — the user already has content; this is a silent catch-up.
+  const reconcile = useCallback(async () => {
+    const limit = Math.min(Math.max(inboxSessionsRef.current.length, PAGE_SIZE), 100);
+    try {
+      const result = await api.listInbox({ platform: 'avibe', limit });
+      setInboxSessions((prev) => {
+        const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
+        const merged = prev.map((s) => incoming.get(s.session_id) ?? s);
+        const have = new Set(prev.map((s) => s.session_id));
+        for (const s of result.sessions) if (!have.has(s.session_id)) merged.push(s);
+        merged.sort(byActivityDesc);
+        return merged;
+      });
+      // Whole-account unread map (not paginated) — always authoritative.
+      setUnreadBySession(result.unread_by_session ?? {});
+    } catch (err) {
+      console.error('[inbox] reconcile failed', err);
     }
+  }, [api]);
+
+  useEffect(() => {
+    // Mount (epoch 0) does a full first-page load; every resume-driven reconnect
+    // (the connectionEpoch bump) reconciles the already-loaded window instead —
+    // see reconcile. The broker fans events out live with no replay (sse_broker
+    // .py ``/api/events``), so anything published while the socket was down is
+    // gone from the stream and must be re-read. Plain HTTP, independent of
+    // whether the SSE stream itself comes back up.
+    void (connectionEpoch === 0 ? refresh() : reconcile());
     const disconnect = api.connectWorkbenchEvents({
       onInboxSessionUpdated: (row) => {
         setInboxSessions((prev) => upsertSession(prev, row));
@@ -138,13 +175,37 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         }
       },
       onError: (err) => {
-        // Browser EventSource auto-reconnects; keep this a log, not a crash,
-        // so the workbench stays usable while the dev proxy restarts / etc.
+        // Browser EventSource auto-reconnects on transient drops; the
+        // visibility/online resync below covers what it can't — a frozen mobile
+        // tab whose socket died without ever firing a clean error. Keep this a
+        // log, not a crash, so the workbench stays usable.
         console.debug('[inbox] sse error', err);
       },
     });
     return disconnect;
-  }, [api, refresh]);
+  }, [api, refresh, reconcile, connectionEpoch]);
+
+  // Recover after the OS suspended us. A backgrounded mobile PWA has its page
+  // frozen and its SSE socket dropped, and the broker never replays the gap; on
+  // iOS the stream frequently does NOT auto-reconnect (it can sit in a zombie
+  // OPEN state that never fires onerror), so neither the live handlers nor the
+  // refresh above re-fire on their own. Bump the connection epoch when the tab
+  // becomes visible again or the network returns: the effect above tears the
+  // dead stream down, reopens it, and re-reads the feed + unread map — so the
+  // inbox cards and sidebar dots catch up to messages that arrived while away.
+  // StatusContext (runtime status) and ChatPage (transcript) already resync on
+  // visibility; the inbox feed was the surface missing it.
+  useEffect(() => {
+    const resync = () => {
+      if (document.visibilityState === 'visible') setConnectionEpoch((e) => e + 1);
+    };
+    document.addEventListener('visibilitychange', resync);
+    window.addEventListener('online', resync);
+    return () => {
+      document.removeEventListener('visibilitychange', resync);
+      window.removeEventListener('online', resync);
+    };
+  }, []);
 
   const totalUnread = useMemo(
     () => Object.values(unreadBySession).reduce((sum, n) => sum + (n || 0), 0),


### PR DESCRIPTION
## What

Mobile PWA fix: when the app is backgrounded, the OS freezes the page and tears down the SSE (`EventSource` → `GET /api/events`) connection. The broker (`vibe/sse_broker.py`) fans events out **live with no replay**, so anything published during the gap is lost; and on iOS `EventSource` frequently does **not** auto-reconnect (it can sit in a zombie `OPEN` state that never fires `onerror`). Result: reopening the app showed a **stale inbox feed and missing unread dots**, and a chat left open stopped receiving live replies.

## Changed capability

**Resume-driven SSE reconnect + reconcile** for the two realtime surfaces that lacked it:

- **Inbox feed + sidebar/nav unread dots** (`WorkbenchInboxContext`): on `visibilitychange→visible` / `online`, bump a `connectionEpoch` that tears down the (possibly dead) stream, reopens it, and reconciles. The resume path uses a **windowed reconcile** that preserves already-loaded pages (re-reads up to the loaded row count, capped at the API's 100 max, merges in place, leaves the keyset cursor untouched) — so a resume after "load more" doesn't collapse the feed back to page one. The unread map is whole-account (not paginated), so it stays authoritative.
- **Chat transcript** (`ChatPage`): it already reconciled on visibility but never rebuilt the socket; added the same epoch-bump reopen on visible/online alongside the existing immediate reconcile (the reopen's `onConnected` re-runs reconcile — idempotent).

`StatusContext` (runtime status) already resynced on visibility; this brings the inbox + chat streams in line.

## Evidence layers

- **Unit**: none — the UI has no test harness for context providers (no `*.test.tsx` exists; not introducing one per repo convention).
- **Contract / Scenario**: N/A — no scenario catalog covers the workbench realtime UI.
- **Build**: `npm run build` (tsc + vite) passes.
- **Review**: local `codex review` — PASS (one P2 about pagination loss on reconnect, fixed here via the windowed reconcile).
- **Residual manual checks** (need a device): background the iOS PWA, send a message from another client, reopen → inbox card + unread dot appear; same with a chat left open; verify "load more" pages survive a resume.

## Risk

Frontend-only, additive: existing live handlers + mount load are unchanged; resume adds a reconnect + reconcile. Worst case on a >100-row loaded feed is rows past 100 keep slightly stale preview/activity until their next live update (unread is always corrected).
