### PR TITLE
fix(sessions): bind legacy default session rows

### DIFF
--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1102,7 +1102,7 @@ def _find_agent_session_row_id(
         if row_id:
             return row_id
         legacy_row_id = conn.execute(
-            base_query.where(agent_sessions.c.agent_backend == "")
+            base_query.where(agent_sessions.c.agent_backend.in_(["", "default"]))
             .where(agent_sessions.c.agent_variant.in_(["", "default"]))
             .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
             .limit(1)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from sqlalchemy import select
 
 from config import paths
@@ -258,7 +259,8 @@ def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: 
         service.close()
 
 
-def test_bind_agent_session_upgrades_legacy_default_anchor_row(tmp_path: Path) -> None:
+@pytest.mark.parametrize("legacy_backend", ["", "default"])
+def test_bind_agent_session_upgrades_legacy_default_anchor_row(tmp_path: Path, legacy_backend: str) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
     try:
@@ -289,7 +291,7 @@ def test_bind_agent_session_upgrades_legacy_default_anchor_row(tmp_path: Path) -
                 conn,
                 scope_id=scope_id,
                 session_anchor="slack_171717.123",
-                agent_backend="",
+                agent_backend=legacy_backend,
                 agent_variant="default",
                 workdir=str(tmp_path / "repo"),
                 native_session_id="",


### PR DESCRIPTION
## What

- Treat legacy `agent_backend="default"` rows the same as empty backend rows when binding a concrete backend-native session.
- Extend the regression test to cover both historical placeholder shapes.

## Why

While updating the master regression environment, an isolated compatibility check reproduced the original unique-key failure for legacy rows that stored both backend and variant as `default`. Those rows are placeholders, not real backends, so binding `codex` should upgrade the existing row instead of inserting another row for the same scope/thread anchor.

## Tests

- `python3 -m pytest tests/test_sqlite_sessions_store.py tests/test_agent_run_target.py -q`
- `python3 -m ruff check storage/sessions_service.py tests/test_sqlite_sessions_store.py`

## Evidence layers

- Unit: updated SQLite session binding coverage
- Contract: preserves one row per `(scope_id, session_anchor)` while binding a concrete backend
- Scenario: legacy default session row followed by Codex native bind
- Residual manual checks: IM end-to-end send still requires platform-side message input
