### PR TITLE
fix(opencode): refresh uncached provider config

### DIFF
--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -54,6 +54,14 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         processes; fall back to restart for older OpenCode versions.
         """
         previous_server = await self._client_manager.reset_config(opencode_config)
+        adopted_uncached_server = False
+        if previous_server is None:
+            previous_server = await OpenCodeServerManager.get_instance_if_managed_server_exists(
+                binary=self.opencode_config.binary,
+                port=self.opencode_config.port,
+                request_timeout_seconds=self.opencode_config.request_timeout_seconds,
+            )
+            adopted_uncached_server = previous_server is not None
         self.opencode_config = opencode_config
         self.controller.config.opencode = opencode_config
         if previous_server is not None:
@@ -71,6 +79,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     logger.warning("OpenCode global config refresh failed; falling back to restart", exc_info=True)
                     refreshed = False
             if not refreshed:
+                if adopted_uncached_server and runtime_unchanged:
+                    return
                 detach = getattr(previous_server, "detach_after_deferred_refresh", None)
                 if callable(detach):
                     await detach()

--- a/modules/agents/opencode/config_reconciler.py
+++ b/modules/agents/opencode/config_reconciler.py
@@ -1,0 +1,234 @@
+"""Reconcile OpenCode user config, auth storage, and live runtime config."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+LOCAL_PROVIDER_IDS = {"ollama", "lmstudio", "lm-studio"}
+USER_MODEL_META_KEY = "vibe_remote"
+
+
+@dataclass(frozen=True)
+class OpenCodeConfigReconciler:
+    """Build the config payload that should be applied to live OpenCode.
+
+    ``opencode.json`` is the source of truth for user-managed config.
+    ``auth.json`` is the source of truth for provider credentials.
+    The live OpenCode config is only a preservation source for providers
+    OpenCode owns at runtime, currently auth-backed and local providers.
+    """
+
+    local_provider_ids: frozenset[str] = frozenset(LOCAL_PROVIDER_IDS)
+
+    def reconcile(
+        self,
+        *,
+        user_config: Mapping[str, Any],
+        live_config: Mapping[str, Any],
+        auth_entries: Mapping[str, Mapping[str, Any]],
+    ) -> Dict[str, Any]:
+        merged = copy.deepcopy(dict(user_config))
+        user_providers = user_config.get("provider")
+        if not isinstance(user_providers, Mapping):
+            if "provider" in user_config:
+                merged.pop("provider", None)
+            else:
+                live_providers = live_config.get("provider")
+                live_providers = live_providers if isinstance(live_providers, Mapping) else {}
+                preserved = self._reconcile_providers(
+                    user_providers={},
+                    live_providers=live_providers,
+                    auth_entries=auth_entries,
+                )
+                if preserved:
+                    merged["provider"] = preserved
+            return merged
+
+        live_providers = live_config.get("provider")
+        live_providers = live_providers if isinstance(live_providers, Mapping) else {}
+        merged["provider"] = self._reconcile_providers(
+            user_providers=user_providers,
+            live_providers=live_providers,
+            auth_entries=auth_entries,
+        )
+        return merged
+
+    def _reconcile_providers(
+        self,
+        *,
+        user_providers: Mapping[str, Any],
+        live_providers: Mapping[str, Any],
+        auth_entries: Mapping[str, Mapping[str, Any]],
+    ) -> Dict[str, Any]:
+        merged: Dict[str, Any] = {}
+        for provider_id, user_provider in user_providers.items():
+            if not isinstance(provider_id, str) or not isinstance(user_provider, Mapping):
+                continue
+            merged[provider_id] = self._reconcile_user_provider(
+                provider_id=provider_id,
+                user_provider=user_provider,
+                live_provider=live_providers.get(provider_id),
+                auth_entry=auth_entries.get(provider_id),
+            )
+
+        for provider_id, auth_entry in auth_entries.items():
+            if provider_id in merged or not isinstance(provider_id, str) or not isinstance(auth_entry, Mapping):
+                continue
+            live_provider = live_providers.get(provider_id)
+            if isinstance(live_provider, Mapping):
+                merged[provider_id] = self._copy_auth_backed_live_provider(
+                    live_provider=live_provider,
+                    auth_entry=auth_entry,
+                )
+            else:
+                auth_api_key = self._auth_api_key(auth_entry)
+                if auth_api_key:
+                    merged[provider_id] = {"options": {"apiKey": auth_api_key}}
+
+        for provider_id, live_provider in live_providers.items():
+            if provider_id in merged or not isinstance(provider_id, str) or not isinstance(live_provider, Mapping):
+                continue
+            if self._is_local_provider(provider_id):
+                merged[provider_id] = self._copy_live_local_provider(live_provider)
+
+        return merged
+
+    def _reconcile_user_provider(
+        self,
+        *,
+        provider_id: str,
+        user_provider: Mapping[str, Any],
+        live_provider: Any,
+        auth_entry: Mapping[str, Any] | None,
+    ) -> Dict[str, Any]:
+        if isinstance(live_provider, Mapping):
+            provider = self._deep_merge_config(dict(live_provider), user_provider)
+        else:
+            provider = copy.deepcopy(dict(user_provider))
+
+        is_local_provider = self._is_local_provider(provider_id)
+        self._reconcile_user_provider_options(provider, user_provider, auth_entry, is_local_provider)
+        self._reconcile_user_provider_models(provider, user_provider, is_local_provider)
+        return provider
+
+    def _reconcile_user_provider_options(
+        self,
+        provider: Dict[str, Any],
+        user_provider: Mapping[str, Any],
+        auth_entry: Mapping[str, Any] | None,
+        is_local_provider: bool,
+    ) -> None:
+        user_options = user_provider.get("options")
+        auth_api_key = self._auth_api_key(auth_entry)
+        if isinstance(user_options, Mapping):
+            options = copy.deepcopy(dict(user_options))
+            if auth_api_key and "apiKey" not in options:
+                options["apiKey"] = auth_api_key
+            provider["options"] = options
+            return
+
+        if "options" in user_provider:
+            provider.pop("options", None)
+            return
+
+        if auth_api_key:
+            provider["options"] = {"apiKey": auth_api_key}
+            return
+
+        if is_local_provider and isinstance(provider.get("options"), Mapping):
+            return
+
+        provider.pop("options", None)
+
+    @staticmethod
+    def _reconcile_user_provider_models(
+        provider: Dict[str, Any],
+        user_provider: Mapping[str, Any],
+        is_local_provider: bool,
+    ) -> None:
+        user_models = user_provider.get("models")
+        if isinstance(user_models, Mapping):
+            if is_local_provider and isinstance(provider.get("models"), Mapping):
+                provider["models"] = OpenCodeConfigReconciler._merge_local_provider_models(
+                    provider["models"],
+                    user_models,
+                )
+            else:
+                provider["models"] = copy.deepcopy(dict(user_models))
+        elif "models" in user_provider:
+            provider.pop("models", None)
+
+    @staticmethod
+    def _merge_local_provider_models(live_models: Mapping[str, Any], user_models: Mapping[str, Any]) -> Dict[str, Any]:
+        merged: Dict[str, Any] = {}
+        for model_id, model_info in live_models.items():
+            if not isinstance(model_id, str):
+                continue
+            if isinstance(model_info, Mapping) and OpenCodeConfigReconciler._is_explicit_user_model(model_info):
+                continue
+            merged[model_id] = copy.deepcopy(model_info)
+        merged.update(copy.deepcopy(dict(user_models)))
+        return merged
+
+    @staticmethod
+    def _copy_live_local_provider(live_provider: Mapping[str, Any]) -> Dict[str, Any]:
+        provider = copy.deepcopy(dict(live_provider))
+        models = provider.get("models")
+        if isinstance(models, Mapping):
+            provider["models"] = OpenCodeConfigReconciler._merge_local_provider_models(models, {})
+        return provider
+
+    @staticmethod
+    def _is_explicit_user_model(model_info: Mapping[str, Any]) -> bool:
+        meta = model_info.get(USER_MODEL_META_KEY)
+        return isinstance(meta, Mapping) and meta.get("user_model") is True
+
+    def _copy_auth_backed_live_provider(
+        self,
+        *,
+        live_provider: Mapping[str, Any],
+        auth_entry: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        provider = copy.deepcopy(dict(live_provider))
+        auth_api_key = self._auth_api_key(auth_entry)
+        options = provider.get("options")
+        if auth_api_key:
+            if not isinstance(options, Mapping):
+                options = {}
+            else:
+                options = copy.deepcopy(dict(options))
+            options["apiKey"] = auth_api_key
+            provider["options"] = options
+        elif auth_entry.get("type") == "oauth" and isinstance(options, Mapping):
+            options = copy.deepcopy(dict(options))
+            options.pop("apiKey", None)
+            if options:
+                provider["options"] = options
+            else:
+                provider.pop("options", None)
+        return provider
+
+    def _is_local_provider(self, provider_id: str) -> bool:
+        return provider_id.lower() in self.local_provider_ids
+
+    @staticmethod
+    def _auth_api_key(auth_entry: Mapping[str, Any] | None) -> str | None:
+        if not isinstance(auth_entry, Mapping) or auth_entry.get("type") != "api":
+            return None
+        key = auth_entry.get("key")
+        return key if isinstance(key, str) and key else None
+
+    @classmethod
+    def _deep_merge_config(cls, base: Any, override: Any) -> Any:
+        if not isinstance(base, Mapping) or not isinstance(override, Mapping):
+            return copy.deepcopy(override)
+        merged = copy.deepcopy(dict(base))
+        for key, value in override.items():
+            current = merged.get(key)
+            if isinstance(current, Mapping) and isinstance(value, Mapping):
+                merged[key] = cls._deep_merge_config(current, value)
+            else:
+                merged[key] = copy.deepcopy(value)
+        return merged

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -19,8 +19,9 @@ import aiohttp
 
 from config import paths
 from core.process_isolation import isolated_subprocess_kwargs, terminate_process_tree
+from modules.agents.opencode.config_reconciler import OpenCodeConfigReconciler
 from vibe import runtime
-from vibe.opencode_config import load_first_opencode_user_config
+from vibe.opencode_config import load_first_opencode_user_config, read_opencode_provider_auth_entries
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +103,38 @@ class OpenCodeServerManager:
                     f"ignoring new params binary={binary}, port={port}, "
                     f"request_timeout_seconds={request_timeout_seconds}"
                 )
+            return cls._instance
+
+    @classmethod
+    async def get_instance_if_managed_server_exists(
+        cls,
+        binary: str = "opencode",
+        port: int = DEFAULT_OPENCODE_PORT,
+        request_timeout_seconds: int = 60,
+    ) -> Optional["OpenCodeServerManager"]:
+        with cls._class_lock:
+            if cls._instance is not None:
+                return cls._instance
+
+            pid_file = paths.get_logs_dir() / "opencode_server.json"
+            try:
+                data = json.loads(pid_file.read_text())
+            except Exception:
+                return None
+            if not isinstance(data, dict) or data.get("port") != port:
+                return None
+            pid = data.get("pid")
+            if not isinstance(pid, int) or not runtime.pid_alive(pid):
+                return None
+            command = runtime.get_process_command(pid)
+            if not command or not cls._is_opencode_serve_cmd(command, port):
+                return None
+
+            cls._instance = cls(
+                binary=binary,
+                port=port,
+                request_timeout_seconds=request_timeout_seconds,
+            )
             return cls._instance
 
     @property
@@ -212,11 +245,16 @@ class OpenCodeServerManager:
         if config is None:
             return False
 
-        await self.ensure_running()
         total_timeout: Optional[int] = None if self.request_timeout_seconds <= 0 else self.request_timeout_seconds
         async with self._get_lock():
             if self._active_requests > 0 or self._has_active_run_sessions():
                 return False
+            if not await self._is_healthy():
+                return False
+            current_config = await self._get_global_config_snapshot()
+            if current_config is None:
+                return False
+            config = self._merge_global_config_snapshot(current_config, config)
             async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=total_timeout)) as session:
                 async with session.patch(
                     f"{self.base_url}/global/config",
@@ -1145,6 +1183,28 @@ class OpenCodeServerManager:
         """
         probe = load_first_opencode_user_config(logger_instance=logger)
         return probe.config
+
+    def _merge_global_config_snapshot(self, current_config: Dict[str, Any], user_config: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            auth_entries = read_opencode_provider_auth_entries(logger_instance=logger)
+        except Exception as exc:
+            logger.debug("Could not read OpenCode auth entries during global config merge: %s", exc)
+            auth_entries = {}
+        return OpenCodeConfigReconciler().reconcile(
+            user_config=user_config,
+            live_config=current_config,
+            auth_entries=auth_entries,
+        )
+
+    async def _get_global_config_snapshot(self) -> Optional[Dict[str, Any]]:
+        total_timeout: Optional[int] = None if self.request_timeout_seconds <= 0 else self.request_timeout_seconds
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=total_timeout)) as session:
+            async with session.get(f"{self.base_url}/global/config") as resp:
+                if resp.status != 200:
+                    await resp.read()
+                    return None
+                data = await resp.json()
+                return data if isinstance(data, dict) else None
 
     def _get_agent_config(self, config: Dict[str, Any], agent_name: Optional[str]) -> Dict[str, Any]:
         """Get agent-specific config from opencode.json with type safety."""

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1144,6 +1144,142 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             request_timeout_seconds=60,
         )
 
+    async def test_opencode_agent_refresh_runtime_config_attaches_uncached_server(self):
+        from config.v2_compat import OpenCodeCompatConfig
+        from modules.agents.opencode.agent import OpenCodeAgent
+        from modules.agents.opencode.server import OpenCodeServerManager
+
+        old_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/old/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        new_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
+        live_server = SimpleNamespace(
+            binary="/old/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+            refresh_global_config=AsyncMock(return_value=True),
+            detach_after_deferred_refresh=AsyncMock(),
+            reload_runtime_config=AsyncMock(),
+        )
+        agent = OpenCodeAgent.__new__(OpenCodeAgent)
+        agent.opencode_config = old_config
+        agent.controller = SimpleNamespace(config=SimpleNamespace(opencode=old_config))
+        agent._client_manager = SimpleNamespace(
+            reset_config=AsyncMock(return_value=None),
+        )
+
+        with patch.object(
+            OpenCodeServerManager,
+            "get_instance_if_managed_server_exists",
+            AsyncMock(return_value=live_server),
+        ) as get_instance:
+            await agent.refresh_runtime_config(new_config)
+
+        agent._client_manager.reset_config.assert_awaited_once_with(new_config)
+        get_instance.assert_awaited_once_with(
+            binary="/old/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        live_server.refresh_global_config.assert_not_awaited()
+        live_server.detach_after_deferred_refresh.assert_awaited_once()
+        live_server.reload_runtime_config.assert_awaited_once_with(
+            binary="/new/opencode",
+            port=4100,
+            request_timeout_seconds=15,
+        )
+
+    async def test_opencode_agent_refresh_runtime_config_skips_uncached_refresh_without_managed_server(self):
+        from config.v2_compat import OpenCodeCompatConfig
+        from modules.agents.opencode.agent import OpenCodeAgent
+        from modules.agents.opencode.server import OpenCodeServerManager
+
+        old_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        new_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        agent = OpenCodeAgent.__new__(OpenCodeAgent)
+        agent.opencode_config = old_config
+        agent.controller = SimpleNamespace(config=SimpleNamespace(opencode=old_config))
+        agent._client_manager = SimpleNamespace(
+            reset_config=AsyncMock(return_value=None),
+        )
+
+        with patch.object(
+            OpenCodeServerManager,
+            "get_instance_if_managed_server_exists",
+            AsyncMock(return_value=None),
+        ) as get_instance:
+            await agent.refresh_runtime_config(new_config)
+
+        agent._client_manager.reset_config.assert_awaited_once_with(new_config)
+        get_instance.assert_awaited_once_with(
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        self.assertIs(agent.opencode_config, new_config)
+        self.assertIs(agent.controller.config.opencode, new_config)
+
+    async def test_opencode_agent_refresh_runtime_config_does_not_restart_uncached_adopted_server_on_refresh_miss(self):
+        from config.v2_compat import OpenCodeCompatConfig
+        from modules.agents.opencode.agent import OpenCodeAgent
+        from modules.agents.opencode.server import OpenCodeServerManager
+
+        old_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        new_config = OpenCodeCompatConfig(
+            enabled=True,
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+        )
+        live_server = SimpleNamespace(
+            binary="/opencode",
+            port=4096,
+            request_timeout_seconds=60,
+            refresh_global_config=AsyncMock(return_value=False),
+            detach_after_deferred_refresh=AsyncMock(),
+            reload_runtime_config=AsyncMock(),
+        )
+        agent = OpenCodeAgent.__new__(OpenCodeAgent)
+        agent.opencode_config = old_config
+        agent.controller = SimpleNamespace(config=SimpleNamespace(opencode=old_config))
+        agent._client_manager = SimpleNamespace(
+            reset_config=AsyncMock(return_value=None),
+        )
+
+        with patch.object(
+            OpenCodeServerManager,
+            "get_instance_if_managed_server_exists",
+            AsyncMock(return_value=live_server),
+        ):
+            await agent.refresh_runtime_config(new_config)
+
+        live_server.refresh_global_config.assert_awaited_once()
+        live_server.detach_after_deferred_refresh.assert_not_awaited()
+        live_server.reload_runtime_config.assert_not_awaited()
+
     async def test_opencode_agent_refresh_runtime_config_restarts_when_runtime_changes(self):
         from config.v2_compat import OpenCodeCompatConfig
         from modules.agents.opencode.agent import OpenCodeAgent

--- a/tests/test_opencode_config_reconciler.py
+++ b/tests/test_opencode_config_reconciler.py
@@ -1,0 +1,365 @@
+from modules.agents.opencode.config_reconciler import OpenCodeConfigReconciler
+
+
+def _reconcile(user_config, live_config=None, auth_entries=None):
+    return OpenCodeConfigReconciler().reconcile(
+        user_config=user_config,
+        live_config=live_config or {},
+        auth_entries=auth_entries or {},
+    )
+
+
+def test_user_config_is_top_level_source_of_truth():
+    assert _reconcile(
+        {"provider": {"deepseek": {"options": {"baseURL": "https://api.deepseek.com"}}}},
+        {
+            "permission": "allow",
+            "model": "openai/gpt-5",
+            "provider": {"deepseek": {"options": {"baseURL": "https://old.example"}}},
+        },
+    ) == {
+        "provider": {"deepseek": {"options": {"baseURL": "https://api.deepseek.com"}}}
+    }
+
+
+def test_user_options_do_not_resurrect_live_deleted_keys():
+    assert _reconcile(
+        {"provider": {"openai": {"options": {"apiKey": "sk-config"}}}},
+        {
+            "provider": {
+                "openai": {
+                    "options": {
+                        "apiKey": "sk-config",
+                        "baseURL": "https://deleted.example/v1",
+                    }
+                }
+            }
+        },
+    )["provider"]["openai"]["options"] == {"apiKey": "sk-config"}
+
+
+def test_missing_user_options_drops_live_options_without_auth():
+    provider = _reconcile(
+        {"provider": {"deepseek": {"models": {"deepseek-v4": {"id": "deepseek-v4"}}}}},
+        {
+            "provider": {
+                "deepseek": {
+                    "options": {
+                        "apiKey": "sk-stale",
+                        "baseURL": "https://stale.example",
+                    },
+                    "models": {"deepseek-v4": {"id": "deepseek-v4"}},
+                }
+            }
+        },
+    )["provider"]["deepseek"]
+
+    assert "options" not in provider
+    assert provider["models"] == {"deepseek-v4": {"id": "deepseek-v4"}}
+
+
+def test_missing_user_options_preserves_auth_json_api_key():
+    provider = _reconcile(
+        {"provider": {"deepseek": {"models": {"deepseek-v4": {"id": "deepseek-v4"}}}}},
+        {
+            "provider": {
+                "deepseek": {
+                    "options": {
+                        "apiKey": "sk-stale-live",
+                        "baseURL": "https://stale.example",
+                    },
+                    "models": {"deepseek-v4": {"id": "deepseek-v4"}},
+                }
+            }
+        },
+        {"deepseek": {"type": "api", "key": "sk-auth-json"}},
+    )["provider"]["deepseek"]
+
+    assert provider["options"] == {"apiKey": "sk-auth-json"}
+    assert provider["models"] == {"deepseek-v4": {"id": "deepseek-v4"}}
+
+
+def test_auth_json_key_overrides_stale_live_key_when_user_has_options():
+    assert _reconcile(
+        {"provider": {"openai": {"options": {"baseURL": "https://relay.example/v1"}}}},
+        {
+            "provider": {
+                "openai": {
+                    "options": {
+                        "apiKey": "sk-old-live",
+                        "baseURL": "https://old.example/v1",
+                    }
+                }
+            }
+        },
+        {"openai": {"type": "api", "key": "sk-new-auth"}},
+    )["provider"]["openai"]["options"] == {
+        "baseURL": "https://relay.example/v1",
+        "apiKey": "sk-new-auth",
+    }
+
+
+def test_oauth_user_provider_does_not_reintroduce_stale_api_key():
+    assert _reconcile(
+        {"provider": {"openai": {"options": {"baseURL": "https://relay.example/v1"}}}},
+        {
+            "provider": {
+                "openai": {
+                    "options": {
+                        "apiKey": "sk-stale",
+                        "baseURL": "https://old.example/v1",
+                    }
+                }
+            }
+        },
+        {"openai": {"type": "oauth", "refresh": "oauth-refresh"}},
+    )["provider"]["openai"]["options"] == {"baseURL": "https://relay.example/v1"}
+
+
+def test_user_models_do_not_resurrect_live_deleted_models():
+    assert _reconcile(
+        {
+            "provider": {
+                "deepseek": {
+                    "options": {"baseURL": "https://api.deepseek.com"},
+                    "models": {"keep-model": {"id": "keep-model"}},
+                }
+            }
+        },
+        {
+            "provider": {
+                "deepseek": {
+                    "options": {"baseURL": "https://api.deepseek.com"},
+                    "models": {
+                        "keep-model": {"id": "keep-model"},
+                        "deleted-model": {"id": "deleted-model"},
+                    },
+                }
+            }
+        },
+    )["provider"]["deepseek"]["models"] == {"keep-model": {"id": "keep-model"}}
+
+
+def test_provider_absent_from_user_config_is_dropped_unless_auth_or_local():
+    assert set(
+        _reconcile(
+            {"provider": {"anthropic": {"options": {"baseURL": "https://relay.example/v1"}}}},
+            {
+                "provider": {
+                    "anthropic": {"options": {"baseURL": "https://relay.example/v1"}},
+                    "openai": {"options": {"apiKey": "sk-stale"}},
+                }
+            },
+        )["provider"].keys()
+    ) == {"anthropic"}
+
+
+def test_auth_backed_provider_absent_from_user_config_is_preserved():
+    assert set(
+        _reconcile(
+            {"provider": {"claude-relay": {"options": {"baseURL": "https://relay.example/v1"}}}},
+            {
+                "provider": {
+                    "openai": {
+                        "options": {
+                            "apiKey": "sk-live",
+                            "baseURL": "https://api.openai.com/v1",
+                        }
+                    },
+                    "claude-relay": {"options": {"baseURL": "https://old.example/v1"}},
+                }
+            },
+            {"openai": {"type": "oauth", "refresh": "oauth-refresh"}},
+        )["provider"].keys()
+    ) == {"claude-relay", "openai"}
+
+
+def test_auth_backed_provider_absent_from_user_config_uses_auth_json_key():
+    openai = _reconcile(
+        {"provider": {"claude-relay": {"options": {"baseURL": "https://relay.example/v1"}}}},
+        {
+            "provider": {
+                "openai": {
+                    "options": {
+                        "apiKey": "sk-old-live",
+                        "baseURL": "https://api.openai.com/v1",
+                    }
+                }
+            }
+        },
+        {"openai": {"type": "api", "key": "sk-new-auth"}},
+    )["provider"]["openai"]
+
+    assert openai["options"] == {
+        "apiKey": "sk-new-auth",
+        "baseURL": "https://api.openai.com/v1",
+    }
+
+
+def test_auth_api_provider_missing_from_live_snapshot_is_preserved_from_auth_json():
+    assert _reconcile(
+        {"provider": {"claude-relay": {"options": {"baseURL": "https://relay.example/v1"}}}},
+        {"provider": {"claude-relay": {"options": {"baseURL": "https://old.example/v1"}}}},
+        {"openai": {"type": "api", "key": "sk-auth-json"}},
+    )["provider"]["openai"] == {"options": {"apiKey": "sk-auth-json"}}
+
+
+def test_local_provider_absent_from_user_config_is_preserved():
+    assert set(
+        _reconcile(
+            {"provider": {"claude-relay": {"options": {"baseURL": "https://relay.example/v1"}}}},
+            {
+                "provider": {
+                    "ollama": {
+                        "options": {"baseURL": "http://localhost:11434/v1"},
+                        "models": {"llama3.1": {"id": "llama3.1"}},
+                    },
+                    "claude-relay": {"options": {"baseURL": "https://old.example/v1"}},
+                }
+            },
+        )["provider"].keys()
+    ) == {"claude-relay", "ollama"}
+
+
+def test_local_provider_models_config_preserves_live_options():
+    ollama = _reconcile(
+        {"provider": {"ollama": {"models": {"custom-local": {"id": "custom-local"}}}}},
+        {
+            "provider": {
+                "ollama": {
+                    "options": {"baseURL": "http://localhost:11434/v1"},
+                    "models": {"llama3.1": {"id": "llama3.1"}},
+                }
+            }
+        },
+    )["provider"]["ollama"]
+
+    assert ollama["options"] == {"baseURL": "http://localhost:11434/v1"}
+    assert ollama["models"]["custom-local"] == {"id": "custom-local"}
+
+
+def test_local_provider_user_models_are_added_to_live_models():
+    ollama = _reconcile(
+        {"provider": {"ollama": {"models": {"custom-local": {"id": "custom-local"}}}}},
+        {
+            "provider": {
+                "ollama": {
+                    "options": {"baseURL": "http://localhost:11434/v1"},
+                    "models": {
+                        "llama3.1": {"id": "llama3.1"},
+                        "qwen3": {"id": "qwen3"},
+                    },
+                }
+            }
+        },
+    )["provider"]["ollama"]
+
+    assert ollama["models"] == {
+        "llama3.1": {"id": "llama3.1"},
+        "qwen3": {"id": "qwen3"},
+        "custom-local": {"id": "custom-local"},
+    }
+
+
+def test_local_provider_deleted_user_model_is_not_restored_from_live_models():
+    ollama = _reconcile(
+        {"provider": {"ollama": {"models": {"kept-user-model": {"id": "kept-user-model"}}}}},
+        {
+            "provider": {
+                "ollama": {
+                    "options": {"baseURL": "http://localhost:11434/v1"},
+                    "models": {
+                        "runtime-model": {"id": "runtime-model"},
+                        "deleted-user-model": {
+                            "id": "deleted-user-model",
+                            "name": "deleted-user-model",
+                            "vibe_remote": {"user_model": True},
+                        },
+                    },
+                }
+            }
+        },
+    )["provider"]["ollama"]
+
+    assert ollama["models"] == {
+        "runtime-model": {"id": "runtime-model"},
+        "kept-user-model": {"id": "kept-user-model"},
+    }
+
+
+def test_local_provider_unmarked_runtime_model_with_matching_name_is_preserved():
+    ollama = _reconcile(
+        {"provider": {"ollama": {"models": {"custom-local": {"id": "custom-local"}}}}},
+        {
+            "provider": {
+                "ollama": {
+                    "options": {"baseURL": "http://localhost:11434/v1"},
+                    "models": {
+                        "runtime-model": {"id": "runtime-model", "name": "runtime-model"},
+                    },
+                }
+            }
+        },
+    )["provider"]["ollama"]
+
+    assert ollama["models"] == {
+        "runtime-model": {"id": "runtime-model", "name": "runtime-model"},
+        "custom-local": {"id": "custom-local"},
+    }
+
+
+def test_no_user_provider_section_preserves_only_auth_and_local_runtime_providers():
+    assert set(
+        _reconcile(
+            {"model": "openai/gpt-5"},
+            {
+                "provider": {
+                    "openai": {"options": {"apiKey": "sk-old-live"}},
+                    "ollama": {"options": {"baseURL": "http://localhost:11434/v1"}},
+                    "deleted-custom": {"options": {"apiKey": "sk-deleted"}},
+                }
+            },
+            {"openai": {"type": "api", "key": "sk-new-auth"}},
+        )["provider"].keys()
+    ) == {"openai", "ollama"}
+
+
+def test_local_provider_absent_from_user_config_drops_stale_user_models():
+    ollama = _reconcile(
+        {"model": "openai/gpt-5"},
+        {
+            "provider": {
+                "ollama": {
+                    "options": {"baseURL": "http://localhost:11434/v1"},
+                    "models": {
+                        "runtime-model": {"id": "runtime-model", "name": "runtime-model"},
+                        "deleted-user-model": {
+                            "id": "deleted-user-model",
+                            "name": "deleted-user-model",
+                            "vibe_remote": {"user_model": True},
+                        },
+                    },
+                }
+            }
+        },
+    )["provider"]["ollama"]
+
+    assert ollama["models"] == {
+        "runtime-model": {"id": "runtime-model", "name": "runtime-model"},
+    }
+
+
+def test_no_user_provider_section_preserves_auth_api_provider_missing_from_live_snapshot():
+    assert _reconcile(
+        {"model": "openai/gpt-5"},
+        {"provider": {"ollama": {"options": {"baseURL": "http://localhost:11434/v1"}}}},
+        {"openai": {"type": "api", "key": "sk-auth-json"}},
+    )["provider"]["openai"] == {"options": {"apiKey": "sk-auth-json"}}
+
+
+def test_explicit_non_object_user_provider_removes_provider_payload():
+    assert "provider" not in _reconcile(
+        {"provider": None},
+        {"provider": {"openai": {"options": {"apiKey": "sk-live"}}}},
+        {"openai": {"type": "api", "key": "sk-auth"}},
+    )

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -36,9 +36,10 @@ OpenCodeServerManager = SERVER_MODULE.OpenCodeServerManager
 
 
 class _FakeResponse:
-    def __init__(self, *, status: int = 204, text: str = ""):
+    def __init__(self, *, status: int = 204, text: str = "", json_data=None):
         self.status = status
         self._text = text
+        self._json_data = json_data
 
     async def __aenter__(self):
         return self
@@ -52,13 +53,21 @@ class _FakeResponse:
     async def read(self):
         return self._text.encode()
 
+    async def json(self):
+        return self._json_data if self._json_data is not None else {}
+
 
 class _FakeSession:
     def __init__(self):
+        self.gets = []
         self.posts = []
         self.puts = []
         self.patches = []
         self.closed = False
+
+    def get(self, url, headers=None, timeout=None):
+        self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+        return _FakeResponse(status=200)
 
     def post(self, url, json=None, headers=None):
         self.posts.append({"url": url, "json": json, "headers": headers})
@@ -141,9 +150,27 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 encoding="utf-8",
             )
 
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "deepseek": {
+                                    "options": {
+                                        "apiKey": "sk-live",
+                                        "baseURL": "https://stale.example",
+                                    }
+                                },
+                                "openai": {"options": {"apiKey": "sk-openai"}},
+                            }
+                        },
+                    )
+
             manager = OpenCodeServerManager(binary="opencode", port=4096)
-            fake_session = _FakeSession()
-            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
 
             with (
                 patch("vibe.opencode_config.Path.home", return_value=tmp_home),
@@ -154,6 +181,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertTrue(refreshed)
             self.assertTrue(fake_session.closed)
+            self.assertEqual(len(fake_session.gets), 1)
             self.assertEqual(len(fake_session.patches), 1)
             self.assertEqual(
                 fake_session.patches[0]["url"],
@@ -164,10 +192,575 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 {
                     "provider": {
                         "deepseek": {
-                            "options": {"baseURL": "https://api.deepseek.com"}
+                            "options": {
+                                "baseURL": "https://api.deepseek.com",
+                            }
                         }
                     }
                 },
+            )
+
+    async def test_refresh_global_config_preserves_auth_json_api_key(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"anthropic":{"options":{"baseURL":"https://relay.example/v1"}}}}',
+                encoding="utf-8",
+            )
+            auth_path = tmp_home / ".local" / "share" / "opencode" / "auth.json"
+            auth_path.parent.mkdir(parents=True, exist_ok=True)
+            auth_path.write_text(
+                '{"anthropic":{"type":"api","key":"sk-auth-json"}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "anthropic": {
+                                    "options": {
+                                        "apiKey": "sk-auth-json",
+                                        "baseURL": "https://stale.example",
+                                    }
+                                }
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                fake_session.patches[0]["json"]["provider"]["anthropic"]["options"],
+                {
+                    "apiKey": "sk-auth-json",
+                    "baseURL": "https://relay.example/v1",
+                },
+            )
+
+    async def test_refresh_global_config_does_not_resurrect_deleted_provider_options(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"openai":{"options":{"apiKey":"sk-config"}}}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "openai": {
+                                    "options": {
+                                        "apiKey": "sk-config",
+                                        "baseURL": "https://deleted.example/v1",
+                                    }
+                                }
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                fake_session.patches[0]["json"]["provider"]["openai"]["options"],
+                {"apiKey": "sk-config"},
+            )
+
+    async def test_refresh_global_config_oauth_entry_clears_stale_api_key(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"openai":{"options":{"baseURL":"https://relay.example/v1"}}}}',
+                encoding="utf-8",
+            )
+            auth_path = tmp_home / ".local" / "share" / "opencode" / "auth.json"
+            auth_path.parent.mkdir(parents=True, exist_ok=True)
+            auth_path.write_text(
+                '{"openai":{"type":"oauth","refresh":"oauth-refresh"}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "openai": {
+                                    "options": {
+                                        "apiKey": "sk-stale",
+                                        "baseURL": "https://old.example/v1",
+                                    }
+                                }
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                fake_session.patches[0]["json"]["provider"]["openai"]["options"],
+                {"baseURL": "https://relay.example/v1"},
+            )
+
+    async def test_refresh_global_config_drops_live_provider_missing_from_user_config(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"anthropic":{"options":{"baseURL":"https://relay.example/v1"}}}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "anthropic": {"options": {"baseURL": "https://relay.example/v1"}},
+                                "openai": {
+                                    "options": {
+                                        "apiKey": "sk-stale",
+                                        "baseURL": "https://deleted.example/v1",
+                                    }
+                                },
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                set(fake_session.patches[0]["json"]["provider"].keys()),
+                {"anthropic"},
+            )
+
+    async def test_refresh_global_config_preserves_new_provider_options(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"claude-relay":{"name":"Claude Relay","npm":"@ai-sdk/anthropic","options":{"baseURL":"https://relay.example/v1","apiKey":"sk-new"},"models":{"claude-opus-4.8":{"id":"claude-opus-4.8"}}}}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(status=200, json_data={"provider": {}})
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            provider = fake_session.patches[0]["json"]["provider"]["claude-relay"]
+            self.assertEqual(
+                provider["options"],
+                {"baseURL": "https://relay.example/v1", "apiKey": "sk-new"},
+            )
+            self.assertIn("claude-opus-4.8", provider["models"])
+
+    async def test_refresh_global_config_uses_auth_json_api_key_over_stale_live_key(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"openai":{"options":{"baseURL":"https://relay.example/v1"}}}}',
+                encoding="utf-8",
+            )
+            auth_path = tmp_home / ".local" / "share" / "opencode" / "auth.json"
+            auth_path.parent.mkdir(parents=True, exist_ok=True)
+            auth_path.write_text(
+                '{"openai":{"type":"api","key":"sk-new-auth"}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "openai": {
+                                    "options": {
+                                        "apiKey": "sk-old-live",
+                                        "baseURL": "https://old.example/v1",
+                                    }
+                                }
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                fake_session.patches[0]["json"]["provider"]["openai"]["options"],
+                {"baseURL": "https://relay.example/v1", "apiKey": "sk-new-auth"},
+            )
+
+    async def test_refresh_global_config_drops_live_options_when_user_options_section_is_absent(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"deepseek":{"models":{"deepseek-v4-flash":{"id":"deepseek-v4-flash"}}}}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "deepseek": {
+                                    "options": {
+                                        "apiKey": "sk-stale",
+                                        "baseURL": "https://stale.example",
+                                    },
+                                    "models": {"deepseek-v4-flash": {"id": "deepseek-v4-flash"}},
+                                }
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            provider = fake_session.patches[0]["json"]["provider"]["deepseek"]
+            self.assertNotIn("options", provider)
+            self.assertIn("deepseek-v4-flash", provider["models"])
+
+    async def test_refresh_global_config_preserves_auth_key_when_only_models_configured(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"deepseek":{"models":{"deepseek-v4-flash":{"id":"deepseek-v4-flash"}}}}}',
+                encoding="utf-8",
+            )
+            auth_path = tmp_home / ".local" / "share" / "opencode" / "auth.json"
+            auth_path.parent.mkdir(parents=True, exist_ok=True)
+            auth_path.write_text(
+                '{"deepseek":{"type":"api","key":"sk-auth-json"}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "deepseek": {
+                                    "options": {
+                                        "apiKey": "sk-stale-live",
+                                        "baseURL": "https://stale.example",
+                                    },
+                                    "models": {"deepseek-v4-flash": {"id": "deepseek-v4-flash"}},
+                                }
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            provider = fake_session.patches[0]["json"]["provider"]["deepseek"]
+            self.assertEqual(provider["options"], {"apiKey": "sk-auth-json"})
+            self.assertIn("deepseek-v4-flash", provider["models"])
+
+    async def test_refresh_global_config_drops_deleted_user_models(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"deepseek":{"options":{"baseURL":"https://api.deepseek.com"},"models":{"keep-model":{"id":"keep-model"}}}}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "deepseek": {
+                                    "options": {"baseURL": "https://api.deepseek.com"},
+                                    "models": {
+                                        "keep-model": {"id": "keep-model"},
+                                        "deleted-model": {"id": "deleted-model"},
+                                    },
+                                }
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                fake_session.patches[0]["json"]["provider"]["deepseek"]["models"],
+                {"keep-model": {"id": "keep-model"}},
+            )
+
+    async def test_refresh_global_config_keeps_auth_backed_provider_absent_from_user_config(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"claude-relay":{"options":{"baseURL":"https://relay.example/v1"}}}}',
+                encoding="utf-8",
+            )
+            auth_path = tmp_home / ".local" / "share" / "opencode" / "auth.json"
+            auth_path.parent.mkdir(parents=True, exist_ok=True)
+            auth_path.write_text(
+                '{"openai":{"type":"oauth","refresh":"oauth-refresh"}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "openai": {"options": {"baseURL": "https://api.openai.com/v1"}},
+                                "claude-relay": {"options": {"baseURL": "https://old.example/v1"}},
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            self.assertEqual(
+                set(fake_session.patches[0]["json"]["provider"].keys()),
+                {"claude-relay", "openai"},
+            )
+            self.assertEqual(
+                fake_session.patches[0]["json"]["provider"]["openai"]["options"],
+                {"baseURL": "https://api.openai.com/v1"},
+            )
+            self.assertEqual(
+                fake_session.patches[0]["json"]["provider"]["claude-relay"]["options"],
+                {"baseURL": "https://relay.example/v1"},
+            )
+
+    async def test_refresh_global_config_preserves_local_provider_absent_from_user_config(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"claude-relay":{"options":{"baseURL":"https://relay.example/v1"}}}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "provider": {
+                                "ollama": {
+                                    "name": "Ollama",
+                                    "options": {"baseURL": "http://localhost:11434/v1"},
+                                    "models": {"llama3.1": {"id": "llama3.1"}},
+                                },
+                                "claude-relay": {"options": {"baseURL": "https://old.example/v1"}},
+                            }
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            providers = fake_session.patches[0]["json"]["provider"]
+            self.assertEqual(set(providers.keys()), {"claude-relay", "ollama"})
+            self.assertEqual(
+                providers["ollama"]["models"],
+                {"llama3.1": {"id": "llama3.1"}},
+            )
+            self.assertEqual(
+                providers["claude-relay"]["options"],
+                {"baseURL": "https://relay.example/v1"},
+            )
+
+    async def test_refresh_global_config_drops_removed_top_level_settings(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                '{"provider":{"deepseek":{"options":{"baseURL":"https://api.deepseek.com"}}}}',
+                encoding="utf-8",
+            )
+
+            class _SnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    return _FakeResponse(
+                        status=200,
+                        json_data={
+                            "permission": "allow",
+                            "model": "openai/gpt-5",
+                            "provider": {
+                                "deepseek": {"options": {"baseURL": "https://old.example"}}
+                            },
+                        },
+                    )
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _SnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertTrue(refreshed)
+            patched_config = fake_session.patches[0]["json"]
+            self.assertNotIn("permission", patched_config)
+            self.assertNotIn("model", patched_config)
+            self.assertEqual(
+                patched_config["provider"]["deepseek"]["options"],
+                {"baseURL": "https://api.deepseek.com"},
             )
 
     async def test_refresh_global_config_returns_false_when_global_endpoint_is_unavailable(self):
@@ -184,7 +777,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
             manager = OpenCodeServerManager(binary="opencode", port=4096)
             fake_session = _UnavailableSession()
-            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
 
             with (
                 patch("vibe.opencode_config.Path.home", return_value=tmp_home),
@@ -199,6 +792,34 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 ["http://127.0.0.1:4096/global/config"],
             )
 
+    async def test_refresh_global_config_returns_false_when_snapshot_unavailable(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text('{"provider":{"deepseek":{"models":{}}}}', encoding="utf-8")
+
+            class _UnavailableSnapshotSession(_FakeSession):
+                def get(self, url, headers=None, timeout=None):
+                    self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                    if url.endswith("/global/config"):
+                        return _FakeResponse(status=404)
+                    return _FakeResponse(status=200, json_data={"healthy": True})
+
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            fake_session = _UnavailableSnapshotSession()
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.aiohttp, "ClientSession", return_value=fake_session),
+                patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()),
+            ):
+                refreshed = await manager.refresh_global_config()
+
+            self.assertFalse(refreshed)
+            self.assertEqual(fake_session.patches, [])
+
     async def test_refresh_global_config_defers_when_request_active(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_home = Path(tmp_dir)
@@ -208,7 +829,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
             manager = OpenCodeServerManager(binary="opencode", port=4096)
             fake_session = _FakeSession()
-            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
             manager._active_requests = 1
 
             with (
@@ -252,7 +873,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             release = asyncio.Event()
             manager = OpenCodeServerManager(binary="opencode", port=4096)
             fake_session = _BlockingSession(entered, release)
-            manager.ensure_running = AsyncMock(return_value="http://127.0.0.1:4096")  # type: ignore[method-assign]
+            manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
 
             with (
                 patch("vibe.opencode_config.Path.home", return_value=tmp_home),
@@ -479,6 +1100,29 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(fake_session.closed)
         self.assertIsNone(manager._http_session)
+
+    async def test_get_instance_if_managed_server_exists_rejects_reused_pid(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            logs_dir = Path(tmp_dir)
+            pid_file = logs_dir / "opencode_server.json"
+            pid_file.write_text('{"pid": 654, "port": 4096}', encoding="utf-8")
+
+            previous = OpenCodeServerManager._instance
+            OpenCodeServerManager._instance = None
+            try:
+                with (
+                    patch.object(SERVER_MODULE.paths, "get_logs_dir", return_value=logs_dir),
+                    patch.object(SERVER_MODULE.runtime, "pid_alive", return_value=True),
+                    patch.object(SERVER_MODULE.runtime, "get_process_command", return_value="python app.py"),
+                ):
+                    manager = await OpenCodeServerManager.get_instance_if_managed_server_exists(
+                        binary="opencode",
+                        port=4096,
+                    )
+            finally:
+                OpenCodeServerManager._instance = previous
+
+            self.assertIsNone(manager)
 
     async def test_set_api_key_auth_uses_official_auth_endpoint(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)


### PR DESCRIPTION
## What
- Ensure OpenCode runtime refresh attaches to the live singleton server even when the controller-side OpenCode agent has not cached it yet.
- Merge OpenCode's live global config snapshot before PATCHing `opencode.json` overrides, so OAuth/auth-store-derived keys are preserved while deleted config keys do not get resurrected.
- Add regression coverage for uncached-server refresh and global config merge behavior.

## Why
Settings UI saves can start or use `opencode serve` through provider/catalog/test paths before any IM OpenCode agent turn has cached the server. In that state the controller receives the refresh marker, but the previous refresh path has no cached server to update, so newly added custom providers such as `claude-relay` remain absent from OpenCode's live `/global/config` and provider tests fail with a 500.

## Validation
- `uv run pytest tests/test_opencode_server.py tests/test_agent_auth_service.py::AgentAuthServiceTests::test_opencode_agent_refresh_runtime_config_uses_global_config_refresh tests/test_agent_auth_service.py::AgentAuthServiceTests::test_opencode_agent_refresh_runtime_config_attaches_uncached_server tests/test_agent_auth_service.py::AgentAuthServiceTests::test_refresh_opencode_runtime_reloads_v2_cli_path tests/test_save_opencode_provider_auth.py::test_save_custom_provider_persists_config_and_key tests/test_save_opencode_provider_auth.py::test_save_provider_auth_persists_api_key_in_provider_options -q`
- `uv run ruff check modules/agents/opencode/server.py modules/agents/opencode/agent.py tests/test_opencode_server.py tests/test_agent_auth_service.py`
- Regression container manual check: after forcing live config refresh, `claude-relay` appeared in OpenCode `/provider` and provider test returned `ok: true` for `claude-opus-4.8`.
