### PR TITLE
fix(regression): guard paired master resets

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -926,14 +926,13 @@ def should_seed_state(runner: Runner, target: RegressionTarget, *, reset_mode: s
     return result.returncode != 0
 
 
-def target_remote_pairing_state(runner: Runner, target: RegressionTarget, *, remote: str | None) -> bool | None:
-    if runner.dry_run:
-        return False
-    script = textwrap.dedent(f"""
+def remote_pairing_probe_script() -> str:
+    return textwrap.dedent(f"""
         import json
+        import os
         from pathlib import Path
 
-        path = Path({str(AVIBE_HOME + "/config/config.json")!r})
+        path = Path(os.environ.get("AVIBE_REMOTE_PAIRING_CONFIG_PATH", {str(AVIBE_HOME + "/config/config.json")!r}))
         if not path.exists():
             print(json.dumps({{"state": "unpaired"}}))
             raise SystemExit(0)
@@ -948,15 +947,30 @@ def target_remote_pairing_state(runner: Runner, target: RegressionTarget, *, rem
             print(json.dumps({{"state": "unpaired"}}))
             raise SystemExit(0)
 
+        vibe_cloud = remote_access.get("vibe_cloud")
+        if not isinstance(vibe_cloud, dict):
+            vibe_cloud = {{}}
         paired = bool(
             remote_access.get("enabled")
             or remote_access.get("public_url")
             or remote_access.get("tunnel_id")
             or remote_access.get("credentials_file")
             or remote_access.get("cloudflared_config")
+            or vibe_cloud.get("enabled")
+            or vibe_cloud.get("public_url")
+            or vibe_cloud.get("instance_id")
+            or vibe_cloud.get("tunnel_token")
+            or vibe_cloud.get("instance_secret")
+            or vibe_cloud.get("session_secret")
         )
         print(json.dumps({{"state": "paired" if paired else "unpaired"}}))
     """).strip()
+
+
+def target_remote_pairing_state(runner: Runner, target: RegressionTarget, *, remote: str | None) -> bool | None:
+    if runner.dry_run:
+        return False
+    script = remote_pairing_probe_script()
     result = runner.run(
         root_exec(target, f"python3 - <<'PY'\n{script}\nPY", remote=remote),
         capture=True,

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -932,38 +932,53 @@ def remote_pairing_probe_script() -> str:
         import os
         from pathlib import Path
 
-        path = Path(os.environ.get("AVIBE_REMOTE_PAIRING_CONFIG_PATH", {str(AVIBE_HOME + "/config/config.json")!r}))
-        if not path.exists():
+        default_paths = [{str(AVIBE_HOME + "/config/config.json")!r}, {str(LEGACY_HOME + "/config/config.json")!r}]
+        env_paths = os.environ.get("AVIBE_REMOTE_PAIRING_CONFIG_PATHS")
+        if env_paths:
+            paths = [Path(path) for path in env_paths.split(os.pathsep) if path]
+        else:
+            legacy_env_path = os.environ.get("AVIBE_REMOTE_PAIRING_CONFIG_PATH")
+            paths = [Path(legacy_env_path)] if legacy_env_path else [Path(path) for path in default_paths]
+
+        saw_config = False
+        for path in paths:
+            if not path.exists():
+                continue
+            saw_config = True
+            try:
+                payload = json.loads(path.read_text())
+            except Exception:
+                print(json.dumps({{"state": "unknown", "path": str(path)}}))
+                raise SystemExit(0)
+
+            remote_access = payload.get("remote_access") if isinstance(payload, dict) else None
+            if not isinstance(remote_access, dict):
+                continue
+
+            vibe_cloud = remote_access.get("vibe_cloud")
+            if not isinstance(vibe_cloud, dict):
+                vibe_cloud = {{}}
+            paired = bool(
+                remote_access.get("enabled")
+                or remote_access.get("public_url")
+                or remote_access.get("tunnel_id")
+                or remote_access.get("credentials_file")
+                or remote_access.get("cloudflared_config")
+                or vibe_cloud.get("enabled")
+                or vibe_cloud.get("public_url")
+                or vibe_cloud.get("instance_id")
+                or vibe_cloud.get("tunnel_token")
+                or vibe_cloud.get("instance_secret")
+                or vibe_cloud.get("session_secret")
+            )
+            if paired:
+                print(json.dumps({{"state": "paired", "path": str(path)}}))
+                raise SystemExit(0)
+
+        if not saw_config:
             print(json.dumps({{"state": "unpaired"}}))
             raise SystemExit(0)
-        try:
-            payload = json.loads(path.read_text())
-        except Exception:
-            print(json.dumps({{"state": "unknown"}}))
-            raise SystemExit(0)
-
-        remote_access = payload.get("remote_access") if isinstance(payload, dict) else None
-        if not isinstance(remote_access, dict):
-            print(json.dumps({{"state": "unpaired"}}))
-            raise SystemExit(0)
-
-        vibe_cloud = remote_access.get("vibe_cloud")
-        if not isinstance(vibe_cloud, dict):
-            vibe_cloud = {{}}
-        paired = bool(
-            remote_access.get("enabled")
-            or remote_access.get("public_url")
-            or remote_access.get("tunnel_id")
-            or remote_access.get("credentials_file")
-            or remote_access.get("cloudflared_config")
-            or vibe_cloud.get("enabled")
-            or vibe_cloud.get("public_url")
-            or vibe_cloud.get("instance_id")
-            or vibe_cloud.get("tunnel_token")
-            or vibe_cloud.get("instance_secret")
-            or vibe_cloud.get("session_secret")
-        )
-        print(json.dumps({{"state": "paired" if paired else "unpaired"}}))
+        print(json.dumps({{"state": "unpaired"}}))
     """).strip()
 
 

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -926,7 +926,7 @@ def should_seed_state(runner: Runner, target: RegressionTarget, *, reset_mode: s
     return result.returncode != 0
 
 
-def target_has_remote_pairing(runner: Runner, target: RegressionTarget, *, remote: str | None) -> bool:
+def target_remote_pairing_state(runner: Runner, target: RegressionTarget, *, remote: str | None) -> bool | None:
     if runner.dry_run:
         return False
     result = runner.run(
@@ -935,11 +935,11 @@ def target_has_remote_pairing(runner: Runner, target: RegressionTarget, *, remot
         check=False,
     )
     if result.returncode != 0:
-        return False
+        return None
     try:
         payload = json.loads(result.stdout or "{}")
     except json.JSONDecodeError:
-        return False
+        return None
     return bool(payload.get("paired") or payload.get("enabled") or payload.get("public_url"))
 
 
@@ -953,12 +953,13 @@ def guard_paired_master_reset(
 ) -> None:
     if reset_mode == "none" or target.target != MASTER_TARGET or allow_reset_paired_master:
         return
-    if not target_has_remote_pairing(runner, target, remote=remote):
+    pairing_state = target_remote_pairing_state(runner, target, remote=remote)
+    if pairing_state is False:
         return
     raise RegressionError(
-        "Refusing to reset the paired master regression environment because it would delete "
-        "Avibe Cloud remote-access pairing state. Re-run with --allow-reset-paired-master "
-        "only if you intentionally want to pair it again afterward."
+        "Refusing to reset the master regression environment because Avibe Cloud pairing "
+        "state is present or could not be verified safely. Re-run with "
+        "--allow-reset-paired-master only if you intentionally want to pair it again afterward."
     )
 
 

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -926,6 +926,42 @@ def should_seed_state(runner: Runner, target: RegressionTarget, *, reset_mode: s
     return result.returncode != 0
 
 
+def target_has_remote_pairing(runner: Runner, target: RegressionTarget, *, remote: str | None) -> bool:
+    if runner.dry_run:
+        return False
+    result = runner.run(
+        tenant_exec(target, f"{VENV_DIR}/bin/vibe remote status --json", remote=remote),
+        capture=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    return bool(payload.get("paired") or payload.get("enabled") or payload.get("public_url"))
+
+
+def guard_paired_master_reset(
+    runner: Runner,
+    target: RegressionTarget,
+    *,
+    reset_mode: str,
+    allow_reset_paired_master: bool,
+    remote: str | None,
+) -> None:
+    if reset_mode == "none" or target.target != MASTER_TARGET or allow_reset_paired_master:
+        return
+    if not target_has_remote_pairing(runner, target, remote=remote):
+        return
+    raise RegressionError(
+        "Refusing to reset the paired master regression environment because it would delete "
+        "Avibe Cloud remote-access pairing state. Re-run with --allow-reset-paired-master "
+        "only if you intentionally want to pair it again afterward."
+    )
+
+
 def run_prepare_state(runner: Runner, target: RegressionTarget, *, reset_mode: str, remote: str | None) -> None:
     if not should_seed_state(runner, target, reset_mode=reset_mode, remote=remote):
         print("Existing Avibe state found; skipping regression state seed.")
@@ -1257,6 +1293,14 @@ def cmd_up(args: argparse.Namespace) -> int:
             processes=args.processes,
             remote=args.remote,
         )
+        if target_exists:
+            guard_paired_master_reset(
+                runner,
+                target,
+                reset_mode=args.reset_mode,
+                allow_reset_paired_master=getattr(args, "allow_reset_paired_master", False),
+                remote=args.remote,
+            )
         if not args.dry_run and not seed_requires_env and should_seed_state(runner, target, reset_mode=args.reset_mode, remote=args.remote):
             require_runtime_seed_env()
         stop_service_for_update(runner, target, remote=args.remote)
@@ -1442,6 +1486,11 @@ def build_parser() -> argparse.ArgumentParser:
     up.add_argument("--disk", default="80GiB")
     up.add_argument("--processes", default="8192")
     up.add_argument("--reset-mode", choices=["none", "config", "all"], default="none")
+    up.add_argument(
+        "--allow-reset-paired-master",
+        action="store_true",
+        help="Allow reset-mode config/all to delete Avibe Cloud pairing state from the master regression environment.",
+    )
     up.add_argument("--clean", action="store_true", help="Remove stale files before source sync.")
     up.add_argument("--force-deps", action="store_true", help="Force Python dependency refresh.")
     up.add_argument("--no-build-ui", action="store_true", help="Skip npm ci/build for UI assets.")

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -929,8 +929,36 @@ def should_seed_state(runner: Runner, target: RegressionTarget, *, reset_mode: s
 def target_remote_pairing_state(runner: Runner, target: RegressionTarget, *, remote: str | None) -> bool | None:
     if runner.dry_run:
         return False
+    script = textwrap.dedent(f"""
+        import json
+        from pathlib import Path
+
+        path = Path({str(AVIBE_HOME + "/config/config.json")!r})
+        if not path.exists():
+            print(json.dumps({{"state": "unpaired"}}))
+            raise SystemExit(0)
+        try:
+            payload = json.loads(path.read_text())
+        except Exception:
+            print(json.dumps({{"state": "unknown"}}))
+            raise SystemExit(0)
+
+        remote_access = payload.get("remote_access") if isinstance(payload, dict) else None
+        if not isinstance(remote_access, dict):
+            print(json.dumps({{"state": "unpaired"}}))
+            raise SystemExit(0)
+
+        paired = bool(
+            remote_access.get("enabled")
+            or remote_access.get("public_url")
+            or remote_access.get("tunnel_id")
+            or remote_access.get("credentials_file")
+            or remote_access.get("cloudflared_config")
+        )
+        print(json.dumps({{"state": "paired" if paired else "unpaired"}}))
+    """).strip()
     result = runner.run(
-        tenant_exec(target, f"{VENV_DIR}/bin/vibe remote status --json", remote=remote),
+        root_exec(target, f"python3 - <<'PY'\n{script}\nPY", remote=remote),
         capture=True,
         check=False,
     )
@@ -940,7 +968,12 @@ def target_remote_pairing_state(runner: Runner, target: RegressionTarget, *, rem
         payload = json.loads(result.stdout or "{}")
     except json.JSONDecodeError:
         return None
-    return bool(payload.get("paired") or payload.get("enabled") or payload.get("public_url"))
+    state = payload.get("state")
+    if state == "paired":
+        return True
+    if state == "unpaired":
+        return False
+    return None
 
 
 def guard_paired_master_reset(
@@ -1282,6 +1315,14 @@ def cmd_up(args: argparse.Namespace) -> int:
         seed_requires_env = not args.dry_run and (args.reset_mode != "none" or not target_exists)
         if seed_requires_env:
             require_runtime_seed_env()
+        if target_exists:
+            guard_paired_master_reset(
+                runner,
+                target,
+                reset_mode=args.reset_mode,
+                allow_reset_paired_master=getattr(args, "allow_reset_paired_master", False),
+                remote=args.remote,
+            )
         ensure_project_and_instance(
             runner,
             target,
@@ -1294,14 +1335,6 @@ def cmd_up(args: argparse.Namespace) -> int:
             processes=args.processes,
             remote=args.remote,
         )
-        if target_exists:
-            guard_paired_master_reset(
-                runner,
-                target,
-                reset_mode=args.reset_mode,
-                allow_reset_paired_master=getattr(args, "allow_reset_paired_master", False),
-                remote=args.remote,
-            )
         if not args.dry_run and not seed_requires_env and should_seed_state(runner, target, reset_mode=args.reset_mode, remote=args.remote):
             require_runtime_seed_env()
         stop_service_for_update(runner, target, remote=args.remote)

--- a/scripts/run_regression.sh
+++ b/scripts/run_regression.sh
@@ -77,7 +77,7 @@ while [ $# -gt 0 ]; do
             incus_args+=(--remote "$2")
             shift 2
             ;;
-        --dry-run|--clean|--force-deps|--no-build-ui|--yes)
+        --allow-reset-paired-master|--dry-run|--clean|--force-deps|--no-build-ui|--yes)
             incus_args+=("$1")
             shift
             ;;

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -697,7 +697,7 @@ def test_guard_paired_master_reset_rejects_remote_access_state() -> None:
 
         def run(self, command, **kwargs):
             commands.append(command)
-            return subprocess.CompletedProcess(command, 0, stdout='{"paired": true, "public_url": "https://test-app.avibe.bot"}')
+            return subprocess.CompletedProcess(command, 0, stdout='{"state": "paired"}')
 
     target = incus_regression.RegressionTarget(
         target="master",
@@ -719,7 +719,7 @@ def test_guard_paired_master_reset_rejects_remote_access_state() -> None:
         )
 
     joined = "\n".join(" ".join(command) for command in commands)
-    assert "vibe remote status --json" in joined
+    assert "/home/avibe/.avibe/config/config.json" in joined
 
 
 def test_guard_paired_master_reset_fails_closed_when_probe_fails() -> None:
@@ -774,6 +774,59 @@ def test_guard_paired_master_reset_fails_closed_when_probe_json_is_invalid() -> 
             allow_reset_paired_master=False,
             remote=None,
         )
+
+
+def test_guard_paired_master_reset_fails_closed_when_config_is_unreadable() -> None:
+    class UnreadableConfigRunner:
+        dry_run = False
+
+        def run(self, command, **kwargs):
+            return subprocess.CompletedProcess(command, 0, stdout='{"state": "unknown"}')
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    with pytest.raises(incus_regression.RegressionError, match="could not be verified safely"):
+        incus_regression.guard_paired_master_reset(
+            UnreadableConfigRunner(),
+            target,
+            reset_mode="config",
+            allow_reset_paired_master=False,
+            remote=None,
+        )
+
+
+def test_guard_paired_master_reset_allows_verified_unpaired_config() -> None:
+    class UnpairedRunner:
+        dry_run = False
+
+        def run(self, command, **kwargs):
+            return subprocess.CompletedProcess(command, 0, stdout='{"state": "unpaired"}')
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    incus_regression.guard_paired_master_reset(
+        UnpairedRunner(),
+        target,
+        reset_mode="config",
+        allow_reset_paired_master=False,
+        remote=None,
+    )
 
 
 def test_guard_paired_master_reset_allows_explicit_override() -> None:
@@ -1207,6 +1260,64 @@ def test_up_checks_platform_seed_env_before_existing_reset_mutation(tmp_path: Pa
     )
 
     with pytest.raises(SystemExit):
+        incus_regression.cmd_up(args)
+
+    assert calls == ["require_runtime_seed_env"]
+
+
+def test_up_rejects_paired_master_reset_before_instance_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    class ExistingRunner:
+        def __init__(self, *, dry_run=False):
+            self.dry_run = dry_run
+
+        def exists(self, command):
+            return True
+
+        def run(self, command, **kwargs):
+            return subprocess.CompletedProcess(command, 0, stdout='{"state": "paired"}')
+
+    def record(name):
+        def wrapper(*args, **kwargs):
+            calls.append(name)
+
+        return wrapper
+
+    monkeypatch.setattr(incus_regression, "current_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(incus_regression, "load_env_file", lambda repo_root, env_file: None)
+    monkeypatch.setattr(incus_regression, "require_incus", lambda: None)
+    monkeypatch.setattr(incus_regression, "require_runtime_seed_env", record("require_runtime_seed_env"))
+    monkeypatch.setattr(incus_regression, "Runner", ExistingRunner)
+    monkeypatch.setattr(incus_regression, "ensure_project_and_instance", record("ensure_project_and_instance"))
+    monkeypatch.setattr(incus_regression, "stop_service_for_update", record("stop_service_for_update"))
+
+    args = argparse.Namespace(
+        target="master",
+        slug=None,
+        host_port=None,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+        worktree_port_start=15200,
+        worktree_port_end=15399,
+        env_file=None,
+        dry_run=False,
+        image="avibe-regression-base-current",
+        storage_pool="default",
+        network="incusbr0",
+        cpus="2",
+        memory="4GiB",
+        disk="20GiB",
+        processes="4096",
+        remote=None,
+        clean=False,
+        force_deps=False,
+        no_build_ui=True,
+        reset_mode="config",
+        allow_reset_paired_master=False,
+    )
+
+    with pytest.raises(incus_regression.RegressionError, match="pairing state is present"):
         incus_regression.cmd_up(args)
 
     assert calls == ["require_runtime_seed_env"]

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -749,7 +749,38 @@ def test_remote_pairing_probe_detects_nested_vibe_cloud_config(tmp_path: Path) -
         text=True,
     )
 
-    assert json.loads(result.stdout) == {"state": "paired"}
+    assert json.loads(result.stdout)["state"] == "paired"
+
+
+def test_remote_pairing_probe_detects_legacy_only_config(tmp_path: Path) -> None:
+    missing_new_config = tmp_path / ".avibe" / "config" / "config.json"
+    legacy_config = tmp_path / ".vibe_remote" / "config" / "config.json"
+    legacy_config.parent.mkdir(parents=True)
+    legacy_config.write_text(
+        json.dumps(
+            {
+                "remote_access": {
+                    "provider": "vibe_cloud",
+                    "vibe_cloud": {
+                        "public_url": "https://test-app.avibe.bot",
+                    },
+                }
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", incus_regression.remote_pairing_probe_script()],
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "AVIBE_REMOTE_PAIRING_CONFIG_PATHS": os.pathsep.join([str(missing_new_config), str(legacy_config)]),
+        },
+        text=True,
+    )
+
+    assert json.loads(result.stdout)["state"] == "paired"
 
 
 def test_guard_paired_master_reset_fails_closed_when_probe_fails() -> None:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -689,6 +689,91 @@ def test_prepare_state_reset_all_deletes_target_home_before_copy(monkeypatch: py
     assert "ln -sfn /home/avibe/.avibe /home/avibe/.vibe_remote" in joined
 
 
+def test_guard_paired_master_reset_rejects_remote_access_state() -> None:
+    commands = []
+
+    class PairingRunner:
+        dry_run = False
+
+        def run(self, command, **kwargs):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout='{"paired": true, "public_url": "https://test-app.avibe.bot"}')
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    with pytest.raises(incus_regression.RegressionError, match="paired master regression environment"):
+        incus_regression.guard_paired_master_reset(
+            PairingRunner(),
+            target,
+            reset_mode="config",
+            allow_reset_paired_master=False,
+            remote=None,
+        )
+
+    joined = "\n".join(" ".join(command) for command in commands)
+    assert "vibe remote status --json" in joined
+
+
+def test_guard_paired_master_reset_allows_explicit_override() -> None:
+    class FailingRunner:
+        dry_run = False
+
+        def run(self, command, **kwargs):
+            raise AssertionError("override should skip remote status probing")
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    incus_regression.guard_paired_master_reset(
+        FailingRunner(),
+        target,
+        reset_mode="all",
+        allow_reset_paired_master=True,
+        remote=None,
+    )
+
+
+def test_guard_paired_master_reset_ignores_worktree_targets() -> None:
+    class FailingRunner:
+        dry_run = False
+
+        def run(self, command, **kwargs):
+            raise AssertionError("worktree resets are not protected by master pairing guard")
+
+    target = incus_regression.RegressionTarget(
+        target="worktree",
+        slug="feature",
+        project="avr-wt-feature",
+        instance="avibe-wt-feature",
+        host_port=15200,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    incus_regression.guard_paired_master_reset(
+        FailingRunner(),
+        target,
+        reset_mode="all",
+        allow_reset_paired_master=False,
+        remote=None,
+    )
+
+
 def test_write_runtime_env_uses_stdin_not_command_line() -> None:
     commands = []
     inputs = []

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -4,6 +4,7 @@ import argparse
 import io
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tarfile
@@ -720,6 +721,35 @@ def test_guard_paired_master_reset_rejects_remote_access_state() -> None:
 
     joined = "\n".join(" ".join(command) for command in commands)
     assert "/home/avibe/.avibe/config/config.json" in joined
+
+
+def test_remote_pairing_probe_detects_nested_vibe_cloud_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "remote_access": {
+                    "provider": "vibe_cloud",
+                    "vibe_cloud": {
+                        "enabled": True,
+                        "public_url": "https://test-app.avibe.bot",
+                        "instance_id": "inst_123",
+                        "tunnel_token": "token_123",
+                    },
+                }
+            }
+        )
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", incus_regression.remote_pairing_probe_script()],
+        check=True,
+        capture_output=True,
+        env={**os.environ, "AVIBE_REMOTE_PAIRING_CONFIG_PATH": str(config_path)},
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == {"state": "paired"}
 
 
 def test_guard_paired_master_reset_fails_closed_when_probe_fails() -> None:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -709,7 +709,7 @@ def test_guard_paired_master_reset_rejects_remote_access_state() -> None:
         ui_port=5123,
     )
 
-    with pytest.raises(incus_regression.RegressionError, match="paired master regression environment"):
+    with pytest.raises(incus_regression.RegressionError, match="pairing state is present"):
         incus_regression.guard_paired_master_reset(
             PairingRunner(),
             target,
@@ -720,6 +720,60 @@ def test_guard_paired_master_reset_rejects_remote_access_state() -> None:
 
     joined = "\n".join(" ".join(command) for command in commands)
     assert "vibe remote status --json" in joined
+
+
+def test_guard_paired_master_reset_fails_closed_when_probe_fails() -> None:
+    class BrokenProbeRunner:
+        dry_run = False
+
+        def run(self, command, **kwargs):
+            return subprocess.CompletedProcess(command, 1, stdout="", stderr="venv missing")
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    with pytest.raises(incus_regression.RegressionError, match="could not be verified safely"):
+        incus_regression.guard_paired_master_reset(
+            BrokenProbeRunner(),
+            target,
+            reset_mode="config",
+            allow_reset_paired_master=False,
+            remote=None,
+        )
+
+
+def test_guard_paired_master_reset_fails_closed_when_probe_json_is_invalid() -> None:
+    class InvalidJsonRunner:
+        dry_run = False
+
+        def run(self, command, **kwargs):
+            return subprocess.CompletedProcess(command, 0, stdout="not json")
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    with pytest.raises(incus_regression.RegressionError, match="could not be verified safely"):
+        incus_regression.guard_paired_master_reset(
+            InvalidJsonRunner(),
+            target,
+            reset_mode="all",
+            allow_reset_paired_master=False,
+            remote=None,
+        )
 
 
 def test_guard_paired_master_reset_allows_explicit_override() -> None:

--- a/tests/test_regression_script.py
+++ b/tests/test_regression_script.py
@@ -98,3 +98,20 @@ def test_regression_wrapper_accepts_documented_remote_flag() -> None:
     )
 
     assert "lab:avibe-master" in result.stdout
+
+
+def test_regression_wrapper_accepts_paired_master_reset_override() -> None:
+    result = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "run_regression.sh"),
+            "--reset-config",
+            "--allow-reset-paired-master",
+            "--dry-run",
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "prepare_regression.py --output-root /home/avibe/.regression-seed --reset-mode config" in result.stdout


### PR DESCRIPTION
## Summary
- block `--reset-mode config/all` on an existing paired master regression environment by default
- add an explicit `--allow-reset-paired-master` override for intentional destructive resets
- forward the override through `scripts/run_regression.sh` and cover the guard in tests

## Why
The master regression environment is long-running and owns the Avibe Cloud pairing for `test-app.avibe.bot`. Resetting its Avibe home deletes that pairing state and forces a new pairing code. This guard makes the default path preserve the pairing and requires an explicit opt-in before clearing it.

## Validation
- `PYTHONPATH=. uv run --no-project --with pytest python -m pytest tests/test_incus_regression.py tests/test_regression_script.py -q`
- `uv run --no-project --with ruff ruff check scripts/incus_regression.py tests/test_incus_regression.py tests/test_regression_script.py`
- `bash -n scripts/run_regression.sh`
- live preflight: paired master regression rejected `--reset-mode config` before service stop/source sync/state deletion, and `https://test-app.avibe.bot/health` remained 200
