### PR TITLE
fix(workbench): live-reorder project sessions

### DIFF
--- a/ui/src/context/WorkbenchProjectsContext.tsx
+++ b/ui/src/context/WorkbenchProjectsContext.tsx
@@ -126,6 +126,19 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   // Projects with an in-flight session fetch — serialises first-page / load-more /
   // reconcile per project so they can't race or truncate an append.
   const inFlightRef = useRef<Set<string>>(new Set());
+  const pendingReconcileRef = useRef<Map<string, number>>(new Map());
+
+  const queueReconcile = useCallback((projectId: string, minCount = 0) => {
+    const pending = pendingReconcileRef.current.get(projectId) ?? 0;
+    pendingReconcileRef.current.set(projectId, Math.max(pending, minCount));
+  }, []);
+
+  const takePendingReconcile = useCallback((projectId: string): number | null => {
+    const pending = pendingReconcileRef.current.get(projectId);
+    if (pending === undefined) return null;
+    pendingReconcileRef.current.delete(projectId);
+    return pending;
+  }, []);
 
   const fetchProjects = useCallback(async () => {
     try {
@@ -142,6 +155,55 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   useEffect(() => {
     void fetchProjects();
   }, [fetchProjects]);
+
+  // (Re)connect reconcile: rebuild a project's ALREADY-paged-in window (not just
+  // page 1) so a transient SSE reconnect / controller restart doesn't truncate an
+  // expanded project back to the first page. Pages in chunks because the server
+  // clamps the limit to 200 — a single large request would silently truncate
+  // windows >200 rows. Silent (no loading flag) so visible rows don't flicker.
+  const reconcileSessions = useCallback(
+    async (projectId: string, opts?: { minCount?: number }) => {
+      if (inFlightRef.current.has(projectId)) {
+        queueReconcile(projectId, opts?.minCount ?? 0);
+        return;
+      }
+      let minCount = opts?.minCount ?? 0;
+      while (true) {
+        const targetCount = Math.max(sessionsRef.current[projectId]?.sessions?.length ?? 0, minCount);
+        if (targetCount === 0) return; // nothing loaded to reconcile
+        inFlightRef.current.add(projectId);
+        try {
+          const acc: WorkbenchSession[] = [];
+          const seen = new Set<string>();
+          let before: string | undefined;
+          let nextBeforeId: string | null = null;
+          do {
+            const res = await api.listSessions({ projectId, status: 'active', limit: SESSIONS_PAGE_SIZE, beforeId: before });
+            for (const s of res.sessions) {
+              if (!seen.has(s.id)) {
+                seen.add(s.id);
+                acc.push(s);
+              }
+            }
+            nextBeforeId = res.next_before_id;
+            before = res.next_before_id ?? undefined;
+          } while (before && acc.length < targetCount);
+          setSessions((prev) => ({
+            ...prev,
+            [projectId]: { sessions: acc, cursor: nextBeforeId, loading: false, loadingMore: false, error: false },
+          }));
+        } catch {
+          /* keep the current window on a failed reconcile */
+        } finally {
+          inFlightRef.current.delete(projectId);
+        }
+        const pendingMinCount = takePendingReconcile(projectId);
+        if (pendingMinCount === null) return;
+        minCount = pendingMinCount;
+      }
+    },
+    [api, queueReconcile, takePendingReconcile],
+  );
 
   // Load the first page (append=false) or the next page (append=true) of a
   // project's sessions, with dedupe + per-project serialisation.
@@ -186,49 +248,13 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         });
       } finally {
         inFlightRef.current.delete(projectId);
+        const pendingMinCount = takePendingReconcile(projectId);
+        if (pendingMinCount !== null) {
+          void reconcileSessions(projectId, { minCount: pendingMinCount });
+        }
       }
     },
-    [api],
-  );
-
-  // (Re)connect reconcile: rebuild a project's ALREADY-paged-in window (not just
-  // page 1) so a transient SSE reconnect / controller restart doesn't truncate an
-  // expanded project back to the first page. Pages in chunks because the server
-  // clamps the limit to 200 — a single large request would silently truncate
-  // windows >200 rows. Silent (no loading flag) so visible rows don't flicker.
-  const reconcileSessions = useCallback(
-    async (projectId: string) => {
-      if (inFlightRef.current.has(projectId)) return;
-      const targetCount = sessionsRef.current[projectId]?.sessions?.length ?? 0;
-      if (targetCount === 0) return; // nothing loaded to reconcile
-      inFlightRef.current.add(projectId);
-      try {
-        const acc: WorkbenchSession[] = [];
-        const seen = new Set<string>();
-        let before: string | undefined;
-        let nextBeforeId: string | null = null;
-        do {
-          const res = await api.listSessions({ projectId, status: 'active', limit: SESSIONS_PAGE_SIZE, beforeId: before });
-          for (const s of res.sessions) {
-            if (!seen.has(s.id)) {
-              seen.add(s.id);
-              acc.push(s);
-            }
-          }
-          nextBeforeId = res.next_before_id;
-          before = res.next_before_id ?? undefined;
-        } while (before && acc.length < targetCount);
-        setSessions((prev) => ({
-          ...prev,
-          [projectId]: { sessions: acc, cursor: nextBeforeId, loading: false, loadingMore: false, error: false },
-        }));
-      } catch {
-        /* keep the current window on a failed reconcile */
-      } finally {
-        inFlightRef.current.delete(projectId);
-      }
-    },
-    [api],
+    [api, reconcileSessions, takePendingReconcile],
   );
 
   // Keep the tree live: patch a row's status dot / title from SSE, and refetch
@@ -254,7 +280,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         if (!REORDER_ACTIVITY_EVENTS.has(data.event)) return;
         const projectId = projectsRef.current?.find((project) => project.scope_id === data.scope_id)?.id;
         if (!projectId) return;
-        void reconcileSessions(projectId);
+        void reconcileSessions(projectId, { minCount: data.event === 'created' ? 1 : 0 });
       },
       onSessionStatus: ({ session_id, agent_status }) => {
         setSessions((prev) =>
@@ -297,7 +323,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         if (alreadyLoaded) {
           setSessions((prev) => {
             const cur = prev[projectId] ?? EMPTY_SESSIONS;
-            return { ...prev, [projectId]: { ...cur, sessions: [session, ...(cur.sessions ?? [])] } };
+            const rows = cur.sessions ?? [];
+            return { ...prev, [projectId]: { ...cur, sessions: [session, ...rows.filter((s) => s.id !== session.id)] } };
           });
         }
         setExpanded((prev) => {

--- a/ui/src/context/WorkbenchProjectsContext.tsx
+++ b/ui/src/context/WorkbenchProjectsContext.tsx
@@ -94,6 +94,8 @@ function patchSessionRow(
   return changed ? next : prev;
 }
 
+const REORDER_ACTIVITY_EVENTS = new Set(['created', 'user_message', 'show_event']);
+
 const WorkbenchProjectsContext = createContext<WorkbenchProjectsTree | null>(null);
 
 // Single source of truth for the workbench projects/sessions tree. The desktop
@@ -115,6 +117,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
 
   // Stale-closure-safe mirrors so the SSE (re)connect reconcile reads the current
   // expanded set + loaded window without re-subscribing the stream on every change.
+  const projectsRef = useRef<WorkbenchProject[] | null>(null);
+  projectsRef.current = projects;
   const sessionsRef = useRef<Record<string, ProjectSessionsState>>({});
   sessionsRef.current = sessions;
   const expandedRef = useRef<Set<string>>(new Set());
@@ -240,9 +244,17 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         }
       },
       onSessionActivity: (data) => {
-        if (data.event !== 'updated' || !Object.prototype.hasOwnProperty.call(data, 'title')) return;
-        const nextTitle = data.title ?? null;
-        setSessions((prev) => patchSessionRow(prev, data.session_id, (s) => (s.title === nextTitle ? s : { ...s, title: nextTitle })));
+        if (data.event === 'updated' && Object.prototype.hasOwnProperty.call(data, 'title')) {
+          const nextTitle = data.title ?? null;
+          setSessions((prev) =>
+            patchSessionRow(prev, data.session_id, (s) => (s.title === nextTitle ? s : { ...s, title: nextTitle })),
+          );
+          return;
+        }
+        if (!REORDER_ACTIVITY_EVENTS.has(data.event)) return;
+        const projectId = projectsRef.current?.find((project) => project.scope_id === data.scope_id)?.id;
+        if (!projectId) return;
+        void reconcileSessions(projectId);
       },
       onSessionStatus: ({ session_id, agent_status }) => {
         setSessions((prev) =>


### PR DESCRIPTION
## Summary
- Reconcile the loaded project session window when session activity changes the ordering timestamp.
- Keep title updates on the existing local patch path, so ordinary renames still avoid a list reload.
- Scope the refresh to activity events that bump recency: creation, user messages, and Show Page events.

## Evidence
- Unit: not changed; this is a narrow Workbench provider cache update.
- Contract: not changed; reuses existing `session.activity` SSE payloads.
- Scenario: Workbench project session list should move a newly active loaded session without a page refresh.
- Residual manual checks: none.

## Validation
- `npm run build` in `ui/`
