### PR TITLE
ci(tests): shard unit test gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
@@ -19,8 +23,14 @@ jobs:
           pip install pre-commit
           pre-commit run --all-files
 
-  unit-tests:
+  unit-test-shards:
+    name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+        shard-total: [4]
     steps:
       - uses: actions/checkout@v5
 
@@ -45,8 +55,21 @@ jobs:
       - name: Install package and test deps
         run: pip install -e . pytest
 
-      - name: Run unit tests (one file per process)
-        run: bash scripts/ci_unit_tests.sh
+      - name: Run unit tests shard ${{ matrix.shard }}/${{ matrix.shard-total }}
+        run: bash scripts/ci_unit_tests.sh "${{ matrix.shard }}" "${{ matrix.shard-total }}"
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: unit-test-shards
+    if: always()
+    steps:
+      - name: Verify unit test shards
+        run: |
+          if [ "${{ needs['unit-test-shards'].result }}" != "success" ]; then
+            echo "Unit test shards finished with result: ${{ needs['unit-test-shards'].result }}"
+            exit 1
+          fi
+          echo "All unit test shards passed."
 
   npm-wrapper:
     runs-on: ubuntu-latest

--- a/scripts/ci_unit_tests.sh
+++ b/scripts/ci_unit_tests.sh
@@ -10,19 +10,67 @@
 # pollution. Making the stubs fixture-scoped so a single ``pytest tests/`` works
 # is tracked separately; until then this is how the unit suite is CI-gated.
 #
+# CI may pass a shard index and total shard count to split the file list across
+# multiple runners while preserving the one-process-per-file isolation.
+#
 # Excludes ``tests/e2e`` (Docker) and the ``integration`` marker (Docker +
 # platform tokens) — those run in dedicated jobs. ``-p no:randomly`` keeps a
 # deterministic order if pytest-randomly happens to be installed (no-op when it
 # is not), and ``-o addopts=""`` ignores any ambient addopts.
 set -uo pipefail
 
-PYTEST=(python -m pytest)
+SHARD_INDEX="${1:-0}"
+SHARD_TOTAL="${2:-1}"
+
+case "$SHARD_INDEX" in
+  ''|*[!0-9]*)
+    echo "Shard index must be a non-negative integer, got: $SHARD_INDEX" >&2
+    exit 2
+    ;;
+esac
+
+case "$SHARD_TOTAL" in
+  ''|*[!0-9]*)
+    echo "Shard total must be a positive integer, got: $SHARD_TOTAL" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$SHARD_TOTAL" -lt 1 ]; then
+  echo "Shard total must be at least 1, got: $SHARD_TOTAL" >&2
+  exit 2
+fi
+
+if [ "$SHARD_INDEX" -ge "$SHARD_TOTAL" ]; then
+  echo "Shard index must be less than shard total, got: $SHARD_INDEX >= $SHARD_TOTAL" >&2
+  exit 2
+fi
+
+PYTHON_BIN="${PYTHON:-}"
+if [ -z "$PYTHON_BIN" ]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="python"
+  else
+    echo "Unable to find python3 or python on PATH." >&2
+    exit 127
+  fi
+fi
+
+PYTEST=("$PYTHON_BIN" -m pytest)
 
 failed=""
 empty=""
-total=0
+selected=0
+ordinal=0
 while IFS= read -r f; do
-  total=$((total + 1))
+  if [ $((ordinal % SHARD_TOTAL)) -ne "$SHARD_INDEX" ]; then
+    ordinal=$((ordinal + 1))
+    continue
+  fi
+  ordinal=$((ordinal + 1))
+  selected=$((selected + 1))
   "${PYTEST[@]}" "$f" -m "not integration" -p no:randomly -o addopts="" -q
   rc=$?
   if [ "$rc" -eq 0 ]; then
@@ -36,7 +84,8 @@ while IFS= read -r f; do
 done < <(find tests -name 'test_*.py' -not -path 'tests/e2e/*' | sort)
 
 echo "========================================"
-echo "Ran ${total} unit test file(s), one process each."
+echo "Discovered ${ordinal} unit test file(s)."
+echo "Ran ${selected} unit test file(s), one process each, for shard ${SHARD_INDEX}/${SHARD_TOTAL}."
 if [ -n "$empty" ]; then
   echo "No unit tests collected (skipped):"
   for f in $empty; do echo "  $f"; done


### PR DESCRIPTION
## Summary
- shard the CI unit-test gate across four runners while preserving one pytest process per file
- keep the final required check name as `unit-tests` via a lightweight aggregate job
- cancel stale in-progress PR workflow runs for the same PR, while keeping master push runs complete

## Test Plan
- `npm ci && npm run build` in `ui/`
- `python3 -m pip install -e . pytest`
- `bash scripts/ci_unit_tests.sh 3 4`
- `bash -n scripts/ci_unit_tests.sh`
- YAML parse check for `.github/workflows/lint.yml`
- shard coverage check: 155 files split as 39/39/39/38 with no misses or duplicates
- `git diff --check`

## Notes
- This does not remove any CI coverage. The deeper follow-up is still to fix the module-level test pollution so the suite can eventually run as a normal pytest invocation.
