### PR TITLE
docs(regression): macOS/Lima incus connection + clearer port-preflight error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,28 @@ Standard path:
 - default command: `./scripts/run_regression.sh`
 - direct runner: `python3 scripts/incus_regression.py up --target master`
 
+Connecting to Incus on macOS (Lima):
+
+- macOS has no native Incus daemon. The regression environment runs inside the
+  Lima VM `avibe-incus-regression`, and `incusd` there listens **only on its unix
+  socket** (no TLS `core.https_address`, no guest→host socket forward). So a plain
+  host `incus` (default `local` remote) has nothing to dial and the runner aborts
+  with "you must connect to a remote server".
+- Drive the runner through the VM with the `INCUS_CMD` knob (the runner splices it
+  in place of `incus`):
+
+  ```
+  INCUS_CMD="limactl shell avibe-incus-regression -- sudo incus" ./scripts/run_regression.sh
+  ```
+
+  Optionally add the Lima user to the `incus-admin` group inside the VM to drop the
+  `sudo`. This is the supported way to run the regression CLI on macOS — not a hack.
+- Symptom when this is missing: `incus info` fails, so `up` wrongly concludes the
+  instance does not exist, takes the create path, and trips the host-port preflight
+  on the UI port the already-running env is forwarding (e.g. 15130). The fix is the
+  connection above — not removing the preflight, which is correctly skipped once the
+  client can see the existing instance.
+
 Rules:
 
 - do **not** use `--reset-config` or `--reset-all` unless the user explicitly requests reset behavior

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1340,7 +1340,22 @@ def cmd_up(args: argparse.Namespace) -> int:
         runner = Runner(dry_run=args.dry_run)
         target_exists = runner.exists(incus("info", remote_ref(args.remote, target.instance), project=target.project))
         if not args.dry_run and not target_exists and args.remote is None:
-            ensure_host_port_available(target.ui_host, target.host_port)
+            try:
+                ensure_host_port_available(target.ui_host, target.host_port)
+            except RegressionError as exc:
+                # A reachable incus client would have reported the instance as existing
+                # above and skipped this preflight. The usual macOS cause is that `incus`
+                # can't reach the Lima VM daemon, so `incus info` failed and the instance
+                # only *looks* absent — point the operator at the real fix.
+                raise RegressionError(
+                    f"{exc}\n"
+                    "If this instance already exists, the incus client is probably not "
+                    "reaching the daemon (on macOS incus runs in the Lima VM), so the "
+                    "earlier `incus info` failed and the instance looks absent. Set "
+                    "INCUS_CMD to drive incus through the VM, e.g. "
+                    "INCUS_CMD='limactl shell avibe-incus-regression -- sudo incus', so the "
+                    "runner sees the existing instance and skips this preflight."
+                ) from exc
         seed_requires_env = not args.dry_run and (args.reset_mode != "none" or not target_exists)
         if seed_requires_env:
             require_runtime_seed_env()


### PR DESCRIPTION
## What

Document how the regression runner reaches Incus on macOS, so agents stop hitting a confusing "connect to a remote server" / port-in-use failure — and make that failure self-explaining.

## Why

macOS has no native incusd. The regression env runs inside the Lima VM `avibe-incus-regression`, where incusd listens **only on its unix socket** (no TLS `core.https_address`, no guest→host socket forward), so a plain host `incus` (default `local` remote) has nothing to dial. The supported path is the runner's `INCUS_CMD` knob:

```
INCUS_CMD="limactl shell avibe-incus-regression -- sudo incus" ./scripts/run_regression.sh
```

When that connection is missing, `incus info` fails, so `up` wrongly concludes the instance is absent, takes the create path, and trips the host-port preflight on the UI port the running env already forwards (e.g. 15130). The preflight is **correct** (it is skipped once the client can see the instance) — so this adds a hint to its failure pointing at the `INCUS_CMD` fix instead of removing the check.

## Changes

- `AGENTS.md`: new "Connecting to Incus on macOS (Lima)" subsection under Regression Testing.
- `scripts/incus_regression.py`: wrap the `up` host-port preflight to append an `INCUS_CMD` hint on failure (no happy-path behavior change).
- (The project-root `AGENTS.md`, outside this git repo, got a matching one-paragraph macro pointer.)

## Evidence layers

- **contract/manual**: connection method verified live via read-only `run_regression.sh --status` through the VM (master env healthy); `incus info` via the VM returns 0, confirming the preflight is correctly skipped on update.
- **lint**: `ruff` clean; `ast.parse` OK.
- **unit/scenario**: none (docs + error-string only).