### PR TITLE
fix(ui): route PWA notification clicks to chats

### DIFF
--- a/ui/public/push-sw.js
+++ b/ui/public/push-sw.js
@@ -31,11 +31,17 @@ self.addEventListener('notificationclick', (event) => {
     type: 'vibe.notification-click',
     url: targetUrl.pathname + targetUrl.search + targetUrl.hash,
   };
+  const appShellPaths = ['/inbox', '/agents', '/skills', '/harness', '/vaults', '/projects', '/more', '/chat', '/admin'];
+  const isAppShellClient = (url) => {
+    if (url.origin !== self.location.origin) return false;
+    if (url.pathname === '/') return true;
+    return appShellPaths.some((path) => url.pathname === path || url.pathname.startsWith(`${path}/`));
+  };
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
       for (const client of clients) {
-        if ('focus' in client && new URL(client.url).origin === self.location.origin) {
+        if ('focus' in client && isAppShellClient(new URL(client.url))) {
           return client.focus().then((focusedClient) => {
             (focusedClient || client).postMessage(message);
             return focusedClient || client;

--- a/ui/public/push-sw.js
+++ b/ui/public/push-sw.js
@@ -22,17 +22,28 @@ self.addEventListener('push', (event) => {
 
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const targetUrl = new URL(event.notification.data?.url || '/inbox', self.location.origin).href;
+  const targetUrl = new URL(event.notification.data?.url || '/inbox', self.location.origin);
+  if (targetUrl.origin !== self.location.origin) {
+    targetUrl.href = new URL('/inbox', self.location.origin).href;
+  }
+  const href = targetUrl.href;
+  const message = {
+    type: 'vibe.notification-click',
+    url: targetUrl.pathname + targetUrl.search + targetUrl.hash,
+  };
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
       for (const client of clients) {
         if ('focus' in client && new URL(client.url).origin === self.location.origin) {
-          return client.navigate(targetUrl).then((navigatedClient) => (navigatedClient || client).focus());
+          return client.focus().then((focusedClient) => {
+            (focusedClient || client).postMessage(message);
+            return focusedClient || client;
+          });
         }
       }
       if (self.clients.openWindow) {
-        return self.clients.openWindow(targetUrl);
+        return self.clients.openWindow(href);
       }
       return undefined;
     }),

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { Wizard } from './components/Wizard';
 import { AppShell } from './components/AppShell';
 import { Workbench } from './components/Workbench';
@@ -111,6 +111,37 @@ const AccessBlocked = ({ code }: { code: string | null }) => {
 
 type GuardStatus = 'loading' | 'ready' | 'needs-setup' | 'remote-login-required' | 'access-blocked';
 
+const notificationClickPath = (value: unknown): string | null => {
+    if (typeof value !== 'string' || !value.startsWith('/')) return null;
+    try {
+        const parsed = new URL(value, window.location.origin);
+        if (parsed.origin !== window.location.origin) return null;
+        return parsed.pathname + parsed.search + parsed.hash;
+    } catch {
+        return null;
+    }
+};
+
+const WebPushNotificationNavigator = () => {
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (!('serviceWorker' in navigator)) return;
+
+        const onMessage = (event: MessageEvent) => {
+            const data = event.data;
+            if (!data || typeof data !== 'object' || data.type !== 'vibe.notification-click') return;
+            const path = notificationClickPath(data.url);
+            if (path) navigate(path);
+        };
+
+        navigator.serviceWorker.addEventListener('message', onMessage);
+        return () => navigator.serviceWorker.removeEventListener('message', onMessage);
+    }, [navigate]);
+
+    return null;
+};
+
 // Wrapper to check if setup is needed.
 //
 // Validation is global (auth session + setup state), so we only run it
@@ -215,6 +246,8 @@ const AuthGuard = ({ children }: { children: ReactNode }) => {
 
 function AppRoutes() {
   return (
+    <>
+    <WebPushNotificationNavigator />
     <Routes>
       <Route element={<AuthGuard><AppShell /></AuthGuard>}>
         <Route path="/setup" element={<Wizard />} />
@@ -281,6 +314,7 @@ function AppRoutes() {
         <Route path="/doctor/logs" element={<Navigate to="/admin/logs" replace />} />
       </Route>
     </Routes>
+    </>
   );
 }
 


### PR DESCRIPTION
## What
- Route Web Push notification clicks through the active PWA window with a service-worker message.
- Keep `openWindow` as the fallback when no Vibe Remote window is open.
- Validate notification click targets as same-origin relative paths before React Router navigation.

## Why
Real inbox pushes already carry `/chat/<session_id>`, but relying only on `WindowClient.navigate()` is not reliable enough for iOS PWA resume behavior. Posting the target route to the focused app lets React Router open the matching chat page after the app is foregrounded.

## Validation
- `npm run build` from `ui/`

## Risk
Low. The change only affects notification click handling; notification delivery and payload generation are unchanged.
