### PR TITLE
fix(core): accept plain-markdown-link quick-reply buttons in a group

### DIFF
--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -71,25 +71,33 @@ _FILE_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\((file://(?:[^()]+|\([^)]*\))+)\)"
 # Tolerated link forms: plain Markdown ``[label](https://…)``, Slack-escaped
 # ``[label](<https://…>)``, and Slack autolink ``<https://…|label>``. Only
 # ``http(s)`` targets count (a bare ``[label](foo)`` is left alone).
+#
+# ``_PLAIN_URL`` allows one level of balanced parentheses (e.g. Wikipedia
+# ``…/A_(B)``) like ``_FILE_LINK_RE`` does, so such a URL doesn't truncate at the
+# first ``)`` and drop the rest of the button group.
+_PLAIN_URL = r"https?://(?:[^()\s]|\([^()]*\))+"
+# Optional link wrapper after a ``[label]`` token: ``(<https://…>)`` or ``(https://…)``.
+_LINK_SUFFIX = r"(?:\((?:<https?://[^>\n]+>|" + _PLAIN_URL + r")\))?"
+
 _BUTTON_BLOCK_RE = re.compile(
     r"\n-{3,}\s*\n"  # --- separator line
-    r"((?:\s*(?:\[[^\]]+\](?:\((?:<https?://[^>\n]+>|https?://[^)\n]+)\))?|<https?://[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
+    r"((?:\s*(?:\[[^\]]+\]" + _LINK_SUFFIX + r"|<https?://[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
     r"\s*$",  # trailing whitespace / end of string
 )
 
 # Individual button tokens. Link variants are accepted for compatibility only;
 # the bracket label (or Slack link text) remains the quick-reply payload.
 _BUTTON_TOKEN_RE = re.compile(
-    r"\[([^\]]+)\](?:\((?:<https?://[^>\n]+>|https?://[^)\n]+)\))?|<https?://[^|>\n]+\|([^>\n]+)>"
+    r"\[([^\]]+)\]" + _LINK_SUFFIX + r"|<https?://[^|>\n]+\|([^>\n]+)>"
 )
 
-# A plain ``[label](https://…)`` link (no angle brackets) is ambiguous: on its
-# own after ``---`` it is a genuine reference link, not a button. It is only
-# treated as a button inside a group with other buttons (see ``_extract_buttons``);
-# the angle-bracket / Slack forms are unambiguous and always count as buttons.
-# Matches a block that is *nothing but* one plain Markdown link — note ``|`` is
-# allowed inside the URL, so detection can't rely on a stray ``|`` in the block.
-_LONE_PLAIN_LINK_RE = re.compile(r"\[[^\]]+\]\(https?://[^)\n]+\)")
+# A block that is *only* plain ``[label](https://…)`` links (one or more, with no
+# ``|``/``｜`` separator and no bare/angle/Slack token) is a genuine reference-link
+# section, not a button group — see ``_extract_buttons``. Plain links become
+# buttons only when an explicit separator or another unambiguous token is present.
+# (Detection matches the whole block instead of scanning for ``|``, which a URL
+# may itself contain.)
+_PLAIN_LINKS_ONLY_RE = re.compile(r"(?:\s*\[[^\]]+\]\(" + _PLAIN_URL + r"\)\s*)+")
 
 # Silent output blocks are intentionally simple and model-facing.  They are
 # stripped before any reply enhancement parsing so hidden text cannot create
@@ -198,6 +206,14 @@ def _extract_buttons(text: str) -> Tuple[List[QuickReplyButton], str]:
         return [], text
 
     block = m.group(1)
+    # A block made up solely of plain Markdown links with no ``|``/``｜``
+    # separator is a genuine reference-link section (``---\n[Release notes](…)``,
+    # possibly several on their own lines), not a button group — leave the text
+    # untouched. Plain links become buttons only alongside a separator or another
+    # unambiguous token (bare ``[label]`` / angle / Slack link).
+    if _PLAIN_LINKS_ONLY_RE.fullmatch(block.strip()):
+        return [], text
+
     buttons: List[QuickReplyButton] = []
     for bracket_label, slack_label in _BUTTON_TOKEN_RE.findall(block):
         label = bracket_label or slack_label
@@ -206,15 +222,6 @@ def _extract_buttons(text: str) -> Tuple[List[QuickReplyButton], str]:
             buttons.append(QuickReplyButton(text=label))
 
     if not buttons:
-        return [], text
-
-    # A block that is *only* a single plain Markdown link
-    # (``---\n[Release notes](https://…)``) is a genuine reference link, not a
-    # one-button group — leave the text untouched. A plain link counts as a
-    # button only alongside other buttons; the angle-bracket / Slack link forms
-    # are unambiguous and always render as buttons. (Count tokens rather than
-    # scanning for ``|`` — a URL may itself contain ``|``.)
-    if len(buttons) == 1 and _LONE_PLAIN_LINK_RE.fullmatch(block.strip()):
         return [], text
 
     # Enforce a reasonable upper bound on button count

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -66,17 +66,30 @@ _FILE_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\((file://(?:[^()]+|\([^)]*\))+)\)"
 
 # Matches the quick-reply button block at the end of the text.
 # A horizontal rule (``---``) on its own line, followed by bracket buttons.
-# Accept link-formatted variants defensively because some agents accidentally
-# wrap a quick-reply label in a Markdown/Slack link.
+# Accept link-formatted variants defensively because agents routinely wrap a
+# quick-reply label in a link — the label stays the payload, the URL is dropped.
+# Tolerated link forms: plain Markdown ``[label](https://…)``, Slack-escaped
+# ``[label](<https://…>)``, and Slack autolink ``<https://…|label>``. Only
+# ``http(s)`` targets count (a bare ``[label](foo)`` is left alone).
 _BUTTON_BLOCK_RE = re.compile(
     r"\n-{3,}\s*\n"  # --- separator line
-    r"((?:\s*(?:\[[^\]]+\](?:\(<https?://[^)>\n]+>\))?|<https?://[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
+    r"((?:\s*(?:\[[^\]]+\](?:\((?:<https?://[^>\n]+>|https?://[^)\n]+)\))?|<https?://[^|>\n]+\|[^>\n]+>)\s*(?:[|｜]\s*)?)+)"  # button tokens
     r"\s*$",  # trailing whitespace / end of string
 )
 
 # Individual button tokens. Link variants are accepted for compatibility only;
-# the button label remains the quick-reply payload.
-_BUTTON_TOKEN_RE = re.compile(r"\[([^\]]+)\](?:\(<https?://[^)>\n]+>\))?|<https?://[^|>\n]+\|([^>\n]+)>")
+# the bracket label (or Slack link text) remains the quick-reply payload.
+_BUTTON_TOKEN_RE = re.compile(
+    r"\[([^\]]+)\](?:\((?:<https?://[^>\n]+>|https?://[^)\n]+)\))?|<https?://[^|>\n]+\|([^>\n]+)>"
+)
+
+# A plain ``[label](https://…)`` link (no angle brackets) is ambiguous: on its
+# own after ``---`` it is a genuine reference link, not a button. It is only
+# treated as a button inside a group with other buttons (see ``_extract_buttons``);
+# the angle-bracket / Slack forms are unambiguous and always count as buttons.
+# Matches a block that is *nothing but* one plain Markdown link — note ``|`` is
+# allowed inside the URL, so detection can't rely on a stray ``|`` in the block.
+_LONE_PLAIN_LINK_RE = re.compile(r"\[[^\]]+\]\(https?://[^)\n]+\)")
 
 # Silent output blocks are intentionally simple and model-facing.  They are
 # stripped before any reply enhancement parsing so hidden text cannot create
@@ -193,6 +206,15 @@ def _extract_buttons(text: str) -> Tuple[List[QuickReplyButton], str]:
             buttons.append(QuickReplyButton(text=label))
 
     if not buttons:
+        return [], text
+
+    # A block that is *only* a single plain Markdown link
+    # (``---\n[Release notes](https://…)``) is a genuine reference link, not a
+    # one-button group — leave the text untouched. A plain link counts as a
+    # button only alongside other buttons; the angle-bracket / Slack link forms
+    # are unambiguous and always render as buttons. (Count tokens rather than
+    # scanning for ``|`` — a URL may itself contain ``|``.)
+    if len(buttons) == 1 and _LONE_PLAIN_LINK_RE.fullmatch(block.strip()):
         return [], text
 
     # Enforce a reasonable upper bound on button count

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -230,13 +230,33 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
 
     def test_process_reply_preserves_lone_plain_link_with_pipe_in_url(self):
         # A lone reference link whose URL contains ``|`` must still be preserved
-        # as text: the lone-link disambiguation counts parsed tokens rather than
-        # scanning the block for a stray ``|`` (which a URL may legitimately hold).
+        # as text: the lone-link disambiguation matches the whole block rather than
+        # scanning for a stray ``|`` (which a URL may legitimately hold).
         text = "Done.\n\n---\n[chart](https://example.com/a?b=1|2)"
         reply = process_reply(text)
 
         self.assertEqual(reply.text, text)
         self.assertEqual(reply.buttons, [])
+
+    def test_process_reply_preserves_multiple_plain_reference_links_without_separator(self):
+        # Several plain Markdown links after ``---`` with no ``|`` separator are a
+        # reference-link section, not a button group — they must stay as text.
+        text = "Done.\n\n---\n[Release notes](https://example.com/r)\n[Changelog](https://example.com/c)"
+        reply = process_reply(text)
+
+        self.assertEqual(reply.text, text)
+        self.assertEqual(reply.buttons, [])
+
+    def test_process_reply_accepts_plain_link_button_with_balanced_parens_in_url(self):
+        # A plain-link button whose URL contains balanced parentheses (e.g. a
+        # Wikipedia ``A_(B)`` target) must not truncate at the first ``)`` and drop
+        # the group.
+        reply = process_reply(
+            "Done.\n\n---\n[Wiki](https://en.wikipedia.org/wiki/A_(B)) | [Done]"
+        )
+
+        self.assertEqual(reply.text, "Done.")
+        self.assertEqual([button.text for button in reply.buttons], ["Wiki", "Done"])
 
     def test_prompt_includes_task_watch_and_hook_usage_with_current_session_id(self):
         context = MessageContext(

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -206,6 +206,38 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(reply.text, text)
         self.assertEqual(reply.buttons, [])
 
+    def test_process_reply_accepts_plain_markdown_link_button_within_group(self):
+        # Regression: a plain ``[label](https://…)`` token used to drop EVERY
+        # button in the group (its trailing ``(url)`` broke the end-anchored
+        # block match). A link inside a ``|`` group must render as a button, with
+        # the label as the payload and the URL discarded.
+        reply = process_reply(
+            "Done.\n\n---\n"
+            "[👀 我先确认] | [🔗 看 PR](https://github.com/cyhhao/vibe-remote/pull/451) | [✅ 直接合并]"
+        )
+
+        self.assertEqual(reply.text, "Done.")
+        self.assertEqual(
+            [button.text for button in reply.buttons],
+            ["👀 我先确认", "🔗 看 PR", "✅ 直接合并"],
+        )
+
+    def test_process_reply_accepts_plain_markdown_link_button_as_last_token(self):
+        reply = process_reply("Done.\n\n---\n[A] | [docs](https://example.com)")
+
+        self.assertEqual(reply.text, "Done.")
+        self.assertEqual([button.text for button in reply.buttons], ["A", "docs"])
+
+    def test_process_reply_preserves_lone_plain_link_with_pipe_in_url(self):
+        # A lone reference link whose URL contains ``|`` must still be preserved
+        # as text: the lone-link disambiguation counts parsed tokens rather than
+        # scanning the block for a stray ``|`` (which a URL may legitimately hold).
+        text = "Done.\n\n---\n[chart](https://example.com/a?b=1|2)"
+        reply = process_reply(text)
+
+        self.assertEqual(reply.text, text)
+        self.assertEqual(reply.buttons, [])
+
     def test_prompt_includes_task_watch_and_hook_usage_with_current_session_id(self):
         context = MessageContext(
             user_id="U1",


### PR DESCRIPTION
## Capability

**Quick-reply button parsing** (`core/reply_enhancer.process_reply`) — a button written as a plain Markdown link now renders as a button instead of silently dropping the whole button group.

## Problem

When an agent writes a quick-reply button as a plain Markdown link — e.g. `[🔗 看 PR](https://github.com/cyhhao/vibe-remote/pull/451)` in a `---` button block — **every** button in that block disappeared.

Root cause: the trailing button block is matched with an end-anchored regex that only tolerated the **Slack-escaped** link forms `[label](<https://…>)` and `<https://…|label>`. Commit `7457afdb` deliberately restricted the plain `(url)` form so a *lone* reference link (`---\n[Release notes](https://…)`) wouldn't be hijacked into a button. But that restriction also meant a plain link **inside a group** left a dangling `(url)` that failed the `\s*$` anchor → `_extract_buttons` returned nothing → all buttons lost.

This is **unified, not per-channel**: `process_reply` is the single parser. `core/message_dispatcher.py` feeds both the IM keyboards and the avibe workbench `quick_replies`; the workbench frontend (`ChatPage.tsx`) only renders the server-parsed list. So the bug hit IM and the workbench identically (it surfaced on the workbench because that's where it was noticed).

## Fix (`core/reply_enhancer.py`)

- Accept plain `[label](http(s)://…)` tokens in the block/token regexes (angle brackets now optional; `http(s)`-only target restriction from `7457afdb` kept).
- Preserve `7457afdb`'s intent: a block that is **only a single plain link** stays a reference link (left as text); a plain link **alongside other buttons** renders as a button.
- Disambiguate by **parsed-token count**, not by scanning for `|` — a URL may legitimately contain `|`, which a naive `"|" in block` check would misread (caught in self-review and covered by a test).
- Button label remains the payload; the URL is dropped.

## Scenarios

No scenario catalog covers reply-enhancer button parsing (the catalog under `tests/scenarios/` is auth/setup-flow only), so no scenario IDs apply.

## Evidence

- **Unit:** `tests/test_reply_enhancer_platform.py` — added 3 cases: plain-link button inside a group (mid + last token), and a lone reference link whose URL contains `|` stays preserved. The existing `test_process_reply_preserves_plain_markdown_reference_link_block` (lone plain link → not a button) still passes. **27 passed.**
- **Contract / scenario:** n/a (no existing layer for this parser).
- **Residual manual checks:** `ruff` clean on both files; ran downstream button consumers (`test_message_dispatcher_result_fallback.py` 19 passed, `test_message_handler_typing.py` 27 passed); end-to-end ran the real failing message string through `process_reply` and confirmed all three buttons now parse, while lone reference links (incl. `|`-in-URL) stay text.
