### PR TITLE
feat(claude): add Claude Fable 5 to the model catalog

### DIFF
--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -334,6 +334,7 @@ def _supports_claude_xhigh_reasoning(target_model: Optional[str]) -> bool:
         normalized_model in {"opus", "opus[1m]"}
         or normalized_model.startswith("claude-opus-4-7")
         or normalized_model.startswith("claude-opus-4-8")
+        or normalized_model.startswith("claude-fable-5")
     )
 
 
@@ -347,6 +348,7 @@ def _supports_claude_max_reasoning(target_model: Optional[str]) -> bool:
         or normalized_model.startswith("claude-opus-4-7")
         or normalized_model.startswith("claude-opus-4-8")
         or normalized_model.startswith("claude-sonnet-4-6")
+        or normalized_model.startswith("claude-fable-5")
     )
 
 
@@ -360,6 +362,7 @@ def supports_claude_1m_context(target_model: Optional[str]) -> bool:
         or normalized_model.startswith("claude-opus-4-7")
         or normalized_model.startswith("claude-opus-4-8")
         or normalized_model.startswith("claude-sonnet-4-6")
+        or normalized_model.startswith("claude-fable-5")
     )
 
 

--- a/modules/im/discord.py
+++ b/modules/im/discord.py
@@ -32,8 +32,27 @@ from modules.agents.opencode.utils import (
 )
 from modules.agents.native_sessions.display import format_display_summary, format_display_time
 from modules.agents.native_sessions.types import NativeResumeSession
+from vibe.claude_model_catalog import DEFAULT_CLAUDE_MODEL_ALIASES
 
 logger = logging.getLogger(__name__)
+
+
+def _prioritize_claude_model_choices(models: List[str], current_model: Optional[str]) -> List[str]:
+    """Order Claude model ids so the active selection and the canonical bare
+    aliases (opus/sonnet/haiku) survive Discord's 25-option select-menu cap.
+
+    ``api.claude_models()`` appends the bare aliases after the full catalog, so a
+    plain truncation silently drops the most useful, always-valid picks — and the
+    user's current selection. Surfacing them first means the cap only trims the
+    long tail of dated snapshots instead.
+    """
+    priority: List[str] = []
+    seen: set[str] = set()
+    for candidate in (current_model, *DEFAULT_CLAUDE_MODEL_ALIASES):
+        if candidate and candidate in models and candidate not in seen:
+            priority.append(candidate)
+            seen.add(candidate)
+    return priority + [model for model in models if model not in seen]
 
 
 class DiscordBot(BaseIMClient):
@@ -1682,13 +1701,16 @@ class DiscordBot(BaseIMClient):
                             default=self.claude_model in (None, "__default__"),
                         )
                     ]
+                    # Discord select menus cap at 25 options; prioritize the active
+                    # pick and the bare aliases so the truncation below only trims the
+                    # long tail of dated snapshots (see _prioritize_claude_model_choices).
                     model_options += [
                         discord.SelectOption(
                             label=_prefixed_label("discord.labels.model", format_claude_model_label(m)),
                             value=m,
                             default=m == self.claude_model,
                         )
-                        for m in claude_models
+                        for m in _prioritize_claude_model_choices(claude_models, self.claude_model)
                     ]
                     if len(model_options) > 25:
                         model_options = model_options[:25]

--- a/tests/test_claude_model_catalog.py
+++ b/tests/test_claude_model_catalog.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from vibe.claude_model_catalog import (
+    FALLBACK_CLAUDE_MODELS,
+    infer_models_from_bundle,
+    load_catalog_models,
+    sort_catalog_models,
+)
+
+
+def test_fable_is_tracked_in_catalog_and_fallback():
+    assert "claude-fable-5" in load_catalog_models()
+    assert "claude-fable-5" in FALLBACK_CLAUDE_MODELS
+
+
+def test_fable_sorts_above_other_families():
+    ordered = sort_catalog_models(
+        [
+            "claude-haiku-4-5",
+            "claude-opus-4-8",
+            "claude-fable-5",
+            "claude-sonnet-4-6",
+        ]
+    )
+    # Fable is the Mythos-class tier and must lead the catalog ordering.
+    assert ordered[0] == "claude-fable-5"
+    assert ordered.index("claude-fable-5") < ordered.index("claude-opus-4-8")
+
+
+def test_bundle_inference_detects_fable_and_skips_mythos_preview(tmp_path):
+    bundle = tmp_path / "cli.js"
+    bundle.write_bytes(
+        b'pick("claude-fable-5");fallback="claude-opus-4-8";"claude-mythos-preview"'
+    )
+
+    models = infer_models_from_bundle(bundle)
+
+    assert models == ["claude-fable-5", "claude-opus-4-8"]
+    # `claude-mythos-preview` carries no version segment and is not a publicly
+    # callable model, so it must not leak into the catalog.
+    assert "claude-mythos-preview" not in models

--- a/tests/test_claude_reasoning_options.py
+++ b/tests/test_claude_reasoning_options.py
@@ -40,6 +40,12 @@ def test_claude_reasoning_options_add_xhigh_and_max_for_opus_48() -> None:
     assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "xhigh", "max"]
 
 
+def test_claude_reasoning_options_add_xhigh_and_max_for_fable_5() -> None:
+    options = build_claude_reasoning_options("claude-fable-5")
+
+    assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "xhigh", "max"]
+
+
 def test_claude_reasoning_options_add_max_for_opus_46() -> None:
     options = build_claude_reasoning_options("claude-opus-4-6")
 
@@ -80,6 +86,8 @@ def test_normalize_claude_reasoning_effort_drops_invalid_efforts() -> None:
     assert normalize_claude_reasoning_effort("claude-opus-4-8", "max") == "max"
     assert normalize_claude_reasoning_effort("claude-opus-4-6", "max") == "max"
     assert normalize_claude_reasoning_effort("claude-sonnet-4-6", "max") == "max"
+    assert normalize_claude_reasoning_effort("claude-fable-5", "xhigh") == "xhigh"
+    assert normalize_claude_reasoning_effort("claude-fable-5", "max") == "max"
     assert normalize_claude_reasoning_effort("opus", "xhigh") == "xhigh"
     assert normalize_claude_reasoning_effort("opus", "max") == "max"
 
@@ -89,6 +97,7 @@ def test_claude_1m_context_labels() -> None:
     assert format_claude_model_label("claude-opus-4-7") == "claude-opus-4-7 [1M]"
     assert format_claude_model_label("claude-opus-4-6") == "claude-opus-4-6 [1M]"
     assert format_claude_model_label("claude-sonnet-4-6") == "claude-sonnet-4-6 [1M]"
+    assert format_claude_model_label("claude-fable-5") == "claude-fable-5 [1M]"
     assert format_claude_model_label("opus[1m]") == "opus[1m] [1M]"
     assert format_claude_model_label("sonnet") == "sonnet [1M]"
     assert format_claude_model_label("sonnet[1m]") == "sonnet[1m] [1M]"

--- a/tests/test_discord_model_picker.py
+++ b/tests/test_discord_model_picker.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.im.discord import _prioritize_claude_model_choices
+
+
+def test_prioritize_pulls_aliases_ahead_of_catalog_tail():
+    # claude_models() appends the bare aliases after the full catalog.
+    models = ["claude-fable-5", "claude-opus-4-8", "opus", "sonnet", "haiku"]
+    result = _prioritize_claude_model_choices(models, None)
+
+    assert result[:3] == ["opus", "sonnet", "haiku"]
+    # No entries gained or lost — only reordered.
+    assert sorted(result) == sorted(models)
+
+
+def test_prioritize_puts_current_selection_first():
+    models = ["claude-fable-5", "claude-opus-4-8", "opus", "sonnet", "haiku"]
+    result = _prioritize_claude_model_choices(models, "claude-opus-4-8")
+
+    assert result[0] == "claude-opus-4-8"
+    assert result[1:4] == ["opus", "sonnet", "haiku"]
+    assert sorted(result) == sorted(models)
+
+
+def test_prioritize_ignores_missing_or_default_selection():
+    models = ["claude-fable-5", "opus"]
+
+    # __default__ / None / unknown ids are not real catalog entries and must not
+    # be injected into the option list.
+    assert _prioritize_claude_model_choices(models, "__default__") == ["opus", "claude-fable-5"]
+    assert _prioritize_claude_model_choices(models, None) == ["opus", "claude-fable-5"]
+
+
+def test_prioritized_aliases_survive_discord_25_cap():
+    # Regression for the P2: 24 catalog ids plus the 3 bare aliases appended last.
+    # The Claude modal prepends one default option then slices model_options to 25,
+    # so only the first 24 model entries survive. Prioritization must keep the
+    # always-valid aliases inside that window.
+    catalog = [f"claude-catalog-{i}" for i in range(24)]
+    models = catalog + ["opus", "sonnet", "haiku"]
+
+    result = _prioritize_claude_model_choices(models, None)
+
+    assert {"opus", "sonnet", "haiku"} <= set(result[:24])

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -122,7 +122,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
     if (cached?.length) return cached;
     const fallback = claudeReasoningOptions[''] || [];
     const normalized = modelKey.toLowerCase();
-    if (normalized.includes('claude-opus-4-7') || normalized === 'opus' || normalized === 'opus[1m]') {
+    if (normalized.includes('claude-opus-4-7') || normalized.includes('claude-fable-5') || normalized === 'opus' || normalized === 'opus[1m]') {
       const opts = [...fallback];
       if (!opts.some((o) => o.value === 'xhigh')) opts.push({ value: 'xhigh', label: 'Extra High' });
       if (!opts.some((o) => o.value === 'max')) opts.push({ value: 'max', label: 'Max' });

--- a/vibe/claude_model_catalog.py
+++ b/vibe/claude_model_catalog.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 DEFAULT_CLAUDE_MODEL_ALIASES: tuple[str, ...] = ("opus", "sonnet", "haiku")
 FALLBACK_CLAUDE_MODELS: tuple[str, ...] = (
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
@@ -20,12 +21,14 @@ FALLBACK_CLAUDE_MODELS: tuple[str, ...] = (
     "claude-haiku-4",
 )
 
+# Fable is Anthropic's Mythos-class tier, positioned above Opus, so it sorts first.
 _CLAUDE_FAMILY_ORDER = {
-    "opus": 0,
-    "sonnet": 1,
-    "haiku": 2,
+    "fable": 0,
+    "opus": 1,
+    "sonnet": 2,
+    "haiku": 3,
 }
-_CLAUDE_MODEL_PATTERN = re.compile(rb"claude-(?:opus|sonnet|haiku)-\d+(?:-\d+)*(?:-\d{8})?")
+_CLAUDE_MODEL_PATTERN = re.compile(rb"claude-(?:opus|sonnet|haiku|fable)-\d+(?:-\d+)*(?:-\d{8})?")
 
 
 def get_catalog_path(repo_root: Path | None = None) -> Path:

--- a/vibe/data/claude_models.json
+++ b/vibe/data/claude_models.json
@@ -1,5 +1,6 @@
 {
   "models": [
+    "claude-fable-5",
     "claude-opus-4",
     "claude-opus-4-20250514",
     "claude-opus-4-8",


### PR DESCRIPTION
## Capability

Add **Claude Fable 5** (`claude-fable-5`) to the tracked Claude model catalog so it is selectable in the routing / model pickers for the Claude Code backend.

Anthropic released Fable 5 on 2026-06-09 — a Mythos-class model callable through Claude Code — after this repo's catalog snapshot was last regenerated, so it was missing from the list.

## Changes

- `vibe/data/claude_models.json`: add `claude-fable-5` (top of the list).
- `vibe/claude_model_catalog.py`:
  - add `claude-fable-5` to `FALLBACK_CLAUDE_MODELS`.
  - **root-cause / future-proofing:** extend `_CLAUDE_MODEL_PATTERN` to match the `fable` family. The pattern previously matched only `opus|sonnet|haiku`, so `infer_models_from_bundle` (used by `scripts/update_claude_model_catalog.py`) would silently drop any new family — meaning a manual catalog edit would be wiped on the next regeneration. Observed concretely: the current bundle already ships `claude-mythos-preview`, which this layer drops today.
  - add `fable` to `_CLAUDE_FAMILY_ORDER` (above `opus`, matching Anthropic's "Mythos-class sits above Opus" framing) so it sorts first instead of last.

### Deliberate scope decisions

- **Fable only, not Mythos.** Mythos 5 is not generally callable (Project Glasswing only), so auto-surfacing it in the user's model dropdown would be misleading. The detector still won't match `claude-mythos-preview` (no version segment), preserving current behavior.
- **Reasoning effort** falls through to the base `low/medium/high` for fable — no evidence yet of `xhigh`/`max` support, so no change to `_supports_claude_*_reasoning`.

## Evidence layers

- **Unit:** new `tests/test_claude_model_catalog.py` (3 cases) — catalog/fallback membership, fable-sorts-first ordering, and bundle-inference detecting fable while skipping `claude-mythos-preview`. Existing `test_ui_api.py::test_claude_models_merge_catalog_and_settings` and `test_claude_reasoning_options.py` still pass (12 passed total).
- **Manual:** direct runtime check — `load_catalog_models()` returns fable at index 0; `_CLAUDE_MODEL_PATTERN` matches `claude-fable-5`, still matches `claude-opus-4-8`, and does not match `claude-mythos-preview`.
- **Contract / Scenario:** N/A — no scenario catalog covers the static model list.
- `ruff check` clean on changed files.

## Note for users

Invoking `claude-fable-5` also requires a Claude Code build that ships the model. This catalog change only makes it selectable.
