### PR TITLE
fix(scripts): make incus_tenant scaffold Incus 6.0 compatible

### DIFF
--- a/scripts/incus_tenant.py
+++ b/scripts/incus_tenant.py
@@ -24,7 +24,7 @@ from typing import Sequence
 
 
 PROJECT_PREFIX = "vr-"
-INSTANCE_NAME = "vibe"
+INSTANCE_NAME_PREFIX = "vibe-"
 TENANT_USER = "vibey"
 TENANT_HOME = f"/home/{TENANT_USER}"
 TENANT_WORKDIR = f"{TENANT_HOME}/work"
@@ -89,6 +89,22 @@ class Runner:
             return False
         result = subprocess.run(list(command), text=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return result.returncode == 0
+
+
+def instance_name(tenant: str) -> str:
+    validate_tenant(tenant)
+    default = f"{INSTANCE_NAME_PREFIX}{tenant}"
+    if shutil.which("incus") is None:
+        return default
+    result = subprocess.run(
+        ["incus", "project", "get", project_name(tenant), "user.vibe_remote.instance_name"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    configured = result.stdout.strip() if result.returncode == 0 else ""
+    return configured or default
 
 
 def project_name(tenant: str) -> str:
@@ -198,7 +214,7 @@ def cloud_init_user_data(spec: TenantSpec) -> str:
     install_command = install_prefix + "curl -fsSL https://avibe.bot/install.sh | bash"
     runcmd = [
         ["mkdir", "-p", TENANT_WORKDIR, f"{TENANT_HOME}/.vibe_remote/config"],
-        ["chown", "-R", f"{TENANT_USER}:{TENANT_USER}", TENANT_WORKDIR, f"{TENANT_HOME}/.vibe_remote"],
+        ["chown", "-R", f"{TENANT_USER}:{TENANT_USER}", TENANT_HOME],
         ["su", "-", TENANT_USER, "-c", install_command],
         ["systemctl", "daemon-reload"],
         ["systemctl", "enable", "--now", "vibe-remote.service"],
@@ -234,7 +250,7 @@ def cloud_init_user_data(spec: TenantSpec) -> str:
         set -euo pipefail
         echo "tenant={spec.tenant}"
         echo "project={spec.project}"
-        echo "instance={INSTANCE_NAME}"
+        echo "instance={instance_name(spec.tenant)}"
         echo "ui=http://127.0.0.1:{spec.ui_port}"
         echo "workdir={TENANT_WORKDIR}"
         """
@@ -260,7 +276,7 @@ def cloud_init_user_data(spec: TenantSpec) -> str:
         "    lock_passwd: true",
         "write_files:",
         f"  - path: {TENANT_HOME}/.vibe_remote/config/config.json",
-        f"    owner: {TENANT_USER}:{TENANT_USER}",
+        "    owner: root:root",
         "    permissions: '0600'",
         "    content: |",
         yaml_block(config_json),
@@ -317,7 +333,6 @@ def project_create_config(spec: TenantSpec) -> list[str]:
         f"limits.cpu={spec.cpus}",
         f"limits.memory={spec.memory}",
         f"limits.processes={spec.processes}",
-        f"limits.disk.pool.{spec.storage_pool}={spec.disk}",
         f"user.vibe_remote.tenant={spec.tenant}",
         f"user.vibe_remote.instance_type={spec.instance_type}",
         f"user.vibe_remote.ui_host={spec.ui_host}",
@@ -382,7 +397,7 @@ def proxy_device_args(spec: TenantSpec) -> list[str]:
         "config",
         "device",
         "add",
-        INSTANCE_NAME,
+        instance_name(spec.tenant),
         "ui",
         "proxy",
         f"listen={tcp_endpoint(spec.ui_host, spec.ui_host_port)}",
@@ -394,12 +409,13 @@ def proxy_device_args(spec: TenantSpec) -> list[str]:
 
 
 def create_instance(runner: Runner, spec: TenantSpec) -> None:
-    if runner.exists(incus("info", INSTANCE_NAME, project=spec.project)):
+    name = instance_name(spec.tenant)
+    if runner.exists(incus("info", name, project=spec.project)):
         raise TenantError(f"Tenant instance already exists in project {spec.project}.")
     command = incus(
         "init",
         spec.image,
-        INSTANCE_NAME,
+        name,
         "--profile",
         "default",
         "--config",
@@ -411,7 +427,7 @@ def create_instance(runner: Runner, spec: TenantSpec) -> None:
     runner.run(command)
     if spec.ui_host_port:
         runner.run(incus(*proxy_device_args(spec), project=spec.project))
-    runner.run(incus("start", INSTANCE_NAME, project=spec.project))
+    runner.run(incus("start", name, project=spec.project))
 
 
 def cmd_create(args: argparse.Namespace) -> int:
@@ -442,12 +458,12 @@ def cmd_create(args: argparse.Namespace) -> int:
     print("")
     print(f"Tenant created: {spec.tenant}")
     print(f"Project: {spec.project}")
-    print(f"Instance: {INSTANCE_NAME}")
+    print(f"Instance: {instance_name(spec.tenant)}")
     print(f"Wait for setup: python3 scripts/incus_tenant.py wait-ready {spec.tenant}")
     if spec.ui_host_port:
         print(f"Web UI: http://{spec.ui_host}:{spec.ui_host_port}")
     else:
-        print(f"Web UI: incus --project {spec.project} exec {INSTANCE_NAME} -- vibe remote")
+        print(f"Web UI: incus --project {spec.project} exec {instance_name(spec.tenant)} -- vibe remote")
     return 0
 
 
@@ -455,11 +471,12 @@ def cmd_wait_ready(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    runner.run(incus("exec", INSTANCE_NAME, "--", "cloud-init", "status", "--wait", project=project))
+    name = instance_name(args.tenant)
+    runner.run(incus("exec", name, "--", "cloud-init", "status", "--wait", project=project))
     runner.run(
-        incus("exec", INSTANCE_NAME, "--", "systemctl", "is-active", "--quiet", "vibe-remote.service", project=project)
+        incus("exec", name, "--", "systemctl", "is-active", "--quiet", "vibe-remote.service", project=project)
     )
-    runner.run(incus("exec", INSTANCE_NAME, "--", "systemctl", "status", "vibe-remote", "--no-pager", project=project), check=False)
+    runner.run(incus("exec", name, "--", "systemctl", "status", "vibe-remote", "--no-pager", project=project), check=False)
     return 0
 
 
@@ -467,7 +484,7 @@ def cmd_lifecycle(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    runner.run(incus(args.action, INSTANCE_NAME, project=project))
+    runner.run(incus(args.action, instance_name(args.tenant), project=project))
     return 0
 
 
@@ -475,7 +492,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    runner.run(incus("restart", INSTANCE_NAME, project=project))
+    runner.run(incus("restart", instance_name(args.tenant), project=project))
     return 0
 
 
@@ -485,8 +502,8 @@ def cmd_status(args: argparse.Namespace) -> int:
     runner = Runner(dry_run=args.dry_run)
     checks = [
         ("instance list", incus("list", project=project)),
-        ("tenant info", incus("exec", INSTANCE_NAME, "--", "vibe-tenant-info", project=project)),
-        ("vibe status", incus("exec", INSTANCE_NAME, "--", *tenant_user_bash("vibe status"), project=project)),
+        ("tenant info", incus("exec", instance_name(args.tenant), "--", "vibe-tenant-info", project=project)),
+        ("vibe status", incus("exec", instance_name(args.tenant), "--", *tenant_user_bash("vibe status"), project=project)),
     ]
     failed: list[str] = []
     for name, command in checks:
@@ -518,7 +535,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    runner.run(incus("exec", INSTANCE_NAME, "--", *tenant_user_bash("exec bash -l"), project=project))
+    runner.run(incus("exec", instance_name(args.tenant), "--", *tenant_user_bash("exec bash -l"), project=project))
     return 0
 
 
@@ -532,7 +549,7 @@ def cmd_exec(args: argparse.Namespace) -> int:
     runner.run(
         incus(
             "exec",
-            INSTANCE_NAME,
+            instance_name(args.tenant),
             "--",
             *tenant_user_bash('exec "$@"', *command),
             project=project,
@@ -561,15 +578,16 @@ def cmd_delete(args: argparse.Namespace) -> int:
             raise TenantError("Confirmation did not match; aborting.")
     runner = Runner(dry_run=args.dry_run)
     if args.dry_run:
-        runner.run(incus("delete", INSTANCE_NAME, "--force", project=project))
+        runner.run(incus("delete", instance_name(args.tenant), "--force", project=project))
         runner.run(incus("project", "delete", project))
         return 0
     if not runner.exists(incus("project", "show", project)):
         raise TenantError(f"Tenant project {project} does not exist.")
-    if runner.exists(incus("info", INSTANCE_NAME, project=project)):
-        runner.run(incus("delete", INSTANCE_NAME, "--force", project=project))
+    name = instance_name(args.tenant)
+    if runner.exists(incus("info", name, project=project)):
+        runner.run(incus("delete", name, "--force", project=project))
     else:
-        print(f"Tenant instance {INSTANCE_NAME} is already absent in project {project}.", file=sys.stderr)
+        print(f"Tenant instance {name} is already absent in project {project}.", file=sys.stderr)
     runner.run(incus("project", "delete", project))
     return 0
 

--- a/scripts/incus_tenant.py
+++ b/scripts/incus_tenant.py
@@ -25,6 +25,7 @@ from typing import Sequence
 
 PROJECT_PREFIX = "vr-"
 INSTANCE_NAME_PREFIX = "vibe-"
+LEGACY_INSTANCE_NAME = "vibe"
 TENANT_USER = "vibey"
 TENANT_HOME = f"/home/{TENANT_USER}"
 TENANT_WORKDIR = f"{TENANT_HOME}/work"
@@ -91,20 +92,41 @@ class Runner:
         return result.returncode == 0
 
 
-def instance_name(tenant: str) -> str:
+def default_instance_name(tenant: str) -> str:
+    """The per-tenant instance name used for newly created tenants."""
     validate_tenant(tenant)
-    default = f"{INSTANCE_NAME_PREFIX}{tenant}"
-    if shutil.which("incus") is None:
-        return default
-    result = subprocess.run(
-        ["incus", "project", "get", project_name(tenant), "user.vibe_remote.instance_name"],
+    return f"{INSTANCE_NAME_PREFIX}{tenant}"
+
+
+def _incus_query(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         check=False,
     )
-    configured = result.stdout.strip() if result.returncode == 0 else ""
-    return configured or default
+
+
+def instance_name(tenant: str, *, dry_run: bool = False) -> str:
+    """Resolve the incus instance name for managing an existing tenant.
+
+    Resolution order: an explicit ``user.vibe_remote.instance_name`` project
+    override, then the legacy shared ``vibe`` instance (tenants created before
+    per-tenant names had no override), then the per-tenant default. Dry runs stay
+    purely local and never touch the incus daemon.
+    """
+    default = default_instance_name(tenant)
+    if dry_run or shutil.which("incus") is None:
+        return default
+    project = project_name(tenant)
+    override = _incus_query(incus("project", "get", project, "user.vibe_remote.instance_name"))
+    configured = override.stdout.strip() if override.returncode == 0 else ""
+    if configured:
+        return configured
+    if _incus_query(incus("info", LEGACY_INSTANCE_NAME, project=project)).returncode == 0:
+        return LEGACY_INSTANCE_NAME
+    return default
 
 
 def project_name(tenant: str) -> str:
@@ -250,7 +272,7 @@ def cloud_init_user_data(spec: TenantSpec) -> str:
         set -euo pipefail
         echo "tenant={spec.tenant}"
         echo "project={spec.project}"
-        echo "instance={instance_name(spec.tenant)}"
+        echo "instance={default_instance_name(spec.tenant)}"
         echo "ui=http://127.0.0.1:{spec.ui_port}"
         echo "workdir={TENANT_WORKDIR}"
         """
@@ -397,7 +419,7 @@ def proxy_device_args(spec: TenantSpec) -> list[str]:
         "config",
         "device",
         "add",
-        instance_name(spec.tenant),
+        default_instance_name(spec.tenant),
         "ui",
         "proxy",
         f"listen={tcp_endpoint(spec.ui_host, spec.ui_host_port)}",
@@ -409,7 +431,7 @@ def proxy_device_args(spec: TenantSpec) -> list[str]:
 
 
 def create_instance(runner: Runner, spec: TenantSpec) -> None:
-    name = instance_name(spec.tenant)
+    name = default_instance_name(spec.tenant)
     if runner.exists(incus("info", name, project=spec.project)):
         raise TenantError(f"Tenant instance already exists in project {spec.project}.")
     command = incus(
@@ -458,12 +480,12 @@ def cmd_create(args: argparse.Namespace) -> int:
     print("")
     print(f"Tenant created: {spec.tenant}")
     print(f"Project: {spec.project}")
-    print(f"Instance: {instance_name(spec.tenant)}")
+    print(f"Instance: {default_instance_name(spec.tenant)}")
     print(f"Wait for setup: python3 scripts/incus_tenant.py wait-ready {spec.tenant}")
     if spec.ui_host_port:
         print(f"Web UI: http://{spec.ui_host}:{spec.ui_host_port}")
     else:
-        print(f"Web UI: incus --project {spec.project} exec {instance_name(spec.tenant)} -- vibe remote")
+        print(f"Web UI: incus --project {spec.project} exec {default_instance_name(spec.tenant)} -- vibe remote")
     return 0
 
 
@@ -471,7 +493,7 @@ def cmd_wait_ready(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    name = instance_name(args.tenant)
+    name = instance_name(args.tenant, dry_run=args.dry_run)
     runner.run(incus("exec", name, "--", "cloud-init", "status", "--wait", project=project))
     runner.run(
         incus("exec", name, "--", "systemctl", "is-active", "--quiet", "vibe-remote.service", project=project)
@@ -484,7 +506,7 @@ def cmd_lifecycle(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    runner.run(incus(args.action, instance_name(args.tenant), project=project))
+    runner.run(incus(args.action, instance_name(args.tenant, dry_run=args.dry_run), project=project))
     return 0
 
 
@@ -492,7 +514,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    runner.run(incus("restart", instance_name(args.tenant), project=project))
+    runner.run(incus("restart", instance_name(args.tenant, dry_run=args.dry_run), project=project))
     return 0
 
 
@@ -500,10 +522,11 @@ def cmd_status(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
+    inst = instance_name(args.tenant, dry_run=args.dry_run)
     checks = [
         ("instance list", incus("list", project=project)),
-        ("tenant info", incus("exec", instance_name(args.tenant), "--", "vibe-tenant-info", project=project)),
-        ("vibe status", incus("exec", instance_name(args.tenant), "--", *tenant_user_bash("vibe status"), project=project)),
+        ("tenant info", incus("exec", inst, "--", "vibe-tenant-info", project=project)),
+        ("vibe status", incus("exec", inst, "--", *tenant_user_bash("vibe status"), project=project)),
     ]
     failed: list[str] = []
     for name, command in checks:
@@ -535,7 +558,7 @@ def cmd_shell(args: argparse.Namespace) -> int:
     maybe_require_incus(args)
     project = project_name(args.tenant)
     runner = Runner(dry_run=args.dry_run)
-    runner.run(incus("exec", instance_name(args.tenant), "--", *tenant_user_bash("exec bash -l"), project=project))
+    runner.run(incus("exec", instance_name(args.tenant, dry_run=args.dry_run), "--", *tenant_user_bash("exec bash -l"), project=project))
     return 0
 
 
@@ -549,7 +572,7 @@ def cmd_exec(args: argparse.Namespace) -> int:
     runner.run(
         incus(
             "exec",
-            instance_name(args.tenant),
+            instance_name(args.tenant, dry_run=args.dry_run),
             "--",
             *tenant_user_bash('exec "$@"', *command),
             project=project,
@@ -578,12 +601,12 @@ def cmd_delete(args: argparse.Namespace) -> int:
             raise TenantError("Confirmation did not match; aborting.")
     runner = Runner(dry_run=args.dry_run)
     if args.dry_run:
-        runner.run(incus("delete", instance_name(args.tenant), "--force", project=project))
+        runner.run(incus("delete", instance_name(args.tenant, dry_run=args.dry_run), "--force", project=project))
         runner.run(incus("project", "delete", project))
         return 0
     if not runner.exists(incus("project", "show", project)):
         raise TenantError(f"Tenant project {project} does not exist.")
-    name = instance_name(args.tenant)
+    name = instance_name(args.tenant, dry_run=args.dry_run)
     if runner.exists(incus("info", name, project=project)):
         runner.run(incus("delete", name, "--force", project=project))
     else:

--- a/tests/test_incus_tenant_scaffold.py
+++ b/tests/test_incus_tenant_scaffold.py
@@ -101,6 +101,53 @@ def test_instance_name_defaults_to_per_tenant_slug(monkeypatch):
     assert incus_tenant.instance_name("demo-01") == "vibe-demo-01"
 
 
+def _fake_incus_query(*, override="", legacy_exists=False):
+    def run(command):
+        joined = " ".join(command)
+        if "user.vibe_remote.instance_name" in joined:
+            return subprocess.CompletedProcess(command, 0 if override else 1, override, "")
+        if "info" in command:
+            return subprocess.CompletedProcess(command, 0 if legacy_exists else 1, "", "")
+        return subprocess.CompletedProcess(command, 1, "", "")
+
+    return run
+
+
+def test_instance_name_prefers_project_override(monkeypatch):
+    monkeypatch.setattr(incus_tenant.shutil, "which", lambda name: "/usr/bin/incus")
+    monkeypatch.setattr(incus_tenant, "_incus_query", _fake_incus_query(override="renamed-demo"))
+
+    assert incus_tenant.instance_name("demo-01") == "renamed-demo"
+
+
+def test_instance_name_falls_back_to_legacy_vibe(monkeypatch):
+    # Tenants created before per-tenant names have a "vibe" instance and no
+    # override; management commands must still target it instead of vibe-<tenant>.
+    monkeypatch.setattr(incus_tenant.shutil, "which", lambda name: "/usr/bin/incus")
+    monkeypatch.setattr(incus_tenant, "_incus_query", _fake_incus_query(legacy_exists=True))
+
+    assert incus_tenant.instance_name("demo-01") == "vibe"
+
+
+def test_instance_name_defaults_when_no_legacy_instance(monkeypatch):
+    monkeypatch.setattr(incus_tenant.shutil, "which", lambda name: "/usr/bin/incus")
+    monkeypatch.setattr(incus_tenant, "_incus_query", _fake_incus_query(legacy_exists=False))
+
+    assert incus_tenant.instance_name("demo-01") == "vibe-demo-01"
+
+
+def test_instance_name_dry_run_never_touches_incus(monkeypatch):
+    # Dry-run planning must not depend on the incus daemon/permissions.
+    monkeypatch.setattr(incus_tenant.shutil, "which", lambda name: "/usr/bin/incus")
+
+    def explode(command):
+        raise AssertionError(f"dry-run must not call incus: {command}")
+
+    monkeypatch.setattr(incus_tenant, "_incus_query", explode)
+
+    assert incus_tenant.instance_name("demo-01", dry_run=True) == "vibe-demo-01"
+
+
 def test_parser_accepts_create_dry_run():
     parser = incus_tenant.build_parser()
     args = parser.parse_args(

--- a/tests/test_incus_tenant_scaffold.py
+++ b/tests/test_incus_tenant_scaffold.py
@@ -58,6 +58,10 @@ def test_cloud_init_configures_vibe_user_service_and_ui():
     assert '"setup_port": 5123' in data
     assert '"default_backend": "codex"' in data
     assert "https://avibe.bot/install.sh" in data
+    # The installer runs as vibey, so cloud-init must own the whole home (not just
+    # work/ + .vibe_remote) and write the root-created config as root before chown.
+    assert '"/home/vibey"]' in data
+    assert "owner: root:root" in data
 
 
 def test_profile_yaml_sets_resources_and_devices():
@@ -79,6 +83,22 @@ def test_project_create_config_uses_vm_limit_for_vm():
     assert "user.vibe_remote.ui_host=127.0.0.1" in config
     assert "restricted=true" in config
     assert "restricted.devices.proxy=allow" in config
+
+
+def test_project_create_config_omits_invalid_disk_pool_key():
+    # `limits.disk.pool.<pool>` is not a valid Incus 6.0 project config key and
+    # makes `incus project create` fail; root disk size lives on the profile.
+    config = incus_tenant.project_create_config(tenant_spec(disk="50GiB"))
+
+    assert not any(item.startswith("limits.disk.pool") for item in config)
+
+
+def test_instance_name_defaults_to_per_tenant_slug(monkeypatch):
+    # Per-tenant instance names avoid DNS collisions on the shared incus bridge;
+    # with no incus binary present it falls back to the prefixed slug.
+    monkeypatch.setattr(incus_tenant.shutil, "which", lambda name: None)
+
+    assert incus_tenant.instance_name("demo-01") == "vibe-demo-01"
 
 
 def test_parser_accepts_create_dry_run():
@@ -300,6 +320,7 @@ def test_wait_ready_checks_tenant_service_active(monkeypatch):
             return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(incus_tenant, "Runner", RecordingRunner)
+    monkeypatch.setattr(incus_tenant.shutil, "which", lambda name: None)
 
     assert incus_tenant.cmd_wait_ready(argparse.Namespace(tenant="demo-01", dry_run=True)) == 0
     assert [
@@ -307,7 +328,7 @@ def test_wait_ready_checks_tenant_service_active(monkeypatch):
         "--project",
         "vr-demo-01",
         "exec",
-        "vibe",
+        "vibe-demo-01",
         "--",
         "systemctl",
         "is-active",
@@ -331,10 +352,11 @@ def test_delete_returns_error_when_project_missing(monkeypatch):
         incus_tenant.cmd_delete(argparse.Namespace(tenant="demo-01", yes=True, dry_run=False))
 
 
-def test_delete_dry_run_prints_cleanup_plan(capsys):
+def test_delete_dry_run_prints_cleanup_plan(monkeypatch, capsys):
+    monkeypatch.setattr(incus_tenant.shutil, "which", lambda name: None)
     exit_code = incus_tenant.main(["delete", "--dry-run", "-y", "demo-01"])
 
     assert exit_code == 0
     output = capsys.readouterr().out
-    assert "incus --project vr-demo-01 delete vibe --force" in output
+    assert "incus --project vr-demo-01 delete vibe-demo-01 --force" in output
     assert "incus project delete vr-demo-01" in output


### PR DESCRIPTION
## Capability

Make the `scripts/incus_tenant.py` tenant scaffold work on **Incus 6.0** hosts
out of the box. The scaffold had drifted from reality: bootstrapping real hosts
required hand-patching the copy on each machine, and `master` would still fail a
fresh `create` on Incus 6.0. This ports those validated fixes back into the repo.

## Changes

- **Drop invalid `limits.disk.pool.<pool>` project key.** Incus 6.0 rejects this
  key in `incus project create`, so `create` aborted before doing anything. Root
  disk size already lives on the profile root device (`profile_yaml`), so removing
  the project-level key is sufficient and correct.
- **Per-tenant instance names.** Instances are now named `vibe-<tenant>` (with an
  optional `user.vibe_remote.instance_name` project override) instead of the
  shared constant `vibe`, which collided on the shared `incusbr0` bridge DNS when
  more than one tenant ran on a host.
- **Fix cloud-init home ownership.** chown the whole tenant home and write the
  initial `config.json` as `root` (then chown), so the vibey-run installer no
  longer trips over a root-owned `/home/vibey`.

## Evidence

- **Unit:** `tests/test_incus_tenant_scaffold.py` updated + extended — new
  assertions that `project_create_config` emits no `limits.disk.pool*` key, that
  `instance_name()` returns the per-tenant slug, and that cloud-init chowns the
  full home / writes config as root. Existing instance-name assumptions updated.
  `ruff check` clean; 23 passed locally.
- **Manual / production:** the equivalent patched scaffold was used to bootstrap
  and create live tenants on Incus 6.0 hosts (claude-sg, and a fresh `demo`
  tenant on claude-sg2); `create --dry-run` confirms no `limits.disk.pool` key and
  `vibe-<tenant>` instance naming.
- **Scenario / contract:** n/a — no scenario catalog covers this ops script.
