### PR TITLE
fix(regression): keep three-regression on avibe home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Worktree behavior:
 - code is built from the worktree where the script is invoked
 - runtime state is shared from the primary checkout's `.runtime/three-regression/`
 - this keeps pairing (`remote_access` config), agent CLI homes, sessions, Show Page workspaces, and Show Runtime cache stable while still allowing any worktree to update the regression image
-- if an older container was started with per-worktree `_tmp/three-regression/` state or the old `/data/vibe_remote` home, the script imports that state before recreating it
+- the regression runner treats `.runtime/three-regression/home/.avibe/` as the normal 3.0 state; it does not import older harness layouts automatically
 
 ## 4. Configuration and Routing Model
 

--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -109,9 +109,8 @@ The container uses a real persistent home directory mounted at `/home/avibe`.
 That means Avibe's default-home behavior is exercised in regression:
 `/home/avibe/.avibe` is the active runtime home, and a legacy
 `/home/avibe/.vibe_remote` path is left as the product-managed compatibility
-symlink after migration. Older regression state under `.runtime/three-regression/vibe/`
-is imported as `home/.vibe_remote/` so the first 3.0 startup covers the same
-home migration path old users hit.
+symlink after product startup. The runner now treats `home/.avibe/` as the
+normal 3.0 state and does not import older harness layouts automatically.
 
 Persistence rules:
 

--- a/scripts/prepare_three_regression.py
+++ b/scripts/prepare_three_regression.py
@@ -53,11 +53,6 @@ SUPPORTED_BACKENDS = {"opencode", "claude", "codex"}
 RESET_MODES = {"none", "config", "all"}
 CONTAINER_HOME = Path("/home/avibe")
 CONTAINER_AVIBE_HOME = CONTAINER_HOME / ".avibe"
-CONTAINER_LEGACY_HOME = CONTAINER_HOME / ".vibe_remote"
-LEGACY_CONTAINER_HOME = Path("/root")
-LEGACY_CONTAINER_VIBE_HOME = Path("/data/vibe_remote")
-LEGACY_CONTAINER_AVIBE_HOME = LEGACY_CONTAINER_HOME / ".avibe"
-LEGACY_CONTAINER_VIBE_REMOTE_HOME = LEGACY_CONTAINER_HOME / ".vibe_remote"
 DEFAULT_CWD = str(CONTAINER_AVIBE_HOME / "workdir")
 CONTAINER_OPENCODE_CLI = "/usr/local/bin/opencode"
 
@@ -116,7 +111,7 @@ def _build_routing(name: str) -> dict:
 
 
 def _default_cwd() -> str:
-    return _normalize_container_path(_env("THREE_REGRESSION_DEFAULT_CWD", DEFAULT_CWD))
+    return _normalize_stale_container_path(_env("THREE_REGRESSION_DEFAULT_CWD", DEFAULT_CWD))
 
 
 def _ui_host() -> str:
@@ -315,92 +310,60 @@ def _avibe_home(output_root: Path) -> Path:
     return _home_root(output_root) / ".avibe"
 
 
-def _legacy_vibe_remote_home(output_root: Path) -> Path:
-    return _home_root(output_root) / ".vibe_remote"
-
-
 def _active_vibe_dir(output_root: Path) -> Path:
-    avibe_home = _avibe_home(output_root)
-    legacy_home = _legacy_vibe_remote_home(output_root)
-    if avibe_home.exists() or avibe_home.is_symlink():
-        return avibe_home
-    if legacy_home.exists() or legacy_home.is_symlink():
-        return legacy_home
-    return avibe_home
-
-
-def _has_vibe_home_state(path: Path) -> bool:
-    if not path.exists() and not path.is_symlink():
-        return False
-    if path.is_symlink():
-        return True
-    if any(
-        marker.exists()
-        for marker in (
-            path / "config" / "config.json",
-            path / "state" / "settings.json",
-            path / "state" / "sessions.json",
-            path / "state" / "vibe.sqlite",
-        )
-    ):
-        return True
-    workdir = path / "workdir"
-    if workdir.exists() and workdir.is_dir():
-        return any(workdir.iterdir())
-    return False
+    return _avibe_home(output_root)
 
 
 def _agent_home(output_root: Path) -> Path:
     return _home_root(output_root)
 
 
-def _legacy_shared_home(output_root: Path) -> Path:
-    return output_root / "shared-home"
-
-
-def _legacy_vibe_dir(output_root: Path) -> Path:
-    return output_root / "vibe"
-
-
-def _normalize_container_path(value: str | None) -> str:
+def _normalize_stale_container_path(value: str | None) -> str:
     if not value:
         return value or ""
-    replacements = (
-        (str(LEGACY_CONTAINER_VIBE_HOME), str(CONTAINER_AVIBE_HOME)),
-        (str(LEGACY_CONTAINER_AVIBE_HOME), str(CONTAINER_AVIBE_HOME)),
-        (str(LEGACY_CONTAINER_VIBE_REMOTE_HOME), str(CONTAINER_LEGACY_HOME)),
-        (str(LEGACY_CONTAINER_HOME), str(CONTAINER_HOME)),
+    prefix_replacements = (
+        ("/data/vibe_remote", str(CONTAINER_AVIBE_HOME)),
+        ("/root/.avibe", str(CONTAINER_AVIBE_HOME)),
+        ("/root/.vibe_remote", str(CONTAINER_AVIBE_HOME)),
+        ("/root", str(CONTAINER_HOME)),
     )
     normalized = value
-    for old, new in replacements:
+    for old, new in prefix_replacements:
         if normalized == old:
             return new
         if normalized.startswith(old + "/"):
             return new + normalized[len(old):]
+    for old, new in prefix_replacements[:-1]:
+        normalized = normalized.replace(old + "/", new + "/")
     return normalized
 
 
-def _rewrite_json_paths(value):
+def _rewrite_json_stale_container_paths(value):
     if isinstance(value, dict):
-        return {key: _rewrite_json_paths(item) for key, item in value.items()}
+        return {
+            _normalize_stale_container_path(key) if isinstance(key, str) else key: _rewrite_json_stale_container_paths(
+                item
+            )
+            for key, item in value.items()
+        }
     if isinstance(value, list):
-        return [_rewrite_json_paths(item) for item in value]
+        return [_rewrite_json_stale_container_paths(item) for item in value]
     if isinstance(value, str):
-        return _normalize_container_path(value)
+        return _normalize_stale_container_path(value)
     return value
 
 
-def _rewrite_json_file_paths(path: Path) -> None:
+def _rewrite_json_file_stale_container_paths(path: Path) -> None:
     if not path.exists() or not path.is_file():
         return
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         return
-    _write_json(path, _rewrite_json_paths(payload))
+    _write_json(path, _rewrite_json_stale_container_paths(payload))
 
 
-def _rewrite_sqlite_paths(db_path: Path) -> None:
+def _rewrite_sqlite_stale_container_paths(db_path: Path) -> None:
     if not db_path.exists() or not db_path.is_file():
         return
     with sqlite3.connect(str(db_path)) as conn:
@@ -426,89 +389,21 @@ def _rewrite_sqlite_paths(db_path: Path) -> None:
                 for rowid, value in rows:
                     if not isinstance(value, str):
                         continue
-                    next_value = _normalize_container_path(value)
+                    next_value = _normalize_stale_container_path(value)
                     if column.endswith("_json"):
                         try:
                             next_value = json.dumps(
-                                _rewrite_json_paths(json.loads(value)),
+                                _rewrite_json_stale_container_paths(json.loads(value)),
                                 separators=(",", ":"),
                             )
                         except json.JSONDecodeError:
-                            next_value = _normalize_container_path(value)
+                            next_value = _normalize_stale_container_path(value)
                     if next_value != value:
                         conn.execute(
                             f'update "{table}" set "{column}" = ? where rowid = ?',
                             (next_value, rowid),
                         )
         conn.commit()
-
-
-def _move_path(src: Path, dst: Path) -> None:
-    if not src.exists() and not src.is_symlink():
-        return
-    if dst.exists() or dst.is_symlink():
-        return
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(src), str(dst))
-
-
-def _remove_empty_dirs(root: Path) -> None:
-    if not root.exists() or not root.is_dir():
-        return
-    for current, dirs, _files in os.walk(root, topdown=False):
-        for dirname in dirs:
-            target = Path(current) / dirname
-            try:
-                target.rmdir()
-            except OSError:
-                pass
-    try:
-        root.rmdir()
-    except OSError:
-        pass
-
-
-def _migrate_legacy_layout(output_root: Path, *, reset_mode: str) -> None:
-    home_root = _home_root(output_root)
-    if reset_mode == "all" and home_root.exists():
-        shutil.rmtree(home_root)
-    if reset_mode == "all":
-        for stale in (_legacy_vibe_dir(output_root), _legacy_shared_home(output_root)):
-            if stale.exists() or stale.is_symlink():
-                if stale.is_dir() and not stale.is_symlink():
-                    shutil.rmtree(stale)
-                else:
-                    stale.unlink()
-    home_root.mkdir(parents=True, exist_ok=True)
-
-    legacy_vibe = _legacy_vibe_dir(output_root)
-    legacy_shared = _legacy_shared_home(output_root)
-    avibe_home = _avibe_home(output_root)
-    legacy_home = _legacy_vibe_remote_home(output_root)
-
-    if legacy_vibe.exists() and not legacy_home.exists() and not _has_vibe_home_state(avibe_home):
-        _remove_empty_dirs(avibe_home)
-
-    if legacy_vibe.exists() and not avibe_home.exists() and not legacy_home.exists():
-        # Seed the old default home so first 3.0 startup exercises the product
-        # migration from ~/.vibe_remote to ~/.avibe.
-        _move_path(legacy_vibe, legacy_home)
-    elif legacy_vibe.exists() and (avibe_home.exists() or legacy_home.exists()):
-        # A prior mixed layout can happen during local harness development. Keep
-        # existing real-home state authoritative and leave the old directory
-        # untouched rather than merging possibly stale data.
-        pass
-
-    if legacy_shared.exists():
-        for relative in (
-            ".claude",
-            ".claude.json",
-            ".codex",
-            ".config/opencode",
-            ".local/share/opencode",
-        ):
-            _move_path(legacy_shared / relative, home_root / relative)
-        _remove_empty_dirs(legacy_shared)
 
 
 def _ensure_shared_home(output_root: Path, reset_mode: str = "none") -> Path:
@@ -728,16 +623,24 @@ def _normalize_config_payload(path: Path) -> None:
 
 def _normalize_existing_state(vibe_dir: Path) -> None:
     config_path = vibe_dir / "config" / "config.json"
-    _rewrite_json_file_paths(config_path)
+    _rewrite_json_file_stale_container_paths(config_path)
     _normalize_config_payload(config_path)
-    _rewrite_json_file_paths(vibe_dir / "state" / "settings.json")
-    _rewrite_json_file_paths(vibe_dir / "state" / "sessions.json")
-    _rewrite_sqlite_paths(vibe_dir / "state" / "vibe.sqlite")
+    _rewrite_json_file_stale_container_paths(vibe_dir / "state" / "settings.json")
+    _rewrite_json_file_stale_container_paths(vibe_dir / "state" / "sessions.json")
+    _rewrite_json_file_stale_container_paths(vibe_dir / "state" / "scheduled_tasks.json")
+    _rewrite_sqlite_stale_container_paths(vibe_dir / "state" / "vibe.sqlite")
 
 
 def prepare(output_root: Path, reset_mode: str = "none") -> None:
     _validate_reset_mode(reset_mode)
-    _migrate_legacy_layout(output_root, reset_mode=reset_mode)
+    home_root = _home_root(output_root)
+    if reset_mode == "all" and (home_root.exists() or home_root.is_symlink()):
+        if home_root.is_dir() and not home_root.is_symlink():
+            shutil.rmtree(home_root)
+        else:
+            home_root.unlink()
+    home_root.mkdir(parents=True, exist_ok=True)
+
     vibe_dir = _active_vibe_dir(output_root)
     config_path = vibe_dir / "config" / "config.json"
     settings_path = vibe_dir / "state" / "settings.json"

--- a/scripts/run_three_regression.sh
+++ b/scripts/run_three_regression.sh
@@ -10,9 +10,6 @@ PYTHON_BIN="${PYTHON_BIN:-python3}"
 DOCKER_BIN="${DOCKER_BIN:-}"
 CONTAINER_HOME="/home/avibe"
 CONTAINER_AVIBE_HOME="$CONTAINER_HOME/.avibe"
-CONTAINER_LEGACY_HOME="$CONTAINER_HOME/.vibe_remote"
-LEGACY_CONTAINER_HOME="/root"
-LEGACY_CONTAINER_VIBE_HOME="/data/vibe_remote"
 
 resolve_git_common_repo_root() {
     local common_dir
@@ -235,12 +232,6 @@ print_summary() {
     local ui_host="${THREE_REGRESSION_ACCESS_HOST:-${THREE_REGRESSION_UI_HOST:-$bind_host}}"
     local default_backend="${THREE_REGRESSION_DEFAULT_BACKEND:-opencode}"
     local config_path="$OUTPUT_ROOT/home/.avibe/config/config.json"
-    if [ ! -f "$config_path" ]; then
-        config_path="$OUTPUT_ROOT/home/.vibe_remote/config/config.json"
-    fi
-    if [ ! -f "$config_path" ]; then
-        config_path="$OUTPUT_ROOT/vibe/config/config.json"
-    fi
     local display_root
     display_root="$OUTPUT_ROOT"
     case "$display_root" in
@@ -327,14 +318,9 @@ snapshot_agent_runtime_state() {
     snapshot_container_path "$CONTAINER_HOME/.codex" "$home_root" ".codex"
     snapshot_container_path "$CONTAINER_HOME/.config/opencode" "$home_root/.config" "opencode"
     snapshot_container_path "$CONTAINER_HOME/.local/share/opencode" "$home_root/.local/share" "opencode"
-    snapshot_container_path "$LEGACY_CONTAINER_HOME/.claude" "$home_root" ".claude"
-    snapshot_container_path "$LEGACY_CONTAINER_HOME/.claude.json" "$home_root" ".claude.json"
-    snapshot_container_path "$LEGACY_CONTAINER_HOME/.codex" "$home_root" ".codex"
-    snapshot_container_path "$LEGACY_CONTAINER_HOME/.config/opencode" "$home_root/.config" "opencode"
-    snapshot_container_path "$LEGACY_CONTAINER_HOME/.local/share/opencode" "$home_root/.local/share" "opencode"
 }
 
-snapshot_vibe_remote_state() {
+snapshot_avibe_state() {
     if [ "$RESET_MODE" = "all" ]; then
         return 0
     fi
@@ -350,20 +336,13 @@ snapshot_vibe_remote_state() {
     fi
 
     local avibe_target="$OUTPUT_ROOT/home/.avibe"
-    local legacy_target="$OUTPUT_ROOT/home/.vibe_remote"
-    local old_layout_target="$OUTPUT_ROOT/vibe"
-    if [ -f "$avibe_target/config/config.json" ] || [ -f "$legacy_target/config/config.json" ] || [ -f "$old_layout_target/config/config.json" ]; then
+    if [ -f "$avibe_target/config/config.json" ]; then
         return 0
     fi
 
     mkdir -p "$OUTPUT_ROOT/home"
-    echo "Importing Vibe Remote state from the existing regression container..."
-    if "$DOCKER_BIN" cp "$cid:$CONTAINER_AVIBE_HOME/." "$avibe_target" >/dev/null 2>&1; then
-        return 0
-    fi
-    mkdir -p "$legacy_target"
-    "$DOCKER_BIN" cp "$cid:$CONTAINER_LEGACY_HOME/." "$legacy_target" >/dev/null 2>&1 || \
-        "$DOCKER_BIN" cp "$cid:$LEGACY_CONTAINER_VIBE_HOME/." "$legacy_target" >/dev/null 2>&1 || true
+    echo "Importing Avibe state from the existing regression container..."
+    "$DOCKER_BIN" cp "$cid:$CONTAINER_AVIBE_HOME/." "$avibe_target" >/dev/null 2>&1 || true
 }
 
 write_regression_metadata() {
@@ -460,7 +439,7 @@ PY
 
 case "$MODE" in
     down)
-        snapshot_vibe_remote_state
+        snapshot_avibe_state
         snapshot_agent_runtime_state
         "$DOCKER_BIN" compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" down --remove-orphans
         exit 0
@@ -478,7 +457,7 @@ case "$MODE" in
         ;;
 esac
 
-snapshot_vibe_remote_state
+snapshot_avibe_state
 snapshot_agent_runtime_state
 
 echo "Stopping previous regression container..."

--- a/tests/test_prepare_three_regression.py
+++ b/tests/test_prepare_three_regression.py
@@ -25,7 +25,7 @@ def _set_required_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "OPENAI_BASE_URL": "https://openai.example",
         "OPENAI_API_BASE": "https://openai.example/v1",
         "THREE_REGRESSION_UI_HOST": "192.168.2.3",
-        "THREE_REGRESSION_DEFAULT_CWD": "/data/vibe_remote/workdir",
+        "THREE_REGRESSION_DEFAULT_CWD": "/home/avibe/.avibe/workdir",
         "THREE_REGRESSION_DEFAULT_BACKEND": "opencode",
         "THREE_REGRESSION_LOG_LEVEL": "DEBUG",
         "THREE_REGRESSION_LANGUAGE": "en",
@@ -171,7 +171,7 @@ def test_prepare_preserves_existing_state_without_reset(tmp_path: Path, monkeypa
     }
 
 
-def test_prepare_migrates_legacy_state_layout_to_default_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_prepare_ignores_legacy_regression_layout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     module = _load_module()
     _set_required_env(monkeypatch)
 
@@ -209,63 +209,26 @@ def test_prepare_migrates_legacy_state_layout_to_default_home(tmp_path: Path, mo
     (old_vibe / "workdir" / "keep.txt").write_text("keep-me", encoding="utf-8")
     (old_shared / ".claude").mkdir(parents=True)
     (old_shared / ".claude" / "settings.json").write_text("{}", encoding="utf-8")
-    (old_shared / ".claude.json").write_text("{}", encoding="utf-8")
-    (old_shared / ".codex").mkdir(parents=True)
-    (old_shared / ".codex" / "config.toml").write_text("", encoding="utf-8")
-    (old_shared / ".codex" / "auth.json").write_text("{}", encoding="utf-8")
-    (old_shared / ".config" / "opencode").mkdir(parents=True)
-    (old_shared / ".config" / "opencode" / "opencode.json").write_text("{}", encoding="utf-8")
 
     module.prepare(tmp_path)
 
-    legacy_home = tmp_path / "home" / ".vibe_remote"
-    assert not old_vibe.exists()
-    assert not old_shared.exists()
-    assert legacy_home.is_dir()
-    assert not (tmp_path / "home" / ".avibe").exists()
-    assert (legacy_home / "workdir" / "keep.txt").read_text(encoding="utf-8") == "keep-me"
-    config = json.loads((legacy_home / "config" / "config.json").read_text(encoding="utf-8"))
-    settings = json.loads((legacy_home / "state" / "settings.json").read_text(encoding="utf-8"))
+    avibe_home = tmp_path / "home" / ".avibe"
+    assert old_vibe.exists()
+    assert old_shared.exists()
+    assert not (tmp_path / "home" / ".vibe_remote").exists()
+    assert avibe_home.is_dir()
+    assert (old_vibe / "workdir" / "keep.txt").read_text(encoding="utf-8") == "keep-me"
+    config = json.loads((avibe_home / "config" / "config.json").read_text(encoding="utf-8"))
+    settings = json.loads((avibe_home / "state" / "settings.json").read_text(encoding="utf-8"))
     assert config["runtime"]["default_cwd"] == "/home/avibe/.avibe/workdir"
     assert config["agents"]["opencode"]["cli_path"] == "/usr/local/bin/opencode"
-    assert settings["scopes"]["channel"]["slack"]["C123"]["custom_cwd"] == "/home/avibe/.avibe/workdir"
+    assert settings["scopes"]["channel"]["slack"]["C123SLACK"]["custom_cwd"] == "/home/avibe/.avibe/workdir"
     assert (tmp_path / "home" / ".claude.json").is_file()
 
 
-def test_prepare_migrates_legacy_layout_when_new_home_is_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    module = _load_module()
-    _set_required_env(monkeypatch)
-
-    old_vibe = tmp_path / "vibe"
-    (old_vibe / "config").mkdir(parents=True)
-    (old_vibe / "state").mkdir(parents=True)
-    (old_vibe / "workdir").mkdir(parents=True)
-    (old_vibe / "config" / "config.json").write_text(
-        json.dumps(
-            {
-                "runtime": {"default_cwd": "/data/vibe_remote/workdir"},
-                "agents": {"opencode": {"cli_path": "opencode"}},
-            }
-        ),
-        encoding="utf-8",
-    )
-    (old_vibe / "state" / "settings.json").write_text("{}", encoding="utf-8")
-    (old_vibe / "state" / "sessions.json").write_text("{}", encoding="utf-8")
-    (old_vibe / "workdir" / "keep.txt").write_text("keep-me", encoding="utf-8")
-    (tmp_path / "home" / ".avibe").mkdir(parents=True)
-
-    module.prepare(tmp_path)
-
-    legacy_home = tmp_path / "home" / ".vibe_remote"
-    assert not old_vibe.exists()
-    assert legacy_home.is_dir()
-    assert not (tmp_path / "home" / ".avibe").exists()
-    assert (legacy_home / "workdir" / "keep.txt").read_text(encoding="utf-8") == "keep-me"
-
-
-def test_prepare_keeps_new_home_authoritative_when_it_has_state(
+def test_prepare_keeps_avibe_home_authoritative_when_legacy_layout_exists(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+) -> None:
     module = _load_module()
     _set_required_env(monkeypatch)
 
@@ -291,7 +254,7 @@ def test_prepare_keeps_new_home_authoritative_when_it_has_state(
     assert json.loads((avibe_home / "config" / "config.json").read_text(encoding="utf-8")) == {"new": True}
 
 
-def test_prepare_rewrites_legacy_sqlite_workdirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_prepare_repairs_stale_container_paths_inside_avibe_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     module = _load_module()
     _set_required_env(monkeypatch)
 
@@ -299,9 +262,39 @@ def test_prepare_rewrites_legacy_sqlite_workdirs(tmp_path: Path, monkeypatch: py
     state_dir = vibe_dir / "state"
     (vibe_dir / "config").mkdir(parents=True)
     state_dir.mkdir(parents=True)
-    (vibe_dir / "config" / "config.json").write_text("{}", encoding="utf-8")
-    (state_dir / "settings.json").write_text("{}", encoding="utf-8")
-    (state_dir / "sessions.json").write_text("{}", encoding="utf-8")
+    (vibe_dir / "config" / "config.json").write_text(
+        json.dumps(
+            {
+                "runtime": {"default_cwd": "/data/vibe_remote/workdir"},
+                "agents": {"opencode": {"cli_path": "opencode"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (state_dir / "settings.json").write_text(
+        json.dumps({"scopes": {"channel": {"slack": {"C123": {"custom_cwd": "/data/vibe_remote/workdir"}}}}}),
+        encoding="utf-8",
+    )
+    (state_dir / "sessions.json").write_text(
+        json.dumps(
+            {
+                "thread_bindings": {
+                    "slack_1774535203.606599:/data/vibe_remote/workdir": "ses-old",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (state_dir / "scheduled_tasks.json").write_text(
+        json.dumps(
+            {
+                "tasks": [
+                    {"prompt": "Send ![image](file:///data/vibe_remote/workdir/concert.jpg)"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
     db_path = state_dir / "vibe.sqlite"
     with sqlite3.connect(db_path) as conn:
         conn.execute("create table agent_sessions (id text primary key, workdir text)")
@@ -320,6 +313,20 @@ def test_prepare_rewrites_legacy_sqlite_workdirs(tmp_path: Path, monkeypatch: py
         )
 
     module.prepare(tmp_path)
+
+    config = json.loads((vibe_dir / "config" / "config.json").read_text(encoding="utf-8"))
+    settings = json.loads((state_dir / "settings.json").read_text(encoding="utf-8"))
+    sessions = json.loads((state_dir / "sessions.json").read_text(encoding="utf-8"))
+    scheduled_tasks = json.loads((state_dir / "scheduled_tasks.json").read_text(encoding="utf-8"))
+    assert config["runtime"]["default_cwd"] == "/home/avibe/.avibe/workdir"
+    assert config["agents"]["opencode"]["cli_path"] == "/usr/local/bin/opencode"
+    assert settings["scopes"]["channel"]["slack"]["C123"]["custom_cwd"] == "/home/avibe/.avibe/workdir"
+    assert "slack_1774535203.606599:/home/avibe/.avibe/workdir" in sessions["thread_bindings"]
+    assert "slack_1774535203.606599:/data/vibe_remote/workdir" not in sessions["thread_bindings"]
+    assert (
+        scheduled_tasks["tasks"][0]["prompt"]
+        == "Send ![image](file:///home/avibe/.avibe/workdir/concert.jpg)"
+    )
 
     with sqlite3.connect(db_path) as conn:
         session_workdir = conn.execute("select workdir from agent_sessions where id = 'ses-old'").fetchone()[0]

--- a/ui/index.html
+++ b/ui/index.html
@@ -10,7 +10,7 @@
          when the keyboard opened, so iOS is handled in layout instead (top-aligned
          home + visualViewport --app-vvh chat, see useViewportHeightVar). -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>avibe</title>
+    <title>Avibe</title>
 
     <!-- PWA / iOS standalone: "Add to Home Screen" launches a full-screen app
          (no Safari chrome), which sidesteps the iOS keyboard whitespace/accessory
@@ -25,7 +25,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="avibe" />
+    <meta name="apple-mobile-web-app-title" content="Avibe" />
     <meta name="theme-color" content="#080812" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/ui/public/manifest.webmanifest
+++ b/ui/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "avibe",
-  "short_name": "avibe",
+  "name": "Avibe",
+  "short_name": "Avibe",
   "description": "Operate your local AI agents from Web and messaging apps.",
   "start_url": "/",
   "scope": "/",

--- a/ui/public/push-sw.js
+++ b/ui/public/push-sw.js
@@ -6,7 +6,7 @@ self.addEventListener('push', (event) => {
     payload = {};
   }
 
-  const title = typeof payload.title === 'string' && payload.title ? payload.title : 'avibe';
+  const title = typeof payload.title === 'string' && payload.title ? payload.title : 'Avibe';
   const url = typeof payload.url === 'string' && payload.url ? payload.url : '/inbox';
   const options = {
     body: typeof payload.body === 'string' ? payload.body : '',


### PR DESCRIPTION
## What
- Keep the three-regression runner on the normal 3.0 state layout: `home/.avibe` mounted as `/home/avibe/.avibe`.
- Stop the regression scripts from importing older harness layouts into `.vibe_remote`.
- Preserve state hygiene for stale container paths already inside `.avibe` config/state, including config, settings, sessions, scheduled tasks, and sqlite workdir payloads.
- Set the PWA/mobile install display name to `Avibe`.

## Evidence
- Unit: `pytest -q tests/test_prepare_three_regression.py tests/test_three_regression_script.py`
- Contract: `ruff check scripts/prepare_three_regression.py tests/test_prepare_three_regression.py`
- Scenario/manual: `./scripts/run_three_regression.sh`, followed by `./scripts/run_three_regression.sh --no-build` after state-hygiene fixes.
- Manual checks: regression `/health` is OK, `/show/sesrj6s96fjeg/` returns 200, active config/state have no `/data/vibe_remote` references outside backup files, Show Page node_modules links are clean, and manifest/iOS app title read `Avibe`.

## Notes
- This intentionally does not add a migration script. The runner now expects the 3.0 regression state shape and only repairs stale paths inside that active state.
