### PR TITLE
feat(cli): agent run sessions follow the invocation cwd; fix codex stale-cwd transport cache

### DIFF
--- a/core/services/sessions.py
+++ b/core/services/sessions.py
@@ -119,6 +119,7 @@ def reserve_agent_session(
     agent_name: Optional[str] = None,
     model: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    workdir: Optional[str] = None,
     db_path: Optional[Path] = None,
 ) -> Optional[str]:
     """Reserve a new ``agent_sessions`` row keyed by an IM-style scope.
@@ -138,6 +139,7 @@ def reserve_agent_session(
             agent_name=agent_name,
             model=model,
             reasoning_effort=reasoning_effort,
+            workdir=workdir,
         )
     finally:
         service.close()
@@ -152,6 +154,7 @@ def reserve_private_agent_session(
     agent_name: Optional[str] = None,
     model: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    workdir: Optional[str] = None,
     db_path: Optional[Path] = None,
 ) -> Optional[str]:
     """Reserve a private (no IM scope) session, e.g. when ``vibe agent run``
@@ -169,6 +172,7 @@ def reserve_private_agent_session(
             agent_name=agent_name,
             model=model,
             reasoning_effort=reasoning_effort,
+            workdir=workdir,
         )
     finally:
         service.close()

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -57,6 +58,13 @@ class CodexAgent(BaseAgent):
         self._transports: Dict[str, CodexTransport] = {}
         self._transport_locks: Dict[str, asyncio.Lock] = {}
         self._transport_last_activity: Dict[str, float] = {}
+        # cwd inode at app-server spawn time, keyed like ``_transports``. A
+        # cached app-server whose directory was deleted (even if re-created
+        # with the same path) sits in a dead inode and fails every
+        # ``thread/start`` with a misleading "failed to load configuration:
+        # No such file or directory" (#561); the inode comparison detects
+        # that staleness BEFORE paying a failed RPC.
+        self._transport_cwd_inodes: Dict[str, Optional[int]] = {}
 
         self._session_mgr = CodexSessionManager()
         self._turn_registry = CodexTurnRegistry()
@@ -415,6 +423,7 @@ class CodexAgent(BaseAgent):
 
                 self._transports.pop(cwd, None)
                 self._transport_last_activity.pop(cwd, None)
+                self._cwd_inodes().pop(cwd, None)
 
                 for base_session_id in list(self._session_mgr.sessions_for_cwd(cwd)):
                     # Keep the persisted thread mapping so a later transport restart
@@ -443,6 +452,11 @@ class CodexAgent(BaseAgent):
                 "transport is not available",
                 "stdout closed",
                 "timed out after 120s",
+                # codex resolves configuration against its process cwd at
+                # thread/start; a cwd deleted out from under the app-server
+                # surfaces as this RPC error (#561). A restart respawns the
+                # process in the (re-created) directory.
+                "failed to load configuration",
             )
         )
 
@@ -460,6 +474,7 @@ class CodexAgent(BaseAgent):
             if current is transport:
                 self._transports.pop(cwd, None)
                 self._transport_last_activity.pop(cwd, None)
+                self._cwd_inodes().pop(cwd, None)
             try:
                 await transport.stop()
             except Exception as exc:
@@ -487,8 +502,19 @@ class CodexAgent(BaseAgent):
             # Double-check after acquiring lock
             existing = self._transports.get(cwd)
             if existing and existing.is_initialized:
-                self._touch_transport_activity(cwd)
-                return existing
+                # Reuse only while the directory the app-server was spawned in
+                # is still the SAME directory (#561): after a delete (+ possible
+                # re-create) the cached process sits in a dead inode and every
+                # thread/start fails. Untracked legacy entries reuse as before.
+                spawned_ino = self._cwd_inodes().get(cwd)
+                stale_cwd = spawned_ino is not None and self._cwd_inode(cwd) != spawned_ino
+                if not stale_cwd:
+                    self._touch_transport_activity(cwd)
+                    return existing
+                logger.warning(
+                    "Codex transport cwd was replaced under the cached app-server; restarting transport for cwd=%s",
+                    cwd,
+                )
 
             # Stop stale transport if any
             if existing:
@@ -520,6 +546,7 @@ class CodexAgent(BaseAgent):
 
             await transport.start()
             self._transports[cwd] = transport
+            self._cwd_inodes()[cwd] = self._cwd_inode(cwd)
             self._touch_transport_activity(cwd)
             return transport
 
@@ -1044,6 +1071,18 @@ class CodexAgent(BaseAgent):
                 logger.debug("Could not delete ack message: %s", err)
             finally:
                 request.ack_message_id = None
+
+    def _cwd_inodes(self) -> Dict[str, Optional[int]]:
+        if not hasattr(self, "_transport_cwd_inodes"):
+            self._transport_cwd_inodes = {}
+        return self._transport_cwd_inodes
+
+    @staticmethod
+    def _cwd_inode(cwd: str) -> Optional[int]:
+        try:
+            return os.stat(cwd).st_ino
+        except OSError:
+            return None
 
     def _touch_transport_activity(self, cwd: str) -> None:
         if not hasattr(self, "_transport_last_activity"):

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -152,6 +152,7 @@ class SQLiteSessionsService:
         agent_name: str | None = None,
         model: str | None = None,
         reasoning_effort: str | None = None,
+        workdir: str | None = None,
     ) -> str | None:
         now = _utc_now_iso()
         backend = str(agent_backend or "default")
@@ -170,6 +171,9 @@ class SQLiteSessionsService:
                 agent_name=agent_name,
                 model=model,
                 reasoning_effort=reasoning_effort,
+                # Explicit caller workdir (e.g. the CLI's invocation cwd) wins;
+                # None keeps the scope-settings snapshot fallback.
+                workdir=workdir,
                 metadata={"legacy_scope_key": str(scope_key)},
                 now=now,
                 require_workdir=False,
@@ -185,6 +189,7 @@ class SQLiteSessionsService:
         agent_name: str | None = None,
         model: str | None = None,
         reasoning_effort: str | None = None,
+        workdir: str | None = None,
     ) -> str:
         now = _utc_now_iso()
         platform_key = str(platform or "slack").strip() or "slack"
@@ -216,6 +221,7 @@ class SQLiteSessionsService:
                 agent_name=agent_name,
                 model=model,
                 reasoning_effort=reasoning_effort,
+                workdir=workdir,
                 metadata={"legacy_scope_key": scope_key, **metadata_payload},
                 now=now,
                 require_workdir=False,

--- a/tests/test_cli_agent_run_schema.py
+++ b/tests/test_cli_agent_run_schema.py
@@ -180,3 +180,123 @@ def test_agent_run_callback_session_requires_async(capsys) -> None:
     captured = capsys.readouterr()
     payload = json.loads(captured.out or captured.err)
     assert payload["code"] == "callback_requires_async"
+
+
+def _read_session_workdir(db_path: Path, session_id: str):
+    from sqlalchemy import select
+
+    from storage.db import create_sqlite_engine
+    from storage.models import agent_sessions
+
+    engine = create_sqlite_engine(db_path)
+    with engine.connect() as conn:
+        return conn.execute(
+            select(agent_sessions.c.workdir).where(agent_sessions.c.id == session_id)
+        ).scalar_one()
+
+
+def test_agent_run_private_session_workdir_follows_invocation_cwd(tmp_path: Path, capsys, monkeypatch) -> None:
+    """A private (no --deliver-key) reservation snapshots the CLI invocation's
+    cwd as the new session's workdir — like every other CLI tool — instead of
+    leaving it blank and falling to the global default cwd at dispatch."""
+
+    import os
+
+    from storage.importer import ensure_sqlite_state
+
+    state_home = tmp_path / "home"
+    invoke_dir = tmp_path / "repo"
+    invoke_dir.mkdir()
+    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+        ensure_sqlite_state()
+        db_path = state_home / "state" / "vibe.sqlite"
+        agent_store = cli.VibeAgentStore(db_path)
+        agent_store.create(name="worker", backend="codex")
+        request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
+        args = _parse_agent_run(["--agent", "worker", "--async", "--message", "hi"])
+        monkeypatch.chdir(invoke_dir)
+        expected = os.getcwd()
+
+        with (
+            patch("vibe.cli._agent_store", return_value=agent_store),
+            patch("vibe.cli._task_request_store", return_value=request_store),
+            patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+            patch("vibe.cli._primary_platform", return_value="slack"),
+        ):
+            result = cli.cmd_agent_run(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert _read_session_workdir(db_path, payload["session_id"]) == expected
+
+
+def test_agent_run_explicit_cwd_wins(tmp_path: Path, capsys, monkeypatch) -> None:
+    from storage.importer import ensure_sqlite_state
+
+    state_home = tmp_path / "home"
+    invoke_dir = tmp_path / "repo"
+    invoke_dir.mkdir()
+    picked_dir = tmp_path / "elsewhere"
+    picked_dir.mkdir()
+    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+        ensure_sqlite_state()
+        db_path = state_home / "state" / "vibe.sqlite"
+        agent_store = cli.VibeAgentStore(db_path)
+        agent_store.create(name="worker", backend="codex")
+        request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
+        args = _parse_agent_run(
+            ["--agent", "worker", "--cwd", str(picked_dir), "--async", "--message", "hi"]
+        )
+        monkeypatch.chdir(invoke_dir)
+
+        with (
+            patch("vibe.cli._agent_store", return_value=agent_store),
+            patch("vibe.cli._task_request_store", return_value=request_store),
+            patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+            patch("vibe.cli._primary_platform", return_value="slack"),
+        ):
+            result = cli.cmd_agent_run(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert _read_session_workdir(db_path, payload["session_id"]) == str(picked_dir)
+
+
+def test_agent_run_cwd_must_exist(tmp_path: Path, capsys) -> None:
+    args = _parse_agent_run(
+        ["--agent", "worker", "--create-session", "--cwd", str(tmp_path / "missing"), "--async", "--message", "hi"]
+    )
+
+    result = cli.cmd_agent_run(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out or captured.err)
+    assert payload["code"] == "cwd_not_found"
+
+
+def test_agent_run_cwd_rejected_with_existing_session(capsys) -> None:
+    """An existing session keeps its own workdir — --cwd cannot re-route it."""
+
+    args = _parse_agent_run(["--session-id", "ses123", "--cwd", "/tmp", "--async", "--message", "hi"])
+
+    result = cli.cmd_agent_run(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out or captured.err)
+    assert payload["code"] == "cwd_with_existing_session"
+
+
+def test_resolve_run_cwd_deliver_key_defers_to_scope(monkeypatch, tmp_path: Path) -> None:
+    """Without --cwd, a --deliver-key reservation returns None so the target
+    scope's configured workdir snapshot stays authoritative; an explicit --cwd
+    still wins."""
+
+    from types import SimpleNamespace
+
+    monkeypatch.chdir(tmp_path)
+    args = SimpleNamespace(cwd=None, deliver_key="slack::channel::C123")
+    assert cli._resolve_run_cwd(args, session_policy="create", help_command="x") is None
+    args = SimpleNamespace(cwd=str(tmp_path), deliver_key="slack::channel::C123")
+    assert cli._resolve_run_cwd(args, session_policy="create", help_command="x") == str(tmp_path)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1761,5 +1761,86 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class CodexTransportCwdStalenessTests(unittest.IsolatedAsyncioTestCase):
+    """#561: a cached app-server whose spawn directory was deleted (and possibly
+    re-created at the same path) sits in a dead inode and fails every
+    thread/start with "failed to load configuration"."""
+
+    def _agent(self):
+        agent = object.__new__(CodexAgent)
+        agent._transports = {}
+        agent._transport_locks = {}
+        agent._transport_last_activity = {}
+        agent._transport_cwd_inodes = {}
+        agent._session_locks = {}
+        agent._session_mgr = SimpleNamespace(sessions_for_cwd=lambda cwd: [])
+        agent.codex_config = SimpleNamespace(binary="codex", extra_args=[])
+        return agent
+
+    async def test_cached_transport_evicted_when_cwd_inode_changes(self):
+        import tempfile
+
+        agent = self._agent()
+        with tempfile.TemporaryDirectory() as cwd:
+            stale = SimpleNamespace(is_initialized=True, stop=AsyncMock())
+            agent._transports[cwd] = stale
+            # Simulate "spawned in a directory that was since replaced": the
+            # recorded spawn-time inode differs from the current one.
+            agent._transport_cwd_inodes[cwd] = os.stat(cwd).st_ino + 1
+
+            fresh = SimpleNamespace(
+                is_initialized=True,
+                start=AsyncMock(),
+                on_notification=Mock(),
+                on_server_request=Mock(),
+            )
+            with patch.object(_MODULE, "CodexTransport", return_value=fresh):
+                result = await agent._get_or_create_transport(cwd)
+
+            stale.stop.assert_awaited_once()
+            self.assertIs(result, fresh)
+            fresh.start.assert_awaited_once()
+            # The new spawn re-records the CURRENT inode.
+            self.assertEqual(agent._transport_cwd_inodes[cwd], os.stat(cwd).st_ino)
+
+    async def test_cached_transport_reused_while_cwd_unchanged(self):
+        import tempfile
+
+        agent = self._agent()
+        with tempfile.TemporaryDirectory() as cwd:
+            cached = SimpleNamespace(is_initialized=True, stop=AsyncMock())
+            agent._transports[cwd] = cached
+            agent._transport_cwd_inodes[cwd] = os.stat(cwd).st_ino
+
+            with patch.object(_MODULE, "CodexTransport") as ctor:
+                result = await agent._get_or_create_transport(cwd)
+
+            self.assertIs(result, cached)
+            cached.stop.assert_not_awaited()
+            ctor.assert_not_called()
+
+    async def test_untracked_legacy_entry_reuses_without_inode(self):
+        import tempfile
+
+        agent = self._agent()
+        with tempfile.TemporaryDirectory() as cwd:
+            cached = SimpleNamespace(is_initialized=True, stop=AsyncMock())
+            agent._transports[cwd] = cached
+            # No recorded inode (legacy entry) -> reuse as before, no eviction.
+            with patch.object(_MODULE, "CodexTransport") as ctor:
+                result = await agent._get_or_create_transport(cwd)
+            self.assertIs(result, cached)
+            ctor.assert_not_called()
+
+    def test_config_load_failure_is_recoverable(self):
+        agent = object.__new__(CodexAgent)
+        err = RuntimeError(
+            "Codex RPC error: {'code': -32600, 'message': "
+            "'failed to load configuration: No such file or directory (os error 2)'}"
+        )
+        self.assertTrue(agent._is_recoverable_transport_error(err))
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -2715,7 +2715,44 @@ def _validate_definition_update_delivery_target(
     )
 
 
-def _reserve_cli_session(*, agent, deliver_key: Optional[str]) -> str:
+def _resolve_run_cwd(args, *, session_policy: str, help_command: str) -> Optional[str]:
+    """Working directory for a session this run RESERVES; None = scope snapshot.
+
+    An explicit ``--cwd`` must exist and always wins. Without it, a private
+    (no ``--deliver-key``) reservation follows the CLI invocation's cwd — the
+    caller stands in a concrete directory, which IS the natural context, like
+    every other CLI tool. A ``--deliver-key`` reservation keeps the target
+    scope's configured workdir (returning None defers to the scope snapshot in
+    ``create_agent_session_row``): the scope's binding is the deliberate choice
+    there, not wherever the CLI happens to run. ``--session-id`` reserves
+    nothing — an existing session keeps its workdir — so ``--cwd`` is an error.
+    """
+    raw = (getattr(args, "cwd", None) or "").strip()
+    if session_policy == "existing":
+        if raw:
+            raise TaskCliError(
+                "--cwd only applies when this run creates a session",
+                code="cwd_with_existing_session",
+                hint="An existing --session-id keeps its own working directory.",
+                help_command=help_command,
+            )
+        return None
+    if raw:
+        resolved = os.path.abspath(os.path.expanduser(raw))
+        if not os.path.isdir(resolved):
+            raise TaskCliError(
+                f"--cwd directory does not exist: {resolved}",
+                code="cwd_not_found",
+                hint="Point --cwd to an existing directory, or omit it to use the invocation directory.",
+                help_command=help_command,
+            )
+        return resolved
+    if (getattr(args, "deliver_key", None) or "").strip():
+        return None
+    return os.getcwd()
+
+
+def _reserve_cli_session(*, agent, deliver_key: Optional[str], workdir: Optional[str] = None) -> str:
     # Route through ``core.services.sessions`` so the CLI shares the same
     # business API as the UI server and the future N3 internal endpoint;
     # see docs/plans/workbench-dispatch-architecture.md §6 (C2).
@@ -2732,6 +2769,7 @@ def _reserve_cli_session(*, agent, deliver_key: Optional[str]) -> str:
             agent_name=agent.name,
             model=agent.model,
             reasoning_effort=agent.reasoning_effort,
+            workdir=workdir,
         )
     else:
         platform = _primary_platform()
@@ -2744,6 +2782,7 @@ def _reserve_cli_session(*, agent, deliver_key: Optional[str]) -> str:
             agent_name=agent.name,
             model=agent.model,
             reasoning_effort=agent.reasoning_effort,
+            workdir=workdir,
         )
     if not session_id:
         raise TaskCliError(
@@ -2808,11 +2847,12 @@ def cmd_agent_run(args):
             )
         session_id = (args.session_id or "").strip() or None
         session_key = ""
+        run_cwd = _resolve_run_cwd(args, session_policy=session_policy, help_command="vibe agent run --help")
         agent = _agent_store().require_enabled(agent_name) if agent_name else None
         if session_policy == "create":
-            session_id = _reserve_cli_session(agent=agent, deliver_key=args.deliver_key)
+            session_id = _reserve_cli_session(agent=agent, deliver_key=args.deliver_key, workdir=run_cwd)
         elif session_policy == "none":
-            session_id = _reserve_cli_session(agent=agent, deliver_key=None)
+            session_id = _reserve_cli_session(agent=agent, deliver_key=None, workdir=run_cwd)
         if session_id:
             target = resolve_session_id_target(session_id)
             session_key = target.session_key.to_key()
@@ -5774,6 +5814,15 @@ def build_parser():
     agent_run_parser.add_argument("--create-session", action="store_true", help="Create a new Avibe Session ID before running")
     agent_run_parser.add_argument("--create-session-per-run", action="store_true", help="Create a new Avibe Session ID for each definition run")
     agent_run_parser.add_argument("--deliver-key", help="Scope ID used as delivery target when creating or sending to a target")
+    agent_run_parser.add_argument(
+        "--cwd",
+        help=(
+            "Working directory for the NEW session. Defaults to the directory the command is "
+            "invoked from; sessions created with --deliver-key default to the target scope's "
+            "configured workdir instead. Invalid with --session-id (an existing session keeps "
+            "its own working directory)."
+        ),
+    )
     agent_run_parser.add_argument("--post-to", choices=("thread", "channel"))
     agent_run_parser.add_argument("--callback-session-id", help="Caller Session ID to receive the completed async run result")
     agent_run_parser.add_argument("--async", dest="async_run", action="store_true", help="Queue the run and return immediately")


### PR DESCRIPTION
## Capability

**`vibe agent run` session working directory + codex transport cache health.** Closes #561.

### 1. Sessions follow the invocation cwd (new `--cwd` flag)

A session reserved by `vibe agent run` (`--create-session` or a plain sessionless run) was created with a blank workdir and fell through to the global `runtime.default_cwd` at dispatch — surprising (every other CLI runs where you invoke it) and fragile when that default points at a volatile path (the #561 incident ran in `default_cwd=/tmp/test`).

- Private (no `--deliver-key`) reservations snapshot the **CLI invocation's cwd** as the session workdir.
- New `--cwd PATH` (validated to exist, `~`/relative expanded) always wins.
- `--deliver-key` reservations keep deferring to the **target scope's configured workdir** unless `--cwd` is passed — the scope's binding is the deliberate choice there.
- `--cwd` with `--session-id` errors (`cwd_with_existing_session`): an existing session owns its workdir.
- `workdir` threaded through `core.services.sessions.reserve_agent_session` / `reserve_private_agent_session` into `create_agent_session_row` (which already accepted it). `vibe task add` definitions and scheduled/watch runs are unchanged.

### 2. codex: evict cached app-server when its cwd inode changes (#561)

A per-cwd cached app-server whose directory was deleted (even if re-created at the same path) sits in a dead inode; codex then fails every `thread/start` with the misleading `failed to load configuration: No such file or directory`, and retries hit the same poisoned cache entry until the process dies.

- `_get_or_create_transport` records the cwd inode at spawn and compares on reuse: mismatch → stop the stale transport, respawn in the current directory — before paying a failed RPC. Untracked legacy entries reuse as before.
- `failed to load configuration` joins the recoverable transport-error markers, so `handle_message`'s existing drop-respawn-**retry-once** path also self-heals mid-call (no retry loop on a genuinely broken config).

## Evidence layers

- **Unit**: 5 new CLI tests (`tests/test_cli_agent_run_schema.py`: follow-cwd e2e to the stored row, explicit `--cwd` wins, missing dir errors, `--session-id` conflict errors, deliver-key defers to scope) + 4 new codex transport tests (`tests/test_codex_agent.py`: inode-mismatch eviction + re-record, unchanged reuse, legacy no-inode reuse, recoverable classification). Full group 150 passed locally (`test_codex_agent`, `test_cli_agent_run_schema`, `test_cli_task_command`, `test_core_services_sessions`, `test_workbench_session_defaults`).
- **Contract**: `agent_run` JSON envelope unchanged (schema snapshot test untouched and green); `reserve_*` gain an optional kwarg only.
- **Scenario**: no scenario catalog covers CLI session reservation; none updated.
- **Residual manual checks**: live incident forensics in #561 (root cause verified against service logs + DB + dir birth time); post-merge, `vibe agent run` from a repo dir should land its session there (`vibe session list` workdir column).

## Review

Cross-model reviewed by Codex: NO FINDINGS — verified scheduled tasks / watch follow-ups / run definitions are unaffected, `--cwd` expansion/validation edges, the per-cwd lock ordering around the inode check, and that the new recoverable marker stays retry-once.