### PR TITLE
fix(show): materialize page workspace before proxy

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -88,6 +88,15 @@ def _create_show_page(session_id: str, visibility: str) -> str | None:
         store.close()
 
 
+def _create_show_page_record(session_id: str, visibility: str) -> str | None:
+    store = ShowPageStore()
+    try:
+        page = store.update_visibility(session_id, visibility)
+        return page.share_id
+    finally:
+        store.close()
+
+
 def _create_agent_session(session_id: str) -> None:
     from storage import messages_service
     from storage.db import create_sqlite_engine
@@ -220,6 +229,25 @@ def test_private_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
     assert "authorization" not in manager.calls[0][2]
     assert "cookie" not in manager.calls[0][2]
     assert "x-vibe-csrf-token" not in manager.calls[0][2]
+
+
+def test_private_show_page_materializes_workspace_before_runtime_proxy(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page_record("ses123", "private")
+    page_dir = paths.get_show_pages_dir() / "ses123"
+    assert not (page_dir / "src" / "App.tsx").exists()
+    manager = _FakeShowRuntimeManager(body=b"<h1>Runtime Page</h1>")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get("/show/ses123/", base_url="http://127.0.0.1:5123")
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert b"Runtime Page" in response.content
+    assert (page_dir / "src" / "App.tsx").exists()
+    assert manager.calls[0][1] == "/sessions/ses123/app/"
 
 
 def test_private_show_page_injects_runtime_event_config(monkeypatch, tmp_path):
@@ -3215,6 +3243,30 @@ def test_public_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
     assert response.status_code == 200
     assert b"Public Runtime Page" in response.content
     assert manager.calls[0][0] == "GET"
+    assert manager.calls[0][1] == "/sessions/ses123/app/"
+    assert manager.calls[0][2]["x-vibe-show-base"] == f"/p/{share_id}/"
+
+
+def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page_record("ses123", "public")
+    page_dir = paths.get_show_pages_dir() / "ses123"
+    assert not (page_dir / "src" / "App.tsx").exists()
+    manager = _FakeShowRuntimeManager(body=b"<h1>Public Runtime Page</h1>")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert b"Public Runtime Page" in response.content
+    assert (page_dir / "src" / "App.tsx").exists()
     assert manager.calls[0][1] == "/sessions/ses123/app/"
     assert manager.calls[0][2]["x-vibe-show-base"] == f"/p/{share_id}/"
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6505,7 +6505,7 @@ def redirect_private_show_page_to_canonical_path(session_id):
     methods=["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 )
 async def serve_private_show_page(session_id, asset_path):
-    from core.show_pages import ShowPageStore, show_page_dir
+    from core.show_pages import ShowPageStore, ensure_show_page_dir
 
     store = ShowPageStore()
     try:
@@ -6518,6 +6518,7 @@ async def serve_private_show_page(session_id, asset_path):
             return _show_page_not_found_response()
         if asset_path.strip("/") in {"__show/events", "__events"}:
             return await _show_events_response(page.session_id)
+        page_dir = ensure_show_page_dir(page.session_id)
         response = None
         if request.method in {"GET", "HEAD"} or _is_show_api_asset(asset_path):
             try:
@@ -6537,7 +6538,7 @@ async def serve_private_show_page(session_id, asset_path):
                 else:
                     logger.debug("Show runtime unavailable; serving static Show Page", exc_info=True)
         if response is None:
-            response = _show_page_file_response(show_page_dir(page.session_id), asset_path)
+            response = _show_page_file_response(page_dir, asset_path)
         if request.method in {"GET", "HEAD"}:
             if _is_show_runtime_immutable_asset_path(asset_path):
                 return response
@@ -6573,7 +6574,7 @@ def redirect_public_show_page_to_canonical_path(share_id):
     methods=["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 )
 async def serve_public_show_page(share_id, asset_path):
-    from core.show_pages import ShowPageStore, show_page_dir
+    from core.show_pages import ShowPageStore, ensure_show_page_dir
 
     store = ShowPageStore()
     try:
@@ -6591,6 +6592,7 @@ async def serve_public_show_page(share_id, asset_path):
         if request.method in {"GET", "HEAD"}:
             if shim_response := _show_runtime_public_client_shim_response(asset_path):
                 return shim_response
+        page_dir = ensure_show_page_dir(page.session_id)
         response = None
         if request.method in {"GET", "HEAD"} or _is_show_api_asset(asset_path):
             try:
@@ -6610,7 +6612,7 @@ async def serve_public_show_page(share_id, asset_path):
                 else:
                     logger.debug("Show runtime unavailable; serving static public Show Page", exc_info=True)
         if response is None:
-            response = _show_page_file_response(show_page_dir(page.session_id), asset_path)
+            response = _show_page_file_response(page_dir, asset_path)
         if request.method in {"GET", "HEAD"}:
             if _is_show_runtime_immutable_asset_path(asset_path):
                 return response


### PR DESCRIPTION
## Summary
- materialize private and public Show Page workspaces before proxying requests to Show Runtime
- keep fallback static serving on the same materialized directory
- add regression coverage for DB-only Show Page records that have not written React workspace files yet

## Evidence
- unit: `PYTHONPATH=. uv run --no-project --with pytest python -m pytest tests/test_ui_show_pages.py -q -k 'materializes_workspace_before_runtime_proxy or private_show_page_uses_runtime_when_available or public_show_page_uses_runtime_when_available'`
- lint: `uv run --no-project --with ruff ruff check vibe/ui_server.py tests/test_ui_show_pages.py`
- contract: private `/show/<session>/` and public `/p/<share>/` both preserve existing runtime proxy semantics
- residual manual checks: update the Incus regression environment and verify first-open Show Page loading against the public test URL
