### PR TITLE
ci: run npm wrapper on avibe runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,14 +15,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64, avibe]
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-          cache: pip
-          cache-dependency-path: |
-            pyproject.toml
-            requirements.txt
-            uv.lock
+      - name: Create Python virtualenv
+        run: |
+          python3 -m venv .venv
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
       - name: Run pre-commit (ruff)
         run: |
           pip install pre-commit
@@ -53,14 +49,10 @@ jobs:
           npm ci
           npm run build
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: |
-            pyproject.toml
-            requirements.txt
-            uv.lock
+      - name: Create Python virtualenv
+        run: |
+          python3 -m venv .venv
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Install package and test deps
         run: pip install -e . pytest
@@ -116,14 +108,10 @@ jobs:
           npm run validate:theme
           npm run build
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: |
-            pyproject.toml
-            requirements.txt
-            uv.lock
+      - name: Create Python virtualenv
+        run: |
+          python3 -m venv .venv
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Install build and test dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,19 +18,17 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
       - name: Run pre-commit (ruff)
         run: |
           pip install pre-commit
           pre-commit run --all-files
 
-  unit-test-shards:
-    name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
+  build-ui-assets:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2, 3]
-        shard-total: [4]
     steps:
       - uses: actions/checkout@v5
 
@@ -40,17 +38,46 @@ jobs:
           cache: "npm"
           cache-dependency-path: ui/package-lock.json
 
-      # hatchling force-includes ui/dist into the (editable) install, so it must
-      # exist before `pip install -e .`.
       - name: Build UI assets
         working-directory: ui
         run: |
           npm ci
+          npm run validate:theme
           npm run build
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: ui-dist-linux
+          path: ui/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  unit-test-shards:
+    name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
+    runs-on: ubuntu-latest
+    needs: build-ui-assets
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+        shard-total: [4]
+    steps:
+      - uses: actions/checkout@v5
+
+      # hatchling force-includes ui/dist into the (editable) install, so it must
+      # exist before `pip install -e .`.
+      - uses: actions/download-artifact@v5
+        with:
+          name: ui-dist-linux
+          path: ui/dist
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install package and test deps
         run: pip install -e . pytest
@@ -90,25 +117,22 @@ jobs:
 
   install-upgrade-regression:
     runs-on: ubuntu-latest
+    needs: build-ui-assets
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/download-artifact@v5
         with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: ui/package-lock.json
-
-      - name: Build UI assets
-        working-directory: ui
-        run: |
-          npm ci
-          npm run validate:theme
-          npm run build
+          name: ui-dist-linux
+          path: ui/dist
 
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install build and test dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,12 +12,17 @@ concurrency:
 
 jobs:
   ruff:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            uv.lock
       - name: Run pre-commit (ruff)
         run: |
           pip install pre-commit
@@ -25,7 +30,7 @@ jobs:
 
   unit-test-shards:
     name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +56,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            uv.lock
 
       - name: Install package and test deps
         run: pip install -e . pytest
@@ -59,7 +69,7 @@ jobs:
         run: bash scripts/ci_unit_tests.sh "${{ matrix.shard }}" "${{ matrix.shard-total }}"
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     needs: unit-test-shards
     if: always()
     steps:
@@ -89,7 +99,7 @@ jobs:
         run: npm pack --dry-run
 
   install-upgrade-regression:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     steps:
       - uses: actions/checkout@v5
 
@@ -109,6 +119,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            uv.lock
 
       - name: Install build and test dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,9 +89,15 @@ jobs:
         run: npm pack --dry-run
 
   install-upgrade-regression:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     steps:
       - uses: actions/checkout@v5
+
+      - name: Verify self-hosted runner tools
+        run: |
+          docker info
+          node --version || true
+          python3 --version || true
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           pip install pre-commit
           pre-commit run --all-files
 
-  build-ui-assets:
+  build-linux-artifacts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -48,6 +48,19 @@ jobs:
           npm run validate:theme
           npm run build
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+
+      - name: Build package artifact
+        run: |
+          pip install build
+          python -m build --wheel
+
       - uses: actions/upload-artifact@v5
         with:
           name: ui-dist-linux
@@ -55,10 +68,17 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - uses: actions/upload-artifact@v5
+        with:
+          name: vibe-wheel-linux
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 1
+
   unit-test-shards:
     name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
     runs-on: ubuntu-latest
-    needs: build-ui-assets
+    needs: build-linux-artifacts
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +140,7 @@ jobs:
 
   install-upgrade-regression:
     runs-on: ubuntu-latest
-    needs: build-ui-assets
+    needs: build-linux-artifacts
     steps:
       - uses: actions/checkout@v5
 
@@ -128,6 +148,11 @@ jobs:
         with:
           name: ui-dist-linux
           path: ui/dist
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: vibe-wheel-linux
+          path: dist
 
       - uses: actions/setup-python@v6
         with:
@@ -137,12 +162,9 @@ jobs:
             pyproject.toml
             uv.lock
 
-      - name: Install build and test dependencies
+      - name: Install package and test dependencies
         run: |
-          pip install -e . build pytest
-
-      - name: Build package artifact
-        run: python -m build
+          pip install dist/*.whl pytest
 
       - name: Run install and upgrade regressions
         run: |
@@ -157,31 +179,14 @@ jobs:
 
   windows-install-smoke:
     runs-on: windows-latest
+    needs: build-linux-artifacts
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/download-artifact@v5
         with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: ui/package-lock.json
-
-      - name: Build UI assets
-        working-directory: ui
-        run: |
-          npm ci
-          npm run validate:theme
-          npm run build
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install build dependencies
-        run: pip install build
-
-      - name: Build package artifact
-        run: python -m build
+          name: vibe-wheel-linux
+          path: dist
 
       - name: Run Windows installer smoke test
         shell: pwsh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   ruff:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -25,7 +25,7 @@ jobs:
 
   unit-test-shards:
     name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,7 @@ jobs:
         run: bash scripts/ci_unit_tests.sh "${{ matrix.shard }}" "${{ matrix.shard-total }}"
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     needs: unit-test-shards
     if: always()
     steps:
@@ -89,7 +89,7 @@ jobs:
         run: npm pack --dry-run
 
   install-upgrade-regression:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
           echo "All unit test shards passed."
 
   npm-wrapper:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, avibe]
     steps:
       - uses: actions/checkout@v5
 
@@ -89,15 +89,9 @@ jobs:
         run: npm pack --dry-run
 
   install-upgrade-regression:
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Verify self-hosted runner tools
-        run: |
-          docker info
-          node --version || true
-          python3 --version || true
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,13 +12,12 @@ concurrency:
 
 jobs:
   ruff:
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Create Python virtualenv
-        run: |
-          python3 -m venv .venv
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Run pre-commit (ruff)
         run: |
           pip install pre-commit
@@ -26,7 +25,7 @@ jobs:
 
   unit-test-shards:
     name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -49,10 +48,9 @@ jobs:
           npm ci
           npm run build
 
-      - name: Create Python virtualenv
-        run: |
-          python3 -m venv .venv
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Install package and test deps
         run: pip install -e . pytest
@@ -61,7 +59,7 @@ jobs:
         run: bash scripts/ci_unit_tests.sh "${{ matrix.shard }}" "${{ matrix.shard-total }}"
 
   unit-tests:
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     needs: unit-test-shards
     if: always()
     steps:
@@ -91,7 +89,7 @@ jobs:
         run: npm pack --dry-run
 
   install-upgrade-regression:
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -108,10 +106,9 @@ jobs:
           npm run validate:theme
           npm run build
 
-      - name: Create Python virtualenv
-        run: |
-          python3 -m venv .venv
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Install build and test dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   ruff:
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -25,7 +25,7 @@ jobs:
 
   unit-test-shards:
     name: unit-tests (${{ matrix.shard }}/${{ matrix.shard-total }})
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,7 @@ jobs:
         run: bash scripts/ci_unit_tests.sh "${{ matrix.shard }}" "${{ matrix.shard-total }}"
 
   unit-tests:
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     needs: unit-test-shards
     if: always()
     steps:
@@ -89,7 +89,7 @@ jobs:
         run: npm pack --dry-run
 
   install-upgrade-regression:
-    runs-on: [self-hosted, Linux, X64, avibe]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary
- Move the lightweight `npm-wrapper` lint workflow job to the `avibe` self-hosted Linux x64 runner.
- Reuse shared hosted Linux artifacts across the lint workflow: `ui/dist` for Linux tests and a prebuilt wheel for Linux install/upgrade plus Windows installer smoke checks.
- Keep heavy Linux lint jobs and Docker-based install/upgrade regression on GitHub-hosted Ubuntu after repeated A/B testing showed the current self-hosted host is slower and less stable for CPU/time-sensitive jobs.

## Scenarios
- GitHub Actions lint workflow npm wrapper validation.
- GitHub Actions lint workflow UI asset reuse for Linux unit and install/upgrade checks.
- GitHub Actions lint workflow wheel reuse for Linux install/upgrade and Windows installer smoke checks.

## Evidence
- Unit: not run locally, workflow-only change.
- Contract: not run locally, workflow-only change.
- Scenario: validated `.github/workflows/lint.yml` parses as YAML.
- Residual manual checks: `git diff --check -- .github/workflows/lint.yml` passed.
- Runner prep: four `avibe` self-hosted runners are online; Docker, buildx, Python venv/pip, and `cyh` Docker access were verified on `claude-us`.
- Network tuning: the runner now prefers IPv4 because IPv6 routes to PyPI/Fastly and npm/Cloudflare were timing out; default PyPI/npm downloads are fast after this change.
- A/B result: full Linux migration was retested after the IPv4 fix and reverted again. Downloads no longer timed out, but the 2 vCPU host became CPU-bound, `install-upgrade-regression` failed after 7m39s on a service-lock timing failure, and one unit shard failed on an SSE broker timeout.
- Prior workflow optimization result: lint completed successfully with `build-ui-assets` in 35s, Linux unit shards in 1m32s-1m45s, and `install-upgrade-regression` in 1m50s; the previous stable hosted run had unit shards up to 2m31s and install/upgrade regression at 2m21s.
- Current workflow optimization result: latest lint run completed successfully with `build-linux-artifacts` in 40s, Windows install smoke in 1m19s, Linux install/upgrade regression in 1m43s, and Linux unit shards in 1m30s-1m51s.
