### PR TITLE
fix(claude): suppress synthetic tool-use errors

### DIFF
--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -91,6 +91,8 @@ class ClaudeAgent(BaseAgent):
             if callable(mark_session_active):
                 mark_session_active(runtime_session_key)
 
+            self._suppressed_synthetic_results.discard(runtime_session_key)
+
             # Queue reaction BEFORE sending query to avoid race condition where
             # a fast result arrives before the reaction is queued
             if request.ack_reaction_message_id and request.ack_reaction_emoji:
@@ -308,6 +310,7 @@ class ClaudeAgent(BaseAgent):
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)
         self._native_session_ids.pop(composite_key, None)
+        self._suppressed_synthetic_results.discard(composite_key)
         if not preserve_pending_request_state:
             self._pending_reactions.pop(composite_key, None)
             self._pending_requests.pop(composite_key, None)
@@ -457,6 +460,7 @@ class ClaudeAgent(BaseAgent):
                             assistant_text,
                         ):
                             continue
+                        self._suppressed_synthetic_results.discard(composite_key)
                         if assistant_text:
                             self._last_assistant_text[composite_key] = assistant_text
 
@@ -528,6 +532,7 @@ class ClaudeAgent(BaseAgent):
                             await self._clear_pending_reactions(composite_key, context)
                             return
                         if formatted_message and formatted_message.strip():
+                            self._suppressed_synthetic_results.discard(composite_key)
                             await self.controller.emit_agent_message(
                                 context,
                                 "system",
@@ -608,6 +613,7 @@ class ClaudeAgent(BaseAgent):
                         continue
 
                     # Ignore UserMessage/tool results; toolcalls are emitted from ToolUseBlock.
+                    self._suppressed_synthetic_results.discard(composite_key)
                     continue
                 except Exception as e:
                     logger.error(f"Error processing message from Claude: {e}", exc_info=True)
@@ -678,6 +684,8 @@ class ClaudeAgent(BaseAgent):
         # The except blocks above handle the cancel/error cases; the
         # normal-result case is handled by _remove_pending_reaction()
         # inside the loop.
+        finally:
+            self._suppressed_synthetic_results.discard(composite_key)
 
     async def _handle_synthetic_api_error_message(
         self,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -91,8 +91,6 @@ class ClaudeAgent(BaseAgent):
             if callable(mark_session_active):
                 mark_session_active(runtime_session_key)
 
-            self._suppressed_synthetic_results.discard(runtime_session_key)
-
             # Queue reaction BEFORE sending query to avoid race condition where
             # a fast result arrives before the reaction is queued
             if request.ack_reaction_message_id and request.ack_reaction_emoji:
@@ -460,7 +458,6 @@ class ClaudeAgent(BaseAgent):
                             assistant_text,
                         ):
                             continue
-                        self._suppressed_synthetic_results.discard(composite_key)
                         if assistant_text:
                             self._last_assistant_text[composite_key] = assistant_text
 
@@ -532,7 +529,6 @@ class ClaudeAgent(BaseAgent):
                             await self._clear_pending_reactions(composite_key, context)
                             return
                         if formatted_message and formatted_message.strip():
-                            self._suppressed_synthetic_results.discard(composite_key)
                             await self.controller.emit_agent_message(
                                 context,
                                 "system",
@@ -613,7 +609,6 @@ class ClaudeAgent(BaseAgent):
                         continue
 
                     # Ignore UserMessage/tool results; toolcalls are emitted from ToolUseBlock.
-                    self._suppressed_synthetic_results.discard(composite_key)
                     continue
                 except Exception as e:
                     logger.error(f"Error processing message from Claude: {e}", exc_info=True)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -449,6 +449,13 @@ class ClaudeAgent(BaseAgent):
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
                             return
+                        if await self._handle_synthetic_api_error_message(
+                            context,
+                            composite_key,
+                            message,
+                            assistant_text,
+                        ):
+                            continue
                         if assistant_text:
                             self._last_assistant_text[composite_key] = assistant_text
 
@@ -667,6 +674,34 @@ class ClaudeAgent(BaseAgent):
         # The except blocks above handle the cancel/error cases; the
         # normal-result case is handled by _remove_pending_reaction()
         # inside the loop.
+
+    async def _handle_synthetic_api_error_message(
+        self,
+        context: MessageContext,
+        composite_key: str,
+        message,
+        text: str,
+    ) -> bool:
+        """Settle Claude Code synthetic API errors without publishing them as chat."""
+
+        if not self._is_synthetic_api_error_message(message):
+            return False
+
+        pending_request = self._pop_pending_request(composite_key)
+        self._adopt_pending_turn_token(context, pending_request)
+        logger.warning(
+            "Claude synthetic API error for session %s suppressed from user-visible transcript: %s",
+            composite_key,
+            text or "<empty>",
+        )
+        await self.controller.emit_agent_message(context, "result", "", is_error=True)
+        if pending_request is not None:
+            await self._remove_ack_reaction(pending_request)
+        self._last_assistant_text.pop(composite_key, None)
+        self._pending_assistant_message.pop(composite_key, None)
+        self._discard_pending_reaction(composite_key)
+        self._mark_session_idle_if_no_pending_requests(composite_key)
+        return True
 
     async def _delete_ack(self, context: MessageContext, request: AgentRequest):
         service = getattr(self.controller, "processing_indicator", None)
@@ -946,6 +981,13 @@ class ClaudeAgent(BaseAgent):
     def _is_auth_failure_assistant_message(self, message) -> bool:
         error_kind = (getattr(message, "error", "") or "").strip().lower()
         return error_kind == "authentication_failed"
+
+    @staticmethod
+    def _is_synthetic_api_error_message(message) -> bool:
+        if getattr(message, "isApiErrorMessage", False):
+            return True
+        model = str(getattr(message, "model", "") or "").strip().lower()
+        return model == "<synthetic>"
 
     def _detect_message_type(self, message) -> Optional[str]:
         """Infer message type name from Claude SDK class."""

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -36,6 +36,7 @@ class ClaudeAgent(BaseAgent):
         self._last_assistant_text: dict[str, str] = {}
         self._pending_assistant_message: dict[str, str] = {}
         self._native_session_ids: dict[str, str] = {}
+        self._suppressed_synthetic_results: dict[str, str] = {}
         # Store reaction info per session as a queue (FIFO) for cleanup after result
         # Each entry is (reaction_message_id, emoji)
         self._pending_reactions: dict[str, list[tuple[str, str]]] = {}
@@ -538,6 +539,9 @@ class ClaudeAgent(BaseAgent):
                     if message_type == "result":
                         self._pending_assistant_message.pop(composite_key, None)
                         result_text = getattr(message, "result", None)
+                        if self._consume_suppressed_synthetic_result(composite_key, result_text):
+                            self._last_assistant_text.pop(composite_key, None)
+                            continue
                         if not result_text:
                             # ResultMessage had no text; use the last assistant
                             # text as a fallback so the user still sees output.
@@ -684,13 +688,13 @@ class ClaudeAgent(BaseAgent):
     ) -> bool:
         """Settle Claude Code synthetic API errors without publishing them as chat."""
 
-        if not self._is_synthetic_api_error_message(message):
+        if not self._is_synthetic_api_error_message(message, text):
             return False
 
         pending_request = self._pop_pending_request(composite_key)
         self._adopt_pending_turn_token(context, pending_request)
         logger.warning(
-            "Claude synthetic API error for session %s suppressed from user-visible transcript: %s",
+            "Claude malformed tool-use synthetic API error for session %s suppressed from user-visible transcript: %s",
             composite_key,
             text or "<empty>",
         )
@@ -699,8 +703,21 @@ class ClaudeAgent(BaseAgent):
             await self._remove_ack_reaction(pending_request)
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)
+        self._suppressed_synthetic_results[composite_key] = text
         self._discard_pending_reaction(composite_key)
         self._mark_session_idle_if_no_pending_requests(composite_key)
+        return True
+
+    def _consume_suppressed_synthetic_result(self, composite_key: str, text: Optional[str]) -> bool:
+        expected_text = self._suppressed_synthetic_results.pop(composite_key, None)
+        if expected_text is None:
+            return False
+        if (text or "").strip() != expected_text.strip():
+            return False
+        logger.warning(
+            "Claude paired malformed tool-use synthetic ResultMessage for session %s suppressed",
+            composite_key,
+        )
         return True
 
     async def _delete_ack(self, context: MessageContext, request: AgentRequest):
@@ -983,11 +1000,23 @@ class ClaudeAgent(BaseAgent):
         return error_kind == "authentication_failed"
 
     @staticmethod
-    def _is_synthetic_api_error_message(message) -> bool:
-        if getattr(message, "isApiErrorMessage", False):
-            return True
-        model = str(getattr(message, "model", "") or "").strip().lower()
-        return model == "<synthetic>"
+    def _is_synthetic_api_error_message(message, text: Optional[str] = None) -> bool:
+        if not getattr(message, "isApiErrorMessage", False):
+            model = str(getattr(message, "model", "") or "").strip().lower()
+            if model != "<synthetic>":
+                return False
+        return ClaudeAgent._is_malformed_tool_call_retry_failure_text(text)
+
+    @staticmethod
+    def _is_malformed_tool_call_retry_failure_text(text: Optional[str]) -> bool:
+        normalized = " ".join((text or "").strip().lower().split())
+        if not normalized:
+            return False
+        return (
+            "tool call" in normalized
+            and "could not be parsed" in normalized
+            and "retry also failed" in normalized
+        )
 
     def _detect_message_type(self, message) -> Optional[str]:
         """Infer message type name from Claude SDK class."""

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -36,7 +36,7 @@ class ClaudeAgent(BaseAgent):
         self._last_assistant_text: dict[str, str] = {}
         self._pending_assistant_message: dict[str, str] = {}
         self._native_session_ids: dict[str, str] = {}
-        self._suppressed_synthetic_results: dict[str, str] = {}
+        self._suppressed_synthetic_results: set[str] = set()
         # Store reaction info per session as a queue (FIFO) for cleanup after result
         # Each entry is (reaction_message_id, emoji)
         self._pending_reactions: dict[str, list[tuple[str, str]]] = {}
@@ -703,20 +703,19 @@ class ClaudeAgent(BaseAgent):
             await self._remove_ack_reaction(pending_request)
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)
-        self._suppressed_synthetic_results[composite_key] = text
+        self._suppressed_synthetic_results.add(composite_key)
         self._discard_pending_reaction(composite_key)
         self._mark_session_idle_if_no_pending_requests(composite_key)
         return True
 
     def _consume_suppressed_synthetic_result(self, composite_key: str, text: Optional[str]) -> bool:
-        expected_text = self._suppressed_synthetic_results.pop(composite_key, None)
-        if expected_text is None:
+        if composite_key not in self._suppressed_synthetic_results:
             return False
-        if (text or "").strip() != expected_text.strip():
-            return False
+        self._suppressed_synthetic_results.discard(composite_key)
         logger.warning(
-            "Claude paired malformed tool-use synthetic ResultMessage for session %s suppressed",
+            "Claude paired malformed tool-use synthetic ResultMessage for session %s suppressed: %s",
             composite_key,
+            text or "<empty>",
         )
         return True
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -540,7 +540,7 @@ class ClaudeAgent(BaseAgent):
                     if message_type == "result":
                         self._pending_assistant_message.pop(composite_key, None)
                         result_text = getattr(message, "result", None)
-                        if self._consume_suppressed_synthetic_result(composite_key, result_text):
+                        if self._consume_suppressed_synthetic_result(composite_key, message, result_text):
                             self._last_assistant_text.pop(composite_key, None)
                             continue
                         if not result_text:
@@ -711,9 +711,14 @@ class ClaudeAgent(BaseAgent):
         self._mark_session_idle_if_no_pending_requests(composite_key)
         return True
 
-    def _consume_suppressed_synthetic_result(self, composite_key: str, text: Optional[str]) -> bool:
+    def _consume_suppressed_synthetic_result(self, composite_key: str, message, text: Optional[str]) -> bool:
         if composite_key not in self._suppressed_synthetic_results:
             return False
+
+        if not self._is_malformed_tool_call_retry_failure_result(message, text):
+            self._suppressed_synthetic_results.discard(composite_key)
+            return False
+
         self._suppressed_synthetic_results.discard(composite_key)
         logger.warning(
             "Claude paired malformed tool-use synthetic ResultMessage for session %s suppressed: %s",
@@ -1019,6 +1024,25 @@ class ClaudeAgent(BaseAgent):
             and "could not be parsed" in normalized
             and "retry also failed" in normalized
         )
+
+    @staticmethod
+    def _is_malformed_tool_call_retry_failure_result(message, text: Optional[str]) -> bool:
+        subtype = (getattr(message, "subtype", "") or "").strip().lower()
+        if subtype != "error" and not getattr(message, "is_error", False):
+            return False
+
+        candidates = [text or ""]
+        errors = getattr(message, "errors", None) or []
+        candidates.extend(str(error) for error in errors)
+        normalized = " ".join(" ".join(candidates).strip().lower().split())
+        if not normalized:
+            return False
+        if ClaudeAgent._is_malformed_tool_call_retry_failure_text(normalized):
+            return True
+        has_tool = "tool call" in normalized or "tool-call" in normalized or "tool-use" in normalized
+        has_parse = "parse" in normalized or "parsing" in normalized or "malformed" in normalized
+        has_retry = "retry" in normalized or "retried" in normalized
+        return has_tool and has_parse and has_retry
 
     def _detect_message_type(self, message) -> Optional[str]:
         """Infer message type name from Claude SDK class."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "claude-agent-sdk>=0.1.66",
+    "claude-agent-sdk>=0.2.93",
     "anyio>=4.0.0",
     "APScheduler>=3.10.4",
     "slack-sdk>=3.26.0",

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1024,6 +1024,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             {
                 "subtype": "error",
                 "result": "The tool-use request failed after Claude Code retried parsing.",
+                "is_error": True,
                 "duration_ms": 1,
             },
         )()
@@ -1114,6 +1115,85 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         agent.emit_result_message.assert_not_awaited()
         self.assertEqual(agent._pending_requests[composite_key], [followup_request])
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
+        self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
+
+    async def test_synthetic_marker_does_not_suppress_non_error_followup_result_in_open_receiver(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent._remove_ack_reaction = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+        agent._extract_text_blocks = lambda message, context: (
+            "The model's tool call could not be parsed (retry also failed)."
+        )
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={},
+        )
+        composite_key = "session-1:/tmp/work"
+        failed_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        agent._pending_requests[composite_key] = [failed_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:")]
+
+        assistant_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [],
+                "isApiErrorMessage": True,
+                "model": "<synthetic>",
+                "error": None,
+            },
+        )()
+        followup_result = type(
+            "ResultMessage",
+            (),
+            {
+                "subtype": "success",
+                "result": "next turn result",
+                "is_error": False,
+                "duration_ms": 1,
+            },
+        )()
+
+        class _OpenReceiverClient:
+            def __init__(self):
+                self.ready = asyncio.Event()
+
+            def receive_messages(self):
+                async def _iterate():
+                    yield assistant_message
+                    await self.ready.wait()
+                    yield followup_result
+
+                return _iterate()
+
+        client = _OpenReceiverClient()
+        receiver_task = asyncio.create_task(
+            agent._receive_messages(client, "session-1", "/tmp/work", context, composite_key=composite_key)
+        )
+
+        while composite_key not in agent._suppressed_synthetic_results:
+            await asyncio.sleep(0)
+
+        followup_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T2"}))
+        agent._pending_requests[composite_key] = [followup_request]
+        agent._pending_reactions[composite_key] = [("m2", ":eyes:")]
+        client.ready.set()
+        await receiver_task
+
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        agent.emit_result_message.assert_awaited_once_with(
+            context,
+            "next turn result",
+            subtype="success",
+            duration_ms=1,
+            parse_mode="markdown",
+            request=followup_request,
+        )
+        self.assertNotIn(composite_key, agent._pending_requests)
         self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
 
     async def test_synthetic_api_error_without_paired_result_does_not_suppress_later_turn(self):

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -884,6 +884,56 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(composite_key, controller.receiver_tasks)
         self.assertNotIn(composite_key, controller.claude_sessions)
 
+    async def test_synthetic_api_error_settles_turn_without_user_visible_result(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent._remove_ack_reaction = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={},
+        )
+        composite_key = "session-1:/tmp/work"
+        pending_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        next_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T2"}))
+        agent._pending_requests[composite_key] = [pending_request, next_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:"), ("m2", ":eyes:")]
+        agent._pending_assistant_message[composite_key] = "stale assistant"
+        agent._last_assistant_text[composite_key] = "stale text"
+
+        text_block = type("TextBlock", (), {"text": "The model's tool call could not be parsed (retry also failed)."})()
+        assistant_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [text_block],
+                "isApiErrorMessage": True,
+                "model": "<synthetic>",
+                "error": None,
+            },
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield assistant_message
+
+                return _iterate()
+
+        await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        agent.emit_result_message.assert_not_awaited()
+        agent._remove_ack_reaction.assert_awaited_once_with(pending_request)
+        self.assertEqual(context.platform_specific["turn_token"], "T1")
+        self.assertEqual(agent._pending_requests[composite_key], [next_request])
+        self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
+        self.assertNotIn(composite_key, agent._pending_assistant_message)
+        self.assertNotIn(composite_key, agent._last_assistant_text)
+
     async def test_assistant_auth_error_without_is_api_error_flag_still_triggers_recovery(self):
         """Scenario: AUTH-SETUP-902"""
         controller = _StubController()

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1044,6 +1044,82 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
         self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
 
+    async def test_synthetic_api_error_without_paired_result_does_not_suppress_later_turn(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent._remove_ack_reaction = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+        agent._extract_text_blocks = lambda message, context: (
+            "The model's tool call could not be parsed (retry also failed)."
+        )
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={},
+        )
+        composite_key = "session-1:/tmp/work"
+        failed_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        agent._pending_requests[composite_key] = [failed_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:")]
+
+        assistant_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [],
+                "isApiErrorMessage": True,
+                "model": "<synthetic>",
+                "error": None,
+            },
+        )()
+
+        class _SyntheticOnlyClient:
+            def receive_messages(self):
+                async def _iterate():
+                    yield assistant_message
+
+                return _iterate()
+
+        await agent._receive_messages(
+            _SyntheticOnlyClient(),
+            "session-1",
+            "/tmp/work",
+            context,
+            composite_key=composite_key,
+        )
+
+        self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
+
+        next_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T2"}))
+        agent._pending_requests[composite_key] = [next_request]
+        agent._pending_reactions[composite_key] = [("m2", ":eyes:")]
+        normal_result = type(
+            "ResultMessage",
+            (),
+            {"subtype": "success", "result": "next turn result", "duration_ms": 1},
+        )()
+
+        class _ResultClient:
+            def receive_messages(self):
+                async def _iterate():
+                    yield normal_result
+
+                return _iterate()
+
+        await agent._receive_messages(_ResultClient(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        agent.emit_result_message.assert_awaited_once_with(
+            context,
+            "next turn result",
+            subtype="success",
+            duration_ms=1,
+            parse_mode="markdown",
+            request=next_request,
+        )
+        self.assertNotIn(composite_key, agent._pending_requests)
+
     async def test_non_malformed_synthetic_api_error_remains_visible(self):
         controller = _StubController()
         controller._get_session_key = lambda context: "avibe::project::p1"

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -987,6 +987,63 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
         self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
 
+    async def test_synthetic_api_error_suppresses_next_result_even_when_text_differs(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent._remove_ack_reaction = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+        agent._extract_text_blocks = lambda message, context: (
+            "The model's tool call could not be parsed (retry also failed)."
+        )
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={},
+        )
+        composite_key = "session-1:/tmp/work"
+        failed_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        next_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T2"}))
+        agent._pending_requests[composite_key] = [failed_request, next_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:"), ("m2", ":eyes:")]
+
+        assistant_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [],
+                "isApiErrorMessage": True,
+                "model": "<synthetic>",
+                "error": None,
+            },
+        )()
+        result_message = type(
+            "ResultMessage",
+            (),
+            {
+                "subtype": "error",
+                "result": "The tool-use request failed after Claude Code retried parsing.",
+                "duration_ms": 1,
+            },
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield assistant_message
+                    yield result_message
+
+                return _iterate()
+
+        await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        agent.emit_result_message.assert_not_awaited()
+        self.assertEqual(agent._pending_requests[composite_key], [next_request])
+        self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
+        self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
+
     async def test_non_malformed_synthetic_api_error_remains_visible(self):
         controller = _StubController()
         controller._get_session_key = lambda context: "avibe::project::p1"

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -891,6 +891,8 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         agent = ClaudeAgent(controller)
         agent._remove_ack_reaction = AsyncMock()
         agent.emit_result_message = AsyncMock()
+        error_text = "The model's tool call could not be parsed (retry also failed)."
+        agent._extract_text_blocks = lambda message, context: error_text
         context = SimpleNamespace(
             user_id="U1",
             channel_id="C1",
@@ -904,12 +906,11 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         agent._pending_assistant_message[composite_key] = "stale assistant"
         agent._last_assistant_text[composite_key] = "stale text"
 
-        text_block = type("TextBlock", (), {"text": "The model's tool call could not be parsed (retry also failed)."})()
         assistant_message = type(
             "AssistantMessage",
             (),
             {
-                "content": [text_block],
+                "content": [],
                 "isApiErrorMessage": True,
                 "model": "<synthetic>",
                 "error": None,
@@ -933,6 +934,113 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
         self.assertNotIn(composite_key, agent._pending_assistant_message)
         self.assertNotIn(composite_key, agent._last_assistant_text)
+
+    async def test_synthetic_api_error_suppresses_paired_result_without_popping_next_request(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent._remove_ack_reaction = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+        error_text = "The model's tool call could not be parsed (retry also failed)."
+        agent._extract_text_blocks = lambda message, context: error_text
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={},
+        )
+        composite_key = "session-1:/tmp/work"
+        failed_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        next_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T2"}))
+        agent._pending_requests[composite_key] = [failed_request, next_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:"), ("m2", ":eyes:")]
+
+        assistant_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [],
+                "isApiErrorMessage": True,
+                "model": "<synthetic>",
+                "error": None,
+            },
+        )()
+        result_message = type(
+            "ResultMessage",
+            (),
+            {"subtype": "error", "result": error_text, "duration_ms": 1},
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield assistant_message
+                    yield result_message
+
+                return _iterate()
+
+        await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        agent.emit_result_message.assert_not_awaited()
+        self.assertEqual(agent._pending_requests[composite_key], [next_request])
+        self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
+        self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
+
+    async def test_non_malformed_synthetic_api_error_remains_visible(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent.emit_result_message = AsyncMock()
+        error_text = "Claude API rate_limit: retry later."
+        agent._extract_text_blocks = lambda message, context: error_text
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={},
+        )
+        composite_key = "session-1:/tmp/work"
+        pending_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        agent._pending_requests[composite_key] = [pending_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:")]
+
+        assistant_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [],
+                "isApiErrorMessage": True,
+                "model": "<synthetic>",
+                "error": "rate_limit",
+            },
+        )()
+        result_message = type(
+            "ResultMessage",
+            (),
+            {"subtype": "error", "result": error_text, "duration_ms": 1},
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield assistant_message
+                    yield result_message
+
+                return _iterate()
+
+        await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        controller.emit_agent_message.assert_not_awaited()
+        agent.emit_result_message.assert_awaited_once_with(
+            context,
+            error_text,
+            subtype="error",
+            duration_ms=1,
+            parse_mode="markdown",
+            request=pending_request,
+        )
+        self.assertNotIn(composite_key, agent._pending_requests)
 
     async def test_assistant_auth_error_without_is_api_error_flag_still_triggers_recovery(self):
         """Scenario: AUTH-SETUP-902"""

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1044,6 +1044,78 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
         self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
 
+    async def test_synthetic_api_error_keeps_marker_when_followup_queues_before_paired_result(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent._remove_ack_reaction = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+        agent._extract_text_blocks = lambda message, context: (
+            "The model's tool call could not be parsed (retry also failed)."
+        )
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={},
+        )
+        composite_key = "session-1:/tmp/work"
+        failed_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        agent._pending_requests[composite_key] = [failed_request]
+        agent._pending_reactions[composite_key] = [("m1", ":eyes:")]
+
+        assistant_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [],
+                "isApiErrorMessage": True,
+                "model": "<synthetic>",
+                "error": None,
+            },
+        )()
+        paired_result = type(
+            "ResultMessage",
+            (),
+            {
+                "subtype": "error",
+                "result": "The model's tool call could not be parsed (retry also failed).",
+                "duration_ms": 1,
+            },
+        )()
+
+        class _DelayedPairedResultClient:
+            def __init__(self):
+                self.ready = asyncio.Event()
+
+            def receive_messages(self):
+                async def _iterate():
+                    yield assistant_message
+                    await self.ready.wait()
+                    yield paired_result
+
+                return _iterate()
+
+        client = _DelayedPairedResultClient()
+        receiver_task = asyncio.create_task(
+            agent._receive_messages(client, "session-1", "/tmp/work", context, composite_key=composite_key)
+        )
+
+        while composite_key not in agent._suppressed_synthetic_results:
+            await asyncio.sleep(0)
+
+        followup_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T2"}))
+        agent._pending_requests[composite_key] = [followup_request]
+        agent._pending_reactions[composite_key] = [("m2", ":eyes:")]
+        client.ready.set()
+        await receiver_task
+
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        agent.emit_result_message.assert_not_awaited()
+        self.assertEqual(agent._pending_requests[composite_key], [followup_request])
+        self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
+        self.assertNotIn(composite_key, agent._suppressed_synthetic_results)
+
     async def test_synthetic_api_error_without_paired_result_does_not_suppress_later_turn(self):
         controller = _StubController()
         controller._get_session_key = lambda context: "avibe::project::p1"

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,76 @@ wheels = [
 ]
 
 [[package]]
+name = "avibe-os"
+source = { editable = "." }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-socks" },
+    { name = "alembic" },
+    { name = "anyio" },
+    { name = "apscheduler" },
+    { name = "claude-agent-sdk" },
+    { name = "discord-py" },
+    { name = "fastapi" },
+    { name = "httpx", extra = ["socks"] },
+    { name = "imagesize" },
+    { name = "lark-oapi" },
+    { name = "markdown-to-mrkdwn" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "python-socks", extra = ["asyncio"] },
+    { name = "pywebpush" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "slack-sdk" },
+    { name = "sqlalchemy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.8.0" },
+    { name = "aiohttp-socks", specifier = ">=0.8.0" },
+    { name = "alembic", specifier = ">=1.13.0" },
+    { name = "anyio", specifier = ">=4.0.0" },
+    { name = "apscheduler", specifier = ">=3.10.4" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.93" },
+    { name = "discord-py", specifier = ">=2.4.0" },
+    { name = "fastapi", specifier = ">=0.110" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
+    { name = "imagesize", specifier = ">=1.4.1" },
+    { name = "lark-oapi", specifier = ">=1.4.0" },
+    { name = "markdown-to-mrkdwn", specifier = ">=0.2.0" },
+    { name = "packaging", specifier = ">=23.0" },
+    { name = "psutil", specifier = ">=5.9.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "python-socks", extras = ["asyncio"], specifier = ">=2.0.0" },
+    { name = "pywebpush", specifier = ">=2.0.3" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "requests", specifier = ">=2.31.0" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
+    { name = "slack-sdk", specifier = ">=3.26.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.27" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -476,20 +546,21 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.66"
+version = "0.2.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
+    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/74/ff47c188637e16a781afcc8419da487a4860ba6d8e4ad16ea29f40e99038/claude_agent_sdk-0.1.66.tar.gz", hash = "sha256:b8fb14198456f536f71733a4da84ec79c44d7f91b06ff34a4786087a1b043c48", size = 233308, upload-time = "2026-04-23T23:35:23.209Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/9b/66f0f671095a80f78f80aace954f4475705de17933120ff61bc8acc31d68/claude_agent_sdk-0.2.93.tar.gz", hash = "sha256:4fa2f534028c9054eb34960497147df345cb0042331694dfacd54560dd6378bd", size = 253644, upload-time = "2026-06-06T01:44:57.726Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/e0/a1f0e510b506dc3dd6da47eeaf1e750882d2ade11cda8f301a353290b671/claude_agent_sdk-0.1.66-py3-none-macosx_11_0_arm64.whl", hash = "sha256:18c35bdf52ba3c2a0a694fa3981484e5f5432e7c96cfbd76d70d73aef2a8b87e", size = 63218880, upload-time = "2026-04-23T23:35:27.679Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/c1/f451c5168d98027665b2356b7baebbb898d5ab3bded41788e5c823790ba7/claude_agent_sdk-0.1.66-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:c8281b0af9733bdcd4672dcc334006af6e5bf83098be38e66222feb9e32a0f41", size = 65184888, upload-time = "2026-04-23T23:35:31.932Z" },
-    { url = "https://files.pythonhosted.org/packages/59/40/49b81d04cc579e207676626eb777d7c99e566777fd696643db2c550c86ee/claude_agent_sdk-0.1.66-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:32536a6033dd6ea0fd63191389e77b4208f7ebafea8f8cb4d0befeff52e60a11", size = 76632992, upload-time = "2026-04-23T23:35:36.851Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/17/5cd8da44188b115cd5b836d6bd293e242d7533c15aa9e4ad634024f9c182/claude_agent_sdk-0.1.66-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:10abd64e5f8dc65eb2f592c1d4db5607129ef983ecabdfd5ecf4b2692ee02293", size = 76610323, upload-time = "2026-04-23T23:35:42.639Z" },
-    { url = "https://files.pythonhosted.org/packages/90/fc/205a918b36e118370942e464578bb6637ffb2c749c63d8d1c634d4e3aefd/claude_agent_sdk-0.1.66-py3-none-win_amd64.whl", hash = "sha256:729984e3198bb62c96387b6c4bbe433eca2eb439abe5663c1bf1532e9e340d2b", size = 78346312, upload-time = "2026-04-23T23:35:48.219Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b6/62fbdf6862b8f06b71e35cb76753cd4fcf3cbbfc74cf369d129e43045d96/claude_agent_sdk-0.2.93-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4fbf4f2c6e6b1085adaac304fa00ac29169a239fc3a15d114d964d2e77ce3e85", size = 64824363, upload-time = "2026-06-06T01:45:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1d/eb11c804242bf39ba305fdff6dd18bbcb0732dce6baeb8c9df637d700b6d/claude_agent_sdk-0.2.93-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:04779660231c399ffb37a467f3ce070349e34232163a5d92d94dbae7ae168ec3", size = 66888963, upload-time = "2026-06-06T01:45:04.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e2/196e32d83bf95dc9227958d0f70f5c7bd53495dc7af7c8448c7027311fce/claude_agent_sdk-0.2.93-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6263db6cc6778bb041931190e0316db9ceec1f570ea116554e23683339520ae0", size = 74450006, upload-time = "2026-06-06T01:45:09.438Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/84/479d0f52c0459780ed469ac874377838fcb19089d7ec5ac0630507dd35e6/claude_agent_sdk-0.2.93-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:10064d8e2c36e31248a517d74913c5c26bc0677ddbd63ffe614891ab638df0ac", size = 74621071, upload-time = "2026-06-06T01:45:13.938Z" },
+    { url = "https://files.pythonhosted.org/packages/db/80/5286c4a5ad126d8ee24329de9693c5700c8f6e2b0113799b2787573bebd1/claude_agent_sdk-0.2.93-py3-none-win_amd64.whl", hash = "sha256:51fb629151aff62b6db370bc595104fb609142e08385391f49162fc9ceb6696a", size = 75251517, upload-time = "2026-06-06T01:45:18.03Z" },
 ]
 
 [[package]]
@@ -1971,6 +2042,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "socksio"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2238,76 +2318,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
 ]
-
-[[package]]
-name = "avibe-os"
-source = { editable = "." }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "aiohttp-socks" },
-    { name = "alembic" },
-    { name = "anyio" },
-    { name = "apscheduler" },
-    { name = "claude-agent-sdk" },
-    { name = "discord-py" },
-    { name = "fastapi" },
-    { name = "httpx", extra = ["socks"] },
-    { name = "imagesize" },
-    { name = "lark-oapi" },
-    { name = "markdown-to-mrkdwn" },
-    { name = "packaging" },
-    { name = "psutil" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
-    { name = "python-socks", extra = ["asyncio"] },
-    { name = "pywebpush" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "sentry-sdk" },
-    { name = "slack-sdk" },
-    { name = "sqlalchemy" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.8.0" },
-    { name = "aiohttp-socks", specifier = ">=0.8.0" },
-    { name = "alembic", specifier = ">=1.13.0" },
-    { name = "anyio", specifier = ">=4.0.0" },
-    { name = "apscheduler", specifier = ">=3.10.4" },
-    { name = "claude-agent-sdk", specifier = ">=0.1.66" },
-    { name = "discord-py", specifier = ">=2.4.0" },
-    { name = "fastapi", specifier = ">=0.110" },
-    { name = "httpx", extras = ["socks"], specifier = ">=0.27" },
-    { name = "imagesize", specifier = ">=1.4.1" },
-    { name = "lark-oapi", specifier = ">=1.4.0" },
-    { name = "markdown-to-mrkdwn", specifier = ">=0.2.0" },
-    { name = "packaging", specifier = ">=23.0" },
-    { name = "psutil", specifier = ">=5.9.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9.0" },
-    { name = "python-multipart", specifier = ">=0.0.9" },
-    { name = "python-socks", extras = ["asyncio"], specifier = ">=2.0.0" },
-    { name = "pywebpush", specifier = ">=2.0.3" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "requests", specifier = ">=2.31.0" },
-    { name = "sentry-sdk", specifier = ">=2.0.0" },
-    { name = "slack-sdk", specifier = ">=3.26.0" },
-    { name = "sqlalchemy", specifier = ">=2.0.0" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
-    { name = "typing-extensions", specifier = ">=4.12.2" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.27" },
-]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "watchfiles"


### PR DESCRIPTION
## Summary

Fix Claude Code synthetic API errors from malformed tool-use attempts so they settle the active turn without being published as user-visible chat results.

## Root Cause

Claude Code can produce a synthetic API error after the model returns `stop_reason=tool_use` without a valid `tool_use` block and the built-in retry also fails. The SDK parses that terminal synthetic assistant/error event correctly, but Avibe previously treated it like an ordinary assistant/result message and mirrored it into the transcript.

## Changes

- Detect Claude synthetic API error assistant messages by `isApiErrorMessage` / `<synthetic>` model marker.
- Settle the current turn with an empty error result while suppressing the synthetic text from durable chat messages.
- Preserve queued follow-up requests and their reactions instead of clearing the whole session queue.
- Update `claude-agent-sdk` dependency metadata and lockfile to `0.2.93`.

## Evidence

- Unit: updated Claude session coverage for synthetic API errors.
- Contract: preserves normal assistant/result handling and auth recovery paths.
- Scenario: malformed Claude tool-use retry failure no longer appears as a user-visible result bubble.
- Residual manual checks: live Claude CLI/model malformed tool-use reproduction remains upstream-dependent.

## Validation

- `uv run ruff check modules/agents/claude_agent.py tests/test_claude_agent_sessions.py`
- `uv run pytest tests/test_claude_agent_sessions.py -q`
