### PR TITLE
fix(show): unify recovery loading delay

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -28,6 +28,7 @@ SHARE_ID_BYTES = 8
 SHOW_EVENT_WRITE_TOKEN_COOKIE = "vibe_show_event_token"
 SHOW_EVENT_WRITE_TOKEN_HEADER = "X-Vibe-Show-Token"
 SHOW_CLI_EVENT_TOKEN_HEADER = "X-Vibe-Show-Cli-Token"
+SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS = 10
 _SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
 _LIKE_ESCAPE = "\\"
 
@@ -366,6 +367,7 @@ def _default_index_html(session_id: str) -> str:
 def show_page_runtime_recovery_html(session_id: str) -> str:
     session_id = validate_session_id(session_id)
     escaped = _escape_html(session_id)
+    loading_delay = f"{SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS}s"
     prompt = (
         "Please repair this Vibe Remote Show Page. Open the Show Page workspace for session "
         f"{session_id}, read the local Show Page/runtime instructions, then replace src/App.tsx "
@@ -409,7 +411,7 @@ def show_page_runtime_recovery_html(session_id: str) -> str:
         font-size: 15px;
         font-weight: 760;
         color: #526078;
-        animation: show-recovery-loading-out 0.18s ease 5s forwards;
+        animation: show-recovery-loading-out 0.18s ease {loading_delay} forwards;
       }}
       .show-recovery-loading::before {{
         content: "";
@@ -431,7 +433,7 @@ def show_page_runtime_recovery_html(session_id: str) -> str:
         opacity: 0;
         visibility: hidden;
         transform: translateY(6px);
-        animation: show-recovery-panel-in 0.22s ease 5s forwards;
+        animation: show-recovery-panel-in 0.22s ease {loading_delay} forwards;
       }}
       .show-recovery-panel p {{
         max-width: 720px;

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -25,6 +25,7 @@ from typing import Any
 import httpx
 
 from config import paths
+from core.show_pages import SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS
 from core.process_isolation import KILL_SIGNAL, isolated_subprocess_kwargs, signal_process_tree
 
 
@@ -156,6 +157,8 @@ class ShowRuntimeManager:
                         "127.0.0.1",
                         "--port",
                         "0",
+                        "--fallback-delay-seconds",
+                        str(SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS),
                     ],
                     stdout=stdout,
                     stderr=stderr,

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -10,7 +10,12 @@ from unittest.mock import patch
 import pytest
 
 from config import paths
-from core.show_pages import ShowPageStore, ensure_show_page_dir, show_cli_event_token
+from core.show_pages import (
+    SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS,
+    ShowPageStore,
+    ensure_show_page_dir,
+    show_cli_event_token,
+)
 from core.show_runtime import ShowRuntimeManager, _runtime_platform_tag, _safe_extract_tar, set_show_runtime_manager_for_tests
 from tests.test_ui_remote_access_auth import _mock_interface, _remote_peer, _save_config
 from vibe import remote_access
@@ -354,6 +359,23 @@ def test_private_show_page_falls_back_to_static_when_runtime_unavailable(monkeyp
     assert b"Ready to visualize" in response.content
     assert b"Copy prompt" in response.content
     assert b'src="./src/main.tsx"' not in response.content
+
+
+def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    set_show_runtime_manager_for_tests(_FakeShowRuntimeManager(fail=True))
+    try:
+        response = app.test_client().get("/show/ses123/", base_url="http://127.0.0.1:5123")
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    body = response.content.decode("utf-8")
+    loading_delay = f"{SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS}s"
+    assert f"show-recovery-loading-out 0.18s ease {loading_delay} forwards" in body
+    assert f"show-recovery-panel-in 0.22s ease {loading_delay} forwards" in body
+    assert "ease 5s forwards" not in body
 
 
 def test_private_show_page_api_does_not_fall_back_to_static(monkeypatch, tmp_path):
@@ -1148,6 +1170,38 @@ def test_show_runtime_manager_reports_missing_command(tmp_path):
 
     assert result.available is False
     assert result.reason == "runtime_command_missing"
+
+
+def test_show_runtime_manager_passes_recovery_delay_to_runtime(monkeypatch, tmp_path):
+    from core.show_pages import SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS
+
+    captured = {}
+
+    class FakeProcess:
+        def poll(self):
+            return None
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        return FakeProcess()
+
+    async def fake_startup_url():
+        return "http://127.0.0.1:12345"
+
+    manager = ShowRuntimeManager(
+        command="/bin/echo",
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+    )
+    monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: [command])
+    monkeypatch.setattr("core.show_runtime.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(manager, "_read_startup_url", fake_startup_url)
+
+    result = asyncio.run(manager.ensure())
+
+    assert result.available is True
+    index = captured["command"].index("--fallback-delay-seconds")
+    assert captured["command"][index + 1] == str(SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS)
 
 
 def test_show_runtime_manager_uses_managed_runtime_bin(tmp_path):


### PR DESCRIPTION
## Summary

- Raises the Vibe Remote Show Page recovery loading delay from 5 seconds to 10 seconds.
- Uses one Vibe Remote constant as the product-level delay source.
- Passes the same delay to the managed Show Runtime via `--fallback-delay-seconds` so the runtime-injected fallback matches the Python recovery page.
- Adds regression coverage for the recovery HTML delay and the managed runtime launch argument.

## Why

Users can see the recovery "Ready to visualize" page too early when first-load Vite/React warmup takes longer than 5 seconds. The delay also existed in two different layers: the Python fallback for an unavailable runtime and the runtime-injected fallback before React mounts. This PR keeps the two layers but makes Vibe Remote own one timing value for both.

## Dependency

Requires `avibe-bot/vibe-show-runtime#14`, which adds the `--fallback-delay-seconds` CLI option.

## Validation

- `uv run ruff check core/show_pages.py core/show_runtime.py tests/test_ui_show_pages.py`
- `uv run pytest tests/test_ui_show_pages.py -q`
