### PR TITLE
ci: use uv for lint dependency installs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -161,7 +161,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,8 +51,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
+
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
             pyproject.toml
             uv.lock
 
@@ -103,7 +106,7 @@ jobs:
             uv.lock
 
       - name: Install package and test deps
-        run: pip install -e . pytest
+        run: uv pip install --system -e . pytest
 
       - name: Run unit tests shard ${{ matrix.shard }}/${{ matrix.shard-total }}
         run: bash scripts/ci_unit_tests.sh "${{ matrix.shard }}" "${{ matrix.shard-total }}"
@@ -157,14 +160,17 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
+
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
             pyproject.toml
             uv.lock
 
       - name: Install package and test dependencies
         run: |
-          pip install dist/*.whl pytest
+          uv pip install --system dist/*.whl pytest
 
       - name: Run install and upgrade regressions
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,11 +51,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@v8.2.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
+          cache: "pip"
+          cache-dependency-path: |
             pyproject.toml
             uv.lock
 
@@ -100,8 +97,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
+
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
             pyproject.toml
             uv.lock
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -101,6 +101,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
+          save-cache: false
           cache-dependency-glob: |
             pyproject.toml
             uv.lock

--- a/scripts/ci_unit_tests.sh
+++ b/scripts/ci_unit_tests.sh
@@ -11,7 +11,9 @@
 # is tracked separately; until then this is how the unit suite is CI-gated.
 #
 # CI may pass a shard index and total shard count to split the file list across
-# multiple runners while preserving the one-process-per-file isolation.
+# multiple runners while preserving the one-process-per-file isolation. Shards
+# are assigned by a deterministic file-size/test-count heuristic instead of by
+# sorted-list modulo so large test modules are spread more evenly.
 #
 # Excludes ``tests/e2e`` (Docker) and the ``integration`` marker (Docker +
 # platform tokens) — those run in dedicated jobs. ``-p no:randomly`` keeps a
@@ -60,19 +62,78 @@ fi
 
 PYTEST=("$PYTHON_BIN" -m pytest)
 
+select_unit_test_files() {
+  "$PYTHON_BIN" - "$SHARD_INDEX" "$SHARD_TOTAL" <<'PY'
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+shard_index = int(sys.argv[1])
+shard_total = int(sys.argv[2])
+
+files = sorted(
+    path
+    for path in Path("tests").rglob("test_*.py")
+    if "tests/e2e/" not in path.as_posix()
+)
+
+
+def estimate_weight(path: Path) -> int:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    line_count = text.count("\n") + 1
+    test_count = len(re.findall(r"^\s*(?:async\s+def|def)\s+test_", text, re.MULTILINE))
+    class_count = len(re.findall(r"^\s*class\s+Test", text, re.MULTILINE))
+    return max(1, line_count + (test_count * 20) + (class_count * 60))
+
+
+weighted_files = [(estimate_weight(path), path.as_posix()) for path in files]
+shards: list[dict[str, object]] = [
+    {"weight": 0, "files": []}
+    for _ in range(shard_total)
+]
+
+for weight, file_path in sorted(weighted_files, key=lambda item: (-item[0], item[1])):
+    target = min(
+        range(shard_total),
+        key=lambda index: (
+            shards[index]["weight"],
+            len(shards[index]["files"]),  # type: ignore[arg-type]
+            index,
+        ),
+    )
+    shards[target]["weight"] = int(shards[target]["weight"]) + weight
+    shard_files = shards[target]["files"]
+    assert isinstance(shard_files, list)
+    shard_files.append(file_path)
+
+selected_files = sorted(shards[shard_index]["files"])
+print(
+    "Planned "
+    f"{len(files)} unit test file(s) across {shard_total} shard(s); "
+    f"shard {shard_index} has {len(selected_files)} file(s), "
+    f"estimated weight {shards[shard_index]['weight']}.",
+    file=sys.stderr,
+)
+for file_path in selected_files:
+    print(file_path)
+PY
+}
+
 failed=""
 empty=""
 selected=0
-ordinal=0
+discovered=0
 while IFS= read -r f; do
-  if [ $((ordinal % SHARD_TOTAL)) -ne "$SHARD_INDEX" ]; then
-    ordinal=$((ordinal + 1))
-    continue
-  fi
-  ordinal=$((ordinal + 1))
+  discovered=$((discovered + 1))
   selected=$((selected + 1))
+  started_at=$(date +%s)
   "${PYTEST[@]}" "$f" -m "not integration" -p no:randomly -o addopts="" -q
   rc=$?
+  finished_at=$(date +%s)
+  elapsed=$((finished_at - started_at))
+  echo "Finished $f in ${elapsed}s with exit code $rc."
   if [ "$rc" -eq 0 ]; then
     :
   elif [ "$rc" -eq 5 ]; then
@@ -81,10 +142,12 @@ while IFS= read -r f; do
   else
     failed="$failed $f"
   fi
-done < <(find tests -name 'test_*.py' -not -path 'tests/e2e/*' | sort)
+done < <(select_unit_test_files)
+
+discovered=$(find tests -name 'test_*.py' -not -path 'tests/e2e/*' | sort | wc -l | tr -d ' ')
 
 echo "========================================"
-echo "Discovered ${ordinal} unit test file(s)."
+echo "Discovered ${discovered} unit test file(s)."
 echo "Ran ${selected} unit test file(s), one process each, for shard ${SHARD_INDEX}/${SHARD_TOTAL}."
 if [ -n "$empty" ]; then
   echo "No unit tests collected (skipped):"


### PR DESCRIPTION
## Summary
- Use `astral-sh/setup-uv@v8.2.0` for the lint workflow jobs that install Linux test dependencies.
- Replace the repeated `pip install` calls in Linux unit shards and install/upgrade regression with `uv pip install --system`.
- Rebalance Linux unit test shards with a deterministic file-weight heuristic and emit per-file timings for future calibration.
- Prevent parallel unit shards from saving the same uv cache key; shards restore cache only, while the non-matrix install/upgrade job can still save cache.
- Keep artifact build on the existing pip path so the experiment only changes test dependency installation and unit shard scheduling.

## Scenarios
- GitHub Actions lint workflow Linux unit shard dependency installation.
- GitHub Actions lint workflow Linux unit shard balancing.
- GitHub Actions lint workflow Linux uv cache behavior under parallel matrix shards.
- GitHub Actions lint workflow Linux install/upgrade regression dependency installation.

## Evidence
- Unit: not run locally, workflow-only change.
- Contract: not run locally, workflow-only change.
- Scenario: validated `.github/workflows/lint.yml` parses as YAML; validated `scripts/ci_unit_tests.sh` with `bash -n`.
- Residual manual checks: `git diff --check -- .github/workflows/lint.yml scripts/ci_unit_tests.sh` passed; local shard estimate distribution is balanced across 4 shards.
- CI timing: latest lint run passed with build-linux-artifacts at 47s, Linux unit shards in 1m07s-1m33s, Linux install/upgrade regression at 1m26s, and Windows install smoke at 2m22s.
- Baseline after PR #481 was Linux unit shards in 1m30s-1m51s and Linux install/upgrade regression at 1m43s. The uv-only trial before shard rebalance had Linux unit shards in 1m11s-1m33s.
