### PR TITLE
docs(readme): de-narrow positioning from coding to general agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **Drives** ![Claude Code](https://img.shields.io/badge/Claude%20Code-D4A27F?style=flat-square&logo=anthropic&logoColor=white) ![OpenCode](https://img.shields.io/badge/OpenCode-00B4D8?style=flat-square) ![Codex](https://img.shields.io/badge/Codex-412991?style=flat-square)
 
-**Reach it from** ![Slack](https://img.shields.io/badge/Slack-4A154B?style=flat-square&logo=slack&logoColor=white) ![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white) ![Telegram](https://img.shields.io/badge/Telegram-26A5E4?style=flat-square&logo=telegram&logoColor=white) ![WeChat](https://img.shields.io/badge/WeChat-07C160?style=flat-square&logo=wechat&logoColor=white) ![Lark](https://img.shields.io/badge/Lark%20%2F%20Feishu-3370FF?style=flat-square&logo=bytedance&logoColor=white) ![Browser](https://img.shields.io/badge/Browser-111827?style=flat-square&logo=googlechrome&logoColor=white)
+**Reach it from** ![Browser](https://img.shields.io/badge/Browser-111827?style=flat-square&logo=googlechrome&logoColor=white) ![Slack](https://img.shields.io/badge/Slack-4A154B?style=flat-square&logo=slack&logoColor=white) ![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white) ![Telegram](https://img.shields.io/badge/Telegram-26A5E4?style=flat-square&logo=telegram&logoColor=white) ![WeChat](https://img.shields.io/badge/WeChat-07C160?style=flat-square&logo=wechat&logoColor=white) ![Lark](https://img.shields.io/badge/Lark%20%2F%20Feishu-3370FF?style=flat-square&logo=bytedance&logoColor=white)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ---
 
-## Your coding agent is brilliant — and stuck
+## Your AI agent is brilliant — and stuck
 
 Claude Code, Codex, OpenCode are incredible. But:
 
@@ -102,8 +102,6 @@ You're on a plane, at a café, on a borrowed laptop. The agent pings that a job 
 | **One substrate, every first-party agent** | Drive the *official* Claude Code, Codex, and OpenCode. Bring your own subscription or keys, switch per task, and never get locked into one vendor's silo. |
 | **Browser and chat, both first-class** | Operate from the browser Workbench, or from Slack, Discord, Telegram, WeChat, and Lark / Feishu. Same agent, same sessions. |
 | **No middleman** | No extra reasoning loop sits between you and your agent. Tokens go straight to the agent you chose. |
-
-Coding is the first strong workload — not the product boundary.
 
 ---
 
@@ -207,7 +205,7 @@ Full references: [Commands](docs/COMMANDS.md) · [CLI](docs/CLI.md)
 
 ## Prerequisites
 
-You need at least one coding agent installed:
+You need at least one agent installed:
 
 <details>
 <summary><b>OpenCode</b> (recommended)</summary>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -18,7 +18,7 @@
 
 **驱动** ![Claude Code](https://img.shields.io/badge/Claude%20Code-D4A27F?style=flat-square&logo=anthropic&logoColor=white) ![OpenCode](https://img.shields.io/badge/OpenCode-00B4D8?style=flat-square) ![Codex](https://img.shields.io/badge/Codex-412991?style=flat-square)
 
-**从这些地方找到它** ![Slack](https://img.shields.io/badge/Slack-4A154B?style=flat-square&logo=slack&logoColor=white) ![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white) ![Telegram](https://img.shields.io/badge/Telegram-26A5E4?style=flat-square&logo=telegram&logoColor=white) ![WeChat](https://img.shields.io/badge/WeChat-07C160?style=flat-square&logo=wechat&logoColor=white) ![Lark](https://img.shields.io/badge/Lark%20%2F%20Feishu-3370FF?style=flat-square&logo=bytedance&logoColor=white) ![Browser](https://img.shields.io/badge/Browser-111827?style=flat-square&logo=googlechrome&logoColor=white)
+**从这些地方找到它** ![Browser](https://img.shields.io/badge/Browser-111827?style=flat-square&logo=googlechrome&logoColor=white) ![Slack](https://img.shields.io/badge/Slack-4A154B?style=flat-square&logo=slack&logoColor=white) ![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat-square&logo=discord&logoColor=white) ![Telegram](https://img.shields.io/badge/Telegram-26A5E4?style=flat-square&logo=telegram&logoColor=white) ![WeChat](https://img.shields.io/badge/WeChat-07C160?style=flat-square&logo=wechat&logoColor=white) ![Lark](https://img.shields.io/badge/Lark%20%2F%20Feishu-3370FF?style=flat-square&logo=bytedance&logoColor=white)
 
 </div>
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -28,7 +28,7 @@
 
 ---
 
-## 你的编程 agent 很强——但被困住了
+## 你的 AI agent 很强——但被困住了
 
 Claude Code、Codex、OpenCode 都很能打。但是：
 
@@ -102,8 +102,6 @@ Windows 上推荐用 WSL，兼容性最好——见 [从零用 WSL 跑 Avibe](do
 | **一套底座，通吃所有第一方 agent** | 驱动*官方*的 Claude Code、Codex、OpenCode。自带订阅或 key，按任务切换，不被任何一家的 silo 绑死。 |
 | **浏览器和聊天，都是一等入口** | 用浏览器 Workbench，或 Slack、Discord、Telegram、微信、飞书。同一个 agent，同一批会话。 |
 | **没有中间人** | 你和 agent 之间没有第二层推理。token 直接花在你选的 agent 上。 |
-
-coding 只是第一个强场景，不是产品边界。
 
 ---
 
@@ -207,7 +205,7 @@ vibe runs       # 查看 agent 运行历史
 
 ## 前置条件
 
-至少装一个编程 agent：
+至少装一个 agent：
 
 <details>
 <summary><b>OpenCode</b>（推荐）</summary>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -682,13 +682,13 @@
   },
   "welcome": {
     "title": "Welcome to Avibe",
-    "subtitle": "Connect your favorite IM platforms and set up local AI agents that stay on your machine.",
+    "subtitle": "This machine is now home to your AI agent. Talk to it from the built-in Workbench — or connect Slack, Discord, Telegram, Lark, and WeChat.",
     "getStarted": "Get started",
     "card1Title": "Local-first",
     "card2Title": "Multi-platform",
     "card3Title": "Multi-agent",
     "feature1": "Your data + agents stay on your machine.",
-    "feature2": "Slack, Discord, Telegram, Lark, WeChat — one bot.",
+    "feature2": "Slack, Discord, Telegram, Lark, WeChat — one place.",
     "feature3": "Claude, OpenCode, Codex — route per channel."
   },
   "modeSelection": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -682,13 +682,13 @@
   },
   "welcome": {
     "title": "欢迎使用 Avibe",
-    "subtitle": "连接你常用的 IM 平台，并配置始终运行在本机上的本地 AI agent。",
+    "subtitle": "这台机器现在是你 AI 伙伴的家。用内置的 Workbench 就能和它对话，也可以接上 Slack、Discord、Telegram、飞书、微信。",
     "getStarted": "开始设置",
     "card1Title": "本地优先",
     "card2Title": "多平台",
     "card3Title": "多 Agent",
     "feature1": "数据与 Agent 都留在你自己的机器上。",
-    "feature2": "Slack、Discord、Telegram、飞书、微信，一个 bot 全搞定。",
+    "feature2": "Slack、Discord、Telegram、飞书、微信，一个入口全搞定。",
     "feature3": "Claude、OpenCode、Codex —— 按群/频道路由。"
   },
   "modeSelection": {


### PR DESCRIPTION
Avibe is a general local-first Agent OS, not coding-only. Drops the 'coding agent' framing (EN+ZH): hero header `Your coding agent`→`Your AI agent`, prerequisites `one coding agent`→`one agent`, and removes the 'Coding is the first strong workload' caveat line. Agent names (Claude Code/Codex/OpenCode) stay as examples. Docs-only; manual: `coding`/`编程` residual = 0.