### PR TITLE
fix(release): keep Show Runtime release assets immutable per tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,19 +272,20 @@ jobs:
             gh "${ARGS[@]}" || gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" >/dev/null
           fi
 
-          # Python distributions are safe to refresh (PyPI itself is skip-existing).
-          gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" dist/* --clobber
-
           # Show Runtime archives + manifest are IMMUTABLE per tag and must NOT be
           # re-clobbered. The runtime tarball is not byte-reproducible, so a re-run of
-          # this workflow rebuilds different bytes. Meanwhile the manifest baked into the
-          # wheel is published to PyPI immutably (skip-existing). If a re-run clobbered the
-          # release archive with its fresh build, the already-published wheel's manifest and
-          # the hosted archive would diverge, and every Show Runtime install would fail its
-          # integrity check (runtime_archive_size_mismatch). So upload each runtime asset
-          # only if absent; if it already exists, require byte-identity and fail loudly.
+          # this workflow rebuilds different bytes, while the manifest baked into the wheel
+          # is published to PyPI immutably (skip-existing). Clobbering the release archive
+          # with a fresh build would desync the published wheel's manifest from the hosted
+          # archive, and every Show Runtime install would fail its integrity check
+          # (runtime_archive_size_mismatch).
+          #
+          # Verify immutability BEFORE mutating ANY release asset (including dist/*), so a
+          # mismatch fails the job without having already replaced the wheel/sdist. Upload
+          # each runtime asset only if absent; if it already exists, require byte-identity.
           existing="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name')"
           tmp="$(mktemp -d)"
+          runtime_to_upload=()
           for path in runtime-artifacts/vibe-show-runtime-node-*.tgz runtime-artifacts/show-runtime-manifest.json; do
             name="$(basename "$path")"
             if grep -qxF "$name" <<<"$existing"; then
@@ -298,9 +299,16 @@ jobs:
                 exit 1
               fi
             else
-              gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" "$path"
+              runtime_to_upload+=("$path")
             fi
           done
+
+          # Immutability gate passed — only now is it safe to mutate the release.
+          if [ "${#runtime_to_upload[@]}" -gt 0 ]; then
+            gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" "${runtime_to_upload[@]}"
+          fi
+          # Python distributions are safe to refresh (PyPI itself is skip-existing).
+          gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" dist/* --clobber
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,12 +272,35 @@ jobs:
             gh "${ARGS[@]}" || gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" >/dev/null
           fi
 
-          gh release upload "$TAG" \
-            --repo "${GITHUB_REPOSITORY}" \
-            dist/* \
-            runtime-artifacts/vibe-show-runtime-node-*.tgz \
-            runtime-artifacts/show-runtime-manifest.json \
-            --clobber
+          # Python distributions are safe to refresh (PyPI itself is skip-existing).
+          gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" dist/* --clobber
+
+          # Show Runtime archives + manifest are IMMUTABLE per tag and must NOT be
+          # re-clobbered. The runtime tarball is not byte-reproducible, so a re-run of
+          # this workflow rebuilds different bytes. Meanwhile the manifest baked into the
+          # wheel is published to PyPI immutably (skip-existing). If a re-run clobbered the
+          # release archive with its fresh build, the already-published wheel's manifest and
+          # the hosted archive would diverge, and every Show Runtime install would fail its
+          # integrity check (runtime_archive_size_mismatch). So upload each runtime asset
+          # only if absent; if it already exists, require byte-identity and fail loudly.
+          existing="$(gh release view "$TAG" --repo "${GITHUB_REPOSITORY}" --json assets --jq '.assets[].name')"
+          tmp="$(mktemp -d)"
+          for path in runtime-artifacts/vibe-show-runtime-node-*.tgz runtime-artifacts/show-runtime-manifest.json; do
+            name="$(basename "$path")"
+            if grep -qxF "$name" <<<"$existing"; then
+              rm -f "$tmp/$name"
+              gh release download "$TAG" --repo "${GITHUB_REPOSITORY}" --pattern "$name" --dir "$tmp" --clobber
+              if cmp -s "$tmp/$name" "$path"; then
+                echo "Release asset '$name' already present and byte-identical; skipping (immutable per tag)."
+              else
+                echo "::error::Release asset '$name' already exists for $TAG but differs from this run's build." >&2
+                echo "::error::The Show Runtime tarball is not byte-reproducible and this run rebuilt it; overwriting would desync the release from the PyPI wheel's manifest. Cut a NEW version instead of re-running the release." >&2
+                exit 1
+              fi
+            else
+              gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" "$path"
+            fi
+          done
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Capability

Make the publish workflow's GitHub **release** Show Runtime assets consistent with the **PyPI wheel's** baked-in manifest, so Show Runtime installs stop failing with `runtime_archive_size_mismatch`.

## Root cause (confirmed on v3.0.1)

The Show Runtime tarball is **not byte-reproducible** (`npm run build` + tar/gzip embed timestamps/ordering), and `publish.yml` rebuilds it on every run.

- The manifest is generated from a run's build and **baked into the avibe-os wheel**, which is published to PyPI **immutably** (`skip-existing`).
- The same archive was uploaded to the GitHub release with **`gh release upload --clobber`**.
- `publish.yml` ran **3×** for v3.0.1 (2 failures + 1 success). A later run rebuilt the runtime (**different bytes**) and **clobbered** the release archive, while PyPI kept the earlier wheel. The published wheel's manifest (`linux-x64` size `16,814,372`, sha `bc3f7c…`) then no longer matched the hosted archive (`16,832,514`), so the install integrity check (`core/show_runtime.py::_downloaded_archive_matches`) correctly rejected it on every tenant.

## Change

Treat the Show Runtime archives + `show-runtime-manifest.json` as **immutable per tag**:

- upload each only if it is **absent** from the release;
- if it already exists, **download and require byte-identity**; on any difference **fail the job loudly** (the operator must cut a new version rather than re-run the release);
- Python distributions (`dist/*`) keep `--clobber` (PyPI is itself `skip-existing`).

This mirrors PyPI's immutability so a re-run can never desync the hosted runtime archive from the already-published wheel's manifest.

## Evidence

- **Manual:** `python -c yaml.safe_load` parses `publish.yml`; the embedded upload script passes `bash -n` (placeholders substituted). No workflow unit-test harness exists in this repo.
- **Scenario/contract/unit:** n/a — CI workflow change.

## Follow-ups (not in this PR)

- **Belt-and-suspenders:** make the runtime tarball **byte-reproducible** (`vibe-show-runtime` bundling: fixed `--mtime`/`--sort`/`--owner`/`gzip -n`). With reproducible bytes, re-runs/multiple runs can never diverge regardless of upload semantics.
- `release_ai.yml` builds the Show Runtime for `v*` tags but discards it (only uploads for `gh-v*`) — wasted compute and a second non-reproducible build; gate it to `gh-v*` only.
- **Live remediation of v3.0.1** (already-released, broken assets) is handled out-of-band, separate from this workflow fix.
