### PR TITLE
chore(ui): reword sidebar subtitle to the colleague tagline

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -534,7 +534,7 @@
   },
   "appShell": {
     "title": "Avibe OS",
-    "subtitle": "Agent OS",
+    "subtitle": "AI as a colleague",
     "workspaceLabel": "Workspace",
     "openControlPanel": "Control Panel",
     "backToWorkbench": "Back to Workbench",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -534,7 +534,7 @@
   },
   "appShell": {
     "title": "Avibe OS",
-    "subtitle": "Agent 操作系统",
+    "subtitle": "把 AI 当同事",
     "workspaceLabel": "工作区",
     "openControlPanel": "控制面板",
     "backToWorkbench": "返回工作台",


### PR DESCRIPTION
## Capability
Sidebar / mobile-header brand lockup (`appShell.subtitle`). Copy-only follow-up to #492.

## Change
After #492 made the wordmark **"Avibe OS"**, the subtitle still read "Agent OS" / "Agent 操作系统" — both lines ended in "OS". Reworded to echo the product thesis ("AI as Colleague, Not Tool"):

| Locale | Before | After |
|--------|--------|-------|
| en | Agent OS | **AI as a colleague** |
| zh | Agent 操作系统 | **把 AI 当同事** |

## Evidence layers
- **Unit / contract / scenario:** none — pure i18n copy; no key added/removed, no code path touched, both locales updated in lockstep.
- **Build:** `tsc -b && vite build` passes; both `en.json` / `zh.json` validate as JSON.
- **Residual manual:** recommend a glance at the sidebar brand at desktop width (11px subtitle truncates in the 240px rail; the new strings are short enough to fit).