### PR TITLE
fix(claude): disable sandbox for remote sessions

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -917,8 +917,8 @@ class AgentAuthService:
             force_oauth=True,
         )
 
-        should_force_sandbox = getattr(session_handler, "_should_force_claude_sandbox", None)
-        if callable(should_force_sandbox) and should_force_sandbox():
+        should_mark_isolated = getattr(session_handler, "_should_mark_claude_isolated_env", None)
+        if callable(should_mark_isolated) and should_mark_isolated():
             claude_env["IS_SANDBOX"] = "1"
 
         option_kwargs = {

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 CLAUDE_NO_CONVERSATION_RE = re.compile(r"No conversation found with session ID:\s*(\S+)")
 CLAUDE_REMOTE_DISALLOWED_TOOLS = ["AskUserQuestion", "EnterPlanMode", "ExitPlanMode"]
 CLAUDE_REMOTE_PERMISSION_MODE = "bypassPermissions"
+CLAUDE_REMOTE_SANDBOX = {"enabled": False}
 
 
 class ClaudeSessionNotFoundError(RuntimeError):
@@ -399,7 +400,7 @@ class SessionHandler(BaseHandler):
         geteuid = getattr(os, "geteuid", None)
         return bool(geteuid and geteuid() == 0)
 
-    def _should_force_claude_sandbox(self) -> bool:
+    def _should_mark_claude_isolated_env(self) -> bool:
         if os.environ.get("IS_SANDBOX"):
             return False
         return self._running_as_root()
@@ -784,9 +785,9 @@ class SessionHandler(BaseHandler):
         from vibe.claude_config import build_claude_subprocess_env
 
         claude_env = build_claude_subprocess_env(getattr(self.config, "claude", None))
-        if self._should_force_claude_sandbox():
+        if self._should_mark_claude_isolated_env():
             claude_env["IS_SANDBOX"] = "1"
-            logger.info("Detected Claude bypassPermissions running as root; forcing IS_SANDBOX=1 for Claude subprocess")
+            logger.info("Detected Claude bypassPermissions running as root; marking Claude subprocess as isolated")
 
         option_kwargs: Dict[str, Any] = {
             "permission_mode": CLAUDE_REMOTE_PERMISSION_MODE,
@@ -795,6 +796,7 @@ class SessionHandler(BaseHandler):
             "resume": stored_claude_session_id if stored_claude_session_id else None,
             "extra_args": extra_args,
             "setting_sources": ["user", "project", "local"],  # Load all setting sources (user, project CLAUDE.md, local overrides)
+            "sandbox": CLAUDE_REMOTE_SANDBOX,
             # Disable interactive-only Claude Code tools that remote IM sessions
             # cannot answer programmatically.
             "disallowed_tools": CLAUDE_REMOTE_DISALLOWED_TOOLS,

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -605,6 +605,7 @@ def test_session_handler_forces_bypass_mode_and_auto_approves_claude_tool_permis
 
     assert captured["connected"] is True
     assert captured["options"].permission_mode == "bypassPermissions"
+    assert captured["options"].sandbox == {"enabled": False}
     assert result.behavior == "allow"
 
 

--- a/tests/test_claude_container_sandbox.py
+++ b/tests/test_claude_container_sandbox.py
@@ -41,28 +41,28 @@ class _Controller:
         return f"{getattr(context, 'platform', None) or 'test'}::{self._get_settings_key(context)}"
 
 
-def test_force_claude_sandbox_in_root_container(monkeypatch) -> None:
+def test_mark_claude_isolated_env_in_root_container(monkeypatch) -> None:
     monkeypatch.delenv("IS_SANDBOX", raising=False)
     monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
 
     handler = SessionHandler(_Controller())
 
-    assert handler._should_force_claude_sandbox() is True
+    assert handler._should_mark_claude_isolated_env() is True
 
 
-def test_skip_forced_sandbox_when_env_already_set(monkeypatch) -> None:
+def test_skip_isolated_env_marker_when_env_already_set(monkeypatch) -> None:
     monkeypatch.setenv("IS_SANDBOX", "1")
     monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
 
     handler = SessionHandler(_Controller())
 
-    assert handler._should_force_claude_sandbox() is False
+    assert handler._should_mark_claude_isolated_env() is False
 
 
-def test_skip_forced_sandbox_when_not_root(monkeypatch) -> None:
+def test_skip_isolated_env_marker_when_not_root(monkeypatch) -> None:
     monkeypatch.delenv("IS_SANDBOX", raising=False)
     monkeypatch.setattr(os, "geteuid", lambda: 501, raising=False)
 
     handler = SessionHandler(_Controller())
 
-    assert handler._should_force_claude_sandbox() is False
+    assert handler._should_mark_claude_isolated_env() is False


### PR DESCRIPTION
## Summary
- force Avibe-created Claude Code sessions to pass `sandbox: { enabled: false }` through `ClaudeAgentOptions`
- keep `bypassPermissions` and the auto-allow permission callback for remote IM autonomy
- rename the root/container `IS_SANDBOX` helper so it is treated as an isolated-environment marker, not the Claude Bash sandbox switch

## Evidence
- Unit: `uv run pytest tests/test_claude_cli_path.py tests/test_claude_container_sandbox.py tests/test_agent_auth_service.py`
- Contract: not applicable
- Scenario: not applicable
- Residual manual checks: verified `claude-agent-sdk` builds `--settings {"sandbox":{"enabled":false}}` from the SDK option

## Risk
- Existing root/container support is preserved; only Claude Code Bash sandboxing is explicitly disabled for remote sessions.
