### PR TITLE
Delete historical tool call messages

### DIFF
--- a/storage/alembic/versions/20260608_0021_delete_message_tool_calls.py
+++ b/storage/alembic/versions/20260608_0021_delete_message_tool_calls.py
@@ -1,0 +1,26 @@
+"""delete historical message tool-call rows
+
+Revision ID: 20260608_0021
+Revises: 20260608_0020
+Create Date: 2026-06-08
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260608_0021"
+down_revision = "20260608_0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.exec_driver_sql("delete from messages where type = 'tool_call'")
+
+
+def downgrade() -> None:
+    # Tool-call rows are disposable trace data. This cleanup intentionally does
+    # not attempt to reconstruct deleted historical rows.
+    return None

--- a/storage/alembic/versions/20260608_0021_delete_message_tool_calls.py
+++ b/storage/alembic/versions/20260608_0021_delete_message_tool_calls.py
@@ -17,6 +17,20 @@ depends_on = None
 
 def upgrade() -> None:
     bind = op.get_bind()
+    bind.exec_driver_sql(
+        """
+        update show_session_events
+        set message_id = null
+        where message_id in (select id from messages where type = 'tool_call')
+        """
+    )
+    bind.exec_driver_sql(
+        """
+        update media_objects
+        set message_id = null
+        where message_id in (select id from messages where type = 'tool_call')
+        """
+    )
     bind.exec_driver_sql("delete from messages where type = 'tool_call'")
 
 

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -12,7 +12,7 @@ from config import paths
 from storage.db import create_sqlite_engine, sqlite_url
 
 INITIAL_REVISION = "20260501_0001"
-LATEST_SCHEMA_REVISION = "20260608_0020"
+LATEST_SCHEMA_REVISION = "20260608_0021"
 REMOVE_LEGACY_DEFAULT_AGENT_REVISION = "20260530_0008"
 INITIAL_TABLES = {
     "state_meta",

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -538,6 +538,22 @@ def _ensure_agent_events_indexes(conn: sqlite3.Connection, tables: set[str]) -> 
 def _delete_historical_message_tool_calls(conn: sqlite3.Connection, tables: set[str]) -> None:
     if "messages" not in tables:
         return
+    if "show_session_events" in tables:
+        conn.execute(
+            """
+            update show_session_events
+            set message_id = null
+            where message_id in (select id from messages where type = 'tool_call')
+            """
+        )
+    if "media_objects" in tables:
+        conn.execute(
+            """
+            update media_objects
+            set message_id = null
+            where message_id in (select id from messages where type = 'tool_call')
+            """
+        )
     conn.execute("delete from messages where type = 'tool_call'")
 
 

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -222,6 +222,7 @@ def _stamp_existing_initial_schema(db_path: Path, cfg: Config) -> None:
                 missing = _missing_head_schema_description(conn, tables)
                 raise RuntimeError(f"existing SQLite head schema is incomplete; missing: {missing}")
             _ensure_head_indexes(conn, tables)
+            _delete_historical_message_tool_calls(conn, tables)
             conn.commit()
             _run_remove_legacy_default_agent_migration(db_path)
             command.stamp(cfg, LATEST_SCHEMA_REVISION)
@@ -532,6 +533,12 @@ def _ensure_agent_events_indexes(conn: sqlite3.Connection, tables: set[str]) -> 
         "create index if not exists ix_agent_events_turn_sequence_id "
         "on agent_events (turn_id, sequence, id)"
     )
+
+
+def _delete_historical_message_tool_calls(conn: sqlite3.Connection, tables: set[str]) -> None:
+    if "messages" not in tables:
+        return
+    conn.execute("delete from messages where type = 'tool_call'")
 
 
 def _ensure_head_indexes(conn: sqlite3.Connection, tables: set[str]) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -237,6 +237,37 @@ def test_run_migrations_deletes_historical_message_tool_calls(tmp_path: Path) ->
                 )
             """
         )
+        conn.execute(
+            """
+            insert into show_session_events (
+                id, session_id, event_type, actor, scope, anchor_json, payload_json,
+                message_id, created_at
+            ) values
+                (
+                    'show_tool', 'ses_cleanup', 'annotation', 'agent', 'session',
+                    '{}', '{}', 'msg_tool', 'now'
+                ),
+                (
+                    'show_result', 'ses_cleanup', 'annotation', 'agent', 'session',
+                    '{}', '{}', 'msg_result', 'now'
+                )
+            """
+        )
+        conn.execute(
+            """
+            insert into media_objects (
+                token, scope_id, message_id, kind, source, local_path, created_at
+            ) values
+                (
+                    'media_tool', 'scope_cleanup', 'msg_tool', 'file', 'agent',
+                    '/tmp/tool.txt', 'now'
+                ),
+                (
+                    'media_result', 'scope_cleanup', 'msg_result', 'file', 'agent',
+                    '/tmp/result.txt', 'now'
+                )
+            """
+        )
         conn.commit()
 
     run_migrations(db_path)
@@ -245,8 +276,12 @@ def test_run_migrations_deletes_historical_message_tool_calls(tmp_path: Path) ->
     with sqlite3.connect(db_path) as conn:
         version = conn.execute("select version_num from alembic_version").fetchone()
         rows = conn.execute("select id, type from messages order by id").fetchall()
+        show_refs = conn.execute("select id, message_id from show_session_events order by id").fetchall()
+        media_refs = conn.execute("select token, message_id from media_objects order by token").fetchall()
     assert version == (HEAD_REVISION,)
     assert rows == [("msg_result", "result")]
+    assert show_refs == [("show_result", "msg_result"), ("show_tool", None)]
+    assert media_refs == [("media_result", "msg_result"), ("media_tool", None)]
 
 
 def test_run_migrations_deletes_tool_calls_when_stamping_unversioned_head_schema(tmp_path: Path) -> None:
@@ -285,6 +320,37 @@ def test_run_migrations_deletes_tool_calls_when_stamping_unversioned_head_schema
                 )
             """
         )
+        conn.execute(
+            """
+            insert into show_session_events (
+                id, session_id, event_type, actor, scope, anchor_json, payload_json,
+                message_id, created_at
+            ) values
+                (
+                    'show_stamp_tool', 'ses_stamp_cleanup', 'annotation', 'agent', 'session',
+                    '{}', '{}', 'msg_stamp_tool', 'now'
+                ),
+                (
+                    'show_stamp_result', 'ses_stamp_cleanup', 'annotation', 'agent', 'session',
+                    '{}', '{}', 'msg_stamp_result', 'now'
+                )
+            """
+        )
+        conn.execute(
+            """
+            insert into media_objects (
+                token, scope_id, message_id, kind, source, local_path, created_at
+            ) values
+                (
+                    'media_stamp_tool', 'scope_stamp_cleanup', 'msg_stamp_tool', 'file', 'agent',
+                    '/tmp/stamp-tool.txt', 'now'
+                ),
+                (
+                    'media_stamp_result', 'scope_stamp_cleanup', 'msg_stamp_result', 'file', 'agent',
+                    '/tmp/stamp-result.txt', 'now'
+                )
+            """
+        )
         conn.commit()
         assert conn.execute("select name from sqlite_master where name = 'alembic_version'").fetchone() is None
 
@@ -294,8 +360,12 @@ def test_run_migrations_deletes_tool_calls_when_stamping_unversioned_head_schema
     with sqlite3.connect(db_path) as conn:
         version = conn.execute("select version_num from alembic_version").fetchone()
         rows = conn.execute("select id, type from messages order by id").fetchall()
+        show_refs = conn.execute("select id, message_id from show_session_events order by id").fetchall()
+        media_refs = conn.execute("select token, message_id from media_objects order by token").fetchall()
     assert version == (HEAD_REVISION,)
     assert rows == [("msg_stamp_result", "result")]
+    assert show_refs == [("show_stamp_result", "msg_stamp_result"), ("show_stamp_tool", None)]
+    assert media_refs == [("media_stamp_result", "msg_stamp_result"), ("media_stamp_tool", None)]
 
 
 def test_run_migrations_runs_legacy_default_cleanup_when_stamping_existing_head_schema(tmp_path: Path) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -16,7 +16,7 @@ from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
 
 
-HEAD_REVISION = "20260608_0020"
+HEAD_REVISION = "20260608_0021"
 
 
 def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
@@ -203,6 +203,50 @@ def test_run_migrations_adds_agent_events_from_previous_head(tmp_path: Path) -> 
     assert "ix_agent_events_session_type_created_id" in agent_event_indexes
     assert "ix_agent_events_scope_created_id" in agent_event_indexes
     assert "ix_agent_events_turn_sequence_id" in agent_event_indexes
+
+
+def test_run_migrations_deletes_historical_message_tool_calls(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+
+    run_migrations(db_path, revision="20260608_0020")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            insert into scopes (
+                id, platform, scope_type, native_id, is_private, supports_threads,
+                metadata_json, first_seen_at, last_seen_at, updated_at
+            ) values (
+                'scope_cleanup', 'avibe', 'project', 'proj_cleanup', 0, 0,
+                '{}', 'now', 'now', 'now'
+            )
+            """
+        )
+        conn.execute(
+            """
+            insert into messages (
+                id, scope_id, session_id, platform, author, type, content_text,
+                content_json, metadata_json, created_at, updated_at
+            ) values
+                (
+                    'msg_tool', 'scope_cleanup', null, 'avibe', 'agent', 'tool_call',
+                    'ran tool', '{"text":"ran tool"}', '{}', 'now', 'now'
+                ),
+                (
+                    'msg_result', 'scope_cleanup', null, 'avibe', 'agent', 'result',
+                    'done', '{"text":"done"}', '{}', 'now', 'now'
+                )
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute("select version_num from alembic_version").fetchone()
+        rows = conn.execute("select id, type from messages order by id").fetchall()
+    assert version == (HEAD_REVISION,)
+    assert rows == [("msg_result", "result")]
 
 
 def test_run_migrations_runs_legacy_default_cleanup_when_stamping_existing_head_schema(tmp_path: Path) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -249,6 +249,55 @@ def test_run_migrations_deletes_historical_message_tool_calls(tmp_path: Path) ->
     assert rows == [("msg_result", "result")]
 
 
+def test_run_migrations_deletes_tool_calls_when_stamping_unversioned_head_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    engine = create_sqlite_engine(db_path)
+    try:
+        metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            insert into scopes (
+                id, platform, scope_type, native_id, is_private, supports_threads,
+                metadata_json, first_seen_at, last_seen_at, updated_at
+            ) values (
+                'scope_stamp_cleanup', 'avibe', 'project', 'proj_stamp_cleanup', 0, 0,
+                '{}', 'now', 'now', 'now'
+            )
+            """
+        )
+        conn.execute(
+            """
+            insert into messages (
+                id, scope_id, session_id, platform, author, type, content_text,
+                content_json, metadata_json, created_at, updated_at
+            ) values
+                (
+                    'msg_stamp_tool', 'scope_stamp_cleanup', null, 'avibe', 'agent', 'tool_call',
+                    'ran tool', '{"text":"ran tool"}', '{}', 'now', 'now'
+                ),
+                (
+                    'msg_stamp_result', 'scope_stamp_cleanup', null, 'avibe', 'agent', 'result',
+                    'done', '{"text":"done"}', '{}', 'now', 'now'
+                )
+            """
+        )
+        conn.commit()
+        assert conn.execute("select name from sqlite_master where name = 'alembic_version'").fetchone() is None
+
+    run_migrations(db_path)
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute("select version_num from alembic_version").fetchone()
+        rows = conn.execute("select id, type from messages order by id").fetchall()
+    assert version == (HEAD_REVISION,)
+    assert rows == [("msg_stamp_result", "result")]
+
+
 def test_run_migrations_runs_legacy_default_cleanup_when_stamping_existing_head_schema(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     engine = create_sqlite_engine(db_path)


### PR DESCRIPTION
## Summary

- Add a follow-up migration that deletes historical `messages.type = 'tool_call'` rows.
- Null dependent `show_session_events.message_id` and `media_objects.message_id` references before deleting those messages.
- Run the same cleanup in the unversioned-head schema stamp path so direct stamping to the latest schema does not skip the data cleanup.
- Bump the SQLite schema head to `20260608_0021`.

## Scenario IDs

- `tool-call-agent-events-pr2`

## Evidence

- Unit: `uv run pytest tests/test_sqlite_state_migration.py::test_run_migrations_deletes_historical_message_tool_calls tests/test_sqlite_state_migration.py::test_run_migrations_deletes_tool_calls_when_stamping_unversioned_head_schema -q`
- Contract: `uv run ruff check storage/migrations.py storage/alembic/versions/20260608_0021_delete_message_tool_calls.py tests/test_sqlite_state_migration.py`
- Scenario: verified normal upgrade and unversioned-head stamp paths delete only historical `tool_call` message rows while preserving non-tool-call references.
- Residual manual checks: no UI/regression run; this PR is a SQLite cleanup migration.

## Dependency

- PR #504 is already merged and introduced `agent_events` plus the new `tool_call` write path.
