### PR TITLE
Fix agent run callback result payload

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -536,12 +536,13 @@ class ConsolidatedMessageDispatcher:
                 and (context.platform_specific or {}).get("task_trigger_kind") == "agent_run"
             ):
                 terminal_status = "failed" if is_error else "succeeded"
-            self._record_suppressed_run_message(
-                context,
-                text,
-                message_id,
-                terminal_status=terminal_status,
-            )
+            if canonical_type == "result" or (context.platform_specific or {}).get("task_trigger_kind") != "agent_run":
+                self._record_suppressed_run_message(
+                    context,
+                    text,
+                    message_id,
+                    terminal_status=terminal_status,
+                )
             if canonical_type == "result":
                 await self._clear_consolidated_state(context)
                 self._signal_turn_complete(context)

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1370,24 +1370,10 @@ class ScheduledTaskService:
 
     def _build_callback_message(self, run: dict[str, Any]) -> str:
         status = _normalize_requested_run_status(run.get("status")) or str(run.get("status") or "")
-        lines = [
-            "Async Agent Run completed.",
-            "",
-            f"Run ID: {run.get('id') or ''}",
-            f"Status: {status}",
-        ]
-        agent = run.get("agent_name") or run.get("agent_backend")
-        if agent:
-            lines.append(f"Agent: {agent}")
-        target_session = run.get("session_id")
-        if target_session:
-            lines.append(f"Target Session: {target_session}")
         result_text = str(run.get("result_text") or "").strip()
         if not result_text:
             result_text = self._fallback_callback_result(run, status=status)
-        if result_text:
-            lines.extend(["", result_text])
-        return "\n".join(lines).strip()
+        return result_text.strip()
 
     @staticmethod
     def _fallback_callback_result(run: dict[str, Any], *, status: str) -> str:

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -177,7 +177,7 @@ Useful Harness queries include schema discovery, current session lookup, existin
 
 `vibe watch add` creates a managed monitor, usually backed by a small script or command, for any observable condition that must be watched until true: product signals, business events, files, logs, CI/reviews/deploys, service health, data freshness, and similar signals.
 
-Use `vibe agent run --async --callback-session-id {default_session_id}` when one Agent delegates work to another Session and the completed run result should return to this caller Session as a follow-up Agent message.
+Use `vibe agent run --async --callback-session-id {default_session_id}` when one Agent delegates work to another Session and the final result text should return to this caller Session as a follow-up Agent message.
 
 `--post-to` changes the delivery target, not the session scope. Use `--post-to channel` when the session should stay thread-scoped but the follow-up message should be posted to the parent channel. For tasks, use `--message "..."` or `--message-file <path>` as the stored message. For watches, use `--prefix "..."` for the follow-up instruction prepended before waiter stdout.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -208,10 +208,11 @@ vibe agent run --async --session-id sesworker123 --callback-session-id sescaller
 vibe agent run --async --create-session --deliver-key slack::channel::C999 --agent release-reviewer --message 'Post the deployment summary.'
 ```
 
-Use `--callback-session-id` when an async run should send its full terminal
-result back into a caller Session as a follow-up Agent message. The callback is
+Use `--callback-session-id` when an async run should send its final result text
+back into a caller Session as a follow-up Agent message. The callback is
 independent from ordinary delivery: if the target run also posts to its IM scope,
-the caller Session still receives the result.
+the caller Session still receives the result. Process messages such as system
+notes, tool calls, and intermediate assistant updates are not included.
 
 `vibe hook send` is kept only as a deprecated compatibility entrypoint. New
 automation should use `vibe agent run`.

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -189,10 +189,10 @@ vibe agent run --async --session-id sesworker123 --callback-session-id sescaller
 vibe agent run --async --create-session --deliver-key slack::channel::C999 --agent release-reviewer --message 'Post the deployment summary.'
 ```
 
-当异步 run 的完整终态结果需要回到调用方 Session 时，使用
+当异步 run 的最终结果文本需要回到调用方 Session 时，使用
 `--callback-session-id`。这个 callback 与普通投递相互独立：即使目标 run 已经把
-结果发到了自己的 IM scope，调用方 Session 仍然会收到完整结果并触发一次跟进
-Agent 消息。
+结果发到了自己的 IM scope，调用方 Session 仍然会收到结果并触发一次跟进
+Agent 消息。system、tool call、assistant 中间过程消息不会包含在 callback 里。
 
 `vibe hook send` 仅作为 deprecated 兼容入口保留。新的自动化入口应使用
 `vibe agent run`。

--- a/docs/plans/agent-run-callback-session.md
+++ b/docs/plans/agent-run-callback-session.md
@@ -62,33 +62,22 @@ Rules:
 
 ## Message Content
 
-The callback message should contain the completed run result, not a tiny status
-notification.
+The callback message should contain only the completed run's final result text,
+not a status notification or process transcript.
 
 Priority:
 
 1. Use `agent_runs.result_text` when present.
-2. If the run failed and has no `result_text`, construct a full failure result
-   from `error`, `stderr`, and relevant run metadata.
+2. If the run failed and has no `result_text`, construct a failure result from
+   `error`, `stderr`, and stdout when useful for diagnosing a failed run.
 3. If the run was canceled and has no `result_text`, construct a cancellation
    result.
 4. If there is truly no result content, skip sending an empty callback but
    persist the callback state as skipped.
 
-Recommended wrapper format:
-
-```text
-Async Agent Run completed.
-
-Run ID: <run-id>
-Status: <succeeded|failed|canceled>
-Agent: <agent-name>
-Target Session: <target-session-id>
-
-<full result text or failure details>
-```
-
-The wrapper is intentionally small. The result text remains the main payload.
+Do not include wrapper metadata such as run id, status, agent name, target
+session, system messages, tool calls, or intermediate assistant updates in the
+callback body.
 
 ## CLI/API Shape
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -539,13 +539,6 @@ class ClaudeAgent(BaseAgent):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
                             return
-                        if formatted_message and formatted_message.strip():
-                            await self.controller.emit_agent_message(
-                                context,
-                                "system",
-                                formatted_message,
-                                parse_mode="markdown",
-                            )
                         continue
 
                     if message_type == "result":

--- a/modules/agents/codex/event_handler.py
+++ b/modules/agents/codex/event_handler.py
@@ -98,17 +98,7 @@ class CodexEventHandler:
             self._agent._session_mgr.set_thread_id(request.base_session_id, thread_id)
             self._agent.bind_agent_session_id(request, thread_id)
 
-        system_text = self._agent._get_formatter(request.context).format_system_message(
-            request.working_path,
-            "init",
-            thread_id,
-        )
-        await self._agent.controller.emit_agent_message(
-            request.context,
-            "system",
-            system_text,
-            parse_mode="markdown",
-        )
+        return
 
     async def _on_turn_started(self, params: dict[str, Any], request: AgentRequest) -> None:
         turn_obj = params.get("turn", {})
@@ -485,14 +475,7 @@ class CodexEventHandler:
         pass
 
     async def _on_context_compacted(self, params: dict[str, Any], request: AgentRequest) -> None:
-        # Routine status, not a turn outcome — emit as ``system`` (process log) so
-        # it doesn't drive the per-session inbox preview/eligibility as if it were
-        # a reply or terminal failure (Codex P2). Terminal failures stay ``notify``.
-        await self._agent.controller.emit_agent_message(
-            request.context,
-            "system",
-            "🗜️ Codex context was compacted to free up token space.",
-        )
+        return
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -225,16 +225,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             request.session_key,
         )
 
-        if self._session_manager.mark_initialized(session_id):
-            system_text = self._get_formatter(request.context).format_system_message(
-                request.working_path, "init", session_id
-            )
-            await self.controller.emit_agent_message(
-                request.context,
-                "system",
-                system_text,
-                parse_mode="markdown",
-            )
+        self._session_manager.mark_initialized(session_id)
 
         try:
             override_agent, override_model, override_reasoning = self.controller.get_opencode_overrides(request.context)

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -790,7 +790,7 @@ Delivery controls (apply to `vibe agent run --create-session`, `vibe task add`, 
 - `--message` and `--message-file` are the current user-message flags for task, watch, and agent-run commands
 - `vibe task add` stores the message template and creates Agent Runs when the time trigger fires
 - `vibe agent run --async` queues one Agent Run immediately without storing a task definition
-- `--callback-session-id` on an async Agent Run sends the completed run result back into the caller Session as a follow-up Agent message; it is independent from `--post-to` and `--deliver-key`
+- `--callback-session-id` on an async Agent Run sends the final result text back into the caller Session as a follow-up Agent message; it is independent from `--post-to` and `--deliver-key`
 - `vibe watch add` uses `--message` as the instruction template for the Agent Run created after the waiter reaches a reportable state
 
 Legacy compatibility:

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -819,6 +819,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(getattr(runtime_client, "_vibe_native_session_id"), "session-sdk")
         self.assertEqual(agent._native_session_ids[composite_key], "session-sdk")
+        controller.emit_agent_message.assert_not_awaited()
 
     async def test_init_message_binds_native_session_to_existing_agent_session(self):
         controller = _StubController()

--- a/tests/test_codex_event_handler.py
+++ b/tests/test_codex_event_handler.py
@@ -122,12 +122,7 @@ class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
         agent._session_mgr.set_thread_id.assert_called_once_with("session-1", "thread-1")
         agent.bind_agent_session_id.assert_called_once_with(request, "thread-1")
         self.assertEqual(request.context.platform_specific["agent_session_id"], "sesk8m4q2p7x")
-        agent.controller.emit_agent_message.assert_awaited_once_with(
-            request.context,
-            "system",
-            "system message",
-            parse_mode="markdown",
-        )
+        agent.controller.emit_agent_message.assert_not_awaited()
 
     async def test_retrying_error_is_suppressed(self):
         agent = _StubAgent()

--- a/tests/test_message_dispatcher_scheduled.py
+++ b/tests/test_message_dispatcher_scheduled.py
@@ -209,6 +209,47 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_suppressed_agent_run_ignores_non_result_process_messages(self):
+        controller = _StubController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "suppress_delivery": True,
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-agent",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def record_run_message(self, run_id, *, text, message_id=None, terminal_status=None):
+                calls.append(("record", run_id, text, message_id, terminal_status))
+
+            def close(self):
+                calls.append(("close",))
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            system_id = await dispatcher.emit_agent_message(context, "system", "system prompt")
+            tool_id = await dispatcher.emit_agent_message(context, "tool_call", "shell command")
+            assistant_id = await dispatcher.emit_agent_message(context, "assistant", "working note")
+            result_id = await dispatcher.emit_agent_message(context, "result", "final result")
+
+        self.assertEqual(system_id, "suppressed:run-agent")
+        self.assertEqual(tool_id, "suppressed:run-agent")
+        self.assertEqual(assistant_id, "suppressed:run-agent")
+        self.assertEqual(result_id, "suppressed:run-agent")
+        self.assertEqual(controller.im_client.sent, [])
+        self.assertEqual(
+            calls,
+            [
+                ("record", "run-agent", "final result", "suppressed:run-agent", "succeeded"),
+                ("close",),
+            ],
+        )
+
     async def test_suppressed_notify_records_private_run_output(self):
         controller = _StubController()
         dispatcher = ConsolidatedMessageDispatcher(controller)

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -336,7 +336,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("`vibe watch add` creates a managed monitor", prompt)
         self.assertIn("product signals, business events, files, logs, CI/reviews/deploys", prompt)
         self.assertIn("vibe agent run --async --callback-session-id sesk8m4q2p7x", prompt)
-        self.assertIn("completed run result should return to this caller Session", prompt)
+        self.assertIn("final result text should return to this caller Session", prompt)
         self.assertIn(
             "`--post-to` changes the delivery target, not the session scope. Use `--post-to channel` when the session should stay thread-scoped but the follow-up message should be posted to the parent channel.",
             prompt,

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1346,7 +1346,7 @@ def test_agent_run_preserves_failed_terminal_status(tmp_path: Path, monkeypatch)
     assert completed["result_text"] == "terminal failed"
 
 
-def test_agent_run_callback_enqueues_full_result_to_caller_session(tmp_path: Path, monkeypatch) -> None:
+def test_agent_run_callback_enqueues_only_result_to_caller_session(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     caller_session_id = _make_avibe_session(monkeypatch, tmp_path)
     request_store = TaskExecutionStore()
@@ -1393,11 +1393,7 @@ def test_agent_run_callback_enqueues_full_result_to_caller_session(tmp_path: Pat
     assert callback_run["session_id"] == caller_session_id
     assert callback_run["source_kind"] == "callback"
     assert callback_run["parent_run_id"] == request.id
-    assert "Async Agent Run completed." in callback_run["message"]
-    assert f"Run ID: {request.id}" in callback_run["message"]
-    assert "Status: succeeded" in callback_run["message"]
-    assert "Target Session: target-session" in callback_run["message"]
-    assert "complete delegated result" in callback_run["message"]
+    assert callback_run["message"] == "complete delegated result"
 
 
 def test_agent_run_callback_builds_failure_message_without_result_text(tmp_path: Path, monkeypatch) -> None:
@@ -1427,8 +1423,7 @@ def test_agent_run_callback_builds_failure_message_without_result_text(tmp_path:
     assert original["callback_status"] == "sent"
     callback_run = request_store.get_run(original["callback_run_id"])
     assert callback_run is not None
-    assert "Status: failed" in callback_run["message"]
-    assert "Error: agent crashed" in callback_run["message"]
+    assert callback_run["message"] == "Error: agent crashed"
 
 
 def test_agent_run_synchronous_dispatch_error_marks_failed(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## What

Fix async Agent Run callback payloads so caller Sessions receive only the final result text, and stop backend adapters from emitting routine `system` process messages.

## Why

The callback is meant to deliver the delegated run's result, not replay run metadata or process messages. Previously, suppressed async Agent Runs could persist system/tool-call/assistant process messages into `agent_runs.result_text`, callback messages wrapped the result with run id/status metadata, and backend adapters still generated routine `system` messages such as init/status banners.

## Changes

- Only persist suppressed Agent Run output into `result_text` for terminal `result` messages.
- Build callback follow-up messages from `result_text` only, with failure/cancel fallback text only when no result exists.
- Stop OpenCode, Codex, and Claude adapters from emitting routine `system` process messages.
- Preserve Claude/Codex native session binding from init events while dropping their display message.
- Clarify CLI, prompt injection, and skill docs that callback sends final result text and excludes process messages.
- Add regression coverage for process-message exclusion, result-only callback payloads, and no system init emit.

## Validation

- `npm ci && npm run build` in `ui/` to satisfy packaged editable build requirements for tests.
- `uv run pytest tests/test_message_dispatcher_scheduled.py tests/test_scheduled_tasks.py tests/test_reply_enhancer_platform.py tests/test_codex_event_handler.py tests/test_claude_agent_sessions.py tests/test_multi_platform_runtime.py -q`
- `uv run ruff check core/message_dispatcher.py core/scheduled_tasks.py core/system_prompt_injection.py modules/agents/opencode/agent.py modules/agents/codex/event_handler.py modules/agents/claude_agent.py tests/test_message_dispatcher_scheduled.py tests/test_scheduled_tasks.py tests/test_reply_enhancer_platform.py tests/test_codex_event_handler.py tests/test_claude_agent_sessions.py`

## Scenario evidence

- Unit: updated targeted dispatcher/scheduled task/prompt/backend tests.
- Contract: callback message body now asserted to equal final result text.
- Scenario: async Agent Run callback from delegated target Session to caller Session.
- Residual manual checks: no live IM callback smoke in this turn.
