### PR TITLE
fix(harness): complete agent runs on terminal result

### DIFF
--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -114,7 +114,7 @@ def create_app(controller: "Controller") -> FastAPI:
         True if a turn was started, False on an empty queue / failure."""
         return await manager.flush_queue(session_id)
 
-    async def _submit_scheduled_turn(session_id: str, context: MessageContext, text: str) -> None:
+    async def _submit_scheduled_turn(session_id: str, context: MessageContext, text: str) -> str:
         """Run a scheduled / watch turn through the SAME unified ``manager.submit``
         the interactive Chat path uses, so a scheduled run can never preempt an
         active Chat turn and gets the full turn lifecycle (in_flight + turn.start /
@@ -123,8 +123,7 @@ def create_app(controller: "Controller") -> FastAPI:
         a fresh ``queued`` row attributed to the harness.
         """
         if not session_id:
-            await manager.submit(None, context, text, source=SOURCE_SCHEDULED)
-            return
+            return await manager.submit(None, context, text, source=SOURCE_SCHEDULED)
 
         def _enqueue() -> None:
             from core.message_mirror import _scope_id_for_session
@@ -153,7 +152,7 @@ def create_app(controller: "Controller") -> FastAPI:
                         metadata={SCHEDULED_PROVENANCE_KEY: capture_scheduled_provenance(context)},
                     )
 
-        await manager.submit(session_id, context, text, source=SOURCE_SCHEDULED, enqueue=_enqueue)
+        return await manager.submit(session_id, context, text, source=SOURCE_SCHEDULED, enqueue=_enqueue)
 
     @app.get("/internal/health")
     async def _health() -> dict[str, Any]:

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -178,7 +178,14 @@ class ConsolidatedMessageDispatcher:
             self._consolidated_message_ids.pop(consolidated_key, None)
             self._consolidated_message_buffers.pop(consolidated_key, None)
 
-    def _record_suppressed_run_message(self, context: MessageContext, text: str, message_id: str) -> None:
+    def _record_suppressed_run_message(
+        self,
+        context: MessageContext,
+        text: str,
+        message_id: str,
+        *,
+        terminal_status: Optional[str] = None,
+    ) -> None:
         payload = context.platform_specific or {}
         run_id = str(payload.get("task_execution_id") or "").strip()
         if not run_id:
@@ -186,9 +193,43 @@ class ConsolidatedMessageDispatcher:
         store = None
         try:
             store = SQLiteBackgroundTaskStore()
-            store.record_run_message(run_id, text=text, message_id=message_id)
+            store.record_run_message(
+                run_id,
+                text=text,
+                message_id=message_id,
+                terminal_status=terminal_status,
+            )
         except Exception as err:
             logger.warning("Failed to record suppressed run output for %s: %s", run_id, err)
+        finally:
+            if store is not None:
+                store.close()
+
+    def _record_agent_run_terminal_result(
+        self,
+        context: MessageContext,
+        text: str,
+        message_id: str | None,
+        *,
+        is_error: bool,
+    ) -> None:
+        payload = context.platform_specific or {}
+        if payload.get("task_trigger_kind") != "agent_run":
+            return
+        run_id = str(payload.get("task_execution_id") or "").strip()
+        if not run_id:
+            return
+        store = None
+        try:
+            store = SQLiteBackgroundTaskStore()
+            store.record_run_message(
+                run_id,
+                text=text,
+                message_id=message_id,
+                terminal_status="failed" if is_error else "succeeded",
+            )
+        except Exception as err:
+            logger.warning("Failed to record agent run terminal result for %s: %s", run_id, err)
         finally:
             if store is not None:
                 store.close()
@@ -448,6 +489,12 @@ class ConsolidatedMessageDispatcher:
                 # finished: release the streaming SSE waiter so it closes now
                 # instead of hanging until the safety timeout, with no visible chunk.
                 await self._clear_consolidated_state(context)
+                self._record_agent_run_terminal_result(
+                    context,
+                    text,
+                    None,
+                    is_error=is_error,
+                )
                 self._signal_turn_complete(context)
             return None
 
@@ -483,7 +530,18 @@ class ConsolidatedMessageDispatcher:
 
         if (context.platform_specific or {}).get("suppress_delivery"):
             message_id = f"suppressed:{(context.platform_specific or {}).get('task_execution_id') or canonical_type}"
-            self._record_suppressed_run_message(context, text, message_id)
+            terminal_status = None
+            if (
+                canonical_type == "result"
+                and (context.platform_specific or {}).get("task_trigger_kind") == "agent_run"
+            ):
+                terminal_status = "failed" if is_error else "succeeded"
+            self._record_suppressed_run_message(
+                context,
+                text,
+                message_id,
+                terminal_status=terminal_status,
+            )
             if canonical_type == "result":
                 await self._clear_consolidated_state(context)
                 self._signal_turn_complete(context)
@@ -644,6 +702,13 @@ class ConsolidatedMessageDispatcher:
             # a fresh log message instead of appending to the previous one.
             await self._clear_consolidated_state(context)
 
+            self._record_agent_run_terminal_result(
+                context,
+                display_text,
+                primary_message_id,
+                is_error=is_error,
+            )
+
             # Persist the delivered result (cleaned text == what was shown).
             # avibe always persists (SSE is its delivery); for IM a result that
             # failed every send/upload (primary_message_id is None) is NOT
@@ -679,6 +744,12 @@ class ConsolidatedMessageDispatcher:
                 await _stream_chunk(
                     self.controller, context, text=display_text, message_id=primary_message_id, kind="result"
                 )
+            else:
+                # A terminal result still completes the turn even if every IM
+                # delivery path failed and therefore produced no durable message id.
+                # Without this release, direct agent_run and avibe turn waiters keep
+                # waiting forever despite the backend having already finished.
+                self._signal_turn_complete(context)
 
             return primary_message_id
 

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -174,6 +174,13 @@ class TaskExecutionResult:
     session_id: Optional[str]
 
 
+@dataclass(frozen=True)
+class AgentRunExecutionResult:
+    error: Optional[str]
+    complete_on_return: bool
+    requeue_on_return: bool = False
+
+
 def resolve_session_id_target(session_id: str, *, db_path: Optional[Path] = None) -> ResolvedSessionIdTarget:
     raw = (session_id or "").strip()
     if not raw:
@@ -779,6 +786,7 @@ class TaskExecutionStore:
                 TaskExecutionRequest.from_dict(item)
                 for item in self._sqlite.list_runs(status="pending")
                 if item.get("request_type") in {"task_run", "hook_send", "agent_run", "scheduled", "watch", "webhook"}
+                and not (item.get("metadata") or {}).get("workbench_queue_holds_run")
             ]
         self._ensure_dirs()
         requests: list[TaskExecutionRequest] = []
@@ -967,9 +975,12 @@ class TaskExecutionStore:
         payload = json.loads(processing_path.read_text(encoding="utf-8"))
         return TaskExecutionRequest.from_dict(payload)
 
-    def requeue(self, request_id: str) -> None:
+    def requeue(self, request_id: str, *, metadata: Optional[dict[str, Any]] = None) -> None:
         if self._sqlite is not None:
-            self._sqlite.update_run_status(request_id, status="queued", updated_at=_utc_now_iso())
+            if metadata is not None:
+                self._sqlite.mark_run_queued_from_running(request_id, updated_at=_utc_now_iso(), metadata=metadata)
+            else:
+                self._sqlite.update_run_status(request_id, status="queued", updated_at=_utc_now_iso())
             return
         processing_path = self._request_path(request_id, state="processing")
         pending_path = self._request_path(request_id, state="pending")
@@ -1374,16 +1385,19 @@ class ScheduledTaskService:
                     raise ValueError("agent run requires message")
                 if not (request.session_id or request.session_key):
                     raise ValueError("agent run currently requires session_id or a resolvable session target")
-                error = await self._execute_request(
+                result = await self._execute_agent_run(
                     session_key=request.session_key,
                     session_id=request.session_id,
                     post_to=request.post_to,
                     deliver_key=request.deliver_key,
-                    prompt=request.message,
+                    message=request.message,
                     execution_id=request.id,
-                    trigger_kind="agent_run",
                     agent_name=request.agent_name,
                 )
+                error = result.error
+                should_complete = result.complete_on_return
+                if result.requeue_on_return:
+                    self.request_store.requeue(request.id, metadata={"workbench_queue_holds_run": True})
             else:
                 raise ValueError(f"unknown task request type: {request.request_type}")
         except asyncio.CancelledError:
@@ -1393,6 +1407,7 @@ class ScheduledTaskService:
         except Exception as exc:
             error = str(exc)
             logger.error("Task execution request %s failed: %s", request.id, exc, exc_info=True)
+            should_complete = True
         finally:
             if should_complete:
                 self.request_store.complete(
@@ -1441,6 +1456,65 @@ class ScheduledTaskService:
         self.store.mark_task_result(task.id, error=error, disable_one_shot=disable_one_shot)
         self.reconcile_jobs()
         return TaskExecutionResult(error=error, session_key=session_key, session_id=session_id)
+
+    async def _execute_agent_run(
+        self,
+        *,
+        session_key: Optional[str],
+        post_to: Optional[str],
+        deliver_key: Optional[str],
+        message: str,
+        execution_id: str,
+        session_id: Optional[str] = None,
+        agent_name: Optional[str] = None,
+    ) -> AgentRunExecutionResult:
+        """Execute one direct Agent Run and wait for the real terminal result.
+
+        Direct ``vibe agent run`` records model one concrete Agent turn. Async
+        backends (Codex/Claude) return from ``handle_scheduled_message`` once the
+        prompt is submitted, while their actual result arrives later through
+        ``emit_agent_message``. Use the shared dispatch sink so the run stays
+        ``running`` until that terminal result is emitted.
+        """
+        from core.services.dispatch import SOURCE_SCHEDULED, dispatch_turn
+
+        target_info = resolve_session_id_target(session_id) if session_id else None
+        target = target_info.session_key if target_info else parse_session_key(session_key or "")
+        delivery_target = self._resolve_delivery_target(
+            session_target=target,
+            post_to=post_to,
+            deliver_key=deliver_key,
+        )
+        context = await self._build_context(
+            target,
+            delivery_target=delivery_target,
+            execution_id=execution_id,
+            trigger_kind="agent_run",
+            session_id=session_id,
+            agent_name=agent_name,
+            target_info=target_info,
+        )
+
+        gate = getattr(self.controller, "session_turn_gate", None)
+        if target.platform == "avibe" and session_id and gate is not None:
+            state = await gate.submit_scheduled(session_id, context, message)
+            if state == "enqueued":
+                return AgentRunExecutionResult(error=None, complete_on_return=False, requeue_on_return=True)
+            return AgentRunExecutionResult(error=None, complete_on_return=False)
+
+        async def _noop_chunk(_envelope: dict) -> None:
+            return None
+
+        result = await dispatch_turn(
+            self.controller,
+            context,
+            message,
+            source=SOURCE_SCHEDULED,
+            on_chunk=_noop_chunk,
+        )
+        if result:
+            return AgentRunExecutionResult(error=str(result), complete_on_return=True)
+        return AgentRunExecutionResult(error=None, complete_on_return=False)
 
     def _reserve_runtime_session(self, *, agent_name: Optional[str], deliver_key: Optional[str]) -> str:
         if not deliver_key:

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -453,6 +453,22 @@ class SessionTurnManager:
                 # Restore the stable scheduled:/watch:/webhook: native id so the
                 # flushed prompt persists + dedupes under it (Codex P2), not None.
                 context.message_id = scheduled_message_id
+            run_id = str(scheduled_prov.get("task_execution_id") or "").strip()
+            if scheduled_prov.get("task_trigger_kind") == "agent_run" and run_id:
+                try:
+                    from storage.background import SQLiteBackgroundTaskStore
+
+                    store = SQLiteBackgroundTaskStore()
+                    try:
+                        claimed = store.claim_queued_run_for_workbench(run_id)
+                    finally:
+                        store.close()
+                except Exception:
+                    logger.warning("queue flush: failed to mark agent_run %s running", run_id, exc_info=True)
+                    return False
+                if not claimed:
+                    logger.info("queue flush: skipped agent_run %s because it is no longer queued", run_id)
+                    return False
             await self._run(session_id, context, scheduled_text, source=SOURCE_SCHEDULED)
         return True
 

--- a/docs/plans/agent-run-terminal-lifecycle.md
+++ b/docs/plans/agent-run-terminal-lifecycle.md
@@ -1,0 +1,71 @@
+# Agent Run Terminal Lifecycle
+
+## Background
+
+`vibe agent run` currently records an `agent_run` row and marks it succeeded as
+soon as the harness request submits the prompt to the backend path. For async
+backends such as Codex, submitting the prompt only starts the native turn; tool
+events and the terminal result arrive later through `emit_agent_message`.
+
+This makes `run.status=succeeded` and `completed_at` appear before the run's
+final `result_text` is available.
+
+## Goal
+
+For direct `agent_run` requests, the run lifecycle must model one concrete
+Agent turn:
+
+- `queued` before claim
+- `running` while the backend turn is active
+- terminal only after the backend emits its real result
+
+The fix should use the existing terminal-result signal. It must not add sleeps,
+post-completion polling, or Codex-specific behavior.
+
+## Design
+
+Keep the existing request queue and run storage. Change only the direct
+`agent_run` lifecycle:
+
+1. Build the same scheduled/harness `MessageContext` with `task_execution_id`.
+2. For private/non-avibe runs, run the turn through
+   `dispatch_turn(..., source=SOURCE_SCHEDULED, on_chunk=noop)` so dispatch
+   returns only after the terminal result.
+3. For avibe/workbench sessions, keep routing through the session turn gate so
+   queueing, Stop, and browser lifecycle remain unchanged.
+4. When `emit_agent_message(..., "result", ...)` carries
+   `task_trigger_kind="agent_run"`, update the run record with `result_text`,
+   message id, terminal status, and `completed_at`.
+5. Treat terminal delivery and run completion as separate concerns: even when
+   every IM send/upload fails, the terminal result still releases the turn
+   waiter and records the run result.
+6. When an avibe agent run is queued behind an active workbench turn, return
+   the run row to `queued` and let the workbench queue hold it until flush time.
+   The background drain skips those held rows so the same run is not claimed
+   twice.
+
+This makes the outbound terminal-result chokepoint the source of truth for
+direct Agent Run completion, while preserving the existing avibe gate for
+workbench sessions.
+
+## Scope
+
+This change is intentionally limited to `request_type == "agent_run"`.
+Stored tasks and watches may still mean "trigger/follow-up submitted"; changing
+that semantic together would be a broader product migration.
+
+## Validation
+
+- Unit test that a direct private `agent_run` stays `running` until a delayed
+  terminal result is emitted.
+- Unit tests that suppressed and visible `agent_run` terminal output update the
+  run status.
+- Unit test that avibe `agent_run` still routes through the session gate and
+  does not complete at submit time.
+- Unit test that failed terminal results remain failed and are not overwritten
+  by request-submission success.
+- Unit test that synchronous dispatch errors are recorded as failed runs.
+- Unit test that terminal delivery failure still releases the waiting turn.
+- Unit test that busy avibe agent runs remain queued until the workbench queue
+  actually starts them.
+- Existing scheduled task and dispatcher tests remain green.

--- a/storage/background.py
+++ b/storage/background.py
@@ -634,12 +634,68 @@ class SQLiteBackgroundTaskStore:
         with self.engine.begin() as conn:
             conn.execute(update(agent_runs).where(agent_runs.c.id == run_id).values(**values))
 
+    def mark_run_queued_from_running(
+        self,
+        run_id: str,
+        *,
+        updated_at: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        now = updated_at or _utc_now_iso()
+        values: dict[str, Any] = {
+            "status": "queued",
+            "started_at": None,
+            "updated_at": now,
+        }
+        if metadata is not None:
+            values["metadata_json"] = _json_dumps(metadata)
+        with self.engine.begin() as conn:
+            result = conn.execute(
+                update(agent_runs)
+                .where(agent_runs.c.id == run_id)
+                .where(agent_runs.c.status.in_(_status_query_values("running")))
+                .values(**values)
+            )
+            return bool(result.rowcount)
+
+    def claim_queued_run_for_workbench(
+        self,
+        run_id: str,
+        *,
+        started_at: Optional[str] = None,
+    ) -> bool:
+        now = started_at or _utc_now_iso()
+        with self.engine.begin() as conn:
+            row = conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().first()
+            if not row:
+                return False
+            if bool(row["cancel_requested"]) or normalize_run_status(row["status"]) == "canceled":
+                conn.execute(
+                    update(agent_runs)
+                    .where(agent_runs.c.id == run_id)
+                    .values(status="canceled", completed_at=now, updated_at=now)
+                )
+                return False
+            result = conn.execute(
+                update(agent_runs)
+                .where(agent_runs.c.id == run_id)
+                .where(agent_runs.c.status.in_(_status_query_values("queued")))
+                .values(
+                    status="running",
+                    started_at=now,
+                    updated_at=now,
+                    metadata_json=_json_dumps({"workbench_queue_holds_run": False}),
+                )
+            )
+            return bool(result.rowcount)
+
     def record_run_message(
         self,
         run_id: str,
         *,
         text: str,
         message_id: str | None = None,
+        terminal_status: Optional[str] = None,
         updated_at: Optional[str] = None,
     ) -> None:
         now = updated_at or _utc_now_iso()
@@ -656,14 +712,18 @@ class SQLiteBackgroundTaskStore:
             message_ids = _json_loads(row["message_ids_json"], [])
             if message_id:
                 message_ids.append(message_id)
+            values: dict[str, Any] = {
+                "result_text": result_text,
+                "message_ids_json": _json_dumps(message_ids),
+                "updated_at": now,
+            }
+            if terminal_status:
+                values["status"] = normalize_run_status(terminal_status)
+                values["completed_at"] = now
             conn.execute(
                 update(agent_runs)
                 .where(agent_runs.c.id == run_id)
-                .values(
-                    result_text=result_text,
-                    message_ids_json=_json_dumps(message_ids),
-                    updated_at=now,
-                )
+                .values(**values)
             )
 
     def recover_processing_runs(self) -> None:

--- a/tests/test_message_dispatcher_scheduled.py
+++ b/tests/test_message_dispatcher_scheduled.py
@@ -32,6 +32,14 @@ class _StubIMClient:
         return message_id
 
 
+class _FailingIMClient(_StubIMClient):
+    async def send_message(self, context, text, parse_mode=None, reply_to=None):
+        raise RuntimeError("send failed")
+
+    async def send_message_with_buttons(self, context, text, keyboard, parse_mode=None):
+        raise RuntimeError("button send failed")
+
+
 class _StubSettingsManager:
     def _canonicalize_message_type(self, message_type):
         return message_type
@@ -65,6 +73,9 @@ class _StubController:
 
     def get_im_client_for_context(self, context):
         return self.im_client
+
+    def mark_turn_complete(self, context):
+        pass
 
 
 class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
@@ -146,8 +157,8 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
         calls = []
 
         class _Store:
-            def record_run_message(self, run_id, *, text, message_id=None):
-                calls.append(("record", run_id, text, message_id))
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
 
             def close(self):
                 calls.append(("close",))
@@ -159,7 +170,41 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             calls,
             [
-                ("record", "run-1", "private output", "suppressed:run-1"),
+                ("record", "run-1", "private output", "suppressed:run-1", None),
+                ("close",),
+            ],
+        )
+
+    async def test_suppressed_agent_run_result_marks_run_terminal(self):
+        controller = _StubController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "suppress_delivery": True,
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-agent",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
+
+            def close(self):
+                calls.append(("close",))
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            message_id = await dispatcher.emit_agent_message(context, "result", "private agent output")
+
+        self.assertEqual(message_id, "suppressed:run-agent")
+        self.assertEqual(
+            calls,
+            [
+                ("record", "run-agent", "private agent output", "suppressed:run-agent", "succeeded"),
                 ("close",),
             ],
         )
@@ -179,8 +224,8 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
         calls = []
 
         class _Store:
-            def record_run_message(self, run_id, *, text, message_id=None):
-                calls.append(("record", run_id, text, message_id))
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
 
             def close(self):
                 calls.append(("close",))
@@ -193,7 +238,154 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             calls,
             [
-                ("record", "run-1", "auth recovery required", "suppressed:run-1"),
+                ("record", "run-1", "auth recovery required", "suppressed:run-1", None),
+                ("close",),
+            ],
+        )
+
+    async def test_visible_agent_run_result_marks_run_terminal(self):
+        controller = _StubController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-visible",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
+
+            def close(self):
+                calls.append(("close",))
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            message_id = await dispatcher.emit_agent_message(context, "result", "visible result")
+
+        self.assertEqual(message_id, "bot-msg-1")
+        self.assertEqual(
+            calls,
+            [
+                ("record", "run-visible", "visible result", "bot-msg-1", "succeeded"),
+                ("close",),
+            ],
+        )
+
+    async def test_visible_agent_run_error_result_marks_run_failed(self):
+        controller = _StubController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-failed",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
+
+            def close(self):
+                calls.append(("close",))
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            message_id = await dispatcher.emit_agent_message(context, "result", "backend failed", is_error=True)
+
+        self.assertEqual(message_id, "bot-msg-1")
+        self.assertEqual(
+            calls,
+            [
+                ("record", "run-failed", "backend failed", "bot-msg-1", "failed"),
+                ("close",),
+            ],
+        )
+
+    async def test_empty_agent_run_error_result_marks_failed_and_releases_turn(self):
+        controller = _StubController()
+        released = []
+
+        def _mark_turn_complete(context):
+            released.append(context.channel_id)
+
+        controller.mark_turn_complete = _mark_turn_complete
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-empty-failed",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
+
+            def close(self):
+                calls.append(("close",))
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            message_id = await dispatcher.emit_agent_message(context, "result", "", is_error=True)
+
+        self.assertIsNone(message_id)
+        self.assertEqual(released, ["C123"])
+        self.assertEqual(
+            calls,
+            [
+                ("record", "run-empty-failed", "", None, "failed"),
+                ("close",),
+            ],
+        )
+
+    async def test_agent_run_result_delivery_failure_still_releases_turn(self):
+        controller = _StubController()
+        controller.im_client = _FailingIMClient()
+        released = []
+
+        def _mark_turn_complete(context):
+            released.append(context.channel_id)
+
+        controller.mark_turn_complete = _mark_turn_complete
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-delivery-failed",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
+
+            def close(self):
+                calls.append(("close",))
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            message_id = await dispatcher.emit_agent_message(context, "result", "final but undelivered")
+
+        self.assertIsNone(message_id)
+        self.assertEqual(released, ["C123"])
+        self.assertEqual(
+            calls,
+            [
+                ("record", "run-delivery-failed", "final but undelivered", None, "succeeded"),
                 ("close",),
             ],
         )

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1176,6 +1176,332 @@ def test_drain_requests_executes_hook_send(tmp_path: Path) -> None:
     assert payload["ok"] is True
 
 
+def test_agent_run_stays_running_until_terminal_result(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_key="slack::channel::C123",
+        message="make an image",
+        agent_name="codex",
+    )
+    settings_manager = SimpleNamespace(get_store=lambda: SimpleNamespace(get_user=lambda *_args, **_kwargs: None))
+    terminal_event: asyncio.Event | None = None
+
+    class _Controller:
+        platform_settings_managers = {"slack": settings_manager}
+
+        def __init__(self) -> None:
+            self.active_turn_sinks: dict[str, dict] = {}
+            self.message_handler = SimpleNamespace(handle_scheduled_message=self._handle_scheduled_message)
+
+        def get_im_client_for_context(self, _context):
+            return SimpleNamespace(
+                should_use_thread_for_reply=lambda: True,
+                should_use_thread_for_dm_session=lambda: False,
+            )
+
+        def _get_session_key(self, context):
+            return f"{context.platform}:{context.channel_id}:{context.thread_id or ''}"
+
+        def get_turn_sink(self, session_key):
+            return self.active_turn_sinks.get(session_key)
+
+        def register_turn_sink(self, session_key, *, on_chunk, done_event, turn_token=None):
+            self.active_turn_sinks[session_key] = {
+                "on_chunk": on_chunk,
+                "done_event": done_event,
+                "turn_token": turn_token,
+            }
+
+        def pop_turn_sink(self, session_key, done_event=None):
+            self.active_turn_sinks.pop(session_key, None)
+
+        async def _handle_scheduled_message(self, context, message, parsed_session_key=None):
+            async def _finish_later() -> None:
+                assert terminal_event is not None
+                await terminal_event.wait()
+                sink = self.get_turn_sink(self._get_session_key(context))
+                assert sink is not None
+                store = SQLiteBackgroundTaskStore()
+                try:
+                    store.record_run_message(
+                        request.id,
+                        text="final image result",
+                        message_id=f"suppressed:{request.id}",
+                        terminal_status="succeeded",
+                    )
+                finally:
+                    store.close()
+                sink["done_event"].set()
+
+            asyncio.create_task(_finish_later())
+            return None
+
+    async def _exercise() -> None:
+        nonlocal terminal_event
+        terminal_event = asyncio.Event()
+        controller = _Controller()
+        service = ScheduledTaskService(
+            controller=controller,
+            store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+            request_store=request_store,
+        )
+
+        await service._drain_requests()
+        execution = service._inflight_executions.get(request.id)
+        assert execution is not None
+
+        await asyncio.sleep(0.01)
+        running = request_store.get_run(request.id)
+        assert running is not None
+        assert running["status"] == "running"
+        assert running.get("completed_at") is None
+
+        terminal_event.set()
+        await execution
+
+    asyncio.run(_exercise())
+
+    completed = request_store.get_run(request.id)
+    assert completed is not None
+    assert completed["status"] == "succeeded"
+    assert completed["completed_at"] is not None
+    assert completed["result_text"] == "final image result"
+
+
+def test_agent_run_preserves_failed_terminal_status(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_key="slack::channel::C123",
+        message="make an image",
+        agent_name="codex",
+    )
+    settings_manager = SimpleNamespace(get_store=lambda: SimpleNamespace(get_user=lambda *_args, **_kwargs: None))
+
+    class _Controller:
+        platform_settings_managers = {"slack": settings_manager}
+
+        def __init__(self) -> None:
+            self.active_turn_sinks: dict[str, dict] = {}
+            self.message_handler = SimpleNamespace(handle_scheduled_message=self._handle_scheduled_message)
+
+        def get_im_client_for_context(self, _context):
+            return SimpleNamespace(
+                should_use_thread_for_reply=lambda: True,
+                should_use_thread_for_dm_session=lambda: False,
+            )
+
+        def _get_session_key(self, context):
+            return f"{context.platform}:{context.channel_id}:{context.thread_id or ''}"
+
+        def get_turn_sink(self, session_key):
+            return self.active_turn_sinks.get(session_key)
+
+        def register_turn_sink(self, session_key, *, on_chunk, done_event, turn_token=None):
+            self.active_turn_sinks[session_key] = {
+                "on_chunk": on_chunk,
+                "done_event": done_event,
+                "turn_token": turn_token,
+            }
+
+        def pop_turn_sink(self, session_key, done_event=None):
+            self.active_turn_sinks.pop(session_key, None)
+
+        async def _handle_scheduled_message(self, context, message, parsed_session_key=None):
+            sink = self.get_turn_sink(self._get_session_key(context))
+            assert sink is not None
+            store = SQLiteBackgroundTaskStore()
+            try:
+                store.record_run_message(
+                    request.id,
+                    text="terminal failed",
+                    message_id=f"suppressed:{request.id}",
+                    terminal_status="failed",
+                )
+            finally:
+                store.close()
+            sink["done_event"].set()
+            return None
+
+    controller = _Controller()
+    service = ScheduledTaskService(
+        controller=controller,
+        store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=request_store,
+    )
+
+    async def _exercise() -> None:
+        await service._drain_requests()
+        execution = service._inflight_executions.get(request.id)
+        if execution is not None:
+            await execution
+
+    asyncio.run(_exercise())
+
+    completed = request_store.get_run(request.id)
+    assert completed is not None
+    assert completed["status"] == "failed"
+    assert completed["completed_at"] is not None
+    assert completed["result_text"] == "terminal failed"
+
+
+def test_agent_run_synchronous_dispatch_error_marks_failed(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_key="slack::channel::C123",
+        message="use missing agent",
+        agent_name="missing",
+    )
+    settings_manager = SimpleNamespace(get_store=lambda: SimpleNamespace(get_user=lambda *_args, **_kwargs: None))
+
+    class _Controller:
+        platform_settings_managers = {"slack": settings_manager}
+
+        def __init__(self) -> None:
+            self.active_turn_sinks: dict[str, dict] = {}
+            self.message_handler = SimpleNamespace(handle_scheduled_message=self._handle_scheduled_message)
+
+        def get_im_client_for_context(self, _context):
+            return SimpleNamespace(
+                should_use_thread_for_reply=lambda: True,
+                should_use_thread_for_dm_session=lambda: False,
+            )
+
+        def _get_session_key(self, context):
+            return f"{context.platform}:{context.channel_id}:{context.thread_id or ''}"
+
+        def get_turn_sink(self, session_key):
+            return self.active_turn_sinks.get(session_key)
+
+        def register_turn_sink(self, session_key, *, on_chunk, done_event, turn_token=None):
+            self.active_turn_sinks[session_key] = {
+                "on_chunk": on_chunk,
+                "done_event": done_event,
+                "turn_token": turn_token,
+            }
+
+        def pop_turn_sink(self, session_key, done_event=None):
+            self.active_turn_sinks.pop(session_key, None)
+
+        async def _handle_scheduled_message(self, context, message, parsed_session_key=None):
+            sink = self.get_turn_sink(self._get_session_key(context))
+            assert sink is not None
+            sink["done_event"].set()
+            return "agent 'missing' is not available"
+
+    controller = _Controller()
+    service = ScheduledTaskService(
+        controller=controller,
+        store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=request_store,
+    )
+
+    async def _exercise() -> None:
+        await service._drain_requests()
+        execution = service._inflight_executions.get(request.id)
+        if execution is not None:
+            await execution
+
+    asyncio.run(_exercise())
+
+    completed = request_store.get_run(request.id)
+    assert completed is not None
+    assert completed["status"] == "failed"
+    assert completed["completed_at"] is not None
+    assert completed["error"] == "agent 'missing' is not available"
+
+
+def test_avibe_agent_run_routes_through_gate_without_completing_early(monkeypatch, tmp_path) -> None:
+    session_id = _make_avibe_session(monkeypatch, tmp_path)
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id=session_id,
+        message="run in workbench session",
+        agent_name="codex",
+    )
+    submitted: list[tuple] = []
+    handler_calls: list = []
+
+    async def _submit_scheduled(sid, ctx, text):
+        submitted.append((sid, text, ctx.platform, ctx.platform_specific.get("task_execution_id")))
+        return "ran"
+
+    async def _handle_scheduled_message(context, message, parsed_session_key=None):
+        handler_calls.append(message)
+        return None
+
+    gate = SimpleNamespace(submit_scheduled=_submit_scheduled, in_flight={})
+    controller = _avibe_controller_double(gate=gate, handle_scheduled_message=_handle_scheduled_message)
+    service = ScheduledTaskService(
+        controller=controller,
+        store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=request_store,
+    )
+
+    async def _exercise() -> None:
+        await service._drain_requests()
+        execution = service._inflight_executions.get(request.id)
+        assert execution is not None
+        await execution
+
+    asyncio.run(_exercise())
+
+    run = request_store.get_run(request.id)
+    assert run is not None
+    assert run["status"] == "running"
+    assert run.get("completed_at") is None
+    assert submitted == [(session_id, "run in workbench session", "avibe", request.id)]
+    assert handler_calls == []
+
+
+def test_busy_avibe_agent_run_returns_to_queued_and_is_held_by_workbench_queue(monkeypatch, tmp_path) -> None:
+    session_id = _make_avibe_session(monkeypatch, tmp_path)
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id=session_id,
+        message="run behind active workbench turn",
+        agent_name="codex",
+    )
+    submitted: list[tuple] = []
+    handler_calls: list = []
+
+    async def _submit_scheduled(sid, ctx, text):
+        submitted.append((sid, text, ctx.platform_specific.get("task_execution_id")))
+        return "enqueued"
+
+    async def _handle_scheduled_message(context, message, parsed_session_key=None):
+        handler_calls.append(message)
+        return None
+
+    gate = SimpleNamespace(submit_scheduled=_submit_scheduled, in_flight={session_id: object()})
+    controller = _avibe_controller_double(gate=gate, handle_scheduled_message=_handle_scheduled_message)
+    service = ScheduledTaskService(
+        controller=controller,
+        store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=request_store,
+    )
+
+    async def _exercise() -> None:
+        await service._drain_requests()
+        execution = service._inflight_executions.get(request.id)
+        assert execution is not None
+        await execution
+        await service._drain_requests()
+
+    asyncio.run(_exercise())
+
+    run = request_store.get_run(request.id)
+    assert run is not None
+    assert run["status"] == "queued"
+    assert run.get("started_at") is None
+    assert run.get("completed_at") is None
+    assert (run.get("metadata") or {}).get("workbench_queue_holds_run") is True
+    assert submitted == [(session_id, "run behind active workbench turn", request.id)]
+    assert handler_calls == []
+
+
 def test_drain_requests_reserves_watch_create_per_run_before_session_validation(tmp_path: Path) -> None:
     request_store = TaskExecutionStore(tmp_path / "task_requests")
     request = request_store.enqueue_definition_run(
@@ -1301,14 +1627,43 @@ def test_drain_requests_agent_run_passes_agent_name(tmp_path: Path) -> None:
     settings_manager = SimpleNamespace(get_store=lambda: SimpleNamespace(get_user=lambda *_args, **_kwargs: None))
     calls = []
 
-    async def _handle_scheduled_message(context, message, parsed_session_key=None):
-        calls.append((context, message, parsed_session_key))
-        return None
+    class _Controller:
+        platform_settings_managers = {"slack": settings_manager}
 
-    controller = SimpleNamespace(
-        platform_settings_managers={"slack": settings_manager},
-        message_handler=SimpleNamespace(handle_scheduled_message=_handle_scheduled_message),
-    )
+        def __init__(self) -> None:
+            self.active_turn_sinks: dict[str, dict] = {}
+            self.message_handler = SimpleNamespace(handle_scheduled_message=self._handle_scheduled_message)
+
+        def get_im_client_for_context(self, _context):
+            return SimpleNamespace(
+                should_use_thread_for_reply=lambda: True,
+                should_use_thread_for_dm_session=lambda: False,
+            )
+
+        def _get_session_key(self, context):
+            return f"{context.platform}:{context.channel_id}:{context.thread_id or ''}"
+
+        def get_turn_sink(self, session_key):
+            return self.active_turn_sinks.get(session_key)
+
+        def register_turn_sink(self, session_key, *, on_chunk, done_event, turn_token=None):
+            self.active_turn_sinks[session_key] = {
+                "on_chunk": on_chunk,
+                "done_event": done_event,
+                "turn_token": turn_token,
+            }
+
+        def pop_turn_sink(self, session_key, done_event=None):
+            self.active_turn_sinks.pop(session_key, None)
+
+        async def _handle_scheduled_message(self, context, message, parsed_session_key=None):
+            calls.append((context, message, parsed_session_key))
+            sink = self.get_turn_sink(self._get_session_key(context))
+            assert sink is not None
+            sink["done_event"].set()
+            return None
+
+    controller = _Controller()
     service = ScheduledTaskService(
         controller=controller,
         store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
@@ -1320,11 +1675,13 @@ def test_drain_requests_agent_run_passes_agent_name(tmp_path: Path) -> None:
     assert len(calls) == 1
     context, message, parsed = calls[0]
     assert message == "review build"
-    assert parsed.to_key() == "slack::channel::C123"
+    assert parsed is None
+    assert context.platform == "slack"
+    assert context.channel_id == "C123"
     assert context.message_id == f"agent_run:{request.id}"
     assert context.platform_specific["vibe_agent_name"] == "release-reviewer"
-    payload = json.loads((request_store.completed_dir / f"{request.id}.json").read_text(encoding="utf-8"))
-    assert payload["ok"] is True
+    payload = json.loads((request_store.processing_dir / f"{request.id}.json").read_text(encoding="utf-8"))
+    assert payload["request_type"] == "agent_run"
 
 
 def test_run_task_request_does_not_disable_one_shot(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- make direct Agent Harness `vibe agent run` completion follow the backend terminal result instead of request submission
- keep avibe/workbench agent runs on the existing session turn gate so queueing, Stop, and browser lifecycle remain unchanged
- record terminal status for agent-run result messages while leaving regular task/watch output semantics unchanged

## Capability

Direct Agent Run lifecycle now represents one concrete agent turn: queued before claim, running while the backend is active, and terminal only after the backend emits the real result.

## Affected scenarios

Scenario IDs: N/A. There is no cataloged scenario ID for direct Agent Run terminal lifecycle; this is covered by focused unit and dispatcher contract tests.

## Evidence

- Unit: added direct private agent-run delayed terminal-result coverage and avibe gate routing coverage
- Contract: added dispatcher tests for visible and suppressed agent-run terminal result recording
- Scenario: not updated; no cataloged scenario for this lifecycle path
- Residual manual: isolated runtime reproduction showed running before terminal result and succeeded after terminal result; live installed CLI was not restarted from this worktree
