### PR TITLE
docs(cli): clarify cron weekday semantics

### DIFF
--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -199,6 +199,8 @@ def test_task_add_help_includes_examples_and_threadless_guidance(capsys) -> None
     assert "`--session-id` chooses which Agent Session Avibe will continue using when the task runs." in captured.out
     assert "--post-to" in captured.out
     assert "--deliver-key" in captured.out
+    assert "Cron weekday digits use APScheduler semantics: 0=Mon through 6=Sun; 7 is invalid." in captured.out
+    assert "Prefer weekday names such as mon, tue, or sun when scheduling by day of week." in captured.out
 
 
 def test_hook_send_help_describes_runtime_effects(capsys) -> None:
@@ -242,6 +244,8 @@ def test_task_update_help_includes_partial_update_guidance(capsys) -> None:
     assert "keeping its task ID" in captured.out
     assert "--reset-delivery" in captured.out
     assert "Unspecified fields keep their existing values." in captured.out
+    assert "Cron weekday digits use APScheduler semantics: 0=Mon through 6=Sun; 7 is invalid." in captured.out
+    assert "Prefer weekday names such as mon, tue, or sun when scheduling by day of week." in captured.out
 
 
 def test_hook_send_help_includes_examples_and_threadless_guidance(capsys) -> None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -274,6 +274,7 @@ def _task_add_examples_text() -> str:
           Use --deliver-key only when delivery must go to a different explicit target.
           `--message` and `--message-file` provide the stored user message that will be sent each time the task runs.
           Use --cron for recurring jobs and --at for one-shot jobs.
+          Cron weekday digits use APScheduler semantics: 0=Mon through 6=Sun; 7 is invalid. Prefer weekday names such as mon, tue, or sun when scheduling by day of week.
           --timezone controls how --cron and naive --at timestamps are interpreted.
 
         Examples:
@@ -301,6 +302,7 @@ def _task_update_examples_text() -> str:
           Unspecified fields keep their existing values.
           Use --reset-delivery to return to following the session target directly.
           When changing schedule fields, pass either --cron or --at.
+          Cron weekday digits use APScheduler semantics: 0=Mon through 6=Sun; 7 is invalid. Prefer weekday names such as mon, tue, or sun when scheduling by day of week.
           Use --clear-name if you want the task to stop storing a custom name.
         """
     )


### PR DESCRIPTION
## What changed

- Clarifies `vibe task add --help` and `vibe task update --help` with APScheduler weekday-number semantics.
- Adds regression coverage for both help entries.

## Evidence

- Unit: `uv run pytest tests/test_cli_task_command.py`
- Lint: `ruff check vibe/cli.py tests/test_cli_task_command.py`
- UI/package prep: `npm run build` in `ui/` to satisfy editable package forced includes before pytest

## Risk

Low. This only changes CLI help text and assertions around that help output.
