### PR TITLE
fix(show): rewrite public runtime private paths

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -820,6 +820,40 @@ def test_show_runtime_source_rewrites_prefixed_fs_vite_cache_dep_imports(monkeyp
     )
 
 
+def test_public_show_runtime_source_rewrites_private_runtime_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(
+        body=(
+            b'import "/show/ses123/@vite/client";\n'
+            b'import "/show/ses123/@react-refresh";\n'
+            b'const socketPath = "/show/ses123/__vite_hmr";\n'
+        ),
+        extra_headers={
+            "content-type": "text/javascript",
+            "cache-control": "no-cache",
+            "etag": "source-etag",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/src/App.tsx?t=1780732068677",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert f'"/p/{share_id}/@vite/client"'.encode() in response.content
+    assert f'"/p/{share_id}/@react-refresh"'.encode() in response.content
+    assert f'"/p/{share_id}/__vite_hmr"'.encode() in response.content
+    assert b'"/show/ses123/' not in response.content
+    assert response.headers["cache-control"] == "no-store"
+    assert "etag" not in response.headers
+
+
 def test_show_runtime_source_preserves_dot_vite_dep_import_paths(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5656,6 +5656,12 @@ async def _show_page_runtime_response(
     else:
         if proxied.status_code == 200:
             content = _rewrite_show_runtime_public_deps(content, response_headers, session_id=session_id)
+            content = _rewrite_public_show_runtime_private_paths(
+                content,
+                response_headers,
+                session_id=session_id,
+                external_prefix=external_prefix,
+            )
         _apply_show_runtime_cache_headers(
             asset_path,
             response_headers,
@@ -5786,6 +5792,31 @@ def _rewrite_show_runtime_public_deps(content: bytes, headers: dict[str, str], *
         return f"{match.group('quote')}{public_path}{match.group('rest')}{match.group('quote')}"
 
     rewritten = _SHOW_RUNTIME_PUBLIC_DEP_RE.sub(replace, text)
+    if rewritten == text:
+        return content
+    _strip_mutated_show_runtime_headers(headers)
+    return rewritten.encode("utf-8")
+
+
+def _rewrite_public_show_runtime_private_paths(
+    content: bytes,
+    headers: dict[str, str],
+    *,
+    session_id: str,
+    external_prefix: str | None,
+) -> bytes:
+    if not external_prefix:
+        return content
+    content_type = _response_header(headers, "content-type") or ""
+    if not _show_response_is_javascript(content_type):
+        return content
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return content
+    private_prefix = f"/show/{quote(session_id, safe='')}/"
+    public_prefix = f"{external_prefix.rstrip('/')}/"
+    rewritten = text.replace(private_prefix, public_prefix)
     if rewritten == text:
         return content
     _strip_mutated_show_runtime_headers(headers)


### PR DESCRIPTION
## Summary

- rewrite public Show Runtime JS so private /show/<session>/ runtime paths become the public /p/<share>/ prefix
- prevent public pages from redirecting unauthenticated visitors to the private Show route for Vite refresh/client modules
- add regression coverage for public runtime source rewriting and cache header stripping

## Tests

- npm ci && npm run build (ui/)
- uv run pytest tests/test_ui_show_pages.py -q
- uv run ruff check vibe/ui_server.py tests/test_ui_show_pages.py
- git diff --check
- regression environment verified https://test-app.avibe.bot/p/UAeBLpyM7mY/ renders via CDP
