### PR TITLE
fix(sessions): resolve agent before session creation

### DIFF
--- a/core/services/agent_run_target.py
+++ b/core/services/agent_run_target.py
@@ -63,6 +63,16 @@ class AgentRunTarget:
         }
 
 
+@dataclass(frozen=True)
+class ResolvedAgentTarget:
+    agent_id: Optional[str]
+    agent_name: Optional[str]
+    agent_backend: str
+    agent_variant: str
+    model: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+
+
 def resolve_agent_run_target(
     context: MessageContext,
     *,
@@ -175,6 +185,13 @@ def resolve_agent_run_target(
                 )
 
         if not scope_id:
+            agent_target = _resolve_agent_target(
+                context,
+                controller=controller,
+                scope_row=None,
+                platform=platform,
+                settings_key=settings_key,
+            )
             return _cache_target(
                 context,
                 _unpersisted_target(
@@ -186,9 +203,17 @@ def resolve_agent_run_target(
                     anchor=anchor,
                     source=source,
                     workdir_source="no_scope",
+                    agent_target=agent_target,
                 ),
             )
 
+        agent_target = _resolve_agent_target(
+            context,
+            controller=controller,
+            scope_row=scope_row,
+            platform=platform,
+            settings_key=settings_key,
+        )
         resolved_new_workdir = _resolve_workdir(
             _normalize_workdir(scope_row.get("workdir")) if scope_row else None,
             controller=controller,
@@ -210,6 +235,7 @@ def resolve_agent_run_target(
                     source=source,
                     workdir=resolved_new_workdir,
                     workdir_source="scope_read",
+                    agent_target=agent_target,
                 ),
             )
 
@@ -217,11 +243,12 @@ def resolve_agent_run_target(
             conn,
             scope_id=str(scope_id),
             session_anchor=anchor,
-            agent_backend=_optional_str(scope_row.get("agent_backend")) if scope_row else "",
-            agent_variant=_optional_str(scope_row.get("agent_variant")) if scope_row else None,
-            agent_name=_optional_str(scope_row.get("agent_name")) if scope_row else None,
-            model=_optional_str(scope_row.get("model")) if scope_row else None,
-            reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
+            agent_id=agent_target.agent_id,
+            agent_backend=agent_target.agent_backend,
+            agent_variant=agent_target.agent_variant,
+            agent_name=agent_target.agent_name,
+            model=agent_target.model,
+            reasoning_effort=agent_target.reasoning_effort,
             workdir=resolved_new_workdir,
             metadata={"created_via": "agent_run_target", "source": source},
         )
@@ -341,6 +368,106 @@ def _target_id(context: MessageContext, target_payload: dict[str, Any]) -> Optio
     payload = context.platform_specific or {}
     value = target_payload.get("id") or payload.get("agent_session_id") or payload.get("workbench_session_id")
     return _optional_str(value)
+
+
+def _resolve_agent_target(
+    context: MessageContext,
+    *,
+    controller: Any,
+    scope_row: Optional[dict[str, Any]],
+    platform: str,
+    settings_key: str,
+) -> ResolvedAgentTarget:
+    """Resolve the concrete Vibe Agent/backend before a Session row exists."""
+
+    scope_agent_name = _optional_str(scope_row.get("agent_name")) if scope_row else None
+    scope_backend = _supported_backend(scope_row.get("agent_backend")) if scope_row else None
+    resolver = getattr(controller, "resolve_vibe_agent_for_context", None)
+    if scope_agent_name and callable(resolver):
+        try:
+            agent = resolver(context, override_agent_name=scope_agent_name, required=False)
+        except TypeError:
+            agent = resolver(context, required=False)
+        except Exception:
+            logger.debug("Failed to resolve scoped Vibe Agent for new session", exc_info=True)
+            agent = None
+        if agent is not None:
+            target = _agent_target_from_vibe_agent(agent, scope_row=scope_row)
+            if target is not None and (scope_backend is None or target.agent_backend == scope_backend):
+                return target
+
+    if scope_backend:
+        return ResolvedAgentTarget(
+            agent_id=None,
+            agent_name=scope_agent_name,
+            agent_backend=scope_backend,
+            agent_variant=_agent_variant_for_backend(scope_backend, scope_row),
+            model=_optional_str(scope_row.get("model")) if scope_row else None,
+            reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
+        )
+
+    if callable(resolver):
+        try:
+            agent = resolver(context, required=False)
+        except Exception:
+            logger.debug("Failed to resolve Vibe Agent for new session", exc_info=True)
+            agent = None
+        if agent is not None:
+            target = _agent_target_from_vibe_agent(agent, scope_row=scope_row)
+            if target is not None:
+                return target
+
+    router = getattr(controller, "agent_router", None)
+    resolved = None
+    if router is not None:
+        try:
+            resolved = router.resolve(platform, settings_key)
+        except Exception:
+            logger.debug("Failed to resolve router backend for new session", exc_info=True)
+        resolved = resolved or getattr(router, "global_default", None)
+    backend = _supported_backend(resolved) or _supported_backend(
+        getattr(getattr(controller, "config", None), "default_backend", None)
+    )
+    if backend is None:
+        from modules.agents.catalog import DEFAULT_AGENT_BACKEND
+
+        backend = DEFAULT_AGENT_BACKEND
+    return ResolvedAgentTarget(
+        agent_id=None,
+        agent_name=None,
+        agent_backend=backend,
+        agent_variant=backend,
+        model=_optional_str(scope_row.get("model")) if scope_row else None,
+        reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
+    )
+
+
+def _agent_target_from_vibe_agent(agent: Any, *, scope_row: Optional[dict[str, Any]]) -> Optional[ResolvedAgentTarget]:
+    backend = _supported_backend(getattr(agent, "backend", None))
+    if not backend:
+        return None
+    scope_model = _optional_str(scope_row.get("model")) if scope_row else None
+    scope_effort = _optional_str(scope_row.get("reasoning_effort")) if scope_row else None
+    return ResolvedAgentTarget(
+        agent_id=_optional_str(getattr(agent, "id", None)),
+        agent_name=_optional_str(getattr(agent, "name", None)),
+        agent_backend=backend,
+        agent_variant=_agent_variant_for_backend(backend, scope_row),
+        model=scope_model or _optional_str(getattr(agent, "model", None)),
+        reasoning_effort=scope_effort or _optional_str(getattr(agent, "reasoning_effort", None)),
+    )
+
+
+def _supported_backend(value: Any) -> Optional[str]:
+    backend = _optional_str(value)
+    if backend in {"opencode", "claude", "codex"}:
+        return backend
+    return None
+
+
+def _agent_variant_for_backend(backend: str, scope_row: Optional[dict[str, Any]]) -> str:
+    variant = _optional_str(scope_row.get("agent_variant")) if scope_row else None
+    return variant or backend
 
 
 def _scope_for_context(conn, context: MessageContext, platform: str, settings_key: str) -> Optional[dict[str, Any]]:
@@ -492,6 +619,7 @@ def _unpersisted_target(
     source: str,
     workdir_source: str,
     workdir: Optional[str] = None,
+    agent_target: Optional[ResolvedAgentTarget] = None,
 ) -> AgentRunTarget:
     resolved_workdir = workdir or _resolve_workdir(
         _normalize_workdir(scope_row.get("workdir")) if scope_row else None,
@@ -510,11 +638,12 @@ def _unpersisted_target(
         source=source,
         scope_id=_optional_str(scope_row.get("scope_id")) if scope_row else None,
         scope_type=_optional_str(scope_row.get("scope_type")) if scope_row else None,
-        agent_name=_optional_str(scope_row.get("agent_name")) if scope_row else None,
-        agent_backend=_optional_str(scope_row.get("agent_backend")) if scope_row else None,
-        agent_variant=_optional_str(scope_row.get("agent_variant")) if scope_row else None,
-        model=_optional_str(scope_row.get("model")) if scope_row else None,
-        reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
+        agent_id=agent_target.agent_id if agent_target else None,
+        agent_name=agent_target.agent_name if agent_target else None,
+        agent_backend=agent_target.agent_backend if agent_target else None,
+        agent_variant=agent_target.agent_variant if agent_target else None,
+        model=agent_target.model if agent_target else None,
+        reasoning_effort=agent_target.reasoning_effort if agent_target else None,
     )
 
 

--- a/core/services/agent_run_target.py
+++ b/core/services/agent_run_target.py
@@ -425,9 +425,7 @@ def _resolve_agent_target(
         except Exception:
             logger.debug("Failed to resolve router backend for new session", exc_info=True)
         resolved = resolved or getattr(router, "global_default", None)
-    backend = _supported_backend(resolved) or _supported_backend(
-        getattr(getattr(controller, "config", None), "default_backend", None)
-    )
+    backend = _supported_backend(resolved) or _configured_default_backend(controller)
     if backend is None:
         from modules.agents.catalog import DEFAULT_AGENT_BACKEND
 
@@ -439,6 +437,14 @@ def _resolve_agent_target(
         agent_variant=backend,
         model=_optional_str(scope_row.get("model")) if scope_row else None,
         reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
+    )
+
+
+def _configured_default_backend(controller: Any) -> Optional[str]:
+    config = getattr(controller, "config", None)
+    agents = getattr(config, "agents", None)
+    return _supported_backend(getattr(agents, "default_backend", None)) or _supported_backend(
+        getattr(config, "default_backend", None)
     )
 
 

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1087,7 +1087,7 @@ def _find_agent_session_row_id(
         .where(agent_sessions.c.status != "archived")
     )
     if backend != "unknown":
-        return conn.execute(
+        row_id = conn.execute(
             base_query.where(agent_sessions.c.agent_backend == backend)
             .order_by(
                 case(
@@ -1099,6 +1099,22 @@ def _find_agent_session_row_id(
             )
             .limit(1)
         ).scalar_one_or_none()
+        if row_id:
+            return row_id
+        legacy_row_id = conn.execute(
+            base_query.where(agent_sessions.c.agent_backend == "")
+            .where(agent_sessions.c.agent_variant.in_(["", "default"]))
+            .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        if legacy_row_id:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == legacy_row_id)
+                .values(agent_backend=backend, agent_variant=backend)
+            )
+            return legacy_row_id
+        return None
     return conn.execute(
         base_query.where(agent_sessions.c.agent_variant == requested).limit(1)
     ).scalar_one_or_none()

--- a/tests/test_agent_run_target.py
+++ b/tests/test_agent_run_target.py
@@ -15,10 +15,19 @@ from storage.settings_service import upsert_scope
 
 def _controller(tmp_path):
     ensure_sqlite_state()
+    default_agent = SimpleNamespace(
+        id="agent-codex-default",
+        name="codex",
+        backend="codex",
+        model=None,
+        reasoning_effort=None,
+    )
     return SimpleNamespace(
         sqlite_engine=create_sqlite_engine(),
         primary_platform="slack",
-        config=SimpleNamespace(platform="slack", claude=SimpleNamespace(cwd=None)),
+        config=SimpleNamespace(platform="slack", claude=SimpleNamespace(cwd=None), default_backend="codex"),
+        agent_router=SimpleNamespace(resolve=lambda _platform, _settings_key: "codex", global_default="codex"),
+        resolve_vibe_agent_for_context=lambda _context, required=False: default_agent,
     )
 
 
@@ -120,10 +129,63 @@ def test_im_channel_scope_workdir_creates_session_snapshot(tmp_path):
     assert target.scope_id == "slack::channel::C123"
     assert target.workdir == str(workdir)
     assert target.session_anchor == "slack_171717.123"
+    assert target.agent_id == "agent-codex-default"
+    assert target.agent_name == "codex"
+    assert target.agent_backend == "codex"
+    assert target.agent_variant == "codex"
     assert target.agent_session_id
     with controller.sqlite_engine.connect() as conn:
         session = sessions_service.get_session(conn, target.agent_session_id)
     assert session["workdir"] == str(workdir)
+    assert session["agent_id"] == "agent-codex-default"
+    assert session["agent_name"] == "codex"
+    assert session["agent_backend"] == "codex"
+    assert session["agent_variant"] == "codex"
+
+
+def test_new_im_session_uses_resolved_vibe_agent(tmp_path):
+    workdir = tmp_path / "channel"
+    agent = SimpleNamespace(
+        id="agent-reviewer",
+        name="reviewer",
+        backend="codex",
+        model="gpt-5.5",
+        reasoning_effort="high",
+    )
+    controller = _controller(tmp_path)
+    controller.resolve_vibe_agent_for_context = lambda _context, required=False: agent
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(workdir))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.agent_id == "agent-reviewer"
+    assert target.agent_name == "reviewer"
+    assert target.agent_backend == "codex"
+    assert target.agent_variant == "codex"
+    assert target.model == "gpt-5.5"
+    assert target.reasoning_effort == "high"
+    with controller.sqlite_engine.connect() as conn:
+        session = sessions_service.get_session(conn, target.agent_session_id)
+    assert session["agent_id"] == "agent-reviewer"
+    assert session["agent_name"] == "reviewer"
+    assert session["agent_backend"] == "codex"
+    assert session["agent_variant"] == "codex"
+    assert session["model"] == "gpt-5.5"
+    assert session["reasoning_effort"] == "high"
 
 
 def test_new_im_session_without_scope_settings_snapshots_default_cwd(tmp_path):

--- a/tests/test_agent_run_target.py
+++ b/tests/test_agent_run_target.py
@@ -188,6 +188,42 @@ def test_new_im_session_uses_resolved_vibe_agent(tmp_path):
     assert session["reasoning_effort"] == "high"
 
 
+def test_new_im_session_falls_back_to_v2_agents_default_backend(tmp_path):
+    workdir = tmp_path / "channel"
+    controller = _controller(tmp_path)
+    del controller.agent_router
+    del controller.resolve_vibe_agent_for_context
+    controller.config = SimpleNamespace(
+        platform="slack",
+        claude=SimpleNamespace(cwd=None),
+        agents=SimpleNamespace(default_backend="claude"),
+    )
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(conn, scope_id, workdir=str(workdir))
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.agent_backend == "claude"
+    assert target.agent_variant == "claude"
+    with controller.sqlite_engine.connect() as conn:
+        session = sessions_service.get_session(conn, target.agent_session_id)
+    assert session["agent_backend"] == "claude"
+    assert session["agent_variant"] == "claude"
+
+
 def test_new_im_session_without_scope_settings_snapshots_default_cwd(tmp_path):
     default_cwd = tmp_path / "default"
     controller = _controller(tmp_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -258,6 +258,66 @@ def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: 
         service.close()
 
 
+def test_bind_agent_session_upgrades_legacy_default_anchor_row(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        from storage.agent_session_rows import create_agent_session_row
+        from storage.models import scope_settings
+
+        with service.engine.begin() as conn:
+            scope_id = upsert_scope(conn, "slack", "channel", "C123", now="2026-06-04T05:00:00Z")
+            conn.execute(
+                scope_settings.insert().values(
+                    scope_id=scope_id,
+                    enabled=1,
+                    role=None,
+                    workdir=str(tmp_path / "repo"),
+                    agent_name=None,
+                    agent_backend=None,
+                    agent_variant=None,
+                    model=None,
+                    reasoning_effort=None,
+                    require_mention=None,
+                    settings_version=1,
+                    settings_json="{}",
+                    created_at="2026-06-04T05:00:00Z",
+                    updated_at="2026-06-04T05:00:00Z",
+                )
+            )
+            legacy_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                session_anchor="slack_171717.123",
+                agent_backend="",
+                agent_variant="default",
+                workdir=str(tmp_path / "repo"),
+                native_session_id="",
+                require_workdir=False,
+            )
+
+        bound_id = service.bind_agent_session(
+            scope_key="slack::channel::C123",
+            agent_name="codex",
+            session_anchor="slack_171717.123",
+            native_session_id="thread-native-1",
+        )
+
+        assert bound_id == legacy_id
+        with service.engine.connect() as conn:
+            rows = conn.execute(
+                select(
+                    agent_sessions.c.id,
+                    agent_sessions.c.agent_backend,
+                    agent_sessions.c.agent_variant,
+                    agent_sessions.c.native_session_id,
+                )
+            ).all()
+        assert rows == [(legacy_id, "codex", "codex", "thread-native-1")]
+    finally:
+        service.close()
+
+
 def test_sqlite_sessions_service_binds_reserved_agent_session_by_id(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)


### PR DESCRIPTION
## What
- Resolve the concrete Vibe Agent/backend before creating an `agent_sessions` row for a new IM thread.
- Persist the resolved agent id/name/backend/variant/model/effort on the first Session row instead of writing an empty/default placeholder.
- Reuse and upgrade legacy empty/default rows during native-session binding so existing incomplete rows do not create duplicate `(scope_id, session_anchor)` inserts.

## Why
Fixes Slack/Codex thread startup failures where `agent_run_target` created a default/empty row and Codex later attempted to insert a second row for the same `(scope_id, session_anchor)`, tripping the unique Session invariant.

## Evidence
- Unit: `tests/test_agent_run_target.py`
- Unit: `tests/test_sqlite_sessions_store.py`
- Contract: `tests/test_workbench_session_defaults.py`
- Backend regression: `tests/test_codex_agent.py`, `tests/test_claude_agent_sessions.py`
- Residual manual checks: not run; this is covered by isolated SQLite/session routing tests.
