### PR TITLE
fix(regression): tolerate opencode installer path

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1181,7 +1181,18 @@ def cmd_build_base(args: argparse.Namespace) -> int:
                 npm install -g @anthropic-ai/claude-code @openai/codex
                 curl -fsSL https://askill.sh | sh -s -- -b /usr/local/bin
                 HOME=/usr/local curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path
-                install -o root -g root -m 0755 /usr/local/.opencode/bin/opencode /usr/local/bin/opencode
+                opencode_bin=""
+                for candidate in /usr/local/.opencode/bin/opencode /root/.opencode/bin/opencode; do
+                    if [ -x "$candidate" ]; then
+                        opencode_bin="$candidate"
+                        break
+                    fi
+                done
+                if [ -z "$opencode_bin" ]; then
+                    echo "OpenCode installer did not produce an opencode binary" >&2
+                    exit 1
+                fi
+                install -o root -g root -m 0755 "$opencode_bin" /usr/local/bin/opencode
                 askill --version
                 opencode --version
                 node --version

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -394,7 +394,8 @@ def test_build_base_uses_publishable_temp_instance() -> None:
     assert "npm install -g @anthropic-ai/claude-code @openai/codex" in joined
     assert "https://askill.sh | sh -s -- -b /usr/local/bin" in joined
     assert "HOME=/usr/local curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path" in joined
-    assert "install -o root -g root -m 0755 /usr/local/.opencode/bin/opencode /usr/local/bin/opencode" in joined
+    assert "/usr/local/.opencode/bin/opencode /root/.opencode/bin/opencode" in joined
+    assert 'install -o root -g root -m 0755 "$opencode_bin" /usr/local/bin/opencode' in joined
     assert "cloud-init clean --logs || true" in joined
     assert "incus publish avibe-regression-base-build --alias avibe-regression-base-current" in joined
 


### PR DESCRIPTION
## Summary
- tolerate the OpenCode installer placing the binary under `/root/.opencode/bin`
- keep installing a root-owned `/usr/local/bin/opencode` for the regression base image
- cover the installer-path fallback in Incus regression tests

## Why
The local Incus base image build failed when the OpenCode installer wrote the binary to `/root/.opencode/bin/opencode` instead of the previously expected `/usr/local/.opencode/bin/opencode`. That prevented clean regression environment rebuilds.

## Validation
- `uv run pytest tests/test_incus_regression.py -q`
- rebuilt the local Incus regression base image successfully after the fix
