### PR TITLE
fix(opencode): restart server after provider config changes

### DIFF
--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -58,8 +58,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         self.controller.config.opencode = opencode_config
         if previous_server is not None:
             refreshed = False
+            runtime_unchanged = (
+                previous_server.binary == opencode_config.binary
+                and previous_server.port == opencode_config.port
+                and previous_server.request_timeout_seconds == opencode_config.request_timeout_seconds
+            )
             refresh_global_config = getattr(previous_server, "refresh_global_config", None)
-            if callable(refresh_global_config):
+            if runtime_unchanged and callable(refresh_global_config):
                 try:
                     refreshed = bool(await refresh_global_config())
                 except Exception:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -46,21 +46,31 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         return await self._client_manager.get_server()
 
     async def refresh_runtime_config(self, opencode_config) -> None:
-        """Reload runtime config and restart the shared server.
+        """Reload runtime config and refresh the shared server.
 
         OpenCode caches opencode.json provider/model config in the serve
-        process. A backend refresh after Settings writes must therefore stop
-        the server, not just swap the Python-side runtime config.
+        process. Prefer OpenCode's own global-config reload endpoint so
+        Settings writes take effect without terminating active serve
+        processes; fall back to restart for older OpenCode versions.
         """
         previous_server = await self._client_manager.reset_config(opencode_config)
         self.opencode_config = opencode_config
         self.controller.config.opencode = opencode_config
         if previous_server is not None:
-            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
-            if callable(detach):
-                await detach()
-            elif hasattr(previous_server, "restart_for_auth_refresh"):
-                await previous_server.restart_for_auth_refresh()
+            refreshed = False
+            refresh_global_config = getattr(previous_server, "refresh_global_config", None)
+            if callable(refresh_global_config):
+                try:
+                    refreshed = bool(await refresh_global_config())
+                except Exception:
+                    logger.warning("OpenCode global config refresh failed; falling back to restart", exc_info=True)
+                    refreshed = False
+            if not refreshed:
+                detach = getattr(previous_server, "detach_after_deferred_refresh", None)
+                if callable(detach):
+                    await detach()
+                elif hasattr(previous_server, "restart_for_auth_refresh"):
+                    await previous_server.restart_for_auth_refresh()
             reload_config = getattr(previous_server, "reload_runtime_config", None)
             if callable(reload_config):
                 await reload_config(

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -46,16 +46,16 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         return await self._client_manager.get_server()
 
     async def refresh_runtime_config(self, opencode_config) -> None:
-        """Reload persisted runtime config before restarting the shared server."""
+        """Reload runtime config and restart the shared server.
+
+        OpenCode caches opencode.json provider/model config in the serve
+        process. A backend refresh after Settings writes must therefore stop
+        the server, not just swap the Python-side runtime config.
+        """
         previous_server = await self._client_manager.reset_config(opencode_config)
         self.opencode_config = opencode_config
         self.controller.config.opencode = opencode_config
         if previous_server is not None:
-            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
-            if callable(detach):
-                await detach()
-            elif hasattr(previous_server, "restart_for_auth_refresh"):
-                await previous_server.restart_for_auth_refresh()
             reload_config = getattr(previous_server, "reload_runtime_config", None)
             if callable(reload_config):
                 await reload_config(
@@ -63,6 +63,11 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     port=opencode_config.port,
                     request_timeout_seconds=opencode_config.request_timeout_seconds,
                 )
+            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
+            if callable(detach):
+                await detach()
+            elif hasattr(previous_server, "restart_for_auth_refresh"):
+                await previous_server.restart_for_auth_refresh()
 
     async def handle_message(self, request: AgentRequest) -> None:
         lock = self._session_manager.get_session_lock(request.base_session_id)

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -56,6 +56,11 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         self.opencode_config = opencode_config
         self.controller.config.opencode = opencode_config
         if previous_server is not None:
+            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
+            if callable(detach):
+                await detach()
+            elif hasattr(previous_server, "restart_for_auth_refresh"):
+                await previous_server.restart_for_auth_refresh()
             reload_config = getattr(previous_server, "reload_runtime_config", None)
             if callable(reload_config):
                 await reload_config(
@@ -63,11 +68,6 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     port=opencode_config.port,
                     request_timeout_seconds=opencode_config.request_timeout_seconds,
                 )
-            detach = getattr(previous_server, "detach_after_deferred_refresh", None)
-            if callable(detach):
-                await detach()
-            elif hasattr(previous_server, "restart_for_auth_refresh"):
-                await previous_server.restart_for_auth_refresh()
 
     async def handle_message(self, request: AgentRequest) -> None:
         lock = self._session_manager.get_session_lock(request.base_session_id)

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -198,6 +198,41 @@ class OpenCodeServerManager:
                 return
             await self._restart_for_auth_refresh_locked()
 
+    async def refresh_global_config(self) -> bool:
+        """Ask a live OpenCode server to reload global opencode.json config.
+
+        OpenCode's HTTP API applies ``PATCH /global/config`` to the
+        global config and disposes its cached instances, which refreshes
+        provider options without terminating the shared ``opencode serve``
+        process. Return ``False`` when the endpoint is unavailable so
+        callers can fall back to a process restart.
+        """
+
+        config = self._load_opencode_user_config()
+        if config is None:
+            return False
+
+        await self.ensure_running()
+
+        async with self._request_scope():
+            async with self._get_lock():
+                await self._close_http_session_locked()
+            session = await self._get_http_session()
+            async with session.patch(
+                f"{self.base_url}/global/config",
+                json=config,
+            ) as resp:
+                if resp.status == 200:
+                    await resp.read()
+                    return True
+                if resp.status in (404, 405):
+                    await resp.read()
+                    return False
+                error_text = await resp.text()
+                raise RuntimeError(
+                    f"Failed to refresh OpenCode global config: {resp.status} {error_text}"
+                )
+
     async def reload_runtime_config(
         self,
         *,

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -213,28 +213,25 @@ class OpenCodeServerManager:
             return False
 
         await self.ensure_running()
+        total_timeout: Optional[int] = None if self.request_timeout_seconds <= 0 else self.request_timeout_seconds
         async with self._get_lock():
             if self._active_requests > 0 or self._has_active_run_sessions():
                 return False
-
-        total_timeout: Optional[int] = None if self.request_timeout_seconds <= 0 else self.request_timeout_seconds
-        async with self._request_scope():
             async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=total_timeout)) as session:
-                for path in ("/global/config", "/config"):
-                    async with session.patch(
-                        f"{self.base_url}{path}",
-                        json=config,
-                    ) as resp:
-                        if resp.status == 200:
-                            await resp.read()
-                            return True
-                        if resp.status in (404, 405):
-                            await resp.read()
-                            continue
-                        error_text = await resp.text()
-                        raise RuntimeError(
-                            f"Failed to refresh OpenCode config: {resp.status} {error_text}"
-                        )
+                async with session.patch(
+                    f"{self.base_url}/global/config",
+                    json=config,
+                ) as resp:
+                    if resp.status == 200:
+                        await resp.read()
+                        return True
+                    if resp.status in (404, 405):
+                        await resp.read()
+                        return False
+                    error_text = await resp.text()
+                    raise RuntimeError(
+                        f"Failed to refresh OpenCode global config: {resp.status} {error_text}"
+                    )
         return False
 
     async def reload_runtime_config(

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -213,25 +213,29 @@ class OpenCodeServerManager:
             return False
 
         await self.ensure_running()
+        async with self._get_lock():
+            if self._active_requests > 0 or self._has_active_run_sessions():
+                return False
 
+        total_timeout: Optional[int] = None if self.request_timeout_seconds <= 0 else self.request_timeout_seconds
         async with self._request_scope():
-            async with self._get_lock():
-                await self._close_http_session_locked()
-            session = await self._get_http_session()
-            async with session.patch(
-                f"{self.base_url}/global/config",
-                json=config,
-            ) as resp:
-                if resp.status == 200:
-                    await resp.read()
-                    return True
-                if resp.status in (404, 405):
-                    await resp.read()
-                    return False
-                error_text = await resp.text()
-                raise RuntimeError(
-                    f"Failed to refresh OpenCode global config: {resp.status} {error_text}"
-                )
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=total_timeout)) as session:
+                for path in ("/global/config", "/config"):
+                    async with session.patch(
+                        f"{self.base_url}{path}",
+                        json=config,
+                    ) as resp:
+                        if resp.status == 200:
+                            await resp.read()
+                            return True
+                        if resp.status in (404, 405):
+                            await resp.read()
+                            continue
+                        error_text = await resp.text()
+                        raise RuntimeError(
+                            f"Failed to refresh OpenCode config: {resp.status} {error_text}"
+                        )
+        return False
 
     async def reload_runtime_config(
         self,

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1061,15 +1061,15 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
 
         old_config = OpenCodeCompatConfig(
             enabled=True,
-            binary="/old/opencode",
+            binary="/opencode",
             port=4096,
             request_timeout_seconds=60,
         )
         new_config = OpenCodeCompatConfig(
             enabled=True,
-            binary="/new/opencode",
-            port=4100,
-            request_timeout_seconds=15,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
         )
         calls: list[str] = []
 
@@ -1080,6 +1080,9 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             calls.append("reload")
 
         previous_server = SimpleNamespace(
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
             reload_runtime_config=AsyncMock(side_effect=_reload_runtime_config),
             detach_after_deferred_refresh=AsyncMock(side_effect=_detach),
             refresh_global_config=AsyncMock(return_value=False),
@@ -1096,13 +1099,52 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         agent._client_manager.reset_config.assert_awaited_once_with(new_config)
         previous_server.detach_after_deferred_refresh.assert_awaited_once()
         previous_server.reload_runtime_config.assert_awaited_once_with(
-            binary="/new/opencode",
-            port=4100,
-            request_timeout_seconds=15,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
         )
         self.assertEqual(calls, ["detach", "reload"])
 
     async def test_opencode_agent_refresh_runtime_config_uses_global_config_refresh(self):
+        from config.v2_compat import OpenCodeCompatConfig
+        from modules.agents.opencode.agent import OpenCodeAgent
+
+        old_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        new_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        previous_server = SimpleNamespace(
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+            refresh_global_config=AsyncMock(return_value=True),
+            detach_after_deferred_refresh=AsyncMock(),
+            reload_runtime_config=AsyncMock(),
+        )
+        agent = OpenCodeAgent.__new__(OpenCodeAgent)
+        agent.opencode_config = old_config
+        agent.controller = SimpleNamespace(config=SimpleNamespace(opencode=old_config))
+        agent._client_manager = SimpleNamespace(reset_config=AsyncMock(return_value=previous_server))
+
+        await agent.refresh_runtime_config(new_config)
+
+        previous_server.refresh_global_config.assert_awaited_once()
+        previous_server.detach_after_deferred_refresh.assert_not_awaited()
+        previous_server.reload_runtime_config.assert_awaited_once_with(
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+
+    async def test_opencode_agent_refresh_runtime_config_restarts_when_runtime_changes(self):
         from config.v2_compat import OpenCodeCompatConfig
         from modules.agents.opencode.agent import OpenCodeAgent
 
@@ -1119,6 +1161,9 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             request_timeout_seconds=15,
         )
         previous_server = SimpleNamespace(
+            binary="/old/opencode",
+            port=4096,
+            request_timeout_seconds=60,
             refresh_global_config=AsyncMock(return_value=True),
             detach_after_deferred_refresh=AsyncMock(),
             reload_runtime_config=AsyncMock(),
@@ -1130,8 +1175,8 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
 
         await agent.refresh_runtime_config(new_config)
 
-        previous_server.refresh_global_config.assert_awaited_once()
-        previous_server.detach_after_deferred_refresh.assert_not_awaited()
+        previous_server.refresh_global_config.assert_not_awaited()
+        previous_server.detach_after_deferred_refresh.assert_awaited_once()
         previous_server.reload_runtime_config.assert_awaited_once_with(
             binary="/new/opencode",
             port=4100,

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1017,12 +1017,12 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             async def refresh_runtime_config(self, opencode_config):
                 self.refreshed = opencode_config
                 controller.config.opencode = opencode_config
+                await previous_server.detach_after_deferred_refresh()
                 await previous_server.reload_runtime_config(
                     binary=opencode_config.binary,
                     port=opencode_config.port,
                     request_timeout_seconds=opencode_config.request_timeout_seconds,
                 )
-                await previous_server.detach_after_deferred_refresh()
 
         agent = _FakeOpenCodeAgent()
         controller.agent_service.agents["opencode"] = agent
@@ -1098,7 +1098,7 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             port=4100,
             request_timeout_seconds=15,
         )
-        self.assertEqual(calls, ["detach", "reload"])
+        self.assertEqual(calls, ["reload", "detach"])
 
     async def test_refresh_claude_runtime_reloads_v2_cli_path(self):
         from config.v2_config import AgentsConfig, ClaudeConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1098,7 +1098,7 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             port=4100,
             request_timeout_seconds=15,
         )
-        self.assertEqual(calls, ["reload", "detach"])
+        self.assertEqual(calls, ["detach", "reload"])
 
     async def test_refresh_claude_runtime_reloads_v2_cli_path(self):
         from config.v2_config import AgentsConfig, ClaudeConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1005,6 +1005,7 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         previous_server = SimpleNamespace(
             reload_runtime_config=AsyncMock(),
             detach_after_deferred_refresh=AsyncMock(),
+            refresh_global_config=AsyncMock(return_value=False),
         )
 
         class _FakeOpenCodeAgent:
@@ -1081,6 +1082,7 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         previous_server = SimpleNamespace(
             reload_runtime_config=AsyncMock(side_effect=_reload_runtime_config),
             detach_after_deferred_refresh=AsyncMock(side_effect=_detach),
+            refresh_global_config=AsyncMock(return_value=False),
         )
         agent = OpenCodeAgent.__new__(OpenCodeAgent)
         agent.opencode_config = old_config
@@ -1099,6 +1101,42 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             request_timeout_seconds=15,
         )
         self.assertEqual(calls, ["detach", "reload"])
+
+    async def test_opencode_agent_refresh_runtime_config_uses_global_config_refresh(self):
+        from config.v2_compat import OpenCodeCompatConfig
+        from modules.agents.opencode.agent import OpenCodeAgent
+
+        old_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/old/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        new_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
+        previous_server = SimpleNamespace(
+            refresh_global_config=AsyncMock(return_value=True),
+            detach_after_deferred_refresh=AsyncMock(),
+            reload_runtime_config=AsyncMock(),
+        )
+        agent = OpenCodeAgent.__new__(OpenCodeAgent)
+        agent.opencode_config = old_config
+        agent.controller = SimpleNamespace(config=SimpleNamespace(opencode=old_config))
+        agent._client_manager = SimpleNamespace(reset_config=AsyncMock(return_value=previous_server))
+
+        await agent.refresh_runtime_config(new_config)
+
+        previous_server.refresh_global_config.assert_awaited_once()
+        previous_server.detach_after_deferred_refresh.assert_not_awaited()
+        previous_server.reload_runtime_config.assert_awaited_once_with(
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
 
     async def test_refresh_claude_runtime_reloads_v2_cli_path(self):
         from config.v2_config import AgentsConfig, ClaudeConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -75,6 +75,13 @@ class _FakeSession:
     async def close(self):
         self.closed = True
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
+        return False
+
 
 class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
     async def test_prompt_async_includes_tools_when_provided(self):
@@ -137,12 +144,16 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             manager = OpenCodeServerManager(binary="opencode", port=4096)
             fake_session = _FakeSession()
             manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
-            manager._get_http_session = AsyncMock(return_value=fake_session)  # type: ignore[method-assign]
 
-            with patch("vibe.opencode_config.Path.home", return_value=tmp_home):
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
                 refreshed = await manager.refresh_global_config()
 
             self.assertTrue(refreshed)
+            self.assertTrue(fake_session.closed)
             self.assertEqual(len(fake_session.patches), 1)
             self.assertEqual(
                 fake_session.patches[0]["url"],
@@ -158,6 +169,61 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                     }
                 },
             )
+
+    async def test_refresh_global_config_falls_back_to_documented_config_endpoint(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text('{"provider":{"deepseek":{"models":{}}}}', encoding="utf-8")
+
+            class _FallbackSession(_FakeSession):
+                def patch(self, url, json=None, headers=None):
+                    self.patches.append({"url": url, "json": json, "headers": headers})
+                    if url.endswith("/global/config"):
+                        return _FakeResponse(status=404)
+                    return _FakeResponse(status=200)
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _FallbackSession()
+            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                [call["url"] for call in fake_session.patches],
+                [
+                    "http://127.0.0.1:4096/global/config",
+                    "http://127.0.0.1:4096/config",
+                ],
+            )
+
+    async def test_refresh_global_config_defers_when_request_active(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text('{"provider":{"deepseek":{"models":{}}}}', encoding="utf-8")
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _FakeSession()
+            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+            manager._active_requests = 1
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertFalse(refreshed)
+            self.assertEqual(fake_session.patches, [])
 
     async def test_find_opencode_serve_pids_windows_uses_netstat_and_command_lookup(self):
         netstat_output = """

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -170,22 +170,20 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 },
             )
 
-    async def test_refresh_global_config_falls_back_to_documented_config_endpoint(self):
+    async def test_refresh_global_config_returns_false_when_global_endpoint_is_unavailable(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_home = Path(tmp_dir)
             config_path = tmp_home / ".config" / "opencode" / "opencode.json"
             config_path.parent.mkdir(parents=True, exist_ok=True)
             config_path.write_text('{"provider":{"deepseek":{"models":{}}}}', encoding="utf-8")
 
-            class _FallbackSession(_FakeSession):
+            class _UnavailableSession(_FakeSession):
                 def patch(self, url, json=None, headers=None):
                     self.patches.append({"url": url, "json": json, "headers": headers})
-                    if url.endswith("/global/config"):
-                        return _FakeResponse(status=404)
-                    return _FakeResponse(status=200)
+                    return _FakeResponse(status=404)
 
             manager = OpenCodeServerManager(binary="opencode", port=4096)
-            fake_session = _FallbackSession()
+            fake_session = _UnavailableSession()
             manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
 
             with (
@@ -195,13 +193,10 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             ):
                 refreshed = await manager.refresh_global_config()
 
-            self.assertTrue(refreshed)
+            self.assertFalse(refreshed)
             self.assertEqual(
                 [call["url"] for call in fake_session.patches],
-                [
-                    "http://127.0.0.1:4096/global/config",
-                    "http://127.0.0.1:4096/config",
-                ],
+                ["http://127.0.0.1:4096/global/config"],
             )
 
     async def test_refresh_global_config_defers_when_request_active(self):
@@ -224,6 +219,59 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertFalse(refreshed)
             self.assertEqual(fake_session.patches, [])
+
+    async def test_refresh_global_config_blocks_new_request_scope_while_patching(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text('{"provider":{"deepseek":{"models":{}}}}', encoding="utf-8")
+
+            class _BlockingResponse(_FakeResponse):
+                def __init__(self, entered: asyncio.Event, release: asyncio.Event):
+                    super().__init__(status=200)
+                    self._entered = entered
+                    self._release = release
+
+                async def __aenter__(self):
+                    self._entered.set()
+                    await self._release.wait()
+                    return self
+
+            class _BlockingSession(_FakeSession):
+                def __init__(self, entered: asyncio.Event, release: asyncio.Event):
+                    super().__init__()
+                    self._entered = entered
+                    self._release = release
+
+                def patch(self, url, json=None, headers=None):
+                    self.patches.append({"url": url, "json": json, "headers": headers})
+                    return _BlockingResponse(self._entered, self._release)
+
+            entered = asyncio.Event()
+            release = asyncio.Event()
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _BlockingSession(entered, release)
+            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refresh_task = asyncio.create_task(manager.refresh_global_config())
+                await entered.wait()
+                request_scope = manager._request_scope()
+                request_task = asyncio.create_task(request_scope.__aenter__())
+                await asyncio.sleep(0)
+
+                self.assertFalse(request_task.done())
+                release.set()
+                self.assertTrue(await refresh_task)
+                await request_task
+                self.assertEqual(manager._active_requests, 1)
+                await request_scope.__aexit__(None, None, None)
+                self.assertEqual(manager._active_requests, 0)
 
     async def test_find_opencode_serve_pids_windows_uses_netstat_and_command_lookup(self):
         netstat_output = """

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -49,11 +49,15 @@ class _FakeResponse:
     async def text(self):
         return self._text
 
+    async def read(self):
+        return self._text.encode()
+
 
 class _FakeSession:
     def __init__(self):
         self.posts = []
         self.puts = []
+        self.patches = []
         self.closed = False
 
     def post(self, url, json=None, headers=None):
@@ -62,6 +66,10 @@ class _FakeSession:
 
     def put(self, url, json=None, headers=None):
         self.puts.append({"url": url, "json": json, "headers": headers})
+        return _FakeResponse(status=200)
+
+    def patch(self, url, json=None, headers=None):
+        self.patches.append({"url": url, "json": json, "headers": headers})
         return _FakeResponse(status=200)
 
     async def close(self):
@@ -113,6 +121,41 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 {
                     "model": "openai/gpt-5",
                     "reasoningEffort": "high",
+                },
+            )
+
+    async def test_refresh_global_config_patches_live_server(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"deepseek":{"options":{"baseURL":"https://api.deepseek.com"}}}}',
+                encoding="utf-8",
+            )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _FakeSession()
+            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+            manager._get_http_session = AsyncMock(return_value=fake_session)  # type: ignore[method-assign]
+
+            with patch("vibe.opencode_config.Path.home", return_value=tmp_home):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(len(fake_session.patches), 1)
+            self.assertEqual(
+                fake_session.patches[0]["url"],
+                "http://127.0.0.1:4096/global/config",
+            )
+            self.assertEqual(
+                fake_session.patches[0]["json"],
+                {
+                    "provider": {
+                        "deepseek": {
+                            "options": {"baseURL": "https://api.deepseek.com"}
+                        }
+                    }
                 },
             )
 

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -1254,13 +1254,6 @@ export const OpencodeProviderConfig: React.FC<{
                                 {provider.description}
                               </span>
                             )}
-                            {provider.custom && provider.adapter && (
-                              <span className="text-[11px] text-muted">
-                                {provider.adapter === 'anthropic-compatible'
-                                  ? t('settings.backends.opencodeCustomProviderAdapterAnthropic')
-                                  : t('settings.backends.opencodeCustomProviderAdapterOpenAI')}
-                              </span>
-                            )}
                           </div>
                           {expanded ? (
                             <ChevronUp className="mt-0.5 size-4 shrink-0 text-muted" />


### PR DESCRIPTION
## Summary
- restart the live OpenCode serve process after provider config refresh so newly added custom providers and models are loaded immediately
- keep the runtime config reload ordering aligned with the next spawned server
- remove the duplicate custom-provider adapter label in the Provider card header

## Root Cause
OpenCode caches `opencode.json` provider and model config inside the `opencode serve` process. Vibe Remote already requested an OpenCode backend refresh after Settings writes, but the controller-acknowledged path only refreshed the Python-side runtime config and did not actually restart the live OpenCode server. Newly added custom providers such as `gpt-relay` therefore appeared in Vibe's UI overlay but were still missing from OpenCode's model index, causing `ProviderModelNotFoundError` during the provider test.

## Validation
- `npm run build`
- `uv run ruff check modules/agents/opencode/agent.py tests/test_agent_auth_service.py`
- `uv run pytest tests/test_agent_auth_service.py tests/test_save_opencode_provider_auth.py`
- regression container probe: after restarting `opencode serve`, `gpt-relay/gpt-5.5` provider test returned `ok: true`

## Evidence Layers
- unit: OpenCode runtime refresh ordering and provider auth regression tests
- contract: existing provider save/test contracts preserved
- scenario: regression `gpt-relay` custom OpenAI-compatible provider test
- residual manual checks: re-deploy this branch to three-regression and verify the duplicate label is gone in the browser
