### PR TITLE
feat(deps): auto-update askill managed dependency

### DIFF
--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -5,6 +5,7 @@ This module provides:
 1. Periodic checking for new versions on PyPI
 2. Slack notifications to workspace owner when updates are available
 3. Automatic update installation when the system is idle
+4. Managed local dependency reconciliation, such as askill
 """
 
 import asyncio
@@ -37,6 +38,7 @@ UPDATE_BUTTON_ACTION_ID = "vibe_update_now"
 
 # Minimum check interval to prevent tight loops (in minutes)
 MIN_CHECK_INTERVAL_MINUTES = 1
+MANAGED_DEPENDENCY_CHECK_INTERVAL_MINUTES = 60
 
 # Grace period after sending an update notification before auto-update can proceed (in minutes).
 # This gives admins time to read the notification and decide whether to update manually.
@@ -205,9 +207,6 @@ class UpdateChecker:
         """Start the periodic update checker."""
         if self._running:
             return
-        if self.config.check_interval_minutes <= 0:
-            logger.info("Update checker disabled (check_interval_minutes=0)")
-            return
 
         # Initialize last_activity_at if not set (for idle detection baseline)
         if not self.state.last_activity_at:
@@ -277,9 +276,16 @@ class UpdateChecker:
 
             # Reload config and get interval (with minimum bound to prevent tight loop)
             self._reload_config()
-            interval = max(self.config.check_interval_minutes, MIN_CHECK_INTERVAL_MINUTES)
+            configured_interval = (
+                self.config.check_interval_minutes
+                if self.config.check_interval_minutes > 0
+                else MANAGED_DEPENDENCY_CHECK_INTERVAL_MINUTES
+            )
+            interval = max(configured_interval, MIN_CHECK_INTERVAL_MINUTES)
 
-            # If interval is set to 0 (disabled), keep loop alive so hot-reload can re-enable
+            # Even when product self-update checks are disabled, the loop stays
+            # alive for managed local dependencies such as askill. Clamp to the
+            # minimum so hot-reload can re-enable product checks too.
             await asyncio.sleep(interval * 60)
 
     async def _do_check(self) -> None:
@@ -287,6 +293,7 @@ class UpdateChecker:
         try:
             # Reload config for hot-reload support (e.g., user toggled auto_update in UI)
             self._reload_config()
+            await self._reconcile_managed_dependencies()
 
             # Skip if disabled
             if self.config.check_interval_minutes <= 0:
@@ -350,6 +357,21 @@ class UpdateChecker:
                     await self._perform_update(latest, **update_kwargs)
         except Exception as e:
             logger.error(f"Update check failed: {e}", exc_info=True)
+
+    async def _reconcile_managed_dependencies(self) -> None:
+        """Keep required local dependencies current on the shared update cadence."""
+        try:
+            from vibe import api
+
+            result = await asyncio.to_thread(api.reconcile_askill_auto_update)
+            if not result.get("ok"):
+                logger.warning("askill managed dependency reconcile failed: %s", result.get("message") or result)
+            elif result.get("skipped"):
+                logger.debug("askill managed dependency reconcile skipped: %s", result.get("reason"))
+            else:
+                logger.info("askill managed dependency reconcile completed: %s", result.get("action") or "updated")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("askill managed dependency reconcile raised: %s", exc, exc_info=True)
 
     async def _get_version_info_async(self) -> Dict[str, Any]:
         """Get version info asynchronously."""

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -79,6 +79,19 @@ def test_ensure_askill_force_reinstalls_even_when_present(monkeypatch):
     assert flag["installed"] is True
 
 
+def test_ensure_askill_skips_when_install_already_running():
+    assert api._ASKILL_INSTALL_LOCK.acquire(blocking=False) is True
+    try:
+        out = api.ensure_askill_installed(force=True)
+    finally:
+        api._ASKILL_INSTALL_LOCK.release()
+
+    assert out["ok"] is False
+    assert out["skipped"] is True
+    assert out["reason"] == "askill_install_already_running"
+    assert "already running" in out["message"]
+
+
 def test_askill_status_missing(monkeypatch):
     monkeypatch.setattr(api, "resolve_cli_path", lambda b: None)
     s = api.askill_status()
@@ -100,9 +113,122 @@ def test_askill_status_present_parses_version(monkeypatch):
     assert s["installed"] and s["version"] == "0.1.13" and s["status"] == "ready"
 
 
+def test_askill_update_status_compares_latest(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "askill_status",
+        lambda: {"id": "askill", "installed": True, "version": "0.1.13", "status": "ready", "path": "/x"},
+    )
+    monkeypatch.setattr(api, "_cached_latest_askill", lambda: "0.1.14")
+
+    s = api.askill_update_status()
+
+    assert s["latest_version"] == "0.1.14"
+    assert s["has_update"] is True
+    assert s["auto_update"] is True
+
+
+def test_reconcile_askill_auto_update_installs_when_missing(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {"id": "askill", "installed": False, "version": None, "status": "missing", "latest_version": "0.1.14"},
+    )
+    calls = []
+
+    def fake_ensure(force=False):
+        calls.append(force)
+        return {"ok": True, "installed": True, "changed": True, "path": "/x/askill"}
+
+    monkeypatch.setattr(api, "ensure_askill_installed", fake_ensure)
+
+    out = api.reconcile_askill_auto_update()
+
+    assert calls == [False]
+    assert out["ok"] is True and out["action"] == "install"
+
+
+def test_reconcile_askill_auto_update_refreshes_when_newer(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {
+            "id": "askill",
+            "installed": True,
+            "version": "0.1.13",
+            "status": "ready",
+            "latest_version": "0.1.14",
+            "has_update": True,
+        },
+    )
+    calls = []
+
+    def fake_ensure(force=False):
+        calls.append(force)
+        return {"ok": True, "installed": True, "changed": True, "path": "/x/askill"}
+
+    monkeypatch.setattr(api, "ensure_askill_installed", fake_ensure)
+
+    out = api.reconcile_askill_auto_update()
+
+    assert calls == [True]
+    assert out["ok"] is True
+    assert out["action"] == "update"
+    assert out["from_version"] == "0.1.13"
+    assert out["latest_version"] == "0.1.14"
+
+
+def test_reconcile_askill_auto_update_refreshes_when_current_version_unknown(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {
+            "id": "askill",
+            "installed": True,
+            "version": None,
+            "status": "unknown",
+            "latest_version": "0.1.14",
+            "has_update": False,
+        },
+    )
+    calls = []
+
+    def fake_ensure(force=False):
+        calls.append(force)
+        return {"ok": True, "installed": True, "changed": True, "path": "/x/askill"}
+
+    monkeypatch.setattr(api, "ensure_askill_installed", fake_ensure)
+
+    out = api.reconcile_askill_auto_update()
+
+    assert calls == [True]
+    assert out["ok"] is True
+    assert out["action"] == "refresh_unknown_version"
+    assert out["latest_version"] == "0.1.14"
+
+
+def test_reconcile_askill_auto_update_skips_when_disabled(monkeypatch):
+    monkeypatch.setenv("VIBE_ASKILL_AUTO_UPDATE", "0")
+    monkeypatch.setattr(api, "askill_update_status", lambda **_: pytest.fail("should not probe"))
+
+    out = api.reconcile_askill_auto_update()
+
+    assert out == {"ok": True, "skipped": True, "reason": "askill_auto_update_disabled"}
+
+
 def test_dependencies_status_shape(monkeypatch):
     monkeypatch.setattr(
-        api, "askill_status", lambda: {"id": "askill", "installed": True, "version": "0.1.13", "status": "ready", "path": "/x"}
+        api,
+        "askill_update_status",
+        lambda **_: {
+            "id": "askill",
+            "installed": True,
+            "version": "0.1.13",
+            "latest_version": None,
+            "has_update": False,
+            "status": "ready",
+            "path": "/x",
+        },
     )
     import core.show_runtime as srt_mod
 
@@ -116,6 +242,7 @@ def test_dependencies_status_shape(monkeypatch):
     by = {d["id"]: d for d in out["deps"]}
     assert list(by) == ["askill", "show-runtime", "node"]
     assert by["askill"]["status"] == "ready" and by["askill"]["version"] == "0.1.13" and by["askill"]["required"]
+    assert by["askill"]["latest_version"] is None and by["askill"]["has_update"] is False
     assert by["show-runtime"]["installed"] and by["show-runtime"]["version"] == "1.4.0"
     assert by["node"]["installed"] and by["node"]["version"] == "20.11"
 
@@ -123,7 +250,9 @@ def test_dependencies_status_shape(monkeypatch):
 def test_dependencies_status_node_unsupported_not_ready(monkeypatch):
     # Node present but below the runtime minimum (node_supported False) -> not ready.
     monkeypatch.setattr(
-        api, "askill_status", lambda: {"id": "askill", "installed": True, "version": "0.1.13", "status": "ready", "path": "/x"}
+        api,
+        "askill_update_status",
+        lambda **_: {"id": "askill", "installed": True, "version": "0.1.13", "status": "ready", "path": "/x"},
     )
     import core.show_runtime as srt_mod
 

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -7,6 +7,8 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from config.v2_settings import SettingsStore, UserSettings
@@ -240,6 +242,53 @@ def test_silent_release_metadata_skips_notifications_but_keeps_auto_update(monke
     assert performed == [("1.0.1", {"suppress_post_update_notification": True})]
 
 
+def test_update_check_reconciles_askill_even_when_product_auto_update_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    checker = UpdateChecker(
+        _StubController(SettingsStore.get_instance()),
+        UpdateConfig(check_interval_minutes=1, notify_admins=False, auto_update=False),
+    )
+    reconciled = []
+    monkeypatch.setattr(
+        "vibe.api.reconcile_askill_auto_update",
+        lambda: reconciled.append(True) or {"ok": True, "action": "update"},
+    )
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_pypi_version_sync",
+        lambda: {"current": "1.0.0", "latest": "1.0.1", "has_update": True, "error": None},
+    )
+    performed = []
+
+    async def fake_perform_update(target_version, **kwargs):
+        performed.append((target_version, kwargs))
+        return {"ok": True, "restarting": False, "message": "ok"}
+
+    monkeypatch.setattr(checker, "_perform_update", fake_perform_update)
+
+    asyncio.run(checker._do_check())
+
+    assert reconciled == [True]
+    assert performed == []
+
+
+def test_update_check_reconciles_askill_even_when_product_checks_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig(check_interval_minutes=0))
+    reconciled = []
+    monkeypatch.setattr(
+        "vibe.api.reconcile_askill_auto_update",
+        lambda: reconciled.append(True) or {"ok": True, "skipped": True, "reason": "up_to_date"},
+    )
+    monkeypatch.setattr(update_checker, "_fetch_pypi_version_sync", lambda: pytest.fail("product check should be skipped"))
+
+    asyncio.run(checker._do_check())
+
+    assert reconciled == [True]
+
+
 def test_suppressed_post_update_notification_does_not_write_marker(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
@@ -301,6 +350,21 @@ def test_stop_returns_cancellable_task(monkeypatch, tmp_path):
         assert task is not None
         await checker.wait_stopped(task)
         assert task.done()
+
+    asyncio.run(run_test())
+
+
+def test_start_keeps_running_for_managed_dependencies_when_product_checks_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+
+    async def run_test():
+        checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig(check_interval_minutes=0))
+        checker.start()
+        await asyncio.sleep(0)
+        task = checker.stop()
+        assert task is not None
+        await checker.wait_stopped(task)
 
     asyncio.run(run_test())
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2877,6 +2877,9 @@ def _run_install_command(
 # =============================================================================
 
 
+_ASKILL_INSTALL_LOCK = threading.Lock()
+
+
 def _truncate_install_output(output: str, limit: int = 8192) -> str:
     return output if len(output) <= limit else "...(truncated)\n" + output[-limit:]
 
@@ -2914,21 +2917,31 @@ def ensure_askill_installed(force: bool = False) -> dict:
     inherit, and we must not claim "installed" while ``/api/skills`` still
     answers ``askill_not_found``.
     """
-    existing = resolve_cli_path("askill")
-    if existing and not force:
-        return {"ok": True, "installed": True, "changed": False, "path": existing}
-    result = install_askill()
-    resolved = resolve_cli_path("askill")
-    installed = bool(resolved)
-    result["installed"] = installed
-    result["changed"] = installed and bool(result.get("ok"))
-    result["path"] = resolved
-    if result.get("ok") and not installed:
-        result["ok"] = False
-        result["message"] = (
-            result.get("message") or "askill installed but was not found on PATH; restart the service or check PATH."
-        )
-    return result
+    if not _ASKILL_INSTALL_LOCK.acquire(blocking=False):
+        return {
+            "ok": False,
+            "skipped": True,
+            "reason": "askill_install_already_running",
+            "message": "askill install or update is already running; try again shortly.",
+        }
+    try:
+        existing = resolve_cli_path("askill")
+        if existing and not force:
+            return {"ok": True, "installed": True, "changed": False, "path": existing}
+        result = install_askill()
+        resolved = resolve_cli_path("askill")
+        installed = bool(resolved)
+        result["installed"] = installed
+        result["changed"] = installed and bool(result.get("ok"))
+        result["path"] = resolved
+        if result.get("ok") and not installed:
+            result["ok"] = False
+            result["message"] = (
+                result.get("message") or "askill installed but was not found on PATH; restart the service or check PATH."
+            )
+        return result
+    finally:
+        _ASKILL_INSTALL_LOCK.release()
 
 
 def askill_status() -> dict:
@@ -2954,6 +2967,94 @@ def askill_status() -> dict:
     return {"id": "askill", "installed": True, "version": version, "status": "ready", "path": path}
 
 
+def _askill_auto_update_disabled() -> bool:
+    """Return whether the managed askill reconcile loop is explicitly disabled."""
+    skip_value = os.environ.get(_ASKILL_SKIP_ENV, "").strip().lower()
+    if skip_value in _TRUTHY_ENV_VALUES:
+        return True
+    value = os.environ.get(_ASKILL_AUTO_UPDATE_ENV, "").strip().lower()
+    return value in _FALSY_ENV_VALUES
+
+
+def _fetch_latest_askill_version() -> str | None:
+    return _fetch_github_latest_release_version(_ASKILL_RELEASE_REPOSITORY, user_agent="avibe/askill-dependency")
+
+
+def _cached_latest_askill() -> str | None:
+    # Share the backend lifecycle cache so every local tool latest probe obeys the
+    # same one-hour success TTL and short failure TTL.
+    key = "askill"
+    with _BACKEND_CACHE_LOCK:
+        cached = _BACKEND_LATEST_CACHE.get(key)
+    if cached:
+        ttl = _BACKEND_LATEST_TTL_SECONDS if cached[1] else _BACKEND_LATEST_FAILURE_TTL_SECONDS
+        if time.time() - cached[0] < ttl:
+            return cached[1]
+    latest = _fetch_latest_askill_version()
+    with _BACKEND_CACHE_LOCK:
+        _BACKEND_LATEST_CACHE[key] = (time.time(), latest)
+    return latest
+
+
+def askill_update_status(*, include_latest: bool = True) -> dict:
+    """Return local askill version plus best-effort upstream update state."""
+    current = askill_status()
+    latest = _cached_latest_askill() if include_latest else None
+    current_version = current.get("version") if current.get("installed") else None
+    has_update = bool(include_latest and current.get("installed") and _compare_versions(current_version, latest))
+    out = {
+        **current,
+        "latest_version": latest,
+        "has_update": has_update,
+        "auto_update": not _askill_auto_update_disabled(),
+    }
+    if current.get("installed") and current_version is None:
+        out["status"] = "unknown"
+    return out
+
+
+def reconcile_askill_auto_update() -> dict:
+    """Install or refresh askill as a required managed dependency.
+
+    This runs from the shared update checker cadence but is intentionally
+    independent of ``update.auto_update``. Avibe owns askill as a local runtime
+    dependency for Skills; disabling product self-upgrades must not strand that
+    dependency on an incompatible CLI contract. Operators can still disable this
+    reconcile loop with ``VIBE_ASKILL_AUTO_UPDATE=0`` or ``VIBE_INSTALL_SKIP_ASKILL``.
+    """
+    if _askill_auto_update_disabled():
+        return {"ok": True, "skipped": True, "reason": "askill_auto_update_disabled"}
+
+    status = askill_update_status()
+    if not status.get("installed"):
+        result = ensure_askill_installed(force=False)
+        result["action"] = "install"
+        return result
+
+    latest = status.get("latest_version")
+    if latest is None:
+        return {"ok": True, "skipped": True, "reason": "latest_unavailable", "status": status}
+
+    if status.get("version") is None:
+        logger.info("askill local version is unknown; refreshing managed dependency")
+        result = ensure_askill_installed(force=True)
+        result["action"] = "refresh_unknown_version"
+        result["latest_version"] = latest
+        return result
+
+    if not status.get("has_update"):
+        return {"ok": True, "skipped": True, "reason": "up_to_date", "status": status}
+
+    logger.info("askill update available: %s -> %s", status.get("version"), latest)
+    result = ensure_askill_installed(force=True)
+    result["action"] = "update"
+    result["from_version"] = status.get("version")
+    result["latest_version"] = latest
+    with _BACKEND_CACHE_LOCK:
+        _BACKEND_LATEST_CACHE.pop("askill", None)
+    return result
+
+
 # =============================================================================
 # Dependencies aggregate + manual install jobs (askill / show runtime)
 # =============================================================================
@@ -2974,7 +3075,7 @@ def dependencies_status() -> dict:
     """
     deps: list[dict] = []
 
-    a = askill_status()
+    a = askill_update_status(include_latest=False)
     deps.append(
         {
             "id": "askill",
@@ -2982,6 +3083,8 @@ def dependencies_status() -> dict:
             "required": True,
             "installed": a["installed"],
             "version": a.get("version"),
+            "latest_version": a.get("latest_version"),
+            "has_update": a.get("has_update", False),
             "status": a["status"],
         }
     )
@@ -3234,6 +3337,11 @@ _BACKEND_LATEST_TTL_SECONDS = 3600.0
 # transient outage doesn't pin "—" for the full hour.
 _BACKEND_LATEST_FAILURE_TTL_SECONDS = 120.0
 _BACKEND_RUNTIME_USER_AGENT = "avibe/backend-runtime"
+_ASKILL_RELEASE_REPOSITORY = "avibe-bot/askill"
+_ASKILL_AUTO_UPDATE_ENV = "VIBE_ASKILL_AUTO_UPDATE"
+_ASKILL_SKIP_ENV = "VIBE_INSTALL_SKIP_ASKILL"
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+_FALSY_ENV_VALUES = {"0", "false", "no", "off"}
 
 def _parse_semver(text: str) -> str | None:
     """Extract the first dotted-numeric version token from *text*.
@@ -3266,17 +3374,7 @@ def _probe_cli_version(cli_path: str | None) -> str | None:
     return _parse_semver(output.strip())
 
 
-def _fetch_latest_version(name: str) -> str | None:
-    """Best-effort upstream lookup. Returns ``None`` on any failure."""
-    probe = latest_probe_for_backend(name)
-    if not probe:
-        return None
-    kind, ident = probe
-    url = (
-        f"https://api.github.com/repos/{ident}/releases/latest"
-        if kind == "github"
-        else f"https://registry.npmjs.org/{ident}/latest"
-    )
+def _http_opener_for_best_effort_probe():
     try:
         from vibe.proxy import resolve_proxy
 
@@ -3284,24 +3382,51 @@ def _fetch_latest_version(name: str) -> str | None:
     except Exception:
         proxy = None
 
-    req = urllib.request.Request(url, headers={"User-Agent": _BACKEND_RUNTIME_USER_AGENT})
     if proxy and not proxy.lower().startswith("socks"):
-        opener = urllib.request.build_opener(
-            urllib.request.ProxyHandler({"http": proxy, "https": proxy})
-        )
-    else:
-        # SOCKS proxies need aiohttp_socks; latest-version probe is best-effort
-        # so we silently fall back to direct urlopen rather than complicate the
-        # cache path. Direct-connection failures are cached for a short TTL.
-        opener = urllib.request.build_opener()
+        return urllib.request.build_opener(urllib.request.ProxyHandler({"http": proxy, "https": proxy}))
+    # SOCKS proxies need aiohttp_socks; latest-version probes are best-effort
+    # so we silently fall back to direct urlopen rather than complicate the
+    # cache path. Direct-connection failures are cached for a short TTL.
+    return urllib.request.build_opener()
+
+
+def _fetch_github_latest_release_version(repo: str, *, user_agent: str = _BACKEND_RUNTIME_USER_AGENT) -> str | None:
+    """Best-effort GitHub release lookup. Returns a normalized version or None."""
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/releases/latest",
+        headers={"Accept": "application/vnd.github+json", "User-Agent": user_agent},
+    )
+    try:
+        with _http_opener_for_best_effort_probe().open(req, timeout=5) as resp:  # noqa: S310 - trusted registry
+            payload = json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.debug("Latest GitHub release probe failed for %s: %s", repo, exc)
+        return None
+    raw = payload.get("tag_name")
+    if not isinstance(raw, str):
+        return None
+    return raw.lstrip("v").strip() or None
+
+
+def _fetch_latest_version(name: str) -> str | None:
+    """Best-effort upstream lookup. Returns ``None`` on any failure."""
+    probe = latest_probe_for_backend(name)
+    if not probe:
+        return None
+    kind, ident = probe
+    if kind == "github":
+        return _fetch_github_latest_release_version(ident)
+
+    url = f"https://registry.npmjs.org/{ident}/latest"
+    req = urllib.request.Request(url, headers={"User-Agent": _BACKEND_RUNTIME_USER_AGENT})
 
     try:
-        with opener.open(req, timeout=5) as resp:  # noqa: S310 - trusted registries
+        with _http_opener_for_best_effort_probe().open(req, timeout=5) as resp:  # noqa: S310 - trusted registries
             payload = json.loads(resp.read().decode("utf-8"))
     except Exception as exc:  # pragma: no cover - network failure path
         logger.debug("Latest version probe failed for %s: %s", name, exc)
         return None
-    raw = payload.get("tag_name") if kind == "github" else payload.get("version")
+    raw = payload.get("version")
     if not isinstance(raw, str):
         return None
     return raw.lstrip("v").strip() or None


### PR DESCRIPTION
## Summary
- add askill to the shared update-check cadence as a required managed dependency
- detect the latest askill GitHub release and refresh the local CLI when missing, stale, or version-unknown
- keep askill reconcile independent of the product `update.auto_update` toggle, with `VIBE_ASKILL_AUTO_UPDATE=0` / `VIBE_INSTALL_SKIP_ASKILL` as operational escape hatches
- serialize askill installs so startup reconcile, manual repair, and periodic reconcile do not run competing installers

## Evidence
- Unit: `uv run pytest tests/test_local_deps.py tests/test_update_checker_platforms.py`
- Contract: askill dependency status keeps the existing `/api/dependencies` shape and adds optional update fields without blocking on latest probes
- Scenario: no catalog scenario affected
- Residual manual checks: `npm run build` in `ui/` to regenerate `ui/dist` for packaging-aware local validation; `uv run ruff check vibe/api.py core/update_checker.py tests/test_local_deps.py tests/test_update_checker_platforms.py`

## Notes
- Avibe self-updates still obey idle and `update.auto_update`; askill reconcile is treated as dependency maintenance and does not require idle time or restart Avibe.
