### PR TITLE
Add docstring to get_agent_display_name

### DIFF
--- a/modules/agents/__init__.py
+++ b/modules/agents/__init__.py
@@ -6,6 +6,15 @@ from .service import AgentService
 
 
 def get_agent_display_name(agent_name: Optional[str], fallback: Optional[str] = None) -> str:
+    """Return the display name for an agent name.
+
+    Args:
+        agent_name: Optional name of the agent.
+        fallback: Optional fallback name to use if agent_name is not provided.
+
+    Returns:
+        The cleaned display name string in lowercase, processed by display_name_for_backend.
+    """
     candidate = (agent_name or fallback or "Agent").strip()
     if not candidate:
         candidate = "Agent"


### PR DESCRIPTION
## Problem
The `get_agent_display_name` function was missing a docstring, which impacted code readability and documentation quality for a public function.

## Changes
- Added a detailed docstring to the `get_agent_display_name` function, following standard Python conventions with `Args` and `Returns` sections to clearly describe parameters and return value.

## Verification
- The function's behavior is unchanged; only documentation was added. Code review or tests can confirm that the function still works as expected.