### PR TITLE
perf(show): cache successful Vite deps

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -124,6 +124,7 @@ class ShowRuntimeManager:
         self.stdout_path = self.runtime_dir / "stdout.log"
         self.stderr_path = self.runtime_dir / "stderr.log"
         self.install_log_path = self.runtime_dir / "install.log"
+        self.cache_root = self.runtime_dir / "vite-cache"
         self._install_attempted = False
         self._install_reason: str | None = None
         self._managed_command: list[str] | None = None
@@ -145,6 +146,7 @@ class ShowRuntimeManager:
                 return ShowRuntimeResult(False, reason=self._install_reason or "runtime_command_missing")
             self.runtime_dir.mkdir(parents=True, exist_ok=True)
             self.workspace_root.mkdir(parents=True, exist_ok=True)
+            self.cache_root.mkdir(parents=True, exist_ok=True)
             with self.stdout_path.open("w", encoding="utf-8") as stdout, self.stderr_path.open(
                 "w", encoding="utf-8"
             ) as stderr:
@@ -153,6 +155,8 @@ class ShowRuntimeManager:
                         *command,
                         "--workspace-root",
                         str(self.workspace_root),
+                        "--cache-root",
+                        str(self.cache_root),
                         "--host",
                         "127.0.0.1",
                         "--port",

--- a/docs/plans/show-service-runtime.md
+++ b/docs/plans/show-service-runtime.md
@@ -59,12 +59,16 @@ point through the local UI server and Avibe Cloud tunnel.
 
 ## Current Integration Contract
 
-Vibe Remote proxies private Show Pages to the sidecar:
+Vibe Remote proxies live Show Pages to the sidecar for both private and public
+visibility:
 
 ```text
 GET/HEAD /show/<session-id>/...
 ANY      /show/<session-id>/api/...
 WS       /show/<session-id>/__vite_hmr
+
+GET/HEAD /p/<share-id>/...
+WS       /p/<share-id>/__vite_hmr
 ```
 
 Sidecar routes:
@@ -79,9 +83,9 @@ ANY  /sessions/:sessionId/app/*
 
 Important policies:
 
-- private `/show/...` can use live service runtime
-- public `/p/...` keeps static/public-file behavior for now
-- live service handlers are not exposed through public share links yet
+- private `/show/...` and public `/p/...` both serve live runtime pages and HMR
+- public page rendering stays live, while write/event/handler/agent-action
+  capabilities are controlled separately by visibility and permission policy
 - offline pages keep the existing offline response
 - Vibe Remote never forwards UI cookies, authorization headers, CSRF headers,
   or `Set-Cookie` between browser and sidecar
@@ -169,6 +173,28 @@ can use presets or override CSS variables without editing component source.
 
 Dependencies are owned by the runtime, not by each session.
 
+Cloudflare Tunnel makes Vite dev-mode request count and cache-key stability
+visible. The Show Page must stay live in every visibility mode, so the
+performance fix is to cache immutable Vite optimized dependencies separately
+from session source rather than serving a public snapshot.
+
+Target cache policy:
+
+- successful Vite optimized dependency responses: long immutable cache
+- session HTML and injected config: no-store
+- session source modules such as `src/App.tsx`: fresh/HMR-controlled
+- runtime package `@fs/.../dist` paths: fresh until they move behind a
+  content-addressed runtime asset namespace
+- HMR WebSocket, event streams, and handlers: never cached
+
+The current integration passes a shared runtime cache root to the sidecar so
+Vite optimized deps do not live under each session workspace. Vibe Remote also
+marks successful Vite optimized dependency responses as long-cacheable for both
+session-local `.vite/deps/...`, Vite default `node_modules/.vite/deps/...`,
+and relocated `@fs/.../vite-cache/.../deps` URLs. These immutable dependency
+responses do not carry Show Page write-token cookies; session source modules
+and in-place runtime dist paths stay fresh.
+
 The next distribution step is the manifest/cache model described in
 `show-runtime-manifest-cache.md`: Vibe Remote wheels should carry a pinned
 runtime manifest, while official install and upgrade flows prepare only the
@@ -248,7 +274,9 @@ prompt behavior changes.
 - Add runtime status to `vibe show status`.
 - Add sidecar logs/error surfacing to the UI.
 - Implement active-context TTL/LRU limits in the runtime package.
-- Define public snapshot publishing for `/p/<share-id>/`; do not proxy live
-  handlers publicly until that policy exists.
+- Add a stable runtime asset namespace and cache policy so immutable runtime
+  resources can be reused across session and share URLs without disabling HMR.
+- Keep public write/event/handler permissions explicit; public page rendering
+  and HMR remain live by default.
 - Expand `@avibe/show-ui` component coverage and default visualization
   dependencies.

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -324,6 +324,154 @@ def test_private_show_page_runtime_config_overrides_existing_client_defaults(mon
     assert '"writeToken":"token-ses123"' in body
 
 
+def test_show_runtime_vendor_deps_are_cacheable(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/.vite/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert "set-cookie" not in response.headers
+
+
+def test_show_runtime_node_modules_vendor_deps_are_cacheable(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/node_modules/.vite/deps/react.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert "set-cookie" not in response.headers
+
+
+def test_show_runtime_relocated_vendor_deps_are_cacheable(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/@fs/Users/cyh/.vibe_remote/runtime/show-runtime/vite-cache/abc123/ses123/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert "set-cookie" not in response.headers
+
+
+def test_show_runtime_vendor_dep_errors_are_not_marked_immutable(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"missing",
+        status_code=404,
+        extra_headers={
+            "content-type": "text/plain",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/.vite/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert response.headers["cache-control"] == "no-cache"
+
+
+def test_show_runtime_fs_dist_paths_are_not_marked_immutable(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/@fs/Users/cyh/.vibe_remote/runtime/show-runtime/source/github/main/packages/ui/dist/theme.js",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-cache"
+
+
+def test_show_runtime_session_source_is_not_marked_immutable(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default function App() {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/src/App.tsx?t=1780732068677",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-cache"
+
+
 def test_public_show_page_does_not_inject_write_runtime_config(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)
@@ -685,6 +833,32 @@ def test_public_show_page_clears_show_event_write_cookie(monkeypatch, tmp_path):
     cookies = "\n".join(response.headers.getlist("set-cookie"))
     assert "vibe_show_event_token=" in cookies
     assert "Max-Age=0" in cookies
+
+
+def test_public_show_page_immutable_deps_do_not_clear_write_cookie(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/node_modules/.vite/deps/react.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert "set-cookie" not in response.headers
 
 
 def test_show_events_stream_replays_all_persisted_pages_before_live(monkeypatch, tmp_path):
@@ -1172,7 +1346,7 @@ def test_show_runtime_manager_reports_missing_command(tmp_path):
     assert result.reason == "runtime_command_missing"
 
 
-def test_show_runtime_manager_passes_recovery_delay_to_runtime(monkeypatch, tmp_path):
+def test_show_runtime_manager_passes_runtime_options(monkeypatch, tmp_path):
     from core.show_pages import SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS
 
     captured = {}
@@ -1200,6 +1374,8 @@ def test_show_runtime_manager_passes_recovery_delay_to_runtime(monkeypatch, tmp_
     result = asyncio.run(manager.ensure())
 
     assert result.available is True
+    cache_index = captured["command"].index("--cache-root")
+    assert captured["command"][cache_index + 1] == str(tmp_path / "runtime" / "vite-cache")
     index = captured["command"].index("--fallback-delay-seconds")
     assert captured["command"][index + 1] == str(SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -84,6 +84,7 @@ _SHOW_RUNTIME_MODULE_SCRIPT_RE = re.compile(
     r"<script\b(?=[^>]*\btype\s*=\s*['\"]module['\"])[^>]*>",
     re.IGNORECASE,
 )
+_SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 
 STRUCTURED_LOG_PATTERN = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s+-\s+([\w.]+)\s+-\s+(\w+)\s+-\s+(.*)$")
 LEVEL_HINT_PATTERN = re.compile(r"\b(DEBUG|INFO|WARNING|ERROR|CRITICAL)\b")
@@ -238,6 +239,8 @@ def _is_show_api_mutation() -> bool:
 
 
 def _ensure_csrf_cookie(response: Response) -> Response:
+    if _is_current_show_runtime_immutable_asset_request():
+        return response
     if response.headers.getlist("Set-Cookie"):
         for cookie_header in response.headers.getlist("Set-Cookie"):
             if cookie_header.startswith(f"{CSRF_COOKIE_NAME}="):
@@ -1202,6 +1205,8 @@ def add_csrf_cookie(response: Response) -> Response:
 def renew_remote_access_cookie(response: Response) -> Response:
     # Logout handler explicitly clears the session cookie; never re-issue it.
     if getattr(g, "remote_session_logout", False):
+        return response
+    if _is_current_show_runtime_immutable_asset_request():
         return response
     renew = getattr(g, "remote_session_renew", None)
     if not renew:
@@ -5430,6 +5435,8 @@ async def _show_page_runtime_response(
     if _should_inject_show_runtime_config(proxied.status_code, response_headers, inject_private_config=inject_private_config):
         content = _inject_show_runtime_config(content, session_id)
         _strip_mutated_show_runtime_headers(response_headers)
+    else:
+        _apply_show_runtime_cache_headers(asset_path, response_headers, status_code=proxied.status_code)
     return FastAPIResponse(content=content, status_code=proxied.status_code, headers=response_headers)
 
 
@@ -5450,6 +5457,52 @@ def _strip_mutated_show_runtime_headers(headers: dict[str, str]) -> None:
     for name in ("cache-control", "etag", "expires", "last-modified", "content-length"):
         _remove_response_header(headers, name)
     headers["Cache-Control"] = "no-store"
+
+
+def _apply_show_runtime_cache_headers(asset_path: str, headers: dict[str, str], *, status_code: int) -> None:
+    relative = (asset_path or "").strip("/")
+    if not relative or relative == "index.html":
+        _remove_response_header(headers, "cache-control")
+        headers["Cache-Control"] = "no-store"
+        return
+    if status_code < 200 or status_code >= 300:
+        return
+    if _is_show_runtime_immutable_asset(relative):
+        _remove_response_header(headers, "cache-control")
+        _remove_response_header(headers, "set-cookie")
+        headers["Cache-Control"] = _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL
+
+
+def _is_show_runtime_immutable_asset(relative_asset_path: str) -> bool:
+    if relative_asset_path.startswith(".vite/deps/"):
+        return True
+    if relative_asset_path.startswith("node_modules/.vite/deps/"):
+        return True
+    if relative_asset_path.startswith("@fs/") and _is_relocated_vite_dep_path(relative_asset_path):
+        return True
+    return False
+
+
+def _is_relocated_vite_dep_path(relative_asset_path: str) -> bool:
+    return (
+        "/deps/" in relative_asset_path
+        and (
+            "/vite-cache/" in relative_asset_path
+            or "/.vite-cache/" in relative_asset_path
+        )
+    )
+
+
+def _is_show_runtime_immutable_asset_path(asset_path: str) -> bool:
+    return _is_show_runtime_immutable_asset((asset_path or "").strip("/"))
+
+
+def _is_current_show_runtime_immutable_asset_request() -> bool:
+    path = (request.path or "").strip("/")
+    parts = path.split("/", 2)
+    if len(parts) < 3 or parts[0] not in {"show", "p"}:
+        return False
+    return _is_show_runtime_immutable_asset_path(parts[2])
 
 
 def _remove_response_header(headers: dict[str, str], name: str) -> None:
@@ -5615,6 +5668,8 @@ async def serve_private_show_page(session_id, asset_path):
         if response is None:
             response = _show_page_file_response(show_page_dir(page.session_id), asset_path)
         if request.method in {"GET", "HEAD"}:
+            if _is_show_runtime_immutable_asset_path(asset_path):
+                return response
             return _with_show_event_write_cookie(response, page.session_id, enabled=True)
         return response
     finally:
@@ -5683,6 +5738,8 @@ async def serve_public_show_page(share_id, asset_path):
         if response is None:
             response = _show_page_file_response(show_page_dir(page.session_id), asset_path)
         if request.method in {"GET", "HEAD"}:
+            if _is_show_runtime_immutable_asset_path(asset_path):
+                return response
             return _with_show_event_write_cookie(response, page.session_id, enabled=False)
         return response
     finally:


### PR DESCRIPTION
## Summary

- pass a managed `--cache-root` to the Show Runtime sidecar
- mark successful Vite optimized dependency responses as long-cacheable through the Vibe Remote proxy
- keep session HTML/source modules, runtime `@fs` dist paths, HMR, handlers, and error responses fresh
- update the Show Runtime integration plan to remove the old public snapshot direction

## Why

Remote Show Pages through Cloudflare Tunnel spend time on Vite dependency requests. The change preserves live HMR everywhere while reducing repeated Vite optimized dependency cost. Runtime package dist paths are intentionally not marked immutable until they move behind content-addressed runtime asset URLs.

## Dependency

Depends on avibe-bot/vibe-show-runtime#15 or equivalent runtime support for `--cache-root`.

## Evidence

- `uv run ruff check core/show_runtime.py vibe/ui_server.py tests/test_ui_show_pages.py`
- `uv run pytest tests/test_ui_show_pages.py -q`

## Residual checks

- Browser/network timing through Cloudflare Tunnel after both PRs are installed together.
