### PR TITLE
fix(workbench): lock chat agent picker to session backend

### DIFF
--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -269,18 +269,13 @@ def update_session(
     if existing is None:
         raise LookupError(f"Session not found: {session_id}")
 
-    # Backend is pinned once the session has a real native conversation AND a
-    # concrete backend recorded. Allow changing the agent/model/effort within the
-    # SAME backend; reject a switch to a DIFFERENT backend (it would strand the
-    # native and lose context). Two transitions are NOT a switch and must be
-    # allowed: (a) no native yet (empty native_session_id) — backend is still free;
-    # (b) a plain Workbench chat created with an EMPTY agent_backend — its first
-    # real backend selection from the chat header is the initial pin, not a switch
-    # away from a concrete backend (Codex P2: otherwise the chat can't pick an
-    # agent/model after its first reply).
+    # Backend is pinned as soon as the session row has a concrete backend. Allow
+    # changing the agent/model/effort within the SAME backend; reject a switch to
+    # a DIFFERENT backend. A plain Workbench chat may still have an EMPTY
+    # agent_backend (legacy/global-default inheritance), so empty -> concrete is
+    # the initial pin rather than a backend switch.
     if (
         agent_backend is not _UNSET
-        and existing.native_session_id
         and str(existing.agent_backend or "")
         and str(agent_backend) != str(existing.agent_backend or "")
     ):

--- a/tests/test_core_services_sessions.py
+++ b/tests/test_core_services_sessions.py
@@ -214,7 +214,7 @@ def test_update_session_present_null_clears_model_and_effort(isolated_state):
 
 def test_update_session_present_null_clears_agent_route(isolated_state):
     """The Chat header's "Default" item sends present nulls; update_session must
-    clear the route fields instead of treating null as "field omitted"."""
+    clear an unpinned route instead of treating null as "field omitted"."""
 
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -222,7 +222,7 @@ def test_update_session_present_null_clears_agent_route(isolated_state):
         session = sessions_service.create_session(
             conn,
             scope_id=scope_id,
-            agent_backend="codex",
+            agent_backend="",
             agent_name="codex",
             agent_id="agent-1",
             agent_variant="codex",
@@ -382,14 +382,10 @@ def test_reset_running_agent_status_clears_only_running(isolated_state):
         assert sessions_service.get_session(conn, failed)["agent_status"] == "failed"
 
 
-def test_update_session_pins_backend_after_native_bound(isolated_state):
-    """A session is locked to its backend once it has a native conversation:
+def test_update_session_pins_concrete_backend_at_creation(isolated_state):
+    """A session is locked to its backend once it has a concrete backend:
     same-backend agent/model changes are allowed; a cross-backend switch raises
-    SessionBackendLockedError. A session with no native yet can still switch
-    freely (the avibe header picks the backend before the first turn)."""
-    from sqlalchemy import update as sa_update
-
-    from storage.models import agent_sessions
+    SessionBackendLockedError."""
 
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -397,37 +393,23 @@ def test_update_session_pins_backend_after_native_bound(isolated_state):
         sid = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="claude"
         )["id"]
-        # No native yet → switching backend is allowed.
-        sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
-        # Bind a native → backend is now pinned.
-        conn.execute(
-            sa_update(agent_sessions).where(agent_sessions.c.id == sid).values(native_session_id="nat-1")
-        )
         # Same-backend change (different agent / model) is still allowed.
-        sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex-pro", model="o3")
+        sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude-pro", model="opus")
         # Cross-backend switch is rejected.
         with pytest.raises(sessions_service.SessionBackendLockedError):
-            sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude")
+            sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
 
 
 def test_update_session_blank_backend_takes_first_concrete_pin(isolated_state):
     """A plain Workbench chat is created with an EMPTY agent_backend. After its
-    first turn binds a native, selecting the real agent in the chat header is the
-    INITIAL pin, not a cross-backend switch — it must be allowed, then lock the
-    session to that backend going forward (Codex P2: otherwise the chat can't pick
-    an agent/model after its first reply)."""
-    from sqlalchemy import update as sa_update
-
-    from storage.models import agent_sessions
+    first real backend selection is the INITIAL pin, not a cross-backend switch
+    — it must be allowed, then lock the session to that backend going forward."""
 
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         scope_id = _seed_avibe_scope(conn)
         sid = sessions_service.create_session(conn, scope_id=scope_id, agent_backend="")["id"]
-        conn.execute(
-            sa_update(agent_sessions).where(agent_sessions.c.id == sid).values(native_session_id="nat-blank")
-        )
-        # Empty -> concrete is the first pin, allowed even with a native bound.
+        # Empty -> concrete is the first pin.
         sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
         assert sessions_service.get_session(conn, sid)["agent_backend"] == "codex"
         # Now pinned: a different backend is rejected.
@@ -435,13 +417,10 @@ def test_update_session_blank_backend_takes_first_concrete_pin(isolated_state):
             sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude")
 
 
-def test_update_session_bound_session_cannot_clear_backend_to_default(isolated_state):
-    """Once a native thread exists, clearing back to inherited default could let a
-    future global default switch route the old native through another backend."""
-
-    from sqlalchemy import update as sa_update
-
-    from storage.models import agent_sessions
+def test_update_session_pinned_session_cannot_clear_backend_to_default(isolated_state):
+    """Once a session has a concrete backend, clearing back to inherited default
+    could let a future default switch route the old session through another
+    backend."""
 
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -449,7 +428,6 @@ def test_update_session_bound_session_cannot_clear_backend_to_default(isolated_s
         sid = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="codex", agent_name="codex"
         )["id"]
-        conn.execute(sa_update(agent_sessions).where(agent_sessions.c.id == sid).values(native_session_id="nat-codex"))
 
         with pytest.raises(sessions_service.SessionBackendLockedError):
             sessions_service.update_session(

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -32,6 +32,8 @@ interface AgentRoutePickerProps {
   value: AgentRouteValue;
   agents: VibeAgentBrief[];
   onChange: (patch: AgentRoutePatch) => void | Promise<void>;
+  /** Optional backend allow-list for existing sessions whose backend is pinned. */
+  allowedBackends?: string[];
   /** Trigger label when no agent is selected — the create flow shows "默认 · …". */
   defaultLabel?: string;
   /** Concrete route to display while `value` is inheriting a project/global default. */
@@ -63,6 +65,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   value,
   agents,
   onChange,
+  allowedBackends,
   defaultLabel,
   defaultRoute,
   isDefaultRoute,
@@ -131,13 +134,22 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   const triggerLabel = (routeIsDefault && defaultLabel) || currentAgent || defaultLabel || t('chat.pickAgent');
   const compactTriggerLabel = currentAgent || defaultLabel || t('chat.pickAgent');
 
+  const allowedBackendSet = useMemo(
+    () => new Set((allowedBackends ?? []).map((item) => item.trim()).filter(Boolean)),
+    [allowedBackends],
+  );
+  const visibleAgents = useMemo(
+    () => (allowedBackendSet.size === 0 ? agents : agents.filter((agent) => allowedBackendSet.has(agent.backend))),
+    [agents, allowedBackendSet],
+  );
+
   const grouped = useMemo(() => {
     const groups: Record<string, VibeAgentBrief[]> = {};
-    for (const agent of agents) {
+    for (const agent of visibleAgents) {
       (groups[agent.backend] ||= []).push(agent);
     }
     return groups;
-  }, [agents]);
+  }, [visibleAgents]);
 
   // Fetch the active backend's model list the first time the menu opens for it;
   // cached per backend so toggling agents doesn't refetch.
@@ -248,7 +260,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
                 <span className="flex-1 truncate font-semibold">{defaultLabel}</span>
               </RouteItem>
             )}
-            {agents.length === 0 && (
+            {visibleAgents.length === 0 && (
               <div className="px-2 py-3 text-center text-[11px] text-muted">{t('chat.noAgents')}</div>
             )}
             {Object.entries(grouped).map(([be, list]) => (

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -907,7 +907,8 @@ interface ChatHeaderBarProps {
 const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack }) => {
   const { t } = useTranslation();
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
-  const canClearToDefault = !session.native_session_id;
+  const pinnedBackend = session.agent_backend?.trim() || null;
+  const canClearToDefault = !pinnedBackend && !session.native_session_id;
   const defaultRoute = defaultAgent
     ? {
         agent_name: defaultAgent.name,
@@ -943,6 +944,7 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
           value={session}
           agents={agents}
           onChange={onPatch}
+          allowedBackends={pinnedBackend ? [pinnedBackend] : undefined}
           defaultLabel={
             canClearToDefault
               ? defaultAgent


### PR DESCRIPTION
## Summary

- pin Workbench session backend updates as soon as a session has a concrete backend
- restrict the chat header Agent picker to Agents from the current session backend
- keep new-session and project-default pickers unrestricted so they can still choose a backend before session creation

## Evidence

- Unit/contract: `uv run pytest tests/test_core_services_sessions.py tests/test_workbench_session_defaults.py tests/test_ui_session_stream.py -q`
- Frontend build: `npm run build`
- Python lint: `uv run ruff check storage/workbench_sessions_service.py tests/test_core_services_sessions.py`
- Residual manual checks: `npm run lint -- --max-warnings=0` still fails on existing repo-wide ESLint debt unrelated to this change
