### PR TITLE
docs(readme): Show Pages + voice highlights + Roadmap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Reusable skills — your conventions, your workflows — managed in one place an
 
 <img src="assets/screenshots/v3/skills-en.png" alt="Skills — manage agent skills across every backend, powered by askill" />
 
+### 🎨 Show Pages — it shows, not just tells
+
+When a picture beats a paragraph, your agent hands you a live web page — a flowchart, a mind map, a dashboard, a diff — built for the task and reachable from your phone through the same tunnel.
+
+### 🎙️ Talk, don't type
+
+Built-in, high-quality voice-to-text. Brief your agent by voice — the fastest way to kick off work from your phone.
+
 ### 📱 In your pocket
 
 <img src="assets/screenshots/v3/workbench-mobile-en.png" alt="Avibe on mobile" width="270" align="right" />
@@ -91,6 +99,8 @@ You're on a plane, at a café, on a borrowed laptop. The agent pings that a job 
 **Your data plane stays on your machine**; `avibe.bot` only carries the control-plane handshake.
 
 <br clear="all"/>
+
+**Plus** — per-channel agent routing · resumable sessions (thread = session) · instant agent switching · interactive prompts (buttons & modals) · file attachments · completion notifications.
 
 ---
 
@@ -256,6 +266,19 @@ uv tool uninstall avibe-os
 uv tool uninstall vibe-remote   # legacy installs
 rm -rf ~/.avibe ~/.vibe_remote
 ```
+
+---
+
+## Roadmap
+
+What's coming next:
+
+- **Vault** — hand secret keys straight to an encrypted backend, never through the agent. When a job needs one, a CLI writes it to a file at runtime, so it never enters the agent's context.
+- **Interaction-first interface** — less wall-of-text chat, more doing: annotate and act directly on interactive pages, and talk to your agent right there.
+- **SaaS mode** — one-click hosted onboarding with a cloud relay, while execution still stays on your own machine.
+- **An Avibe-native agent** — a first-party agent tuned for this runtime, alongside the official CLIs you bring.
+
+Shipped recently: the Agent Harness, Show Pages, voice-to-text, and the Skills manager.
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -76,6 +76,14 @@ Windows 上推荐用 WSL，兼容性最好——见 [从零用 WSL 跑 Avibe](do
 
 <img src="assets/screenshots/v3/skills-zh.png" alt="Skills——跨所有后端管理 agent 技能，由 askill 驱动" />
 
+### 🎨 Show Pages——用画的，不只是说的
+
+当一张图胜过一段话，agent 直接给你一个实时网页——流程图、思维导图、仪表盘、diff——为这件事现做，通过同一条隧道手机也能打开。
+
+### 🎙️ 说话，别打字
+
+自带高质量语音转文字。用语音给 agent 交代事情——在手机上发起工作最快的方式。
+
 ### 📱 装进口袋
 
 <img src="assets/screenshots/v3/workbench-mobile-zh.png" alt="移动端的 Avibe" width="270" align="right" />
@@ -91,6 +99,8 @@ Windows 上推荐用 WSL，兼容性最好——见 [从零用 WSL 跑 Avibe](do
 **数据面留在你的机器上**；`avibe.bot` 只负责控制面的握手。
 
 <br clear="all"/>
+
+**还有** —— 按频道路由 · 可恢复会话（thread = session）· 中途换 agent · 交互式提问（按钮与弹窗）· 文件附件 · 完成通知。
 
 ---
 
@@ -256,6 +266,19 @@ uv tool uninstall avibe-os
 uv tool uninstall vibe-remote   # 旧版安装
 rm -rf ~/.avibe ~/.vibe_remote
 ```
+
+---
+
+## 路线图
+
+接下来要做的：
+
+- **Vault** —— 把 secret key 直接交给加密的后端，全程不经过 agent。需要用时，命令行在运行时把它写进文件，绝不进入 agent 的上下文。
+- **以交互为主的界面** —— 少一点大段文字的 Chat，多一点直接动手：在交互页面上标注、操作，并就地和 agent 对话。
+- **SaaS 模式** —— 一键托管上手 + 云端中继，而执行依然留在你自己的机器上。
+- **Avibe 原生 agent** —— 为这个运行时调校的第一方 agent，与你自带的官方 CLI 并存。
+
+近期已上线：Agent Harness、Show Pages、语音转文字、Skills 管理。
 
 ---
 


### PR DESCRIPTION
Rounds out the README so every highlight is covered, and adds a Roadmap.

- **What you get**: adds **Show Pages** (agents hand you a live page — flowchart, mind map, dashboard, diff) and **voice-to-text**.
- A **Plus** line gathers the smaller highlights: per-channel routing, resumable sessions (thread = session), mid-chat agent switching, interactive prompts, file attachments, completion notifications.
- New **Roadmap** section: Vault (secret keys never touch the agent), interaction-first interface, SaaS mode, an Avibe-native agent — plus a 'shipped recently' line.
- EN + ZH kept 1:1. Docs-only; manual: headings/links self-checked.