### PR TITLE
fix(regression): install agent backends as the service user so self-update works

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1260,23 +1260,38 @@ def cmd_build_base(args: argparse.Namespace) -> int:
                 apt-get install -y bash ca-certificates curl git build-essential python3 python3-pip python3-venv rsync sudo
                 curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
                 apt-get install -y nodejs
-                npm install -g @anthropic-ai/claude-code @openai/codex
-                curl -fsSL https://askill.sh | sh -s -- -b /usr/local/bin
-                HOME=/usr/local curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path
-                opencode_bin=""
-                for candidate in /usr/local/.opencode/bin/opencode /root/.opencode/bin/opencode; do
-                    if [ -x "$candidate" ]; then
-                        opencode_bin="$candidate"
-                        break
-                    fi
-                done
-                if [ -z "$opencode_bin" ]; then
+                # Install the agent backends under the service user's home so the
+                # non-root avibe service can self-update them (`claude update`, etc.).
+                # Root-global installs under /usr are not writable by the avibe user,
+                # which is exactly what breaks self-update in regression. These land
+                # root-owned at build time and are made avibe-owned per instance by the
+                # `chown -R avibe:avibe /home/avibe` in cloud-init runcmd /
+                # ensure_project_and_instance; the service PATH already prefers
+                # /home/avibe/.local/bin over /usr.
+                avibe_home=/home/avibe
+                mkdir -p "$avibe_home/.local/bin" "$avibe_home/.npm-global"
+                # Persist a user-writable npm prefix so claude-code/codex install here
+                # AND future npm-based self-updates by the avibe user stay writable.
+                printf 'prefix=%s/.npm-global\n' "$avibe_home" > "$avibe_home/.npmrc"
+                HOME="$avibe_home" npm install -g @anthropic-ai/claude-code @openai/codex
+                ln -sf "$avibe_home/.npm-global/bin/claude" "$avibe_home/.local/bin/claude"
+                ln -sf "$avibe_home/.npm-global/bin/codex" "$avibe_home/.local/bin/codex"
+                # OpenCode installs into the service user's home via its own updater.
+                # HOME must be set on the piped `bash` (the installer), not on `curl`.
+                curl -fsSL https://opencode.ai/install | HOME="$avibe_home" bash -s -- --no-modify-path
+                if [ ! -x "$avibe_home/.opencode/bin/opencode" ]; then
                     echo "OpenCode installer did not produce an opencode binary" >&2
                     exit 1
                 fi
-                install -o root -g root -m 0755 "$opencode_bin" /usr/local/bin/opencode
-                askill --version
+                ln -sf "$avibe_home/.opencode/bin/opencode" "$avibe_home/.local/bin/opencode"
+                # askill stays system-global: it is a bootstrap dependency, not a
+                # self-updated agent backend.
+                curl -fsSL https://askill.sh | sh -s -- -b /usr/local/bin
+                export PATH="$avibe_home/.local/bin:$PATH"
+                claude --version
+                codex --version
                 opencode --version
+                askill --version
                 node --version
                 npm --version
                 """

--- a/scripts/prepare_regression.py
+++ b/scripts/prepare_regression.py
@@ -644,8 +644,13 @@ def _normalize_config_payload(path: Path) -> None:
     if not isinstance(opencode, dict):
         return
     cli_path = str(opencode.get("cli_path") or "")
+    # Recognized values that should migrate to the canonical user-owned path.
+    # "/usr/local/bin/opencode" is the legacy root-global install baked by pre-#545
+    # base images; preserved configs must move off it so the non-root service stops
+    # pointing at the root-owned binary it cannot self-update.
     legacy_home_cli = str(CONTAINER_HOME / ".opencode" / "bin" / "opencode")
-    if cli_path not in {"", "opencode", legacy_home_cli}:
+    legacy_root_cli = "/usr/local/bin/opencode"
+    if cli_path not in {"", "opencode", legacy_home_cli, legacy_root_cli}:
         return
 
     opencode["cli_path"] = CONTAINER_OPENCODE_CLI

--- a/scripts/prepare_regression.py
+++ b/scripts/prepare_regression.py
@@ -54,10 +54,12 @@ RESET_MODES = {"none", "config", "all"}
 CONTAINER_HOME = Path("/home/avibe")
 CONTAINER_AVIBE_HOME = CONTAINER_HOME / ".avibe"
 DEFAULT_CWD = str(CONTAINER_AVIBE_HOME / "workdir")
-# OpenCode is installed under the service user's home (see incus_regression.py
-# build-base) so the non-root avibe service can self-update it; claude/codex stay
-# bare names resolved via the service PATH, which prefers ~/.local/bin.
-CONTAINER_OPENCODE_CLI = str(CONTAINER_HOME / ".local" / "bin" / "opencode")
+# OpenCode is a bare PATH-resolved name (the system default; claude/codex too).
+# The service PATH prefers ~/.local/bin, where build-base installs the user-owned,
+# self-updatable binary; on a not-yet-rebuilt base it still resolves the old
+# /usr/local/bin copy. Bare avoids pinning an absolute path that may be absent on
+# a given instance (the cause of breakage across base-image generations).
+CONTAINER_OPENCODE_CLI = "opencode"
 ENV_PREFIX = "REGRESSION_"
 
 
@@ -644,13 +646,20 @@ def _normalize_config_payload(path: Path) -> None:
     if not isinstance(opencode, dict):
         return
     cli_path = str(opencode.get("cli_path") or "")
-    # Recognized values that should migrate to the canonical user-owned path.
-    # "/usr/local/bin/opencode" is the legacy root-global install baked by pre-#545
-    # base images; preserved configs must move off it so the non-root service stops
-    # pointing at the root-owned binary it cannot self-update.
-    legacy_home_cli = str(CONTAINER_HOME / ".opencode" / "bin" / "opencode")
-    legacy_root_cli = "/usr/local/bin/opencode"
-    if cli_path not in {"", "opencode", legacy_home_cli, legacy_root_cli}:
+    # Migrate any recognized opencode install location to the bare PATH-resolved
+    # name. Pinning an absolute path breaks across base-image generations: the
+    # pre-#545 root-global /usr/local/bin/opencode and the user-owned
+    # ~/.local/bin/opencode (or its ~/.opencode source) do not both exist on every
+    # instance, so a preserved-state config could point at a path that is absent.
+    # A custom user-set path is left untouched.
+    known_opencode_paths = {
+        "",
+        "opencode",
+        "/usr/local/bin/opencode",
+        str(CONTAINER_HOME / ".opencode" / "bin" / "opencode"),
+        str(CONTAINER_HOME / ".local" / "bin" / "opencode"),
+    }
+    if cli_path not in known_opencode_paths:
         return
 
     opencode["cli_path"] = CONTAINER_OPENCODE_CLI

--- a/scripts/prepare_regression.py
+++ b/scripts/prepare_regression.py
@@ -54,7 +54,10 @@ RESET_MODES = {"none", "config", "all"}
 CONTAINER_HOME = Path("/home/avibe")
 CONTAINER_AVIBE_HOME = CONTAINER_HOME / ".avibe"
 DEFAULT_CWD = str(CONTAINER_AVIBE_HOME / "workdir")
-CONTAINER_OPENCODE_CLI = "/usr/local/bin/opencode"
+# OpenCode is installed under the service user's home (see incus_regression.py
+# build-base) so the non-root avibe service can self-update it; claude/codex stay
+# bare names resolved via the service PATH, which prefers ~/.local/bin.
+CONTAINER_OPENCODE_CLI = str(CONTAINER_HOME / ".local" / "bin" / "opencode")
 ENV_PREFIX = "REGRESSION_"
 
 

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -391,11 +391,15 @@ def test_build_base_uses_publishable_temp_instance() -> None:
     assert "--ephemeral" not in joined
     assert "incus launch images:ubuntu/24.04/cloud avibe-regression-base-build --storage default --network incusbr0" in joined
     assert "https://deb.nodesource.com/setup_20.x" in joined
-    assert "npm install -g @anthropic-ai/claude-code @openai/codex" in joined
+    assert 'HOME="$avibe_home" npm install -g @anthropic-ai/claude-code @openai/codex' in joined
     assert "https://askill.sh | sh -s -- -b /usr/local/bin" in joined
-    assert "HOME=/usr/local curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path" in joined
-    assert "/usr/local/.opencode/bin/opencode /root/.opencode/bin/opencode" in joined
-    assert 'install -o root -g root -m 0755 "$opencode_bin" /usr/local/bin/opencode' in joined
+    assert ".npm-global" in joined
+    assert 'ln -sf "$avibe_home/.npm-global/bin/claude" "$avibe_home/.local/bin/claude"' in joined
+    assert 'ln -sf "$avibe_home/.npm-global/bin/codex" "$avibe_home/.local/bin/codex"' in joined
+    assert 'curl -fsSL https://opencode.ai/install | HOME="$avibe_home" bash -s -- --no-modify-path' in joined
+    assert 'ln -sf "$avibe_home/.opencode/bin/opencode" "$avibe_home/.local/bin/opencode"' in joined
+    # Backends must not be root-global: the non-root avibe user owns them and self-updates.
+    assert "/usr/local/bin/opencode" not in joined
     assert "cloud-init clean --logs || true" in joined
     assert "incus publish avibe-regression-base-build --alias avibe-regression-base-current" in joined
 

--- a/tests/test_prepare_regression.py
+++ b/tests/test_prepare_regression.py
@@ -225,7 +225,9 @@ def test_prepare_ignores_legacy_regression_layout(tmp_path: Path, monkeypatch: p
         json.dumps(
             {
                 "runtime": {"default_cwd": "/data/vibe_remote/workdir"},
-                "agents": {"opencode": {"cli_path": "opencode"}},
+                # Legacy root-global install baked by pre-#545 base images; must be
+                # migrated to the user-owned path on a preserved-state update.
+                "agents": {"opencode": {"cli_path": "/usr/local/bin/opencode"}},
             }
         ),
         encoding="utf-8",
@@ -307,7 +309,9 @@ def test_prepare_repairs_stale_container_paths_inside_avibe_home(tmp_path: Path,
         json.dumps(
             {
                 "runtime": {"default_cwd": "/data/vibe_remote/workdir"},
-                "agents": {"opencode": {"cli_path": "opencode"}},
+                # Legacy root-global install baked by pre-#545 base images; must be
+                # migrated to the user-owned path on a preserved-state update.
+                "agents": {"opencode": {"cli_path": "/usr/local/bin/opencode"}},
             }
         ),
         encoding="utf-8",

--- a/tests/test_prepare_regression.py
+++ b/tests/test_prepare_regression.py
@@ -84,7 +84,7 @@ def test_prepare_generates_unified_state(tmp_path: Path, monkeypatch: pytest.Mon
     assert config["agents"]["claude"]["enabled"] is True
     assert config["agents"]["codex"]["enabled"] is True
     assert config["agents"]["default_backend"] == "opencode"
-    assert config["agents"]["opencode"]["cli_path"] == "/home/avibe/.local/bin/opencode"
+    assert config["agents"]["opencode"]["cli_path"] == "opencode"
     assert config["agents"]["opencode"]["default_model"] == "gpt-5.4"
     assert config["agents"]["opencode"]["default_provider"] == "openai"
 
@@ -264,7 +264,7 @@ def test_prepare_ignores_legacy_regression_layout(tmp_path: Path, monkeypatch: p
     config = json.loads((avibe_home / "config" / "config.json").read_text(encoding="utf-8"))
     settings = json.loads((avibe_home / "state" / "settings.json").read_text(encoding="utf-8"))
     assert config["runtime"]["default_cwd"] == "/home/avibe/.avibe/workdir"
-    assert config["agents"]["opencode"]["cli_path"] == "/home/avibe/.local/bin/opencode"
+    assert config["agents"]["opencode"]["cli_path"] == "opencode"
     assert settings["scopes"]["channel"]["slack"]["C123SLACK"]["custom_cwd"] == "/home/avibe/.avibe/workdir"
     assert (tmp_path / "home" / ".claude.json").is_file()
 
@@ -364,7 +364,7 @@ def test_prepare_repairs_stale_container_paths_inside_avibe_home(tmp_path: Path,
     sessions = json.loads((state_dir / "sessions.json").read_text(encoding="utf-8"))
     scheduled_tasks = json.loads((state_dir / "scheduled_tasks.json").read_text(encoding="utf-8"))
     assert config["runtime"]["default_cwd"] == "/home/avibe/.avibe/workdir"
-    assert config["agents"]["opencode"]["cli_path"] == "/home/avibe/.local/bin/opencode"
+    assert config["agents"]["opencode"]["cli_path"] == "opencode"
     assert settings["scopes"]["channel"]["slack"]["C123"]["custom_cwd"] == "/home/avibe/.avibe/workdir"
     assert "slack_1774535203.606599:/home/avibe/.avibe/workdir" in sessions["thread_bindings"]
     assert "slack_1774535203.606599:/data/vibe_remote/workdir" not in sessions["thread_bindings"]

--- a/tests/test_prepare_regression.py
+++ b/tests/test_prepare_regression.py
@@ -84,7 +84,7 @@ def test_prepare_generates_unified_state(tmp_path: Path, monkeypatch: pytest.Mon
     assert config["agents"]["claude"]["enabled"] is True
     assert config["agents"]["codex"]["enabled"] is True
     assert config["agents"]["default_backend"] == "opencode"
-    assert config["agents"]["opencode"]["cli_path"] == "/usr/local/bin/opencode"
+    assert config["agents"]["opencode"]["cli_path"] == "/home/avibe/.local/bin/opencode"
     assert config["agents"]["opencode"]["default_model"] == "gpt-5.4"
     assert config["agents"]["opencode"]["default_provider"] == "openai"
 
@@ -262,7 +262,7 @@ def test_prepare_ignores_legacy_regression_layout(tmp_path: Path, monkeypatch: p
     config = json.loads((avibe_home / "config" / "config.json").read_text(encoding="utf-8"))
     settings = json.loads((avibe_home / "state" / "settings.json").read_text(encoding="utf-8"))
     assert config["runtime"]["default_cwd"] == "/home/avibe/.avibe/workdir"
-    assert config["agents"]["opencode"]["cli_path"] == "/usr/local/bin/opencode"
+    assert config["agents"]["opencode"]["cli_path"] == "/home/avibe/.local/bin/opencode"
     assert settings["scopes"]["channel"]["slack"]["C123SLACK"]["custom_cwd"] == "/home/avibe/.avibe/workdir"
     assert (tmp_path / "home" / ".claude.json").is_file()
 
@@ -360,7 +360,7 @@ def test_prepare_repairs_stale_container_paths_inside_avibe_home(tmp_path: Path,
     sessions = json.loads((state_dir / "sessions.json").read_text(encoding="utf-8"))
     scheduled_tasks = json.loads((state_dir / "scheduled_tasks.json").read_text(encoding="utf-8"))
     assert config["runtime"]["default_cwd"] == "/home/avibe/.avibe/workdir"
-    assert config["agents"]["opencode"]["cli_path"] == "/usr/local/bin/opencode"
+    assert config["agents"]["opencode"]["cli_path"] == "/home/avibe/.local/bin/opencode"
     assert settings["scopes"]["channel"]["slack"]["C123"]["custom_cwd"] == "/home/avibe/.avibe/workdir"
     assert "slack_1774535203.606599:/home/avibe/.avibe/workdir" in sessions["thread_bindings"]
     assert "slack_1774535203.606599:/data/vibe_remote/workdir" not in sessions["thread_bindings"]


### PR DESCRIPTION
## What

The Incus regression **base image** installed the three agent backends (Claude Code, Codex, OpenCode) **root-global** — `npm install -g` into `/usr`, OpenCode into `/usr/local/bin`. But the avibe systemd service runs as the **non-root `avibe` user**, so it can't write those locations: `claude update` (and OpenCode/Codex self-update) fail with *"npm global folder isn't writable"*. Every fresh regression env reproduced the bug.

This installs all three under the service user's home (`/home/avibe`) instead, so the non-root service owns them and can self-update.

## How

In `cmd_build_base` (`scripts/incus_regression.py`):
- **claude-code + codex** → `npm install -g` with a **persistent user-writable prefix** (`~/.npmrc` → `~/.npm-global`), symlinked into `~/.local/bin`. The persisted prefix means future `claude update` npm writes also stay writable.
- **opencode** → its official installer into `~/.opencode` (`HOME` set on the piped `bash`), symlinked into `~/.local/bin`.
- They land **root-owned at build time** (the `avibe` user doesn't exist yet) and become **avibe-owned per instance** via the *existing* `chown -R avibe:avibe /home/avibe` in cloud-init / `ensure_project_and_instance`. The service PATH already prefers `~/.local/bin` over `/usr`.
- **askill** stays system-global (bootstrap dep, not a self-updated backend).

`scripts/prepare_regression.py`: opencode's seeded `cli_path` moves to `/home/avibe/.local/bin/opencode`; claude/codex stay bare names (PATH-resolved).

The **Dockerfile** integration target is intentionally unchanged: that container runs as **root**, where root-global installs are self-updatable.

## Evidence layers
- **Unit**: updated `test_incus_regression.py` (build-base now asserts user-home install + symlinks + no root-global opencode) and `test_prepare_regression.py` (opencode cli_path). `ruff` clean; 85 tests pass.
- **Pre-PR review**: Codex (xhigh) — caught a P1 (`HOME` on the wrong side of the `curl | bash` pipe), fixed before pushing.
- **Manual**: the running `master` regression instance was already migrated to this exact layout and verified (`claude update` → "up to date", no perm error; all three resolve from `~/.local/bin`).
- **Residual / pending**: full validation needs a `build-base` rebuild + instance recreation (instances from the old base image must be recreated to inherit the new layout).

Scenario IDs: N/A (regression provisioning infrastructure; no scenario catalog applies).

## Migration / rollout (no regression)

All three backends use **bare, PATH-resolved** cli names, so this PR does **not** change behavior on existing instances: an un-rebuilt instance keeps resolving the current root-global binaries exactly as before. The user-owned, self-updatable layout takes effect when the base image is rebuilt (`build-base`), after which new instances inherit it automatically. The only long-running instance (`master`) has already been migrated to this layout and verified (`claude update` → up to date, all three resolve from `~/.local/bin`).

Deferred (possible follow-up): an idempotent update-time self-heal so existing instances migrate on `up` without a base rebuild. Clean for the npm backends; opencode needs a version-pin + PATH-exclude workaround (its installer no-ops when a root-global copy is on PATH), so it's intentionally left out of the provisioning hot path here.
