### PR TITLE
feat(ui): single-flow platforms settings + drop user-facing primary platform

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -324,7 +324,12 @@ class PlatformsConfig:
             supported_text = "', '".join(supported_platform_ids())
             raise ValueError(f"Config 'platforms.primary' must be one of: '{supported_text}'")
         elif self.primary not in normalized:
-            normalized.insert(0, self.primary)
+            # ``enabled`` is the source of truth and ``primary`` is now an
+            # internal default with no user-facing control. A primary that is
+            # not in the enabled set (e.g. a stale value surviving a deep config
+            # merge after the platform was disabled) must FOLLOW enabled, not
+            # resurrect a removed platform by forcing itself back into the list.
+            self.primary = normalized[0]
         self.enabled = normalized
 
 

--- a/tests/test_v2_config_platform_registry.py
+++ b/tests/test_v2_config_platform_registry.py
@@ -134,6 +134,31 @@ def test_validate_strips_workbench_and_retargets_primary() -> None:
     assert workbench.primary == "avibe"
 
 
+def test_validate_derives_primary_from_enabled_without_resurrecting() -> None:
+    # ``enabled`` is the source of truth; ``primary`` is an internal default with
+    # no user-facing control. A stale primary that is NOT in the enabled set
+    # (e.g. surviving a deep config merge after the platform was disabled) must
+    # FOLLOW enabled — retarget to the first enabled platform — instead of
+    # forcing the removed platform back into ``enabled``. This is what lets the
+    # UI persist an enabled-set change by sending only ``platforms.enabled``.
+    stale = PlatformsConfig(enabled=["discord"], primary="slack")
+    stale.validate()
+    assert stale.enabled == ["discord"]
+    assert stale.primary == "discord"
+
+    # Order preserved; primary tracks the first enabled platform.
+    multi = PlatformsConfig(enabled=["telegram", "discord"], primary="slack")
+    multi.validate()
+    assert multi.enabled == ["telegram", "discord"]
+    assert multi.primary == "telegram"
+
+    # A primary still present in enabled is left untouched.
+    kept = PlatformsConfig(enabled=["slack", "discord"], primary="discord")
+    kept.validate()
+    assert kept.enabled == ["slack", "discord"]
+    assert kept.primary == "discord"
+
+
 def test_config_payload_includes_platform_catalog_and_setup_state() -> None:
     config = _base_config(
         platforms=PlatformsConfig(enabled=["slack", "discord", "telegram", "lark", "wechat"], primary="slack"),
@@ -178,14 +203,16 @@ def test_platforms_validate_allows_empty_enabled_and_anchors_avibe() -> None:
 
 
 def test_platforms_validate_keeps_non_empty_enabled_unchanged() -> None:
-    # Has-IM behavior is untouched: the primary is still force-inserted into a
-    # non-empty enabled list at the front.
+    # ``enabled`` is the source of truth: a stale primary not in the enabled set
+    # retargets to the first enabled platform; the enabled list is NOT grown to
+    # resurrect the removed platform (see
+    # test_validate_derives_primary_from_enabled_without_resurrecting).
     platforms = PlatformsConfig(enabled=["discord"], primary="slack")
 
     platforms.validate()
 
-    assert platforms.primary == "slack"
-    assert platforms.enabled == ["slack", "discord"]
+    assert platforms.primary == "discord"
+    assert platforms.enabled == ["discord"]
 
 
 def test_workbench_only_config_round_trips_with_avibe_primary() -> None:

--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -14,35 +14,24 @@ import { Summary } from './steps/Summary';
 import { useApi } from '../context/ApiContext';
 import clsx from 'clsx';
 import {
-  WORKBENCH_PLATFORM_ID,
   getEnabledPlatforms,
-  getPrimaryPlatform,
   platformHasRunnableConfig,
   platformSupportsChannels,
 } from '../lib/platforms';
 import { withoutConfiguredSecretMarker, withSecretDraft, withSecretDrafts } from '../lib/secretFields';
 import { WizardChrome } from './visual';
 
-const getPrimaryPlatformForEnabledSet = (data: any, enabledPlatforms: string[]) => {
-  const primaryPlatform = getPrimaryPlatform(data);
-  if (enabledPlatforms.includes(primaryPlatform)) {
-    return primaryPlatform;
-  }
-  return enabledPlatforms[0] || WORKBENCH_PLATFORM_ID;
-};
-
 const getPersistableWizardPlatforms = (data: any) =>
   getEnabledPlatforms(data).filter((platform) => platformHasRunnableConfig(data, platform));
 
 const buildConfigPayload = (data: any, enabledPlatformOverride?: string[]) => {
   const enabledPlatforms = enabledPlatformOverride ?? getEnabledPlatforms(data);
-  const primaryPlatform = getPrimaryPlatformForEnabledSet(data, enabledPlatforms);
 
   return {
-  platform: primaryPlatform,
+  // No user-facing primary platform: the backend derives an internal default
+  // from ``platforms.enabled``, so the wizard sends only the enabled set.
   platforms: {
     enabled: enabledPlatforms,
-    primary: primaryPlatform,
   },
   mode: data.mode || 'self_host',
   version: 'v2',

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -9,7 +9,6 @@ import { SettingsPageShell } from './SettingsPageShell';
 import {
   platformHasCapability,
   getEnabledPlatforms,
-  getPrimaryPlatform,
 } from '@/lib/platforms';
 import {
   CompactField,
@@ -43,9 +42,10 @@ const SAVE_KEYS = [
 ] as const;
 
 function buildMessagePatch(config: any, extraPatch: Record<string, unknown> = {}) {
-  const patch: Record<string, unknown> = {
-    platform: getPrimaryPlatform(config),
-  };
+  // ``save_config`` merges onto the stored config and the backend derives the
+  // internal default platform from ``platforms.enabled``, so this messaging
+  // save no longer sends a ``platform``/primary field.
+  const patch: Record<string, unknown> = {};
 
   for (const key of SAVE_KEYS) {
     patch[key] = config?.[key];

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -1,17 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
-import { Check, ChevronUp, Loader2, Pencil, RefreshCw, RotateCw } from 'lucide-react';
+import { Check, ChevronUp, Loader2, Pencil, RotateCw } from 'lucide-react';
 
 import { useApi } from '@/context/ApiContext';
 import { useStatus } from '@/context/StatusContext';
 import { useToast } from '@/context/ToastContext';
 import {
-  WORKBENCH_PLATFORM_ID,
   getEnabledPlatforms,
   getImPlatforms,
   getPlatformCatalog,
-  getPrimaryPlatform,
   platformHasRunnableConfig,
 } from '@/lib/platforms';
 import { PlatformIcon } from '@/components/visual';
@@ -21,7 +19,6 @@ import { TelegramConfig } from '@/components/steps/TelegramConfig';
 import { LarkConfig } from '@/components/steps/LarkConfig';
 import { WeChatConfig } from '@/components/steps/WeChatConfig';
 import { SettingsPageShell } from './SettingsPageShell';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 
 const PLATFORM_TILE_STYLES: Record<string, { bg: string; border: string }> = {
@@ -33,18 +30,30 @@ const PLATFORM_TILE_STYLES: Record<string, { bg: string; border: string }> = {
   wechat: { bg: 'bg-[#07C16026]', border: 'border-[#07C16055]' },
 };
 
-type ExpandedKey = string | null; // 'enabled' | platform id | null
+const tileStyle = (id: string) =>
+  PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
 
+// The platforms settings page is a SINGLE linear flow (no two-step staging):
+//  - the "Enabled platforms" grid is always open and is the master control;
+//  - checking a tile reveals that platform's config below (frontend-only) when
+//    it still needs credentials, or enables it immediately when it is already
+//    configured; unchecking disables (if enabled) or just hides the draft card;
+//  - nothing is persisted / restarts until a platform's credentials validate
+//    and save. There is no user-facing "primary platform" — the backend derives
+//    an internal default from the enabled set, so this page never sends one.
 export const SettingsPlatformsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
   const { control } = useStatus();
   const { showToast } = useToast();
   const [config, setConfig] = useState<any>(null);
-  const [expanded, setExpanded] = useState<ExpandedKey>(null);
-  const [draftEnabled, setDraftEnabled] = useState<string[]>([]);
-  const [draftPrimary, setDraftPrimary] = useState<string>('');
-  const [savingEnabled, setSavingEnabled] = useState(false);
+  // Platforms the user revealed to configure but has NOT enabled yet (no creds
+  // saved). Frontend-only: these show a config card below but persist nothing
+  // until their save validates. Enabled platforms always show a card too.
+  const [revealed, setRevealed] = useState<string[]>([]);
+  // Which platform's credential form is expanded (the "Configure" toggle).
+  const [openConfig, setOpenConfig] = useState<string | null>(null);
+  const [busyPlatform, setBusyPlatform] = useState<string | null>(null);
   const [restartPhase, setRestartPhase] = useState<'idle' | 'saving' | 'restarting'>('idle');
 
   useEffect(() => {
@@ -52,25 +61,16 @@ export const SettingsPlatformsPage: React.FC = () => {
   }, [api]);
 
   const platformCatalog = useMemo(() => (config ? getPlatformCatalog(config) : []), [config]);
-  // The in-process workbench is always-on and cannot be toggled as an IM
-  // transport, so it is excluded from the enable grid (mirroring the wizard).
-  // The full catalog is kept for descriptor/title lookups elsewhere.
-  const togglablePlatforms = useMemo(
-    () => (config ? getImPlatforms(config) : []),
-    [config]
-  );
+  // The in-process workbench is always-on and not a togglable IM transport.
+  const togglablePlatforms = useMemo(() => (config ? getImPlatforms(config) : []), [config]);
   const enabledPlatforms = useMemo(() => (config ? getEnabledPlatforms(config) : []), [config]);
-  const primary = useMemo(() => (config ? getPrimaryPlatform(config) : ''), [config]);
 
-  const toggle = (key: string) => {
-    setExpanded((prev) => (prev === key ? null : key));
-    if (key === 'enabled') {
-      setDraftEnabled(enabledPlatforms);
-      setDraftPrimary(primary);
-    }
-  };
-
-  const closeAll = () => setExpanded(null);
+  // Cards appear for every enabled platform plus any the user revealed to set
+  // up, in stable catalog order so the list never reshuffles on toggle.
+  const cardPlatforms = useMemo(() => {
+    const shown = new Set([...enabledPlatforms, ...revealed]);
+    return togglablePlatforms.filter((p) => shown.has(p.id)).map((p) => p.id);
+  }, [togglablePlatforms, enabledPlatforms, revealed]);
 
   const saveConfig = async (nextData: any) => {
     const savedConfig = await api.saveConfig(nextData);
@@ -93,18 +93,18 @@ export const SettingsPlatformsPage: React.FC = () => {
     }
   };
 
-  const saveAndRestart = async (nextData: any) => {
+  // Persist the enabled set and restart. ``primary`` is intentionally omitted:
+  // the backend normalizes it from ``enabled`` (first enabled, or the workbench
+  // when empty), so the UI never chooses or sends one.
+  const persistEnabled = async (nextEnabled: string[]) => {
     setRestartPhase('saving');
     try {
       try {
-        await saveConfig(nextData);
+        await saveConfig({ ...config, platforms: { enabled: nextEnabled } });
       } catch {
-        // Surface save failures to the user instead of letting the rejection
-        // propagate as an unhandled async error from the click handler.
         showToast(t('common.saveFailed'), 'error');
-        return;
+        return false;
       }
-      closeAll();
       setRestartPhase('restarting');
       try {
         await control('restart');
@@ -112,84 +112,85 @@ export const SettingsPlatformsPage: React.FC = () => {
       } catch {
         showToast(t('platform.restartFailed'), 'error');
       }
+      return true;
     } finally {
       setRestartPhase('idle');
     }
   };
 
-  const handleApplyPlatform = async (platform: string, nextData: any) => {
-    const wasEnabled = enabledPlatforms.includes(platform);
-    if (wasEnabled) {
-      await savePlatformSettings(platform, nextData);
-      await saveAndRestart(nextData);
+  const toggleTile = async (id: string) => {
+    if (busyPlatform) return;
+    const enabled = enabledPlatforms.includes(id);
+    if (enabled) {
+      // Uncheck an enabled platform → disable immediately (single step).
+      setBusyPlatform(id);
+      try {
+        await persistEnabled(enabledPlatforms.filter((p) => p !== id));
+        setRevealed((prev) => prev.filter((p) => p !== id));
+        setOpenConfig((prev) => (prev === id ? null : prev));
+      } finally {
+        setBusyPlatform(null);
+      }
       return;
     }
-    const preservedPrimary = primary || WORKBENCH_PLATFORM_ID;
-    const saveData = {
-      ...nextData,
-      platform: preservedPrimary,
-      platforms: { enabled: enabledPlatforms, primary: preservedPrimary },
-    };
+    if (revealed.includes(id)) {
+      // Uncheck a still-unsaved draft → just hide its card, persist nothing.
+      setRevealed((prev) => prev.filter((p) => p !== id));
+      setOpenConfig((prev) => (prev === id ? null : prev));
+      return;
+    }
+    if (platformHasRunnableConfig(config, id)) {
+      // Already configured → checking enables it immediately.
+      setBusyPlatform(id);
+      try {
+        await persistEnabled([...enabledPlatforms, id]);
+      } finally {
+        setBusyPlatform(null);
+      }
+      return;
+    }
+    // Not configured yet → reveal its config card to enter credentials.
+    setRevealed((prev) => (prev.includes(id) ? prev : [...prev, id]));
+    setOpenConfig(id);
+  };
+
+  // A platform's credential form was saved. Validate-then-enable: persist the
+  // credentials, and if they make the platform runnable, add it to the enabled
+  // set and restart. An already-enabled platform just re-saves + restarts.
+  const handleApplyPlatform = async (platform: string, nextData: any) => {
+    const wasEnabled = enabledPlatforms.includes(platform);
+    setBusyPlatform(platform);
+    setRestartPhase('saving');
     try {
-      const savedConfig = await saveConfig(saveData);
-      const shouldEnable = platform && !wasEnabled && platformHasRunnableConfig(savedConfig, platform);
-      if (!shouldEnable) {
-        showToast(t('common.saved'), 'success');
-        closeAll();
+      let savedConfig: any;
+      try {
+        savedConfig = await saveConfig({ ...nextData, platforms: { enabled: enabledPlatforms } });
+      } catch {
+        showToast(t('common.saveFailed'), 'error');
         return;
       }
       await savePlatformSettings(platform, nextData);
-      const nextEnabled = [...enabledPlatforms, platform];
-      const resolvedPrimary = primary && primary !== WORKBENCH_PLATFORM_ID ? primary : platform;
-      await saveAndRestart({
-        platform: resolvedPrimary,
-        platforms: { enabled: nextEnabled, primary: resolvedPrimary },
-      });
-    } catch {
-      showToast(t('common.saveFailed'), 'error');
-    }
-  };
-
-  const toggleDraftPlatform = (id: string) => {
-    setDraftEnabled((prev) => {
-      if (prev.includes(id)) {
-        // Allow clearing the last platform: an empty set is the supported
-        // workbench-only state (Apply anchors primary to "avibe").
-        const next = prev.filter((p) => p !== id);
-        if (next.length && draftPrimary === id) setDraftPrimary(next[0]);
-        return next;
+      const runnable = platformHasRunnableConfig(savedConfig, platform);
+      if (!wasEnabled && !runnable) {
+        // Saved credentials but they are incomplete — keep the card open so the
+        // user can finish; nothing is enabled, no restart.
+        showToast(t('common.saved'), 'success');
+        return;
       }
-      if (!platformHasRunnableConfig(config, id)) {
-        setExpanded(id);
-        showToast(t('platform.configureBeforeEnable'), 'error');
-        return prev;
+      const nextEnabled = wasEnabled ? enabledPlatforms : [...enabledPlatforms, platform];
+      setRestartPhase('restarting');
+      try {
+        await saveConfig({ ...savedConfig, platforms: { enabled: nextEnabled } });
+        await control('restart');
+        showToast(t('platform.restartedSuccess'), 'success');
+        setRevealed((prev) => prev.filter((p) => p !== platform));
+        setOpenConfig((prev) => (prev === platform ? null : prev));
+      } catch {
+        showToast(t('platform.restartFailed'), 'error');
       }
-      const next = [...prev, id];
-      if (!prev.length) setDraftPrimary(id);
-      return next;
-    });
-  };
-
-  const applyEnabled = async () => {
-    // An empty external-platform set is the supported workbench-only state:
-    // the in-process Avibe Workbench is the sole inbound surface, so anchor
-    // ``primary`` to "avibe" (mirroring the wizard/backend/controller, which
-    // all anchor the primary to the workbench when no IM platform is enabled).
-    // For a non-empty set, keep the user's primary if it survived the edit,
-    // otherwise fall back to the first remaining platform.
-    const resolvedPrimary = draftEnabled.length
-      ? (draftEnabled.includes(draftPrimary) ? draftPrimary : draftEnabled[0])
-      : WORKBENCH_PLATFORM_ID;
-    const nextData = {
-      ...config,
-      platform: resolvedPrimary,
-      platforms: { enabled: draftEnabled, primary: resolvedPrimary },
-    };
-    setSavingEnabled(true);
-    try {
-      await saveAndRestart(nextData);
     } finally {
-      setSavingEnabled(false);
+      setRestartPhase('idle');
+      setBusyPlatform(null);
     }
   };
 
@@ -233,122 +234,81 @@ export const SettingsPlatformsPage: React.FC = () => {
             </div>
           </div>
         )}
-        {/* Enabled platforms card */}
-        <CollapseCard
-          expanded={expanded === 'enabled'}
-          onToggle={() => toggle('enabled')}
-          header={
-            <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
-              <div className="min-w-0">
-                <div className="text-[14px] font-semibold text-foreground">{t('platform.enabledPlatforms')}</div>
-                <div className="mt-1 flex flex-wrap items-center gap-1.5">
-                  {enabledPlatforms.map((id) => {
-                    const descriptor = platformCatalog.find((p) => p.id === id);
-                    const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
-                    return (
-                      <span
-                        key={id}
-                        className={clsx(
-                          'inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-medium text-foreground',
-                          tile.bg,
-                          tile.border
-                        )}
-                      >
-                        <PlatformIcon platform={id as any} size={12} />
-                        {t(descriptor?.title_key || `platform.${id}.title`)}
-                        {id === primary && (
-                          <span className="rounded bg-mint/20 px-1 text-[9px] font-bold uppercase tracking-wide text-mint">
-                            {t('platform.primary')}
-                          </span>
-                        )}
-                      </span>
-                    );
-                  })}
-                </div>
-              </div>
-            </div>
-          }
-        >
-          <div className="space-y-4 px-5 py-4">
-            <p className="text-[12px] leading-relaxed text-muted">{t('platform.subtitle')}</p>
 
-            <div className="grid grid-cols-2 gap-2.5 md:grid-cols-3 lg:grid-cols-5">
-              {togglablePlatforms.map((platform) => {
-                const id = platform.id;
-                const active = draftEnabled.includes(id);
-                const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
-                return (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() => toggleDraftPlatform(id)}
+        {/* Enabled platforms — always open, the master control. Check a tile to
+            reveal its setup below; nothing persists until credentials save. */}
+        <section className="overflow-hidden rounded-xl border border-border bg-surface-2">
+          <div className="border-b border-border px-5 py-4">
+            <div className="text-[14px] font-semibold text-foreground">{t('platform.enabledPlatforms')}</div>
+            <p className="mt-1 text-[12px] leading-relaxed text-muted">{t('platform.subtitle')}</p>
+          </div>
+          <div className="grid grid-cols-2 gap-2.5 px-5 py-4 md:grid-cols-3 lg:grid-cols-5">
+            {togglablePlatforms.map((platform) => {
+              const id = platform.id;
+              const active = enabledPlatforms.includes(id) || revealed.includes(id);
+              const tile = tileStyle(id);
+              const busy = busyPlatform === id;
+              const otherBusy = !!busyPlatform && !busy;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => void toggleTile(id)}
+                  disabled={busy || otherBusy}
+                  aria-pressed={active}
+                  className={clsx(
+                    'relative flex flex-col items-center gap-2 rounded-xl px-3 py-3.5 transition-colors',
+                    active
+                      ? 'border-2 border-mint bg-mint/[0.16]'
+                      : 'border border-foreground/[0.08] bg-background hover:border-foreground/[0.16] hover:bg-foreground/[0.02]',
+                    otherBusy && 'opacity-50'
+                  )}
+                >
+                  {active && (
+                    <span className="absolute right-1.5 top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-mint text-background">
+                      {busy ? <Loader2 size={10} className="animate-spin" /> : <Check size={11} strokeWidth={3} />}
+                    </span>
+                  )}
+                  <span
                     className={clsx(
-                      'flex flex-col items-center gap-2 rounded-xl px-3 py-3.5 transition-colors',
-                      active
-                        ? 'border-2 border-mint bg-mint/[0.16]'
-                        : 'border border-foreground/[0.08] bg-background hover:border-foreground/[0.16] hover:bg-foreground/[0.02]'
+                      'inline-flex size-9 items-center justify-center rounded-[10px] border',
+                      tile.bg,
+                      tile.border
                     )}
                   >
-                    <span
-                      className={clsx(
-                        'inline-flex size-9 items-center justify-center rounded-[10px] border',
-                        tile.bg,
-                        tile.border
-                      )}
-                    >
-                      <PlatformIcon platform={id as any} size={18} />
-                    </span>
-                    <span
-                      className={clsx(
-                        'text-[12px] leading-tight transition-colors',
-                        active ? 'font-bold text-foreground' : 'font-medium text-muted'
-                      )}
-                    >
-                      {t(platform.title_key || `platform.${id}.title`)}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-
-            <div className="flex items-center justify-end gap-2 border-t border-border pt-3">
-              <Button
-                type="button"
-                variant="secondary"
-                size="xs"
-                onClick={closeAll}
-                disabled={savingEnabled}
-              >
-                {t('common.cancel')}
-              </Button>
-              <Button
-                type="button"
-                variant="brand"
-                size="xs"
-                onClick={() => void applyEnabled()}
-                disabled={savingEnabled}
-              >
-                {savingEnabled ? <RefreshCw size={12} className="animate-spin" /> : <Check size={12} />}
-                {t('platform.apply')}
-              </Button>
-            </div>
+                    <PlatformIcon platform={id as any} size={18} />
+                  </span>
+                  <span
+                    className={clsx(
+                      'text-[12px] leading-tight transition-colors',
+                      active ? 'font-bold text-foreground' : 'font-medium text-muted'
+                    )}
+                  >
+                    {t(platform.title_key || `platform.${id}.title`)}
+                  </span>
+                </button>
+              );
+            })}
           </div>
-        </CollapseCard>
+        </section>
 
-        {/* One card per IM platform: disabled platforms still need a place to add credentials. */}
-        {togglablePlatforms.map((platform) => {
-          const id = platform.id;
+        {/* One config card per enabled-or-revealed platform. Disabled platforms
+            with no credentials only appear here after the user checks them. */}
+        {cardPlatforms.map((id) => {
           const descriptor = platformCatalog.find((p) => p.id === id);
           const label = t(descriptor?.title_key || `platform.${id}.title`);
           const description = t(descriptor?.description_key || `platform.${id}.desc`);
-          const tile = PLATFORM_TILE_STYLES[id] || { bg: 'bg-foreground/[0.04]', border: 'border-foreground/[0.10]' };
+          const tile = tileStyle(id);
           const runnable = platformHasRunnableConfig(config, id);
           const enabled = enabledPlatforms.includes(id);
+          // Reveal the form immediately for a freshly-checked unconfigured
+          // platform; an enabled platform opens collapsed (Configure to edit).
+          const open = openConfig === id || (!enabled && !runnable);
           return (
-            <CollapseCard
+            <PlatformCard
               key={id}
-              expanded={expanded === id}
-              onToggle={() => toggle(id)}
+              expanded={open}
+              onToggle={() => setOpenConfig((prev) => (prev === id ? null : id))}
               header={
                 <div className="flex min-w-0 flex-1 items-center gap-3">
                   <span
@@ -368,13 +328,14 @@ export const SettingsPlatformsPage: React.FC = () => {
                           <Check size={10} />
                           {t('platform.validationSuccess')}
                         </span>
-                      ) : enabled ? (
+                      ) : (
                         <span className="inline-flex items-center gap-1 rounded border border-gold/30 bg-gold/10 px-1.5 py-0.5 text-[10px] font-medium text-gold">
                           {t('platform.stepAddBotToken')}
                         </span>
-                      ) : (
-                        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-                          {t('common.disabled')}
+                      )}
+                      {enabled && (
+                        <Badge variant="success" className="px-1.5 py-0 text-[10px]">
+                          {t('common.enabled')}
                         </Badge>
                       )}
                     </div>
@@ -388,10 +349,10 @@ export const SettingsPlatformsPage: React.FC = () => {
                   platform={id}
                   config={config}
                   onApply={(data) => handleApplyPlatform(id, data)}
-                  onCancel={closeAll}
+                  onCancel={() => setOpenConfig((prev) => (prev === id ? null : prev))}
                 />
               </div>
-            </CollapseCard>
+            </PlatformCard>
           );
         })}
       </div>
@@ -399,7 +360,7 @@ export const SettingsPlatformsPage: React.FC = () => {
   );
 };
 
-const CollapseCard: React.FC<{
+const PlatformCard: React.FC<{
   expanded: boolean;
   onToggle: () => void;
   header: React.ReactNode;
@@ -433,7 +394,7 @@ const CollapseCard: React.FC<{
           ) : (
             <>
               <Pencil size={12} />
-              {t('common.edit')}
+              {t('common.configure')}
             </>
           )}
         </button>

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -301,9 +301,10 @@ export const SettingsPlatformsPage: React.FC = () => {
           const tile = tileStyle(id);
           const runnable = platformHasRunnableConfig(config, id);
           const enabled = enabledPlatforms.includes(id);
-          // Reveal the form immediately for a freshly-checked unconfigured
-          // platform; an enabled platform opens collapsed (Configure to edit).
-          const open = openConfig === id || (!enabled && !runnable);
+          // ``toggleTile`` opens a freshly-revealed platform's form (so settings
+          // appear right when you check it); from then on the Configure/Close
+          // toggle owns the state, so Close actually collapses the card.
+          const open = openConfig === id;
           return (
             <PlatformCard
               key={id}

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -76,9 +76,13 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
   // setup).
   const initialPlatforms = useMemo(() => getEnabledPlatforms(data), [data]);
   const platformCatalog = useMemo(() => getPlatformCatalog(data), [data]);
+  // The credential-tab fallback must be a configurable IM platform — never the
+  // always-on workbench (which has no credentials and isn't in the selectable
+  // grid), so default to the first IM platform rather than the full catalog.
+  const defaultCredentialPlatform = useMemo(() => getImPlatforms(data)[0]?.id || 'slack', [data]);
   const [selected, setSelected] = useState<string[]>(initialPlatforms);
   const [activeCredentialPlatform, setActiveCredentialPlatform] = useState<string>(
-    initialPlatforms[0] || platformCatalog[0]?.id || 'slack'
+    initialPlatforms[0] || defaultCredentialPlatform
   );
   const [credentialDraft, setCredentialDraft] = useState<Record<string, any>>(() => buildInitialCredentialDraft(data));
   const [validating, setValidating] = useState(false);
@@ -86,9 +90,9 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
 
   useEffect(() => {
     if (!selected.includes(activeCredentialPlatform)) {
-      setActiveCredentialPlatform(selected[0] || platformCatalog[0]?.id || 'slack');
+      setActiveCredentialPlatform(selected[0] || defaultCredentialPlatform);
     }
-  }, [activeCredentialPlatform, platformCatalog, selected]);
+  }, [activeCredentialPlatform, defaultCredentialPlatform, selected]);
 
   const togglePlatform = (platform: string) => {
     setSelected((current) => {

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -8,7 +8,6 @@ import {
   getEnabledPlatforms,
   getImPlatforms,
   getPlatformCatalog,
-  getPrimaryPlatform,
   WORKBENCH_PLATFORM_ID,
 } from '../../lib/platforms';
 import { hasUsableSecret, secretInputValue } from '../../lib/secretFields';
@@ -78,8 +77,9 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
   const initialPlatforms = useMemo(() => getEnabledPlatforms(data), [data]);
   const platformCatalog = useMemo(() => getPlatformCatalog(data), [data]);
   const [selected, setSelected] = useState<string[]>(initialPlatforms);
-  const [primary, setPrimary] = useState<string>(getPrimaryPlatform(data));
-  const [activeCredentialPlatform, setActiveCredentialPlatform] = useState<string>(getPrimaryPlatform(data));
+  const [activeCredentialPlatform, setActiveCredentialPlatform] = useState<string>(
+    initialPlatforms[0] || platformCatalog[0]?.id || 'slack'
+  );
   const [credentialDraft, setCredentialDraft] = useState<Record<string, any>>(() => buildInitialCredentialDraft(data));
   const [validating, setValidating] = useState(false);
   const [validationState, setValidationState] = useState<Record<string, ValidationState>>({});
@@ -93,18 +93,10 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
   const togglePlatform = (platform: string) => {
     setSelected((current) => {
       if (current.includes(platform)) {
-        const next = current.filter((item) => item !== platform);
-        if (primary === platform) {
-          setPrimary(next[0] ?? '');
-        }
-        return next;
-      }
-      const next = [...current, platform];
-      if (!current.length) {
-        setPrimary(platform);
+        return current.filter((item) => item !== platform);
       }
       setActiveCredentialPlatform(platform);
-      return next;
+      return [...current, platform];
     });
   };
 
@@ -121,14 +113,12 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
 
   const handleContinue = async () => {
     // Workbench-only setups are valid, so allow an empty IM selection — do not
-    // force a fallback platform into the enabled set.
+    // force a fallback platform into the enabled set. No user-facing primary:
+    // the backend derives its internal default from ``enabled``.
     const normalized = selected;
-    const resolvedPrimary = normalized.includes(primary) ? primary : (normalized[0] ?? '');
     const selectionData = {
-      platform: resolvedPrimary,
       platforms: {
         enabled: normalized,
-        primary: resolvedPrimary,
       },
     };
     const nextData = {

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -17,7 +17,7 @@ import { useApi } from '../../context/ApiContext';
 import { useStatus } from '../../context/StatusContext';
 import { useToast } from '../../context/ToastContext';
 import { copyTextToClipboard } from '../../lib/utils';
-import { getEnabledPlatforms, getPrimaryPlatform } from '../../lib/platforms';
+import { getEnabledPlatforms } from '../../lib/platforms';
 import { withoutConfiguredSecretMarker, withSecretDraft, withSecretDrafts } from '../../lib/secretFields';
 import { EyebrowBadge, WizardCard } from '../visual';
 import { ToggleSwitch } from '../settings/SettingsPrimitives';
@@ -43,7 +43,6 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
   const [bindCode, setBindCode] = useState<string | null>(null);
   const [codeCopied, setCodeCopied] = useState(false);
   const enabledPlatforms = getEnabledPlatforms(data);
-  const primaryPlatform = getPrimaryPlatform(data);
   const discordGuildAllowlist = Array.isArray(data.discordGuildAllowlist)
     ? data.discordGuildAllowlist
     : Array.isArray(data.discord?.guild_allowlist)
@@ -88,10 +87,10 @@ export const Summary: React.FC<SummaryProps> = ({ data, onBack }) => {
     try {
       const updatedData = {
         ...data,
-        platform: primaryPlatform,
+        // No user-facing primary platform: the backend derives its internal
+        // default from ``platforms.enabled``.
         platforms: {
           enabled: enabledPlatforms,
-          primary: primaryPlatform,
         },
         slack: {
           ...data.slack,
@@ -386,12 +385,11 @@ const countConfiguredChannels = (channelConfigsByPlatform: Record<string, Record
 const buildConfigPayload = (data: any) => {
   const agents = data.agents || {};
   const enabledPlatforms = getEnabledPlatforms(data);
-  const primaryPlatform = getPrimaryPlatform(data);
   return {
-    platform: primaryPlatform,
+    // No user-facing primary platform: the backend derives its internal default
+    // from ``platforms.enabled``.
     platforms: {
       enabled: enabledPlatforms,
-      primary: primaryPlatform,
     },
     mode: data.mode || 'self_host',
     version: 'v2',

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -13,6 +13,7 @@
     "save": "Save",
     "skip": "Skip",
     "edit": "Edit",
+    "configure": "Configure",
     "cancel": "Cancel",
     "loading": "Loading...",
     "saving": "Saving...",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -13,6 +13,7 @@
     "save": "保存",
     "skip": "跳过",
     "edit": "编辑",
+    "configure": "配置",
     "cancel": "取消",
     "loading": "加载中...",
     "saving": "保存中...",

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -174,20 +174,6 @@ export const getEnabledPlatforms = (data: any): PlatformName[] => {
   return [getPlatformCatalog(data)[0]?.id || 'slack'];
 };
 
-export const getPrimaryPlatform = (data: any): PlatformName => {
-  const enabled = getEnabledPlatforms(data);
-  const primary = data?.platforms?.primary;
-  if (enabled.includes(primary)) {
-    return primary as PlatformName;
-  }
-  // Workbench-only saves primary="avibe" with enabled=[], so a saved primary
-  // that is a known catalog id stays authoritative even when not in `enabled`.
-  if (primary && getPlatformIds(data).includes(primary)) {
-    return primary as PlatformName;
-  }
-  return enabled[0] || getPlatformCatalog(data)[0]?.id || 'slack';
-};
-
 export const getPlatformDescriptor = (data: any, platform: string): PlatformDescriptor | undefined =>
   getPlatformCatalog(data).find((descriptor) => descriptor.id === platform);
 


### PR DESCRIPTION
## Capability

**Platforms settings page (`/admin/settings/platforms`) interaction model + removal of the user-facing primary platform.** Addresses page feedback on the two-step design.

### 1. Single linear flow (was: two-step staging)

The page used an 'Enabled platforms' collapsible card with **Apply/Cancel** that staged + persisted the enabled set, plus separate per-platform cards behind an **Edit** button — with a chicken-and-egg 'configure before you can enable' gate. Now:

- The 'Enabled platforms' grid is **always open** (the master control); Apply/Cancel staging is gone.
- **Checking a tile** reveals that platform's config card below when it still needs credentials, or **enables it immediately** (+restart) when already configured. **Unchecking** disables an enabled platform (+restart) or just hides an unsaved draft — single-step, no staging.
- Nothing persists until a platform's credentials **validate and save**; until then a checked platform only shows in the frontend.
- Per-card button relabeled **Edit → Configure** (`common.configure`, added to en/zh). Cards render only for enabled-or-revealed platforms, in catalog order. Configure/Close owns the card's expanded state.

### 2. No user-facing 'primary platform'

There's no product use for a user-chosen primary. The frontend no longer uses or sends it (`getPrimaryPlatform` deleted; wizard / PlatformSelection / Summary / messaging saves send only `platforms.enabled`). The data-layer field is **kept** and derived internally.

**Root-cause backend fix (required for correctness):** `POST /api/config` deep-merges onto the stored config, so a disabled platform's stale `platforms.primary` survived and `PlatformsConfig.validate()` force-inserted a primary not in `enabled` **back into** `enabled` — which would re-enable a just-disabled platform. `validate()` now **retargets a stale primary to the first enabled platform** instead of growing `enabled`: enabled is the single source of truth, primary is a derived internal default. Wizard credential-tab default also hardened to the first IM platform (never the always-on workbench).

## Evidence layers

- **Unit**: `tests/test_v2_config_platform_registry.py` — new `test_validate_derives_primary_from_enabled_without_resurrecting` (+ updated `test_platforms_validate_keeps_non_empty_enabled_unchanged`, which had codified the old resurrect behavior). Config group green: `test_v2_config_platform_registry`, `test_api_save_config_merge`, `test_v2_compat_platforms`, `test_workbench_only_runtime`, `test_controller_config_reload` (53 passed). Swept the suite for other tests asserting the old behavior — none.
- **Build**: `npm run build` (tsc + vite) green.
- **Contract**: no API shape change; `reserve_*`/payloads only drop the optional primary. `platforms.primary` still derived + persisted server-side.
- **Scenario**: no scenario catalog covers platform settings; none updated.
- **Residual manual checks (recommend in regression)**: check an unconfigured platform → its card reveals → save creds → enabled+restart; uncheck enabled → disabled+restart; check an already-configured disabled platform → enabled immediately; disable the last platform → workbench-only; Configure/Close collapses the card; wizard completion + messaging save still persist correctly.

## Review

Cross-model reviewed by Codex across 3 rounds: 2 MAJOR (stale-primary resurrection via deep-merge; credential-tab could default to the workbench) + 1 MINOR (dead Close button on a revealed card) — all fixed; final pass confirmed the fixes.