### PR TITLE
perf(workbench): cache config reads longer

### DIFF
--- a/docs/plans/config-read-cache.md
+++ b/docs/plans/config-read-cache.md
@@ -1,0 +1,20 @@
+# Config Read Cache Plan
+
+## Goal
+
+Reduce repeated Workbench UI round-trips to `GET /api/config` over remote links.
+The config payload is read by the app shell and several pages, but changes only
+through explicit mutations in the same API context.
+
+## Scope
+
+- Keep the existing shared read-cache mechanism.
+- Give `/api/config` a longer client-side TTL than generic read endpoints.
+- Keep successful mutating calls invalidating the read cache, so `saveConfig`
+  and related writes still make the next `getConfig()` fresh.
+- Do not change the `/api/config` response shape or add a new endpoint.
+
+## Validation
+
+- Frontend production build.
+- Diff review for cache invalidation paths.

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1092,6 +1092,7 @@ export class ApiError extends Error {
 }
 
 const ApiContext = createContext<ApiContextType | undefined>(undefined);
+const CONFIG_CACHE_TTL_MS = 30_000;
 
 export const useApi = () => {
   const context = useContext(ApiContext);
@@ -1444,7 +1445,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   // is correct (cached error messages would otherwise stay in the
   // old language).
   const value: ApiContextType = useMemo(() => ({
-    getConfig: () => getCachedJson('/api/config'),
+    getConfig: () => getCachedJson('/api/config', CONFIG_CACHE_TTL_MS),
     getPlatformCatalog: () => getJson('/api/platforms'),
     saveConfig: (payload) => postJson('/api/config', payload),
     getSettings: (platform) => getJson(platform ? `/api/settings?platform=${encodeURIComponent(platform)}` : '/api/settings'),


### PR DESCRIPTION
## What changed

- Increased the client-side cache TTL for `GET /api/config` from the generic read-cache window to 30 seconds.
- Kept the existing mutation invalidation path, so successful `saveConfig` and other mutating API calls still clear cached reads before later pages ask for config again.

## Capability

Changed capability: Workbench UI repeated config reads over remote links.

Scenario IDs: none; this area does not have a scenario catalog.

## Evidence

- Frontend: `npm run build` from `ui/`
- Contract: diff review confirms the `/api/config` response shape is unchanged and successful mutations still clear the shared read cache.
- Unit: not run; this is a frontend cache-window change with no backend behavior change.
- Residual manual checks: not run; no local Vibe service restart or live-state mutation.

## Risk

Config reads may be reused for up to 30 seconds when no mutation occurs in this browser tab. Explicit config writes still invalidate the shared read cache immediately, so settings pages should see their own saved changes on the next read.
