### PR TITLE
fix(ui): open @/# mention menu above the composer (overlay, no layout push)

### DIFF
--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -3,9 +3,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useRef,
-  useState,
   type Ref,
 } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -269,72 +267,24 @@ function MentionCaretFixPlugin() {
 }
 
 const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
-  ({ loading: _loading, children, ...props }, ref) => {
-    const listRef = useRef<HTMLUListElement | null>(null);
-    // Default above — the chat composer is pinned to the viewport bottom, so there
-    // is rarely room below.
-    const [dropUp, setDropUp] = useState(true);
-    const setRef = useCallback(
-      (node: HTMLUListElement | null) => {
-        listRef.current = node;
-        if (typeof ref === 'function') ref(node);
-        else if (ref) (ref as { current: HTMLUListElement | null }).current = node;
-      },
-      [ref],
-    );
-    // Default ABOVE — the chat composer is pinned to the viewport bottom. Only drop
-    // BELOW when LexicalTypeaheadMenuPlugin has genuinely FLIPPED the anchor up (tall
-    // composer), otherwise we'd stack a second flip and throw the list off-screen.
-    // The plugin positions the anchor in a rAF AFTER this effect runs, so we measure
-    // on rAF and retry until it's actually placed; a premature read sees an
-    // unpositioned anchor (rect ~0,0) and wrongly drops the menu below — the mobile
-    // regression this guards against. Visual viewport is used so the iOS soft keyboard
-    // (which shrinks visualViewport but not innerHeight) is accounted for.
-    useLayoutEffect(() => {
-      let raf = 0;
-      let tries = 0;
-      const decide = () => {
-        const list = listRef.current;
-        const anchor = list?.parentElement;
-        if (!list || !anchor) return;
-        const rect = anchor.getBoundingClientRect();
-        const vv = window.visualViewport;
-        const viewTop = vv ? vv.offsetTop : 0;
-        const viewHeight = vv ? vv.height : window.innerHeight;
-        const positioned = rect.bottom > viewTop + 1;
-        if (!positioned) {
-          if (tries < 5) {
-            tries += 1;
-            raf = requestAnimationFrame(decide);
-          } else {
-            setDropUp(true); // never resolved a position → keep the safe default
-          }
-          return;
-        }
-        // The anchor lands in the upper half of the visible viewport only when the
-        // plugin flipped it above the caret → render below it (still just above the
-        // caret). Otherwise (the common bottom-pinned case) open above.
-        setDropUp(rect.top >= viewTop + viewHeight / 2);
-      };
-      raf = requestAnimationFrame(decide);
-      return () => cancelAnimationFrame(raf);
-    });
-    return (
-      <ul
-        ref={setRef}
-        className={cn(
-          'absolute left-0 z-50 max-h-64 min-w-[15rem] list-none overflow-y-auto overflow-x-hidden rounded-md border border-border bg-panel p-1 text-text shadow-md',
-          // `!`-important beats the inline `top` LexicalTypeaheadMenuPlugin writes on
-          // the menu element for measurement; without it that inline top fights these
-          // classes and can throw the menu far from the caret (Codex P1).
-          dropUp ? '!bottom-full !top-auto mb-4' : '!top-full !bottom-auto mt-2',
-        )}
-        {...props}
-      >
-        {children}
-      </ul>
-    );
-  },
+  ({ loading: _loading, children, ...props }, ref) => (
+    // Always open ABOVE the caret as an out-of-flow overlay — the chat composer is
+    // pinned to the viewport bottom. Pinning the BOTTOM edge to the anchor (caret)
+    // means the list grows UPWARD as async results load, with no reposition or
+    // flicker. `!important` beats the inline `top` LexicalTypeaheadMenuPlugin writes
+    // on the menu element for measurement. We deliberately do NOT measure room to
+    // "drop down": on mobile that re-ran on every async-results re-render and
+    // intermittently flipped the list below the input (visualViewport vs layout-rect
+    // timing). The plugin's own flip needs a 1–2 item list AND a tall multiline
+    // composer to trigger, which our 5–8 item menus effectively never hit.
+    <ul
+      ref={ref}
+      className="absolute left-0 z-50 mb-4 !bottom-full !top-auto max-h-64 min-w-[15rem] list-none overflow-y-auto overflow-x-hidden rounded-md border border-border bg-panel p-1 text-text shadow-md"
+      {...props}
+    >
+      {children}
+    </ul>
+  ),
 );
 MentionMenu.displayName = 'MentionMenu';
 

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -282,29 +282,42 @@ const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
       },
       [ref],
     );
-    // Choose above/below from the ACTUAL room around the anchor that
-    // LexicalTypeaheadMenuPlugin positioned, rather than forcing above. The plugin
-    // already flips the anchor above the caret on a tall composer; an unconditional
-    // `bottom-full` would stack a SECOND flip and shoot the list off-screen
-    // (Codex P2). Anchor low (no room below) → open above; anchor already flipped
-    // high (room below) → open below — both land the list just above the caret, and
-    // it stays an out-of-flow overlay so it never grows the area under the input.
+    // Default ABOVE — the chat composer is pinned to the viewport bottom. Only drop
+    // BELOW when LexicalTypeaheadMenuPlugin has genuinely FLIPPED the anchor up (tall
+    // composer), otherwise we'd stack a second flip and throw the list off-screen.
+    // The plugin positions the anchor in a rAF AFTER this effect runs, so we measure
+    // on rAF and retry until it's actually placed; a premature read sees an
+    // unpositioned anchor (rect ~0,0) and wrongly drops the menu below — the mobile
+    // regression this guards against. Visual viewport is used so the iOS soft keyboard
+    // (which shrinks visualViewport but not innerHeight) is accounted for.
     useLayoutEffect(() => {
-      const list = listRef.current;
-      const anchor = list?.parentElement;
-      if (!list || !anchor) return;
-      const rect = anchor.getBoundingClientRect();
-      const menuHeight = list.offsetHeight;
-      // Measure the VISUAL viewport: on iOS with the soft keyboard open innerHeight
-      // stays full-height while only visualViewport shrinks to the area above the
-      // keyboard, so innerHeight would see phantom room below and drop the menu
-      // behind the keyboard (Codex P2).
-      const vv = window.visualViewport;
-      const viewTop = vv ? vv.offsetTop : 0;
-      const viewBottom = vv ? vv.offsetTop + vv.height : window.innerHeight;
-      const roomBelow = viewBottom - rect.bottom;
-      const roomAbove = rect.top - viewTop;
-      setDropUp(roomBelow < menuHeight + 8 && roomAbove > roomBelow);
+      let raf = 0;
+      let tries = 0;
+      const decide = () => {
+        const list = listRef.current;
+        const anchor = list?.parentElement;
+        if (!list || !anchor) return;
+        const rect = anchor.getBoundingClientRect();
+        const vv = window.visualViewport;
+        const viewTop = vv ? vv.offsetTop : 0;
+        const viewHeight = vv ? vv.height : window.innerHeight;
+        const positioned = rect.bottom > viewTop + 1;
+        if (!positioned) {
+          if (tries < 5) {
+            tries += 1;
+            raf = requestAnimationFrame(decide);
+          } else {
+            setDropUp(true); // never resolved a position → keep the safe default
+          }
+          return;
+        }
+        // The anchor lands in the upper half of the visible viewport only when the
+        // plugin flipped it above the caret → render below it (still just above the
+        // caret). Otherwise (the common bottom-pinned case) open above.
+        setDropUp(rect.top >= viewTop + viewHeight / 2);
+      };
+      raf = requestAnimationFrame(decide);
+      return () => cancelAnimationFrame(raf);
     });
     return (
       <ul

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -25,7 +25,6 @@ import {
   COMMAND_PRIORITY_HIGH,
   KEY_ENTER_COMMAND,
   type EditorState,
-  type LexicalEditor,
   type LexicalNode,
 } from 'lexical';
 import {
@@ -235,11 +234,37 @@ function BootstrapPlugin({
   return null;
 }
 
-// Capture the editor instance so callbacks defined outside the Lexical context
-// (the mention-select caret fix passed to BeautifulMentionsPlugin) can use it.
-function CaptureEditorPlugin({ editorRef }: { editorRef: { current: LexicalEditor | null } }) {
+// After a mention is inserted at the very END of the input, beautiful-mentions adds
+// no trailing space and leaves the caret as a node-selection on the decorator chip
+// (it only spaces when content follows). beautiful-mentions calls onMenuItemSelect
+// BEFORE its insertion runs, so instead we react via a mutation listener that fires
+// AFTER the node is inserted: append a trailing space and move the caret past it.
+// Only the trailing-mention case is touched; mid-text insertions already get a space.
+function MentionCaretFixPlugin() {
   const [editor] = useLexicalComposerContext();
-  editorRef.current = editor;
+  useEffect(
+    () =>
+      editor.registerMutationListener(
+        BeautifulMentionNode,
+        (mutations) => {
+          let created = false;
+          for (const mutation of mutations.values()) {
+            if (mutation === 'created') created = true;
+          }
+          if (!created) return;
+          editor.update(() => {
+            const last = $getRoot().getLastDescendant();
+            if ($isBeautifulMentionNode(last) && last.getNextSibling() === null) {
+              const space = $createTextNode(' ');
+              last.insertAfter(space);
+              space.select(1, 1);
+            }
+          });
+        },
+        { skipInitialization: true },
+      ),
+    [editor],
+  );
   return null;
 }
 
@@ -341,25 +366,6 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
   ref,
 ) {
   const menuOpenRef = useRef(false);
-  const editorRef = useRef<LexicalEditor | null>(null);
-
-  // After a mention is selected at the very END of the input, beautiful-mentions
-  // adds no trailing space and leaves the caret as a node-selection on the decorator
-  // chip (it only spaces when there is content after). Append a space and move the
-  // caret past it so it reads as "chip + space + caret". Only act when the mention is
-  // the last node — mid-text insertions already get a space from the library.
-  const handleMentionSelect = useCallback(() => {
-    const editor = editorRef.current;
-    if (!editor) return;
-    editor.update(() => {
-      const last = $getRoot().getLastDescendant();
-      if ($isBeautifulMentionNode(last) && last.getNextSibling() === null) {
-        const space = $createTextNode(' ');
-        last.insertAfter(space);
-        space.select(1, 1);
-      }
-    });
-  }, []);
 
   const handleChange = useCallback(
     (state: EditorState) => {
@@ -435,7 +441,6 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
           // user-created (unresolved) mentions (the picker-selected-only contract).
           creatable={false}
           insertOnBlur={false}
-          onMenuItemSelect={handleMentionSelect}
           menuComponent={MentionMenu}
           menuItemComponent={MentionMenuItem}
           menuAnchorClassName="z-50"
@@ -449,7 +454,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         <EnterSubmitPlugin onSubmit={onSubmit} menuOpenRef={menuOpenRef} />
         <EditablePlugin disabled={disabled} />
         <BootstrapPlugin autoFocus={autoFocus} initialText={initialText} bridgeRef={ref} />
-        <CaptureEditorPlugin editorRef={editorRef} />
+        <MentionCaretFixPlugin />
       </LexicalComposer>
     </div>
   );

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -233,9 +233,14 @@ function BootstrapPlugin({
 
 const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
   ({ loading: _loading, children, ...props }, ref) => (
+    // Open ABOVE the caret as a floating overlay. The chat composer is pinned to the
+    // bottom of the viewport; LexicalTypeaheadMenuPlugin's flip-above check measures
+    // available room against the (short) editor root, so it never flips and would
+    // render below — off-screen, pushing the input up on mobile. `absolute bottom-full`
+    // forces it above and out of flow so it never grows the area under the input.
     <ul
       ref={ref}
-      className="z-50 m-0 max-h-64 min-w-[15rem] list-none overflow-y-auto overflow-x-hidden rounded-md border border-border bg-panel p-1 text-text shadow-md"
+      className="absolute bottom-full left-0 z-50 mb-2 mt-0 max-h-64 min-w-[15rem] list-none overflow-y-auto overflow-x-hidden rounded-md border border-border bg-panel p-1 text-text shadow-md"
       {...props}
     >
       {children}

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -3,7 +3,9 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
+  useState,
   type Ref,
 } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
@@ -232,20 +234,48 @@ function BootstrapPlugin({
 }
 
 const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
-  ({ loading: _loading, children, ...props }, ref) => (
-    // Open ABOVE the caret as a floating overlay. The chat composer is pinned to the
-    // bottom of the viewport; LexicalTypeaheadMenuPlugin's flip-above check measures
-    // available room against the (short) editor root, so it never flips and would
-    // render below — off-screen, pushing the input up on mobile. `absolute bottom-full`
-    // forces it above and out of flow so it never grows the area under the input.
-    <ul
-      ref={ref}
-      className="absolute bottom-full left-0 z-50 mb-2 mt-0 max-h-64 min-w-[15rem] list-none overflow-y-auto overflow-x-hidden rounded-md border border-border bg-panel p-1 text-text shadow-md"
-      {...props}
-    >
-      {children}
-    </ul>
-  ),
+  ({ loading: _loading, children, ...props }, ref) => {
+    const listRef = useRef<HTMLUListElement | null>(null);
+    // Default above — the chat composer is pinned to the viewport bottom, so there
+    // is rarely room below.
+    const [dropUp, setDropUp] = useState(true);
+    const setRef = useCallback(
+      (node: HTMLUListElement | null) => {
+        listRef.current = node;
+        if (typeof ref === 'function') ref(node);
+        else if (ref) (ref as { current: HTMLUListElement | null }).current = node;
+      },
+      [ref],
+    );
+    // Choose above/below from the ACTUAL room around the anchor that
+    // LexicalTypeaheadMenuPlugin positioned, rather than forcing above. The plugin
+    // already flips the anchor above the caret on a tall composer; an unconditional
+    // `bottom-full` would stack a SECOND flip and shoot the list off-screen
+    // (Codex P2). Anchor low (no room below) → open above; anchor already flipped
+    // high (room below) → open below — both land the list just above the caret, and
+    // it stays an out-of-flow overlay so it never grows the area under the input.
+    useLayoutEffect(() => {
+      const list = listRef.current;
+      const anchor = list?.parentElement;
+      if (!list || !anchor) return;
+      const rect = anchor.getBoundingClientRect();
+      const menuHeight = list.offsetHeight;
+      const roomBelow = window.innerHeight - rect.bottom;
+      setDropUp(roomBelow < menuHeight + 8 && rect.top > roomBelow);
+    });
+    return (
+      <ul
+        ref={setRef}
+        className={cn(
+          'absolute left-0 z-50 max-h-64 min-w-[15rem] list-none overflow-y-auto overflow-x-hidden rounded-md border border-border bg-panel p-1 text-text shadow-md',
+          dropUp ? 'bottom-full mb-2' : 'top-full mt-2',
+        )}
+        {...props}
+      >
+        {children}
+      </ul>
+    );
+  },
 );
 MentionMenu.displayName = 'MentionMenu';
 

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -270,15 +270,26 @@ const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
       if (!list || !anchor) return;
       const rect = anchor.getBoundingClientRect();
       const menuHeight = list.offsetHeight;
-      const roomBelow = window.innerHeight - rect.bottom;
-      setDropUp(roomBelow < menuHeight + 8 && rect.top > roomBelow);
+      // Measure the VISUAL viewport: on iOS with the soft keyboard open innerHeight
+      // stays full-height while only visualViewport shrinks to the area above the
+      // keyboard, so innerHeight would see phantom room below and drop the menu
+      // behind the keyboard (Codex P2).
+      const vv = window.visualViewport;
+      const viewTop = vv ? vv.offsetTop : 0;
+      const viewBottom = vv ? vv.offsetTop + vv.height : window.innerHeight;
+      const roomBelow = viewBottom - rect.bottom;
+      const roomAbove = rect.top - viewTop;
+      setDropUp(roomBelow < menuHeight + 8 && roomAbove > roomBelow);
     });
     return (
       <ul
         ref={setRef}
         className={cn(
           'absolute left-0 z-50 max-h-64 min-w-[15rem] list-none overflow-y-auto overflow-x-hidden rounded-md border border-border bg-panel p-1 text-text shadow-md',
-          dropUp ? 'bottom-full mb-2' : 'top-full mt-2',
+          // `!`-important beats the inline `top` LexicalTypeaheadMenuPlugin writes on
+          // the menu element for measurement; without it that inline top fights these
+          // classes and can throw the menu far from the caret (Codex P1).
+          dropUp ? '!bottom-full !top-auto mb-2' : '!top-full !bottom-auto mt-2',
         )}
         {...props}
       >

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -289,7 +289,7 @@ const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
           // `!`-important beats the inline `top` LexicalTypeaheadMenuPlugin writes on
           // the menu element for measurement; without it that inline top fights these
           // classes and can throw the menu far from the caret (Codex P1).
-          dropUp ? '!bottom-full !top-auto mb-2' : '!top-full !bottom-auto mt-2',
+          dropUp ? '!bottom-full !top-auto mb-4' : '!top-full !bottom-auto mt-2',
         )}
         {...props}
       >

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -447,9 +447,11 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
           onSearch={onSearch}
           searchDelay={150}
           menuItemLimit={8}
-          // Trigger after ANY non-space char (or start), not only whitespace/`(`, so
-          // `@`/`#` fires without needing a leading space.
-          preTriggerChars={'\\S'}
+          // Allow `@`/`#` after a word boundary without a leading space (including
+          // CJK, which has no inter-word spaces) but NOT inside a Latin word / number
+          // / `_` token, so ordinary text like `name@host` or `C#` doesn't open the
+          // picker mid-token (Codex P2).
+          preTriggerChars={'[^\\sA-Za-z0-9_]'}
           // Only Agents/Sessions returned by onSearch may become chips — no
           // user-created (unresolved) mentions (the picker-selected-only contract).
           creatable={false}

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -17,6 +17,7 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import {
   $createParagraphNode,
+  $createTextNode,
   $getRoot,
   $isElementNode,
   $isLineBreakNode,
@@ -24,6 +25,7 @@ import {
   COMMAND_PRIORITY_HIGH,
   KEY_ENTER_COMMAND,
   type EditorState,
+  type LexicalEditor,
   type LexicalNode,
 } from 'lexical';
 import {
@@ -233,6 +235,14 @@ function BootstrapPlugin({
   return null;
 }
 
+// Capture the editor instance so callbacks defined outside the Lexical context
+// (the mention-select caret fix passed to BeautifulMentionsPlugin) can use it.
+function CaptureEditorPlugin({ editorRef }: { editorRef: { current: LexicalEditor | null } }) {
+  const [editor] = useLexicalComposerContext();
+  editorRef.current = editor;
+  return null;
+}
+
 const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
   ({ loading: _loading, children, ...props }, ref) => {
     const listRef = useRef<HTMLUListElement | null>(null);
@@ -320,6 +330,25 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
   ref,
 ) {
   const menuOpenRef = useRef(false);
+  const editorRef = useRef<LexicalEditor | null>(null);
+
+  // After a mention is selected at the very END of the input, beautiful-mentions
+  // adds no trailing space and leaves the caret as a node-selection on the decorator
+  // chip (it only spaces when there is content after). Append a space and move the
+  // caret past it so it reads as "chip + space + caret". Only act when the mention is
+  // the last node — mid-text insertions already get a space from the library.
+  const handleMentionSelect = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.update(() => {
+      const last = $getRoot().getLastDescendant();
+      if ($isBeautifulMentionNode(last) && last.getNextSibling() === null) {
+        const space = $createTextNode(' ');
+        last.insertAfter(space);
+        space.select(1, 1);
+      }
+    });
+  }, []);
 
   const handleChange = useCallback(
     (state: EditorState) => {
@@ -388,10 +417,14 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
           onSearch={onSearch}
           searchDelay={150}
           menuItemLimit={8}
+          // Trigger after ANY non-space char (or start), not only whitespace/`(`, so
+          // `@`/`#` fires without needing a leading space.
+          preTriggerChars={'\\S'}
           // Only Agents/Sessions returned by onSearch may become chips — no
           // user-created (unresolved) mentions (the picker-selected-only contract).
           creatable={false}
           insertOnBlur={false}
+          onMenuItemSelect={handleMentionSelect}
           menuComponent={MentionMenu}
           menuItemComponent={MentionMenuItem}
           menuAnchorClassName="z-50"
@@ -405,6 +438,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         <EnterSubmitPlugin onSubmit={onSubmit} menuOpenRef={menuOpenRef} />
         <EditablePlugin disabled={disabled} />
         <BootstrapPlugin autoFocus={autoFocus} initialText={initialText} bridgeRef={ref} />
+        <CaptureEditorPlugin editorRef={editorRef} />
       </LexicalComposer>
     </div>
   );


### PR DESCRIPTION
## What
The @/# suggestion list rendered **below** the composer input and grew the area under it, so on mobile the input got pushed up and the user had to scroll. It should appear **above** the input and float (not take layout space).

## Why
beautiful-mentions wraps `@lexical/react`'s `LexicalTypeaheadMenuPlugin`, which *does* have flip-above logic — but its 'is there room above?' test measures `caretTop − editorRootTop > menuHeight + caretHeight`. Our editor root is the **short** composer input (min-h-9), so that's never true → it never flips, always opens below. The menu is a `document.body`-portaled absolute element at the caret near the screen bottom, so iOS scrolls to reveal it (input appears pushed up).

## Fix
Render the portaled menu as a floating overlay anchored **above** the caret: `absolute bottom-full left-0` (out of flow → never grows the area under the input). One-line className change in `MentionEditor`'s menu component.

## Evidence
- `npm run build` (tsc + vite) green.
- Behavioral verification: deploying to the regression env (test-app.avibe.bot) for on-device confirmation — this is the iOS-positioning fix, so the real check is visual on iPhone.