### PR TITLE
fix(ui): refine dashboard brand + workbench platform row

### DIFF
--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -203,17 +203,24 @@ export const Dashboard: React.FC = () => {
     [settingsByPlatform]
   );
 
-  const platformCards = platformCatalog.map((platform) => {
+  // Surface the always-on Avibe Workbench first; IM transports keep catalog
+  // order behind it (Array.prototype.sort is stable).
+  const orderedPlatforms = [...platformCatalog].sort(
+    (a, b) => Number(isWorkbenchPlatform(b.id)) - Number(isWorkbenchPlatform(a.id))
+  );
+
+  const platformCards = orderedPlatforms.map((platform) => {
     const platformSettings = settingsByPlatform[platform.id] || {};
     const groups = platformSettings.channels || {};
     const activeGroups = Object.values(groups).filter((item: any) => item?.enabled).length;
     const discoveredGroups = Object.keys(groups).length;
+    const isWorkbench = isWorkbenchPlatform(platform.id);
     const enabled = enabledPlatforms.includes(platform.id);
     const supportsGroups = platformSupportsChannels(config, platform.id);
 
     // The workbench has no externally-discovered groups, so the group-count
     // summary is meaningless there — leave the subtitle empty.
-    const hint = isWorkbenchPlatform(platform.id)
+    const hint = isWorkbench
       ? null
       : supportsGroups
         ? t('dashboard.platformGroupsHint')
@@ -224,10 +231,17 @@ export const Dashboard: React.FC = () => {
     return {
       id: platform.id,
       title: t(platform.title_key || `platform.${platform.id}.title`),
+      // ``enabled`` still drives the "Active platforms" metric titles below,
+      // which count only configured IM transports. The status pill uses
+      // ``connected`` instead: the in-process workbench is always live, so it
+      // can never read as "not configured".
       enabled,
+      connected: isWorkbench || enabled,
       hint,
-      actionHref: supportsGroups ? '/admin/groups' : '/settings/platforms',
-      actionLabel: supportsGroups ? t('dashboard.manageRoute') : t('dashboard.configure'),
+      // The workbench's action opens the local workbench home rather than IM
+      // group routing.
+      actionHref: isWorkbench ? '/' : supportsGroups ? '/admin/groups' : '/settings/platforms',
+      actionLabel: isWorkbench || supportsGroups ? t('dashboard.manageRoute') : t('dashboard.configure'),
     };
   });
 
@@ -455,12 +469,12 @@ export const Dashboard: React.FC = () => {
                   <span
                     className={clsx(
                       'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium',
-                      platform.enabled
+                      platform.connected
                         ? 'border-mint/30 bg-mint/[0.08] text-mint'
                         : 'border-border bg-foreground/[0.04] text-muted'
                     )}
                   >
-                    {platform.enabled ? t('dashboard.connected') : t('dashboard.notConfigured')}
+                    {platform.connected ? t('dashboard.connected') : t('dashboard.notConfigured')}
                   </span>
                   <Link
                     to={platform.actionHref}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -533,7 +533,7 @@
     "cloudflared_process_unknown": "Avibe found a connector-like process but could not verify ownership. To avoid killing the wrong process, it did not change it. Check the cloudflared process manually and retry."
   },
   "appShell": {
-    "title": "Avibe",
+    "title": "Avibe OS",
     "subtitle": "Agent OS",
     "workspaceLabel": "Workspace",
     "openControlPanel": "Control Panel",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -533,7 +533,7 @@
     "cloudflared_process_unknown": "检测到一个无法确认归属的连接器进程。为避免误杀其它进程，Avibe 没有自动处理。请手动检查 cloudflared 进程后再启动。"
   },
   "appShell": {
-    "title": "Avibe",
+    "title": "Avibe OS",
     "subtitle": "Agent 操作系统",
     "workspaceLabel": "工作区",
     "openControlPanel": "控制面板",


### PR DESCRIPTION
## Capability
Control Panel → **Dashboard** (`/admin/dashboard`): brand wordmark + the **Platform Overview** treatment of the always-on Avibe Workbench peer-platform row. Pure copy/UX; no routing, config, or backend behavior changes.

Addresses four small copy/detail items raised against the live dashboard:

| # | Element | Before | After |
|---|---------|--------|-------|
| 1 | Sidebar brand (`appShell.title`, also mobile header) | "Avibe" | **"Avibe OS"** |
| 2 | Workbench row action link ("Manage") | → `/admin/groups` | → workbench home **`/`** |
| 3 | Workbench row status pill | "Not configured" | always **"Connected"** (the in-process workbench is always live) |
| 4 | Workbench row position in the list | last | **first** |

## Why
The workbench (`avibe`) is registered with `supports_channels=True` and sits last in the catalog, so it previously rendered like an IM transport: a "Manage → group routing" link, a misleading "Not configured" pill (it is never in `enabled`), and bottom placement. It is the local web surface itself, so it deserves first placement, an always-connected status, and an action that opens the workbench rather than IM group routing.

## Implementation notes
- `enabled` (drives the "Active platforms" metric titles, which count only configured IM transports) is kept untouched; the status pill now reads a new `connected = isWorkbench || enabled` so the workbench shows Connected **without** being counted as an active IM platform.
- Ordering uses a stable, non-mutating sort over a `[...platformCatalog]` copy; IM platforms keep their catalog order.

## Evidence layers
- **Unit / contract / scenario:** none — copy/UX only; no scenario catalog covers this surface, no behavioral contract changed.
- **Build:** `tsc -b && vite build` passes (type-check clean).
- **Review:** reviewer subagent pass — verified sort stability/non-mutation, `enabled`/`connected` consistency (metrics unchanged), `/` is the real workbench home (`App.tsx`), no other consumer of the pill's old `enabled`.
- **Residual manual:** recommend a visual check of the dashboard at desktop width.

## Open note
Title is now "Avibe OS" while the subtitle remains "Agent OS" → the two lines both end in "OS". Happy to adjust the subtitle if the doubled "OS" reads awkwardly.