### PR TITLE
fix(ui): middle-truncate long dev versions in the version badge

### DIFF
--- a/ui/src/components/VersionBadge.tsx
+++ b/ui/src/components/VersionBadge.tsx
@@ -8,6 +8,18 @@ import { Button } from './ui/button';
 import { badgeVariants } from './ui/badge';
 import { cn } from '@/lib/utils';
 
+// Dev / regression builds carry long versions like
+// `3.0.1.dev33+g1df6865a1.d20260608`. Middle-truncate so the badge stays
+// compact — the head keeps the semver + dev counter, the tail keeps a few
+// trailing digits, and the elided middle becomes "…". The full string stays
+// available via the trigger's title tooltip and the popup's current-version row.
+function middleTruncateVersion(value: string, max = 16): string {
+  if (value.length <= max) return value;
+  const tail = 4;
+  const head = Math.max(1, max - 1 - tail);
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
 export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = false }) => {
   const { t } = useTranslation();
   const api = useApi();
@@ -96,6 +108,7 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
 
   const hasUpdate = versionInfo?.has_update === true;
   const currentVersion = versionInfo?.current || '...';
+  const displayVersion = middleTruncateVersion(currentVersion);
 
   return (
     <div className="relative" ref={popupRef}>
@@ -107,8 +120,9 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
           badgeVariants({ variant: hasUpdate ? 'warning' : 'secondary' }),
           'relative cursor-pointer rounded-md font-medium tracking-normal hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         )}
+        title={`v${currentVersion}`}
       >
-        v{currentVersion}
+        v{displayVersion}
         {hasUpdate && (
           <span className="absolute -top-1 -right-1 size-2.5 rounded-full border-2 border-background bg-gold animate-pulse" />
         )}


### PR DESCRIPTION
## Capability
Version badge (sidebar status row + chat header). Dev / regression builds carry long versions like `v3.0.1.dev33+g1df6865a1.d20260608` that overflow the small badge.

## Fix
Middle-truncate the badge trigger label (head-biased, ~16 chars): the head keeps the semver + dev counter, the tail keeps a few trailing digits, and the elided middle becomes `…` → **`v3.0.1.dev33…0608`**. Release versions (`v3.0.1`) are short and stay untouched. The **full** version remains available in the trigger's `title` tooltip and in the popup's "Current version" row.

## Evidence layers
- **Unit / contract / scenario:** none — presentational truncation of one label; the underlying `versionInfo.current` is unchanged.
- **Build:** `tsc -b && vite build` passes.
- **Function verified:** ran `middleTruncateVersion` on real strings — `3.0.1.dev33+g1df6865a1.d20260608` → `3.0.1.dev33…0608`; `3.0.1` → `3.0.1` (unchanged); `...` (loading) → unchanged.
- **Residual manual:** confirm in the regression env that the badge now reads compact and the tooltip/popup still show the full version.