### PR TITLE
fix(ui): show-pages polish — offline action label, session→chat link, link icon

### DIFF
--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -15,6 +15,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import clsx from 'clsx';
 
 import { useApi } from '../context/ApiContext';
@@ -167,9 +168,10 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
               title={href}
-              className="truncate font-mono text-[12px] text-muted transition-colors hover:text-foreground hover:underline"
+              className="flex min-w-0 items-center gap-1 font-mono text-[12px] text-muted transition-colors hover:text-foreground hover:underline"
             >
-              {shown}
+              <span className="truncate">{shown}</span>
+              <ExternalLink size={12} className="shrink-0" />
             </a>
           ) : shown ? (
             <span className="truncate font-mono text-[12px] text-muted">{shown}</span>
@@ -201,7 +203,7 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
                     options={[
                       { id: 'private', label: t('showPages.status.private') },
                       { id: 'public', label: t('showPages.status.public') },
-                      { id: 'offline', label: t('showPages.status.offline') },
+                      { id: 'offline', label: t('showPages.visibilityOffline') },
                     ]}
                   />
                 </div>
@@ -260,15 +262,24 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
 
             <div className="flex flex-col gap-3 rounded-xl border border-border bg-foreground/[0.02] p-4">
               <span className={LABEL}>{t('showPages.details')}</span>
-              {[
-                { k: t('showPages.detail.session'), v: page.session_id, mono: true },
+              {([
+                { k: t('showPages.detail.session'), v: page.session_id, mono: true, to: `/chat/${page.session_id}` },
                 { k: t('showPages.detail.workspace'), v: page.path, mono: true },
                 { k: t('showPages.detail.created'), v: absolute(page.created_at), mono: false },
                 { k: t('showPages.detail.updated'), v: relative(page.updated_at), mono: false },
-              ].map((row) => (
+              ] as Array<{ k: string; v: string; mono: boolean; to?: string }>).map((row) => (
                 <div key={row.k} className="flex flex-col gap-1">
                   <span className={LABEL}>{row.k}</span>
-                  <span className={clsx('break-all text-[12px] text-foreground', row.mono && 'font-mono')}>{row.v}</span>
+                  {row.to ? (
+                    <Link
+                      to={row.to}
+                      className={clsx('break-all text-[12px] text-cyan transition-colors hover:text-foreground hover:underline', row.mono && 'font-mono')}
+                    >
+                      {row.v}
+                    </Link>
+                  ) : (
+                    <span className={clsx('break-all text-[12px] text-foreground', row.mono && 'font-mono')}>{row.v}</span>
+                  )}
                 </div>
               ))}
             </div>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -130,6 +130,7 @@
     "empty": "No Show Pages yet. They appear here once an agent session creates one.",
     "emptyFiltered": "No Show Pages match this filter.",
     "visibilityLabel": "Visibility",
+    "visibilityOffline": "Offline",
     "liveLink": "Live link",
     "offlineNoLink": "This page is offline — bring it back with the control above to get a live link.",
     "copy": "Copy",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -130,6 +130,7 @@
     "empty": "暂无展示页面。当 Agent 会话创建展示页面后会显示在这里。",
     "emptyFiltered": "没有符合该筛选条件的展示页面。",
     "visibilityLabel": "可见性",
+    "visibilityOffline": "下线",
     "liveLink": "访问链接",
     "offlineNoLink": "该页面已下线——用上方的开关重新上线即可获得访问链接。",
     "copy": "复制",


### PR DESCRIPTION
## Capability
`/admin/show-pages` polish from page feedback (3 items). UI-only.

| # | Fix |
|---|-----|
| 1 | **Offline option is an action, not a state.** The visibility control's offline choice was reusing the status word "已下线" (already-offline). It now reads **"下线"** (take offline) via a new `showPages.visibilityOffline` key. The status **badge** and the **filter** keep "已下线" (those genuinely show state). EN stays "Offline" for all. |
| 2 | **Session → chat link.** The session id in the detail panel is now a `<Link to="/chat/<session_id>">` (route `/chat/:sessionId`), so it navigates to the corresponding chat page. |
| 3 | **Link affordance.** The row's live link gets a trailing `ExternalLink` icon (text truncates beside it) so users can tell it's a clickable open-in-new-tab link — matching the icon used elsewhere. |

## Evidence layers
- **Unit / contract / scenario:** none — labels + a link + an icon; no logic/contract change.
- **Build:** `tsc -b && vite build` passes; both locales valid JSON.
- **Verified statically:** `/chat/:sessionId` route confirmed in `App.tsx`; the offline relabel is scoped to the visibility radio only (badge/filter untouched); the row link's `truncate` span inside the flex `<a>` ellipsizes with a `shrink-0` icon.
- **Residual manual:** Show Pages is auth-gated (no backend-less preview), so validated by code + review — please confirm live: the session link opens the right chat, the row link shows the icon, and the control reads "下线".