### PR TITLE
fix(opencode): preserve custom provider identity

### DIFF
--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -337,6 +337,33 @@ def test_custom_provider_reader_does_not_treat_builtin_override_as_custom(tmp_pa
     assert read_opencode_custom_providers(home=tmp_path) == {}
 
 
+def test_remove_custom_provider_accepts_opencode_preserved_shape_without_meta(tmp_path: Path) -> None:
+    config_path = get_opencode_config_paths(tmp_path)[0]
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "my-relay": {
+                        "name": "My Relay",
+                        "npm": "@ai-sdk/openai-compatible",
+                        "options": {
+                            "baseURL": "https://relay.example/v1",
+                            "apiKey": "sk-relay",
+                        },
+                        "models": {},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    remove_opencode_custom_provider("my-relay", home=tmp_path)
+
+    assert "provider" not in _read_config(config_path)
+
+
 def test_upsert_custom_anthropic_compatible_provider_writes_adapter(tmp_path: Path) -> None:
     upsert_opencode_custom_provider(
         "anthropic-relay",

--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from vibe.opencode_config import (
+    get_opencode_custom_provider_adapter,
     get_opencode_config_paths,
     read_opencode_provider_base_url,
     read_opencode_provider_user_models,
@@ -298,6 +299,44 @@ def test_upsert_custom_openai_compatible_provider_writes_opencode_shape(tmp_path
     assert "my-relay" in read_opencode_custom_providers(home=tmp_path)
 
 
+def test_custom_provider_reader_accepts_opencode_preserved_shape_without_meta(tmp_path: Path) -> None:
+    config_path = get_opencode_config_paths(tmp_path)[0]
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "my-relay": {
+                        "name": "My Relay",
+                        "npm": "@ai-sdk/openai-compatible",
+                        "options": {
+                            "baseURL": "https://relay.example/v1",
+                            "apiKey": "sk-relay",
+                        },
+                        "models": {},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert get_opencode_custom_provider_adapter(
+        "my-relay",
+        _read_config(config_path)["provider"]["my-relay"],
+    ) == "openai-compatible"
+    assert "my-relay" in read_opencode_custom_providers(home=tmp_path)
+
+
+def test_custom_provider_reader_does_not_treat_builtin_override_as_custom(tmp_path: Path) -> None:
+    upsert_opencode_provider_base_url("openai", "https://relay.example/v1", home=tmp_path)
+
+    config = _read_config(get_opencode_config_paths(tmp_path)[0])
+
+    assert get_opencode_custom_provider_adapter("openai", config["provider"]["openai"]) is None
+    assert read_opencode_custom_providers(home=tmp_path) == {}
+
+
 def test_upsert_custom_anthropic_compatible_provider_writes_adapter(tmp_path: Path) -> None:
     upsert_opencode_custom_provider(
         "anthropic-relay",
@@ -309,6 +348,32 @@ def test_upsert_custom_anthropic_compatible_provider_writes_adapter(tmp_path: Pa
 
     config = _read_config(get_opencode_config_paths(tmp_path)[0])
     assert config["provider"]["anthropic-relay"]["npm"] == "@ai-sdk/anthropic"
+
+
+def test_upsert_api_key_restores_custom_provider_meta(tmp_path: Path) -> None:
+    config_path = get_opencode_config_paths(tmp_path)[0]
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "my-relay": {
+                        "name": "My Relay",
+                        "npm": "@ai-sdk/openai-compatible",
+                        "options": {"baseURL": "https://relay.example/v1"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    upsert_opencode_provider_api_key("my-relay", "sk-relay", home=tmp_path)
+
+    provider = _read_config(config_path)["provider"]["my-relay"]
+    assert provider["options"]["apiKey"] == "sk-relay"
+    assert provider["vibe_remote"]["custom"] is True
+    assert provider["vibe_remote"]["adapter"] == "openai-compatible"
 
 
 def test_upsert_custom_provider_allows_documented_dotted_id(tmp_path: Path) -> None:

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -813,6 +813,65 @@ def test_opencode_provider_catalog_marks_keyless_custom_provider_configured(
     assert provider["custom"] is True
 
 
+def test_opencode_provider_catalog_keeps_custom_provider_without_vibe_meta(
+    monkeypatch, tmp_path
+):
+    class _FakeServer:
+        async def get_providers(self):
+            return {
+                "all": [{"id": "openai", "name": "OpenAI"}],
+                "connected": ["openai"],
+            }
+
+        async def get_provider_auth(self):
+            return {}
+
+        async def get_available_models(self, directory):
+            return {
+                "providers": [{"id": "openai", "models": {"gpt-5": {}}}],
+                "default": {"openai": "gpt-5"},
+            }
+
+        async def close_http_session(self, *, loop=None):
+            pass
+
+    async def _fake_get_server():
+        return _FakeServer()
+
+    config_path = tmp_path / ".config" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "gptg": {
+                        "name": "Gptg",
+                        "npm": "@ai-sdk/openai-compatible",
+                        "options": {
+                            "baseURL": "https://relay.example/v1",
+                            "apiKey": "sk-relay",
+                        },
+                        "models": {},
+                    }
+                }
+            }
+        )
+    )
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(api, "_opencode_get_server", _fake_get_server)
+
+    result = asyncio.run(api.get_opencode_providers_async())
+
+    provider = next(provider for provider in result["providers"] if provider["id"] == "gptg")
+    assert provider["name"] == "Gptg"
+    assert provider["configured"] is True
+    assert provider["has_auth"] is True
+    assert provider["custom"] is True
+    assert provider["adapter"] == "openai-compatible"
+    assert provider["api_key_masked"] == "••••••elay"
+
+
 def test_normalize_backend_routing_payload_prefers_canonical_claude_overrides() -> None:
     result = api._normalize_backend_routing_payload(
         {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -4871,8 +4871,13 @@ async def _get_opencode_providers_async() -> dict:
             for pid_key, pid_config in provider_block.items():
                 if not isinstance(pid_config, dict):
                     continue
-                meta = pid_config.get("vibe_remote")
-                if isinstance(meta, dict) and meta.get("custom") is True:
+                try:
+                    from vibe.opencode_config import get_opencode_custom_provider_adapter
+
+                    custom_adapter = get_opencode_custom_provider_adapter(pid_key, pid_config)
+                except Exception:
+                    custom_adapter = None
+                if custom_adapter is not None:
                     custom_provider_index[pid_key] = pid_config
                 models = pid_config.get("models")
                 if isinstance(models, dict):
@@ -4945,9 +4950,18 @@ async def _get_opencode_providers_async() -> dict:
             for method in auth_methods_list
         )
         local = _is_local_provider(pid, auth_methods_list)
-        custom_meta = custom_provider_index.get(pid, {}).get("vibe_remote")
-        custom = isinstance(custom_meta, dict) and custom_meta.get("custom") is True
-        adapter = custom_meta.get("adapter") if isinstance(custom_meta, dict) else None
+        custom_config = custom_provider_index.get(pid, {})
+        custom_meta = custom_config.get("vibe_remote")
+        custom = pid in custom_provider_index
+        if isinstance(custom_meta, dict):
+            adapter = custom_meta.get("adapter")
+        else:
+            try:
+                from vibe.opencode_config import get_opencode_custom_provider_adapter
+
+                adapter = get_opencode_custom_provider_adapter(pid, custom_config)
+            except Exception:
+                adapter = None
         # Authoritative source for the "configured" badge:
         # - If auth.json carries an entry → configured (user explicitly
         #   set it up, even if OpenCode's cache hasn't caught up yet).

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -511,6 +511,64 @@ def is_reserved_opencode_provider_id(provider_id: str) -> bool:
     return provider_id.strip().lower() in _RESERVED_PROVIDER_IDS
 
 
+def get_opencode_custom_provider_adapter(
+    provider_id: str,
+    provider_config: Dict[str, Any],
+) -> Optional[str]:
+    """Return the compatible-provider adapter for a user custom provider.
+
+    ``vibe_remote.custom`` is the strongest marker, but OpenCode may normalize
+    config through its own schema and drop unknown metadata. A non-reserved
+    provider block using one of the compatible AI SDK packages with a baseURL is
+    still a user-created compatible provider and must stay visible in Settings.
+    """
+
+    if not isinstance(provider_id, str) or not isinstance(provider_config, dict):
+        return None
+    if is_reserved_opencode_provider_id(provider_id):
+        return None
+
+    meta = provider_config.get(_CUSTOM_PROVIDER_META_KEY)
+    if isinstance(meta, dict) and meta.get("custom") is True:
+        adapter = meta.get("adapter")
+        if isinstance(adapter, str) and adapter in _CUSTOM_PROVIDER_ADAPTERS:
+            return adapter
+
+    npm = provider_config.get("npm")
+    adapter = next(
+        (
+            adapter_key
+            for adapter_key, package_name in _CUSTOM_PROVIDER_ADAPTERS.items()
+            if npm == package_name
+        ),
+        None,
+    )
+    if adapter is None:
+        return None
+    options = provider_config.get("options")
+    base_url = options.get("baseURL") if isinstance(options, dict) else None
+    if not isinstance(base_url, str) or not base_url.strip():
+        return None
+    return adapter
+
+
+def _ensure_custom_provider_meta(
+    provider_id: str,
+    provider_config: Dict[str, Any],
+) -> None:
+    adapter = get_opencode_custom_provider_adapter(provider_id, provider_config)
+    if adapter is None:
+        return
+    meta = provider_config.get(_CUSTOM_PROVIDER_META_KEY)
+    if isinstance(meta, dict) and meta.get("custom") is True:
+        return
+    provider_config[_CUSTOM_PROVIDER_META_KEY] = {
+        "custom": True,
+        "adapter": adapter,
+        "adapter_label": _CUSTOM_PROVIDER_LABELS[adapter],
+    }
+
+
 def _normalize_custom_provider_name(name: str) -> str:
     if not isinstance(name, str) or not name.strip():
         raise ValueError("name is required")
@@ -637,8 +695,7 @@ def read_opencode_custom_providers(
     for provider_id, provider_config in provider_map.items():
         if not isinstance(provider_id, str) or not isinstance(provider_config, dict):
             continue
-        meta = provider_config.get(_CUSTOM_PROVIDER_META_KEY)
-        if not isinstance(meta, dict) or meta.get("custom") is not True:
+        if get_opencode_custom_provider_adapter(provider_id, provider_config) is None:
             continue
         out[provider_id] = provider_config
     return out
@@ -809,6 +866,7 @@ def upsert_opencode_provider_api_key(
         raise ValueError(f"OpenCode provider '{provider_id}' options are not an object")
 
     options["apiKey"] = api_key
+    _ensure_custom_provider_meta(provider_id, provider_config)
     return _write_opencode_config(config, target_path)
 
 
@@ -868,6 +926,7 @@ def upsert_opencode_provider_base_url(
         raise ValueError(f"OpenCode provider '{provider_id}' options are not an object")
 
     options["baseURL"] = base_url
+    _ensure_custom_provider_meta(provider_id, provider_config)
     return _write_opencode_config(config, target_path)
 
 

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -768,8 +768,7 @@ def remove_opencode_custom_provider(
     provider_config = provider_map.get(provider_id)
     if not isinstance(provider_config, dict):
         return probe.path
-    meta = provider_config.get(_CUSTOM_PROVIDER_META_KEY)
-    if not isinstance(meta, dict) or meta.get("custom") is not True:
+    if get_opencode_custom_provider_adapter(provider_id, provider_config) is None:
         raise ValueError("Only custom providers can be removed")
     provider_map.pop(provider_id, None)
     if not provider_map:


### PR DESCRIPTION
## Summary
- treat OpenAI/Anthropic-compatible non-built-in provider blocks as custom providers even if OpenCode drops Vibe Remote's private metadata
- restore custom-provider metadata when saving API keys or base URLs for compatible providers
- add regression coverage for config-only compatible providers staying visible in the Settings catalog

## Tests
- `uv run pytest tests/test_opencode_provider_base_url.py tests/test_save_opencode_provider_auth.py tests/test_ui_api.py::test_opencode_provider_catalog_marks_keyless_custom_provider_configured tests/test_ui_api.py::test_opencode_provider_catalog_keeps_custom_provider_without_vibe_meta tests/test_ui_api.py::test_opencode_options_includes_custom_provider_models tests/test_ui_api.py::test_opencode_options_includes_keyless_custom_provider_models`
- `uv run ruff check vibe/api.py vibe/opencode_config.py tests/test_opencode_provider_base_url.py tests/test_ui_api.py`

## Manual regression
- Hot-patched the regression container and verified existing `gptg` is returned by the OpenCode provider catalog as `custom=true`, `configured=true`, with its stored base URL and masked API key.
