### PR TITLE
perf(show): expose runtime deps on public paths

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -381,6 +381,37 @@ def test_show_runtime_public_dep_proxy_is_cacheable(monkeypatch, tmp_path):
     assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/react.js?v=d6d38251"
 
 
+def test_show_runtime_public_dep_proxy_allows_scoped_package_names(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        original = app.test_client().get(
+            "/show/ses123/node_modules/.vite/deps/@avibe_show-ui_theme.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        response = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/%40avibe_show-ui_theme.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert original.status_code == 302
+    assert original.headers["location"] == "/_show-runtime/deps/d6d38251/%40avibe_show-ui_theme.js"
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/@avibe_show-ui_theme.js?v=d6d38251"
+
+
 def test_show_runtime_public_dep_proxy_registers_sibling_chunks(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)
@@ -547,6 +578,35 @@ def test_show_runtime_source_rewrites_dep_imports_to_public_paths(monkeypatch, t
     assert "etag" not in response.headers
     assert public_dep.status_code == 200
     assert public_dep.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+
+def test_show_runtime_source_keeps_partial_js_responses_unmodified(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b'import "/node_modules/.vite/deps/react.js?v=d6d38251";',
+        status_code=206,
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+            "content-range": "bytes 0-52/53",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/src/main.tsx?t=1780732068677",
+            base_url="http://127.0.0.1:5123",
+            headers={"Range": "bytes=0-52"},
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 206
+    assert response.content == b'import "/node_modules/.vite/deps/react.js?v=d6d38251";'
+    assert response.headers["content-range"] == "bytes 0-52/53"
+    assert response.headers["cache-control"] == "no-cache"
 
 
 def test_public_show_page_does_not_inject_write_runtime_config(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -22,6 +22,13 @@ from vibe import remote_access
 from vibe.ui_server import app
 
 
+@pytest.fixture(autouse=True)
+def _clear_show_runtime_public_dep_registry():
+    from vibe import ui_server
+
+    ui_server._SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.clear()
+
+
 class _FakeShowRuntimeManager:
     def __init__(
         self,
@@ -448,6 +455,72 @@ def test_show_runtime_public_dep_proxy_registers_sibling_chunks(monkeypatch, tmp
     assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/chunk-OUYO74D4.js?v=108951fb"
 
 
+def test_show_runtime_public_dep_proxy_derives_chunk_paths_when_registry_is_cold(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        original = app.test_client().get(
+            "/show/ses123/node_modules/.vite/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        chunk = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/chunk-OUYO74D4.js?v=108951fb",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert original.status_code == 302
+    assert chunk.status_code == 200
+    assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/chunk-OUYO74D4.js?v=108951fb"
+
+
+def test_show_runtime_unversioned_vendor_deps_stay_session_scoped(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default {}",
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/node_modules/.vite/deps/react.js",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-cache"
+    assert "location" not in response.headers
+
+
+def test_show_runtime_public_dep_rejects_unversioned_cache_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/_show-runtime/deps/unversioned/react.js",
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 404
+
+
 def test_show_runtime_relocated_vendor_deps_are_cacheable(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)
@@ -578,6 +651,60 @@ def test_show_runtime_source_rewrites_dep_imports_to_public_paths(monkeypatch, t
     assert "etag" not in response.headers
     assert public_dep.status_code == 200
     assert public_dep.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+
+def test_show_runtime_source_preserves_dot_vite_dep_import_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b'import "/.vite/deps/react.js?v=d6d38251";',
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/src/main.tsx?t=1780732068677",
+            base_url="http://127.0.0.1:5123",
+        )
+        public_dep = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/react.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert public_dep.status_code == 200
+    assert manager.calls[-1][1] == "/sessions/ses123/app/.vite/deps/react.js?v=d6d38251"
+
+
+def test_show_runtime_source_keeps_unversioned_dep_imports_session_scoped(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b'import "/node_modules/.vite/deps/react.js";',
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/src/main.tsx?t=1780732068677",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.content == b'import "/node_modules/.vite/deps/react.js";'
+    assert response.headers["cache-control"] == "no-cache"
 
 
 def test_show_runtime_source_keeps_partial_js_responses_unmodified(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -344,12 +344,13 @@ def test_show_runtime_vendor_deps_are_cacheable(monkeypatch, tmp_path):
     finally:
         set_show_runtime_manager_for_tests(None)
 
-    assert response.status_code == 200
-    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert response.status_code == 302
+    assert response.headers["location"] == "/_show-runtime/deps/d6d38251/react-dom_client.js"
+    assert response.headers["cache-control"] == "no-store"
     assert "set-cookie" not in response.headers
 
 
-def test_show_runtime_node_modules_vendor_deps_are_cacheable(monkeypatch, tmp_path):
+def test_show_runtime_public_dep_proxy_is_cacheable(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
@@ -362,16 +363,22 @@ def test_show_runtime_node_modules_vendor_deps_are_cacheable(monkeypatch, tmp_pa
     )
     set_show_runtime_manager_for_tests(manager)
     try:
-        response = app.test_client().get(
+        original = app.test_client().get(
             "/show/ses123/node_modules/.vite/deps/react.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        response = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/react.js?v=d6d38251",
             base_url="http://127.0.0.1:5123",
         )
     finally:
         set_show_runtime_manager_for_tests(None)
 
+    assert original.status_code == 302
     assert response.status_code == 200
     assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
     assert "set-cookie" not in response.headers
+    assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/react.js?v=d6d38251"
 
 
 def test_show_runtime_relocated_vendor_deps_are_cacheable(monkeypatch, tmp_path):
@@ -394,8 +401,8 @@ def test_show_runtime_relocated_vendor_deps_are_cacheable(monkeypatch, tmp_path)
     finally:
         set_show_runtime_manager_for_tests(None)
 
-    assert response.status_code == 200
-    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert response.status_code == 302
+    assert response.headers["location"] == "/_show-runtime/deps/d6d38251/react-dom_client.js"
     assert "set-cookie" not in response.headers
 
 
@@ -470,6 +477,40 @@ def test_show_runtime_session_source_is_not_marked_immutable(monkeypatch, tmp_pa
 
     assert response.status_code == 200
     assert response.headers["cache-control"] == "no-cache"
+
+
+def test_show_runtime_source_rewrites_dep_imports_to_public_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b'import "/node_modules/.vite/deps/react.js?v=d6d38251";\nimport "./App.tsx";',
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+            "etag": "source-etag",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/src/main.tsx?t=1780732068677",
+            base_url="http://127.0.0.1:5123",
+        )
+        public_dep = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/react.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert b'"/_show-runtime/deps/d6d38251/react.js"' in response.content
+    assert b'"./App.tsx"' in response.content
+    assert response.headers["cache-control"] == "no-store"
+    assert "etag" not in response.headers
+    assert public_dep.status_code == 200
+    assert public_dep.headers["cache-control"] == "public, max-age=31536000, immutable"
 
 
 def test_public_show_page_does_not_inject_write_runtime_config(monkeypatch, tmp_path):
@@ -856,8 +897,8 @@ def test_public_show_page_immutable_deps_do_not_clear_write_cookie(monkeypatch, 
     finally:
         set_show_runtime_manager_for_tests(None)
 
-    assert response.status_code == 200
-    assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert response.status_code == 302
+    assert response.headers["location"] == "/_show-runtime/deps/d6d38251/react.js"
     assert "set-cookie" not in response.headers
 
 

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -381,6 +381,42 @@ def test_show_runtime_public_dep_proxy_is_cacheable(monkeypatch, tmp_path):
     assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/react.js?v=d6d38251"
 
 
+def test_show_runtime_public_dep_proxy_registers_sibling_chunks(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=b'import "./chunk-OUYO74D4.js?v=108951fb";\nexport default {}',
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        original = app.test_client().get(
+            "/show/ses123/node_modules/.vite/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        dep = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        chunk = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/chunk-OUYO74D4.js?v=108951fb",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert original.status_code == 302
+    assert dep.status_code == 200
+    assert b'import "./chunk-OUYO74D4.js?v=108951fb"' in dep.content
+    assert chunk.status_code == 200
+    assert chunk.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/chunk-OUYO74D4.js?v=108951fb"
+
+
 def test_show_runtime_relocated_vendor_deps_are_cacheable(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5403,7 +5403,7 @@ async def show_session_prewarm(session_id: str):
 async def show_runtime_public_dep(version: str, asset_name: str):
     if not re.fullmatch(r"[A-Za-z0-9_-]+", version or ""):
         return _show_page_not_found_response()
-    if not re.fullmatch(r"[A-Za-z0-9_.-]+", asset_name or ""):
+    if not re.fullmatch(r"[A-Za-z0-9_@.-]+", asset_name or ""):
         return _show_page_not_found_response()
     runtime_path = _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.get((version, asset_name))
     if not runtime_path:
@@ -5437,6 +5437,7 @@ async def show_runtime_public_dep(version: str, asset_name: str):
         _remove_response_header(response_headers, "cache-control")
         _remove_response_header(response_headers, "set-cookie")
         response_headers["Cache-Control"] = _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL
+    if proxied.status_code == 200:
         _register_public_show_runtime_dep_siblings(proxied.content, response_headers, version=version, runtime_path=runtime_path)
     return FastAPIResponse(content=proxied.content, status_code=proxied.status_code, headers=response_headers)
 
@@ -5496,7 +5497,8 @@ async def _show_page_runtime_response(
         content = _inject_show_runtime_config(content, session_id)
         _strip_mutated_show_runtime_headers(response_headers)
     else:
-        content = _rewrite_show_runtime_public_deps(content, response_headers, session_id=session_id)
+        if proxied.status_code == 200:
+            content = _rewrite_show_runtime_public_deps(content, response_headers, session_id=session_id)
         _apply_show_runtime_cache_headers(asset_path, response_headers, status_code=proxied.status_code)
     return FastAPIResponse(content=content, status_code=proxied.status_code, headers=response_headers)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5401,11 +5401,11 @@ async def show_session_prewarm(session_id: str):
 
 @app.route("/_show-runtime/deps/<version>/<path:asset_name>", methods=["GET", "HEAD"])
 async def show_runtime_public_dep(version: str, asset_name: str):
-    if not re.fullmatch(r"[A-Za-z0-9_-]+", version or ""):
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", version or "") or version == "unversioned":
         return _show_page_not_found_response()
     if not re.fullmatch(r"[A-Za-z0-9_@.-]+", asset_name or ""):
         return _show_page_not_found_response()
-    runtime_path = _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.get((version, asset_name))
+    runtime_path = _public_show_runtime_dep_runtime_path(version, asset_name)
     if not runtime_path:
         return _show_page_not_found_response()
     if request._request.url.query and "?" not in runtime_path:
@@ -5499,7 +5499,12 @@ async def _show_page_runtime_response(
     else:
         if proxied.status_code == 200:
             content = _rewrite_show_runtime_public_deps(content, response_headers, session_id=session_id)
-        _apply_show_runtime_cache_headers(asset_path, response_headers, status_code=proxied.status_code)
+        _apply_show_runtime_cache_headers(
+            asset_path,
+            response_headers,
+            status_code=proxied.status_code,
+            query=starlette_request.url.query,
+        )
     return FastAPIResponse(content=content, status_code=proxied.status_code, headers=response_headers)
 
 
@@ -5522,7 +5527,7 @@ def _strip_mutated_show_runtime_headers(headers: dict[str, str]) -> None:
     headers["Cache-Control"] = "no-store"
 
 
-def _apply_show_runtime_cache_headers(asset_path: str, headers: dict[str, str], *, status_code: int) -> None:
+def _apply_show_runtime_cache_headers(asset_path: str, headers: dict[str, str], *, status_code: int, query: str | None) -> None:
     relative = (asset_path or "").strip("/")
     if not relative or relative == "index.html":
         _remove_response_header(headers, "cache-control")
@@ -5531,6 +5536,8 @@ def _apply_show_runtime_cache_headers(asset_path: str, headers: dict[str, str], 
     if status_code < 200 or status_code >= 300:
         return
     if _is_show_runtime_immutable_asset(relative):
+        if not _show_runtime_dep_version(query):
+            return
         _remove_response_header(headers, "cache-control")
         _remove_response_header(headers, "set-cookie")
         headers["Cache-Control"] = _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL
@@ -5541,6 +5548,7 @@ def _should_redirect_to_public_show_runtime_dep(asset_path: str, starlette_reque
         starlette_request.method == "GET"
         and 200 <= status_code < 300
         and _is_show_runtime_immutable_asset_path(asset_path)
+        and bool(_show_runtime_dep_version(starlette_request.url.query))
         and bool(_public_show_runtime_dep_path(asset_path, starlette_request.url.query))
     )
 
@@ -5550,6 +5558,20 @@ def _register_public_show_runtime_dep(asset_path: str, query: str | None, runtim
     version, name = _public_show_runtime_dep_key(asset_path, query)
     _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY[(version, name)] = runtime_path
     return public_path
+
+
+def _public_show_runtime_dep_runtime_path(version: str, asset_name: str) -> str | None:
+    runtime_path = _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.get((version, asset_name))
+    if runtime_path:
+        return runtime_path
+    if not re.fullmatch(r"chunk-[A-Za-z0-9_-]+\.js", asset_name or ""):
+        return None
+    for (registered_version, _registered_name), registered_path in _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.items():
+        if registered_version != version:
+            continue
+        base_path = registered_path.split("?", 1)[0].rsplit("/", 1)[0]
+        return f"{base_path}/{quote(asset_name, safe='')}"
+    return None
 
 
 def _public_show_runtime_dep_path(asset_path: str, query: str | None = None) -> str:
@@ -5564,7 +5586,9 @@ def _public_show_runtime_dep_key(asset_path: str, query: str | None = None) -> t
     if not _is_show_runtime_immutable_asset_path(relative):
         return "", ""
     name = Path(relative).name
-    version = _show_runtime_dep_version(query) or "unversioned"
+    version = _show_runtime_dep_version(query)
+    if not version:
+        return "", ""
     return version, name
 
 
@@ -5590,10 +5614,12 @@ def _rewrite_show_runtime_public_deps(content: bytes, headers: dict[str, str], *
         return content
 
     def replace(match: re.Match[str]) -> str:
-        version = match.group("version") or "unversioned"
+        version = match.group("version")
+        if not version:
+            return match.group(0)
         name = Path(match.group("path")).name
         public_path = f"{_SHOW_RUNTIME_PUBLIC_DEP_PREFIX}/{quote(version, safe='')}/{quote(name, safe='')}"
-        dep_path = match.group("path").lstrip("./")
+        dep_path = _normalize_show_runtime_dep_import_path(match.group("path"))
         _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY[(version, name)] = f"/sessions/{quote(session_id, safe='')}/app/{quote(dep_path, safe='/@:-._~')}"
         return f"{match.group('quote')}{public_path}{match.group('rest')}{match.group('quote')}"
 
@@ -5602,6 +5628,14 @@ def _rewrite_show_runtime_public_deps(content: bytes, headers: dict[str, str], *
         return content
     _strip_mutated_show_runtime_headers(headers)
     return rewritten.encode("utf-8")
+
+
+def _normalize_show_runtime_dep_import_path(dep_path: str) -> str:
+    if dep_path.startswith("/"):
+        return dep_path[1:]
+    if dep_path.startswith("./"):
+        return dep_path[2:]
+    return dep_path
 
 
 def _register_public_show_runtime_dep_siblings(
@@ -5622,7 +5656,7 @@ def _register_public_show_runtime_dep_siblings(
     for match in _SHOW_RUNTIME_PUBLIC_DEP_SIBLING_RE.finditer(text):
         sibling_name = match.group("name")
         _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.setdefault(
-            (version or "unversioned", sibling_name),
+            (version, sibling_name),
             f"{base_runtime_path}/{quote(sibling_name, safe='')}",
         )
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -85,6 +85,11 @@ _SHOW_RUNTIME_MODULE_SCRIPT_RE = re.compile(
     re.IGNORECASE,
 )
 _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+_SHOW_RUNTIME_PUBLIC_DEP_RE = re.compile(
+    r"(?P<quote>['\"])(?P<path>(?:\.?/)?(?:node_modules/)?\.vite/deps/[^'\"?#]+)(?:\?v=(?P<version>[A-Za-z0-9_-]+))?(?P<rest>[^'\"]*)(?P=quote)"
+)
+_SHOW_RUNTIME_PUBLIC_DEP_PREFIX = "/_show-runtime/deps"
+_SHOW_RUNTIME_PUBLIC_DEP_REGISTRY: dict[tuple[str, str], str] = {}
 
 STRUCTURED_LOG_PATTERN = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s+-\s+([\w.]+)\s+-\s+(\w+)\s+-\s+(.*)$")
 LEVEL_HINT_PATTERN = re.compile(r"\b(DEBUG|INFO|WARNING|ERROR|CRITICAL)\b")
@@ -942,6 +947,7 @@ def _remote_auth_exempt_path() -> bool:
         or path == "/api/cloud/token"
         or path == "/api/csrf-token"
         or path.startswith("/assets/")
+        or path.startswith("/_show-runtime/deps/")
         or path.startswith("/p/")
         or path == "/favicon.ico"
         or path in _PWA_PUBLIC_ASSETS
@@ -949,9 +955,12 @@ def _remote_auth_exempt_path() -> bool:
 
 
 def _remote_auth_exempt_before_host_validation() -> bool:
-    return request.path in {"/auth/callback", "/auth/logout", "/api/session", "/api/csrf-token"} or request.path.startswith(
-        "/assets/"
-    ) or request.path == "/favicon.ico"
+    return (
+        request.path in {"/auth/callback", "/auth/logout", "/api/session", "/api/csrf-token"}
+        or request.path.startswith("/assets/")
+        or request.path.startswith("/_show-runtime/deps/")
+        or request.path == "/favicon.ico"
+    )
 
 
 def _oauth_cookie_signature(secret: str, payload: str) -> str:
@@ -5387,6 +5396,47 @@ async def show_session_prewarm(session_id: str):
     return jsonify({"ok": result.available, "reason": result.reason, "base_url": result.base_url}), status_code
 
 
+@app.route("/_show-runtime/deps/<version>/<path:asset_name>", methods=["GET", "HEAD"])
+async def show_runtime_public_dep(version: str, asset_name: str):
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", version or ""):
+        return _show_page_not_found_response()
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", asset_name or ""):
+        return _show_page_not_found_response()
+    runtime_path = _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.get((version, asset_name))
+    if not runtime_path:
+        return _show_page_not_found_response()
+    if request._request.url.query and "?" not in runtime_path:
+        runtime_path = f"{runtime_path}?{request._request.url.query}"
+    from core.show_runtime import get_show_runtime_manager
+
+    forwarded_headers = {
+        key: value
+        for key, value in request._request.headers.items()
+        if key.lower() in _SHOW_RUNTIME_REQUEST_HEADER_ALLOWLIST
+    }
+    try:
+        proxied = await get_show_runtime_manager().request(
+            request.method,
+            runtime_path,
+            headers=forwarded_headers,
+            body=None,
+        )
+    except Exception:
+        return _show_page_runtime_unavailable_response()
+    response_headers = {
+        key: value
+        for key, value in proxied.headers.items()
+        if key.lower() in _SHOW_RUNTIME_RESPONSE_HEADER_ALLOWLIST
+    }
+    response_headers["X-Content-Type-Options"] = "nosniff"
+    response_headers["Referrer-Policy"] = "no-referrer"
+    if 200 <= proxied.status_code < 300:
+        _remove_response_header(response_headers, "cache-control")
+        _remove_response_header(response_headers, "set-cookie")
+        response_headers["Cache-Control"] = _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL
+    return FastAPIResponse(content=proxied.content, status_code=proxied.status_code, headers=response_headers)
+
+
 async def _show_page_runtime_response(
     session_id: str,
     asset_path: str,
@@ -5432,10 +5482,17 @@ async def _show_page_runtime_response(
     response_headers["X-Content-Type-Options"] = "nosniff"
     response_headers["Referrer-Policy"] = "no-referrer"
     content = proxied.content
+    if _should_redirect_to_public_show_runtime_dep(asset_path, starlette_request, proxied.status_code):
+        public_path = _register_public_show_runtime_dep(asset_path, starlette_request.url.query, runtime_path)
+        response_headers.clear()
+        response_headers["location"] = public_path
+        response_headers["Cache-Control"] = "no-store"
+        return FastAPIResponse(content=b"", status_code=302, headers=response_headers)
     if _should_inject_show_runtime_config(proxied.status_code, response_headers, inject_private_config=inject_private_config):
         content = _inject_show_runtime_config(content, session_id)
         _strip_mutated_show_runtime_headers(response_headers)
     else:
+        content = _rewrite_show_runtime_public_deps(content, response_headers, session_id=session_id)
         _apply_show_runtime_cache_headers(asset_path, response_headers, status_code=proxied.status_code)
     return FastAPIResponse(content=content, status_code=proxied.status_code, headers=response_headers)
 
@@ -5473,6 +5530,81 @@ def _apply_show_runtime_cache_headers(asset_path: str, headers: dict[str, str], 
         headers["Cache-Control"] = _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL
 
 
+def _should_redirect_to_public_show_runtime_dep(asset_path: str, starlette_request: FastAPIRequest, status_code: int) -> bool:
+    return (
+        starlette_request.method == "GET"
+        and 200 <= status_code < 300
+        and _is_show_runtime_immutable_asset_path(asset_path)
+        and bool(_public_show_runtime_dep_path(asset_path, starlette_request.url.query))
+    )
+
+
+def _register_public_show_runtime_dep(asset_path: str, query: str | None, runtime_path: str) -> str:
+    public_path = _public_show_runtime_dep_path(asset_path, query)
+    version, name = _public_show_runtime_dep_key(asset_path, query)
+    _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY[(version, name)] = runtime_path
+    return public_path
+
+
+def _public_show_runtime_dep_path(asset_path: str, query: str | None = None) -> str:
+    version, name = _public_show_runtime_dep_key(asset_path, query)
+    if not version or not name:
+        return ""
+    return f"{_SHOW_RUNTIME_PUBLIC_DEP_PREFIX}/{quote(version, safe='')}/{quote(name, safe='')}"
+
+
+def _public_show_runtime_dep_key(asset_path: str, query: str | None = None) -> tuple[str, str]:
+    relative = (asset_path or "").strip("/")
+    if not _is_show_runtime_immutable_asset_path(relative):
+        return "", ""
+    name = Path(relative).name
+    version = _show_runtime_dep_version(query) or "unversioned"
+    return version, name
+
+
+def _show_runtime_dep_version(query: str | None) -> str | None:
+    if not query:
+        return None
+    parsed = dict(parse_qsl(query, keep_blank_values=True))
+    value = parsed.get("v")
+    if not value:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", value):
+        return None
+    return value
+
+
+def _rewrite_show_runtime_public_deps(content: bytes, headers: dict[str, str], *, session_id: str) -> bytes:
+    content_type = _response_header(headers, "content-type") or ""
+    if not _show_response_is_javascript(content_type):
+        return content
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return content
+
+    def replace(match: re.Match[str]) -> str:
+        version = match.group("version") or "unversioned"
+        name = Path(match.group("path")).name
+        public_path = f"{_SHOW_RUNTIME_PUBLIC_DEP_PREFIX}/{quote(version, safe='')}/{quote(name, safe='')}"
+        dep_path = match.group("path").lstrip("./")
+        _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY[(version, name)] = f"/sessions/{quote(session_id, safe='')}/app/{quote(dep_path, safe='/@:-._~')}"
+        return f"{match.group('quote')}{public_path}{match.group('rest')}{match.group('quote')}"
+
+    rewritten = _SHOW_RUNTIME_PUBLIC_DEP_RE.sub(replace, text)
+    if rewritten == text:
+        return content
+    _strip_mutated_show_runtime_headers(headers)
+    return rewritten.encode("utf-8")
+
+
+def _show_response_is_javascript(content_type: str | None) -> bool:
+    if not content_type:
+        return False
+    lowered = content_type.lower()
+    return "javascript" in lowered or "ecmascript" in lowered
+
+
 def _is_show_runtime_immutable_asset(relative_asset_path: str) -> bool:
     if relative_asset_path.startswith(".vite/deps/"):
         return True
@@ -5499,6 +5631,8 @@ def _is_show_runtime_immutable_asset_path(asset_path: str) -> bool:
 
 def _is_current_show_runtime_immutable_asset_request() -> bool:
     path = (request.path or "").strip("/")
+    if path.startswith("_show-runtime/deps/"):
+        return True
     parts = path.split("/", 2)
     if len(parts) < 3 or parts[0] not in {"show", "p"}:
         return False

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -88,6 +88,9 @@ _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 _SHOW_RUNTIME_PUBLIC_DEP_RE = re.compile(
     r"(?P<quote>['\"])(?P<path>(?:\.?/)?(?:node_modules/)?\.vite/deps/[^'\"?#]+)(?:\?v=(?P<version>[A-Za-z0-9_-]+))?(?P<rest>[^'\"]*)(?P=quote)"
 )
+_SHOW_RUNTIME_PUBLIC_DEP_SIBLING_RE = re.compile(
+    r"(?P<quote>['\"])\./(?P<name>[A-Za-z0-9_.-]+\.js)(?:\?v=(?P<version>[A-Za-z0-9_-]+))?(?P<rest>[^'\"]*)(?P=quote)"
+)
 _SHOW_RUNTIME_PUBLIC_DEP_PREFIX = "/_show-runtime/deps"
 _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY: dict[tuple[str, str], str] = {}
 
@@ -5434,6 +5437,7 @@ async def show_runtime_public_dep(version: str, asset_name: str):
         _remove_response_header(response_headers, "cache-control")
         _remove_response_header(response_headers, "set-cookie")
         response_headers["Cache-Control"] = _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL
+        _register_public_show_runtime_dep_siblings(proxied.content, response_headers, version=version, runtime_path=runtime_path)
     return FastAPIResponse(content=proxied.content, status_code=proxied.status_code, headers=response_headers)
 
 
@@ -5596,6 +5600,29 @@ def _rewrite_show_runtime_public_deps(content: bytes, headers: dict[str, str], *
         return content
     _strip_mutated_show_runtime_headers(headers)
     return rewritten.encode("utf-8")
+
+
+def _register_public_show_runtime_dep_siblings(
+    content: bytes,
+    headers: dict[str, str],
+    *,
+    version: str,
+    runtime_path: str,
+) -> None:
+    content_type = _response_header(headers, "content-type") or ""
+    if not _show_response_is_javascript(content_type):
+        return
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+    base_runtime_path = runtime_path.split("?", 1)[0].rsplit("/", 1)[0]
+    for match in _SHOW_RUNTIME_PUBLIC_DEP_SIBLING_RE.finditer(text):
+        sibling_name = match.group("name")
+        _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.setdefault(
+            (version or "unversioned", sibling_name),
+            f"{base_runtime_path}/{quote(sibling_name, safe='')}",
+        )
 
 
 def _show_response_is_javascript(content_type: str | None) -> bool:


### PR DESCRIPTION
## What

- expose Vite optimized Show Runtime dependencies through `/_show-runtime/deps/<version>/<file>`
- redirect direct session dependency requests to the public dependency path
- rewrite dependency imports in runtime-served JavaScript modules to the public dependency path
- keep session HTML/source modules, HMR, APIs, and event streams fresh

## Why

Cloudflare Tunnel makes repeated session-scoped dependency URLs expensive. The fixed Vite dependency files should be cacheable outside `/show/<session>/...` and `/p/<share>/...` while preserving hot reload for session source and public/private Show Pages.

## Evidence

- `uv run pytest tests/test_ui_show_pages.py -q`
- `uv run ruff check vibe/ui_server.py tests/test_ui_show_pages.py`

## Notes

This is the Vibe Remote proxy-layer version. It does not change Show Runtime's per-session Vite server model, so HMR and editable session source paths stay live.
