### PR TITLE
fix(opencode): refresh provider models after auth save

### DIFF
--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -183,6 +183,62 @@ def test_base_url_absent_leaves_existing_value_untouched(fake_save_env) -> None:
     )
 
 
+def test_save_provider_auth_returns_refreshed_catalog_and_clears_options_cache(
+    fake_save_env, monkeypatch
+) -> None:
+    _server, _home = fake_save_env
+    api._OPENCODE_OPTIONS_CACHE["/tmp/workspace"] = {"data": {"stale": True}, "updated_at": 1}
+    calls = []
+
+    async def _fake_refresh(provider_id: str) -> dict:
+        calls.append(provider_id)
+        return {
+            "ok": True,
+            "provider_id": provider_id,
+            "catalog": {
+                "ok": True,
+                "providers": [
+                    {
+                        "id": "deepseek",
+                        "models": ["deepseek-chat", "deepseek-reasoner"],
+                    }
+                ],
+            },
+        }
+
+    monkeypatch.setattr(api, "_refresh_opencode_provider_catalog_async", _fake_refresh)
+
+    result = _save("deepseek", {"api_key": "sk-deepseek"})
+
+    assert result["ok"] is True
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+    assert calls == ["deepseek"]
+    assert result["catalog_refresh"]["catalog"]["providers"][0]["models"] == [
+        "deepseek-chat",
+        "deepseek-reasoner",
+    ]
+
+
+def test_save_provider_auth_still_succeeds_when_catalog_refresh_lags(
+    fake_save_env, monkeypatch
+) -> None:
+    async def _fake_refresh(provider_id: str) -> dict:
+        return {
+            "ok": False,
+            "provider_id": provider_id,
+            "message": "Provider saved, but model catalog has not refreshed yet",
+            "catalog": {"ok": True, "providers": [{"id": provider_id, "models": []}]},
+        }
+
+    monkeypatch.setattr(api, "_refresh_opencode_provider_catalog_async", _fake_refresh)
+
+    result = _save("deepseek", {"api_key": "sk-deepseek"})
+
+    assert result["ok"] is True
+    assert result["catalog_refresh"]["ok"] is False
+    assert "not refreshed" in result["catalog_refresh"]["message"]
+
+
 def test_save_provider_auth_clears_options_cache(fake_save_env) -> None:
     api._OPENCODE_OPTIONS_CACHE["/repo"] = {"data": {"stale": True}, "updated_at": 1}
 

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -35,7 +35,11 @@ import { OpencodeProviderTestPanel } from '../OpencodeProviderTestPanel';
 import { BackendRuntimeCard } from '../shared/BackendRuntimeCard';
 import { useBackendRuntime } from '../shared/useBackendRuntime';
 import { useApi } from '@/context/ApiContext';
-import type { OpencodeProvider } from '@/context/ApiContext';
+import type {
+  OpencodeMutationResult,
+  OpencodeProvider,
+  OpencodeProviderListResult,
+} from '@/context/ApiContext';
 import { useToast } from '@/context/ToastContext';
 
 type PermissionState = 'idle' | 'loading' | 'success' | 'error';
@@ -225,6 +229,45 @@ export const OpencodeProviderConfig: React.FC<{
     }
   }, [api, t]);
 
+  const applyProvidersResult = useCallback(
+    (result?: OpencodeProviderListResult | null): boolean => {
+      if (result?.ok && Array.isArray(result.providers)) {
+        setProviders(result.providers);
+        setDefaultProvider(result.default_provider || null);
+        setPermissionAllowed(result.permission_allowed === true);
+        setServerStartAttempts(0);
+        setProvidersError(null);
+        return true;
+      }
+      return false;
+    },
+    [],
+  );
+
+  const applyMutationCatalogRefresh = useCallback(
+    (result: OpencodeMutationResult): boolean => {
+      const refresh = result?.catalog_refresh;
+      const catalog = refresh?.catalog;
+      if (applyProvidersResult(catalog)) {
+        if (refresh?.ok === false) {
+          showToast(
+            refresh.message || (t('settings.backends.opencodeProviderCatalogRefreshPending') as string),
+            'warning',
+          );
+        }
+        return true;
+      }
+      if (refresh?.ok === false) {
+        showToast(
+          refresh.message || (t('settings.backends.opencodeProviderCatalogRefreshPending') as string),
+          'warning',
+        );
+      }
+      return false;
+    },
+    [applyProvidersResult, showToast, t],
+  );
+
   useEffect(() => {
     loadProvidersRef.current = loadProviders;
   }, [loadProviders]);
@@ -400,7 +443,9 @@ export const OpencodeProviderConfig: React.FC<{
       setCustomProviderDraft(emptyCustomProviderDraft());
       setShowCustomProviderForm(false);
       showToast(t('settings.backends.opencodeCustomProviderSaved'), 'success');
-      await loadProviders();
+      if (!applyMutationCatalogRefresh(result)) {
+        await loadProviders();
+      }
       const nextId = result.provider_id || providerId;
       setExpandedId(nextId);
       setEditByProvider((prev) => ({
@@ -488,7 +533,9 @@ export const OpencodeProviderConfig: React.FC<{
         error: null,
       });
       showToast(t('settings.backends.opencodeProviderSaved'), 'success');
-      await loadProviders();
+      if (!applyMutationCatalogRefresh(result)) {
+        await loadProviders();
+      }
     } catch (e: any) {
       updateEdit(provider.id, {
         saving: false,

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1016,6 +1016,11 @@ export type OpencodeMutationResult = {
   default_provider?: string;
   provider_id?: string;
   model_id?: string;
+  catalog_refresh?: {
+    ok: boolean;
+    message?: string;
+    catalog?: OpencodeProviderListResult | null;
+  };
 };
 
 export type WebPushStatus = {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -417,6 +417,7 @@
       "opencodeProviderLocalHint": "Local providers do not need credentials — start the runtime and load a model.",
       "opencodeProviderSave": "Save key",
       "opencodeProviderSaved": "Provider credentials saved.",
+      "opencodeProviderCatalogRefreshPending": "Provider saved. Refreshing the model list…",
       "opencodeProviderSaveFailed": "Could not save provider credentials.",
       "opencodeProviderRemove": "Remove key",
       "opencodeProviderRemoveOauth": "Sign out",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -417,6 +417,7 @@
       "opencodeProviderLocalHint": "本地服务商不需要凭据，启动运行时并加载模型即可。",
       "opencodeProviderSave": "保存 Key",
       "opencodeProviderSaved": "服务商凭据已保存。",
+      "opencodeProviderCatalogRefreshPending": "服务商已保存，正在刷新模型列表…",
       "opencodeProviderSaveFailed": "保存服务商凭据失败。",
       "opencodeProviderRemove": "移除 Key",
       "opencodeProviderRemoveOauth": "退出登录",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -4198,6 +4198,8 @@ async def _opencode_get_server():
 
 
 _LOCAL_PROVIDER_IDS = {"ollama", "lmstudio", "lm-studio"}
+_OPENCODE_PROVIDER_REFRESH_ATTEMPTS = 3
+_OPENCODE_PROVIDER_REFRESH_DELAY_SECONDS = 0.5
 
 
 def _opencode_provider_model_ids(provider: dict) -> set[str]:
@@ -4753,6 +4755,73 @@ async def get_opencode_providers_async() -> dict:
         return {"ok": False, "message": str(exc)}
 
 
+def _opencode_provider_models_loaded(catalog: dict, provider_id: str) -> bool:
+    if not isinstance(catalog, dict) or catalog.get("ok") is False:
+        return False
+    providers = catalog.get("providers")
+    if not isinstance(providers, list):
+        return False
+    for provider in providers:
+        if not isinstance(provider, dict):
+            continue
+        if provider.get("id") != provider_id:
+            continue
+        models = provider.get("models")
+        return isinstance(models, list) and len(models) > 0
+    return False
+
+
+def _opencode_provider_present(catalog: dict, provider_id: str) -> bool:
+    if not isinstance(catalog, dict) or catalog.get("ok") is False:
+        return False
+    providers = catalog.get("providers")
+    if not isinstance(providers, list):
+        return False
+    return any(
+        isinstance(provider, dict) and provider.get("id") == provider_id
+        for provider in providers
+    )
+
+
+async def _refresh_opencode_provider_catalog_async(provider_id: str, *, require_models: bool = True) -> dict:
+    """Fetch the provider catalog after an auth/config write.
+
+    OpenCode keeps provider/auth state in the running daemon. After saving a
+    key or base URL we restart/refresh the daemon and then force a fresh catalog
+    read so Settings and Agents do not keep showing the pre-save empty model
+    list until the generic options cache expires.
+    """
+
+    pid = provider_id.strip()
+    last_catalog: dict | None = None
+    for attempt in range(_OPENCODE_PROVIDER_REFRESH_ATTEMPTS):
+        if attempt > 0:
+            await asyncio.sleep(_OPENCODE_PROVIDER_REFRESH_DELAY_SECONDS)
+        catalog = await get_opencode_providers_async()
+        if isinstance(catalog, dict):
+            last_catalog = catalog
+        loaded = (
+            _opencode_provider_models_loaded(catalog, pid)
+            if require_models
+            else _opencode_provider_present(catalog, pid)
+        )
+        if loaded:
+            return {"ok": True, "provider_id": pid, "catalog": catalog}
+    message = (
+        "Provider saved, but model catalog has not refreshed yet"
+        if require_models
+        else "Provider saved, but provider catalog has not refreshed yet"
+    )
+    if isinstance(last_catalog, dict) and last_catalog.get("message"):
+        message = str(last_catalog.get("message"))
+    return {
+        "ok": False,
+        "provider_id": pid,
+        "message": message,
+        "catalog": last_catalog,
+    }
+
+
 def save_opencode_provider_model(provider_id: str, payload: dict) -> dict:
     from vibe.async_bridge import run_coroutine_blocking
 
@@ -4859,10 +4928,15 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
                 "restart": restart,
             }
 
+    catalog_refresh = await _refresh_opencode_provider_catalog_async(
+        provider_id.strip().lower(),
+        require_models=False,
+    )
     return {
         "ok": True,
         "provider_id": provider_id.strip().lower(),
         "restart": restart,
+        "catalog_refresh": catalog_refresh,
     }
 
 
@@ -5250,6 +5324,8 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
     except Exception as exc:
         logger.warning("OpenCode auto-restart after save failed for %s: %s", provider_id, exc)
         result["restart"] = {"ok": False, "message": str(exc)}
+    if result.get("ok"):
+        result["catalog_refresh"] = await _refresh_opencode_provider_catalog_async(provider_id.strip())
     return result
 
 


### PR DESCRIPTION
## Summary
- force-refresh the OpenCode provider catalog after saving provider auth/base URL
- return the refreshed catalog to the Settings UI so newly configured providers show models immediately
- keep save success separate from delayed catalog refresh and show a warning only when refresh lags

## Why
OpenCode can keep provider/auth and model catalog state in the running daemon. A provider key save could succeed while the Settings and Agents model pickers continued to see the pre-save empty model list until cache expiry or a later service restart.

## Tests
- `ruff check vibe/api.py tests/test_save_opencode_provider_auth.py`
- `npm run build`
- `uv run pytest tests/test_save_opencode_provider_auth.py tests/test_ui_api.py -q`

## Evidence Layers
- Unit: updated OpenCode provider auth save tests
- Contract: mutation response now carries `catalog_refresh`
- Scenario: DeepSeek-style provider save followed by immediate model catalog refresh
- Manual: regression container confirmed DeepSeek models are present in provider catalog after latest deployment
