### PR TITLE
fix(release): publish legacy shim for 3.0 patches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,10 +188,16 @@ jobs:
       - name: Build package
         run: python -m build
 
-      - name: Build one-time legacy PyPI shim
-        if: ${{ steps.tag.outputs.tag == 'v3.0.0' }}
-        working-directory: packaging/vibe-remote-shim
-        run: python -m build --outdir ../../dist
+      - name: Build 3.0 compatibility legacy PyPI shim
+        shell: bash
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if [[ "$TAG" =~ ^v3\.0\.[0-9]+$ ]]; then
+            python scripts/prepare_legacy_pypi_shim.py --tag "$TAG"
+            python -m build --outdir dist packaging/vibe-remote-shim
+          else
+            echo "Skipping legacy vibe-remote shim for $TAG"
+          fi
 
       - name: Verify package Show Runtime manifest
         run: |

--- a/packaging/vibe-remote-shim/README.md
+++ b/packaging/vibe-remote-shim/README.md
@@ -2,6 +2,7 @@
 
 `vibe-remote` is the legacy PyPI distribution name for Avibe.
 
-This one-time shim release depends on `avibe-os>=3.0.0` and keeps the `vibe`
-console command available for existing users who upgrade from the old package
-name. New releases should be published as `avibe-os`.
+During the 3.0.x compatibility window, this shim is published with the same
+version as `avibe-os` and pins that exact `avibe-os` version. This keeps update
+notifications and installed versions aligned for users still running clients
+that check the legacy `vibe-remote` PyPI feed.

--- a/packaging/vibe-remote-shim/pyproject.toml
+++ b/packaging/vibe-remote-shim/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "cyhhao", email = "cyhhao@users.noreply.github.com" }
 ]
 dependencies = [
-    "avibe-os>=3.0.0",
+    "avibe-os==3.0.0",
 ]
 
 [project.urls]

--- a/scripts/prepare_legacy_pypi_shim.py
+++ b/scripts/prepare_legacy_pypi_shim.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Prepare the legacy ``vibe-remote`` PyPI shim for a release tag."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+SUPPORTED_TAG_RE = re.compile(r"^v(?P<version>3\.0\.\d+)$")
+
+
+def render_pyproject(version: str) -> str:
+    return f"""[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "vibe-remote"
+version = "{version}"
+description = "Legacy PyPI shim for avibe-os"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    {{ name = "cyhhao", email = "cyhhao@users.noreply.github.com" }}
+]
+dependencies = [
+    "avibe-os=={version}",
+]
+
+[project.urls]
+Homepage = "https://github.com/avibe-bot/avibe"
+Repository = "https://github.com/avibe-bot/avibe"
+Documentation = "https://github.com/avibe-bot/avibe#readme"
+Issues = "https://github.com/avibe-bot/avibe/issues"
+
+[project.scripts]
+vibe = "vibe.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["vibe_remote_shim"]
+"""
+
+
+def prepare_shim(tag: str, project_dir: Path) -> str:
+    match = SUPPORTED_TAG_RE.match(tag)
+    if not match:
+        raise ValueError(f"unsupported legacy shim tag: {tag}")
+
+    version = match.group("version")
+    pyproject_path = project_dir / "pyproject.toml"
+    pyproject_path.write_text(render_pyproject(version), encoding="utf-8")
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="Release tag, for example v3.0.1")
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=Path("packaging/vibe-remote-shim"),
+        help="Path to the legacy shim project directory",
+    )
+    args = parser.parse_args()
+
+    try:
+        version = prepare_shim(args.tag, args.project_dir)
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(f"Prepared vibe-remote legacy shim {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pypi_shim.py
+++ b/tests/test_pypi_shim.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import shutil
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SHIM_PROJECT = ROOT / "packaging" / "vibe-remote-shim"
+PREPARE_SCRIPT = ROOT / "scripts" / "prepare_legacy_pypi_shim.py"
 
 
 def test_legacy_pypi_shim_metadata_points_to_avibe_os() -> None:
@@ -14,7 +18,7 @@ def test_legacy_pypi_shim_metadata_points_to_avibe_os() -> None:
 
     assert project["name"] == "vibe-remote"
     assert project["version"] == "3.0.0"
-    assert project["dependencies"] == ["avibe-os>=3.0.0"]
+    assert project["dependencies"] == ["avibe-os==3.0.0"]
     assert project["scripts"] == {"vibe": "vibe.cli:main"}
 
 
@@ -24,3 +28,36 @@ def test_legacy_pypi_shim_contains_no_runtime_packages() -> None:
 
     assert wheel["packages"] == ["vibe_remote_shim"]
     assert not any((SHIM_PROJECT / package).exists() for package in ("vibe", "config", "core", "modules", "storage"))
+
+
+def test_prepare_legacy_shim_pins_matching_3_0_patch_version(tmp_path: Path) -> None:
+    project = tmp_path / "vibe-remote-shim"
+    shutil.copytree(SHIM_PROJECT, project)
+
+    result = subprocess.run(
+        [sys.executable, str(PREPARE_SCRIPT), "--tag", "v3.0.1", "--project-dir", str(project)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    metadata = tomllib.loads((project / "pyproject.toml").read_text(encoding="utf-8"))
+    assert metadata["project"]["version"] == "3.0.1"
+    assert metadata["project"]["dependencies"] == ["avibe-os==3.0.1"]
+
+
+def test_prepare_legacy_shim_rejects_3_1_and_later(tmp_path: Path) -> None:
+    project = tmp_path / "vibe-remote-shim"
+    shutil.copytree(SHIM_PROJECT, project)
+
+    result = subprocess.run(
+        [sys.executable, str(PREPARE_SCRIPT), "--tag", "v3.1.0", "--project-dir", str(project)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    metadata = tomllib.loads((project / "pyproject.toml").read_text(encoding="utf-8"))
+    assert metadata["project"]["version"] == "3.0.0"


### PR DESCRIPTION
## Summary
- publish the legacy `vibe-remote` PyPI shim for every official `v3.0.x` release instead of only `v3.0.0`
- pin each shim release to the matching `avibe-os` version so V2 and V3 users see and install the same patch version
- stop the compatibility shim automatically at `v3.1.0` and later

## Tests
- `uv run pytest tests/test_pypi_shim.py tests/test_upgrade_flow.py -q`
- simulated `v3.0.1` shim build and verified wheel metadata: `vibe-remote 3.0.1` requires `avibe-os==3.0.1`

## Risk
- limited to release packaging; normal runtime code is unchanged
