### PR TITLE
fix(show): rewrite public chunk deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 RUN npm install -g @anthropic-ai/claude-code 2>/dev/null || echo "WARN: claude-code install failed (optional)"
 RUN npm install -g @openai/codex 2>/dev/null || echo "WARN: codex install failed (optional)"
 # OpenCode: use the official installer and expose the binary on PATH
-RUN bash -lc 'set -euo pipefail; curl -fsSL https://opencode.ai/install | bash && ln -sf /root/.opencode/bin/opencode /usr/local/bin/opencode && opencode --version'
+RUN bash -lc 'set -euo pipefail; curl -fsSL https://opencode.ai/install | bash && ln -sf /root/.opencode/bin/opencode /usr/local/bin/opencode && opencode --version' \
+    || echo "WARN: opencode install failed (optional)"
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -37,11 +37,13 @@ class _FakeShowRuntimeManager:
         fail: bool = False,
         status_code: int = 200,
         extra_headers: dict[str, str] | None = None,
+        bodies_by_path: dict[str, bytes] | None = None,
     ):
         self.body = body
         self.fail = fail
         self.status_code = status_code
         self.extra_headers = extra_headers or {}
+        self.bodies_by_path = bodies_by_path or {}
         self.calls = []
         self.websocket_paths = []
         self.stopped = False
@@ -57,7 +59,7 @@ class _FakeShowRuntimeManager:
             "set-cookie": "__Host-vibe_remote_session=attacker",
             "x-runtime-private-header": "secret",
         } | self.extra_headers
-        return httpx.Response(self.status_code, content=self.body, headers=headers)
+        return httpx.Response(self.status_code, content=self.bodies_by_path.get(path, self.body), headers=headers)
 
     async def websocket_url(self, path):
         self.websocket_paths.append(path)
@@ -352,7 +354,7 @@ def test_show_runtime_vendor_deps_are_cacheable(monkeypatch, tmp_path):
         set_show_runtime_manager_for_tests(None)
 
     assert response.status_code == 302
-    assert response.headers["location"] == "/_show-runtime/deps/d6d38251/react-dom_client.js"
+    assert response.headers["location"] == "/_show-runtime/deps/r4-d6d38251/react-dom_client.js"
     assert response.headers["cache-control"] == "no-store"
     assert "set-cookie" not in response.headers
 
@@ -375,7 +377,7 @@ def test_show_runtime_public_dep_proxy_is_cacheable(monkeypatch, tmp_path):
             base_url="http://127.0.0.1:5123",
         )
         response = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/react.js?v=d6d38251",
+            "/_show-runtime/deps/r4-d6d38251/react.js?v=d6d38251",
             base_url="http://127.0.0.1:5123",
         )
     finally:
@@ -406,14 +408,14 @@ def test_show_runtime_public_dep_proxy_allows_scoped_package_names(monkeypatch, 
             base_url="http://127.0.0.1:5123",
         )
         response = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/%40avibe_show-ui_theme.js?v=d6d38251",
+            "/_show-runtime/deps/r4-d6d38251/%40avibe_show-ui_theme.js?v=d6d38251",
             base_url="http://127.0.0.1:5123",
         )
     finally:
         set_show_runtime_manager_for_tests(None)
 
     assert original.status_code == 302
-    assert original.headers["location"] == "/_show-runtime/deps/d6d38251/%40avibe_show-ui_theme.js"
+    assert original.headers["location"] == "/_show-runtime/deps/r4-d6d38251/%40avibe_show-ui_theme.js"
     assert response.status_code == 200
     assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
     assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/@avibe_show-ui_theme.js?v=d6d38251"
@@ -425,6 +427,9 @@ def test_show_runtime_public_dep_proxy_registers_sibling_chunks(monkeypatch, tmp
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(
         body=b'import "./chunk-OUYO74D4.js?v=108951fb";\nexport default {}',
+        bodies_by_path={
+            "/sessions/ses123/app/node_modules/.vite/deps/chunk-OUYO74D4.js?v=108951fb": b"export const chunk = true;",
+        },
         extra_headers={
             "content-type": "text/javascript",
             "cache-control": "no-cache",
@@ -437,11 +442,11 @@ def test_show_runtime_public_dep_proxy_registers_sibling_chunks(monkeypatch, tmp
             base_url="http://127.0.0.1:5123",
         )
         dep = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/react-dom_client.js?v=d6d38251",
+            "/_show-runtime/deps/r4-d6d38251/react-dom_client.js?v=d6d38251",
             base_url="http://127.0.0.1:5123",
         )
         chunk = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/chunk-OUYO74D4.js?v=108951fb",
+            "/_show-runtime/deps/r4-d6d38251/chunk-OUYO74D4.js?v=108951fb",
             base_url="http://127.0.0.1:5123",
         )
     finally:
@@ -449,10 +454,116 @@ def test_show_runtime_public_dep_proxy_registers_sibling_chunks(monkeypatch, tmp
 
     assert original.status_code == 302
     assert dep.status_code == 200
-    assert b'import "./chunk-OUYO74D4.js?v=108951fb"' in dep.content
+    assert b'import "/_show-runtime/deps/r4-d6d38251/chunk-OUYO74D4.js?v=108951fb"' in dep.content
+    assert dep.headers["cache-control"] == "no-store"
     assert chunk.status_code == 200
     assert chunk.headers["cache-control"] == "public, max-age=31536000, immutable"
     assert manager.calls[-1][1] == "/sessions/ses123/app/node_modules/.vite/deps/chunk-OUYO74D4.js?v=108951fb"
+
+
+def test_show_runtime_public_dep_proxy_rewrites_private_chunk_imports(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager(
+        body=(
+            b'import "/show/ses123/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/'
+            b'abc123/ses123/deps/chunk-QA663NX4.js?v=108951fb";\nexport default {}'
+        ),
+        bodies_by_path={
+            "/sessions/ses123/app/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/"
+            "abc123/ses123/deps/chunk-QA663NX4.js?v=108951fb": b"export const chunk = true;",
+        },
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        original = app.test_client().get(
+            "/show/ses123/node_modules/.vite/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        dep = app.test_client().get(
+            "/_show-runtime/deps/r4-d6d38251/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        chunk = app.test_client().get(
+            "/_show-runtime/deps/r4-d6d38251/chunk-QA663NX4.js?v=108951fb",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert original.status_code == 302
+    assert dep.status_code == 200
+    assert b'import "/_show-runtime/deps/r4-d6d38251/chunk-QA663NX4.js?v=108951fb"' in dep.content
+    assert b'"/show/ses123/@fs/' not in dep.content
+    assert dep.headers["cache-control"] == "no-store"
+    assert chunk.status_code == 200
+    assert manager.calls[-1][1] == (
+        "/sessions/ses123/app/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/"
+        "abc123/ses123/deps/chunk-QA663NX4.js?v=108951fb"
+    )
+
+
+def test_show_runtime_public_dep_proxy_refreshes_private_chunk_registry(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    _create_show_page("ses456", "private")
+    manager = _FakeShowRuntimeManager(
+        body=(
+            b'import "/show/ses123/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/'
+            b'old/ses123/deps/chunk-QA663NX4.js?v=old111";'
+        ),
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        first_original = app.test_client().get(
+            "/show/ses123/node_modules/.vite/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        first_dep = app.test_client().get(
+            "/_show-runtime/deps/r4-d6d38251/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        manager.body = (
+            b'import "/show/ses456/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/'
+            b'new/ses456/deps/chunk-QA663NX4.js?v=new222";'
+        )
+        second_original = app.test_client().get(
+            "/show/ses456/node_modules/.vite/deps/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        second_dep = app.test_client().get(
+            "/_show-runtime/deps/r4-d6d38251/react-dom_client.js?v=d6d38251",
+            base_url="http://127.0.0.1:5123",
+        )
+        chunk = app.test_client().get(
+            "/_show-runtime/deps/r4-d6d38251/chunk-QA663NX4.js?v=new222",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert first_original.status_code == 302
+    assert first_dep.status_code == 200
+    assert first_dep.headers["cache-control"] == "no-store"
+    assert second_original.status_code == 302
+    assert second_dep.status_code == 200
+    assert b"/_show-runtime/deps/r4-d6d38251/chunk-QA663NX4.js?v=new222" in second_dep.content
+    assert second_dep.headers["cache-control"] == "no-store"
+    assert chunk.status_code == 200
+    assert manager.calls[-1][1] == (
+        "/sessions/ses456/app/@fs/home/avibe/.avibe/runtime/show-runtime/vite-cache/"
+        "new/ses456/deps/chunk-QA663NX4.js?v=new222"
+    )
 
 
 def test_show_runtime_public_dep_proxy_derives_chunk_paths_when_registry_is_cold(monkeypatch, tmp_path):
@@ -473,7 +584,7 @@ def test_show_runtime_public_dep_proxy_derives_chunk_paths_when_registry_is_cold
             base_url="http://127.0.0.1:5123",
         )
         chunk = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/chunk-OUYO74D4.js?v=108951fb",
+            "/_show-runtime/deps/r4-d6d38251/chunk-OUYO74D4.js?v=108951fb",
             base_url="http://127.0.0.1:5123",
         )
     finally:
@@ -519,6 +630,20 @@ def test_show_runtime_public_dep_rejects_unversioned_cache_key(monkeypatch, tmp_
     )
 
     assert response.status_code == 404
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_show_runtime_public_dep_rejects_unregistered_cache_key_without_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    response = app.test_client().get(
+        "/_show-runtime/deps/r4-d6d38251/react.js",
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 404
+    assert response.headers["cache-control"] == "no-store"
 
 
 def test_show_runtime_relocated_vendor_deps_are_cacheable(monkeypatch, tmp_path):
@@ -542,7 +667,7 @@ def test_show_runtime_relocated_vendor_deps_are_cacheable(monkeypatch, tmp_path)
         set_show_runtime_manager_for_tests(None)
 
     assert response.status_code == 302
-    assert response.headers["location"] == "/_show-runtime/deps/d6d38251/react-dom_client.js"
+    assert response.headers["location"] == "/_show-runtime/deps/r4-d6d38251/react-dom_client.js"
     assert "set-cookie" not in response.headers
 
 
@@ -625,6 +750,9 @@ def test_show_runtime_source_rewrites_dep_imports_to_public_paths(monkeypatch, t
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(
         body=b'import "/node_modules/.vite/deps/react.js?v=d6d38251";\nimport "./App.tsx";',
+        bodies_by_path={
+            "/sessions/ses123/app/node_modules/.vite/deps/react.js?v=d6d38251": b"export default {}",
+        },
         extra_headers={
             "content-type": "text/javascript",
             "cache-control": "no-cache",
@@ -638,14 +766,14 @@ def test_show_runtime_source_rewrites_dep_imports_to_public_paths(monkeypatch, t
             base_url="http://127.0.0.1:5123",
         )
         public_dep = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/react.js?v=d6d38251",
+            "/_show-runtime/deps/r4-d6d38251/react.js?v=d6d38251",
             base_url="http://127.0.0.1:5123",
         )
     finally:
         set_show_runtime_manager_for_tests(None)
 
     assert response.status_code == 200
-    assert b'"/_show-runtime/deps/d6d38251/react.js"' in response.content
+    assert b'"/_show-runtime/deps/r4-d6d38251/react.js"' in response.content
     assert b'"./App.tsx"' in response.content
     assert response.headers["cache-control"] == "no-store"
     assert "etag" not in response.headers
@@ -675,14 +803,14 @@ def test_show_runtime_source_rewrites_prefixed_fs_vite_cache_dep_imports(monkeyp
             base_url="http://127.0.0.1:5123",
         )
         public_dep = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/react-dom_client.js?v=d6d38251",
+            "/_show-runtime/deps/r4-d6d38251/react-dom_client.js?v=d6d38251",
             base_url="http://127.0.0.1:5123",
         )
     finally:
         set_show_runtime_manager_for_tests(None)
 
     assert response.status_code == 200
-    assert b'"/_show-runtime/deps/d6d38251/react-dom_client.js"' in response.content
+    assert b'"/_show-runtime/deps/r4-d6d38251/react-dom_client.js"' in response.content
     assert response.headers["cache-control"] == "no-store"
     assert "etag" not in response.headers
     assert public_dep.status_code == 200
@@ -710,7 +838,7 @@ def test_show_runtime_source_preserves_dot_vite_dep_import_paths(monkeypatch, tm
             base_url="http://127.0.0.1:5123",
         )
         public_dep = app.test_client().get(
-            "/_show-runtime/deps/d6d38251/react.js?v=d6d38251",
+            "/_show-runtime/deps/r4-d6d38251/react.js?v=d6d38251",
             base_url="http://127.0.0.1:5123",
         )
     finally:
@@ -1160,7 +1288,7 @@ def test_public_show_page_immutable_deps_do_not_clear_write_cookie(monkeypatch, 
         set_show_runtime_manager_for_tests(None)
 
     assert response.status_code == 302
-    assert response.headers["location"] == "/_show-runtime/deps/d6d38251/react.js"
+    assert response.headers["location"] == "/_show-runtime/deps/r4-d6d38251/react.js"
     assert "set-cookie" not in response.headers
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -93,6 +93,7 @@ _SHOW_RUNTIME_PUBLIC_DEP_SIBLING_RE = re.compile(
     r"(?P<quote>['\"])\./(?P<name>[A-Za-z0-9_.-]+\.js)(?:\?v=(?P<version>[A-Za-z0-9_-]+))?(?P<rest>[^'\"]*)(?P=quote)"
 )
 _SHOW_RUNTIME_PUBLIC_DEP_PREFIX = "/_show-runtime/deps"
+_SHOW_RUNTIME_PUBLIC_DEP_CACHE_EPOCH = "r4"
 _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY: dict[tuple[str, str], str] = {}
 
 STRUCTURED_LOG_PATTERN = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\s+-\s+([\w.]+)\s+-\s+(\w+)\s+-\s+(.*)$")
@@ -5459,12 +5460,12 @@ async def show_session_prewarm(session_id: str):
 @app.route("/_show-runtime/deps/<version>/<path:asset_name>", methods=["GET", "HEAD"])
 async def show_runtime_public_dep(version: str, asset_name: str):
     if not re.fullmatch(r"[A-Za-z0-9_-]+", version or "") or version == "unversioned":
-        return _show_page_not_found_response()
+        return _show_runtime_public_dep_not_found_response()
     if not re.fullmatch(r"[A-Za-z0-9_@.-]+", asset_name or ""):
-        return _show_page_not_found_response()
+        return _show_runtime_public_dep_not_found_response()
     runtime_path = _public_show_runtime_dep_runtime_path(version, asset_name)
     if not runtime_path:
-        return _show_page_not_found_response()
+        return _show_runtime_public_dep_not_found_response()
     if request._request.url.query and "?" not in runtime_path:
         runtime_path = f"{runtime_path}?{request._request.url.query}"
     from core.show_runtime import get_show_runtime_manager
@@ -5494,9 +5495,24 @@ async def show_runtime_public_dep(version: str, asset_name: str):
         _remove_response_header(response_headers, "cache-control")
         _remove_response_header(response_headers, "set-cookie")
         response_headers["Cache-Control"] = _SHOW_RUNTIME_IMMUTABLE_CACHE_CONTROL
+    content = proxied.content
     if proxied.status_code == 200:
-        _register_public_show_runtime_dep_siblings(proxied.content, response_headers, version=version, runtime_path=runtime_path)
-    return FastAPIResponse(content=proxied.content, status_code=proxied.status_code, headers=response_headers)
+        content = _rewrite_public_show_runtime_dep_siblings(
+            proxied.content,
+            response_headers,
+            version=version,
+            runtime_path=runtime_path,
+        )
+    return FastAPIResponse(content=content, status_code=proxied.status_code, headers=response_headers)
+
+
+def _show_runtime_public_dep_not_found_response():
+    return FastAPIResponse(
+        content=b'{"error":"not_found"}',
+        status_code=404,
+        media_type="application/json",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 async def _show_page_runtime_response(
@@ -5658,7 +5674,11 @@ def _public_show_runtime_dep_key(asset_path: str, query: str | None = None) -> t
     version = _show_runtime_dep_version(query)
     if not version:
         return "", ""
-    return version, name
+    return _public_show_runtime_dep_version(version), name
+
+
+def _public_show_runtime_dep_version(vite_version: str) -> str:
+    return f"{_SHOW_RUNTIME_PUBLIC_DEP_CACHE_EPOCH}-{vite_version}"
 
 
 def _show_runtime_dep_version(query: str | None) -> str | None:
@@ -5683,9 +5703,10 @@ def _rewrite_show_runtime_public_deps(content: bytes, headers: dict[str, str], *
         return content
 
     def replace(match: re.Match[str]) -> str:
-        version = match.group("version")
-        if not version:
+        vite_version = match.group("version")
+        if not vite_version:
             return match.group(0)
+        version = _public_show_runtime_dep_version(vite_version)
         name = Path(match.group("path")).name
         public_path = f"{_SHOW_RUNTIME_PUBLIC_DEP_PREFIX}/{quote(version, safe='')}/{quote(name, safe='')}"
         dep_path = _normalize_show_runtime_dep_import_path(match.group("path"))
@@ -5710,27 +5731,60 @@ def _normalize_show_runtime_dep_import_path(dep_path: str) -> str:
     return dep_path
 
 
-def _register_public_show_runtime_dep_siblings(
+def _rewrite_public_show_runtime_dep_siblings(
     content: bytes,
     headers: dict[str, str],
     *,
     version: str,
     runtime_path: str,
-) -> None:
+) -> bytes:
     content_type = _response_header(headers, "content-type") or ""
     if not _show_response_is_javascript(content_type):
-        return
+        return content
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError:
-        return
+        return content
     base_runtime_path = runtime_path.split("?", 1)[0].rsplit("/", 1)[0]
-    for match in _SHOW_RUNTIME_PUBLIC_DEP_SIBLING_RE.finditer(text):
+    runtime_app_prefix = runtime_path.split("?", 1)[0].split("/app/", 1)[0] + "/app/"
+    mutated = False
+
+    def register_public_dep(dep_path: str, dep_version: str | None) -> str:
+        nonlocal mutated
+        name = Path(dep_path).name
+        normalized_dep_path = _normalize_show_runtime_dep_import_path(dep_path)
+        registered_runtime_path = f"{runtime_app_prefix}{quote(normalized_dep_path, safe='/@:-._~')}"
+        _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY[(version, name)] = registered_runtime_path
+        mutated = True
+        return _public_show_runtime_dep_import_url(version, name, dep_version)
+
+    def replace_relative_sibling(match: re.Match[str]) -> str:
+        nonlocal mutated
         sibling_name = match.group("name")
-        _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY.setdefault(
-            (version, sibling_name),
-            f"{base_runtime_path}/{quote(sibling_name, safe='')}",
-        )
+        sibling_runtime_path = f"{base_runtime_path}/{quote(sibling_name, safe='')}"
+        sibling_version = match.group("version")
+        _SHOW_RUNTIME_PUBLIC_DEP_REGISTRY[(version, sibling_name)] = sibling_runtime_path
+        mutated = True
+        public_path = _public_show_runtime_dep_import_url(version, sibling_name, sibling_version)
+        return f"{match.group('quote')}{public_path}{match.group('rest')}{match.group('quote')}"
+
+    def replace_absolute_dep(match: re.Match[str]) -> str:
+        public_path = register_public_dep(match.group("path"), match.group("version"))
+        return f"{match.group('quote')}{public_path}{match.group('rest')}{match.group('quote')}"
+
+    rewritten = _SHOW_RUNTIME_PUBLIC_DEP_SIBLING_RE.sub(replace_relative_sibling, text)
+    rewritten = _SHOW_RUNTIME_PUBLIC_DEP_RE.sub(replace_absolute_dep, rewritten)
+    if not mutated:
+        return content
+    _strip_mutated_show_runtime_headers(headers)
+    return rewritten.encode("utf-8")
+
+
+def _public_show_runtime_dep_import_url(version: str, asset_name: str, dep_version: str | None) -> str:
+    public_path = f"{_SHOW_RUNTIME_PUBLIC_DEP_PREFIX}/{quote(version, safe='')}/{quote(asset_name, safe='')}"
+    if dep_version:
+        return f"{public_path}?v={quote(dep_version, safe='')}"
+    return public_path
 
 
 def _show_response_is_javascript(content_type: str | None) -> bool:


### PR DESCRIPTION
## Summary
- rewrite public Show Runtime dependency imports to a proxy-owned `/_show-runtime/deps/r4-...` cache key
- rewrite dependency-internal chunk imports, including both relative `./chunk-*.js` and private `/show/<session>/@fs/.../vite-cache/.../deps/chunk-*.js` forms
- return `no-store` for unresolved public dependency cache keys so cold registry misses cannot be cached at the edge
- keep the regression Docker image resilient when optional OpenCode installation fails

## Root cause
Public Show Page modules could load `/_show-runtime/deps/...` successfully, but the proxied dependency body still contained chunk imports that resolved back to the private `/show/<session>/...` route. That route can return HTML instead of JavaScript, so the browser module graph fails and the React app never mounts.

The existing public dependency URLs were also immutable at Cloudflare. The proxy now owns a cache epoch in the public URL so already-cached broken dependency bodies are bypassed immediately after this fix.

## Validation
- `uv run pytest tests/test_ui_show_pages.py -q`
- `uv run ruff check vibe/ui_server.py tests/test_ui_show_pages.py`
- `git diff --check`
- regression deploy to `https://test-app.avibe.bot`
- verified `/p/UAeBLpyM7mY/src/main.tsx` references `/_show-runtime/deps/r4-...`
- verified `/_show-runtime/deps/r4-0d7a47dd/react-dom_client.js` returns JavaScript, rewrites chunk imports to public URLs, and contains no private `/show/...` refs
