### PR TITLE
fix(watches): fuse store errors to stop retry storms

### DIFF
--- a/core/watches.py
+++ b/core/watches.py
@@ -400,13 +400,18 @@ class ManagedWatchService:
         self._active_tasks: dict[str, asyncio.Task] = {}
         self._active_pids: dict[str, int] = {}
         self._watch_started_at: dict[str, str] = {}
+        self._fused_watch_ids: set[str] = set()
+        self._store_error_fused = False
 
     def start(self) -> None:
         if self._running:
             return
         self._running = True
         self._reconcile_task = asyncio.create_task(self._watch_store())
-        self.reconcile_watches()
+        try:
+            self.reconcile_watches()
+        except Exception as exc:
+            self._fuse_store_after_error("initial_reconcile", exc)
 
     async def stop(self) -> None:
         self._running = False
@@ -428,6 +433,9 @@ class ManagedWatchService:
 
     async def _watch_store(self) -> None:
         while self._running:
+            if self._store_error_fused:
+                await asyncio.sleep(WATCH_RECONCILE_INTERVAL_SECONDS)
+                continue
             try:
                 if self.store.maybe_reload():
                     self.reconcile_watches()
@@ -435,13 +443,15 @@ class ManagedWatchService:
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.error("Managed watch reconcile failed: %s", exc, exc_info=True)
+                self._fuse_store_after_error("reconcile", exc)
             await asyncio.sleep(WATCH_RECONCILE_INTERVAL_SECONDS)
 
     def reconcile_watches(self) -> None:
+        if self._store_error_fused:
+            return
         desired_ids = {watch.id for watch in self.store.list_watches() if watch.enabled}
         for watch in self.store.list_watches():
-            if not watch.enabled or watch.id in self._active_tasks:
+            if not watch.enabled or watch.id in self._active_tasks or watch.id in self._fused_watch_ids:
                 continue
             task = asyncio.create_task(self._run_watch(watch.id))
             self._active_tasks[watch.id] = task
@@ -470,7 +480,31 @@ class ManagedWatchService:
                 "started_at": self._watch_started_at.get(watch_id),
                 "updated_at": now,
             }
-        self.runtime_store.write(payload)
+        try:
+            self.runtime_store.write(payload)
+        except Exception:
+            logger.exception("Failed to persist watch runtime state")
+
+    def _fuse_store_after_error(self, operation: str, exc: Exception, *, watch_id: str | None = None) -> None:
+        if watch_id is not None:
+            self._fused_watch_ids.add(watch_id)
+        self._store_error_fused = True
+        logger.error(
+            "Disabling watch store reconciliation after persistent store error "
+            "(watch_id=%s operation=%s): %s",
+            watch_id,
+            operation,
+            exc,
+            exc_info=True,
+        )
+
+    def _watch_store_call(self, watch_id: str, operation: str, callback) -> bool:
+        try:
+            callback()
+            return True
+        except Exception as exc:
+            self._fuse_store_after_error(operation, exc, watch_id=watch_id)
+            return False
 
     async def _run_watch(self, watch_id: str) -> None:
         lifetime_started = asyncio.get_running_loop().time()
@@ -478,7 +512,10 @@ class ManagedWatchService:
         self._write_runtime_state()
 
         while self._running:
-            self.store.maybe_reload()
+            if watch_id in self._fused_watch_ids:
+                return
+            if not self._watch_store_call(watch_id, "reload", self.store.maybe_reload):
+                return
             watch = self.store.get_watch(watch_id)
             if watch is None or not watch.enabled:
                 return
@@ -495,11 +532,15 @@ class ManagedWatchService:
                             f"{int(watch.lifetime_timeout_seconds)} second(s)."
                         ),
                     )
-                    self.store.mark_cycle_result(
+                    self._watch_store_call(
                         watch.id,
-                        exit_code=None,
-                        error=None,
-                        disable=True,
+                        "mark_cycle_result",
+                        lambda: self.store.mark_cycle_result(
+                            watch.id,
+                            exit_code=None,
+                            error=None,
+                            disable=True,
+                        ),
                     )
                     return
                 cycle_timeout = watch.timeout_seconds
@@ -510,7 +551,8 @@ class ManagedWatchService:
             else:
                 cycle_timeout = watch.timeout_seconds
 
-            self.store.mark_cycle_start(watch.id)
+            if not self._watch_store_call(watch.id, "mark_cycle_start", lambda: self.store.mark_cycle_start(watch.id)):
+                return
             try:
                 result = await self._run_cycle(watch, timeout_seconds=cycle_timeout)
             except asyncio.CancelledError:
@@ -527,13 +569,18 @@ class ManagedWatchService:
                 prompt = _build_prompt(watch.message or watch.prefix, result.stdout)
                 if prompt:
                     self._enqueue_hook(watch, prompt=prompt)
-                self.store.mark_cycle_result(
+                if not self._watch_store_call(
                     watch.id,
-                    exit_code=0,
-                    error=None,
-                    event_detected=True,
-                    disable=watch.mode == "once",
-                )
+                    "mark_cycle_result",
+                    lambda: self.store.mark_cycle_result(
+                        watch.id,
+                        exit_code=0,
+                        error=None,
+                        event_detected=True,
+                        disable=watch.mode == "once",
+                    ),
+                ):
+                    return
                 if watch.mode != "forever":
                     return
                 continue
@@ -541,7 +588,12 @@ class ManagedWatchService:
             if result.timed_out or result.exit_code == 124:
                 error_text = "timed out"
                 if watch.mode == "forever" and 124 in set(watch.retry_exit_codes):
-                    self.store.mark_cycle_result(watch.id, exit_code=124, error=error_text, disable=False)
+                    if not self._watch_store_call(
+                        watch.id,
+                        "mark_cycle_result",
+                        lambda: self.store.mark_cycle_result(watch.id, exit_code=124, error=error_text, disable=False),
+                    ):
+                        return
                     await asyncio.sleep(watch.retry_delay_seconds)
                     continue
                 self._enqueue_failure_hook(
@@ -549,17 +601,40 @@ class ManagedWatchService:
                     exit_code=124,
                     error_text=f"Watch timed out after {int(cycle_timeout)} second(s).",
                 )
-                self.store.mark_cycle_result(watch.id, exit_code=124, error=error_text, disable=True)
+                self._watch_store_call(
+                    watch.id,
+                    "mark_cycle_result",
+                    lambda: self.store.mark_cycle_result(watch.id, exit_code=124, error=error_text, disable=True),
+                )
                 return
 
             error_text = _squash_error(result.stderr) or f"watch command exited with status {result.exit_code}"
             if watch.mode == "forever" and result.exit_code in set(watch.retry_exit_codes):
-                self.store.mark_cycle_result(watch.id, exit_code=result.exit_code, error=error_text, disable=False)
+                if not self._watch_store_call(
+                    watch.id,
+                    "mark_cycle_result",
+                    lambda: self.store.mark_cycle_result(
+                        watch.id,
+                        exit_code=result.exit_code,
+                        error=error_text,
+                        disable=False,
+                    ),
+                ):
+                    return
                 await asyncio.sleep(watch.retry_delay_seconds)
                 continue
 
             self._enqueue_failure_hook(watch, exit_code=result.exit_code, error_text=error_text)
-            self.store.mark_cycle_result(watch.id, exit_code=result.exit_code, error=error_text, disable=True)
+            self._watch_store_call(
+                watch.id,
+                "mark_cycle_result",
+                lambda: self.store.mark_cycle_result(
+                    watch.id,
+                    exit_code=result.exit_code,
+                    error=error_text,
+                    disable=True,
+                ),
+            )
             return
 
     async def _run_cycle(self, watch: ManagedWatch, *, timeout_seconds: float) -> _CycleResult:

--- a/core/watches.py
+++ b/core/watches.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RETRY_EXIT_CODE = 75
 WATCH_RECONCILE_INTERVAL_SECONDS = 2.0
+WATCH_STORE_RECONCILE_FUSE_FAILURES = 3
 
 
 def _utc_now_iso() -> str:
@@ -402,6 +403,7 @@ class ManagedWatchService:
         self._watch_started_at: dict[str, str] = {}
         self._fused_watch_ids: set[str] = set()
         self._store_error_fused = False
+        self._store_reconcile_failures = 0
 
     def start(self) -> None:
         if self._running:
@@ -411,7 +413,7 @@ class ManagedWatchService:
         try:
             self.reconcile_watches()
         except Exception as exc:
-            self._fuse_store_after_error("initial_reconcile", exc)
+            self._handle_reconcile_store_error(exc)
 
     async def stop(self) -> None:
         self._running = False
@@ -440,10 +442,11 @@ class ManagedWatchService:
                 if self.store.maybe_reload():
                     self.reconcile_watches()
                 self.reconcile_watches()
+                self._store_reconcile_failures = 0
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                self._fuse_store_after_error("reconcile", exc)
+                self._handle_reconcile_store_error(exc)
             await asyncio.sleep(WATCH_RECONCILE_INTERVAL_SECONDS)
 
     def reconcile_watches(self) -> None:
@@ -494,6 +497,20 @@ class ManagedWatchService:
             "(watch_id=%s operation=%s): %s",
             watch_id,
             operation,
+            exc,
+            exc_info=True,
+        )
+
+    def _handle_reconcile_store_error(self, exc: Exception) -> None:
+        self._store_reconcile_failures += 1
+        if self._store_reconcile_failures >= WATCH_STORE_RECONCILE_FUSE_FAILURES:
+            self._fuse_store_after_error("reconcile", exc)
+            return
+        logger.warning(
+            "Managed watch reconcile failed; will retry "
+            "(attempt=%s/%s): %s",
+            self._store_reconcile_failures,
+            WATCH_STORE_RECONCILE_FUSE_FAILURES,
             exc,
             exc_info=True,
         )

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -578,9 +578,16 @@ def test_managed_watch_service_fuses_watch_after_store_error(tmp_path: Path) -> 
     assert request_store.list_pending() == []
 
 
-def test_managed_watch_service_fuses_reconcile_after_store_read_error(tmp_path: Path) -> None:
+def test_managed_watch_service_fuses_reconcile_after_store_read_error(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("core.watches.WATCH_RECONCILE_INTERVAL_SECONDS", 0.01)
+
     class FailingListStore(ManagedWatchStore):
+        def __init__(self, path: Path):
+            super().__init__(path)
+            self.calls = 0
+
         def list_watches(self):
+            self.calls += 1
             raise RuntimeError("database disk image is malformed")
 
     store = FailingListStore(tmp_path / "watches.json")
@@ -607,10 +614,55 @@ def test_managed_watch_service_fuses_reconcile_after_store_read_error(tmp_path: 
     asyncio.run(_run())
 
     assert service._store_error_fused is True
+    assert store.calls == 3
     assert service._active_tasks == {}
 
 
-def test_managed_watch_service_start_fuses_initial_reconcile_error(tmp_path: Path) -> None:
+def test_managed_watch_service_retries_transient_reconcile_errors(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr("core.watches.WATCH_RECONCILE_INTERVAL_SECONDS", 0.01)
+
+    class TransientListStore(ManagedWatchStore):
+        def __init__(self, path: Path):
+            super().__init__(path)
+            self.failures_remaining = 2
+
+        def list_watches(self):
+            if self.failures_remaining > 0:
+                self.failures_remaining -= 1
+                raise RuntimeError("database is locked")
+            return super().list_watches()
+
+    store = TransientListStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=request_store,
+        runtime_store=runtime_store,
+    )
+
+    async def _run() -> None:
+        service._running = True
+        task = asyncio.create_task(service._watch_store())
+        for _ in range(100):
+            if store.failures_remaining == 0 and service._store_reconcile_failures == 0:
+                break
+            await asyncio.sleep(0.05)
+        service._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+
+    assert service._store_error_fused is False
+    assert service._store_reconcile_failures == 0
+
+
+def test_managed_watch_service_start_retries_initial_reconcile_error(tmp_path: Path) -> None:
     class FailingListStore(ManagedWatchStore):
         def list_watches(self):
             raise RuntimeError("database disk image is malformed")
@@ -627,7 +679,8 @@ def test_managed_watch_service_start_fuses_initial_reconcile_error(tmp_path: Pat
 
     async def _run() -> None:
         service.start()
-        assert service._store_error_fused is True
+        assert service._store_error_fused is False
+        assert service._store_reconcile_failures == 1
         await service.stop()
 
     asyncio.run(_run())

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -524,3 +524,163 @@ def test_managed_watch_service_forever_non_retry_error_disables_and_enqueues_fai
     assert saved.last_error
     assert len(pending) == 1
     assert pending[0].prompt.startswith("Investigate the failure.\n\nWatch 'Broken forever waiter' stopped because the waiter exited with code 1.")
+
+
+def test_managed_watch_service_fuses_watch_after_store_error(tmp_path: Path) -> None:
+    class FailingResultStore(ManagedWatchStore):
+        def __init__(self, path: Path):
+            super().__init__(path)
+            self.starts = 0
+
+        def mark_cycle_start(self, watch_id: str) -> bool:
+            self.starts += 1
+            return super().mark_cycle_start(watch_id)
+
+        def mark_cycle_result(self, *args, **kwargs) -> bool:
+            raise RuntimeError("database disk image is malformed")
+
+    store = FailingResultStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    watch = store.add_watch(
+        name="Broken persistence",
+        session_key="slack::channel::C123",
+        command=[sys.executable, "-c", "import sys; sys.exit(75)"],
+        shell_command=None,
+        prefix="Should not storm.",
+        cwd=None,
+        mode="forever",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=0.01,
+        post_to=None,
+        deliver_key=None,
+    )
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=request_store,
+        runtime_store=runtime_store,
+    )
+
+    async def _run() -> None:
+        service.start()
+        await asyncio.sleep(0.12)
+        assert watch.id in service._fused_watch_ids
+        await asyncio.sleep(0.08)
+        await service.stop()
+
+    asyncio.run(_run())
+
+    assert store.starts == 1
+    assert service._store_error_fused is True
+    assert request_store.list_pending() == []
+
+
+def test_managed_watch_service_fuses_reconcile_after_store_read_error(tmp_path: Path) -> None:
+    class FailingListStore(ManagedWatchStore):
+        def list_watches(self):
+            raise RuntimeError("database disk image is malformed")
+
+    store = FailingListStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=request_store,
+        runtime_store=runtime_store,
+    )
+
+    async def _run() -> None:
+        service._running = True
+        task = asyncio.create_task(service._watch_store())
+        await asyncio.sleep(0.05)
+        service._running = False
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+
+    assert service._store_error_fused is True
+    assert service._active_tasks == {}
+
+
+def test_managed_watch_service_start_fuses_initial_reconcile_error(tmp_path: Path) -> None:
+    class FailingListStore(ManagedWatchStore):
+        def list_watches(self):
+            raise RuntimeError("database disk image is malformed")
+
+    store = FailingListStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=request_store,
+        runtime_store=runtime_store,
+    )
+
+    async def _run() -> None:
+        service.start()
+        assert service._store_error_fused is True
+        await service.stop()
+
+    asyncio.run(_run())
+
+
+def test_managed_watch_service_ignores_runtime_state_write_failure(tmp_path: Path) -> None:
+    class FailingRuntimeStore(WatchRuntimeStateStore):
+        def __init__(self) -> None:
+            self.writes = 0
+
+        def write(self, payload: dict) -> None:
+            self.writes += 1
+            raise RuntimeError("database disk image is malformed")
+
+        def load(self) -> dict:
+            return {"watches": {}}
+
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    runtime_store = FailingRuntimeStore()
+    watch = store.add_watch(
+        name="Runtime failure",
+        session_key="slack::channel::C123",
+        command=[sys.executable, "-c", "print('done')"],
+        shell_command=None,
+        prefix="Finished.",
+        cwd=None,
+        mode="once",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=0.01,
+        post_to=None,
+        deliver_key=None,
+    )
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=request_store,
+        runtime_store=runtime_store,
+    )
+
+    async def _run() -> None:
+        service.start()
+        for _ in range(100):
+            if watch.id not in service._active_tasks:
+                break
+            await asyncio.sleep(0.02)
+        await service.stop()
+
+    asyncio.run(_run())
+
+    saved = store.get_watch(watch.id)
+    assert saved is not None
+    assert saved.enabled is False
+    assert runtime_store.writes > 0


### PR DESCRIPTION
## Summary
- stop managed watches from repeatedly restarting after persistent watch-store errors
- make watch runtime-state persistence failures non-fatal to task callbacks
- cover initial reconcile, periodic reconcile, cycle-result, and runtime-state failure paths

## Tests
- `python3 -m pytest tests/test_watches.py tests/test_cli_watch_command.py`
- `ruff check core/watches.py tests/test_watches.py`
