### PR TITLE
fix(release): isolate legacy PyPI publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -317,7 +317,11 @@ jobs:
       - build
     if: needs.resolve-tag.outputs.publish_legacy == 'true'
     runs-on: ubuntu-latest
-    environment: pypi
+    # PyPI trusted publishers issue project-scoped tokens for the exact OIDC
+    # claim, including the GitHub environment. Keep the legacy shim on a
+    # separate environment so it can be configured for the vibe-remote project
+    # without colliding with the avibe-os publisher.
+    environment: pypi-vibe-remote
     permissions:
       id-token: write  # Required for trusted publishing
     steps:


### PR DESCRIPTION
## Summary
- move the legacy `vibe-remote` PyPI publish job to a separate GitHub environment, `pypi-vibe-remote`
- keep `avibe-os` on the existing `pypi` environment
- document why the two PyPI projects need distinct OIDC claims

## Evidence
- YAML parsed locally with PyYAML
- `git diff --check`
- created the `pypi-vibe-remote` GitHub environment through the GitHub API

## Release recovery
This lets the `vibe-remote` PyPI project configure its own trusted publisher claim instead of receiving a token scoped to `avibe-os`.
