### PR TITLE
fix(ui): stop a session's draft leaking into the next session on direct switch

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -875,7 +875,15 @@ export const ChatPage: React.FC = () => {
     return <ChatMissing onBack={goBack} />;
   }
 
-  if (loading && !session) {
+  // A direct session→session switch re-renders this SAME ChatPage instance with
+  // the new :sessionId while every piece of state still belongs to the PREVIOUS
+  // session — the reset effect only clears it after this render commits.
+  // Rendering the chat body in those mismatch frames leaks the old session under
+  // the new route: the composer remounts (key change) seeded with the OLD
+  // session's draft and its seed-change would be persisted under the NEW
+  // session id. Treat the mismatch as loading so nothing of the old session
+  // ever mounts under the new route.
+  if ((loading && !session) || (session && session.id !== sessionId)) {
     return (
       <div className="flex h-[60vh] flex-col items-center justify-center gap-2 text-muted">
         <Loader2 className="size-5 animate-spin" />

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -567,10 +567,14 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             // (a session), mirroring the picker + drag-drop. uploadFiles itself
             // no-ops without a session, so this gate is also defense in depth.
             onPasteFiles={mediaEnabled ? (files) => void uploadFiles(files) : undefined}
-            onChange={(text, references) => {
+            onChange={(text, references, isDraftSeed) => {
               setValue(text);
               referencesRef.current = references;
-              onDraftChange?.(text);
+              // A mount-time draft RESTORE is not a user edit: re-persisting it
+              // is at best a redundant write, and under a stale-props remount it
+              // would save the previous session's draft under this session id
+              // (mirrors the plain-textarea path, whose seeding never saves).
+              if (!isDraftSeed) onDraftChange?.(text);
             }}
             onSubmit={submit}
           />

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -64,7 +64,10 @@ export interface MentionEditorProps {
   /** Seed once (saved draft). Markers in the seed restore as plain text in v1. */
   initialText?: string | null;
   className?: string;
-  onChange: (text: string, references: MentionReference[]) => void;
+  /** ``isDraftSeed`` flags the change produced by the mount-time draft seed
+   *  (BootstrapPlugin), so callers can mirror the value without treating the
+   *  restore as a user edit (e.g. skip re-persisting it as a draft). */
+  onChange: (text: string, references: MentionReference[], isDraftSeed?: boolean) => void;
   onSubmit: () => void;
   onSearchAgents: (query: string) => Promise<AgentSearchResult[]>;
   onSearchSessions: (query: string) => Promise<SessionSearchResult[]>;
@@ -206,6 +209,10 @@ function PasteFilesPlugin({ onPasteFiles }: { onPasteFiles?: (files: File[]) => 
   return null;
 }
 
+// Update tag for the mount-time draft seed, so OnChange can tell "restored a
+// saved draft" apart from a real user edit (restoring must not re-persist).
+const DRAFT_SEED_TAG = 'avibe-draft-seed';
+
 function BootstrapPlugin({
   autoFocus,
   initialText,
@@ -255,16 +262,20 @@ function BootstrapPlugin({
       if (autoFocus && !isTouchCapableDevice()) editor.focus();
       return;
     }
-    editor.update(() => {
-      const root = $getRoot();
-      root.clear();
-      const paragraph = $createParagraphNode();
-      root.append(paragraph);
-      // v1: a restored draft seeds as plain text (markers render raw until
-      // re-picked); the content is lossless for sending. Insert the raw draft so
-      // intentional leading/trailing whitespace survives the round-trip.
-      paragraph.selectStart().insertText(raw);
-    });
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const paragraph = $createParagraphNode();
+        root.append(paragraph);
+        // v1: a restored draft seeds as plain text (markers render raw until
+        // re-picked); the content is lossless for sending. Insert the raw draft so
+        // intentional leading/trailing whitespace survives the round-trip.
+        paragraph.selectStart().insertText(raw);
+      },
+      // Tagged so OnChange reports this as a seed, not a user edit.
+      { tag: DRAFT_SEED_TAG },
+    );
     if (autoFocus && !isTouchCapableDevice()) editor.focus();
     // Only on mount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -373,9 +384,9 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
   const menuOpenRef = useRef(false);
 
   const handleChange = useCallback(
-    (state: EditorState) => {
+    (state: EditorState, _editor: unknown, tags: Set<string>) => {
       const { text, references } = serializeEditorState(state);
-      onChange(text, references);
+      onChange(text, references, tags.has(DRAFT_SEED_TAG));
     },
     [onChange],
   );


### PR DESCRIPTION
## Capability

**Composer draft persistence across session switches.** Switching directly from chat A (with a server-loaded draft) to chat B sometimes showed A's draft in B's composer and persisted it as B's draft.

Root cause chain: ChatPage is reused across the route's `:sessionId` swap and resets its state in an effect — one render late. In that stale render the composer remounts (`key={sessionId}`) with `initialDraft` still holding A's draft; MentionEditor's `BootstrapPlugin` seeds `initialText` on mount; the seed fires Lexical OnChange → `onDraftChange` tags the pending save with the CURRENT session id (already B) → the 600ms debounce persists A's text as B's draft.

Two layers:

- **ChatPage loading gate** also treats `session.id !== sessionId` as loading, so nothing of the old session (composer seed, transcript flash) ever mounts under the new route during the mismatch frames.
- **The draft seed is not a user edit**: the mount-time seed update carries a Lexical update tag, surfaces as `isDraftSeed` in `MentionEditor.onChange`, and Composer mirrors the value but skips `onDraftChange` — parity with the plain-textarea path, whose seeding never saves.

## Evidence layers

- **Unit**: no UI unit-test infra; verified by `npm run build` (tsc + vite).
- **Contract**: no API changes (`MentionEditor.onChange` gains an optional third param; sole consumer updated in the same commit).
- **Scenario**: no scenario catalog covers the Web composer; none updated.
- **Residual manual checks**: load a session with a saved draft → switch directly to another session → the other session's composer stays empty and its server draft is untouched; typing / voice append / clear-after-send / failed-send restore still persist as before.

## Review

Cross-model reviewed by Codex: NO FINDINGS. Verified Lexical 0.45 `editor.update({tag})` + `OnChangePlugin` tags param against the installed tree, checked the loading gate for any legit `session.id !== sessionId` state that could spin forever, and confirmed all draft flows that must save still do.