### PR TITLE
fix(claude): reap duplicate resume processes

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -17,6 +17,10 @@ from modules.claude_sdk_compat import (
     is_claude_sdk_buffer_error,
 )
 from modules.agents.native_sessions.base import build_resume_preview
+from modules.agents.claude_process_reaper import (
+    get_claude_client_pid,
+    reap_duplicate_claude_resume_processes,
+)
 from core.avibe_cloud import avibe_cloud_url_available
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 
@@ -82,10 +86,18 @@ class SessionHandler(BaseHandler):
         self.session_last_activity.pop(composite_key, None)
         self.claude_system_prompts.pop(composite_key, None)
 
-    def bind_claude_runtime_session(self, client: ClaudeSDKClient, base_session_id: str, composite_key: str) -> None:
+    def bind_claude_runtime_session(
+        self,
+        client: ClaudeSDKClient,
+        base_session_id: str,
+        composite_key: str,
+        native_session_id: Optional[str] = None,
+    ) -> None:
         """Attach the resolved Claude runtime keys to the connected client."""
         setattr(client, "_vibe_runtime_base_session_id", base_session_id)
         setattr(client, "_vibe_runtime_session_key", composite_key)
+        if native_session_id:
+            setattr(client, "_vibe_native_session_id", native_session_id)
 
     async def _set_claude_model_if_needed(self, client: ClaudeSDKClient, desired_model: Optional[str]) -> None:
         unknown = object()
@@ -511,7 +523,12 @@ class SessionHandler(BaseHandler):
                 logger.info(
                     f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
                 )
-                self.bind_claude_runtime_session(client, base_session_id, composite_key)
+                self.bind_claude_runtime_session(
+                    client,
+                    base_session_id,
+                    composite_key,
+                    stored_claude_session_id,
+                )
                 self.touch_session_activity(composite_key)
                 return client
 
@@ -538,7 +555,12 @@ class SessionHandler(BaseHandler):
                     working_path,
                     explicit_model,
                 )
-                self.bind_claude_runtime_session(client, cached_base, cached_key)
+                self.bind_claude_runtime_session(
+                    client,
+                    cached_base,
+                    cached_key,
+                    cached_session_id or stored_claude_session_id,
+                )
                 self.touch_session_activity(cached_key)
                 return client
             # Always use agent-specific key when effective_agent is set
@@ -706,7 +728,7 @@ class SessionHandler(BaseHandler):
         self.claude_sessions[composite_key] = client
         self.claude_system_prompts[composite_key] = final_system_prompt
         setattr(client, "_vibe_current_model", effective_model)
-        self.bind_claude_runtime_session(client, base_session_id, composite_key)
+        self.bind_claude_runtime_session(client, base_session_id, composite_key, stored_claude_session_id)
         self.touch_session_activity(composite_key)
         logger.info(f"Created new Claude SDK client for {base_session_id} at {working_path}")
 
@@ -953,6 +975,8 @@ class SessionHandler(BaseHandler):
         receiver_task = self.receiver_tasks.pop(composite_key, None)
         client = self.claude_sessions.pop(composite_key, None)
         cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
+        native_session_id = getattr(client, "_vibe_native_session_id", None)
+        keep_pid = get_claude_client_pid(client)
         self.clear_session_tracking(composite_key)
 
         try:
@@ -967,6 +991,11 @@ class SessionHandler(BaseHandler):
         finally:
             if not cleanup_from_receiver:
                 await self._stop_receiver_task(receiver_task, composite_key)
+            await reap_duplicate_claude_resume_processes(
+                native_session_id,
+                keep_pid=keep_pid if cleanup_from_receiver else None,
+                logger=logger,
+            )
 
     async def _disconnect_client(self, client, composite_key: str) -> None:
         try:
@@ -1134,6 +1163,11 @@ class SessionHandler(BaseHandler):
             working_path=working_path,
         )
         logger.info(f"Captured Claude session_id: {claude_session_id} for {base_session_id}")
+        composite_key = f"{base_session_id}:{working_path}" if working_path else None
+        if composite_key:
+            client = self.claude_sessions.get(composite_key)
+            if client is not None:
+                setattr(client, "_vibe_native_session_id", claude_session_id)
         return agent_session_id
 
     def ensure_agent_session_id(

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -631,7 +631,7 @@ class SessionHandler(BaseHandler):
                 composite_key=cached_key,
                 base_session_id=cached_base,
                 working_path=working_path,
-                native_session_id=cached_session_id or stored_claude_session_id,
+                native_session_id=cached_session_id,
                 explicit_model=explicit_model,
             )
             if client is not None:
@@ -642,6 +642,8 @@ class SessionHandler(BaseHandler):
             base_session_id = cached_base
             if cached_session_id:
                 stored_claude_session_id = cached_session_id
+            else:
+                stored_claude_session_id = None
 
         waiting_client = await self._wait_for_claude_session_create(composite_key)
         if waiting_client is not None:
@@ -684,6 +686,10 @@ class SessionHandler(BaseHandler):
             if not create_future.done():
                 create_future.set_result(client)
             return client
+        except asyncio.CancelledError:
+            if not create_future.done():
+                create_future.set_result(None)
+            raise
         except Exception:
             if not create_future.done():
                 create_future.set_result(None)
@@ -1130,6 +1136,7 @@ class SessionHandler(BaseHandler):
             await reap_duplicate_claude_resume_processes(
                 native_session_id,
                 keep_pid=keep_pid if cleanup_from_receiver else None,
+                cli_path=self._get_claude_cli_path_override(),
                 logger=logger,
             )
 

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -58,9 +58,11 @@ class SessionHandler(BaseHandler):
         self.session_last_activity = getattr(controller, "session_last_activity", {})
         self.active_sessions = getattr(controller, "claude_active_sessions", set())
         self.claude_system_prompts = getattr(controller, "claude_system_prompts", {})
+        self.claude_session_creates = getattr(controller, "claude_session_creates", {})
         controller.session_last_activity = self.session_last_activity
         controller.claude_active_sessions = self.active_sessions
         controller.claude_system_prompts = self.claude_system_prompts
+        controller.claude_session_creates = self.claude_session_creates
 
     def touch_session_activity(self, composite_key: str) -> None:
         if composite_key:
@@ -116,6 +118,110 @@ class SessionHandler(BaseHandler):
 
         await set_model(desired_model)
         setattr(client, "_vibe_current_model", desired_model)
+
+    async def _reuse_cached_claude_session_if_available(
+        self,
+        *,
+        composite_key: str,
+        base_session_id: str,
+        working_path: str,
+        context: MessageContext,
+        session_key: str,
+        stored_claude_session_id: Optional[str],
+        current_model: Optional[str],
+        agent_system_prompt: Optional[str],
+    ) -> ClaudeSDKClient | None:
+        client = self.claude_sessions.get(composite_key)
+        if client is None:
+            return None
+
+        next_system_prompt = self._build_claude_system_prompt(
+            context=context,
+            session_key=session_key,
+            agent_name="claude",
+            session_anchor=base_session_id,
+            agent_system_prompt=agent_system_prompt,
+        )
+        cached_system_prompt = self.claude_system_prompts.get(composite_key)
+        if cached_system_prompt != next_system_prompt:
+            logger.info(
+                "Recreating cached Claude SDK client for %s because avibe system prompt changed",
+                composite_key,
+            )
+            await self.cleanup_session(composite_key)
+            return None
+
+        try:
+            await self._set_claude_model_if_needed(client, current_model)
+        except Exception as e:
+            logger.warning(f"Failed to update model on cached Claude session: {e}")
+        logger.info(
+            f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
+        )
+        self.bind_claude_runtime_session(
+            client,
+            base_session_id,
+            composite_key,
+            stored_claude_session_id,
+        )
+        self.touch_session_activity(composite_key)
+        return client
+
+    async def _reuse_cached_claude_subagent_session_if_available(
+        self,
+        *,
+        composite_key: str,
+        base_session_id: str,
+        working_path: str,
+        native_session_id: Optional[str],
+        explicit_model: Optional[str],
+    ) -> ClaudeSDKClient | None:
+        client = self.claude_sessions.get(composite_key)
+        if client is None:
+            return None
+        if explicit_model:
+            try:
+                await self._set_claude_model_if_needed(client, explicit_model)
+            except Exception as e:
+                logger.warning(f"Failed to update model on cached Claude subagent session: {e}")
+        logger.info(
+            "Using Claude subagent session for %s at %s (model_override=%s)",
+            base_session_id,
+            working_path,
+            explicit_model,
+        )
+        self.bind_claude_runtime_session(
+            client,
+            base_session_id,
+            composite_key,
+            native_session_id,
+        )
+        self.touch_session_activity(composite_key)
+        return client
+
+    async def _wait_for_claude_session_create(self, composite_key: str) -> ClaudeSDKClient | None:
+        while True:
+            future = self.claude_session_creates.get(composite_key)
+            if future is None:
+                return None
+            logger.info("Waiting for in-flight Claude SDK client create for %s", composite_key)
+            client = await asyncio.shield(future)
+            if client is not None:
+                return client
+            client = self.claude_sessions.get(composite_key)
+            if client is not None:
+                return client
+            if self.claude_session_creates.get(composite_key) is future:
+                return None
+
+    def _track_claude_session_create(self, composite_key: str) -> asyncio.Future:
+        future = asyncio.get_running_loop().create_future()
+        self.claude_session_creates[composite_key] = future
+        return future
+
+    def _untrack_claude_session_create(self, composite_key: str, future: asyncio.Future) -> None:
+        if self.claude_session_creates.get(composite_key) is future:
+            self.claude_session_creates.pop(composite_key, None)
 
     def get_base_session_id(self, context: MessageContext, source: str = "human") -> str:
         """Get base session ID based on platform and context (without path)"""
@@ -496,40 +602,21 @@ class SessionHandler(BaseHandler):
         explicit_model = subagent_model or routing_model_for_backend(routing, "claude")
         explicit_effort = subagent_reasoning_effort or routing_reasoning_effort_for_backend(routing, "claude")
 
-        if composite_key in self.claude_sessions and not effective_agent:
-            client = self.claude_sessions[composite_key]
+        if not effective_agent:
             # Claude SDK model changes are control requests; only send one when
             # the effective model actually changes.
             current_model = explicit_model or self.config.claude.default_model
-            next_system_prompt = self._build_claude_system_prompt(
+            client = await self._reuse_cached_claude_session_if_available(
+                composite_key=composite_key,
+                base_session_id=base_session_id,
+                working_path=working_path,
                 context=context,
                 session_key=session_key,
-                agent_name="claude",
-                session_anchor=base_session_id,
+                stored_claude_session_id=stored_claude_session_id,
+                current_model=current_model,
                 agent_system_prompt=None,
             )
-            cached_system_prompt = self.claude_system_prompts.get(composite_key)
-            if cached_system_prompt != next_system_prompt:
-                logger.info(
-                    "Recreating cached Claude SDK client for %s because avibe system prompt changed",
-                    composite_key,
-                )
-                await self.cleanup_session(composite_key)
-            else:
-                try:
-                    await self._set_claude_model_if_needed(client, current_model)
-                except Exception as e:
-                    logger.warning(f"Failed to update model on cached Claude session: {e}")
-                logger.info(
-                    f"Using existing Claude SDK client for {base_session_id} at {working_path} (model={current_model})"
-                )
-                self.bind_claude_runtime_session(
-                    client,
-                    base_session_id,
-                    composite_key,
-                    stored_claude_session_id,
-                )
-                self.touch_session_activity(composite_key)
+            if client is not None:
                 return client
 
         if effective_agent:
@@ -540,28 +627,14 @@ class SessionHandler(BaseHandler):
                 cached_base,
                 agent_name="claude",
             )
-            if cached_key in self.claude_sessions:
-                client = self.claude_sessions[cached_key]
-                # When no explicit override, keep the agent/frontmatter model
-                # that was set at session creation.
-                if explicit_model:
-                    try:
-                        await self._set_claude_model_if_needed(client, explicit_model)
-                    except Exception as e:
-                        logger.warning(f"Failed to update model on cached Claude subagent session: {e}")
-                logger.info(
-                    "Using Claude subagent session for %s at %s (model_override=%s)",
-                    cached_base,
-                    working_path,
-                    explicit_model,
-                )
-                self.bind_claude_runtime_session(
-                    client,
-                    cached_base,
-                    cached_key,
-                    cached_session_id or stored_claude_session_id,
-                )
-                self.touch_session_activity(cached_key)
+            client = await self._reuse_cached_claude_subagent_session_if_available(
+                composite_key=cached_key,
+                base_session_id=cached_base,
+                working_path=working_path,
+                native_session_id=cached_session_id or stored_claude_session_id,
+                explicit_model=explicit_model,
+            )
+            if client is not None:
                 return client
             # Always use agent-specific key when effective_agent is set
             # This ensures session continuity even on first use
@@ -569,6 +642,69 @@ class SessionHandler(BaseHandler):
             base_session_id = cached_base
             if cached_session_id:
                 stored_claude_session_id = cached_session_id
+
+        waiting_client = await self._wait_for_claude_session_create(composite_key)
+        if waiting_client is not None:
+            if effective_agent:
+                client = await self._reuse_cached_claude_subagent_session_if_available(
+                    composite_key=composite_key,
+                    base_session_id=base_session_id,
+                    working_path=working_path,
+                    native_session_id=stored_claude_session_id,
+                    explicit_model=explicit_model,
+                )
+            else:
+                client = await self._reuse_cached_claude_session_if_available(
+                    composite_key=composite_key,
+                    base_session_id=base_session_id,
+                    working_path=working_path,
+                    context=context,
+                    session_key=session_key,
+                    stored_claude_session_id=stored_claude_session_id,
+                    current_model=explicit_model or self.config.claude.default_model,
+                    agent_system_prompt=None,
+                )
+            if client is not None:
+                return client
+
+        create_future = self._track_claude_session_create(composite_key)
+        try:
+            client = await self._create_claude_session(
+                context=context,
+                composite_key=composite_key,
+                base_session_id=base_session_id,
+                working_path=working_path,
+                session_key=session_key,
+                stored_claude_session_id=stored_claude_session_id,
+                effective_agent=effective_agent,
+                explicit_model=explicit_model,
+                explicit_effort=explicit_effort,
+                agent_system_prompt=agent_system_prompt,
+            )
+            if not create_future.done():
+                create_future.set_result(client)
+            return client
+        except Exception:
+            if not create_future.done():
+                create_future.set_result(None)
+            raise
+        finally:
+            self._untrack_claude_session_create(composite_key, create_future)
+
+    async def _create_claude_session(
+        self,
+        *,
+        context: MessageContext,
+        composite_key: str,
+        base_session_id: str,
+        working_path: str,
+        session_key: str,
+        stored_claude_session_id: Optional[str],
+        effective_agent: Optional[str],
+        explicit_model: Optional[str],
+        explicit_effort: Optional[str],
+        agent_system_prompt: Optional[str],
+    ) -> ClaudeSDKClient:
 
         # Ensure working directory exists
         if not os.path.exists(working_path):
@@ -702,8 +838,8 @@ class SessionHandler(BaseHandler):
         logger.info(f"  - resume: {options.resume}")
         logger.info(f"  - continue_conversation: {options.continue_conversation}")
         logger.info(f"  - cli_path: {options.cli_path}")
-        if subagent_name:
-            logger.info(f"  - subagent: {subagent_name}")
+        if effective_agent:
+            logger.info(f"  - subagent: {effective_agent}")
 
         # Connect the client
         try:

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -302,9 +302,6 @@ class ClaudeAgent(BaseAgent):
     ) -> None:
         """Drop Claude runtime state without canceling the current receiver task."""
 
-        receiver_task = self.receiver_tasks.pop(composite_key, None)
-        client = self.claude_sessions.pop(composite_key, None)
-        cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)
         self._native_session_ids.pop(composite_key, None)
@@ -312,14 +309,18 @@ class ClaudeAgent(BaseAgent):
         if not preserve_pending_request_state:
             self._pending_reactions.pop(composite_key, None)
             self._pending_requests.pop(composite_key, None)
+        cleanup = getattr(self.session_handler, "cleanup_session", None)
+        if callable(cleanup):
+            await cleanup(composite_key, current_receiver_task=current_receiver_task)
+            return
+        receiver_task = self.receiver_tasks.pop(composite_key, None)
+        client = self.claude_sessions.pop(composite_key, None)
+        cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
         clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
         if callable(clear_tracking):
             clear_tracking(composite_key)
         try:
             if client is not None:
-                # Closing the SDK client first lets the receiver consume the end
-                # of stream. Cancelling it first can leave an anyio cancellation
-                # retry handle spinning in the controller loop.
                 if cleanup_from_receiver:
                     self._disconnect_client_after_receiver(client, composite_key, receiver_task)
                 else:
@@ -401,6 +402,9 @@ class ClaudeAgent(BaseAgent):
                     )
                     if claude_session_id:
                         self._native_session_ids[composite_key] = claude_session_id
+                        runtime_client = self.claude_sessions.get(composite_key)
+                        if runtime_client is client:
+                            setattr(runtime_client, "_vibe_native_session_id", claude_session_id)
                         logger.info(f"Captured Claude session id {claude_session_id} for {base_session_id}")
 
                     if self.claude_client._is_skip_message(message):

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -10,6 +10,7 @@ import subprocess
 from dataclasses import dataclass
 
 KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
+NODE_EXECUTABLES = {"node", "nodejs", "node.exe"}
 
 
 @dataclass(frozen=True)
@@ -68,7 +69,11 @@ def _command_is_claude(command: str) -> bool:
     if not parts:
         return False
     executable = os.path.basename(parts[0])
-    return executable in {"claude", "claude.exe"}
+    if executable in {"claude", "claude.exe"}:
+        return True
+    if executable in NODE_EXECUTABLES and len(parts) > 1:
+        return os.path.basename(parts[1]) in {"claude", "claude.exe"}
+    return False
 
 
 def find_claude_resume_processes(native_session_id: str) -> list[ClaudeProcessRow]:
@@ -102,6 +107,28 @@ def _descendant_pids(rows: list[ClaudeProcessRow], root_pid: int) -> set[int]:
         descendants.add(pid)
         stack.extend(children.get(pid, []))
     return descendants
+
+
+def _runtime_related_pids(rows: list[ClaudeProcessRow], root_pid: int | None) -> set[int]:
+    if root_pid is None:
+        return set()
+    return {root_pid} | _descendant_pids(rows, root_pid)
+
+
+def _same_runtime_rows(
+    rows: list[ClaudeProcessRow],
+    matches: list[ClaudeProcessRow],
+    *,
+    keep_pid: int | None,
+) -> list[ClaudeProcessRow]:
+    runtime_pids = _runtime_related_pids(rows, os.getpid())
+    if keep_pid is not None:
+        runtime_pids.update(_runtime_related_pids(rows, keep_pid))
+        keep_row = next((row for row in rows if row.pid == keep_pid), None)
+        if keep_row is not None:
+            runtime_pids.add(keep_row.ppid)
+            runtime_pids.update(_runtime_related_pids(rows, keep_row.ppid))
+    return [row for row in matches if row.pid in runtime_pids or row.ppid in runtime_pids]
 
 
 def _signal_pid(pid: int, sig: int, logger: logging.Logger) -> bool:
@@ -148,8 +175,9 @@ async def reap_duplicate_claude_resume_processes(
         return 0
 
     keep_pid = keep_pid if isinstance(keep_pid, int) and keep_pid > 0 else None
-    target_rows = [row for row in matches if row.pid != keep_pid]
-    if keep_pid is not None and len(matches) <= 1:
+    scoped_matches = _same_runtime_rows(all_rows, matches, keep_pid=keep_pid)
+    target_rows = [row for row in scoped_matches if row.pid != keep_pid]
+    if len(scoped_matches) <= 1:
         return 0
     if not target_rows:
         return 0

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -177,7 +177,7 @@ async def reap_duplicate_claude_resume_processes(
     keep_pid = keep_pid if isinstance(keep_pid, int) and keep_pid > 0 else None
     scoped_matches = _same_runtime_rows(all_rows, matches, keep_pid=keep_pid)
     target_rows = [row for row in scoped_matches if row.pid != keep_pid]
-    if len(scoped_matches) <= 1:
+    if keep_pid is not None and len(scoped_matches) <= 1:
         return 0
     if not target_rows:
         return 0

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -64,19 +64,24 @@ def _command_has_resume(command: str, native_session_id: str) -> bool:
     return False
 
 
-def _command_is_claude(command: str) -> bool:
+def _command_is_claude(command: str, cli_path: str | None = None) -> bool:
     parts = command.split()
     if not parts:
         return False
+    accepted_names = {"claude", "claude.exe"}
+    if cli_path:
+        configured_name = os.path.basename(cli_path)
+        if configured_name:
+            accepted_names.add(configured_name)
     executable = os.path.basename(parts[0])
-    if executable in {"claude", "claude.exe"}:
+    if executable in accepted_names:
         return True
     if executable in NODE_EXECUTABLES and len(parts) > 1:
-        return os.path.basename(parts[1]) in {"claude", "claude.exe"}
+        return os.path.basename(parts[1]) in accepted_names
     return False
 
 
-def find_claude_resume_processes(native_session_id: str) -> list[ClaudeProcessRow]:
+def find_claude_resume_processes(native_session_id: str, *, cli_path: str | None = None) -> list[ClaudeProcessRow]:
     """Find Claude Code CLI processes for one native ``--resume`` id."""
     if os.name == "nt" or not native_session_id:
         return []
@@ -88,7 +93,7 @@ def find_claude_resume_processes(native_session_id: str) -> list[ClaudeProcessRo
         row
         for row in rows
         if row.pid != os.getpid()
-        and _command_is_claude(row.command)
+        and _command_is_claude(row.command, cli_path=cli_path)
         and _command_has_resume(row.command, native_session_id)
     ]
 
@@ -146,6 +151,7 @@ async def reap_duplicate_claude_resume_processes(
     native_session_id: str | None,
     *,
     keep_pid: int | None = None,
+    cli_path: str | None = None,
     logger: logging.Logger,
     terminate_timeout: float = 2.0,
 ) -> int:
@@ -168,7 +174,7 @@ async def reap_duplicate_claude_resume_processes(
         row
         for row in all_rows
         if row.pid != os.getpid()
-        and _command_is_claude(row.command)
+        and _command_is_claude(row.command, cli_path=cli_path)
         and _command_has_resume(row.command, native_session_id)
     ]
     if not matches:

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -1,0 +1,191 @@
+"""Best-effort cleanup for duplicate Claude Code resume processes."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+
+KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
+
+
+@dataclass(frozen=True)
+class ClaudeProcessRow:
+    pid: int
+    ppid: int
+    command: str
+
+
+def get_claude_client_pid(client: object | None) -> int | None:
+    """Return the SDK-managed Claude CLI pid when the current SDK exposes it."""
+    transport = getattr(client, "_transport", None)
+    process = getattr(transport, "_process", None)
+    pid = getattr(process, "pid", None)
+    return pid if isinstance(pid, int) and pid > 0 else None
+
+
+def _run_ps() -> str:
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,ppid=,command="],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=1.5,
+    )
+    return result.stdout or ""
+
+
+def _parse_ps_rows(output: str) -> list[ClaudeProcessRow]:
+    rows: list[ClaudeProcessRow] = []
+    for line in output.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        rows.append(ClaudeProcessRow(pid=pid, ppid=ppid, command=parts[2]))
+    return rows
+
+
+def _command_has_resume(command: str, native_session_id: str) -> bool:
+    parts = command.split()
+    for index, part in enumerate(parts):
+        if part == "--resume" and index + 1 < len(parts) and parts[index + 1] == native_session_id:
+            return True
+        if part.startswith("--resume=") and part.removeprefix("--resume=") == native_session_id:
+            return True
+    return False
+
+
+def _command_is_claude(command: str) -> bool:
+    parts = command.split()
+    if not parts:
+        return False
+    executable = os.path.basename(parts[0])
+    return executable in {"claude", "claude.exe"}
+
+
+def find_claude_resume_processes(native_session_id: str) -> list[ClaudeProcessRow]:
+    """Find Claude Code CLI processes for one native ``--resume`` id."""
+    if os.name == "nt" or not native_session_id:
+        return []
+    try:
+        rows = _parse_ps_rows(_run_ps())
+    except Exception:
+        return []
+    return [
+        row
+        for row in rows
+        if row.pid != os.getpid()
+        and _command_is_claude(row.command)
+        and _command_has_resume(row.command, native_session_id)
+    ]
+
+
+def _descendant_pids(rows: list[ClaudeProcessRow], root_pid: int) -> set[int]:
+    children: dict[int, list[int]] = {}
+    for row in rows:
+        children.setdefault(row.ppid, []).append(row.pid)
+
+    descendants: set[int] = set()
+    stack = list(children.get(root_pid, []))
+    while stack:
+        pid = stack.pop()
+        if pid in descendants:
+            continue
+        descendants.add(pid)
+        stack.extend(children.get(pid, []))
+    return descendants
+
+
+def _signal_pid(pid: int, sig: int, logger: logging.Logger) -> bool:
+    try:
+        os.kill(pid, sig)
+        return True
+    except ProcessLookupError:
+        return True
+    except Exception:
+        logger.debug("Failed to signal Claude duplicate pid=%s signal=%s", pid, sig, exc_info=True)
+        return False
+
+
+async def reap_duplicate_claude_resume_processes(
+    native_session_id: str | None,
+    *,
+    keep_pid: int | None = None,
+    logger: logging.Logger,
+    terminate_timeout: float = 2.0,
+) -> int:
+    """Terminate duplicate Claude Code CLI processes for one native session.
+
+    This is intentionally conservative: it only matches a full ``--resume`` id
+    and only reaps when more than one matching process exists, or when the
+    caller no longer has a tracked PID to keep.
+    """
+    if not native_session_id or os.name == "nt":
+        return 0
+
+    try:
+        all_rows = _parse_ps_rows(_run_ps())
+    except Exception:
+        logger.debug("Failed to read process table for Claude duplicate cleanup", exc_info=True)
+        return 0
+
+    matches = [
+        row
+        for row in all_rows
+        if row.pid != os.getpid()
+        and _command_is_claude(row.command)
+        and _command_has_resume(row.command, native_session_id)
+    ]
+    if not matches:
+        return 0
+
+    keep_pid = keep_pid if isinstance(keep_pid, int) and keep_pid > 0 else None
+    target_rows = [row for row in matches if row.pid != keep_pid]
+    if keep_pid is not None and len(matches) <= 1:
+        return 0
+    if not target_rows:
+        return 0
+
+    target_pids = {row.pid for row in target_rows}
+    for row in target_rows:
+        target_pids.update(_descendant_pids(all_rows, row.pid))
+    target_pids.discard(os.getpid())
+    if keep_pid is not None:
+        target_pids.discard(keep_pid)
+
+    if not target_pids:
+        return 0
+
+    logger.warning(
+        "Reaping %d duplicate Claude resume process(es) for native session %s (keep_pid=%s)",
+        len(target_pids),
+        native_session_id,
+        keep_pid,
+    )
+    for pid in sorted(target_pids):
+        _signal_pid(pid, signal.SIGTERM, logger)
+
+    deadline = asyncio.get_running_loop().time() + terminate_timeout
+    remaining = set(target_pids)
+    while remaining and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.05)
+        for pid in list(remaining):
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                remaining.discard(pid)
+            except Exception:
+                remaining.discard(pid)
+
+    for pid in sorted(remaining):
+        _signal_pid(pid, KILL_SIGNAL, logger)
+
+    return len(target_pids)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -56,12 +56,46 @@ class _StubController:
         self.config = type("Config", (), {})()
         self.im_client = SimpleNamespace(formatter=SimpleNamespace())
         self.settings_manager = _StubSettingsManager()
-        self.session_handler = SimpleNamespace(cleanup_session=AsyncMock(), capture_session_id=lambda *_: None)
         self.session_manager = _StubSessionManager()
         self.receiver_tasks = {}
         self.claude_sessions = {}
         self.claude_client = SimpleNamespace(_is_skip_message=lambda message: False)
         self.agent_auth_service = SimpleNamespace(maybe_emit_auth_recovery_message=AsyncMock(return_value=False))
+
+        async def _cleanup_session(composite_key, *, current_receiver_task=None):
+            receiver_task = self.receiver_tasks.pop(composite_key, None)
+            client = self.claude_sessions.pop(composite_key, None)
+            cleanup_from_receiver = receiver_task is not None and receiver_task is current_receiver_task
+            clear_tracking = getattr(self.session_handler, "clear_session_tracking", None)
+            if callable(clear_tracking):
+                clear_tracking(composite_key)
+            try:
+                if client is not None:
+                    if cleanup_from_receiver:
+                        async def _deferred_disconnect():
+                            await client.disconnect()
+
+                        asyncio.create_task(_deferred_disconnect())
+                        return
+                    await client.disconnect()
+            finally:
+                if receiver_task is not None and not cleanup_from_receiver:
+                    if receiver_task.done():
+                        try:
+                            receiver_task.exception()
+                        except asyncio.CancelledError:
+                            pass
+                    else:
+                        receiver_task.cancel()
+                        try:
+                            await receiver_task
+                        except asyncio.CancelledError:
+                            pass
+
+        self.session_handler = SimpleNamespace(
+            cleanup_session=AsyncMock(side_effect=_cleanup_session),
+            capture_session_id=lambda *args, **kwargs: None,
+        )
 
 
 class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
@@ -532,6 +566,36 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(session_key, agent._pending_reactions)
         self.assertNotIn(session_key, agent._pending_requests)
 
+    async def test_cleanup_runtime_session_delegates_runtime_cleanup_to_session_handler(self):
+        controller = _StubController()
+        cleanup_calls = []
+        controller.session_handler = SimpleNamespace(
+            cleanup_session=AsyncMock(side_effect=lambda key, **kwargs: cleanup_calls.append((key, kwargs))),
+        )
+        agent = ClaudeAgent(controller)
+        session_key = "wechat_o9:/tmp/work"
+        receiver_task = asyncio.create_task(asyncio.sleep(3600))
+        agent._last_assistant_text[session_key] = "hello"
+        agent._pending_assistant_message[session_key] = "pending"
+        agent._pending_reactions[session_key] = [("m1", "⏳")]
+        agent._pending_requests[session_key] = ["request"]
+        agent._native_session_ids[session_key] = "native-session-1"
+
+        await agent._cleanup_runtime_session(session_key, current_receiver_task=receiver_task)
+
+        controller.session_handler.cleanup_session.assert_awaited_once_with(
+            session_key,
+            current_receiver_task=receiver_task,
+        )
+        self.assertNotIn(session_key, agent._last_assistant_text)
+        self.assertNotIn(session_key, agent._pending_assistant_message)
+        self.assertNotIn(session_key, agent._pending_reactions)
+        self.assertNotIn(session_key, agent._pending_requests)
+        self.assertNotIn(session_key, agent._native_session_ids)
+        receiver_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await receiver_task
+
     async def test_prepare_resume_binding_cleans_only_target_runtime_session(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)
@@ -705,7 +769,10 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         await agent._receive_messages(_Client(), "session-1", "/tmp/work", context)
 
         controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
-        controller.session_handler.cleanup_session.assert_not_awaited()
+        controller.session_handler.cleanup_session.assert_awaited_once_with(
+            composite_key,
+            current_receiver_task=asyncio.current_task(),
+        )
         self.assertNotIn(composite_key, controller.receiver_tasks)
         self.assertNotIn(composite_key, controller.claude_sessions)
         # #216: the failed turn's pending request was retired from the FIFO (so the
@@ -715,6 +782,43 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(context.platform_specific.get("turn_token"), "Ta")
         controller.mark_turn_complete.assert_called_once()
         agent.emit_result_message.assert_not_awaited()
+
+    async def test_receive_init_message_attaches_native_session_id_to_runtime_client(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "slack::channel::C1"
+        controller.emit_agent_message = AsyncMock()
+        controller.session_handler.capture_session_id = lambda *args, **kwargs: "sesk8m4q2p7x"
+        agent = ClaudeAgent(controller)
+        context = SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={})
+        composite_key = "session-1:/tmp/work"
+
+        init_message = type(
+            "SystemMessage",
+            (),
+            {"subtype": "init", "data": {"session_id": "session-sdk"}},
+        )()
+        result_message = type(
+            "ResultMessage",
+            (),
+            {"subtype": "success", "result": "done", "duration_ms": 1},
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield init_message
+                    yield result_message
+
+                return _iterate()
+
+        runtime_client = _Client()
+        controller.claude_sessions[composite_key] = runtime_client
+        agent.emit_result_message = AsyncMock()
+
+        await agent._receive_messages(runtime_client, "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        self.assertEqual(getattr(runtime_client, "_vibe_native_session_id"), "session-sdk")
+        self.assertEqual(agent._native_session_ids[composite_key], "session-sdk")
 
     async def test_init_message_binds_native_session_to_existing_agent_session(self):
         controller = _StubController()
@@ -885,7 +989,10 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         await agent._receive_messages(_Client(), "session-1", "/tmp/work", context)
 
         controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
-        controller.session_handler.cleanup_session.assert_not_awaited()
+        controller.session_handler.cleanup_session.assert_awaited_once_with(
+            composite_key,
+            current_receiver_task=asyncio.current_task(),
+        )
         self.assertEqual(agent._remove_ack_reaction.await_count, 2)
         self.assertEqual(agent._remove_ack_reaction.await_args_list[0].args, (pending_request_1,))
         self.assertEqual(agent._remove_ack_reaction.await_args_list[1].args, (pending_request_2,))

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -408,6 +408,60 @@ def test_session_handler_reuses_cached_claude_client_when_system_prompt_is_uncha
     assert "slack/U456" not in first_client.options.system_prompt["append"]
 
 
+def test_session_handler_coalesces_concurrent_claude_client_creates(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {"clients": [], "connects": 0}
+
+    async def _run() -> None:
+        connect_started = asyncio.Event()
+        release_connect = asyncio.Event()
+
+        class _StubClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+                captured["clients"].append(self)
+
+            async def connect(self) -> None:
+                captured["connects"] += 1
+                connect_started.set()
+                await release_connect.wait()
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def set_model(self, model: str | None) -> None:
+                self.model = model
+
+        monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+        monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+        controller = _Controller(tmp_path)
+        handler = SessionHandler(controller)
+        first_context = MessageContext(user_id="U123", channel_id="C123")
+        second_context = MessageContext(user_id="U456", channel_id="C123")
+
+        first = asyncio.create_task(handler.get_or_create_claude_session(first_context))
+        await connect_started.wait()
+        second = asyncio.create_task(handler.get_or_create_claude_session(second_context))
+        await asyncio.sleep(0)
+
+        assert len(captured["clients"]) == 1
+        assert captured["connects"] == 1
+
+        release_connect.set()
+        first_client, second_client = await asyncio.gather(first, second)
+
+        composite_key = f"slack_C123:{tmp_path}"
+        assert first_client is second_client
+        assert controller.claude_sessions[composite_key] is first_client
+        assert len(captured["clients"]) == 1
+        assert captured["connects"] == 1
+        assert handler.claude_session_creates == {}
+
+    asyncio.run(_run())
+
+
 def test_session_handler_forces_bypass_mode_and_auto_approves_claude_tool_permissions(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -462,6 +462,124 @@ def test_session_handler_coalesces_concurrent_claude_client_creates(
     asyncio.run(_run())
 
 
+def test_session_handler_retries_waiting_claude_create_after_cancellation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {"clients": [], "connects": 0}
+
+    async def _run() -> None:
+        connect_started = asyncio.Event()
+        retry_connected = asyncio.Event()
+
+        class _StubClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+                captured["clients"].append(self)
+
+            async def connect(self) -> None:
+                captured["connects"] += 1
+                if captured["connects"] == 1:
+                    connect_started.set()
+                    await asyncio.Event().wait()
+                else:
+                    retry_connected.set()
+
+            async def disconnect(self) -> None:
+                return None
+
+            async def set_model(self, model: str | None) -> None:
+                self.model = model
+
+        monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+        monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+        controller = _Controller(tmp_path)
+        handler = SessionHandler(controller)
+        first_context = MessageContext(user_id="U123", channel_id="C123")
+        second_context = MessageContext(user_id="U456", channel_id="C123")
+
+        first = asyncio.create_task(handler.get_or_create_claude_session(first_context))
+        await connect_started.wait()
+        second = asyncio.create_task(handler.get_or_create_claude_session(second_context))
+        await asyncio.sleep(0)
+
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        second_client = await asyncio.wait_for(second, timeout=1)
+
+        composite_key = f"slack_C123:{tmp_path}"
+        assert retry_connected.is_set()
+        assert captured["connects"] == 2
+        assert captured["clients"][-1] is second_client
+        assert controller.claude_sessions[composite_key] is second_client
+        assert handler.claude_session_creates == {}
+
+    asyncio.run(_run())
+
+
+def test_session_handler_does_not_resume_main_native_session_for_new_routing_subagent(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {"clients": []}
+
+    class _SubagentSessions(_Sessions):
+        @staticmethod
+        def get_claude_session_id(settings_key, base_session_id):
+            assert settings_key == "test::C123"
+            assert base_session_id == "slack_C123"
+            return "main-native-session"
+
+        @staticmethod
+        def get_agent_session_id(settings_key, base_session_id, agent_name):
+            assert settings_key == "test::C123"
+            assert base_session_id == "slack_C123:reviewer"
+            assert agent_name == "claude"
+            return None
+
+    class _RoutingSettingsManager(_SettingsManager):
+        def __init__(self) -> None:
+            super().__init__()
+            self.sessions = _SubagentSessions()
+
+        @staticmethod
+        def get_channel_routing(settings_key):
+            assert settings_key == "C123"
+            return type("Routing", (), {"claude_agent": "reviewer", "model": None, "reasoning_effort": None})()
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.options = options
+            captured["clients"].append(self)
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            return None
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    controller.settings_manager = _RoutingSettingsManager()
+    controller.platform_settings_managers = {"slack": controller.settings_manager}
+    handler = SessionHandler(controller)
+    context = MessageContext(
+        user_id="U123",
+        channel_id="C123",
+        platform_specific={"routing_subagent": "reviewer"},
+    )
+
+    client = _run_session(handler, context)
+
+    composite_key = f"slack_C123:reviewer:{tmp_path}"
+    assert client.options.resume is None
+    assert not hasattr(client, "_vibe_native_session_id")
+    assert controller.claude_sessions[composite_key] is client
+
+
 def test_session_handler_forces_bypass_mode_and_auto_approves_claude_tool_permissions(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -1229,8 +1347,8 @@ def test_evict_idle_sessions_reaps_native_resume_processes(monkeypatch, tmp_path
         async def disconnect(self) -> None:
             self.disconnects += 1
 
-    async def fake_reap(native_session_id, *, keep_pid=None, logger, terminate_timeout=2.0):
-        captured["reap_calls"].append((native_session_id, keep_pid))
+    async def fake_reap(native_session_id, *, keep_pid=None, cli_path=None, logger, terminate_timeout=2.0):
+        captured["reap_calls"].append((native_session_id, keep_pid, cli_path))
         return 2
 
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
@@ -1252,4 +1370,4 @@ def test_evict_idle_sessions_reaps_native_resume_processes(monkeypatch, tmp_path
     assert evicted == 1
     assert client.disconnects == 1
     assert getattr(client, "_vibe_native_session_id") == "native-session-1"
-    assert captured["reap_calls"] == [("native-session-1", None)]
+    assert captured["reap_calls"] == [("native-session-1", None, "/usr/local/bin/claude-proxy")]

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -1147,3 +1147,55 @@ def test_evict_idle_sessions_rechecks_active_state_before_cleanup(monkeypatch, t
     assert evicted == 0
     assert client.disconnects == 0
     assert composite_key in controller.claude_sessions
+
+
+def test_evict_idle_sessions_reaps_native_resume_processes(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {"reap_calls": []}
+
+    class _StubSessions(_Sessions):
+        @staticmethod
+        def get_claude_session_id(settings_key, base_session_id):
+            assert settings_key == "test::C123"
+            assert base_session_id == "slack_C123"
+            return "native-session-1"
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.disconnects = 0
+            self._transport = type(
+                "Transport",
+                (),
+                {"_process": type("Process", (), {"pid": 4321})()},
+            )()
+            captured["client"] = self
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    async def fake_reap(native_session_id, *, keep_pid=None, logger, terminate_timeout=2.0):
+        captured["reap_calls"].append((native_session_id, keep_pid))
+        return 2
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module, "reap_duplicate_claude_resume_processes", fake_reap)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    controller.settings_manager.sessions = _StubSessions()
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    client = _run_session(handler, context)
+    composite_key = f"slack_C123:{tmp_path}"
+    handler.session_last_activity[composite_key] = 0.0
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 1
+    assert client.disconnects == 1
+    assert getattr(client, "_vibe_native_session_id") == "native-session-1"
+    assert captured["reap_calls"] == [("native-session-1", None)]

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -1,0 +1,79 @@
+import logging
+import signal
+
+import pytest
+
+from modules.agents import claude_process_reaper
+
+
+def test_find_claude_resume_processes_matches_exact_resume_id(monkeypatch):
+    table = "\n".join(
+        [
+            "100 1 /usr/local/bin/claude --resume sess-1 --model opus",
+            "101 1 /usr/local/bin/claude --resume sess-10 --model opus",
+            "102 1 /usr/local/bin/claude --resume=sess-1 --model opus",
+            "103 1 /usr/local/bin/codex --resume sess-1",
+            "104 1 /usr/local/bin/not-claude --resume sess-1",
+        ]
+    )
+    monkeypatch.setattr(claude_process_reaper, "_run_ps", lambda: table)
+
+    rows = claude_process_reaper.find_claude_resume_processes("sess-1")
+
+    assert [row.pid for row in rows] == [100, 102]
+
+
+@pytest.mark.asyncio
+async def test_reap_duplicate_claude_resume_processes_kills_matches_and_descendants(monkeypatch):
+    table = "\n".join(
+        [
+            "100 1 /usr/local/bin/claude --resume sess-1 --model opus",
+            "101 1 /usr/local/bin/claude --resume sess-1 --model opus",
+            "102 101 node helper.js",
+            "200 1 /usr/local/bin/claude --resume sess-2 --model opus",
+        ]
+    )
+    signals = []
+    alive = {100, 101, 102, 200}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid not in alive:
+                raise ProcessLookupError
+            return
+        signals.append((pid, sig))
+        alive.discard(pid)
+
+    monkeypatch.setattr(claude_process_reaper, "_run_ps", lambda: table)
+    monkeypatch.setattr(claude_process_reaper.os, "kill", fake_kill)
+
+    reaped = await claude_process_reaper.reap_duplicate_claude_resume_processes(
+        "sess-1",
+        keep_pid=100,
+        logger=logging.getLogger("test.claude_reaper"),
+    )
+
+    assert reaped == 2
+    assert (101, signal.SIGTERM) in signals
+    assert (102, signal.SIGTERM) in signals
+    assert all(pid not in (100, 200) for pid, _ in signals)
+
+
+@pytest.mark.asyncio
+async def test_reap_duplicate_claude_resume_processes_keeps_single_tracked_pid(monkeypatch):
+    monkeypatch.setattr(
+        claude_process_reaper,
+        "_run_ps",
+        lambda: "100 1 /usr/local/bin/claude --resume sess-1 --model opus",
+    )
+    signals = []
+    monkeypatch.setattr(claude_process_reaper.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    reaped = await claude_process_reaper.reap_duplicate_claude_resume_processes(
+        "sess-1",
+        keep_pid=100,
+        logger=logging.getLogger("test.claude_reaper"),
+    )
+
+    assert reaped == 0
+    assert signals == []

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -90,6 +90,42 @@ def test_reap_duplicate_claude_resume_processes_keeps_single_tracked_pid(monkeyp
     assert signals == []
 
 
+def test_reap_duplicate_claude_resume_processes_reaps_scoped_orphan_without_keep_pid(monkeypatch):
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"100 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
+            "300 1 /usr/local/bin/claude --resume sess-1 --model opus",
+        ]
+    )
+    signals = []
+    alive = {100, 300}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid not in alive:
+                raise ProcessLookupError
+            return
+        signals.append((pid, sig))
+        alive.discard(pid)
+
+    monkeypatch.setattr(claude_process_reaper, "_run_ps", lambda: table)
+    monkeypatch.setattr(claude_process_reaper.os, "kill", fake_kill)
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_duplicate_claude_resume_processes(
+            "sess-1",
+            keep_pid=None,
+            logger=logging.getLogger("test.claude_reaper"),
+        )
+    )
+
+    assert reaped == 1
+    assert (100, signal.SIGTERM) in signals
+    assert all(pid != 300 for pid, _ in signals)
+
+
 def test_reap_duplicate_claude_resume_processes_ignores_unrelated_unique_match(monkeypatch):
     service_pid = os.getpid()
     monkeypatch.setattr(

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -24,6 +24,24 @@ def test_find_claude_resume_processes_matches_exact_resume_id(monkeypatch):
     assert [row.pid for row in rows] == [100, 102, 105]
 
 
+def test_find_claude_resume_processes_matches_configured_wrapper(monkeypatch):
+    table = "\n".join(
+        [
+            "100 1 /usr/local/bin/claude-proxy --resume sess-1 --model opus",
+            "101 1 /usr/local/bin/other-wrapper --resume sess-1 --model opus",
+            "102 1 /usr/local/bin/node /usr/local/bin/claude-proxy --resume=sess-1",
+        ]
+    )
+    monkeypatch.setattr(claude_process_reaper, "_run_ps", lambda: table)
+
+    rows = claude_process_reaper.find_claude_resume_processes(
+        "sess-1",
+        cli_path="/usr/local/bin/claude-proxy",
+    )
+
+    assert [row.pid for row in rows] == [100, 102]
+
+
 def test_reap_duplicate_claude_resume_processes_kills_matches_and_descendants(monkeypatch):
     service_pid = os.getpid()
     table = "\n".join(

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -1,7 +1,7 @@
+import asyncio
 import logging
+import os
 import signal
-
-import pytest
 
 from modules.agents import claude_process_reaper
 
@@ -14,21 +14,23 @@ def test_find_claude_resume_processes_matches_exact_resume_id(monkeypatch):
             "102 1 /usr/local/bin/claude --resume=sess-1 --model opus",
             "103 1 /usr/local/bin/codex --resume sess-1",
             "104 1 /usr/local/bin/not-claude --resume sess-1",
+            "105 1 /usr/local/bin/node /usr/local/bin/claude --resume sess-1",
         ]
     )
     monkeypatch.setattr(claude_process_reaper, "_run_ps", lambda: table)
 
     rows = claude_process_reaper.find_claude_resume_processes("sess-1")
 
-    assert [row.pid for row in rows] == [100, 102]
+    assert [row.pid for row in rows] == [100, 102, 105]
 
 
-@pytest.mark.asyncio
-async def test_reap_duplicate_claude_resume_processes_kills_matches_and_descendants(monkeypatch):
+def test_reap_duplicate_claude_resume_processes_kills_matches_and_descendants(monkeypatch):
+    service_pid = os.getpid()
     table = "\n".join(
         [
-            "100 1 /usr/local/bin/claude --resume sess-1 --model opus",
-            "101 1 /usr/local/bin/claude --resume sess-1 --model opus",
+            f"{service_pid} 1 python service_main.py",
+            f"100 {service_pid} /usr/local/bin/node /usr/local/bin/claude --resume sess-1 --model opus",
+            f"101 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
             "102 101 node helper.js",
             "200 1 /usr/local/bin/claude --resume sess-2 --model opus",
         ]
@@ -47,10 +49,12 @@ async def test_reap_duplicate_claude_resume_processes_kills_matches_and_descenda
     monkeypatch.setattr(claude_process_reaper, "_run_ps", lambda: table)
     monkeypatch.setattr(claude_process_reaper.os, "kill", fake_kill)
 
-    reaped = await claude_process_reaper.reap_duplicate_claude_resume_processes(
-        "sess-1",
-        keep_pid=100,
-        logger=logging.getLogger("test.claude_reaper"),
+    reaped = asyncio.run(
+        claude_process_reaper.reap_duplicate_claude_resume_processes(
+            "sess-1",
+            keep_pid=100,
+            logger=logging.getLogger("test.claude_reaper"),
+        )
     )
 
     assert reaped == 2
@@ -59,20 +63,54 @@ async def test_reap_duplicate_claude_resume_processes_kills_matches_and_descenda
     assert all(pid not in (100, 200) for pid, _ in signals)
 
 
-@pytest.mark.asyncio
-async def test_reap_duplicate_claude_resume_processes_keeps_single_tracked_pid(monkeypatch):
+def test_reap_duplicate_claude_resume_processes_keeps_single_tracked_pid(monkeypatch):
+    service_pid = os.getpid()
     monkeypatch.setattr(
         claude_process_reaper,
         "_run_ps",
-        lambda: "100 1 /usr/local/bin/claude --resume sess-1 --model opus",
+        lambda: "\n".join(
+            [
+                f"{service_pid} 1 python service_main.py",
+                f"100 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
+            ]
+        ),
     )
     signals = []
     monkeypatch.setattr(claude_process_reaper.os, "kill", lambda pid, sig: signals.append((pid, sig)))
 
-    reaped = await claude_process_reaper.reap_duplicate_claude_resume_processes(
-        "sess-1",
-        keep_pid=100,
-        logger=logging.getLogger("test.claude_reaper"),
+    reaped = asyncio.run(
+        claude_process_reaper.reap_duplicate_claude_resume_processes(
+            "sess-1",
+            keep_pid=100,
+            logger=logging.getLogger("test.claude_reaper"),
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []
+
+
+def test_reap_duplicate_claude_resume_processes_ignores_unrelated_unique_match(monkeypatch):
+    service_pid = os.getpid()
+    monkeypatch.setattr(
+        claude_process_reaper,
+        "_run_ps",
+        lambda: "\n".join(
+            [
+                f"{service_pid} 1 python service_main.py",
+                "300 1 /usr/local/bin/claude --resume sess-1 --model opus",
+            ]
+        ),
+    )
+    signals = []
+    monkeypatch.setattr(claude_process_reaper.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_duplicate_claude_resume_processes(
+            "sess-1",
+            keep_pid=None,
+            logger=logging.getLogger("test.claude_reaper"),
+        )
     )
 
     assert reaped == 0


### PR DESCRIPTION
## Summary
- fix Claude runtime cleanup so all explicit/session eviction paths share SessionHandler cleanup
- persist the native Claude session id on the runtime client once it is known
- reap duplicate `claude --resume <native-session-id>` processes during cleanup with conservative exact resume matching

Fixes #542.

## Evidence layers
- Unit: added focused Claude process reaper tests for exact resume matching, descendant cleanup, and single tracked PID preservation
- Contract: extended Claude session lifecycle tests for idle eviction and runtime cleanup delegation
- Scenario: covered idle eviction of a resumed Claude native session and auth-failure cleanup paths
- Residual manual checks: no live tenant process cleanup was run locally; process table behavior is covered with mocked `ps`/signals

## Validation
- `python3 -m pytest tests/test_claude_agent_sessions.py tests/test_claude_cli_path.py tests/test_claude_process_reaper.py tests/test_claude_subprocess_env.py tests/test_claude_container_sandbox.py tests/test_claude_reasoning_options.py tests/test_claude_sdk_compat.py -q`
- `python3 -m ruff check core/handlers/session_handler.py modules/agents/claude_agent.py modules/agents/claude_process_reaper.py tests/test_claude_agent_sessions.py tests/test_claude_cli_path.py tests/test_claude_process_reaper.py`
