### PR TITLE
fix(ui): let the setup wizard scroll on mobile

### DIFF
--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -291,8 +291,18 @@ export const Wizard: React.FC = () => {
   const progressIndex = steps.findIndex((step) => step.id === stepId);
 
   return (
-    <div className={clsx('min-h-screen px-5 py-7 text-foreground md:px-10 md:py-10', wizardGlowClass)}>
-      <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-[1280px] flex-col gap-8">
+    <div
+      className={clsx(
+        // The mobile body is scroll-locked (index.css @media max-width:767px:
+        // html/body overflow-hidden) for the iOS keyboard fix. The wizard
+        // bypasses AppShell, so — like AppShell's <main> — it must be its own
+        // internal scroll container on phones, or tall steps strand the footer
+        // button below the fold. Desktop keeps normal document flow.
+        'h-[var(--app-shell-h)] overflow-y-auto px-5 py-7 text-foreground md:h-auto md:min-h-screen md:overflow-visible md:px-10 md:py-10',
+        wizardGlowClass
+      )}
+    >
+      <div className="mx-auto flex min-h-full max-w-[1280px] flex-col gap-8 md:min-h-[calc(100vh-4rem)]">
         <WizardChrome
           current={Math.max(0, progressIndex)}
           total={Math.max(progressTotal, 1)}


### PR DESCRIPTION
## Capability
Setup wizard (`/setup`) — **vertical scroll on mobile**. Follow-up bug fix to #503: the wizard was made full-bleed/single-column, but on a phone it still couldn't **scroll**, so any step taller than the viewport stranded its footer button (e.g. Welcome's "开始设置") below the fold with no way to reach it. Reported on step 1.

## Root cause
On phones the document is deliberately scroll-locked — `index.css` `@media (max-width:767px)` sets `html, body { height:100%; overflow:hidden }` (the iOS-Safari keyboard fix, so focusing an input can't fling the page). `AppShell` copes because its `<main>` is an internal `overflow-y-auto` scroller. But the wizard **bypasses AppShell** (`App` returns `<Outlet/>` for `/setup`) and had no scroll container of its own — its `min-h-screen` content was simply clipped by the locked body.

## Fix
Make the wizard root its own internal scroll container on phones, mirroring AppShell's exact pattern:
`h-[var(--app-shell-h)] overflow-y-auto` on mobile, reverting to normal document flow at md+ (`md:h-auto md:min-h-screen md:overflow-visible`). Inner wrapper: `min-h-full` on mobile / `md:min-h-[calc(100vh-4rem)]` on desktop. One-line-ish, in `Wizard.tsx`.

## Evidence layers
- **Unit / contract / scenario:** none — layout CSS only; no logic/behavior change.
- **Build:** `tsc -b && vite build` passes.
- **Browser-verified (this time live):** served the built dist and drove `/setup` headless at **390×460** with the mobile body-lock active (`body overflow:hidden`). The primary button started at `bottom:783px` — **below the 460px fold** (`belowFold:true`) — and after scrolling the wizard container it was **fully visible** (`buttonFullyVisible:true`). Welcome also renders cleanly full-bleed. Desktop (≥md) flow unchanged.
- **Residual manual:** please re-confirm on your actual phone across a couple of steps.