### PR TITLE
fix(ui): admin console polish — active-platforms count + show-pages

### DIFF
--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -264,10 +264,13 @@ export const Dashboard: React.FC = () => {
       : t('dashboard.metricCloudHintConfigured')
     : t('dashboard.metricCloudHintDisconnected');
 
-  const enabledPlatformTitles = platformCards
-    .filter((p) => p.enabled)
-    .map((p) => p.title)
-    .join(' · ');
+  // The always-on Avibe Workbench counts as a connected platform (it can never
+  // be "not configured"), so the metric value + its titles use ``connected`` —
+  // consistent with the platform list below and the catalog denominator, which
+  // both already include the workbench.
+  const connectedPlatformCards = platformCards.filter((p) => p.connected);
+  const activePlatformCount = connectedPlatformCards.length;
+  const enabledPlatformTitles = connectedPlatformCards.map((p) => p.title).join(' · ');
 
   return (
     <div className="flex flex-col gap-8">
@@ -401,7 +404,7 @@ export const Dashboard: React.FC = () => {
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <StatCard
           label={t('dashboard.metricPlatforms')}
-          value={`${enabledPlatforms.length} / ${platformCatalog.length}`}
+          value={`${activePlatformCount} / ${platformCatalog.length}`}
           hint={enabledPlatformTitles || t('dashboard.metricPlatformsHint')}
           icon={<PlugZap className="size-4" />}
           to="/admin/settings/platforms"

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -26,7 +26,7 @@ import { Badge } from './ui/badge';
 import { SegmentedRadio, type SegmentedTone } from './ui/segmented';
 
 type Visibility = 'private' | 'public' | 'offline';
-type Filter = 'all' | Visibility;
+type Filter = 'online' | Visibility;
 
 interface ShowPage {
   session_id: string;
@@ -122,11 +122,18 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
 
   return (
     <div className={clsx('border-b border-border last:border-b-0', expanded && 'border-y border-mint/30')}>
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
         className={clsx(
-          'flex w-full items-center gap-4 px-6 py-3.5 text-left transition-colors',
+          'flex w-full cursor-pointer items-center gap-4 px-6 py-3.5 text-left transition-colors',
           expanded ? 'bg-surface-2' : 'hover:bg-foreground/[0.02]'
         )}
       >
@@ -150,7 +157,18 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
         </span>
 
         <span className="hidden w-[280px] shrink-0 items-center gap-1.5 lg:flex">
-          {shown ? (
+          {shown && href ? (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              title={href}
+              className="truncate font-mono text-[12px] text-muted transition-colors hover:text-foreground hover:underline"
+            >
+              {shown}
+            </a>
+          ) : shown ? (
             <span className="truncate font-mono text-[12px] text-muted">{shown}</span>
           ) : (
             <span className="text-[13px] text-muted">—</span>
@@ -162,7 +180,7 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
         <span className="flex w-[24px] shrink-0 justify-end">
           {expanded ? <ChevronUp size={18} className="text-foreground" /> : <ChevronDown size={18} className="text-muted" />}
         </span>
-      </button>
+      </div>
 
       {expanded ? (
         <div className="bg-surface-2 px-6 pb-6 pt-2">
@@ -264,7 +282,7 @@ export function ShowPagesPage() {
   const { showToast } = useToast();
   const [pages, setPages] = useState<ShowPage[]>([]);
   const [search, setSearch] = useState('');
-  const [filter, setFilter] = useState<Filter>('all');
+  const [filter, setFilter] = useState<Filter>('online');
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -323,7 +341,8 @@ export function ShowPagesPage() {
   const visible = useMemo(() => {
     const query = search.trim().toLowerCase();
     return pages.filter((page) => {
-      if (filter !== 'all' && page.visibility !== filter) return false;
+      // "online" = live pages (private + public), i.e. everything but offline.
+      if (filter === 'online' ? page.visibility === 'offline' : page.visibility !== filter) return false;
       if (!query) return true;
       return (page.title || '').toLowerCase().includes(query) || page.session_id.toLowerCase().includes(query);
     });
@@ -369,7 +388,7 @@ export function ShowPagesPage() {
           onChange={setFilter}
           ariaLabel={t('showPages.filterAria')}
           options={[
-            { id: 'all', label: t('showPages.filter.all') },
+            { id: 'online', label: t('showPages.filter.online') },
             { id: 'private', label: t('showPages.filter.private') },
             { id: 'public', label: t('showPages.filter.public') },
             { id: 'offline', label: t('showPages.filter.offline') },

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -127,7 +127,10 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
         tabIndex={0}
         onClick={onToggle}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
+          // Only the row itself toggles via keyboard; let Enter/Space on nested
+          // interactives (the live-link anchor) activate them normally instead
+          // of being swallowed by the row toggle.
+          if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
             e.preventDefault();
             onToggle();
           }

--- a/ui/src/components/ui/segmented.tsx
+++ b/ui/src/components/ui/segmented.tsx
@@ -70,7 +70,7 @@ export function SegmentedRadio<T extends string>({
             disabled={disabled}
             onClick={() => onChange(opt.id)}
             className={clsx(
-              'flex-1 rounded-[4px] px-3 text-[12px] transition-colors',
+              'flex-1 whitespace-nowrap rounded-[4px] px-3 text-[12px] transition-colors',
               active
                 ? ACTIVE_TONES[tone]
                 : 'font-medium text-muted hover:text-foreground',

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -124,7 +124,7 @@
     "allPages": "All pages",
     "sortedRecent": "Sorted by most recent",
     "filterAria": "Filter by visibility",
-    "filter": { "all": "All", "private": "Private", "public": "Public", "offline": "Offline" },
+    "filter": { "online": "Online", "private": "Private", "public": "Public", "offline": "Offline" },
     "status": { "private": "Private", "public": "Public", "offline": "Offline" },
     "col": { "session": "Session", "visibility": "Visibility", "link": "Live link", "updated": "Updated" },
     "empty": "No Show Pages yet. They appear here once an agent session creates one.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -124,7 +124,7 @@
     "allPages": "全部页面",
     "sortedRecent": "按最近活动排序",
     "filterAria": "按可见性筛选",
-    "filter": { "all": "全部", "private": "私有", "public": "公开", "offline": "已下线" },
+    "filter": { "online": "在线", "private": "私有", "public": "公开", "offline": "已下线" },
     "status": { "private": "私有", "public": "公开", "offline": "已下线" },
     "col": { "session": "会话", "visibility": "可见性", "link": "访问链接", "updated": "更新时间" },
     "empty": "暂无展示页面。当 Agent 会话创建展示页面后会显示在这里。",


### PR DESCRIPTION
## Capability
Admin console polish from page feedback — the Dashboard "Active platforms" metric and three `/admin/show-pages` items. UI-only.

| # | Surface | Fix |
|---|---------|-----|
| 1 | Dashboard · Active platforms | **Count the always-on Avibe Workbench.** The numerator used `getEnabledPlatforms` (which strips the workbench) while the denominator (catalog) includes it, so the Workbench was never counted. Now counts connected platforms (workbench + enabled IMs) and lists the Workbench in the hint, consistent with the platform list. |
| 2 | Show Pages · row link | **Make the live link directly clickable** (opens a new tab). It's now a real `<a target="_blank" rel="noopener">` with `stopPropagation`; the row's outer `<button>` became a keyboard-operable `div role="button"` so the anchor isn't illegally nested. |
| 3 | Show Pages · filter | **Rename "All" → "Online" (在线)** = live pages (private + public), excluding offline; it's the default selection. |
| 4 | Show Pages · filter | **Fix "已下线" wrapping** — added `whitespace-nowrap` to the shared `SegmentedRadio` option so CJK labels can't wrap to a second line (benefits every segmented caller). |

## Evidence layers
- **Unit / contract / scenario:** none — UI-only; no logic/contract change beyond the filter predicate; no scenario catalog covers these surfaces.
- **Build:** `tsc -b && vite build` passes; both locales valid JSON; no remaining `showPages.filter.all` reference.
- **Review:** reviewer subagent pass — verified the numerator/denominator are now consistent, the `all`→`online` rename is complete in code + en/zh with correct predicate semantics, the row link is a valid non-nested new-tab anchor with a keyboard-operable row toggle, and `whitespace-nowrap` is a safe shared-primitive addition.
- **Residual manual:** Show Pages is auth-gated (can't render against a backend-less preview), so it was validated by code + review; please confirm live — especially the row-link new-tab open and that the "Online" filter shows your private + public pages.