### PR TITLE
fix(show): rewrite prefixed fs runtime deps

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -653,6 +653,45 @@ def test_show_runtime_source_rewrites_dep_imports_to_public_paths(monkeypatch, t
     assert public_dep.headers["cache-control"] == "public, max-age=31536000, immutable"
 
 
+def test_show_runtime_source_rewrites_prefixed_fs_vite_cache_dep_imports(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(
+        body=(
+            f'import "/p/{share_id}/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/'
+            'abc123/ses123/deps/react-dom_client.js?v=d6d38251";'
+        ).encode("utf-8"),
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+            "etag": "source-etag",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/src/main.tsx?t=1780732068677",
+            base_url="http://127.0.0.1:5123",
+        )
+        public_dep = app.test_client().get(
+            "/_show-runtime/deps/d6d38251/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert b'"/_show-runtime/deps/d6d38251/react-dom_client.js"' in response.content
+    assert response.headers["cache-control"] == "no-store"
+    assert "etag" not in response.headers
+    assert public_dep.status_code == 200
+    assert manager.calls[-1][1] == (
+        "/sessions/ses123/app/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/"
+        "abc123/ses123/deps/react-dom_client.js?v=d6d38251"
+    )
+
+
 def test_show_runtime_source_preserves_dot_vite_dep_import_paths(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -87,7 +87,7 @@ _SHOW_RUNTIME_MODULE_SCRIPT_RE = re.compile(
 )
 _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
 _SHOW_RUNTIME_PUBLIC_DEP_RE = re.compile(
-    r"(?P<quote>['\"])(?P<path>(?:\.?/)?(?:node_modules/)?\.vite/deps/[^'\"?#]+)(?:\?v=(?P<version>[A-Za-z0-9_-]+))?(?P<rest>[^'\"]*)(?P=quote)"
+    r"(?P<quote>['\"])(?P<path>(?:(?:\.?/)?(?:node_modules/)?\.vite/deps/|[^'\"?#]*@fs/[^'\"?#]*/(?:\.vite-cache|vite-cache)/[^'\"?#]*/deps/)[^'\"?#]+)(?:\?v=(?P<version>[A-Za-z0-9_-]+))?(?P<rest>[^'\"]*)(?P=quote)"
 )
 _SHOW_RUNTIME_PUBLIC_DEP_SIBLING_RE = re.compile(
     r"(?P<quote>['\"])\./(?P<name>[A-Za-z0-9_.-]+\.js)(?:\?v=(?P<version>[A-Za-z0-9_-]+))?(?P<rest>[^'\"]*)(?P=quote)"
@@ -5644,6 +5644,9 @@ def _rewrite_show_runtime_public_deps(content: bytes, headers: dict[str, str], *
 
 
 def _normalize_show_runtime_dep_import_path(dep_path: str) -> str:
+    marker_index = dep_path.find("@fs/")
+    if marker_index >= 0:
+        return dep_path[marker_index:]
     if dep_path.startswith("/"):
         return dep_path[1:]
     if dep_path.startswith("./"):


### PR DESCRIPTION
## Summary
- rewrite prefixed Show Runtime `@fs/.../vite-cache/.../deps` imports to public dependency URLs
- normalize those imports back to runtime-local `@fs/...` paths when serving the public cache entry
- cover the public share URL shape emitted by Vite in Show Page tests

## Root cause
Public Show Pages can receive Vite-transformed source imports like `/p/<share>/@fs/.../vite-cache/.../deps/react-dom_client.js?v=<hash>`. The existing public dependency rewrite only matched `.vite/deps` style imports, so browsers still fetched session-scoped `@fs` URLs and paid the proxy plus redirect cost for large vendor chunks.

## Validation
- `uv run pytest tests/test_ui_show_pages.py -q`
- `uv run ruff check vibe/ui_server.py tests/test_ui_show_pages.py`
- `git diff --check`
