### PR TITLE
fix(config): require platform credentials before enable

### DIFF
--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -460,6 +460,48 @@ def test_save_config_rejects_enabled_platform_without_runtime_credentials(monkey
         )
 
 
+def test_save_config_rejects_setup_completion_with_enabled_platform_without_runtime_credentials(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    import pytest
+
+    payload = _full_config_payload()
+    payload["platform"] = "avibe"
+    payload["platforms"] = {"enabled": [], "primary": "avibe"}
+    created = api.save_config(payload)
+    assert created.platforms.enabled == []
+
+    with pytest.raises(ValueError, match="Config 'lark.app_id', 'lark.app_secret' must be provided"):
+        api.save_config(
+            {
+                "platform": "lark",
+                "platforms": {"enabled": ["lark"], "primary": "lark"},
+                "lark": {"domain": "feishu"},
+                "setup_completed": True,
+            }
+        )
+
+
+def test_save_config_allows_unrelated_save_for_legacy_enabled_platform_without_runtime_credentials(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    payload = _full_config_payload()
+    payload["platform"] = "slack"
+    payload["platforms"] = {"enabled": ["slack"], "primary": "slack"}
+    payload["slack"] = {"bot_token": "", "app_token": ""}
+    V2Config.from_payload(payload).save()
+
+    updated = api.save_config({"remote_access": {"vibe_cloud": {"enabled": False}}})
+
+    assert updated.platforms.enabled == ["slack"]
+    assert updated.slack.bot_token == ""
+    assert updated.remote_access.vibe_cloud.enabled is False
+
+
 def test_save_config_preserves_disabled_platform_credentials(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
 

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -653,4 +653,4 @@ def test_platform_runnable_config_keeps_wechat_token_optional():
     source = Path("ui/src/lib/platforms.ts").read_text(encoding="utf-8")
 
     assert "if (platform === 'wechat')" in source
-    assert "return true;" in source
+    assert "return Boolean(data?.wechat);" in source

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -414,19 +414,59 @@ def test_save_config_migrates_legacy_single_platform(monkeypatch, tmp_path):
     assert payload["platforms"] == {"enabled": ["discord"], "primary": "discord"}
 
 
-def test_save_config_rejects_enabled_platform_without_credentials(monkeypatch, tmp_path):
+def test_save_config_rejects_enabled_platform_without_config(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
 
     import pytest
 
-    with pytest.raises(ValueError, match="wechat.*must be provided"):
-        api.save_config(
-            {
-                **_full_config_payload(),
-                "platforms": {"enabled": ["slack", "discord", "wechat"], "primary": "discord"},
-                # wechat config intentionally omitted
-            }
-        )
+    payload = _full_config_payload()
+    payload["platform"] = "avibe"
+    payload["platforms"] = {"enabled": [], "primary": "avibe"}
+    payload["lark"] = None
+    created = api.save_config(payload)
+    assert created.platforms.enabled == []
+    assert created.lark is None
+
+    with pytest.raises(ValueError, match="Config 'lark' must be provided when lark is enabled"):
+        api.save_config({"platform": "lark", "platforms": {"enabled": ["lark"], "primary": "lark"}})
+
+
+def test_save_config_preserves_disabled_platform_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    payload = _full_config_payload()
+    payload["platform"] = "avibe"
+    payload["platforms"] = {"enabled": [], "primary": "avibe"}
+    payload["lark"] = None
+    created = api.save_config(payload)
+    assert created.platforms.enabled == []
+    assert created.lark is None
+
+    updated = api.save_config(
+        {
+            "platform": "lark",
+            "lark": {
+                "app_id": "cli_test",
+                "app_secret": "secret",
+                "domain": "feishu",
+            },
+        }
+    )
+
+    assert updated.platforms.enabled == []
+    assert updated.platforms.primary == "avibe"
+    assert updated.lark is not None
+    assert updated.lark.app_id == "cli_test"
+    assert updated.lark.app_secret == "secret"
+
+    enabled = api.save_config({"platform": "lark", "platforms": {"enabled": ["lark"], "primary": "lark"}})
+
+    assert enabled.platforms.enabled == ["lark"]
+    assert enabled.platforms.primary == "lark"
+    assert enabled.lark is not None
+    assert enabled.lark.app_id == "cli_test"
+    assert enabled.lark.app_secret == "secret"
+
 
 def test_init_sessions_is_noop_when_sessions_file_exists(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
@@ -462,3 +502,11 @@ def test_config_post_does_not_call_init_sessions():
                 break
 
     assert calls_init_sessions is False
+
+
+def test_settings_platforms_apply_uses_parent_platform_identity():
+    source = Path("ui/src/components/settings/SettingsPlatformsPage.tsx").read_text(encoding="utf-8")
+
+    assert "const handleApplyPlatform = async (platform: string, nextData: any)" in source
+    assert "onApply={(data) => handleApplyPlatform(id, data)}" in source
+    assert "const platform = String(nextData?.platform || '')" not in source

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -519,6 +519,46 @@ def test_save_config_allows_unrelated_save_for_legacy_enabled_platform_without_r
     assert updated.remote_access.vibe_cloud.enabled is False
 
 
+def test_save_config_allows_redacted_lark_round_trip_for_legacy_missing_secret(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    payload = _full_config_payload()
+    payload["platform"] = "lark"
+    payload["platforms"] = {"enabled": ["lark"], "primary": "lark"}
+    payload["lark"] = {"app_id": "cli_lark_id", "app_secret": "", "domain": "feishu"}
+    V2Config.from_payload(payload).save()
+
+    updated = api.save_config(
+        {
+            "lark": {
+                "app_id": "cli_lark_id",
+                "has_app_secret": True,
+                "app_secret_length": 0,
+                "domain": "lark",
+            }
+        }
+    )
+
+    assert updated.platforms.enabled == ["lark"]
+    assert updated.lark.app_id == "cli_lark_id"
+    assert updated.lark.app_secret == ""
+    assert updated.lark.domain == "lark"
+
+    import pytest
+
+    with pytest.raises(ValueError, match="Config 'lark.app_secret' must be provided"):
+        api.save_config(
+            {
+                "lark": {
+                    "app_id": "cli_lark_changed",
+                    "has_app_secret": True,
+                    "app_secret_length": 0,
+                    "domain": "lark",
+                }
+            }
+        )
+
+
 def test_save_config_preserves_disabled_platform_credentials(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
 
@@ -598,3 +638,19 @@ def test_settings_platforms_apply_uses_parent_platform_identity():
     assert "const handleApplyPlatform = async (platform: string, nextData: any)" in source
     assert "onApply={(data) => handleApplyPlatform(id, data)}" in source
     assert "const platform = String(nextData?.platform || '')" not in source
+
+
+def test_settings_platforms_persists_discord_guild_scope_before_auto_enable():
+    source = Path("ui/src/components/settings/SettingsPlatformsPage.tsx").read_text(encoding="utf-8")
+
+    assert "const savePlatformSettings = async (platform: string, nextData: any)" in source
+    assert "platform === 'discord'" in source
+    assert "await api.saveSettings({" in source
+    assert "await savePlatformSettings(platform, nextData);" in source
+
+
+def test_platform_runnable_config_keeps_wechat_token_optional():
+    source = Path("ui/src/lib/platforms.ts").read_text(encoding="utf-8")
+
+    assert "if (platform === 'wechat')" in source
+    assert "return true;" in source

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -449,15 +449,32 @@ def test_save_config_rejects_enabled_platform_without_runtime_credentials(monkey
             }
         )
 
-    with pytest.raises(ValueError, match="Config 'slack.app_token' must be provided"):
+    with pytest.raises(ValueError, match="Config 'slack.bot_token' must be provided"):
         api.save_config(
             {
                 **_full_config_payload(),
                 "platform": "slack",
                 "platforms": {"enabled": ["slack"], "primary": "slack"},
-                "slack": {"bot_token": "xoxb-valid", "app_token": ""},
+                "slack": {"bot_token": "", "app_token": "xapp-valid"},
             }
         )
+
+
+def test_save_config_allows_slack_bot_token_only_runtime_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    payload = {
+        **_full_config_payload(),
+        "platform": "slack",
+        "platforms": {"enabled": ["slack"], "primary": "slack"},
+        "slack": {"bot_token": "xoxb-valid", "app_token": ""},
+    }
+
+    config = api.save_config(payload)
+
+    assert config.platforms.enabled == ["slack"]
+    assert config.slack.bot_token == "xoxb-valid"
+    assert config.slack.app_token == ""
 
 
 def test_save_config_rejects_setup_completion_with_enabled_platform_without_runtime_credentials(

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -384,9 +384,12 @@ def test_save_config_accepts_slack_disable_link_unfurl(monkeypatch, tmp_path):
 def test_save_config_preserves_platforms_metadata(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
 
+    payload = _full_config_payload()
+    payload["slack"]["bot_token"] = "xoxb-valid-token"
+    payload["slack"]["app_token"] = "xapp-valid-token"
     updated = api.save_config(
         {
-            **_full_config_payload(),
+            **payload,
             "wechat": {
                 "corp_id": "wk123",
                 "agent_id": "agent1",
@@ -429,6 +432,32 @@ def test_save_config_rejects_enabled_platform_without_config(monkeypatch, tmp_pa
 
     with pytest.raises(ValueError, match="Config 'lark' must be provided when lark is enabled"):
         api.save_config({"platform": "lark", "platforms": {"enabled": ["lark"], "primary": "lark"}})
+
+
+def test_save_config_rejects_enabled_platform_without_runtime_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    import pytest
+
+    with pytest.raises(ValueError, match="Config 'lark.app_id', 'lark.app_secret' must be provided"):
+        api.save_config(
+            {
+                **_full_config_payload(),
+                "platform": "lark",
+                "platforms": {"enabled": ["lark"], "primary": "lark"},
+                "lark": {},
+            }
+        )
+
+    with pytest.raises(ValueError, match="Config 'slack.app_token' must be provided"):
+        api.save_config(
+            {
+                **_full_config_payload(),
+                "platform": "slack",
+                "platforms": {"enabled": ["slack"], "primary": "slack"},
+                "slack": {"bot_token": "xoxb-valid", "app_token": ""},
+            }
+        )
 
 
 def test_save_config_preserves_disabled_platform_credentials(monkeypatch, tmp_path):

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -654,3 +654,13 @@ def test_platform_runnable_config_keeps_wechat_token_optional():
 
     assert "if (platform === 'wechat')" in source
     assert "return Boolean(data?.wechat);" in source
+
+
+def test_wizard_platform_selection_preserves_credential_drafts_on_continue():
+    source = Path("ui/src/components/steps/PlatformSelection.tsx").read_text(encoding="utf-8")
+
+    assert "const nextData = {" in source
+    assert "...credentialDraft," in source
+    assert "await onSave(nextData);" in source
+    assert "onNext(nextData);" in source
+    assert "onNext(selectionData);" not in source

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from http.cookies import SimpleCookie
 
-from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, V2Config
+from config.v2_config import AgentsConfig, PlatformsConfig, RuntimeConfig, SlackConfig, V2Config
 from vibe.ui_server import app, protect_mutating_ui_requests
 
 from tests.ui_server_test_helpers import csrf_headers
@@ -149,6 +149,37 @@ def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
     )
 
     assert response.status_code == 200
+
+
+def test_config_post_returns_400_for_enabled_platform_missing_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    V2Config(
+        mode="self_host",
+        version="v2",
+        platform="avibe",
+        platforms=PlatformsConfig(enabled=[], primary="avibe"),
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    ).save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+
+    response = client.post(
+        "/api/config",
+        json={
+            "platform": "lark",
+            "platforms": {"enabled": ["lark"], "primary": "lark"},
+            "lark": {"domain": "feishu"},
+        },
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+    )
+
+    body = response.get_json()
+    assert response.status_code == 400
+    assert "lark.app_id" in body["error"]
+    assert body["message"] == body["error"]
 
 
 def test_mutation_guard_exempts_e2e_simulation_endpoint(monkeypatch):

--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -236,18 +236,31 @@ export const Wizard: React.FC = () => {
 
   const persistStep = async (stepData: any, mergedData: any) => {
     if (!mergedData) return;
-    if (
-      mergedData.agents ||
-      mergedData.slack ||
-      mergedData.discord ||
-      mergedData.telegram ||
-      mergedData.lark ||
-      mergedData.wechat ||
-      mergedData.mode ||
-      mergedData.platforms ||
-      mergedData.platform ||
-      mergedData.channelConfigsByPlatform
-    ) {
+    const platformSelectionOnly =
+      Boolean(stepData.platforms || stepData.platform) &&
+      !stepData.agents &&
+      !stepData.slack &&
+      !stepData.discord &&
+      !stepData.telegram &&
+      !stepData.lark &&
+      !stepData.wechat &&
+      !stepData.mode &&
+      !stepData.channelConfigsByPlatform;
+    const shouldPersistConfig =
+      !platformSelectionOnly &&
+      Boolean(
+        mergedData.agents ||
+        mergedData.slack ||
+        mergedData.discord ||
+        mergedData.telegram ||
+        mergedData.lark ||
+        mergedData.wechat ||
+        mergedData.mode ||
+        mergedData.platforms ||
+        mergedData.platform ||
+        mergedData.channelConfigsByPlatform
+      );
+    if (shouldPersistConfig) {
       await api.saveConfig(buildConfigPayload(mergedData));
     }
     const discordGuildAllowlist = stepData?.discordGuildAllowlist;

--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -13,13 +13,30 @@ import { ChannelList } from './steps/ChannelList';
 import { Summary } from './steps/Summary';
 import { useApi } from '../context/ApiContext';
 import clsx from 'clsx';
-import { getEnabledPlatforms, getPrimaryPlatform, platformSupportsChannels } from '../lib/platforms';
+import {
+  WORKBENCH_PLATFORM_ID,
+  getEnabledPlatforms,
+  getPrimaryPlatform,
+  platformHasRunnableConfig,
+  platformSupportsChannels,
+} from '../lib/platforms';
 import { withoutConfiguredSecretMarker, withSecretDraft, withSecretDrafts } from '../lib/secretFields';
 import { WizardChrome } from './visual';
 
-const buildConfigPayload = (data: any) => {
-  const enabledPlatforms = getEnabledPlatforms(data);
+const getPrimaryPlatformForEnabledSet = (data: any, enabledPlatforms: string[]) => {
   const primaryPlatform = getPrimaryPlatform(data);
+  if (enabledPlatforms.includes(primaryPlatform)) {
+    return primaryPlatform;
+  }
+  return enabledPlatforms[0] || WORKBENCH_PLATFORM_ID;
+};
+
+const getPersistableWizardPlatforms = (data: any) =>
+  getEnabledPlatforms(data).filter((platform) => platformHasRunnableConfig(data, platform));
+
+const buildConfigPayload = (data: any, enabledPlatformOverride?: string[]) => {
+  const enabledPlatforms = enabledPlatformOverride ?? getEnabledPlatforms(data);
+  const primaryPlatform = getPrimaryPlatformForEnabledSet(data, enabledPlatforms);
 
   return {
   platform: primaryPlatform,
@@ -259,9 +276,9 @@ export const Wizard: React.FC = () => {
         mergedData.platforms ||
         mergedData.platform ||
         mergedData.channelConfigsByPlatform
-      );
+    );
     if (shouldPersistConfig) {
-      await api.saveConfig(buildConfigPayload(mergedData));
+      await api.saveConfig(buildConfigPayload(mergedData, getPersistableWizardPlatforms(mergedData)));
     }
     const discordGuildAllowlist = stepData?.discordGuildAllowlist;
     if (

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -22,6 +22,7 @@ import { LarkConfig } from '@/components/steps/LarkConfig';
 import { WeChatConfig } from '@/components/steps/WeChatConfig';
 import { SettingsPageShell } from './SettingsPageShell';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 const PLATFORM_TILE_STYLES: Record<string, { bg: string; border: string }> = {
   slack: { bg: 'bg-[#4A154B26]', border: 'border-[#4A154B66]' },
@@ -355,9 +356,9 @@ export const SettingsPlatformsPage: React.FC = () => {
                           {t('platform.stepAddBotToken')}
                         </span>
                       ) : (
-                        <span className="inline-flex items-center gap-1 rounded border border-border bg-foreground/[0.04] px-1.5 py-0.5 text-[10px] font-medium text-muted">
+                        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
                           {t('common.disabled')}
-                        </span>
+                        </Badge>
                       )}
                     </div>
                     <p className="mt-0.5 truncate text-[11px] text-muted">{description}</p>

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -12,7 +12,7 @@ import {
   getImPlatforms,
   getPlatformCatalog,
   getPrimaryPlatform,
-  platformHasCredentials,
+  platformHasRunnableConfig,
 } from '@/lib/platforms';
 import { PlatformIcon } from '@/components/visual';
 import { SlackConfig } from '@/components/steps/SlackConfig';
@@ -71,12 +71,17 @@ export const SettingsPlatformsPage: React.FC = () => {
 
   const closeAll = () => setExpanded(null);
 
+  const saveConfig = async (nextData: any) => {
+    const savedConfig = await api.saveConfig(nextData);
+    setConfig(savedConfig);
+    return savedConfig;
+  };
+
   const saveAndRestart = async (nextData: any) => {
     setRestartPhase('saving');
     try {
       try {
-        const savedConfig = await api.saveConfig(nextData);
-        setConfig(savedConfig);
+        await saveConfig(nextData);
       } catch {
         // Surface save failures to the user instead of letting the rejection
         // propagate as an unhandled async error from the click handler.
@@ -96,8 +101,35 @@ export const SettingsPlatformsPage: React.FC = () => {
     }
   };
 
-  const handleApplyPlatform = async (nextData: any) => {
-    await saveAndRestart(nextData);
+  const handleApplyPlatform = async (platform: string, nextData: any) => {
+    const wasEnabled = enabledPlatforms.includes(platform);
+    if (wasEnabled) {
+      await saveAndRestart(nextData);
+      return;
+    }
+    const preservedPrimary = primary || WORKBENCH_PLATFORM_ID;
+    const saveData = {
+      ...nextData,
+      platform: preservedPrimary,
+      platforms: { enabled: enabledPlatforms, primary: preservedPrimary },
+    };
+    try {
+      const savedConfig = await saveConfig(saveData);
+      const shouldEnable = platform && !wasEnabled && platformHasRunnableConfig(savedConfig, platform);
+      if (!shouldEnable) {
+        showToast(t('common.saved'), 'success');
+        closeAll();
+        return;
+      }
+      const nextEnabled = [...enabledPlatforms, platform];
+      const resolvedPrimary = primary && primary !== WORKBENCH_PLATFORM_ID ? primary : platform;
+      await saveAndRestart({
+        platform: resolvedPrimary,
+        platforms: { enabled: nextEnabled, primary: resolvedPrimary },
+      });
+    } catch {
+      showToast(t('common.saveFailed'), 'error');
+    }
   };
 
   const toggleDraftPlatform = (id: string) => {
@@ -108,6 +140,11 @@ export const SettingsPlatformsPage: React.FC = () => {
         const next = prev.filter((p) => p !== id);
         if (next.length && draftPrimary === id) setDraftPrimary(next[0]);
         return next;
+      }
+      if (!platformHasRunnableConfig(config, id)) {
+        setExpanded(id);
+        showToast(t('platform.configureBeforeEnable'), 'error');
+        return prev;
       }
       const next = [...prev, id];
       if (!prev.length) setDraftPrimary(id);
@@ -280,13 +317,15 @@ export const SettingsPlatformsPage: React.FC = () => {
           </div>
         </CollapseCard>
 
-        {/* One card per enabled platform */}
-        {enabledPlatforms.map((id) => {
+        {/* One card per IM platform: disabled platforms still need a place to add credentials. */}
+        {togglablePlatforms.map((platform) => {
+          const id = platform.id;
           const descriptor = platformCatalog.find((p) => p.id === id);
           const label = t(descriptor?.title_key || `platform.${id}.title`);
           const description = t(descriptor?.description_key || `platform.${id}.desc`);
           const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
-          const configured = platformHasCredentials(config, id);
+          const runnable = platformHasRunnableConfig(config, id);
+          const enabled = enabledPlatforms.includes(id);
           return (
             <CollapseCard
               key={id}
@@ -306,14 +345,18 @@ export const SettingsPlatformsPage: React.FC = () => {
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
                       <span className="text-[14px] font-semibold text-foreground">{label}</span>
-                      {configured ? (
+                      {runnable ? (
                         <span className="inline-flex items-center gap-1 rounded border border-mint/30 bg-mint/[0.08] px-1.5 py-0.5 text-[10px] font-medium text-mint">
                           <Check size={10} />
                           {t('platform.validationSuccess')}
                         </span>
-                      ) : (
+                      ) : enabled ? (
                         <span className="inline-flex items-center gap-1 rounded border border-gold/30 bg-gold/10 px-1.5 py-0.5 text-[10px] font-medium text-gold">
                           {t('platform.stepAddBotToken')}
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 rounded border border-border bg-foreground/[0.04] px-1.5 py-0.5 text-[10px] font-medium text-muted">
+                          {t('common.disabled')}
                         </span>
                       )}
                     </div>
@@ -326,7 +369,7 @@ export const SettingsPlatformsPage: React.FC = () => {
                 <PlatformConfigEmbed
                   platform={id}
                   config={config}
-                  onApply={handleApplyPlatform}
+                  onApply={(data) => handleApplyPlatform(id, data)}
                   onCancel={closeAll}
                 />
               </div>

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -78,6 +78,21 @@ export const SettingsPlatformsPage: React.FC = () => {
     return savedConfig;
   };
 
+  const savePlatformSettings = async (platform: string, nextData: any) => {
+    const discordGuildAllowlist = nextData?.discordGuildAllowlist;
+    if (
+      platform === 'discord' &&
+      Array.isArray(discordGuildAllowlist) &&
+      (discordGuildAllowlist.length > 0 || nextData?.discordGuildAllowlistTouched === true)
+    ) {
+      await api.saveSettings({
+        guilds: Object.fromEntries(
+          discordGuildAllowlist.map((guildId: string) => [guildId, { enabled: true }])
+        ),
+      }, 'discord');
+    }
+  };
+
   const saveAndRestart = async (nextData: any) => {
     setRestartPhase('saving');
     try {
@@ -105,6 +120,7 @@ export const SettingsPlatformsPage: React.FC = () => {
   const handleApplyPlatform = async (platform: string, nextData: any) => {
     const wasEnabled = enabledPlatforms.includes(platform);
     if (wasEnabled) {
+      await savePlatformSettings(platform, nextData);
       await saveAndRestart(nextData);
       return;
     }
@@ -122,6 +138,7 @@ export const SettingsPlatformsPage: React.FC = () => {
         closeAll();
         return;
       }
+      await savePlatformSettings(platform, nextData);
       const nextEnabled = [...enabledPlatforms, platform];
       const resolvedPrimary = primary && primary !== WORKBENCH_PLATFORM_ID ? primary : platform;
       await saveAndRestart({

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -131,18 +131,18 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
         primary: resolvedPrimary,
       },
     };
+    const nextData = {
+      ...credentialDraft,
+      discord_client_id: credentialDraft.discord?.client_id || '',
+      ...selectionData,
+    };
 
     if (isPage && onSave) {
-      const nextData = {
-        ...credentialDraft,
-        discord_client_id: credentialDraft.discord?.client_id || '',
-        ...selectionData,
-      };
       await onSave(nextData);
       return;
     }
 
-    onNext(selectionData);
+    onNext(nextData);
   };
 
   const activeDescriptor = platformCatalog.find((item) => item.id === activeCredentialPlatform) || platformCatalog[0];

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -124,9 +124,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
     // force a fallback platform into the enabled set.
     const normalized = selected;
     const resolvedPrimary = normalized.includes(primary) ? primary : (normalized[0] ?? '');
-    const nextData = {
-      ...credentialDraft,
-      discord_client_id: credentialDraft.discord?.client_id || '',
+    const selectionData = {
       platform: resolvedPrimary,
       platforms: {
         enabled: normalized,
@@ -135,11 +133,16 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
     };
 
     if (isPage && onSave) {
+      const nextData = {
+        ...credentialDraft,
+        discord_client_id: credentialDraft.discord?.client_id || '',
+        ...selectionData,
+      };
       await onSave(nextData);
       return;
     }
 
-    onNext(nextData);
+    onNext(selectionData);
   };
 
   const activeDescriptor = platformCatalog.find((item) => item.id === activeCredentialPlatform) || platformCatalog[0];

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -732,6 +732,7 @@
     "selectedSummary": "{{count}} selected",
     "apply": "Apply",
     "applyHint": "Apply updates to the credential tabs below, disabled platforms keep saved tokens.",
+    "configureBeforeEnable": "Configure and save this platform before enabling it.",
     "applyingConfig": "Applying configuration...",
     "restartingService": "Restarting service to apply changes...",
     "restartedSuccess": "Configuration applied and service restarted",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -732,6 +732,7 @@
     "selectedSummary": "已选择 {{count}} 个",
     "apply": "应用",
     "applyHint": "应用下方凭证标签的更新；未启用平台仍会保留已保存凭证。",
+    "configureBeforeEnable": "请先配置并保存该平台，再启用它。",
     "applyingConfig": "正在应用配置...",
     "restartingService": "正在重启服务以使配置生效...",
     "restartedSuccess": "配置已应用，服务已重启",

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -211,5 +211,12 @@ export const platformHasCredentials = (data: any, platform: string): boolean => 
   return credentialFields.every((field) => !!platformConfig?.[field] || !!platformConfig?.[`has_${field}`]);
 };
 
+export const platformHasRunnableConfig = (data: any, platform: string): boolean => {
+  if (platform === 'slack') {
+    return platformHasCredentials(data, platform) && (!!data?.slack?.app_token || !!data?.slack?.has_app_token);
+  }
+  return platformHasCredentials(data, platform);
+};
+
 export const hasConfiguredPlatformCredentials = (data: any): boolean =>
-  getEnabledPlatforms(data).some((platform) => platformHasCredentials(data, platform));
+  getEnabledPlatforms(data).some((platform) => platformHasRunnableConfig(data, platform));

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -212,9 +212,6 @@ export const platformHasCredentials = (data: any, platform: string): boolean => 
 };
 
 export const platformHasRunnableConfig = (data: any, platform: string): boolean => {
-  if (platform === 'slack') {
-    return platformHasCredentials(data, platform) && (!!data?.slack?.app_token || !!data?.slack?.has_app_token);
-  }
   return platformHasCredentials(data, platform);
 };
 

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -212,6 +212,9 @@ export const platformHasCredentials = (data: any, platform: string): boolean => 
 };
 
 export const platformHasRunnableConfig = (data: any, platform: string): boolean => {
+  if (platform === 'wechat') {
+    return true;
+  }
   return platformHasCredentials(data, platform);
 };
 

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -213,7 +213,7 @@ export const platformHasCredentials = (data: any, platform: string): boolean => 
 
 export const platformHasRunnableConfig = (data: any, platform: string): boolean => {
   if (platform === 'wechat') {
-    return true;
+    return Boolean(data?.wechat);
   }
   return platformHasCredentials(data, platform);
 };

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -674,6 +674,17 @@ def _runtime_credential_fields_for_platform(platform: str) -> tuple[str, ...]:
     return get_platform_descriptor(platform).credential_fields
 
 
+def _payload_edits_runtime_credential(section: dict, field: str, base_value: object) -> bool:
+    if field not in section:
+        return False
+    value = section.get(field)
+    if value == base_value:
+        return False
+    if not value and section.get(f"has_{field}") is True:
+        return False
+    return True
+
+
 def _platforms_requiring_runtime_credential_validation(
     config: V2Config,
     payload: dict,
@@ -696,7 +707,15 @@ def _platforms_requiring_runtime_credential_validation(
             continue
         descriptor = get_platform_descriptor(platform)
         section = payload.get(descriptor.config_key)
-        if isinstance(section, dict) and any(field in section for field in required_fields):
+        base_platform_config = descriptor.get_config(base_config) if base_config is not None else None
+        if isinstance(section, dict) and any(
+            _payload_edits_runtime_credential(
+                section,
+                field,
+                getattr(base_platform_config, field, None),
+            )
+            for field in required_fields
+        ):
             platforms.add(platform)
     return platforms
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -31,6 +31,7 @@ from config.v2_settings import (
     routing_to_compat_dict,
 )
 from config.v2_sessions import SessionsStore
+from config.platform_registry import get_platform_descriptor
 from vibe.opencode_config import (
     get_opencode_config_paths,
     load_first_opencode_user_config,
@@ -79,6 +80,12 @@ _PLATFORM_SECRET_FIELDS: dict[str, tuple[str, ...]] = {
     "wechat": ("bot_token",),
 }
 _GATEWAY_SECRET_FIELDS = ("workspace_token", "client_secret")
+_PLATFORM_RUNTIME_CREDENTIAL_FIELDS: dict[str, tuple[str, ...]] = {
+    "slack": ("bot_token", "app_token"),
+    "discord": ("bot_token",),
+    "telegram": ("bot_token",),
+    "lark": ("app_id", "app_secret"),
+}
 
 
 def _parse_agent_import_file(path: Path, *, backend: str):
@@ -667,6 +674,27 @@ def _mark_explicit_audio_asr_enabled(payload: dict) -> dict:
     return {**payload, "audio_asr": {**audio_asr, "enabled_configured": True}}
 
 
+def _validate_enabled_platform_runtime_credentials(config: V2Config) -> None:
+    """Reject enabled IM transports that cannot start after config save.
+
+    ``V2Config.from_payload`` intentionally allows empty credential fields so
+    users can save setup drafts for disabled platforms. Once a platform enters
+    ``platforms.enabled``, however, the running adapter must be able to boot.
+    WeChat is the existing exception: its runtime idles without a token while
+    the QR-login flow completes.
+    """
+    for platform in config.platforms.enabled:
+        required_fields = _PLATFORM_RUNTIME_CREDENTIAL_FIELDS.get(platform)
+        if not required_fields:
+            continue
+        descriptor = get_platform_descriptor(platform)
+        platform_config = descriptor.get_config(config)
+        missing = [field for field in required_fields if not getattr(platform_config, field, None)]
+        if missing:
+            fields_text = "', '".join(f"{descriptor.config_key}.{field}" for field in missing)
+            raise ValueError(f"Config '{fields_text}' must be provided when {platform} is enabled")
+
+
 def save_config(payload: dict) -> V2Config:
     if not isinstance(payload, dict):
         raise ValueError("Config payload must be an object")
@@ -708,6 +736,7 @@ def save_config(payload: dict) -> V2Config:
         merged_payload = _merge_legacy_discord_guild_scope_fields(merged_payload, payload, base_config)
         sanitized_payload, guild_scope_update = _extract_settings_scopes_from_config_payload(merged_payload)
         config = V2Config.from_payload(sanitized_payload)
+        _validate_enabled_platform_runtime_credentials(config)
         if guild_scope_update is not None:
             _save_discord_guild_scope_update(*guild_scope_update)
         elif base_config is not None:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -80,12 +80,6 @@ _PLATFORM_SECRET_FIELDS: dict[str, tuple[str, ...]] = {
     "wechat": ("bot_token",),
 }
 _GATEWAY_SECRET_FIELDS = ("workspace_token", "client_secret")
-_PLATFORM_RUNTIME_CREDENTIAL_FIELDS: dict[str, tuple[str, ...]] = {
-    "slack": ("bot_token", "app_token"),
-    "discord": ("bot_token",),
-    "telegram": ("bot_token",),
-    "lark": ("app_id", "app_secret"),
-}
 
 
 def _parse_agent_import_file(path: Path, *, backend: str):
@@ -674,6 +668,12 @@ def _mark_explicit_audio_asr_enabled(payload: dict) -> dict:
     return {**payload, "audio_asr": {**audio_asr, "enabled_configured": True}}
 
 
+def _runtime_credential_fields_for_platform(platform: str) -> tuple[str, ...]:
+    if platform == "wechat":
+        return ()
+    return get_platform_descriptor(platform).credential_fields
+
+
 def _platforms_requiring_runtime_credential_validation(
     config: V2Config,
     payload: dict,
@@ -691,7 +691,7 @@ def _platforms_requiring_runtime_credential_validation(
     # If a save edits credential fields for an already-enabled platform, reject
     # partial clears or mismatched edits before they are persisted.
     for platform in enabled:
-        required_fields = _PLATFORM_RUNTIME_CREDENTIAL_FIELDS.get(platform)
+        required_fields = _runtime_credential_fields_for_platform(platform)
         if not required_fields:
             continue
         descriptor = get_platform_descriptor(platform)
@@ -715,7 +715,7 @@ def _validate_enabled_platform_runtime_credentials(
     the QR-login flow completes.
     """
     for platform in _platforms_requiring_runtime_credential_validation(config, payload, base_config):
-        required_fields = _PLATFORM_RUNTIME_CREDENTIAL_FIELDS.get(platform)
+        required_fields = _runtime_credential_fields_for_platform(platform)
         if not required_fields:
             continue
         descriptor = get_platform_descriptor(platform)

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -674,7 +674,38 @@ def _mark_explicit_audio_asr_enabled(payload: dict) -> dict:
     return {**payload, "audio_asr": {**audio_asr, "enabled_configured": True}}
 
 
-def _validate_enabled_platform_runtime_credentials(config: V2Config) -> None:
+def _platforms_requiring_runtime_credential_validation(
+    config: V2Config,
+    payload: dict,
+    base_config: Optional[V2Config],
+) -> set[str]:
+    enabled = set(config.platforms.enabled)
+    previous_enabled = set(base_config.platforms.enabled) if base_config is not None else set()
+    platforms = enabled - previous_enabled if "platforms" in payload or "platform" in payload else set()
+
+    # Finishing setup promotes the saved config to a runnable runtime config, so
+    # every enabled adapter must be bootable at that boundary.
+    if payload.get("setup_completed") is True:
+        platforms.update(enabled)
+
+    # If a save edits credential fields for an already-enabled platform, reject
+    # partial clears or mismatched edits before they are persisted.
+    for platform in enabled:
+        required_fields = _PLATFORM_RUNTIME_CREDENTIAL_FIELDS.get(platform)
+        if not required_fields:
+            continue
+        descriptor = get_platform_descriptor(platform)
+        section = payload.get(descriptor.config_key)
+        if isinstance(section, dict) and any(field in section for field in required_fields):
+            platforms.add(platform)
+    return platforms
+
+
+def _validate_enabled_platform_runtime_credentials(
+    config: V2Config,
+    payload: dict,
+    base_config: Optional[V2Config],
+) -> None:
     """Reject enabled IM transports that cannot start after config save.
 
     ``V2Config.from_payload`` intentionally allows empty credential fields so
@@ -683,7 +714,7 @@ def _validate_enabled_platform_runtime_credentials(config: V2Config) -> None:
     WeChat is the existing exception: its runtime idles without a token while
     the QR-login flow completes.
     """
-    for platform in config.platforms.enabled:
+    for platform in _platforms_requiring_runtime_credential_validation(config, payload, base_config):
         required_fields = _PLATFORM_RUNTIME_CREDENTIAL_FIELDS.get(platform)
         if not required_fields:
             continue
@@ -736,7 +767,7 @@ def save_config(payload: dict) -> V2Config:
         merged_payload = _merge_legacy_discord_guild_scope_fields(merged_payload, payload, base_config)
         sanitized_payload, guild_scope_update = _extract_settings_scopes_from_config_payload(merged_payload)
         config = V2Config.from_payload(sanitized_payload)
-        _validate_enabled_platform_runtime_credentials(config)
+        _validate_enabled_platform_runtime_credentials(config, payload, base_config)
         if guild_scope_update is not None:
             _save_discord_guild_scope_update(*guild_scope_update)
         elif base_config is not None:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2195,7 +2195,11 @@ def config_post():
     should_reconcile_remote_access = False
     with CONFIG_LOCK:
         previous_config = _load_remote_access_config() if "remote_access" in payload else None
-        config = api.save_config(payload)
+        try:
+            config = api.save_config(payload)
+        except ValueError as exc:
+            message = str(exc)
+            return jsonify({"ok": False, "error": message, "message": message}), 400
         if _remote_access_settings_changed(previous_config, config, payload):
             if _should_rotate_remote_session_secret(previous_config, config, payload):
                 remote_access.rotate_session_secret(config)


### PR DESCRIPTION
## Summary
- fix Settings -> Platforms so disabled IM platforms still expose their credential setup cards
- keep wizard platform selection as draft state, and persist wizard intermediate config with only platforms that already have runnable credentials
- enforce `/api/config` runtime credential validation for newly enabled platforms, setup completion, and real credential edits on already-enabled platforms, returning a 400 JSON error instead of saving a broken runtime config
- preserve unrelated config saves for legacy installs that already contain an enabled platform with missing credentials

## Affected areas
- `GET/POST /api/config`: blocks direct API callers from enabling Slack, Discord, Telegram, or Lark without required runtime credentials while still allowing unrelated/redacted round-trip edits to existing legacy configs
- Settings -> Platforms: separates credential setup from runtime enablement, persists Discord guild choices before auto-enable, and keeps WeChat enablement valid before QR token completion
- Setup Wizard: full platform choice stays in frontend state, intermediate credential-step saves enable only configured platforms, and final Summary persists the complete enabled set

## Verification
- `uv run pytest tests/test_api_save_config_merge.py tests/test_remote_access_vibe_cloud.py tests/test_ui_server_mutation_protection.py tests/test_ui_remote_access_auth.py` (204 passed)
- `uv run ruff check vibe/api.py vibe/ui_server.py tests/test_api_save_config_merge.py tests/test_ui_server_mutation_protection.py`
- `npm run build` in `ui/`
- `git diff --check`

## Notes
- WeChat remains excluded from runtime credential enforcement because its QR-login flow can legitimately idle before a token exists.
- Slack runtime credential checks follow the shared platform registry: `bot_token` is required, while `app_token` remains optional Socket Mode configuration.
- `npm run build` still reports the existing Vite chunk-size warning.
