### PR TITLE
docs(rebrand): update watch skill Avibe copy

### DIFF
--- a/docs/plans/rebrand-avibe.md
+++ b/docs/plans/rebrand-avibe.md
@@ -508,3 +508,24 @@ Behavior:
 Verification:
 - Shim metadata is covered by `tests/test_pypi_shim.py`.
 - The shim wheel build was verified locally with `python3 -m build --wheel`.
+
+## 16. Execution checkpoint: prompt-skill copy sweep
+
+2026-06-07: re-ran a focused sweep for old `Vibe Remote`, `vibe-remote`,
+`vibe_remote`, `VIBE_REMOTE`, `cyhhao/vibe-remote`, and `~/.vibe_remote`
+references on latest `master`.
+
+Updated:
+- `skills/background-watch-hook/SKILL.md` now says Avibe in Agent-facing watch
+  guidance and uses `avibe-bot/avibe` in GitHub waiter examples.
+
+Still intentionally retained:
+- Main `core/system_prompt_injection.py` is already Avibe-branded and still
+  points the `use-vibe-remote` skill URL at `avibe-bot/avibe`; do not change it
+  to an `avibe.bot` redirect before the 3.0.0 release.
+- `skills/use-vibe-remote` keeps its slug/path for agent compatibility.
+- `VIBE_REMOTE_HOME`, `~/.vibe_remote`, `vibe_remote.log`, cookie names,
+  OpenCode metadata keys, legacy release markers, and `vibe-remote` shim /
+  uninstall references remain compatibility surfaces.
+- Product Hunt badge URLs and historical docs/plans remain old-name references
+  until the external listing or archival docs are explicitly updated.

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -54,7 +54,7 @@ vibe watch add \
 Default behavior:
 
 - returns immediately
-- keeps the waiter managed by Vibe Remote
+- keeps the waiter managed by Avibe
 - lets the agent inspect or stop the watch later
 - creates a follow-up Agent Run after the waiter succeeds or reaches a terminal failure
 
@@ -130,9 +130,9 @@ vibe watch add \
 
 ## Session Targeting
 
-Use the current Vibe Remote context:
+Use the current Avibe context:
 
-- `--session-id` controls which Agent Session Vibe Remote will continue using
+- `--session-id` controls which Agent Session Avibe will continue using
 - use the current Agent Session ID when the follow-up should continue the same session
 - if no usable Agent Session ID is available, confirm the target session first instead of guessing
 - `--post-to channel` only when the follow-up should keep the same Agent Session but publish in the parent channel
@@ -178,7 +178,7 @@ vibe watch add \
   --message "PR #151 has new review activity. Fetch the latest review state, summarize actionable items, and continue handling them if needed." \
   -- \
   uv run --no-project scripts/wait_pr.py \
-    --repo cyhhao/vibe-remote \
+    --repo avibe-bot/avibe \
     --pr 151 \
     --interval 60
 ```
@@ -192,7 +192,7 @@ vibe watch add \
   --message "PR #151 already has review activity. Fetch the latest review state and continue handling it if needed." \
   -- \
   uv run --no-project scripts/wait_pr.py \
-    --repo cyhhao/vibe-remote \
+    --repo avibe-bot/avibe \
     --pr 151 \
     --catch-up
 ```
@@ -209,7 +209,7 @@ vibe watch add \
   --message "PR #151 has new review activity. Fetch the latest review state, summarize actionable items, and continue handling them if needed." \
   -- \
   uv run --no-project scripts/wait_pr.py \
-    --repo cyhhao/vibe-remote \
+    --repo avibe-bot/avibe \
     --pr 151 \
     --interval 60
 ```
@@ -232,7 +232,7 @@ vibe watch add \
   --message "The repository has new pull requests. Review the new PRs and continue as needed." \
   -- \
   uv run --no-project scripts/wait_pr.py \
-    --repo cyhhao/vibe-remote \
+    --repo avibe-bot/avibe \
     --new-prs \
     --interval 60
 ```
@@ -240,8 +240,8 @@ vibe watch add \
 New issues or issue comments:
 
 ```bash
-uv run --no-project scripts/wait_issue.py --repo cyhhao/vibe-remote --new-issues --interval 60
-uv run --no-project scripts/wait_issue.py --repo cyhhao/vibe-remote --issue 157 --interval 60
+uv run --no-project scripts/wait_issue.py --repo avibe-bot/avibe --new-issues --interval 60
+uv run --no-project scripts/wait_issue.py --repo avibe-bot/avibe --issue 157 --interval 60
 ```
 
 GitHub Actions for a pushed commit:


### PR DESCRIPTION
## What changed
- Updated the background-watch-hook Agent skill copy from Vibe Remote to Avibe.
- Updated bundled GitHub waiter examples to use `avibe-bot/avibe`.
- Recorded the focused prompt-skill sweep in the rebrand plan.

## Evidence layers
- Unit: not applicable; docs/skill copy only.
- Contract: not applicable; no CLI/API behavior changed.
- Scenario: prompt-skill copy sweep recorded in `docs/plans/rebrand-avibe.md`.
- Manual: verified `skills/background-watch-hook/SKILL.md` has no old `Vibe Remote` / `cyhhao/vibe-remote` references, and `git diff --check` passed.

## Risk
Low. This only changes Agent-facing skill guidance and planning notes.
