### PR TITLE
feat(ui): paste files into the composer to upload them

### DIFF
--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -563,6 +563,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             initialText={initialDraft}
             onSearchAgents={onSearchAgents!}
             onSearchSessions={onSearchSessions!}
+            // Paste-to-upload: only when this composer has an upload target
+            // (a session), mirroring the picker + drag-drop. uploadFiles itself
+            // no-ops without a session, so this gate is also defense in depth.
+            onPasteFiles={mediaEnabled ? (files) => void uploadFiles(files) : undefined}
             onChange={(text, references) => {
               setValue(text);
               referencesRef.current = references;

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -21,6 +21,7 @@ import {
   $isTextNode,
   COMMAND_PRIORITY_HIGH,
   KEY_ENTER_COMMAND,
+  PASTE_COMMAND,
   type EditorState,
   type LexicalNode,
 } from 'lexical';
@@ -33,6 +34,7 @@ import {
   type BeautifulMentionsMenuItemProps,
 } from 'lexical-beautiful-mentions';
 
+import { filesFromClipboard } from '../../lib/clipboardFiles';
 import { isSoftKeyboardOpen, isTouchCapableDevice } from '../../lib/softKeyboard';
 import { cn } from '../../lib/utils';
 import { dedupeReferences, type MentionReference } from '../../lib/mentions';
@@ -65,6 +67,10 @@ export interface MentionEditorProps {
   onSubmit: () => void;
   onSearchAgents: (query: string) => Promise<AgentSearchResult[]>;
   onSearchSessions: (query: string) => Promise<SessionSearchResult[]>;
+  /** Pasting a file into the editor (clipboard screenshot or OS-copied file)
+   *  hands it here instead of pasting as text. Unset → paste behaves as plain
+   *  text (e.g. when the composer has no upload target). */
+  onPasteFiles?: (files: File[]) => void;
 }
 
 // Per-trigger chip classes — styled in index.css to read like a Badge
@@ -161,6 +167,41 @@ function EditablePlugin({ disabled }: { disabled: boolean }) {
   useEffect(() => {
     editor.setEditable(!disabled);
   }, [editor, disabled]);
+  return null;
+}
+
+// Intercept a paste that carries files (a clipboard screenshot, or a file copied
+// in the OS file manager) and hand it to the composer's uploader instead of
+// letting Lexical insert it as text — the editor sibling of the `+` picker and
+// chat-page drag-drop. Registered at HIGH priority so it runs before Lexical's
+// own (LOW/EDITOR) paste handling: a files paste is consumed here (return true),
+// while a plain text / rich-text paste carries no files and falls through
+// (return false) to normal text pasting. Reads the callback through a ref so the
+// command registers once per editor and never churns on the composer's renders.
+function PasteFilesPlugin({ onPasteFiles }: { onPasteFiles?: (files: File[]) => void }) {
+  const [editor] = useLexicalComposerContext();
+  const handlerRef = useRef(onPasteFiles);
+  handlerRef.current = onPasteFiles;
+  useEffect(
+    () =>
+      editor.registerCommand(
+        PASTE_COMMAND,
+        (event) => {
+          const handler = handlerRef.current;
+          if (!handler) return false;
+          // PASTE_COMMAND can also fire for non-clipboard (input/keyboard) paste
+          // triggers; only a ClipboardEvent carries files.
+          const clipboardData = event instanceof ClipboardEvent ? event.clipboardData : null;
+          const files = filesFromClipboard(clipboardData);
+          if (files.length === 0) return false;
+          event.preventDefault();
+          handler(files);
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH,
+      ),
+    [editor],
+  );
   return null;
 }
 
@@ -281,6 +322,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
     onSubmit,
     onSearchAgents,
     onSearchSessions,
+    onPasteFiles,
   },
   ref,
 ) {
@@ -369,6 +411,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         />
         <EnterSubmitPlugin onSubmit={onSubmit} menuOpenRef={menuOpenRef} />
         <EditablePlugin disabled={disabled} />
+        <PasteFilesPlugin onPasteFiles={onPasteFiles} />
         <BootstrapPlugin autoFocus={autoFocus} initialText={initialText} bridgeRef={ref} />
       </LexicalComposer>
     </div>

--- a/ui/src/lib/clipboardFiles.ts
+++ b/ui/src/lib/clipboardFiles.ts
@@ -1,0 +1,28 @@
+// Pull file blobs out of a clipboard paste, shared by every composer input that
+// supports paste-to-upload. A pasted screenshot rides in ``items`` as a ``file``
+// entry (and usually in ``files`` too); a file copied in the OS file manager
+// lands in ``files`` directly. A plain text / rich-text paste carries no files
+// and returns ``[]`` so the editor handles it as normal text.
+//
+// Pasted screenshots can arrive without a filename, so synthesize a readable,
+// collision-free one: the timestamp separates one paste from the next, the index
+// separates files staged within the same paste (same millisecond). The upload
+// path keys files by their unique on-disk path, so the synthesized name is only
+// ever a display label.
+export function filesFromClipboard(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const direct = Array.from(data.files ?? []);
+  const files =
+    direct.length > 0
+      ? direct
+      : Array.from(data.items ?? [])
+          .filter((it) => it.kind === 'file')
+          .map((it) => it.getAsFile())
+          .filter((f): f is File => f != null);
+  return files.map((file, i) => {
+    if (file.name) return file;
+    const ext = file.type.split('/')[1] || 'dat';
+    const base = file.type.startsWith('image/') ? 'pasted-image' : 'pasted-file';
+    return new File([file], `${base}-${Date.now().toString(36)}-${i}.${ext}`, { type: file.type });
+  });
+}


### PR DESCRIPTION
## Capability

Adds **paste-to-upload** to the chat composer. A clipboard screenshot, or a file copied in the OS file manager, can now be pasted into the input box and is staged + uploaded as an attachment — the third entry point alongside the existing **`+` picker** and **drag-and-drop**.

## How it works (reuse-first)

All three entry points converge on the same `uploadFiles()` in `Composer.tsx`; this change just adds a paste source:

- The chat composer is a Lexical editor (`MentionEditor`), so paste is handled by a new `PasteFilesPlugin` registering `PASTE_COMMAND` at `COMMAND_PRIORITY_HIGH`. A files paste is consumed there (`preventDefault` + return `true`) **before** Lexical's own handlers; a plain-text / rich-text paste carries no files, returns `false`, and falls through to normal pasting.
  - Verified against the installed Lexical source: my handler `HIGH (3)` > beautiful-mentions paste `LOW (1)` > plain-text paste `EDITOR (0)`.
- `Composer` passes `onPasteFiles` **only when it has an upload target** (a session), mirroring the `+` picker and drag-drop gate.
- File extraction lives in a new shared `lib/clipboardFiles.ts` (pure, reusable). Blank-named screenshots get a readable, collision-free synthesized name (`pasted-image-<ts>-<i>.<ext>`) used only as a display label — the upload keys files by their unique on-disk path, so the agent backends (which reference `local_path`) are unaffected by duplicate names.

No backend changes; the existing `/api/sessions/<id>/attachments` endpoint already tolerates blank names and derives kind from mime.

## Scenario IDs

No scenario catalog covers the workbench composer; none referenced.

## Evidence layers

- **Unit:** none added — the UI has no JS test framework (the gate is `npm run build`); the extraction logic is pure and was exercised directly (see manual).
- **Contract:** n/a — no API/contract change.
- **Scenario:** n/a — no composer scenario catalog.
- **Manual / residual:**
  - `npm run build` (tsc + vite) passes.
  - `filesFromClipboard` run on a real Chrome engine against constructed `DataTransfer`s: named screenshot kept as-is; blank-named → `pasted-image.<ext>`; multi-file blank batch → all-unique names; **plain-text paste → `[]` (not hijacked)**; empty/null → `[]`.
  - Lexical paste priority confirmed against the installed `@lexical/plain-text` + `lexical-beautiful-mentions` source (see above).
  - **Residual manual check:** real end-to-end paste of a screenshot inside the running editor (chip appears → uploads) is best confirmed in Incus regression or by manual dogfood; synthesizing a real file-bearing paste event headlessly is unreliable, so it was not automated.