### PR TITLE
fix(show): prefer loopback for session prewarm

### DIFF
--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -315,7 +315,7 @@ def test_show_path_cli_keeps_page_when_prewarm_fails(monkeypatch, tmp_path, caps
     assert (tmp_path / "show" / "ses123" / "index.html").exists()
 
 
-def test_show_path_cli_prewarm_falls_back_to_configured_ui_host(monkeypatch, tmp_path, capsys):
+def test_show_path_cli_prewarm_uses_verified_loopback_for_non_loopback_host(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     config = _save_config()
@@ -325,6 +325,9 @@ def test_show_path_cli_prewarm_falls_back_to_configured_ui_host(monkeypatch, tmp
     attempted = []
 
     class _Response:
+        def __init__(self, payload=None):
+            self.payload = payload or {"ok": True}
+
         def __enter__(self):
             return self
 
@@ -332,12 +335,12 @@ def test_show_path_cli_prewarm_falls_back_to_configured_ui_host(monkeypatch, tmp
             return None
 
         def read(self):
-            return json.dumps({"ok": True}).encode("utf-8")
+            return json.dumps(self.payload).encode("utf-8")
 
     def _urlopen(request, timeout):
         attempted.append((request.full_url, timeout))
-        if request.full_url.startswith("http://127.0.0.1:15130/"):
-            raise OSError("loopback unavailable")
+        if request.full_url == "http://127.0.0.1:15130/status":
+            return _Response({"ui_pid": 123})
         return _Response()
 
     monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
@@ -349,8 +352,54 @@ def test_show_path_cli_prewarm_falls_back_to_configured_ui_host(monkeypatch, tmp
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert attempted == [
+        ("http://127.0.0.1:15130/status", 1),
         ("http://127.0.0.1:15130/api/show/sessions/ses123/prewarm", 3),
-        ("http://192.168.2.3:15130/api/show/sessions/ses123/prewarm", 3),
+    ]
+
+
+def test_show_path_cli_prewarm_falls_back_to_configured_ui_host_after_loopback_mismatch(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    config = _save_config()
+    config.ui.setup_host = "192.168.2.3"
+    config.ui.setup_port = 15130
+    config.save()
+    attempted = []
+
+    class _Response:
+        def __init__(self, payload=None):
+            self.payload = payload or {"ok": True}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return json.dumps(self.payload).encode("utf-8")
+
+    def _urlopen(request, timeout):
+        attempted.append((request.full_url, timeout, bool(getattr(request, "data", None))))
+        if request.full_url == "http://127.0.0.1:15130/status":
+            return _Response({"ui_pid": 999})
+        if request.full_url.startswith("http://127.0.0.1:15130/"):
+            raise AssertionError("unverified loopback target received the prewarm token")
+        return _Response()
+
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
+    monkeypatch.setattr(cli.urllib.request, "urlopen", _urlopen)
+
+    args = cli.build_parser().parse_args(["show", "path", "--session-id", "ses123", "--json"])
+    assert cli.cmd_show_path(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert attempted == [
+        ("http://127.0.0.1:15130/status", 1, False),
+        ("http://192.168.2.3:15130/api/show/sessions/ses123/prewarm", 3, True),
     ]
 
 

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -315,6 +315,45 @@ def test_show_path_cli_keeps_page_when_prewarm_fails(monkeypatch, tmp_path, caps
     assert (tmp_path / "show" / "ses123" / "index.html").exists()
 
 
+def test_show_path_cli_prewarm_falls_back_to_configured_ui_host(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    config = _save_config()
+    config.ui.setup_host = "192.168.2.3"
+    config.ui.setup_port = 15130
+    config.save()
+    attempted = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return json.dumps({"ok": True}).encode("utf-8")
+
+    def _urlopen(request, timeout):
+        attempted.append((request.full_url, timeout))
+        if request.full_url.startswith("http://127.0.0.1:15130/"):
+            raise OSError("loopback unavailable")
+        return _Response()
+
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
+    monkeypatch.setattr(cli.urllib.request, "urlopen", _urlopen)
+
+    args = cli.build_parser().parse_args(["show", "path", "--session-id", "ses123", "--json"])
+    assert cli.cmd_show_path(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert attempted == [
+        ("http://127.0.0.1:15130/api/show/sessions/ses123/prewarm", 3),
+        ("http://192.168.2.3:15130/api/show/sessions/ses123/prewarm", 3),
+    ]
+
+
 def test_show_list_cli_json_reports_existing_pages(monkeypatch, tmp_path, capsys):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     paths.ensure_data_dirs()

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4642,6 +4642,25 @@ def _ui_show_events_host(config: V2Config) -> str:
     return host
 
 
+def _local_show_events_urls(session_id: str) -> list[str]:
+    from urllib.parse import quote
+
+    try:
+        config = V2Config.load()
+    except Exception:
+        return []
+    status = runtime.read_status()
+    port = getattr(config.ui, "setup_port", None)
+    if not status.get("ui_pid") or not port:
+        return []
+    path = f"/api/show/sessions/{quote(session_id, safe='')}/events"
+    configured_host = _ui_show_events_host(config)
+    hosts = ["127.0.0.1"]
+    if configured_host not in hosts:
+        hosts.append(configured_host)
+    return [f"http://{host}:{int(port)}{path}" for host in hosts]
+
+
 def _local_show_events_url(session_id: str) -> str | None:
     from urllib.parse import quote
 
@@ -4656,38 +4675,32 @@ def _local_show_events_url(session_id: str) -> str | None:
     return f"http://{_ui_show_events_host(config)}:{int(port)}/api/show/sessions/{quote(session_id, safe='')}/events"
 
 
-def _local_show_prewarm_url(session_id: str) -> str | None:
-    events_url = _local_show_events_url(session_id)
-    if not events_url:
-        return None
-    return f"{events_url.rsplit('/', 1)[0]}/prewarm"
+def _local_show_prewarm_urls(session_id: str) -> list[str]:
+    return [f"{events_url.rsplit('/', 1)[0]}/prewarm" for events_url in _local_show_events_urls(session_id)]
 
 
 def _request_show_page_prewarm_best_effort(session_id: str, *, base_path: str | None = None) -> dict | None:
     from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
 
-    url = _local_show_prewarm_url(session_id)
-    if not url:
+    urls = _local_show_prewarm_urls(session_id)
+    if not urls:
         return None
     payload = {"base_path": base_path} if base_path else {}
     body = json.dumps(payload).encode("utf-8")
-    request = urllib.request.Request(
-        url,
-        data=body,
-        method="POST",
-        headers={
-            "Content-Type": "application/json",
-            "X-Vibe-Show-Client": "cli",
-            SHOW_CLI_EVENT_TOKEN_HEADER: show_cli_event_token(),
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=3) as response:
-            data = json.loads(response.read().decode("utf-8") or "{}")
-            return data if isinstance(data, dict) else None
-    except Exception:
-        logger.debug("Failed to request Show Page prewarm from live UI", exc_info=True)
-        return None
+    headers = {
+        "Content-Type": "application/json",
+        "X-Vibe-Show-Client": "cli",
+        SHOW_CLI_EVENT_TOKEN_HEADER: show_cli_event_token(),
+    }
+    for url in urls:
+        request = urllib.request.Request(url, data=body, method="POST", headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=3) as response:
+                data = json.loads(response.read().decode("utf-8") or "{}")
+                return data if isinstance(data, dict) else None
+        except Exception:
+            logger.debug("Failed to request Show Page prewarm from live UI at %s", url, exc_info=True)
+    return None
 
 
 def _post_show_event_to_live_ui(session_id: str, payload: dict) -> dict | None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -122,6 +122,11 @@ class TaskCliError(ValueError):
         self.details = details or {}
 
 
+class _LocalShowEventsTarget(NamedTuple):
+    url: str
+    verify_ui_pid: int | None = None
+
+
 def _print_task_error(exc: Exception, *, help_command: str | None = None) -> None:
     if isinstance(exc, TaskCliError):
         payload = {
@@ -4642,7 +4647,7 @@ def _ui_show_events_host(config: V2Config) -> str:
     return host
 
 
-def _local_show_events_urls(session_id: str) -> list[str]:
+def _local_show_events_targets(session_id: str) -> list[_LocalShowEventsTarget]:
     from urllib.parse import quote
 
     try:
@@ -4655,10 +4660,19 @@ def _local_show_events_urls(session_id: str) -> list[str]:
         return []
     path = f"/api/show/sessions/{quote(session_id, safe='')}/events"
     configured_host = _ui_show_events_host(config)
-    hosts = ["127.0.0.1"]
-    if configured_host not in hosts:
-        hosts.append(configured_host)
-    return [f"http://{host}:{int(port)}{path}" for host in hosts]
+    configured_url = f"http://{configured_host}:{int(port)}{path}"
+    if configured_host in {"127.0.0.1", "localhost", "[::1]"}:
+        return [_LocalShowEventsTarget(configured_url)]
+
+    loopback_url = f"http://127.0.0.1:{int(port)}{path}"
+    try:
+        ui_pid = int(status["ui_pid"])
+    except (TypeError, ValueError):
+        ui_pid = None
+    return [
+        _LocalShowEventsTarget(loopback_url, verify_ui_pid=ui_pid),
+        _LocalShowEventsTarget(configured_url),
+    ]
 
 
 def _local_show_events_url(session_id: str) -> str | None:
@@ -4675,15 +4689,42 @@ def _local_show_events_url(session_id: str) -> str | None:
     return f"http://{_ui_show_events_host(config)}:{int(port)}/api/show/sessions/{quote(session_id, safe='')}/events"
 
 
-def _local_show_prewarm_urls(session_id: str) -> list[str]:
-    return [f"{events_url.rsplit('/', 1)[0]}/prewarm" for events_url in _local_show_events_urls(session_id)]
+def _local_show_prewarm_targets(session_id: str) -> list[_LocalShowEventsTarget]:
+    return [
+        _LocalShowEventsTarget(
+            f"{target.url.rsplit('/', 1)[0]}/prewarm",
+            verify_ui_pid=target.verify_ui_pid,
+        )
+        for target in _local_show_events_targets(session_id)
+    ]
+
+
+def _show_prewarm_target_matches_ui_pid(url: str, expected_ui_pid: int | None) -> bool:
+    from urllib.parse import urlsplit, urlunsplit
+
+    if expected_ui_pid is None:
+        return False
+    parts = urlsplit(url)
+    status_url = urlunsplit((parts.scheme, parts.netloc, "/status", "", ""))
+    request = urllib.request.Request(status_url, method="GET", headers={"X-Vibe-Show-Client": "cli"})
+    try:
+        with urllib.request.urlopen(request, timeout=1) as response:
+            payload = json.loads(response.read().decode("utf-8") or "{}")
+    except Exception:
+        logger.debug("Failed to verify Show Page prewarm loopback target at %s", status_url, exc_info=True)
+        return False
+    try:
+        actual_ui_pid = int(payload.get("ui_pid"))
+    except (TypeError, ValueError):
+        return False
+    return actual_ui_pid == expected_ui_pid
 
 
 def _request_show_page_prewarm_best_effort(session_id: str, *, base_path: str | None = None) -> dict | None:
     from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
 
-    urls = _local_show_prewarm_urls(session_id)
-    if not urls:
+    targets = _local_show_prewarm_targets(session_id)
+    if not targets:
         return None
     payload = {"base_path": base_path} if base_path else {}
     body = json.dumps(payload).encode("utf-8")
@@ -4692,7 +4733,11 @@ def _request_show_page_prewarm_best_effort(session_id: str, *, base_path: str | 
         "X-Vibe-Show-Client": "cli",
         SHOW_CLI_EVENT_TOKEN_HEADER: show_cli_event_token(),
     }
-    for url in urls:
+    for target in targets:
+        if target.verify_ui_pid is not None and not _show_prewarm_target_matches_ui_pid(target.url, target.verify_ui_pid):
+            logger.debug("Skipping unverified Show Page prewarm loopback target at %s", target.url)
+            continue
+        url = target.url
         request = urllib.request.Request(url, data=body, method="POST", headers=headers)
         try:
             with urllib.request.urlopen(request, timeout=3) as response:


### PR DESCRIPTION
## What

- try loopback first when the CLI asks the live UI to prewarm a Show Page session
- fall back to the configured UI host if loopback is unavailable
- keep show event posting on the configured UI host path

## Why

Regression environments can expose the UI through a mapped/public host while the service is still reachable from the CLI through loopback inside the runtime. The old single configured-host prewarm path could be blocked by host validation or port mapping, leaving users to pay the session Vite warm-up cost on first page open.

## Evidence

- `uv run pytest tests/test_show_pages.py -q`
- `uv run ruff check vibe/cli.py tests/test_show_pages.py`
- regression container probe: `127.0.0.1:5123` session prewarm returned 200 and created the session Vite cache directory

## Residual Checks

- CI should cover the broader Python and packaging matrix.
