### PR TITLE
fix(ui): auto-focus the chat composer on open (desktop)

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -943,6 +943,7 @@ const Compose: React.FC<ComposeProps> = ({ onSend, onStop, busy, sessionId, init
       sessionId={sessionId}
       initialDraft={initialDraft}
       onDraftChange={onDraftChange}
+      autoFocus
     />
   </div>
 );

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -4,7 +4,7 @@ import { Clock, Loader2, Mic, Paperclip, Plus, Send, Square, Trash2, X } from 'l
 import clsx from 'clsx';
 
 import { apiFetch } from '../../lib/apiFetch';
-import { isSoftKeyboardOpen } from '../../lib/softKeyboard';
+import { isSoftKeyboardOpen, isTouchCapableDevice } from '../../lib/softKeyboard';
 import { cn } from '../../lib/utils';
 import { Button } from '../ui/button';
 
@@ -65,6 +65,10 @@ export interface ComposerProps {
   /** When set, enables file upload + voice input scoped to this session. The
    *  Workbench home leaves it unset → a plain text-only composer. */
   sessionId?: string;
+  /** Focus the textarea on mount (desktop only — skipped on touch devices so it
+   *  never pops the on-screen keyboard). The chat composer remounts per session,
+   *  so this also covers opening / switching sessions. */
+  autoFocus?: boolean;
 }
 
 // The chat-style input row: an auto-growing textarea + a Send/Stop icon button,
@@ -82,6 +86,7 @@ export const Composer: React.FC<ComposerProps> = ({
   disabled = false,
   className,
   sessionId,
+  autoFocus = false,
 }) => {
   const { t } = useTranslation();
   const [value, setValue] = useState('');
@@ -129,6 +134,14 @@ export const Composer: React.FC<ComposerProps> = ({
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
   }, [value]);
+
+  // Desktop only: focus the textarea on mount so opening a chat (and — via the
+  // per-session remount — switching sessions) lands the cursor in the input.
+  // Skipped on touch devices so it never pops the on-screen keyboard.
+  useEffect(() => {
+    if (!autoFocus || isTouchCapableDevice()) return;
+    textareaRef.current?.focus();
+  }, [autoFocus]);
 
   // The mic button only appears when transcription is wired up (Vibe Cloud
   // paired + enabled), so it never dead-ends on click.

--- a/ui/src/lib/softKeyboard.ts
+++ b/ui/src/lib/softKeyboard.ts
@@ -51,3 +51,10 @@ export function isSoftKeyboardOpen(): boolean {
   if (!isTouchDevice || typeof window === 'undefined' || !window.visualViewport) return false;
   return restingHeight - window.visualViewport.height > KEYBOARD_MIN_DELTA;
 }
+
+// True on devices with an on-screen keyboard (touch). Callers gate on this to
+// avoid auto-focusing inputs where focusing would pop the soft keyboard (e.g.
+// opening a chat on mobile); "desktop only" is ``!isTouchCapableDevice()``.
+export function isTouchCapableDevice(): boolean {
+  return isTouchDevice;
+}


### PR DESCRIPTION
## Capability

**Workbench Chat composer auto-focus** — opening or switching to a Chat session now lands the cursor in the message input (desktop).

## Problem

When the Chat page opened (new session, existing session, or switching between sessions) the message input never received focus: the `Composer` held a `textareaRef` but had no mount-time focus, and the `<textarea>` had no `autoFocus`. The only `.focus()` in the area was the message-edit input, unrelated to the composer. So users had to click the box before typing.

## Fix

- Add an opt-in `autoFocus` prop to `Composer` and focus the textarea on mount. The chat composer is already keyed by `sessionId` (it remounts per session), so a mount-time focus covers **new / existing / switched** sessions in one place.
- Only the chat composer passes `autoFocus`; the Workbench-home composer leaves it unset and is unchanged.
- **Desktop only** (per product decision): gated on `!isTouchCapableDevice()` so opening a chat never pops the on-screen keyboard on mobile/touch.
- Reuse over re-roll: promoted the touch-capable check out of `softKeyboard.ts` (it already had a private `isTouchDevice = navigator.maxTouchPoints > 0`) into an exported `isTouchCapableDevice()`, the same signal the soft-keyboard gate uses — no new `navigator.maxTouchPoints` literal in the component.

## Scenarios

No scenario catalog covers the workbench Chat composer (the catalog under `tests/scenarios/` is auth/setup-flow only), so no scenario IDs apply.

## Evidence

- **Unit / contract / scenario:** none added — focus-on-mount is DOM behavior and the UI has no component-test framework (consistent with prior UI-only PRs); introducing one is out of scope.
- **Residual manual checks:** `npm run build` (`ui/`) passes (tsc type-check + vite build); pre-PR code-review clean. Behavioral check to confirm post-deploy: on desktop the input is focused when opening a chat and when switching sessions; on a touch device opening a chat does **not** pop the keyboard.
