### PR TITLE
fix(codex): release Workbench turns on runtime refresh

### DIFF
--- a/core/runtime_commands.py
+++ b/core/runtime_commands.py
@@ -16,6 +16,7 @@ file deletion == acknowledgement.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 import time
@@ -149,7 +150,11 @@ class RuntimeCommandWatcher:
             logger.debug("Could not evict stale err marker %s: %s", err_marker, exc)
 
     async def _handle_restart(self, backend: str, marker: Path) -> None:
-        logger.info("Runtime command: refresh backend=%s", backend)
+        metadata = self._read_marker_metadata(marker)
+        if metadata:
+            logger.info("Runtime command: refresh backend=%s metadata=%s", backend, metadata)
+        else:
+            logger.info("Runtime command: refresh backend=%s", backend)
         handler: Optional[Callable[[str], Awaitable[None]]] = getattr(
             self.controller.agent_auth_service, "_refresh_backend_runtime", None
         )
@@ -169,6 +174,15 @@ class RuntimeCommandWatcher:
             marker.unlink(missing_ok=True)
         except OSError as exc:  # pragma: no cover - best-effort cleanup
             logger.debug("Could not remove marker %s: %s", marker, exc)
+
+    @staticmethod
+    def _read_marker_metadata(marker: Path) -> dict:
+        try:
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        metadata = payload.get("metadata") if isinstance(payload, dict) else None
+        return metadata if isinstance(metadata, dict) else {}
 
     @staticmethod
     def _fail_marker(marker: Path, error: str) -> None:

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -480,6 +480,60 @@ class SessionTurnManager:
         active = entry is not None and not entry.task.done()
         return {"ok": True, "session_id": session_id, "in_flight": active}
 
+    async def release_for_backend_refresh(
+        self,
+        *,
+        backend: str,
+        base_session_ids: set[str],
+    ) -> int:
+        """Release active Workbench turns whose backend runtime is being refreshed.
+
+        A backend refresh is a terminal runtime event: Codex/OpenCode/Claude cached
+        process state can disappear underneath a Workbench turn before that turn's
+        normal result path emits ``turn.end``. The manager owns the Workbench gate,
+        so it must explicitly retire matching in-flight turns before the backend
+        adapter clears its private registry. Otherwise Stop keeps targeting a turn
+        id that no longer exists in the backend.
+        """
+        if not backend or not base_session_ids:
+            return 0
+
+        released = 0
+        tasks_to_settle: list[asyncio.Task] = []
+        for session_id, turn in list(self.in_flight.items()):
+            if session_id not in base_session_ids:
+                continue
+            spec = getattr(turn.context, "platform_specific", None) or {}
+            target = spec.get("agent_session_target")
+            turn_backend = (
+                str(target.get("agent_backend") or "").strip()
+                if isinstance(target, dict)
+                else ""
+            )
+            if turn_backend and turn_backend != backend:
+                continue
+            turn.stop_no_flush = True
+            if turn.task.done():
+                self.in_flight.pop(session_id, None)
+                from core.inbox_events import bus
+
+                bus.publish("turn.end", {"session_id": session_id})
+            else:
+                turn.task.cancel()
+                tasks_to_settle.append(turn.task)
+            if self.controller is not None:
+                self.controller.set_agent_status(session_id, "idle")
+            released += 1
+        if tasks_to_settle:
+            await asyncio.gather(*tasks_to_settle, return_exceptions=True)
+        if released:
+            logger.info(
+                "Released %d active Workbench turn(s) for %s runtime refresh",
+                released,
+                backend,
+            )
+        return released
+
     async def cancel(self, session_id: str) -> dict:
         """Stop the active turn: interrupt the agent's backend run via the SAME path
         the IM ``/stop`` command uses (Claude interrupt / Codex turn-interrupt /

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -263,6 +263,18 @@ class CodexAgent(BaseAgent):
         """Drop app-server runtime state so future turns pick up fresh auth."""
         if not hasattr(self, "_transport_last_activity"):
             self._transport_last_activity = {}
+        base_session_ids = list(self._session_mgr.all_base_sessions())
+        controller = getattr(self, "controller", None)
+        turn_manager = getattr(controller, "session_turns", None)
+        release_for_backend_refresh = getattr(turn_manager, "release_for_backend_refresh", None)
+        if callable(release_for_backend_refresh):
+            try:
+                await release_for_backend_refresh(
+                    backend=self.name,
+                    base_session_ids=set(base_session_ids),
+                )
+            except Exception:
+                logger.warning("Failed to release Workbench turns during Codex refresh", exc_info=True)
         transports = list(self._transports.values())
         self._transports.clear()
         self._transport_last_activity.clear()
@@ -273,7 +285,7 @@ class CodexAgent(BaseAgent):
             except Exception as exc:
                 logger.warning("Failed to stop Codex transport during auth refresh: %s", exc)
 
-        for base_session_id in self._session_mgr.all_base_sessions():
+        for base_session_id in base_session_ids:
             self._session_mgr.invalidate_thread(base_session_id)
             self._turn_registry.clear_session(base_session_id)
             self._clear_thread_developer_instructions(base_session_id)

--- a/tests/test_api_runtime_refresh.py
+++ b/tests/test_api_runtime_refresh.py
@@ -9,9 +9,28 @@ from vibe import api
 
 
 def test_restart_backend_reports_claude_failure_when_controller_unacknowledged(monkeypatch) -> None:
-    monkeypatch.setattr(api, "_request_controller_restart", lambda name: (False, None))
+    monkeypatch.setattr(api, "_request_controller_restart", lambda name, **kwargs: (False, None))
 
     result = api.restart_backend("claude")
 
     assert result["ok"] is False
     assert "not acknowledged" in result["message"]
+
+
+def test_restart_backend_passes_metadata_to_controller_marker(monkeypatch) -> None:
+    captured = {}
+
+    def fake_request(name, **kwargs):
+        captured["name"] = name
+        captured["metadata"] = kwargs.get("metadata")
+        return True, None
+
+    monkeypatch.setattr(api, "_request_controller_restart", fake_request)
+
+    result = api.restart_backend("codex", metadata={"reason": "manual_backend_restart"})
+
+    assert result["ok"] is True
+    assert captured == {
+        "name": "codex",
+        "metadata": {"reason": "manual_backend_restart"},
+    }

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -330,9 +330,18 @@ class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
             invalidate_thread=lambda base_session_id: invalidated.append(base_session_id),
         )
         agent._turn_registry = SimpleNamespace(clear_session=lambda base_session_id: cleared_sessions.append(base_session_id))
+        release_calls = []
+
+        async def release_for_backend_refresh(*, backend, base_session_ids):
+            release_calls.append((backend, set(base_session_ids)))
+
+        agent.controller = SimpleNamespace(
+            session_turns=SimpleNamespace(release_for_backend_refresh=release_for_backend_refresh)
+        )
 
         await agent.refresh_auth_state()
 
+        self.assertEqual(release_calls, [("codex", {"session-1", "session-2"})])
         self.assertEqual(stop_calls, ["a", "b"])
         self.assertEqual(agent._transports, {})
         self.assertEqual(invalidated, ["session-1", "session-2"])

--- a/tests/test_codex_api_auth.py
+++ b/tests/test_codex_api_auth.py
@@ -77,7 +77,7 @@ def test_save_codex_auth_prefers_disk_over_v2config_cache(monkeypatch, tmp_path:
     fake_config = types.SimpleNamespace(agents=fake_agents, save=lambda: None)
     monkeypatch.setattr(api, "load_config", lambda: fake_config)
     # Don't actually restart the backend in unit tests.
-    monkeypatch.setattr(api, "restart_backend", lambda name: {"ok": True})
+    monkeypatch.setattr(api, "restart_backend", lambda name, **kwargs: {"ok": True})
 
     payload = {"auth_mode": "api_key", "api_key": None, "base_url": "https://example/v1"}
     result = api.save_codex_auth(payload)
@@ -105,7 +105,7 @@ def test_save_codex_auth_falls_back_to_v2config_when_disk_empty(
     fake_agents = types.SimpleNamespace(codex=fake_codex)
     fake_config = types.SimpleNamespace(agents=fake_agents, save=lambda: None)
     monkeypatch.setattr(api, "load_config", lambda: fake_config)
-    monkeypatch.setattr(api, "restart_backend", lambda name: {"ok": True})
+    monkeypatch.setattr(api, "restart_backend", lambda name, **kwargs: {"ok": True})
 
     payload = {"auth_mode": "api_key", "api_key": None, "base_url": "https://example/v1"}
     result = api.save_codex_auth(payload)

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -693,6 +693,78 @@ def test_cancel_returns_404_when_session_not_in_flight():
     assert body["code"] == "not_in_flight"
 
 
+def test_release_for_backend_refresh_cancels_matching_turn_and_sets_idle():
+    controller = _build_controller_double()
+    manager = session_turns.SessionTurnManager(controller)
+    statuses = []
+    controller.set_agent_status = lambda session_id, status: statuses.append((session_id, status))
+
+    async def _go():
+        async def _busy():
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_busy())
+        ctx = MessageContext(user_id="U", channel_id="ses_codex", platform="avibe")
+        ctx.platform_specific = {
+            "agent_session_id": "ses_codex",
+            "agent_session_target": {"agent_backend": "codex"},
+        }
+        manager.in_flight["ses_codex"] = session_turns.Turn(task=task, context=ctx)
+
+        released = await manager.release_for_backend_refresh(
+            backend="codex",
+            base_session_ids={"ses_codex"},
+        )
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return released, task.cancelled()
+
+    released, cancelled = asyncio.run(_go())
+
+    assert released == 1
+    assert cancelled is True
+    assert statuses == [("ses_codex", "idle")]
+
+
+def test_release_for_backend_refresh_leaves_other_backend_turn_running():
+    controller = _build_controller_double()
+    manager = session_turns.SessionTurnManager(controller)
+    statuses = []
+    controller.set_agent_status = lambda session_id, status: statuses.append((session_id, status))
+
+    async def _go():
+        async def _busy():
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_busy())
+        ctx = MessageContext(user_id="U", channel_id="ses_claude", platform="avibe")
+        ctx.platform_specific = {
+            "agent_session_id": "ses_claude",
+            "agent_session_target": {"agent_backend": "claude"},
+        }
+        manager.in_flight["ses_claude"] = session_turns.Turn(task=task, context=ctx)
+        try:
+            released = await manager.release_for_backend_refresh(
+                backend="codex",
+                base_session_ids={"ses_claude"},
+            )
+            return released, task.done()
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    released, done = asyncio.run(_go())
+
+    assert released == 0
+    assert done is False
+    assert statuses == []
+
+
 # ---------------------------------------------------------------------
 # Dispatcher hook contract
 # ---------------------------------------------------------------------

--- a/tests/test_runtime_commands.py
+++ b/tests/test_runtime_commands.py
@@ -40,6 +40,26 @@ def test_handle_restart_success_deletes_marker_no_err(tmp_path: Path) -> None:
     assert not (tmp_path / "restart-opencode.cmd.err").exists()
 
 
+def test_handle_restart_reads_marker_metadata(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    async def handler(name: str) -> None:
+        assert name == "codex"
+
+    auth_service = SimpleNamespace(_refresh_backend_runtime=handler)
+    controller = SimpleNamespace(agent_auth_service=auth_service)
+    watcher = RuntimeCommandWatcher(controller, directory=tmp_path)  # type: ignore[arg-type]
+    marker = tmp_path / "restart-codex.abc123.cmd"
+    marker.write_text(
+        '{"backend":"codex","metadata":{"reason":"manual_backend_restart","route":"/api/backend/codex/restart"}}',
+        encoding="utf-8",
+    )
+
+    caplog.set_level("INFO")
+    asyncio.run(watcher._handle_restart("codex", marker))
+
+    assert not marker.exists()
+    assert any("manual_backend_restart" in record.message for record in caplog.records)
+
+
 def test_handle_restart_failure_writes_err_sentinel(tmp_path: Path) -> None:
     """Handler raises → marker deleted AND ``.err`` companion written."""
 

--- a/tests/test_ui_server_install.py
+++ b/tests/test_ui_server_install.py
@@ -123,7 +123,7 @@ def test_install_job_fails_when_runtime_refresh_fails(monkeypatch):
         "install_agent",
         lambda name: {"ok": True, "message": "Installed", "output": "done", "path": "/usr/local/bin/codex"},
     )
-    monkeypatch.setattr(api, "restart_backend", lambda name: {"ok": False, "message": "refresh timeout"})
+    monkeypatch.setattr(api, "restart_backend", lambda name, **kwargs: {"ok": False, "message": "refresh timeout"})
     with api._AGENT_INSTALL_JOB_LOCK:
         api._AGENT_INSTALL_JOBS.clear()
         api._AGENT_INSTALL_LATEST_BY_BACKEND.clear()

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2233,7 +2233,10 @@ def start_agent_install_job(name: str) -> dict:
             result = install_agent(name)
             if result.get("ok") and name != "claude" and supports_runtime_refresh(name):
                 try:
-                    result["restart"] = restart_backend(name)
+                    result["restart"] = restart_backend(
+                        name,
+                        metadata={"reason": "agent_install_job", "source": "ui_api"},
+                    )
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "Backend refresh after %s install job failed: %s",
@@ -3137,7 +3140,12 @@ def _wait_for_controller_ack(marker: Path, timeout: float) -> tuple[bool, str | 
     return False, None
 
 
-def _request_controller_restart(backend: str, timeout: float = 4.0) -> tuple[bool, str | None]:
+def _request_controller_restart(
+    backend: str,
+    timeout: float = 4.0,
+    *,
+    metadata: Optional[dict[str, Any]] = None,
+) -> tuple[bool, str | None]:
     """Ask the controller to refresh a backend via the runtime-command marker.
 
     The controller's ``RuntimeCommandWatcher`` (see ``core/runtime_commands.py``)
@@ -3163,8 +3171,15 @@ def _request_controller_restart(backend: str, timeout: float = 4.0) -> tuple[boo
     reqid = uuid.uuid4().hex[:8]
     marker = _runtime_command_dir() / f"restart-{backend}.{reqid}.cmd"
     try:
+        payload = {"backend": backend, "ts": time.time(), "reqid": reqid}
+        if metadata:
+            payload["metadata"] = {
+                str(k): v
+                for k, v in metadata.items()
+                if isinstance(k, str) and v is not None
+            }
         marker.write_text(
-            json.dumps({"backend": backend, "ts": time.time(), "reqid": reqid}),
+            json.dumps(payload),
             encoding="utf-8",
         )
     except OSError as exc:
@@ -3187,7 +3202,7 @@ def _request_controller_restart(backend: str, timeout: float = 4.0) -> tuple[boo
     return False, None
 
 
-def restart_backend(name: str) -> dict:
+def restart_backend(name: str, *, metadata: Optional[dict[str, Any]] = None) -> dict:
     """Refresh the backend so the next request picks up new config/env.
 
     Preferred path: drop a runtime-command marker that the controller
@@ -3203,7 +3218,7 @@ def restart_backend(name: str) -> dict:
     if not supports_runtime_refresh(name):
         return {"ok": False, "message": f"Restart is not supported for backend: {name}"}
 
-    controller_handled, controller_error = _request_controller_restart(name)
+    controller_handled, controller_error = _request_controller_restart(name, metadata=metadata)
     _invalidate_version_cache(name)
 
     if controller_handled:
@@ -3353,7 +3368,11 @@ def _start_oauth_event_loop() -> tuple[asyncio.AbstractEventLoop, threading.Thre
 def _on_web_auth_success(backend: str) -> None:
     """Tell the live controller to refresh its agent after web OAuth success."""
     try:
-        handled, err = _request_controller_restart(backend, timeout=4.0)
+        handled, err = _request_controller_restart(
+            backend,
+            timeout=4.0,
+            metadata={"reason": "web_auth_success", "source": "oauth_callback"},
+        )
         if handled and err:
             logger.warning("Controller refresh after web auth reported error: %s", err)
         elif not handled:
@@ -3571,7 +3590,10 @@ def remove_backend_api_key(backend: str) -> dict:
     restart: dict
     if backend == "codex":
         try:
-            restart = restart_backend("codex")
+            restart = restart_backend(
+                "codex",
+                metadata={"reason": "remove_api_key", "source": "ui_api"},
+            )
         except Exception as exc:  # noqa: BLE001
             restart = {"ok": False, "message": str(exc)}
     else:
@@ -3840,7 +3862,10 @@ def save_codex_auth(payload: dict) -> dict:
         config.agents.codex.base_url = effective_base_url
         config.save()
 
-    restart_result = restart_backend("codex")
+    restart_result = restart_backend(
+        "codex",
+        metadata={"reason": "save_codex_auth", "source": "ui_api"},
+    )
     state = get_codex_auth()
     state["restart"] = restart_result
     if notices:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2615,7 +2615,15 @@ def backend_restart(name):
 
     from vibe import api
 
-    return jsonify(api.restart_backend(name))
+    metadata = {
+        "reason": "manual_backend_restart",
+        "source": "ui_route",
+        "route": request.path,
+        "method": request.method,
+        "remote_addr": request.headers.get("X-Forwarded-For", request.remote_addr or "").split(",")[0].strip(),
+        "user_agent": (request.headers.get("User-Agent") or "")[:160],
+    }
+    return jsonify(api.restart_backend(name, metadata=metadata))
 
 
 _ALLOWED_DEPENDENCIES = {"askill", "show-runtime"}


### PR DESCRIPTION
## What

Fixes the Workbench/Codex stale-running state that can happen when a Codex runtime refresh interrupts an active turn before the normal terminal result reaches Workbench.

## Why

`CodexAgent.refresh_auth_state()` stopped app-server transports and cleared Codex turn registry state, but Workbench's `SessionTurnManager` still owned the active running gate. Later Stop requests were routed to a turn id that no longer existed in Codex and returned `stop_failed`.

## How

- Add a `SessionTurnManager.release_for_backend_refresh()` path that releases matching active Workbench turns, keeps queued follow-ups from auto-flushing, and settles the session status to idle.
- Call that path from Codex runtime refresh before stopping transports and clearing Codex registry/thread state.
- Add restart marker metadata for UI/API-triggered backend refreshes so future incidents show the route/reason/request context in runtime command logs.

## Evidence

- Unit: `uv run pytest tests/test_internal_server.py::test_cancel_returns_404_when_session_not_in_flight tests/test_internal_server.py::test_release_for_backend_refresh_cancels_matching_turn_and_sets_idle tests/test_internal_server.py::test_release_for_backend_refresh_leaves_other_backend_turn_running tests/test_internal_server.py::test_turn_state_reflects_in_flight tests/test_codex_agent.py::CodexAgentStopTests tests/test_runtime_commands.py tests/test_api_runtime_refresh.py tests/test_codex_api_auth.py tests/test_ui_server_install.py -q`
- Lint: `uv run ruff check core/session_turns.py modules/agents/codex/agent.py core/runtime_commands.py vibe/api.py vibe/ui_server.py tests/test_internal_server.py tests/test_codex_agent.py tests/test_runtime_commands.py tests/test_api_runtime_refresh.py tests/test_codex_api_auth.py tests/test_ui_server_install.py`
- Contract: runtime command marker compatibility is preserved; old markers without metadata still work.
- Scenario: active Workbench Codex turn + backend refresh now releases the running gate before Codex registry is cleared.

## Residual Checks

Manual regression against the running local service was not performed to avoid restarting the active Vibe Remote agent runtime.
