### PR TITLE
fix(workbench): hide harness row actions on mobile

### DIFF
--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -716,12 +716,12 @@ interface RowActionsProps {
   onDelete: () => void;
 }
 
-// Hover-revealed action cluster on each task/watch row. Two icon buttons
-// (toggle + delete) so the row stays compact and design.pen-aligned.
+// Desktop-only hover action cluster. Mobile opens the detail panel first, where
+// destructive/enable controls are explicit instead of invisible row hit targets.
 const RowActions: React.FC<RowActionsProps> = ({ enabled, pending, onToggle, onDelete }) => {
   const { t } = useTranslation();
   return (
-    <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover/row:opacity-100">
+    <div className="pointer-events-none hidden items-center gap-1 opacity-0 transition-opacity group-hover/row:pointer-events-auto group-hover/row:opacity-100 md:flex">
       <button
         type="button"
         onClick={(e) => {


### PR DESCRIPTION
## Summary
- Hide task/watch row action buttons on mobile Harness lists.
- Keep desktop hover actions, but prevent invisible desktop actions from receiving pointer events before hover.
- Leave mobile task/watch operations available through the detail panel after selecting a card.

## Evidence
- Unit: not changed; this is a narrow responsive UI behavior update.
- Contract: not changed; no API changes.
- Scenario: Mobile Harness task/watch list cards should not expose invisible pause/delete row hit targets.
- Residual manual checks: none.

## Validation
- `npm run build` in `ui/`
