### PR TITLE
fix(codex): refresh enabled backend registration

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1386,12 +1386,52 @@ class AgentAuthService:
 
         return getattr(to_app_config(V2Config.load()), backend, None)
 
+    def _register_missing_backend_agent(self, backend: str, runtime_config: Any) -> bool:
+        agent_service = getattr(self.controller, "agent_service", None)
+        if agent_service is None or backend in getattr(agent_service, "agents", {}):
+            return False
+
+        if backend == "codex":
+            from modules.agents.codex import CodexAgent
+
+            self.controller.config.codex = runtime_config
+            agent_service.register(CodexAgent(self.controller, runtime_config))
+        elif backend == "opencode":
+            from modules.agents.opencode import OpenCodeAgent
+
+            self.controller.config.opencode = runtime_config
+            agent_service.register(OpenCodeAgent(self.controller, runtime_config))
+        else:
+            return False
+
+        store = getattr(self.controller, "vibe_agent_store", None)
+        if store is not None:
+            ensure = getattr(store, "ensure_builtin_default_agents", None)
+            if callable(ensure):
+                try:
+                    registered_backends = list(getattr(agent_service, "agents", {}).keys())
+                    ensure(
+                        registered_backends,
+                        default_backend=getattr(
+                            getattr(self.controller, "agent_router", None),
+                            "global_default",
+                            None,
+                        ),
+                    )
+                except Exception as err:  # noqa: BLE001
+                    logger.warning("Failed to sync built-in Agent after %s registration: %s", backend, err)
+
+        logger.info("Registered %s backend after runtime config refresh", backend)
+        return True
+
     async def _refresh_backend_runtime(self, backend: str) -> None:
         agent_service = getattr(self.controller, "agent_service", None)
         refresh_runtime_config = getattr(agent_service, "refresh_runtime_config", None)
         runtime_config = None
         if callable(refresh_runtime_config):
             runtime_config = self._load_backend_runtime_config(backend)
+            if runtime_config is not None and self._register_missing_backend_agent(backend, runtime_config):
+                return
             if runtime_config is not None and await refresh_runtime_config(backend, runtime_config):
                 return
 

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1386,11 +1386,80 @@ class AgentAuthService:
 
         return getattr(to_app_config(V2Config.load()), backend, None)
 
+    def _load_saved_default_backend(self) -> str | None:
+        try:
+            from config.v2_config import V2Config
+
+            return V2Config.load().agents.default_backend
+        except Exception as err:  # noqa: BLE001
+            logger.warning("Failed to load saved default backend during runtime refresh: %s", err)
+            return None
+
+    def _sync_runtime_default_backend(self, default_backend: str | None) -> str | None:
+        if not default_backend:
+            return None
+        agent_service = getattr(self.controller, "agent_service", None)
+        if default_backend not in getattr(agent_service, "agents", {}):
+            return None
+        router = getattr(self.controller, "agent_router", None)
+        if router is None:
+            return default_backend
+        router.global_default = default_backend
+        for route in getattr(router, "platform_routes", {}).values():
+            route.default = default_backend
+        self.controller.config.default_backend = default_backend
+        return default_backend
+
+    def _sync_builtin_default_agents(self, default_backend: str | None = None) -> None:
+        store = getattr(self.controller, "vibe_agent_store", None)
+        agent_service = getattr(self.controller, "agent_service", None)
+        ensure = getattr(store, "ensure_builtin_default_agents", None) if store is not None else None
+        if not callable(ensure) or agent_service is None:
+            return
+        try:
+            ensure(
+                list(getattr(agent_service, "agents", {}).keys()),
+                default_backend=default_backend
+                or getattr(getattr(self.controller, "agent_router", None), "global_default", None),
+            )
+        except Exception as err:  # noqa: BLE001
+            logger.warning("Failed to sync built-in Agents after backend runtime refresh: %s", err)
+
+    async def _unregister_disabled_backend_agent(self, backend: str) -> bool:
+        agent_service = getattr(self.controller, "agent_service", None)
+        agent = getattr(agent_service, "agents", {}).pop(backend, None) if agent_service else None
+        if agent is None:
+            setattr(self.controller.config, backend, None)
+            self._sync_builtin_default_agents()
+            return False
+
+        shutdown = getattr(agent, "shutdown_runtime", None)
+        if callable(shutdown):
+            await shutdown()
+        elif backend == "opencode":
+            server_manager = getattr(agent, "_client_manager", None)
+            reset_config = getattr(server_manager, "reset_config", None)
+            if callable(reset_config):
+                previous_server = await reset_config(None)
+                if previous_server is not None:
+                    detach = getattr(previous_server, "detach_after_deferred_refresh", None)
+                    if callable(detach):
+                        await detach()
+        refresh = getattr(agent, "refresh_auth_state", None)
+        if callable(refresh):
+            await refresh()
+
+        setattr(self.controller.config, backend, None)
+        self._sync_builtin_default_agents()
+        logger.info("Unregistered disabled %s backend after runtime config refresh", backend)
+        return True
+
     def _register_missing_backend_agent(self, backend: str, runtime_config: Any) -> bool:
         agent_service = getattr(self.controller, "agent_service", None)
         if agent_service is None or backend in getattr(agent_service, "agents", {}):
             return False
 
+        default_backend = self._load_saved_default_backend()
         if backend == "codex":
             from modules.agents.codex import CodexAgent
 
@@ -1404,22 +1473,8 @@ class AgentAuthService:
         else:
             return False
 
-        store = getattr(self.controller, "vibe_agent_store", None)
-        if store is not None:
-            ensure = getattr(store, "ensure_builtin_default_agents", None)
-            if callable(ensure):
-                try:
-                    registered_backends = list(getattr(agent_service, "agents", {}).keys())
-                    ensure(
-                        registered_backends,
-                        default_backend=getattr(
-                            getattr(self.controller, "agent_router", None),
-                            "global_default",
-                            None,
-                        ),
-                    )
-                except Exception as err:  # noqa: BLE001
-                    logger.warning("Failed to sync built-in Agent after %s registration: %s", backend, err)
+        active_default = self._sync_runtime_default_backend(default_backend) or default_backend
+        self._sync_builtin_default_agents(active_default)
 
         logger.info("Registered %s backend after runtime config refresh", backend)
         return True
@@ -1430,9 +1485,14 @@ class AgentAuthService:
         runtime_config = None
         if callable(refresh_runtime_config):
             runtime_config = self._load_backend_runtime_config(backend)
+            if runtime_config is None:
+                await self._unregister_disabled_backend_agent(backend)
+                return
             if runtime_config is not None and self._register_missing_backend_agent(backend, runtime_config):
                 return
             if runtime_config is not None and await refresh_runtime_config(backend, runtime_config):
+                active_default = self._sync_runtime_default_backend(self._load_saved_default_backend())
+                self._sync_builtin_default_agents(active_default)
                 return
 
         agent = getattr(agent_service, "agents", {}).get(backend) if agent_service else None

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1395,6 +1395,21 @@ class AgentAuthService:
             logger.warning("Failed to load saved default backend during runtime refresh: %s", err)
             return None
 
+    def _load_saved_enabled_backends(self) -> list[str] | None:
+        try:
+            from config.v2_config import V2Config
+
+            agent_config = V2Config.load().agents
+        except Exception as err:  # noqa: BLE001
+            logger.warning("Failed to load saved enabled backends during runtime refresh: %s", err)
+            return None
+
+        return [
+            backend
+            for backend in ("opencode", "claude", "codex")
+            if bool(getattr(getattr(agent_config, backend, None), "enabled", False))
+        ]
+
     def _sync_runtime_default_backend(self, default_backend: str | None) -> str | None:
         if not default_backend:
             return None
@@ -1410,15 +1425,26 @@ class AgentAuthService:
         self.controller.config.default_backend = default_backend
         return default_backend
 
+    def _revalidate_runtime_default_backend(self, preferred_default: str | None = None) -> str | None:
+        if self._sync_runtime_default_backend(preferred_default):
+            return preferred_default
+        validate = getattr(self.controller, "_validate_default_backend", None)
+        if callable(validate):
+            validate()
+        router_default = getattr(getattr(self.controller, "agent_router", None), "global_default", None)
+        return router_default if self._sync_runtime_default_backend(router_default) else None
+
     def _sync_builtin_default_agents(self, default_backend: str | None = None) -> None:
         store = getattr(self.controller, "vibe_agent_store", None)
-        agent_service = getattr(self.controller, "agent_service", None)
         ensure = getattr(store, "ensure_builtin_default_agents", None) if store is not None else None
-        if not callable(ensure) or agent_service is None:
+        if not callable(ensure):
             return
+        enabled_backends = self._load_saved_enabled_backends()
+        if enabled_backends is None:
+            enabled_backends = list(getattr(getattr(self.controller, "agent_service", None), "agents", {}).keys())
         try:
             ensure(
-                list(getattr(agent_service, "agents", {}).keys()),
+                enabled_backends,
                 default_backend=default_backend
                 or getattr(getattr(self.controller, "agent_router", None), "global_default", None),
             )
@@ -1430,7 +1456,8 @@ class AgentAuthService:
         agent = getattr(agent_service, "agents", {}).pop(backend, None) if agent_service else None
         if agent is None:
             setattr(self.controller.config, backend, None)
-            self._sync_builtin_default_agents()
+            active_default = self._revalidate_runtime_default_backend(self._load_saved_default_backend())
+            self._sync_builtin_default_agents(active_default)
             return False
 
         shutdown = getattr(agent, "shutdown_runtime", None)
@@ -1450,7 +1477,8 @@ class AgentAuthService:
             await refresh()
 
         setattr(self.controller.config, backend, None)
-        self._sync_builtin_default_agents()
+        active_default = self._revalidate_runtime_default_backend(self._load_saved_default_backend())
+        self._sync_builtin_default_agents(active_default)
         logger.info("Unregistered disabled %s backend after runtime config refresh", backend)
         return True
 
@@ -1473,7 +1501,7 @@ class AgentAuthService:
         else:
             return False
 
-        active_default = self._sync_runtime_default_backend(default_backend) or default_backend
+        active_default = self._revalidate_runtime_default_backend(default_backend)
         self._sync_builtin_default_agents(active_default)
 
         logger.info("Registered %s backend after runtime config refresh", backend)
@@ -1491,7 +1519,7 @@ class AgentAuthService:
             if runtime_config is not None and self._register_missing_backend_agent(backend, runtime_config):
                 return
             if runtime_config is not None and await refresh_runtime_config(backend, runtime_config):
-                active_default = self._sync_runtime_default_backend(self._load_saved_default_backend())
+                active_default = self._revalidate_runtime_default_backend(self._load_saved_default_backend())
                 self._sync_builtin_default_agents(active_default)
                 return
 

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -61,6 +61,7 @@ class _StubController:
         )
         self.im_client = _StubIMClient()
         self.agent_service = SimpleNamespace(agents={})
+        self.settings_manager = SimpleNamespace(sessions={})
         self.sessions = SimpleNamespace(get_agent_session_id=lambda *args, **kwargs: None)
         self.session_handler = SimpleNamespace(
             get_session_info=lambda context: ("base-1", "/tmp/workdir", "base-1:/tmp/workdir")
@@ -996,6 +997,32 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         service._load_backend_runtime_config.assert_called_once_with("codex")
         agent.refresh_runtime_config.assert_awaited_once_with(runtime_config)
         agent.refresh_auth_state.assert_not_awaited()
+
+    async def test_refresh_backend_runtime_registers_codex_when_enabled_after_startup(self):
+        from config.v2_compat import CodexCompatConfig
+        from modules.agents.service import AgentService
+
+        controller = _StubController()
+        controller.config.codex = None
+        controller.agent_service = AgentService(controller)
+        register = controller.agent_service.register
+        controller.agent_service.register = Mock(side_effect=register)
+        service = AgentAuthService(controller)
+        runtime_config = CodexCompatConfig(
+            enabled=True,
+            binary="/Users/rk/.nvm/versions/node/v24.12.0/bin/codex",
+            extra_args=[],
+        )
+        service._load_backend_runtime_config = Mock(return_value=runtime_config)
+
+        await service._refresh_backend_runtime("codex")
+
+        service._load_backend_runtime_config.assert_called_once_with("codex")
+        controller.agent_service.register.assert_called_once()
+        registered = controller.agent_service.agents["codex"]
+        self.assertEqual(registered.name, "codex")
+        self.assertIs(registered.codex_config, runtime_config)
+        self.assertIs(controller.config.codex, runtime_config)
 
     async def test_refresh_opencode_runtime_reloads_v2_cli_path(self):
         from config.v2_config import AgentsConfig, OpenCodeConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1026,23 +1026,39 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertIs(controller.config.codex, runtime_config)
 
     async def test_refresh_backend_runtime_unregisters_disabled_codex(self):
+        from modules.agent_router import AgentRouter
         from modules.agents.service import AgentService
 
         controller = _StubController()
         controller.agent_service = AgentService(controller)
+        controller.agent_router = AgentRouter.from_file(None, platform="slack", default_backend="codex")
         controller.config.codex = SimpleNamespace(binary="/old/codex")
+        controller.config.default_backend = "codex"
+        controller.agent_service.register(SimpleNamespace(name="claude"))
         agent = SimpleNamespace(name="codex", shutdown_runtime=AsyncMock())
         controller.agent_service.register(agent)
+        def validate_default():
+            if controller.agent_router.global_default not in controller.agent_service.agents:
+                controller.agent_router.global_default = "claude"
+                for route in controller.agent_router.platform_routes.values():
+                    route.default = "claude"
+
+        controller._validate_default_backend = validate_default
         service = AgentAuthService(controller)
         service._load_backend_runtime_config = Mock(return_value=None)
-        service._sync_builtin_default_agents = Mock()
+        service._load_saved_default_backend = Mock(return_value="codex")
+        service._load_saved_enabled_backends = Mock(return_value=["claude"])
+        service._sync_builtin_default_agents = Mock(wraps=service._sync_builtin_default_agents)
 
         await service._refresh_backend_runtime("codex")
 
         self.assertNotIn("codex", controller.agent_service.agents)
         self.assertIsNone(controller.config.codex)
+        self.assertEqual(controller.agent_router.global_default, "claude")
+        self.assertEqual(controller.agent_router.platform_routes["slack"].default, "claude")
+        self.assertEqual(controller.config.default_backend, "claude")
         agent.shutdown_runtime.assert_awaited_once()
-        service._sync_builtin_default_agents.assert_called_once()
+        service._sync_builtin_default_agents.assert_called_once_with("claude")
 
     async def test_refresh_backend_runtime_restores_saved_default_after_late_registration(self):
         from config.v2_compat import CodexCompatConfig
@@ -1058,6 +1074,7 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         runtime_config = CodexCompatConfig(enabled=True, binary="/opt/codex", extra_args=[])
         service._load_backend_runtime_config = Mock(return_value=runtime_config)
         service._load_saved_default_backend = Mock(return_value="codex")
+        service._load_saved_enabled_backends = Mock(return_value=["codex"])
         service._sync_builtin_default_agents = Mock(wraps=service._sync_builtin_default_agents)
 
         await service._refresh_backend_runtime("codex")
@@ -1066,6 +1083,19 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(controller.agent_router.platform_routes["slack"].default, "codex")
         self.assertEqual(controller.config.default_backend, "codex")
         service._sync_builtin_default_agents.assert_called_once_with("codex")
+
+    async def test_sync_builtin_default_agents_uses_saved_enabled_config(self):
+        controller = _StubController()
+        controller.vibe_agent_store = SimpleNamespace(ensure_builtin_default_agents=Mock())
+        service = AgentAuthService(controller)
+        service._load_saved_enabled_backends = Mock(return_value=["codex"])
+
+        service._sync_builtin_default_agents("codex")
+
+        controller.vibe_agent_store.ensure_builtin_default_agents.assert_called_once_with(
+            ["codex"],
+            default_backend="codex",
+        )
 
     async def test_refresh_opencode_runtime_reloads_v2_cli_path(self):
         from config.v2_config import AgentsConfig, OpenCodeConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1014,6 +1014,7 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
             extra_args=[],
         )
         service._load_backend_runtime_config = Mock(return_value=runtime_config)
+        service._load_saved_default_backend = Mock(return_value="codex")
 
         await service._refresh_backend_runtime("codex")
 
@@ -1023,6 +1024,48 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(registered.name, "codex")
         self.assertIs(registered.codex_config, runtime_config)
         self.assertIs(controller.config.codex, runtime_config)
+
+    async def test_refresh_backend_runtime_unregisters_disabled_codex(self):
+        from modules.agents.service import AgentService
+
+        controller = _StubController()
+        controller.agent_service = AgentService(controller)
+        controller.config.codex = SimpleNamespace(binary="/old/codex")
+        agent = SimpleNamespace(name="codex", shutdown_runtime=AsyncMock())
+        controller.agent_service.register(agent)
+        service = AgentAuthService(controller)
+        service._load_backend_runtime_config = Mock(return_value=None)
+        service._sync_builtin_default_agents = Mock()
+
+        await service._refresh_backend_runtime("codex")
+
+        self.assertNotIn("codex", controller.agent_service.agents)
+        self.assertIsNone(controller.config.codex)
+        agent.shutdown_runtime.assert_awaited_once()
+        service._sync_builtin_default_agents.assert_called_once()
+
+    async def test_refresh_backend_runtime_restores_saved_default_after_late_registration(self):
+        from config.v2_compat import CodexCompatConfig
+        from modules.agent_router import AgentRouter
+        from modules.agents.service import AgentService
+
+        controller = _StubController()
+        controller.agent_service = AgentService(controller)
+        controller.config.codex = None
+        controller.config.default_backend = "claude"
+        controller.agent_router = AgentRouter.from_file(None, platform="slack", default_backend="claude")
+        service = AgentAuthService(controller)
+        runtime_config = CodexCompatConfig(enabled=True, binary="/opt/codex", extra_args=[])
+        service._load_backend_runtime_config = Mock(return_value=runtime_config)
+        service._load_saved_default_backend = Mock(return_value="codex")
+        service._sync_builtin_default_agents = Mock(wraps=service._sync_builtin_default_agents)
+
+        await service._refresh_backend_runtime("codex")
+
+        self.assertEqual(controller.agent_router.global_default, "codex")
+        self.assertEqual(controller.agent_router.platform_routes["slack"].default, "codex")
+        self.assertEqual(controller.config.default_backend, "codex")
+        service._sync_builtin_default_agents.assert_called_once_with("codex")
 
     async def test_refresh_opencode_runtime_reloads_v2_cli_path(self):
         from config.v2_config import AgentsConfig, OpenCodeConfig, RuntimeConfig, SlackConfig, V2Config

--- a/ui/src/components/settings/shared/useBackendRuntime.ts
+++ b/ui/src/components/settings/shared/useBackendRuntime.ts
@@ -229,8 +229,10 @@ export function useBackendRuntime({
     setEnabled(next);
     // Persist immediately so the routing layer picks up the flip
     // without forcing the user to also click Save (the Save button
-    // is reserved for cli_path edits). Roll back on failure.
+    // is reserved for cli_path edits). Roll back only if the config write
+    // itself fails; after a successful save the UI should reflect persisted state.
     void (async () => {
+      let saved = false;
       try {
         const config = await api.getConfig();
         const nextAgents = {
@@ -247,6 +249,7 @@ export function useBackendRuntime({
         await api.saveConfig({
           agents: { ...nextAgents, default_backend: defaultBackend },
         });
+        saved = true;
         if (!deferRestart) {
           const restart = await api.restartBackend(backend);
           if (!restart?.ok) {
@@ -255,7 +258,7 @@ export function useBackendRuntime({
         }
       } catch (e: any) {
         showToast(e?.message || t('common.saveFailed'), 'error');
-        setEnabled(!next);
+        if (!saved) setEnabled(!next);
       }
     })();
   }, [api, backend, deferRestart, enabled, fallbackDefaultBackend, showToast, t]);

--- a/ui/src/components/settings/shared/useBackendRuntime.ts
+++ b/ui/src/components/settings/shared/useBackendRuntime.ts
@@ -247,12 +247,18 @@ export function useBackendRuntime({
         await api.saveConfig({
           agents: { ...nextAgents, default_backend: defaultBackend },
         });
+        if (!deferRestart) {
+          const restart = await api.restartBackend(backend);
+          if (!restart?.ok) {
+            throw new Error(restart?.message || t('common.saveFailed'));
+          }
+        }
       } catch (e: any) {
         showToast(e?.message || t('common.saveFailed'), 'error');
         setEnabled(!next);
       }
     })();
-  }, [api, backend, enabled, fallbackDefaultBackend, showToast, t]);
+  }, [api, backend, deferRestart, enabled, fallbackDefaultBackend, showToast, t]);
 
   const handleLifecycleChanged = useCallback(
     async (info: { installedPath?: string | null } | undefined | null) => {


### PR DESCRIPTION
## What
- Register optional Codex/OpenCode backend agents during live runtime refresh when they were enabled after controller startup.
- Trigger backend runtime refresh when the settings enabled toggle is changed, not only when the CLI path is saved.
- Add coverage for enabling Codex after startup with an absolute nvm-installed CLI path.

## Why
A backend could be persisted as enabled in Settings while the live controller still had no registered `codex` agent, causing Session routing to fail with `Agent 'codex' is not configured`. The Settings test panel rereads config from disk and runs the CLI directly, so it could pass without proving the live Session path was reconciled.

## Validation
- `uv run pytest tests/test_agent_auth_service.py::AgentAuthServiceTests::test_refresh_backend_runtime_registers_codex_when_enabled_after_startup tests/test_agent_auth_service.py::AgentAuthServiceTests::test_refresh_backend_runtime_prefers_runtime_config_reload tests/test_agent_service.py`
- `npm run build` in `ui/`
