### PR TITLE
fix(workbench): project default Agent pre-selects instead of hard-binding new sessions

### DIFF
--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -317,6 +317,16 @@ class SessionTurnManager:
         task = asyncio.create_task(_runner(), name="internal-dispatch-async")
         if isinstance(session_id, str) and session_id:
             self.in_flight[session_id] = Turn(task=task, context=context)
+            # Make the DB row authoritative at ACCEPTANCE, not at dispatch start:
+            # ``update_session``'s backend lock re-checks ``agent_status`` inside
+            # its UPDATE predicate, so writing ``running`` synchronously here —
+            # before the loop can start the dispatch task — closes the startup
+            # window where a cross-backend PATCH could land while the row still
+            # read idle (and would then be silently undone by the bind-time
+            # backfill). The inbound chokepoint's own ``running`` write becomes a
+            # no-op; every terminal path still settles the status (outbound
+            # chokepoint / cancel / startup recovery).
+            self.controller.set_agent_status(session_id, "running")
             bus.publish("turn.start", {"session_id": session_id})
 
     async def flush_queue(self, session_id: str) -> bool:

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -19,7 +19,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.engine import Connection
 
 from storage.agent_session_rows import create_agent_session_row
@@ -313,9 +313,10 @@ def create_session(
 
 class SessionBackendLockedError(Exception):
     """Raised when a caller tries to switch the backend of a session that already
-    has a native conversation. A session is pinned to its backend for life: the
-    native can only be resumed by the backend that created it, so switching would
-    strand it and silently lose context. Changing the agent WITHIN the same
+    has a native conversation (pinned for life: the native can only be resumed by
+    the backend that created it, so switching would strand it and silently lose
+    context) or whose turn is currently running (the in-flight turn will bind its
+    native on the current route any moment). Changing the agent WITHIN the same
     backend stays allowed."""
 
     def __init__(self, *, session_id: str, current_backend: Optional[str], requested_backend: Optional[str]):
@@ -346,6 +347,7 @@ def update_session(
             agent_sessions.c.id,
             agent_sessions.c.agent_backend,
             agent_sessions.c.native_session_id,
+            agent_sessions.c.agent_status,
             agent_sessions.c.metadata_json,
         ).where(agent_sessions.c.id == session_id)
     ).first()
@@ -354,19 +356,25 @@ def update_session(
 
     # Backend is pinned once a NATIVE conversation exists: the native can only
     # be resumed by the backend that created it, so switching (or clearing) the
-    # backend would strand it. Before the first turn nothing is strandable — a
-    # fresh session may carry a project-default backend (see ``create_session``)
-    # and the user can still re-route it to ANY backend or clear back to the
-    # default. Within the same backend, agent/model/effort changes stay allowed
-    # for the session's whole life. Legacy agent-less rows whose native predates
-    # the bind-time backend backfill keep the old empty -> concrete "initial
-    # pin" escape — the row doesn't know which backend owns its native, and
-    # locking them would leave their picker permanently stuck.
-    if (
-        agent_backend is not _UNSET
-        and str(existing.native_session_id or "")
-        and str(existing.agent_backend or "")
-        and str(agent_backend or "") != str(existing.agent_backend or "")
+    # backend would strand it. A RUNNING turn locks it too — the first turn is
+    # already executing on the current route and will bind its native shortly,
+    # so a mid-turn switch would either be silently overwritten by the bind-time
+    # backfill or route queued follow-ups inconsistently (a stale ``running``
+    # after a crash is reset to ``idle`` on startup). Before the first turn
+    # nothing is strandable — a fresh session may carry a project-default
+    # backend (see ``create_session``) and the user can still re-route it to ANY
+    # backend or clear back to the default. Within the same backend,
+    # agent/model/effort changes stay allowed for the session's whole life.
+    # Legacy agent-less rows whose native predates the bind-time backend
+    # backfill keep the old empty -> concrete "initial pin" escape (while idle)
+    # — the row doesn't know which backend owns its native, and locking them
+    # would leave their picker permanently stuck.
+    backend_changes = agent_backend is not _UNSET and str(agent_backend or "") != str(
+        existing.agent_backend or ""
+    )
+    if backend_changes and (
+        (str(existing.native_session_id or "") and str(existing.agent_backend or ""))
+        or str(existing.agent_status or "") == "running"
     ):
         raise SessionBackendLockedError(
             session_id=session_id,
@@ -401,21 +409,23 @@ def update_session(
         values["reasoning_effort"] = reasoning_effort or None
 
     stmt = update(agent_sessions).where(agent_sessions.c.id == session_id)
-    backend_changes = agent_backend is not _UNSET and str(agent_backend or "") != str(
-        existing.agent_backend or ""
-    )
     if backend_changes:
         # Re-assert the lock INSIDE the UPDATE: the guard above is read-then-
-        # write, and the first turn's native bind can commit in between (the
+        # write, and a turn start / native bind can commit in between (the
         # SELECT runs before this statement takes the write lock). The predicate
         # makes the change atomic — it only lands while the session is still
-        # unlocked (no native, or the legacy blank-backend escape) or the row
-        # already converged to the requested backend.
+        # unlocked (idle AND (no native or the legacy blank-backend escape)) or
+        # the row already converged to the requested backend.
         stmt = stmt.where(
             or_(
-                func.coalesce(agent_sessions.c.native_session_id, "") == "",
-                func.coalesce(agent_sessions.c.agent_backend, "") == "",
                 agent_sessions.c.agent_backend == str(agent_backend or ""),
+                and_(
+                    func.coalesce(agent_sessions.c.agent_status, "idle") != "running",
+                    or_(
+                        func.coalesce(agent_sessions.c.native_session_id, "") == "",
+                        func.coalesce(agent_sessions.c.agent_backend, "") == "",
+                    ),
+                ),
             )
         )
     result = conn.execute(stmt.values(**values))

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -269,10 +269,12 @@ def create_session(
         raise PermissionError(f"Scope is archived: {scope_id}")
     # Inherit the project's default Agent when the caller didn't pin a backend.
     # The default lives in ``scope_settings`` (set via Project Settings); adopting
-    # it at creation pins the backend from the first turn (a session's backend is
-    # write-once) and makes the chat header open on the right Agent. No project
-    # default → the fields stay empty and dispatch falls back to the global
-    # default Vibe Agent. An explicit caller backend always wins.
+    # it at creation makes the chat header open on the right Agent and the first
+    # turn run on it. It is a SOFT default: until a native conversation exists
+    # the user can still re-route the session to any backend or clear it back to
+    # the global default (see ``update_session``). No project default → the
+    # fields stay empty and dispatch falls back to the global default Vibe
+    # Agent. An explicit caller backend always wins.
     if not agent_backend and scope_row.get("agent_backend"):
         agent_backend = str(scope_row["agent_backend"])
         if agent_name is None:
@@ -350,15 +352,21 @@ def update_session(
     if existing is None:
         raise LookupError(f"Session not found: {session_id}")
 
-    # Backend is pinned as soon as the session row has a concrete backend. Allow
-    # changing the agent/model/effort within the SAME backend; reject a switch to
-    # a DIFFERENT backend. A plain Workbench chat may still have an EMPTY
-    # agent_backend (legacy/global-default inheritance), so empty -> concrete is
-    # the initial pin rather than a backend switch.
+    # Backend is pinned once a NATIVE conversation exists: the native can only
+    # be resumed by the backend that created it, so switching (or clearing) the
+    # backend would strand it. Before the first turn nothing is strandable — a
+    # fresh session may carry a project-default backend (see ``create_session``)
+    # and the user can still re-route it to ANY backend or clear back to the
+    # default. Within the same backend, agent/model/effort changes stay allowed
+    # for the session's whole life. Legacy agent-less rows whose native predates
+    # the bind-time backend backfill keep the old empty -> concrete "initial
+    # pin" escape — the row doesn't know which backend owns its native, and
+    # locking them would leave their picker permanently stuck.
     if (
         agent_backend is not _UNSET
+        and str(existing.native_session_id or "")
         and str(existing.agent_backend or "")
-        and str(agent_backend) != str(existing.agent_backend or "")
+        and str(agent_backend or "") != str(existing.agent_backend or "")
     ):
         raise SessionBackendLockedError(
             session_id=session_id,

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -19,7 +19,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from sqlalchemy import func, select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.engine import Connection
 
 from storage.agent_session_rows import create_agent_session_row
@@ -400,7 +400,36 @@ def update_session(
     if reasoning_effort is not _UNSET:
         values["reasoning_effort"] = reasoning_effort or None
 
-    conn.execute(update(agent_sessions).where(agent_sessions.c.id == session_id).values(**values))
+    stmt = update(agent_sessions).where(agent_sessions.c.id == session_id)
+    backend_changes = agent_backend is not _UNSET and str(agent_backend or "") != str(
+        existing.agent_backend or ""
+    )
+    if backend_changes:
+        # Re-assert the lock INSIDE the UPDATE: the guard above is read-then-
+        # write, and the first turn's native bind can commit in between (the
+        # SELECT runs before this statement takes the write lock). The predicate
+        # makes the change atomic — it only lands while the session is still
+        # unlocked (no native, or the legacy blank-backend escape) or the row
+        # already converged to the requested backend.
+        stmt = stmt.where(
+            or_(
+                func.coalesce(agent_sessions.c.native_session_id, "") == "",
+                func.coalesce(agent_sessions.c.agent_backend, "") == "",
+                agent_sessions.c.agent_backend == str(agent_backend or ""),
+            )
+        )
+    result = conn.execute(stmt.values(**values))
+    if result.rowcount == 0:
+        current = conn.execute(
+            select(agent_sessions.c.agent_backend).where(agent_sessions.c.id == session_id)
+        ).first()
+        if current is None or not backend_changes:
+            raise LookupError(f"Session not found: {session_id}")
+        raise SessionBackendLockedError(
+            session_id=session_id,
+            current_backend=current.agent_backend,
+            requested_backend=agent_backend,
+        )
     return get_session(conn, session_id)
 
 

--- a/tests/test_controller_agent_status.py
+++ b/tests/test_controller_agent_status.py
@@ -82,3 +82,45 @@ def test_inbound_skips_non_avibe_turn():
 
     # IM turn carries no workbench session id → the dot is never touched.
     assert calls == []
+
+
+def test_run_marks_running_at_acceptance_before_dispatch(monkeypatch, tmp_path):
+    """The status flips ``running`` synchronously when the turn is ACCEPTED
+    (in_flight registration), not when dispatch later starts: update_session's
+    backend lock re-checks ``agent_status`` inside its UPDATE predicate, so the
+    accept-time write closes the startup window where a cross-backend PATCH
+    could land while the row still read idle."""
+
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from storage.importer import ensure_sqlite_state
+
+    ensure_sqlite_state()
+
+    import core.session_turns as session_turns_module
+    from core.session_turns import SessionTurnManager
+
+    calls: list = []
+    dispatched: list = []
+    controller = SimpleNamespace(
+        _session_id_from_context=staticmethod(Controller._session_id_from_context).__func__,
+        set_agent_status=lambda sid, status: calls.append((sid, status)),
+    )
+    mgr = SessionTurnManager(controller)
+
+    async def _dispatch(controller_arg, context, text, **kwargs):
+        dispatched.append(text)
+
+    monkeypatch.setattr(session_turns_module, "dispatch_turn", _dispatch)
+
+    async def _exercise():
+        await mgr._run("ses-accept", _ctx("ses-accept"), "hi")
+        # _run returns right after acceptance; the dispatch task hasn't run yet
+        # (single-threaded loop) — the running mark must already be recorded.
+        assert ("ses-accept", "running") in calls
+        assert dispatched == []
+        turn = mgr.in_flight.get("ses-accept")
+        assert turn is not None
+        await turn.task
+
+    asyncio.run(_exercise())
+    assert dispatched == ["hi"]

--- a/tests/test_core_services_sessions.py
+++ b/tests/test_core_services_sessions.py
@@ -475,6 +475,50 @@ def test_update_session_locks_backend_once_native_exists(isolated_state):
             sessions_service.update_session(conn, sid, agent_backend=None, agent_name=None)
 
 
+def test_update_session_running_turn_locks_backend(isolated_state):
+    """A RUNNING turn locks the backend even before the native is bound: the
+    in-flight first turn is already executing on the current route and will bind
+    its native shortly, so a mid-turn switch would be silently overwritten by
+    the bind-time backfill or route queued follow-ups inconsistently. Same-
+    backend changes stay allowed; a settled turn without a native (failed first
+    turn) unlocks again so the user can re-route to recover."""
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_avibe_scope(conn)
+        sid = sessions_service.create_session(
+            conn, scope_id=scope_id, agent_backend="claude", agent_name="claude"
+        )["id"]
+        sessions_service.set_agent_status(conn, sid, "running")
+        with pytest.raises(sessions_service.SessionBackendLockedError):
+            sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
+        with pytest.raises(sessions_service.SessionBackendLockedError):
+            sessions_service.update_session(conn, sid, agent_backend=None, agent_name=None)
+        # Same-backend agent/model change stays allowed mid-turn.
+        sessions_service.update_session(conn, sid, agent_backend="claude", model="opus")
+        # First turn failed before binding a native → switchable again to recover.
+        sessions_service.set_agent_status(conn, sid, "failed")
+        sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
+        assert sessions_service.get_session(conn, sid)["agent_backend"] == "codex"
+
+
+def test_update_session_running_turn_locks_agent_less_session_too(isolated_state):
+    """An agent-less session's first (global-default) turn also locks while
+    running: a concrete pick would race the bind-time backend backfill the same
+    way. Once settled without a native, the pick is allowed again."""
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_avibe_scope(conn)
+        sid = sessions_service.create_session(conn, scope_id=scope_id, agent_backend="")["id"]
+        sessions_service.set_agent_status(conn, sid, "running")
+        with pytest.raises(sessions_service.SessionBackendLockedError):
+            sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
+        sessions_service.set_agent_status(conn, sid, "idle")
+        sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
+        assert sessions_service.get_session(conn, sid)["agent_backend"] == "codex"
+
+
 def test_update_session_backend_switch_loses_race_with_native_bind(isolated_state):
     """The lock guard is read-then-write and the first turn's native bind can
     commit in between (the SELECT runs before the UPDATE takes the write lock).

--- a/tests/test_core_services_sessions.py
+++ b/tests/test_core_services_sessions.py
@@ -19,7 +19,7 @@ from core.services import sessions as sessions_service
 from storage import workbench_sessions_service as storage_sessions
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
-from storage.models import scope_settings
+from storage.models import agent_sessions, scope_settings
 from storage.settings_service import upsert_scope
 
 
@@ -414,10 +414,19 @@ def test_reset_running_agent_status_clears_only_running(isolated_state):
         assert sessions_service.get_session(conn, failed)["agent_status"] == "failed"
 
 
-def test_update_session_pins_concrete_backend_at_creation(isolated_state):
-    """A session is locked to its backend once it has a concrete backend:
-    same-backend agent/model changes are allowed; a cross-backend switch raises
-    SessionBackendLockedError."""
+def _bind_native(conn, session_id: str, native_id: str = "native-1") -> None:
+    """Simulate the first turn's native bind (``bind_agent_session_by_id``)."""
+    conn.execute(
+        agent_sessions.update()
+        .where(agent_sessions.c.id == session_id)
+        .values(native_session_id=native_id)
+    )
+
+
+def test_update_session_backend_is_free_until_native_bind(isolated_state):
+    """A concrete backend at creation (e.g. inherited from the project's default
+    Agent) is a SOFT default: until a native conversation exists the session can
+    be re-routed to a DIFFERENT backend, or cleared back to the default."""
 
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -425,50 +434,61 @@ def test_update_session_pins_concrete_backend_at_creation(isolated_state):
         sid = sessions_service.create_session(
             conn, scope_id=scope_id, agent_backend="claude", agent_name="claude"
         )["id"]
-        # Same-backend change (different agent / model) is still allowed.
-        sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude-pro", model="opus")
-        # Cross-backend switch is rejected.
-        with pytest.raises(sessions_service.SessionBackendLockedError):
-            sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
-
-
-def test_update_session_blank_backend_takes_first_concrete_pin(isolated_state):
-    """A plain Workbench chat is created with an EMPTY agent_backend. After its
-    first real backend selection is the INITIAL pin, not a cross-backend switch
-    — it must be allowed, then lock the session to that backend going forward."""
-
-    engine = create_sqlite_engine()
-    with engine.begin() as conn:
-        scope_id = _seed_avibe_scope(conn)
-        sid = sessions_service.create_session(conn, scope_id=scope_id, agent_backend="")["id"]
-        # Empty -> concrete is the first pin.
+        # No native yet → cross-backend re-route is allowed.
         sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
         assert sessions_service.get_session(conn, sid)["agent_backend"] == "codex"
-        # Now pinned: a different backend is rejected.
-        with pytest.raises(sessions_service.SessionBackendLockedError):
-            sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude")
+        # ... and so is clearing back to the inherited default.
+        sessions_service.update_session(
+            conn,
+            sid,
+            agent_backend=None,
+            agent_name=None,
+            agent_id=None,
+            agent_variant=None,
+            model=None,
+            reasoning_effort=None,
+        )
+        assert not sessions_service.get_session(conn, sid)["agent_backend"]
 
 
-def test_update_session_pinned_session_cannot_clear_backend_to_default(isolated_state):
-    """Once a session has a concrete backend, clearing back to inherited default
-    could let a future default switch route the old session through another
-    backend."""
+def test_update_session_locks_backend_once_native_exists(isolated_state):
+    """Once the first turn bound a native conversation the backend is pinned for
+    life — the native can only be resumed by the backend that created it.
+    Same-backend agent/model changes stay allowed; a cross-backend switch or a
+    clear back to default raises SessionBackendLockedError."""
 
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         scope_id = _seed_avibe_scope(conn)
         sid = sessions_service.create_session(
-            conn, scope_id=scope_id, agent_backend="codex", agent_name="codex"
+            conn, scope_id=scope_id, agent_backend="claude", agent_name="claude"
         )["id"]
-
+        _bind_native(conn, sid)
+        # Same-backend change (different agent / model) is still allowed.
+        sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude-pro", model="opus")
+        # Cross-backend switch is rejected.
         with pytest.raises(sessions_service.SessionBackendLockedError):
-            sessions_service.update_session(
-                conn,
-                sid,
-                agent_backend=None,
-                agent_name=None,
-                agent_id=None,
-                agent_variant=None,
-                model=None,
-                reasoning_effort=None,
-            )
+            sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
+        # Clearing back to the inherited default is rejected too: a future
+        # default switch could route the old session through another backend.
+        with pytest.raises(sessions_service.SessionBackendLockedError):
+            sessions_service.update_session(conn, sid, agent_backend=None, agent_name=None)
+
+
+def test_update_session_legacy_blank_backend_keeps_initial_pin_escape(isolated_state):
+    """Legacy agent-less rows whose native predates the bind-time backend
+    backfill don't know which backend owns their native; the empty -> concrete
+    "initial pin" stays allowed so their picker isn't permanently stuck. The pin
+    then locks the session like any other."""
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_avibe_scope(conn)
+        sid = sessions_service.create_session(conn, scope_id=scope_id, agent_backend="")["id"]
+        _bind_native(conn, sid)
+        # Empty -> concrete is the initial pin, even with a native bound.
+        sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
+        assert sessions_service.get_session(conn, sid)["agent_backend"] == "codex"
+        # Now pinned: a different backend is rejected.
+        with pytest.raises(sessions_service.SessionBackendLockedError):
+            sessions_service.update_session(conn, sid, agent_backend="claude", agent_name="claude")

--- a/tests/test_core_services_sessions.py
+++ b/tests/test_core_services_sessions.py
@@ -475,6 +475,48 @@ def test_update_session_locks_backend_once_native_exists(isolated_state):
             sessions_service.update_session(conn, sid, agent_backend=None, agent_name=None)
 
 
+def test_update_session_backend_switch_loses_race_with_native_bind(isolated_state):
+    """The lock guard is read-then-write and the first turn's native bind can
+    commit in between (the SELECT runs before the UPDATE takes the write lock).
+    The UPDATE re-asserts the lock in its WHERE predicate, so a cross-backend
+    switch that loses the race raises instead of stamping a backend that
+    mismatches the backend owning the just-bound native."""
+
+    from sqlalchemy import event
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_avibe_scope(conn)
+        sid = sessions_service.create_session(
+            conn, scope_id=scope_id, agent_backend="claude", agent_name="claude"
+        )["id"]
+
+    bind_engine = create_sqlite_engine()
+    fired = {"done": False}
+
+    def bind_native_before_update(_conn, _cursor, statement, _params, _context, _executemany):
+        # Right before update_session's UPDATE executes — i.e. AFTER its lock
+        # check read "no native yet" — land the first turn's native bind on a
+        # separate connection, exactly the racing interleave.
+        if fired["done"] or not statement.lstrip().upper().startswith("UPDATE AGENT_SESSIONS"):
+            return
+        fired["done"] = True
+        with bind_engine.begin() as bind_conn:
+            _bind_native(bind_conn, sid)
+
+    event.listen(engine, "before_cursor_execute", bind_native_before_update)
+    try:
+        with engine.begin() as conn:
+            with pytest.raises(sessions_service.SessionBackendLockedError):
+                sessions_service.update_session(conn, sid, agent_backend="codex", agent_name="codex")
+    finally:
+        event.remove(engine, "before_cursor_execute", bind_native_before_update)
+
+    assert fired["done"], "race interleave never triggered — test setup is broken"
+    with engine.connect() as conn:
+        assert sessions_service.get_session(conn, sid)["agent_backend"] == "claude"
+
+
 def test_update_session_legacy_blank_backend_keeps_initial_pin_escape(isolated_state):
     """Legacy agent-less rows whose native predates the bind-time backend
     backfill don't know which backend owns their native; the empty -> concrete

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -470,3 +470,95 @@ def test_turn_state_idle_preserves_response_for_missing_session(isolated_state):
     body = response.get_json()
     assert body["in_flight"] is False
     assert body["recovered_agent_status"] is False
+
+
+def test_patch_backend_switch_blocked_while_turn_in_flight(isolated_state, tmp_path):
+    """The row's ``agent_status`` lags turn acceptance (``submit`` registers the
+    in-flight gate before dispatch writes ``running``), so a cross-backend PATCH
+    in that startup window must consult the controller's gate and 409 — otherwise
+    the bind-time backend backfill would silently undo the switch."""
+
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+
+    in_flight = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": True}})
+    with patch("vibe.internal_client.turn_state", in_flight):
+        client = app.test_client()
+        headers = csrf_headers(client)
+        response = client.patch(
+            f"/api/sessions/{session_id}",
+            json={"agent_backend": "codex", "agent_name": "codex"},
+            headers=headers,
+        )
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "backend_locked"
+    in_flight.assert_awaited_once()
+
+
+def test_patch_same_backend_change_skips_in_flight_gate(isolated_state, tmp_path):
+    """Same-backend agent/model changes stay allowed mid-turn and don't pay the
+    internal turn-state round-trip."""
+
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+
+    gate = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": True}})
+    with patch("vibe.internal_client.turn_state", gate):
+        client = app.test_client()
+        headers = csrf_headers(client)
+        response = client.patch(
+            f"/api/sessions/{session_id}",
+            json={"agent_backend": "claude", "agent_name": "claude-pro", "model": "opus"},
+            headers=headers,
+        )
+    assert response.status_code == 200
+    assert response.get_json()["agent_name"] == "claude-pro"
+    gate.assert_not_awaited()
+
+
+def test_patch_backend_switch_allowed_when_idle(isolated_state, tmp_path):
+    """No native + no in-flight turn → the (project-default) backend is a soft
+    pin and the cross-backend switch lands."""
+
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+
+    idle = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": False}})
+    with patch("vibe.internal_client.turn_state", idle):
+        client = app.test_client()
+        headers = csrf_headers(client)
+        response = client.patch(
+            f"/api/sessions/{session_id}",
+            json={"agent_backend": "codex", "agent_name": "codex"},
+            headers=headers,
+        )
+    assert response.status_code == 200
+    assert response.get_json()["agent_backend"] == "codex"
+
+
+def test_patch_backend_switch_falls_back_to_row_guard_when_controller_down(isolated_state, tmp_path):
+    """An unreachable controller must not brick the picker: the gate check is
+    best-effort and the row-status guard inside ``update_session`` still
+    applies."""
+
+    from vibe import internal_client
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+
+    async def unavailable(session_id_inner):
+        raise internal_client.InternalServerUnavailable("socket missing")
+
+    with patch("vibe.internal_client.turn_state", unavailable):
+        client = app.test_client()
+        headers = csrf_headers(client)
+        response = client.patch(
+            f"/api/sessions/{session_id}",
+            json={"agent_backend": "codex", "agent_name": "codex"},
+            headers=headers,
+        )
+    assert response.status_code == 200
+    assert response.get_json()["agent_backend"] == "codex"

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -944,6 +944,7 @@ export const ChatPage: React.FC = () => {
           defaultAgentName={defaultAgentName}
           onPatch={patch}
           onBack={goBack}
+          working={working}
         />
 
       {error && (
@@ -1069,18 +1070,21 @@ interface ChatHeaderBarProps {
   defaultAgentName: string | null;
   onPatch: (changes: Partial<WorkbenchSession>) => Promise<void>;
   onBack: () => void;
+  working: boolean;
 }
 
-const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack }) => {
+const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working }) => {
   const { t } = useTranslation();
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
-  // Backend locks only once a NATIVE conversation exists — a native can only be
-  // resumed by the backend that created it (mirrors update_session's guard).
-  // Until then a session may carry a project-default backend, but the user can
-  // still re-route it to any backend or clear back to the default.
-  const hasNative = Boolean(session.native_session_id);
-  const pinnedBackend = hasNative ? session.agent_backend?.trim() || null : null;
-  const canClearToDefault = !hasNative;
+  // Backend locks once a NATIVE conversation exists — a native can only be
+  // resumed by the backend that created it — or while a turn is RUNNING (the
+  // in-flight turn binds its native on the current route any moment); mirrors
+  // update_session's guard. Until then a session may carry a project-default
+  // backend, but the user can still re-route it to any backend or clear back
+  // to the default.
+  const backendLocked = Boolean(session.native_session_id) || working;
+  const pinnedBackend = backendLocked ? session.agent_backend?.trim() || null : null;
+  const canClearToDefault = !backendLocked;
   const defaultRoute = defaultAgent
     ? {
         agent_name: defaultAgent.name,

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -185,6 +185,27 @@ export const ChatPage: React.FC = () => {
     setMessages((prev) => (prev.some((m) => m.id === msg.id) ? prev : mergeById(prev, [msg])));
   }, []);
 
+  // The header's backend lock keys on ``native_session_id``, which the FIRST
+  // turn binds server-side with no dedicated event — so an open page wouldn't
+  // learn it until reload and the picker would keep offering switches the
+  // server now rejects (409). Until the native is known, refresh the row at
+  // the recovery points (turn end / reconnect / tab visible). No-op for the
+  // common already-bound session.
+  const hasNativeRef = useRef(false);
+  useEffect(() => {
+    hasNativeRef.current = Boolean(session?.native_session_id);
+  }, [session]);
+  const refreshSessionRowUntilNativeBound = useCallback(async () => {
+    const id = sessionIdRef.current;
+    if (!id || hasNativeRef.current) return;
+    try {
+      const row = await api.getSession(id);
+      setSession((prev) => (prev && prev.id === row.id && row.id === sessionIdRef.current ? row : prev));
+    } catch {
+      // Best-effort: the next recovery point retries.
+    }
+  }, [api]);
+
   useEffect(() => {
     oldestLoadedIdRef.current = messages[0]?.id ?? null;
     newestLoadedIdRef.current = messages[messages.length - 1]?.id ?? null;
@@ -446,7 +467,14 @@ export const ChatPage: React.FC = () => {
         // The controller confirms the turn settled (terminal result, agent error,
         // or user cancel) — the authoritative end of the working state. There is
         // no turn-duration timeout, so this only fires on a REAL terminal signal.
-        if (data.session_id === sessionIdRef.current) setWorking(false);
+        if (data.session_id === sessionIdRef.current) {
+          setWorking(false);
+          // The first turn binds the native; pick it up so the header's backend
+          // lock engages without a reload. A failed first turn leaves no native
+          // (the refresh confirms that), keeping the backend switchable so the
+          // user can recover by re-routing.
+          void refreshSessionRowUntilNativeBound();
+        }
       },
       onQueueUpdated: (data) => {
         // The send-while-busy queue changed (enqueue / flush / per-item delete).
@@ -472,17 +500,19 @@ export const ChatPage: React.FC = () => {
       },
       onConnected: () => {
         // Every (re)connect recovers any state missed while the socket was down:
-        // dropped message rows, the queue, and whether a turn is still running.
+        // dropped message rows, the queue, whether a turn is still running, and
+        // a native bind whose turn.end we missed.
         void reconcile();
         void refreshQueue();
         void syncTurnState();
+        void refreshSessionRowUntilNativeBound();
       },
       onError: () => {
         // Browser EventSource auto-reconnects; keep the page usable.
       },
     }, { reconnect: connectionEpoch > 0 });
     return disconnect;
-  }, [api, sessionId, appendMessage, reconcile, refreshQueue, syncTurnState, markWorking, connectionEpoch, goBack]);
+  }, [api, sessionId, appendMessage, reconcile, refreshQueue, syncTurnState, refreshSessionRowUntilNativeBound, markWorking, connectionEpoch, goBack]);
 
   // Mobile tabs (the common case for IM users) get backgrounded mid-turn; the
   // SSE feed can be suspended without a clean reconnect, dropping the reply.

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1044,8 +1044,13 @@ interface ChatHeaderBarProps {
 const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack }) => {
   const { t } = useTranslation();
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
-  const pinnedBackend = session.agent_backend?.trim() || null;
-  const canClearToDefault = !pinnedBackend && !session.native_session_id;
+  // Backend locks only once a NATIVE conversation exists — a native can only be
+  // resumed by the backend that created it (mirrors update_session's guard).
+  // Until then a session may carry a project-default backend, but the user can
+  // still re-route it to any backend or clear back to the default.
+  const hasNative = Boolean(session.native_session_id);
+  const pinnedBackend = hasNative ? session.agent_backend?.trim() || null : null;
+  const canClearToDefault = !hasNative;
   const defaultRoute = defaultAgent
     ? {
         agent_name: defaultAgent.name,

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1081,10 +1081,17 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
   // in-flight turn binds its native on the current route any moment); mirrors
   // update_session's guard. Until then a session may carry a project-default
   // backend, but the user can still re-route it to any backend or clear back
-  // to the default.
+  // to the default. A locked session with a KNOWN backend keeps the picker
+  // open for same-backend agent/model changes; locked with a BLANK backend
+  // (the global-default route mid-turn) has no valid choice at all — every
+  // concrete pick would 409 — so the picker disables until the turn settles.
+  // Idle blank-backend rows with a native (legacy, pre-backfill) stay enabled:
+  // the server allows their one-time "initial pin".
+  const concreteBackend = session.agent_backend?.trim() || null;
   const backendLocked = Boolean(session.native_session_id) || working;
-  const pinnedBackend = backendLocked ? session.agent_backend?.trim() || null : null;
+  const pinnedBackend = backendLocked ? concreteBackend : null;
   const canClearToDefault = !backendLocked;
+  const pickerDisabled = working && !concreteBackend;
   const defaultRoute = defaultAgent
     ? {
         agent_name: defaultAgent.name,
@@ -1120,6 +1127,7 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
           value={session}
           agents={agents}
           onChange={onPatch}
+          disabled={pickerDisabled}
           allowedBackends={pinnedBackend ? [pinnedBackend] : undefined}
           defaultLabel={
             canClearToDefault

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -199,7 +199,10 @@ export const ChatPage: React.FC = () => {
     const id = sessionIdRef.current;
     if (!id || hasNativeRef.current) return;
     try {
-      const row = await api.getSession(id);
+      // cache:false — an earlier refresh (page open / reconnect) may have
+      // cached the still-native-less row; a quick turn ending inside the read
+      // cache's TTL would reuse it and leave the picker unlocked.
+      const row = await api.getSession(id, { cache: false });
       setSession((prev) => (prev && prev.id === row.id && row.id === sessionIdRef.current ? row : prev));
     } catch {
       // Best-effort: the next recovery point retries.

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -174,7 +174,7 @@ export type ApiContextType = {
   ) => Promise<{ ok: boolean; backends: GlobalPromptFile[] }>;
   listSessions: (params?: { projectId?: string; status?: 'active' | 'archived' | 'all'; limit?: number; beforeId?: string; q?: string; cache?: boolean }) => Promise<{ sessions: WorkbenchSession[]; next_before_id: string | null }>;
   createSession: (payload: WorkbenchSessionCreate) => Promise<WorkbenchSession>;
-  getSession: (sessionId: string) => Promise<WorkbenchSession>;
+  getSession: (sessionId: string, params?: { cache?: boolean }) => Promise<WorkbenchSession>;
   getSessionBootstrap: (sessionId: string) => Promise<WorkbenchSessionBootstrap>;
   updateSession: (sessionId: string, payload: Partial<WorkbenchSessionUpdate>) => Promise<WorkbenchSession>;
   archiveSession: (sessionId: string) => Promise<WorkbenchSession>;
@@ -1672,7 +1672,10 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       return params?.cache === false ? getJson(path) : getCachedJson(path);
     },
     createSession: (payload) => postJson('/api/sessions', payload),
-    getSession: (sessionId) => getCachedJson(`/api/sessions/${encodeURIComponent(sessionId)}`),
+    getSession: (sessionId, params) =>
+      params?.cache === false
+        ? getJson(`/api/sessions/${encodeURIComponent(sessionId)}`)
+        : getCachedJson(`/api/sessions/${encodeURIComponent(sessionId)}`),
     getSessionBootstrap: (sessionId) =>
       getJson(`/api/sessions/${encodeURIComponent(sessionId)}/bootstrap`),
     updateSession: async (sessionId, payload) => {

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -276,6 +276,9 @@ class CompatTestClient:
     def post(self, url: str, **kwargs: Any) -> CompatTestResponse:
         return self.request("POST", url, **kwargs)
 
+    def patch(self, url: str, **kwargs: Any) -> CompatTestResponse:
+        return self.request("PATCH", url, **kwargs)
+
     def delete(self, url: str, **kwargs: Any) -> CompatTestResponse:
         return self.request("DELETE", url, **kwargs)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3721,9 +3721,25 @@ async def sessions_bootstrap(session_id: str):
     )
 
 
+def _backend_locked_response(err):
+    """Shared 409 payload for a rejected cross-backend session change."""
+    return (
+        jsonify(
+            {
+                "error": str(err),
+                "code": "backend_locked",
+                "current_backend": err.current_backend,
+                "requested_backend": err.requested_backend,
+            }
+        ),
+        409,
+    )
+
+
 @app.route("/api/sessions/<session_id>", methods=["PATCH"])
-def sessions_update(session_id: str):
+async def sessions_update(session_id: str):
     from core.services import sessions as workbench_sessions_service
+    from vibe import internal_client
     from vibe.sse_broker import broker
 
     payload = request.json or {}
@@ -3744,25 +3760,44 @@ def sessions_update(session_id: str):
         return jsonify({"error": "no updatable fields supplied"}), 400
 
     engine = _projects_engine()
+    # The row's ``agent_status`` lags turn acceptance: ``SessionTurnManager.submit``
+    # registers the in-flight gate synchronously, but ``running`` is only written
+    # once dispatch starts — so a cross-backend switch landing in that startup
+    # window would pass the row-status guard and then be silently undone by the
+    # bind-time backend backfill. Consult the controller's authoritative in-flight
+    # registry first; an unreachable/slow controller falls through to the
+    # row-status guard inside ``update_session`` (best effort).
+    if "agent_backend" in updatable:
+        try:
+            with engine.connect() as conn:
+                current = workbench_sessions_service.get_session(conn, session_id)
+        except LookupError as err:
+            return jsonify({"error": str(err)}), 404
+        if str(updatable.get("agent_backend") or "") != str(current.get("agent_backend") or ""):
+            try:
+                turn_result = await internal_client.turn_state(session_id)
+                in_flight = bool((turn_result.get("body") or {}).get("in_flight"))
+            except (internal_client.InternalServerUnavailable, internal_client.InternalServerTimeout):
+                in_flight = False
+            if in_flight:
+                return _backend_locked_response(
+                    workbench_sessions_service.SessionBackendLockedError(
+                        session_id=session_id,
+                        current_backend=current.get("agent_backend"),
+                        requested_backend=updatable.get("agent_backend"),
+                    )
+                )
+
     try:
         with engine.begin() as conn:
             session = workbench_sessions_service.update_session(conn, session_id, **updatable)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
     except workbench_sessions_service.SessionBackendLockedError as err:
-        # A session is pinned to its backend once it has a conversation; the UI
-        # may switch the agent within the same backend, but not across backends.
-        return (
-            jsonify(
-                {
-                    "error": str(err),
-                    "code": "backend_locked",
-                    "current_backend": err.current_backend,
-                    "requested_backend": err.requested_backend,
-                }
-            ),
-            409,
-        )
+        # A session is pinned to its backend once it has a conversation (or a
+        # running turn); the UI may switch the agent within the same backend,
+        # but not across backends.
+        return _backend_locked_response(err)
     # Broadcast so other surfaces (e.g. the sidebar session list) reflect the
     # edit live — renaming a session in the chat header should rename its
     # sidebar row without a manual refresh.


### PR DESCRIPTION
## Capability

**Workbench session backend lock semantics.** A session created under a project with a default Agent inherited that backend as a *hard* pin: `update_session` rejected any cross-backend change as soon as `agent_backend` was concrete, and the chat header locked `allowedBackends` to it — so a freshly created, never-used session could not be re-routed to another backend at all. Product intent: the project default should only **pre-select** the Agent picker.

The physical constraint behind the lock is the **native conversation** (it can only be resumed by the backend that created it), which exists only after the first turn — and dispatch backfills `agent_backend` onto the row at native-bind time. So the lock now keys on `native_session_id`:

- `update_session` rejects a cross-backend switch (or clear) only when a native exists **and** the row has a concrete backend; the legacy empty→concrete "initial pin" escape stays for agent-less rows whose native predates the bind-time backfill (locking them would strand their picker permanently).
- The lock is re-asserted **inside the UPDATE's WHERE predicate**: the guard is read-then-write and the first turn's native bind can commit in between; a zero-rowcount result raises `SessionBackendLockedError` (Codex review MAJOR).
- `ChatHeaderBar`'s `pinnedBackend` / `canClearToDefault` key on `native_session_id`, and the page refreshes the session row at recovery points (turn end / reconnect) until the native is known, so the lock engages live instead of advertising switches the server 409s (Codex review MINOR).

Create-time inheritance is unchanged: the picker still opens on the project default and the first turn runs it. After the first turn the backend locks exactly as before.

## Evidence layers

- **Unit/contract**: `tests/test_core_services_sessions.py` rewritten for the new semantics — soft pin pre-native (switch + clear), lock post-native (switch + clear), legacy blank-backend escape, and a race test that lands the native bind between the lock check and the write via a `before_cursor_execute` hook. 21 passed; adjacent suites (`test_workbench_session_defaults`, `test_ui_session_stream`, `test_cli_task_command`, `test_cli_watch_command`) 130 passed total.
- **Contract (API)**: PATCH `/api/sessions/<id>` 409 `backend_locked` mapping unchanged.
- **Scenario**: no scenario catalog covers workbench session routing; none updated.
- **Residual manual checks**: create a session under a project with a default Agent → picker shows the default but offers all backends; switch to another backend pre-first-message; after the first reply the picker locks to the running backend without a reload.

## Review

Cross-model reviewed by Codex (3 rounds): 1 MAJOR (check-then-write race) and 1 MINOR (stale UI lock) found and fixed in follow-up commits; final pass NO FURTHER FINDINGS.