### PR TITLE
feat(ui): make the setup wizard responsive on mobile

### DIFF
--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -291,7 +291,7 @@ export const Wizard: React.FC = () => {
   const progressIndex = steps.findIndex((step) => step.id === stepId);
 
   return (
-    <div className={clsx('min-h-screen px-4 py-6 text-foreground md:px-10 md:py-10', wizardGlowClass)}>
+    <div className={clsx('min-h-screen px-5 py-7 text-foreground md:px-10 md:py-10', wizardGlowClass)}>
       <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-[1280px] flex-col gap-8">
         <WizardChrome
           current={Math.max(0, progressIndex)}

--- a/ui/src/components/steps/AgentDetection.tsx
+++ b/ui/src/components/steps/AgentDetection.tsx
@@ -493,7 +493,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
 
         {Inner}
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           {onBack ? (
             <Button
               type="button"
@@ -508,7 +508,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
           ) : (
             <span />
           )}
-          <div className="flex flex-col items-end gap-1.5">
+          <div className="flex flex-1 flex-col items-end gap-1.5 sm:flex-none">
             {opencodeNeedsPermission && (
               <p className="text-right text-[12px] text-gold">
                 {t('agentDetection.permissionGateHint')}
@@ -520,6 +520,7 @@ export const AgentDetection: React.FC<AgentDetectionProps> = ({ data, onNext, on
               size="default"
               onClick={() => void handlePrimaryAction()}
               disabled={!canContinue || syncing}
+              className="w-full sm:w-auto"
             >
               {t('common.continue')}
               <ArrowRight size={14} strokeWidth={2.25} />

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -940,7 +940,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               </div>
               <p className="text-[12px] text-muted">{t('wechat.noChannels')}</p>
             </div>
-            <div className="flex items-center justify-between border-t border-border pt-4">
+            <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
               <Button
                 type="button"
                 variant="secondary"
@@ -956,6 +956,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 variant="brand"
                 size="default"
                 onClick={() => onNext && onNext({})}
+                className="flex-1 sm:flex-none"
               >
                 {t('common.continue')}
                 <ArrowRight size={14} strokeWidth={2.25} />
@@ -1228,7 +1229,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                   <HelpCircle size={13} />
                   {t('channelList.cantFindChannel')}
                 </span>
-                <span className="pointer-events-none absolute bottom-full left-0 z-10 mb-2 w-64 whitespace-normal rounded bg-text px-3 py-2 text-xs text-bg opacity-0 shadow-lg transition-opacity group-hover:opacity-100">
+                <span className="pointer-events-none absolute bottom-full left-0 z-10 mb-2 w-[min(16rem,calc(100vw-2.5rem))] whitespace-normal rounded bg-text px-3 py-2 text-xs text-bg opacity-0 shadow-lg transition-opacity group-hover:opacity-100">
                   {pageTab === 'discord'
                     ? t('channelList.discordInviteBotHint')
                     : pageTab === 'lark'
@@ -1577,7 +1578,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 <HelpCircle size={14} />
                 {t('channelList.cantFindChannel')}
               </span>
-              <span className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-text text-bg text-xs rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 w-64 whitespace-normal">
+              <span className="absolute bottom-full left-0 mb-2 px-3 py-2 bg-text text-bg text-xs rounded shadow-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 w-[min(16rem,calc(100vw-2.5rem))] whitespace-normal">
                 {platform === 'discord'
                   ? t('channelList.discordInviteBotHint')
                   : platform === 'lark'
@@ -1702,19 +1703,19 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
           const codexAgents = codexAgentsByCwd[effectiveCwd] || [];
           return (
             <div key={channel.id} className="rounded-xl border border-border bg-surface-3/60 p-4 transition-colors hover:border-border-strong hover:bg-surface-2/70">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 flex-1 items-center gap-3">
                   <button
                     onClick={() => updateConfig(channel.id, { enabled: !channelConfig.enabled })}
-                    className={channelConfig.enabled ? 'text-accent' : 'text-muted'}
+                    className={clsx('shrink-0', channelConfig.enabled ? 'text-accent' : 'text-muted')}
                   >
                     {channelConfig.enabled ? <CheckSquare size={20} /> : <Square size={20} />}
                   </button>
-                  <div>
+                  <div className="min-w-0">
                     <div className="flex items-center gap-1 font-medium text-foreground">
-                      <Hash size={14} className="text-muted" /> {channel.name}
+                      <Hash size={14} className="shrink-0 text-muted" /> <span className="truncate">{channel.name}</span>
                     </div>
-                    <div className="text-xs text-muted font-mono">ID: {channel.id}</div>
+                    <div className="truncate text-xs text-muted font-mono">ID: {channel.id}</div>
                     {platform === 'telegram' && (channel.username || channel.last_seen_at) && (
                       <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted">
                         {channel.username && <span>@{channel.username}</span>}
@@ -1727,7 +1728,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                 </div>
                 <span
                   className={clsx(
-                    'text-xs px-2 py-0.5 rounded-full border',
+                    'shrink-0 whitespace-nowrap text-xs px-2 py-0.5 rounded-full border',
                     platform === 'discord'
                       ? 'bg-surface text-foreground border-border'
                       : platform === 'telegram'
@@ -1789,7 +1790,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       </div>
 
       {!isPage && (
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -1804,6 +1805,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             type="button"
             variant="brand"
             size="default"
+            className="flex-1 sm:flex-none"
             onClick={() => {
               const discordGuildAllowlist = selectedGuildIds;
               if (isWizardMultiPlatform) {

--- a/ui/src/components/steps/DiscordConfig.tsx
+++ b/ui/src/components/steps/DiscordConfig.tsx
@@ -468,7 +468,7 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
 
         <div className="flex flex-col gap-3">{stepShells}</div>
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -485,6 +485,7 @@ export const DiscordConfig: React.FC<DiscordConfigProps> = ({ data, onNext, onBa
             size="default"
             onClick={() => onNext(buildSubmitData())}
             disabled={!isValid}
+            className="flex-1 sm:flex-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />

--- a/ui/src/components/steps/LarkConfig.tsx
+++ b/ui/src/components/steps/LarkConfig.tsx
@@ -557,7 +557,7 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
 
         {bodyContent}
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -577,6 +577,7 @@ export const LarkConfig: React.FC<LarkConfigProps> = ({ data, onNext, onBack, em
               onNext(buildSubmitData());
             }}
             disabled={!isValid}
+            className="flex-1 sm:flex-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
-import { ArrowLeft, ArrowRight, Check, CircleCheckBig, ExternalLink, Loader2, Lock, Plus, Smartphone } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Check, Circle, CircleCheckBig, ExternalLink, Loader2, Lock, Plus, Smartphone } from 'lucide-react';
 import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import {
@@ -499,7 +499,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
       <WizardCard className="gap-8">
         <div className="flex flex-col gap-3">
           <EyebrowBadge tone="mint">{t('platform.eyebrow')}</EyebrowBadge>
-          <h2 className="text-[34px] font-bold leading-[1.1] tracking-[-0.6px] text-foreground">
+          <h2 className="text-[26px] font-bold leading-[1.15] tracking-[-0.6px] text-foreground sm:text-[34px] sm:leading-[1.1]">
             {t('platform.title')}
           </h2>
           <p className="max-w-[680px] text-[15px] leading-[1.5] text-muted">{t('platform.subtitle')}</p>
@@ -539,7 +539,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
                 {t('platform.optionalLabel')}
               </span>
             </div>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3 sm:gap-3">
               {chatPlatforms.map((platform) => {
                 const option = platform.id;
                 const active = selected.includes(option);
@@ -553,7 +553,9 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
                     key={option}
                     onClick={() => togglePlatform(option)}
                     className={clsx(
-                      'flex flex-col items-center gap-2.5 rounded-xl px-4 py-5 transition-colors',
+                      // Phone: a full-width row (icon · name · select indicator).
+                      // sm+: the design's centered vertical tile in a 3-col grid.
+                      'flex flex-row items-center gap-3 rounded-xl px-4 py-3 text-left transition-colors sm:flex-col sm:gap-2.5 sm:py-5 sm:text-center',
                       active
                         ? 'border-2 border-mint bg-mint/[0.16]'
                         : 'border border-foreground/[0.08] bg-background hover:border-foreground/[0.16] hover:bg-foreground/[0.02]'
@@ -561,7 +563,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
                   >
                     <span
                       className={clsx(
-                        'inline-flex size-11 items-center justify-center rounded-[10px] border',
+                        'inline-flex size-11 shrink-0 items-center justify-center rounded-[10px] border',
                         tileTint.bg,
                         tileTint.border
                       )}
@@ -570,12 +572,19 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
                     </span>
                     <span
                       className={clsx(
-                        'text-[13px] leading-tight transition-colors',
+                        'text-[14px] leading-tight transition-colors sm:text-[13px]',
                         active ? 'font-bold text-foreground' : 'font-medium text-muted'
                       )}
                     >
                       {t(platform.title_key || `platform.${option}.title`)}
                     </span>
+                    {/* Selection indicator on the phone row only; on sm+ the
+                        mint border carries the selected state (design.pen). */}
+                    {active ? (
+                      <CircleCheckBig className="ml-auto size-5 shrink-0 text-mint sm:hidden" strokeWidth={2.25} />
+                    ) : (
+                      <Circle className="ml-auto size-5 shrink-0 text-muted/40 sm:hidden" strokeWidth={2} />
+                    )}
                   </button>
                 );
               })}
@@ -583,7 +592,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
           </div>
         </div>
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -599,6 +608,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
             variant="brand"
             size="default"
             onClick={() => void handleContinue()}
+            className="flex-1 sm:flex-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />

--- a/ui/src/components/steps/SlackConfig.tsx
+++ b/ui/src/components/steps/SlackConfig.tsx
@@ -385,7 +385,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
 
         <div className="flex flex-col gap-3">{stepShells}</div>
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -404,6 +404,7 @@ export const SlackConfig: React.FC<SlackConfigProps> = ({ data, onNext, onBack, 
               onNext({ slack: { ...data.slack, bot_token: botToken, app_token: appToken, proxy_url: proxyUrl || undefined }, mode: 'self_host' })
             }
             disabled={!isValid}
+            className="flex-1 sm:flex-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -200,7 +200,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
             <Check size={36} strokeWidth={2.4} />
           </div>
           <div className="space-y-2">
-            <h2 className="text-[38px] font-bold leading-tight tracking-[-0.7px] text-foreground">
+            <h2 className="text-[28px] font-bold leading-tight tracking-[-0.4px] text-foreground sm:text-[38px] sm:tracking-[-0.7px]">
               {t('summary.title')}
             </h2>
             <p className="mx-auto max-w-[600px] text-[15px] leading-[1.55] text-muted">
@@ -218,7 +218,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
               </div>
             </div>
             <div className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2.5">
-              <code className="flex-1 select-all font-mono text-[13px] text-foreground">bind {bindCode}</code>
+              <code className="min-w-0 flex-1 select-all break-all font-mono text-[13px] text-foreground">bind {bindCode}</code>
               <button
                 onClick={copyBindCode}
                 className="rounded-md p-1.5 text-muted transition hover:bg-foreground/[0.04] hover:text-foreground"
@@ -250,7 +250,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
           </div>
           <div className="space-y-2">
             <EyebrowBadge tone="mint">{t('summary.eyebrow')}</EyebrowBadge>
-            <h2 className="text-[38px] font-bold leading-tight tracking-[-0.7px] text-foreground">
+            <h2 className="text-[28px] font-bold leading-tight tracking-[-0.4px] text-foreground sm:text-[38px] sm:tracking-[-0.7px]">
               {t('summary.title')}
             </h2>
             <p className="mx-auto max-w-[600px] text-[15px] leading-[1.55] text-muted">
@@ -265,12 +265,15 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
             <div
               key={row.label}
               className={clsx(
-                'flex items-center justify-between gap-4 px-5 py-3.5',
+                'flex flex-col gap-1 px-5 py-3.5 sm:flex-row sm:items-center sm:justify-between sm:gap-4',
                 idx < recapRows.length - 1 && 'border-b border-border'
               )}
             >
               <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted">{row.label}</span>
-              <span className="truncate font-mono text-[12px] text-foreground" title={row.value}>
+              <span
+                className="min-w-0 break-words font-mono text-[12px] text-foreground sm:truncate"
+                title={row.value}
+              >
                 {row.value}
               </span>
             </div>
@@ -320,7 +323,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
           </div>
         )}
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -332,7 +335,7 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
             <ArrowLeft size={14} strokeWidth={2.25} />
             {t('common.back')}
           </Button>
-          <Button type="button" variant="brand" size="lg" onClick={saveAll} disabled={saving}>
+          <Button type="button" variant="brand" size="lg" onClick={saveAll} disabled={saving} className="flex-1 sm:flex-none">
             {saving ? t('common.saving') : t('summary.finishAndStart')}
             {!saving && <ArrowRight size={16} strokeWidth={2.25} />}
           </Button>

--- a/ui/src/components/steps/TelegramConfig.tsx
+++ b/ui/src/components/steps/TelegramConfig.tsx
@@ -433,7 +433,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
 
         <div className="flex flex-col gap-3">{stepShells}</div>
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -450,6 +450,7 @@ export const TelegramConfig: React.FC<TelegramConfigProps> = ({ data, onNext, on
             size="default"
             onClick={() => onNext(buildSubmitData())}
             disabled={!isValid}
+            className="flex-1 sm:flex-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />

--- a/ui/src/components/steps/WeChatConfig.tsx
+++ b/ui/src/components/steps/WeChatConfig.tsx
@@ -436,7 +436,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
 
         {bodyContent}
 
-        <div className="flex items-center justify-between border-t border-border pt-4">
+        <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
           <Button
             type="button"
             variant="secondary"
@@ -453,6 +453,7 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({ data, onNext, onBack
             size="default"
             onClick={() => onNext(buildSubmitData())}
             disabled={!canProceed}
+            className="flex-1 sm:flex-none"
           >
             {t('common.continue')}
             <ArrowRight size={14} strokeWidth={2.25} />

--- a/ui/src/components/steps/Welcome.tsx
+++ b/ui/src/components/steps/Welcome.tsx
@@ -52,7 +52,7 @@ export const Welcome: React.FC<WelcomeProps> = ({ onNext }) => {
 
         {/* welHead (OpTFX) gap 14 */}
         <div className="flex flex-col items-center gap-3.5">
-          <h1 className="text-[42px] font-bold leading-[1.05] tracking-[-0.8px] text-foreground">
+          <h1 className="text-[28px] font-bold leading-[1.1] tracking-[-0.4px] text-foreground sm:text-[42px] sm:leading-[1.05] sm:tracking-[-0.8px]">
             {t('welcome.title')}
           </h1>
           <p className="max-w-[680px] text-[16px] leading-[1.55] text-muted">

--- a/ui/src/components/visual/WizardCard.tsx
+++ b/ui/src/components/visual/WizardCard.tsx
@@ -23,10 +23,14 @@ export const WizardCard: React.FC<WizardCardProps> = ({
 }) => (
   <div
     className={cn(
-      'mx-auto flex w-full flex-col rounded-2xl border bg-surface-2',
-      'shadow-[0_32px_64px_-12px_rgba(91,255,160,0.078)]',
-      accent ? 'border-mint/35' : 'border-border',
-      size === 'hero' ? 'p-12 md:p-16' : 'px-6 py-8 md:px-12 md:py-10',
+      'mx-auto flex w-full flex-col',
+      // Card chrome (radius / border / surface / shadow) and the large inner
+      // padding kick in from sm up. On phones the wizard goes full-bleed on the
+      // page background with no card — matches the mobile wizard frames in
+      // design.pen (Tbqur / byTzd); the page gutter supplies the side spacing.
+      'sm:rounded-2xl sm:border sm:bg-surface-2 sm:shadow-[0_32px_64px_-12px_rgba(91,255,160,0.078)]',
+      accent ? 'sm:border-mint/35' : 'sm:border-border',
+      size === 'hero' ? 'sm:p-12 md:p-16' : 'sm:px-6 sm:py-8 md:px-12 md:py-10',
       className
     )}
     style={{ maxWidth: width }}


### PR DESCRIPTION
## Capability
Setup wizard (`/setup`) — **mobile responsiveness**. Makes the whole onboarding flow usable on phones, matching the mobile wizard frames in `design.pen` (`Tbqur` / `byTzd`, "Wizard Step: Platforms (Mobile)"). The ≥sm tablet/desktop layout is unchanged.

## What
- **WizardCard (shared shell):** below `sm` the card chrome (border / surface / shadow / radius) and large padding drop away — the wizard goes full-bleed on the page background, with the shell supplying a 20px gutter. This is the single biggest fix and benefits every step. At ≥sm the card is byte-for-byte the same.
- **Wizard shell:** adopt the design's 20/28px mobile gutter.
- **PlatformSelection:** platform tiles become full-width stacked rows (icon · name · trailing select indicator) on phones, reverting to the 3-col vertical-tile grid at sm+; responsive title size.
- **Per-step:** credential steps (Slack/Discord/Telegram/Lark/WeChat), Channels, Summary, Agents, Welcome — collapse rows to one column, clamp hover tooltips to the viewport (`w-[min(16rem,calc(100vw-2.5rem))]`), `truncate`/`min-w-0` long channel rows, responsive headings, and a full-width primary nav button on phones (`flex-1 sm:flex-none`) consistently across every step footer.

UI-only; no behavioral/logic changes.

## Evidence layers
- **Unit / contract / scenario:** none — responsive CSS only; no logic/behavior changed, no scenario catalog covers wizard layout.
- **Build:** `tsc -b && vite build` passes.
- **Review:** reviewer subagent pass — verified the ≥sm layout is pixel-identical, the arbitrary Tailwind class emits CSS in the v4 build, no leftover horizontal overflow in wizard paths, and footer parity across all steps.
- **Residual manual:** recommend dogfooding on a real phone / the regression env. The live wizard needs an *unconfigured* backend to render, so it was validated against the design frame + code rather than live in this pass.

## Design
Verified against `design.pen` mobile frame `Tbqur` (Platforms · Mobile · Dark). Other steps follow the same full-bleed / single-column pattern (design.pen has no per-step mobile frames beyond Platforms).