### PR TITLE
feat: hot platform reconcile — apply platform enable/disable/credential changes with no restart (Phase 2)

### DIFF
--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -38,6 +38,7 @@ class PlatformDescriptor:
     formatter_class: str
     credential_fields: tuple[str, ...]
     capabilities: PlatformCapabilities
+    runtime_reconcile_fields: tuple[str, ...] = ()
     # Structural distinction between real IM transports ("im") and the
     # always-on in-process Avibe Workbench ("workbench"), which lives in the
     # same registry but is never a configurable IM platform. IM-only code paths
@@ -88,6 +89,9 @@ class PlatformDescriptor:
         formatter_cls = _load_attr(self.formatter_module, self.formatter_class)
         return formatter_cls()
 
+    def runtime_reconcile_field_names(self) -> tuple[str, ...]:
+        return self.runtime_reconcile_fields or self.credential_fields
+
     def to_public_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
@@ -127,6 +131,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
         formatter_module="modules.im.formatters",
         formatter_class="SlackFormatter",
         credential_fields=("bot_token",),
+        runtime_reconcile_fields=("bot_token", "app_token", "proxy_url"),
         capabilities=PlatformCapabilities(
             supports_channels=True,
             supports_threads=True,
@@ -148,6 +153,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
         formatter_module="modules.im.formatters",
         formatter_class="DiscordFormatter",
         credential_fields=("bot_token",),
+        runtime_reconcile_fields=("bot_token", "proxy_url"),
         capabilities=PlatformCapabilities(
             supports_channels=True,
             supports_threads=True,
@@ -169,6 +175,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
         formatter_module="modules.im.formatters",
         formatter_class="TelegramFormatter",
         credential_fields=("bot_token",),
+        runtime_reconcile_fields=("bot_token", "use_webhook", "webhook_url", "webhook_secret_token", "proxy_url"),
         capabilities=PlatformCapabilities(
             supports_channels=True,
             supports_threads=False,
@@ -192,6 +199,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
         formatter_module="modules.im.formatters",
         formatter_class="FeishuFormatter",
         credential_fields=("app_id", "app_secret"),
+        runtime_reconcile_fields=("app_id", "app_secret", "domain", "proxy_url"),
         capabilities=PlatformCapabilities(
             supports_channels=True,
             supports_threads=True,
@@ -214,6 +222,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
         formatter_module="modules.im.formatters",
         formatter_class="WeChatFormatter",
         credential_fields=("bot_token",),
+        runtime_reconcile_fields=("bot_token", "base_url", "cdn_base_url", "proxy_url"),
         capabilities=PlatformCapabilities(
             supports_channels=False,
             supports_threads=False,

--- a/core/controller.py
+++ b/core/controller.py
@@ -61,9 +61,9 @@ class RemovedPlatformIMClient(BaseIMClient):
         text: str,
         parse_mode: Optional[str] = None,
         reply_to: Optional[str] = None,
-    ) -> str:
+    ) -> Optional[str]:
         logger.info("Dropping stale outbound message for removed IM platform %s", self.platform)
-        return ""
+        return None
 
     async def send_message_with_buttons(
         self,
@@ -71,9 +71,9 @@ class RemovedPlatformIMClient(BaseIMClient):
         text: str,
         keyboard,
         parse_mode: Optional[str] = None,
-    ) -> str:
+    ) -> Optional[str]:
         logger.info("Dropping stale outbound button message for removed IM platform %s", self.platform)
-        return ""
+        return None
 
     async def edit_message(
         self,

--- a/core/controller.py
+++ b/core/controller.py
@@ -520,6 +520,7 @@ class Controller:
                     "allowed_chat_ids",
                     "allowed_user_ids",
                     "disable_link_unfurl",
+                    "forum_auto_topic",
                 )
                 for platform, client in self.im_clients.items():
                     im_cfg = getattr(client, "config", None)

--- a/core/controller.py
+++ b/core/controller.py
@@ -403,7 +403,7 @@ class Controller:
             for platform in removed + rebuilt:
                 await asyncio.to_thread(self.im_client.remove_client, platform)
                 self.im_clients.pop(platform, None)
-                if platform in removed:
+                if platform in removed or platform in rebuilt:
                     self._removed_im_clients[platform] = RemovedPlatformIMClient(platform)
 
             self.enabled_platforms = next_enabled
@@ -419,10 +419,10 @@ class Controller:
             self._ensure_agent_route_for_platform("avibe")
 
             for platform in rebuilt + added:
-                self._removed_im_clients.pop(platform, None)
                 client = self._build_platform_client(platform, new_config)
                 self.im_clients[platform] = client
                 self.im_client.add_client(platform, client)
+                self._removed_im_clients.pop(platform, None)
 
             self.im_client.set_primary_platform(next_primary)
             self._sync_config_references(new_config)

--- a/core/controller.py
+++ b/core/controller.py
@@ -35,6 +35,105 @@ from vibe.i18n import get_supported_languages, t as i18n_t
 logger = logging.getLogger(__name__)
 
 
+class RemovedPlatformIMClient(BaseIMClient):
+    """No-op sink for stale replies after an IM platform is hot-disabled."""
+
+    def __init__(self, platform: str):
+        from config.v2_config import AvibeConfig
+        from modules.im.formatters.avibe_formatter import AvibeFormatter
+
+        super().__init__(AvibeConfig())
+        self.platform = platform
+        self.formatter = AvibeFormatter()
+
+    def get_default_parse_mode(self) -> Optional[str]:
+        return None
+
+    def should_use_thread_for_reply(self) -> bool:
+        return False
+
+    def supports_message_editing(self, context: Optional[MessageContext] = None) -> bool:
+        return False
+
+    async def send_message(
+        self,
+        context: MessageContext,
+        text: str,
+        parse_mode: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> str:
+        logger.info("Dropping stale outbound message for removed IM platform %s", self.platform)
+        return ""
+
+    async def send_message_with_buttons(
+        self,
+        context: MessageContext,
+        text: str,
+        keyboard,
+        parse_mode: Optional[str] = None,
+    ) -> str:
+        logger.info("Dropping stale outbound button message for removed IM platform %s", self.platform)
+        return ""
+
+    async def edit_message(
+        self,
+        context: MessageContext,
+        message_id: str,
+        text: Optional[str] = None,
+        keyboard: Optional[Any] = None,
+        parse_mode: Optional[str] = None,
+    ) -> bool:
+        return False
+
+    async def remove_inline_keyboard(
+        self,
+        context: MessageContext,
+        message_id: str,
+        text: Optional[str] = None,
+        parse_mode: Optional[str] = None,
+    ) -> bool:
+        return False
+
+    async def answer_callback(self, callback_id: str, text: Optional[str] = None, show_alert: bool = False) -> bool:
+        return False
+
+    def register_handlers(self):
+        return None
+
+    def run(self):
+        return None
+
+    def stop(self):
+        return None
+
+    async def get_user_info(self, user_id: str) -> Dict[str, Any]:
+        return {"id": user_id, "platform": self.platform, "removed": True}
+
+    async def get_channel_info(self, channel_id: str) -> Dict[str, Any]:
+        return {"id": channel_id, "platform": self.platform, "removed": True}
+
+    async def add_reaction(self, context: MessageContext, message_id: str, emoji: str) -> bool:
+        return False
+
+    async def remove_reaction(self, context: MessageContext, message_id: str, emoji: str) -> bool:
+        return False
+
+    async def send_typing_indicator(self, context: MessageContext) -> bool:
+        return False
+
+    async def clear_typing_indicator(self, context: MessageContext) -> bool:
+        return False
+
+    async def delete_message(self, context: MessageContext, message_id: str) -> bool:
+        return False
+
+    async def send_dm(self, user_id: str, text: str, **kwargs):
+        return None
+
+    def format_markdown(self, text: str) -> str:
+        return text
+
+
 def _optional_target_str(value: Any) -> Optional[str]:
     if value is None:
         return None
@@ -69,6 +168,7 @@ class Controller:
         self.enabled_platforms = list(getattr(config, "enabled_platforms", lambda: [config.platform])())
         self.primary_platform = getattr(getattr(config, "platforms", None), "primary", config.platform)
         self._reconcile_lock: Optional[asyncio.Lock] = None
+        self._removed_im_clients: Dict[str, BaseIMClient] = {}
 
         # Session tracking (must be initialized before handlers)
         self.claude_sessions: Dict[str, Any] = {}
@@ -154,6 +254,7 @@ class Controller:
         from modules.im.avibe import AvibeBot, AvibeConfig
 
         self.im_clients["avibe"] = AvibeBot(AvibeConfig())
+        self._removed_im_clients = {}
         formatter = self.im_clients.get(self.primary_platform, self.im_clients["avibe"]).formatter
         self.claude_client = ClaudeClient(self.config.claude, formatter)
 
@@ -302,6 +403,8 @@ class Controller:
             for platform in removed + rebuilt:
                 await asyncio.to_thread(self.im_client.remove_client, platform)
                 self.im_clients.pop(platform, None)
+                if platform in removed:
+                    self._removed_im_clients[platform] = RemovedPlatformIMClient(platform)
 
             self.enabled_platforms = next_enabled
             self.primary_platform = next_primary
@@ -316,6 +419,7 @@ class Controller:
             self._ensure_agent_route_for_platform("avibe")
 
             for platform in rebuilt + added:
+                self._removed_im_clients.pop(platform, None)
                 client = self._build_platform_client(platform, new_config)
                 self.im_clients[platform] = client
                 self.im_client.add_client(platform, client)
@@ -707,10 +811,22 @@ class Controller:
         if context is None:
             return self.im_clients[self.primary_platform]
         platform = context.platform or (context.platform_specific or {}).get("platform") or self.primary_platform
-        return self.im_clients.get(platform, self.im_clients[self.primary_platform])
+        client = self.im_clients.get(platform)
+        if client is not None:
+            return client
+        removed_client = self._removed_im_clients.get(platform)
+        if removed_client is not None:
+            return removed_client
+        return self.im_clients[self.primary_platform]
 
     def _get_im_client_for_platform(self, platform: str) -> BaseIMClient:
-        return self.im_clients.get(platform, self.im_clients[self.primary_platform])
+        client = self.im_clients.get(platform)
+        if client is not None:
+            return client
+        removed_client = self._removed_im_clients.get(platform)
+        if removed_client is not None:
+            return removed_client
+        return self.im_clients[self.primary_platform]
 
     # --- Streaming turn sinks -------------------------------------------
     # A live SSE caller registers a sink before dispatching a turn so the

--- a/core/controller.py
+++ b/core/controller.py
@@ -68,6 +68,7 @@ class Controller:
         self._im_run_exception: Optional[BaseException] = None
         self.enabled_platforms = list(getattr(config, "enabled_platforms", lambda: [config.platform])())
         self.primary_platform = getattr(getattr(config, "platforms", None), "primary", config.platform)
+        self._reconcile_lock: Optional[asyncio.Lock] = None
 
         # Session tracking (must be initialized before handlers)
         self.claude_sessions: Dict[str, Any] = {}
@@ -143,52 +144,25 @@ class Controller:
 
     def _init_modules(self):
         """Initialize core modules"""
-        self.im_clients: Dict[str, BaseIMClient] = IMFactory.create_clients(self.config)
-
-        # Workbench-only install: no external IM platform is enabled, so
-        # ``create_clients`` returns an empty map. Register the in-process
-        # Avibe (Web UI) client as the SOLE client BEFORE the snapshot/primary
-        # access below so ``self.im_client`` resolves to it, ``self.im_clients
-        # [self.primary_platform]`` (== "avibe") works, and avibe joins the
-        # single-client run loop (its ``run()`` fires on_ready + blocks to keep
-        # the service alive — see ``modules/im/avibe.py``). The has-IM path is
-        # unaffected: avibe is added there AFTER the snapshot (further below) and
-        # stays OUT of the MultiIMClient run loop.
-        if not self.im_clients:
-            from modules.im.avibe import AvibeBot, AvibeConfig
-
-            self.primary_platform = "avibe"
-            self.im_clients["avibe"] = AvibeBot(AvibeConfig())
-
-        for platform, client in self.im_clients.items():
+        runtime_clients: Dict[str, BaseIMClient] = IMFactory.create_clients(self.config)
+        for platform, client in runtime_clients.items():
             client.formatter = self._create_formatter(platform)
+        self.primary_platform = self._derive_primary_platform(self.config)
+        self.im_client = MultiIMClient(dict(runtime_clients), primary_platform=self.primary_platform)
+        self.im_clients = dict(runtime_clients)
 
-        # Snapshot the platform map for the multi-runtime wrapper. ``avibe``
-        # is registered into ``self.im_clients`` later (for delivery routing
-        # via get_im_client_for_context) but must NOT join the MultiIMClient
-        # run/callback loop — it has no inbound runtime, so a shared reference
-        # would let it leak in and log a spurious "IM runtime for avibe
-        # exited" warning. The copy keeps the run loop to the real platforms.
-        self.im_client = (
-            self.im_clients[self.primary_platform]
-            if len(self.im_clients) == 1
-            else MultiIMClient(dict(self.im_clients), primary_platform=self.primary_platform)
-        )
-        formatter = self.im_clients[self.primary_platform].formatter
+        from modules.im.avibe import AvibeBot, AvibeConfig
+
+        self.im_clients["avibe"] = AvibeBot(AvibeConfig())
+        formatter = self.im_clients.get(self.primary_platform, self.im_clients["avibe"]).formatter
         self.claude_client = ClaudeClient(self.config.claude, formatter)
 
         # Initialize managers
         self.session_manager = SessionManager()
-        # The settings manager must own a per-platform manager for the primary
-        # so ``get_settings_manager_for_context`` (and its primary fallback) can
-        # always resolve one. For has-IM the primary is already in
-        # ``enabled_platforms`` so this is a no-op; for workbench-only it adds
-        # the "avibe" manager that empty ``enabled_platforms`` would otherwise
-        # omit (which would KeyError on the very first settings lookup).
-        settings_platforms = list(self.enabled_platforms)
-        if self.primary_platform not in settings_platforms:
-            settings_platforms.append(self.primary_platform)
-        self.settings_manager = MultiSettingsManager(settings_platforms, primary_platform=self.primary_platform)
+        self.settings_manager = MultiSettingsManager(
+            self._settings_platforms_for(self.enabled_platforms, self.primary_platform),
+            primary_platform=self.primary_platform,
+        )
         self.platform_settings_managers = self.settings_manager.managers
         self.sessions = self.settings_manager.sessions
         self.native_session_service = None
@@ -205,26 +179,29 @@ class Controller:
         for platform in self.enabled_platforms:
             if platform not in self.agent_router.platform_routes:
                 self.agent_router.platform_routes[platform] = self.agent_router.platform_routes[self.primary_platform]
+        if "avibe" not in self.agent_router.platform_routes:
+            self.agent_router.platform_routes["avibe"] = self.agent_router.platform_routes[self.primary_platform]
 
         # Inject settings_manager into IM client if supported
-        for platform, client in self.im_clients.items():
+        for platform, client in runtime_clients.items():
             self._inject_runtime_dependencies(platform, client)
 
-        # Avibe (the workbench Web UI) is always available as an in-process
-        # delivery surface, independent of which external IM platforms are
-        # enabled. Register it here — after ``self.im_client`` / callbacks /
-        # injection are wired for the real platforms — so
-        # ``get_im_client_for_context("avibe")`` resolves to the SSE-backed
-        # client instead of silently falling back to the primary platform
-        # (which mis-delivered workbench chat replies to e.g. Slack, where
-        # the send fails with channel_not_found and the user sees nothing).
-        # Avibe needs no inbound runtime thread (ui_server REST owns inbound),
-        # no settings-manager injection (it inherits the primary's via
-        # get_settings_manager_for_context), and no callbacks.
-        if "avibe" not in self.im_clients:
-            from modules.im.avibe import AvibeBot, AvibeConfig
+    @staticmethod
+    def _derive_primary_platform(config) -> str:
+        enabled = list(getattr(config, "enabled_platforms", lambda: [getattr(config, "platform", "slack")])())
+        configured_primary = getattr(getattr(config, "platforms", None), "primary", getattr(config, "platform", "slack"))
+        if enabled:
+            return configured_primary if configured_primary in enabled else enabled[0]
+        return "avibe"
 
-            self.im_clients["avibe"] = AvibeBot(AvibeConfig())
+    @staticmethod
+    def _settings_platforms_for(enabled_platforms: list[str], primary_platform: str) -> list[str]:
+        platforms = list(enabled_platforms)
+        if primary_platform not in platforms:
+            platforms.append(primary_platform)
+        if "avibe" not in platforms:
+            platforms.append("avibe")
+        return platforms
 
     def _enabled_agent_backends(self) -> list[str]:
         result: list[str] = []
@@ -247,6 +224,120 @@ class Controller:
 
     def _create_formatter(self, platform: str):
         return get_platform_descriptor(platform).create_formatter()
+
+    @staticmethod
+    def _runtime_reconcile_signature(config, platform: str) -> tuple[Any, ...]:
+        descriptor = get_platform_descriptor(platform)
+        platform_config = descriptor.get_config(config)
+        if platform_config is None:
+            return ()
+        return tuple(getattr(platform_config, field, None) for field in descriptor.runtime_reconcile_field_names())
+
+    def _ensure_agent_route_for_platform(self, platform: str) -> None:
+        if platform in self.agent_router.platform_routes:
+            return
+        fallback = self.agent_router.platform_routes.get(self.primary_platform)
+        if fallback is None:
+            from modules.agent_router import PlatformRoute
+
+            fallback = PlatformRoute(default=self.agent_router.global_default)
+        self.agent_router.platform_routes[platform] = fallback
+
+    def _register_client_runtime(self, platform: str, client: BaseIMClient) -> None:
+        client.formatter = self._create_formatter(platform)
+        if platform not in self.platform_settings_managers:
+            self.settings_manager.add_platform(platform)
+            self.platform_settings_managers = self.settings_manager.managers
+        self._ensure_agent_route_for_platform(platform)
+        self._inject_runtime_dependencies(platform, client)
+
+    def _build_platform_client(self, platform: str, config) -> BaseIMClient:
+        descriptor = get_platform_descriptor(platform)
+        client = descriptor.create_client(config)
+        self._register_client_runtime(platform, client)
+        return client
+
+    def _sync_config_references(self, new_config) -> None:
+        self.config = new_config
+        self.processing_indicator.config = new_config
+        self.audio_asr_service.config = new_config
+        for handler_name in ("command_handler", "settings_handler", "message_handler", "session_handler"):
+            handler = getattr(self, handler_name, None)
+            if handler is not None:
+                handler.config = new_config
+                handler.im_client = self.im_client
+                handler.settings_manager = self.settings_manager
+                handler.sessions = self.sessions
+        for agent in getattr(getattr(self, "agent_service", None), "agents", {}).values():
+            agent.config = new_config
+            agent.im_client = self.im_client
+            agent.settings_manager = self.settings_manager
+            agent.sessions = self.sessions
+        self.claude_client.config = new_config.claude
+        primary_formatter = self.im_clients.get(self.primary_platform, self.im_clients["avibe"]).formatter
+        if primary_formatter is not None:
+            self.claude_client.formatter = primary_formatter
+
+    async def reconcile_platforms(self, new_config) -> dict[str, Any]:
+        """Hot-apply IM platform enablement and runtime credential changes."""
+        if self._reconcile_lock is None:
+            self._reconcile_lock = asyncio.Lock()
+
+        async with self._reconcile_lock:
+            current_enabled = list(self.enabled_platforms)
+            next_enabled = list(getattr(new_config, "enabled_platforms", lambda: [])())
+            current_set = set(current_enabled)
+            next_set = set(next_enabled)
+            removed = [platform for platform in current_enabled if platform not in next_set]
+            added = [platform for platform in next_enabled if platform not in current_set]
+            rebuilt = [
+                platform
+                for platform in next_enabled
+                if platform in current_set
+                and self._runtime_reconcile_signature(self.config, platform)
+                != self._runtime_reconcile_signature(new_config, platform)
+            ]
+            next_primary = self._derive_primary_platform(new_config)
+
+            for platform in removed + rebuilt:
+                await asyncio.to_thread(self.im_client.remove_client, platform)
+                self.im_clients.pop(platform, None)
+
+            self.enabled_platforms = next_enabled
+            self.primary_platform = next_primary
+            self.settings_manager.set_primary_platform(next_primary)
+            self.platform_settings_managers = self.settings_manager.managers
+            for platform in removed:
+                self.settings_manager.remove_platform(platform)
+                self.agent_router.platform_routes.pop(platform, None)
+
+            for platform in next_enabled:
+                self._ensure_agent_route_for_platform(platform)
+            self._ensure_agent_route_for_platform("avibe")
+
+            for platform in rebuilt + added:
+                client = self._build_platform_client(platform, new_config)
+                self.im_clients[platform] = client
+                self.im_client.add_client(platform, client)
+
+            self.im_client.set_primary_platform(next_primary)
+            self._sync_config_references(new_config)
+
+            logger.info(
+                "Hot-reconciled IM platforms: added=%s removed=%s rebuilt=%s primary=%s",
+                added,
+                removed,
+                rebuilt,
+                next_primary,
+            )
+            return {
+                "ok": True,
+                "added": added,
+                "removed": removed,
+                "rebuilt": rebuilt,
+                "enabled": next_enabled,
+                "primary": next_primary,
+            }
 
     def _migrate_discord_guild_scope_from_config(self) -> None:
         if "discord" not in self.platform_settings_managers:

--- a/core/controller.py
+++ b/core/controller.py
@@ -248,12 +248,16 @@ class Controller:
         for platform, client in runtime_clients.items():
             client.formatter = self._create_formatter(platform)
         self.primary_platform = self._derive_primary_platform(self.config)
-        self.im_client = MultiIMClient(dict(runtime_clients), primary_platform=self.primary_platform)
         self.im_clients = dict(runtime_clients)
 
         from modules.im.avibe import AvibeBot, AvibeConfig
 
         self.im_clients["avibe"] = AvibeBot(AvibeConfig())
+        self.im_client = MultiIMClient(
+            dict(runtime_clients),
+            primary_platform=self.primary_platform,
+            auxiliary_clients={"avibe": self.im_clients["avibe"]},
+        )
         self._removed_im_clients = {}
         formatter = self.im_clients.get(self.primary_platform, self.im_clients["avibe"]).formatter
         self.claude_client = ClaudeClient(self.config.claude, formatter)

--- a/core/controller.py
+++ b/core/controller.py
@@ -401,10 +401,9 @@ class Controller:
             next_primary = self._derive_primary_platform(new_config)
 
             for platform in removed + rebuilt:
-                await asyncio.to_thread(self.im_client.remove_client, platform)
                 self.im_clients.pop(platform, None)
-                if platform in removed or platform in rebuilt:
-                    self._removed_im_clients[platform] = RemovedPlatformIMClient(platform)
+                self._removed_im_clients[platform] = RemovedPlatformIMClient(platform)
+                await asyncio.to_thread(self.im_client.remove_client, platform)
 
             self.enabled_platforms = next_enabled
             self.primary_platform = next_primary

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -314,6 +314,19 @@ def create_app(controller: "Controller") -> FastAPI:
             )
         return JSONResponse(status_code=202, content={"ok": True, "session_id": session_id})
 
+    @app.post("/internal/reconcile-platforms")
+    async def _reconcile_platforms() -> Any:
+        """Hot-apply the persisted platform config on the controller loop."""
+        try:
+            from config.v2_compat import to_app_config
+            from config.v2_config import V2Config
+
+            result = await controller.reconcile_platforms(to_app_config(V2Config.load()))
+            return JSONResponse(status_code=200, content=result)
+        except Exception as exc:
+            logger.exception("internal platform reconcile failed")
+            return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
+
     @app.get("/internal/events")
     async def _events() -> Any:
         """Long-lived SSE feed of Controller-side inbox events.

--- a/docs/plans/hot-platform-reconcile.md
+++ b/docs/plans/hot-platform-reconcile.md
@@ -1,0 +1,100 @@
+# Phase 2 — Hot platform reconcile (apply platform changes with no service restart)
+
+## Background
+
+Phase 1 (PR #566) made platform config changes do a **service-only restart** that
+keeps the Web UI process alive. Phase 2 removes the restart entirely for the
+common case: enabling/disabling a platform should just start/stop **that one
+platform's background task**, not bounce the whole service.
+
+## Current mechanics (verified)
+
+- `MultiIMClient` (`modules/im/multi.py`) runs **one daemon thread per platform**;
+  each thread calls the adapter's blocking `client.run()`. It has only
+  all-or-nothing `stop()`/`shutdown()` — no per-platform start/stop.
+- The IM runtime blocks on a worker thread (`Controller._run_im_runtime`,
+  `core/controller.py:513`), spawned from `controller.run()`; the main thread
+  owns the asyncio loop.
+- `IMFactory.create_clients()` builds `im_clients` **once** in
+  `Controller._init_modules` (`controller.py:144-227`). `_refresh_config_from_disk`
+  hot-reloads a SUBSET (message filters/i18n/require_mention) but NOT platform
+  enablement, credentials, settings managers, or agent routes.
+- Internal command channel: `core/internal_server.py` serves HTTP over a unix
+  socket (`dispatch.sock`) on the controller's loop; `vibe/internal_client.py` is
+  the client. Existing commands: dispatch_async, dispatch, turn-state, cancel,
+  health. The UI process already calls it (e.g. bootstrap → turn_state).
+
+## Design
+
+1. **`MultiIMClient.add_client(platform, client)` / `remove_client(platform)`** —
+   start one new daemon thread / signal-stop + join one thread, mutating
+   `self.clients` + `self._threads` under a lock (routing reads must not see a
+   half-removed client).
+2. **`Controller.reconcile_platforms(new_config)`** (async, on the loop) — diff
+   the new enabled set vs running and:
+   - removed → `remove_client` + drop its settings manager;
+   - added → build client via `IMFactory`/descriptor, formatter, settings
+     manager, agent route, register callbacks, `add_client` (start its thread);
+   - recompute `enabled_platforms` + the derived `primary_platform`;
+   - rebuild the single-vs-multi `im_client` wrapper if topology changed.
+   Sync `stop()` calls wrapped in `asyncio.to_thread`/`call_soon_threadsafe`.
+3. **`POST /internal/reconcile-platforms`** on the internal server → calls
+   `controller.reconcile_platforms`.
+4. **`POST /api/config`** (UI process): after saving, if the platform fields
+   changed, send the internal reconcile command instead of scheduling a restart.
+   The platforms page stops calling `control('restart')` for enable/disable.
+
+## Per-adapter hot-stop verdict
+
+| Platform | Clean single-stop? | Notes |
+|---|---|---|
+| Slack | ✅ | async stop-event + socket close |
+| Discord | ✅ | discord.py `client.close()` |
+| Telegram | ✅ | polling loop breaks on event |
+| WeChat | ✅ | poll-task cancel + stop event |
+| **Feishu/Lark** | ⚠️ **No** | `run()` spawns a nested lark-SDK WS **daemon thread** with no exposed stop; hot-remove would leak that thread until process exit |
+
+## Decisions (locked — full scope, "一次到位")
+
+- **D1 — Feishu: patch for clean hot-stop.** Expose a stop on the nested lark
+  WS thread so Feishu can be hot-removed like the others (no fallback restart).
+- **D2 — Credential changes: rebuild, not per-adapter reconnect.** A credential
+  edit on an enabled platform = `remove_client` + `add_client` (tear down the
+  old adapter, build a fresh one with the new config, start it). Reuses the
+  add/remove machinery — no per-adapter "reconnect" code. Works for all 5 once
+  every adapter stops cleanly (D1).
+- **D3 — Trigger.** `POST /api/config` decides reconcile-vs-restart by diffing
+  the platform fields; manual Dashboard/Service restart buttons unchanged. With
+  full scope, platform enable/disable/credential changes ALL hot-reconcile (no
+  restart); a service-only restart remains only for non-platform config that
+  the running service doesn't hot-apply.
+
+## Risks & mitigations
+
+- Routing to a half-removed client → KeyError: mutate `clients` under a lock;
+  routing reads a snapshot.
+- A stuck `client.run()` won't join: bounded `join` timeout + the thread is a
+  daemon (dies at process exit); log a leak warning.
+- Callback re-registration: a newly added client must have callbacks wired
+  before its thread starts so early inbound isn't dropped.
+- Settings-manager file lifecycle for a newly added platform: lazy-load on
+  first access (existing pattern).
+
+## Incremental plan
+
+- **Phase 2a** (this PR): MultiIMClient add/remove + reconcile for the 4 clean
+  adapters; Feishu + credential changes fall back to service-only restart;
+  internal command + `/api/config` trigger; tests (reconcile diff, add/remove,
+  fallback selection).
+- **Phase 2b** (follow-up): Feishu adapter clean WS stop; hot credential
+  reconnect.
+
+## Todo (2a)
+
+- [ ] `MultiIMClient.add_client` / `remove_client` (+ lock around `clients`)
+- [ ] `Controller.reconcile_platforms` + add/remove/update helpers
+- [ ] `/internal/reconcile-platforms` endpoint + `internal_client` method
+- [ ] `POST /api/config`: diff platform fields → reconcile (clean adapters) or
+      service-only restart (Feishu / credential change) fallback
+- [ ] platforms page: skip restart when the change is hot-reconcilable
+- [ ] tests + regression on all 5 IM platforms

--- a/docs/plans/hot-platform-reconcile.md
+++ b/docs/plans/hot-platform-reconcile.md
@@ -29,20 +29,37 @@ platform's background task**, not bounce the whole service.
 1. **`MultiIMClient.add_client(platform, client)` / `remove_client(platform)`** —
    start one new daemon thread / signal-stop + join one thread, mutating
    `self.clients` + `self._threads` under a lock (routing reads must not see a
-   half-removed client).
+   half-removed client). `run()` idles until explicit stop, even when the
+   runtime client set is empty.
 2. **`Controller.reconcile_platforms(new_config)`** (async, on the loop) — diff
    the new enabled set vs running and:
    - removed → `remove_client` + drop its settings manager;
    - added → build client via `IMFactory`/descriptor, formatter, settings
      manager, agent route, register callbacks, `add_client` (start its thread);
+   - enabled + runtime credential/signature change → `remove_client` +
+     `add_client` rebuild;
    - recompute `enabled_platforms` + the derived `primary_platform`;
-   - rebuild the single-vs-multi `im_client` wrapper if topology changed.
+   - keep the single `MultiIMClient` wrapper alive for all topologies.
    Sync `stop()` calls wrapped in `asyncio.to_thread`/`call_soon_threadsafe`.
 3. **`POST /internal/reconcile-platforms`** on the internal server → calls
    `controller.reconcile_platforms`.
 4. **`POST /api/config`** (UI process): after saving, if the platform fields
    changed, send the internal reconcile command instead of scheduling a restart.
    The platforms page stops calling `control('restart')` for enable/disable.
+
+### Always-wrap / workbench-only shape
+
+The controller and `IMFactory.create_client()` now always expose a
+`MultiIMClient` runtime wrapper:
+
+- 4-platform / 1-platform configs: wrapper owns those external IM clients.
+- Workbench-only / disabled-all configs: wrapper owns zero external IM clients
+  and idles; `AvibeBot` stays registered separately in `controller.im_clients`
+  as the in-process delivery target.
+
+This avoids single-vs-multi branching during reconcile and prevents disabling
+all IM platforms from making `im_client.run()` return, which would otherwise
+stop the controller loop.
 
 ## Per-adapter hot-stop verdict
 
@@ -52,7 +69,7 @@ platform's background task**, not bounce the whole service.
 | Discord | ✅ | discord.py `client.close()` |
 | Telegram | ✅ | polling loop breaks on event |
 | WeChat | ✅ | poll-task cancel + stop event |
-| **Feishu/Lark** | ⚠️ **No** | `run()` spawns a nested lark-SDK WS **daemon thread** with no exposed stop; hot-remove would leak that thread until process exit |
+| **Feishu/Lark** | ✅ | lark-oapi exposes no public stop, so `FeishuBot.stop()` uses the SDK client's private async `_disconnect()`, then stops the SDK module event loop to release its infinite `_select()` sleep and joins the nested `feishu-ws` thread |
 
 ## Decisions (locked — full scope, "一次到位")
 
@@ -79,22 +96,9 @@ platform's background task**, not bounce the whole service.
   before its thread starts so early inbound isn't dropped.
 - Settings-manager file lifecycle for a newly added platform: lazy-load on
   first access (existing pattern).
-
-## Incremental plan
-
-- **Phase 2a** (this PR): MultiIMClient add/remove + reconcile for the 4 clean
-  adapters; Feishu + credential changes fall back to service-only restart;
-  internal command + `/api/config` trigger; tests (reconcile diff, add/remove,
-  fallback selection).
-- **Phase 2b** (follow-up): Feishu adapter clean WS stop; hot credential
-  reconnect.
-
-## Todo (2a)
-
-- [ ] `MultiIMClient.add_client` / `remove_client` (+ lock around `clients`)
-- [ ] `Controller.reconcile_platforms` + add/remove/update helpers
-- [ ] `/internal/reconcile-platforms` endpoint + `internal_client` method
-- [ ] `POST /api/config`: diff platform fields → reconcile (clean adapters) or
-      service-only restart (Feishu / credential change) fallback
-- [ ] platforms page: skip restart when the change is hot-reconcilable
-- [ ] tests + regression on all 5 IM platforms
+- Feishu stop relies on lark-oapi private internals because the SDK has no
+  public close API. Keep the test coverage around `_disconnect()` + loop stop so
+  SDK upgrades fail loudly if those internals change.
+- If the internal reconcile socket is unavailable after saving platform config,
+  `/api/config` schedules the existing service-only restart fallback instead of
+  leaving the persisted config unapplied.

--- a/modules/im/avibe.py
+++ b/modules/im/avibe.py
@@ -12,7 +12,7 @@ This module ships the platform-side contract that the
 ``core/handlers`` / ``message_dispatcher`` layer can call uniformly
 across every platform. The REST + SSE wiring lands in later commits and
 will register itself with the ``AvibeBot`` instance held by the
-controller (see ``IMFactory.create_client``).
+controller (see ``Controller._init_modules``).
 """
 
 from __future__ import annotations

--- a/modules/im/base.py
+++ b/modules/im/base.py
@@ -149,6 +149,15 @@ class BaseIMClient(ABC):
         """Whether sent messages can be edited after delivery."""
         return True
 
+    def verify_stopped(self) -> bool:
+        """Return whether adapter-owned runtime resources have stopped.
+
+        ``MultiIMClient.remove_client`` joins the adapter's top-level runtime
+        thread. Adapters that start nested SDK/runtime threads should override
+        this so hot-remove can fail instead of silently leaking callbacks.
+        """
+        return True
+
     def should_use_thread_for_dm_session(self) -> bool:
         """Check if DM conversations should use thread-based session IDs.
 
@@ -305,7 +314,7 @@ class BaseIMClient(ABC):
     @abstractmethod
     async def send_message(
         self, context: MessageContext, text: str, parse_mode: Optional[str] = None, reply_to: Optional[str] = None
-    ) -> str:
+    ) -> Optional[str]:
         """Send a text message
 
         Args:
@@ -315,14 +324,14 @@ class BaseIMClient(ABC):
             reply_to: Optional message ID to reply to
 
         Returns:
-            Message ID of sent message
+            Message ID of sent message, or None when not delivered
         """
         pass
 
     @abstractmethod
     async def send_message_with_buttons(
         self, context: MessageContext, text: str, keyboard: InlineKeyboard, parse_mode: Optional[str] = None
-    ) -> str:
+    ) -> Optional[str]:
         """Send a message with inline buttons
 
         Args:
@@ -332,7 +341,7 @@ class BaseIMClient(ABC):
             parse_mode: Optional formatting mode
 
         Returns:
-            Message ID of sent message
+            Message ID of sent message, or None when not delivered
         """
         pass
 

--- a/modules/im/factory.py
+++ b/modules/im/factory.py
@@ -14,19 +14,8 @@ class IMFactory:
     @staticmethod
     def create_client(config) -> BaseIMClient:
         clients = IMFactory.create_clients(config)
-        # Workbench-only config (``platforms.enabled`` empty, or a legacy
-        # ``["avibe"]``): ``create_clients`` skips the in-process workbench, so
-        # the built map is empty. Return the in-process ``AvibeBot`` directly —
-        # mirroring the controller's avibe fallback (``_init_modules``) — instead
-        # of constructing ``MultiIMClient(clients={}, "avibe")``, which would
-        # raise because the primary is absent from the empty map.
-        if not clients:
-            from modules.im.avibe import AvibeBot, AvibeConfig
-
-            return AvibeBot(AvibeConfig())
-        primary = getattr(getattr(config, "platforms", None), "primary", getattr(config, "platform", "slack"))
-        if len(clients) == 1 and primary in clients:
-            return clients[primary]
+        configured_primary = getattr(getattr(config, "platforms", None), "primary", getattr(config, "platform", "slack"))
+        primary = configured_primary if configured_primary in clients else (next(iter(clients)) if clients else "avibe")
         return MultiIMClient(clients, primary_platform=primary)
 
     @staticmethod

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -5,6 +5,7 @@ import io
 import json
 import logging
 import os
+import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
 
@@ -111,6 +112,7 @@ class FeishuBot(BaseIMClient):
         self._routing_cache: Dict[str, Dict[str, Any]] = {}
         self._stop_event: Optional[asyncio.Event] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._ws_thread: Optional[threading.Thread] = None
         self._recent_event_ids: Dict[str, float] = {}
         self._cached_token: Optional[str] = None
         self._token_expires_at: Optional[float] = None
@@ -3252,8 +3254,6 @@ class FeishuBot(BaseIMClient):
                 domain=self._get_sdk_domain(),
             )
 
-            import threading
-
             def _ws_thread_target():
                 try:
                     logger.info("Feishu WS thread starting, domain=%s", self._get_sdk_domain())
@@ -3262,6 +3262,7 @@ class FeishuBot(BaseIMClient):
                     logger.error("Feishu WS thread crashed: %s", exc, exc_info=True)
 
             ws_thread = threading.Thread(target=_ws_thread_target, daemon=True, name="feishu-ws")
+            self._ws_thread = ws_thread
             ws_thread.start()
 
             logger.info("Feishu WebSocket client started")
@@ -3283,17 +3284,56 @@ class FeishuBot(BaseIMClient):
 
     def stop(self) -> None:
         """Signal the bot to stop."""
-        if self._stop_event is None:
-            return
-        if self._loop and self._loop.is_running():
+        self._stop_ws_client()
+        if self._loop and self._loop.is_running() and self._stop_event is not None:
             self._loop.call_soon_threadsafe(self._stop_event.set)
-        else:
+        elif self._stop_event is not None:
             self._stop_event.set()
+        self._join_ws_thread(timeout=5.0)
+
+    def _stop_ws_client(self) -> None:
+        ws_client = self._ws_client
+        if ws_client is None:
+            return
+        disconnect = getattr(ws_client, "_disconnect", None)
+        if not callable(disconnect):
+            logger.warning("Feishu WS client has no disconnect hook; nested WS thread may leak")
+            return
+        try:
+            import lark_oapi.ws.client as ws_client_module
+
+            ws_loop = getattr(ws_client_module, "loop", None)
+            if ws_loop is not None and ws_loop.is_running():
+                future = asyncio.run_coroutine_threadsafe(disconnect(), ws_loop)
+                future.result(timeout=5.0)
+                # lark-oapi keeps the nested thread inside module-level
+                # _select(), which is just an infinite sleep loop. Stopping the
+                # SDK loop is the only available way to release Client.start().
+                ws_loop.call_soon_threadsafe(ws_loop.stop)
+            else:
+                loop = ws_loop if ws_loop is not None and not ws_loop.is_closed() else asyncio.new_event_loop()
+                if ws_loop is None:
+                    ws_client_module.loop = loop
+                loop.run_until_complete(disconnect())
+        except Exception:
+            logger.exception("Failed to disconnect Feishu WS client")
+
+    def _join_ws_thread(self, timeout: float) -> None:
+        thread = self._ws_thread
+        if thread is None or thread is threading.current_thread():
+            return
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            logger.warning("Feishu WS thread did not stop within %.1fs", timeout)
+        else:
+            self._ws_thread = None
 
     async def shutdown(self) -> None:
         """Best-effort async shutdown."""
+        self._stop_ws_client()
         if self._stop_event is not None:
             self._stop_event.set()
+        await asyncio.to_thread(self._join_ws_thread, 5.0)
 
     # ------------------------------------------------------------------
     # Misc required implementations

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -3328,6 +3328,10 @@ class FeishuBot(BaseIMClient):
         else:
             self._ws_thread = None
 
+    def verify_stopped(self) -> bool:
+        thread = self._ws_thread
+        return thread is None or not thread.is_alive()
+
     async def shutdown(self) -> None:
         """Best-effort async shutdown."""
         self._stop_ws_client()

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -15,6 +15,10 @@ from .base import BaseIMClient, InlineKeyboard, MessageContext
 logger = logging.getLogger(__name__)
 
 
+class IMClientRemovalError(RuntimeError):
+    """Raised when a hot-remove cannot stop a platform runtime cleanly."""
+
+
 class MultiIMClient(BaseIMClient):
     """Delegate inbound/outbound messaging across multiple IM clients."""
 
@@ -204,23 +208,42 @@ class MultiIMClient(BaseIMClient):
             return None
 
         async def _wrapped(*args: Any, **kwargs: Any):
-            should_fire = False
             with self._ready_lock:
                 self._ready_platforms.add(platform)
-                logger.info(
-                    "Platform '%s' ready (%d/%d)",
-                    platform,
-                    len(self._ready_platforms),
-                    len(self._client_snapshot()),
-                )
-                client_count = len(self._client_snapshot())
-                if client_count > 0 and not self._ready_emitted and len(self._ready_platforms) >= client_count:
-                    self._ready_emitted = True
-                    should_fire = True
-            if should_fire:
+            if self._mark_ready_if_complete():
                 await callback(*args, **kwargs)
 
         return _wrapped
+
+    def _mark_ready_if_complete(self) -> bool:
+        """Return True once when all currently registered clients are ready."""
+        with self._ready_lock:
+            client_count = len(self._client_snapshot())
+            logger.info(
+                "IM runtime ready progress (%d/%d)",
+                len(self._ready_platforms),
+                client_count,
+            )
+            if client_count > 0 and not self._ready_emitted and len(self._ready_platforms) >= client_count:
+                self._ready_emitted = True
+                return True
+        return False
+
+    def _aggregate_ready_callback(self) -> Optional[Callable]:
+        if self._registered_callbacks is None:
+            return None
+        return self._registered_callbacks[3].get("on_ready")
+
+    def _fire_aggregate_ready_from_thread(self, callback: Callable) -> None:
+        async def _call_ready() -> None:
+            result = callback()
+            if inspect.isawaitable(result):
+                await result
+
+        try:
+            asyncio.run(_call_ready())
+        except Exception:
+            logger.exception("MultiIMClient aggregate on_ready callback failed")
 
     def _emit_empty_ready_once(self) -> None:
         callback = getattr(self, "on_ready_callback", None)
@@ -378,6 +401,9 @@ class MultiIMClient(BaseIMClient):
                             continue
                         logger.warning("IM runtime for %s exited", platform)
                         self._threads.pop(platform, None)
+                    if self.clients and not self._threads:
+                        logger.error("All enabled IM runtime threads exited")
+                        break
                 time.sleep(0.5)
         finally:
             self.stop()
@@ -425,17 +451,10 @@ class MultiIMClient(BaseIMClient):
         loop. Returns the removed client, or ``None`` if it wasn't present.
         """
         with self._clients_lock:
-            client = self.clients.pop(platform, None)
-            thread = self._threads.pop(platform, None)
-            if platform == self.primary_platform and self.clients:
-                next_platform, next_client = next(iter(self.clients.items()))
-                self.primary_platform = next_platform
-                self.config = next_client.config
-                self.formatter = next_client.formatter
+            client = self.clients.get(platform)
+            thread = self._threads.get(platform)
         if client is None:
             return None
-        with self._ready_lock:
-            self._ready_platforms.discard(platform)
 
         stop_attr = getattr(client, "stop", None)
         if callable(stop_attr) and not inspect.iscoroutinefunction(stop_attr):
@@ -446,7 +465,25 @@ class MultiIMClient(BaseIMClient):
         if thread is not None:
             thread.join(timeout=5.0)
             if thread.is_alive():
-                logger.warning("IM thread for %s did not stop within timeout (leaked)", platform)
+                message = f"IM thread for {platform} did not stop within timeout"
+                logger.error("%s; hot-remove failed", message)
+                raise IMClientRemovalError(message)
+
+        ready_callback = None
+        with self._clients_lock:
+            self.clients.pop(platform, None)
+            self._threads.pop(platform, None)
+            if platform == self.primary_platform and self.clients:
+                next_platform, next_client = next(iter(self.clients.items()))
+                self.primary_platform = next_platform
+                self.config = next_client.config
+                self.formatter = next_client.formatter
+        with self._ready_lock:
+            self._ready_platforms.discard(platform)
+        if self._mark_ready_if_complete():
+            ready_callback = self._aggregate_ready_callback()
+        if ready_callback is not None:
+            self._fire_aggregate_ready_from_thread(ready_callback)
         logger.info("Hot-removed IM platform %s", platform)
         return client
 

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -19,11 +19,12 @@ class MultiIMClient(BaseIMClient):
     """Delegate inbound/outbound messaging across multiple IM clients."""
 
     def __init__(self, clients: Dict[str, BaseIMClient], primary_platform: str):
-        if primary_platform not in clients:
+        if clients and primary_platform not in clients:
             raise ValueError(f"Primary platform '{primary_platform}' is not in enabled clients")
         self.clients = clients
         self.primary_platform = primary_platform
         self._threads: Dict[str, threading.Thread] = {}
+        self._run_started = threading.Event()
         # Guards mutations of ``clients`` / ``_threads`` so the run() monitor
         # loop (IM worker thread) and runtime add/remove_client calls (the
         # reconcile path, on the asyncio loop) can't see a half-updated map.
@@ -32,8 +33,38 @@ class MultiIMClient(BaseIMClient):
         self._ready_lock = threading.Lock()
         self._ready_platforms: set[str] = set()
         self._ready_emitted = False
-        super().__init__(clients[primary_platform].config)
-        self.formatter = clients[primary_platform].formatter
+        self._registered_callbacks: Optional[tuple[Optional[Callable], Optional[Dict[str, Callable]], Optional[Callable], Dict[str, Any]]] = None
+        if clients:
+            super().__init__(clients[primary_platform].config)
+            self.formatter = clients[primary_platform].formatter
+        else:
+            from config.v2_config import AvibeConfig
+
+            super().__init__(AvibeConfig())
+            self.formatter = None
+
+    def _client_snapshot(self) -> Dict[str, BaseIMClient]:
+        with self._clients_lock:
+            return dict(self.clients)
+
+    def _primary_client(self) -> BaseIMClient:
+        with self._clients_lock:
+            client = self.clients.get(self.primary_platform)
+            if client is not None:
+                return client
+            if self.clients:
+                return next(iter(self.clients.values()))
+        raise ValueError("No IM platforms are enabled")
+
+    def set_primary_platform(self, primary_platform: str) -> None:
+        with self._clients_lock:
+            if self.clients and primary_platform not in self.clients:
+                raise ValueError(f"Primary platform '{primary_platform}' is not in enabled clients")
+            self.primary_platform = primary_platform
+            client = self.clients.get(primary_platform)
+            if client is not None:
+                self.config = client.config
+                self.formatter = client.formatter
 
     def _resolve_platform(self, context: Optional[MessageContext] = None) -> str:
         if context is not None:
@@ -71,18 +102,27 @@ class MultiIMClient(BaseIMClient):
         return self.get_client(self._resolve_platform(context))
 
     def get_default_parse_mode(self) -> Optional[str]:
-        return self.clients[self.primary_platform].get_default_parse_mode()
+        try:
+            return self._primary_client().get_default_parse_mode()
+        except ValueError:
+            return None
 
     def should_use_thread_for_reply(self) -> bool:
+        clients = self._client_snapshot()
+        if not clients:
+            return False
         return (
-            len({client.should_use_thread_for_reply() for client in self.clients.values()}) == 1
-            and self.clients[self.primary_platform].should_use_thread_for_reply()
+            len({client.should_use_thread_for_reply() for client in clients.values()}) == 1
+            and self._primary_client().should_use_thread_for_reply()
         )
 
     def should_use_thread_for_dm_session(self) -> bool:
+        clients = self._client_snapshot()
+        if not clients:
+            return False
         return (
-            len({client.should_use_thread_for_dm_session() for client in self.clients.values()}) == 1
-            and self.clients[self.primary_platform].should_use_thread_for_dm_session()
+            len({client.should_use_thread_for_dm_session() for client in clients.values()}) == 1
+            and self._primary_client().should_use_thread_for_dm_session()
         )
 
     def register_callbacks(
@@ -96,22 +136,29 @@ class MultiIMClient(BaseIMClient):
             on_message=on_message, on_command=on_command, on_callback_query=on_callback_query, **kwargs
         )
 
-        for platform, client in self.clients.items():
-            wrapped_kwargs = {key: self._wrap_additional_callback(platform, value) for key, value in kwargs.items()}
-            wrapped_kwargs["on_ready"] = self._wrap_on_ready(platform, kwargs.get("on_ready"))
-            wrapped_commands: Optional[Dict[str, Callable]] = None
-            if on_command is not None:
-                wrapped_commands = {}
-                for name, handler in on_command.items():
-                    wrapped = self._wrap_context_callback(platform, handler)
-                    if wrapped is not None:
-                        wrapped_commands[name] = cast(Callable, wrapped)
-            client.register_callbacks(
-                on_message=self._wrap_context_callback(platform, on_message),
-                on_command=wrapped_commands,
-                on_callback_query=self._wrap_callback_query(platform, on_callback_query),
-                **wrapped_kwargs,
-            )
+        self._registered_callbacks = (on_message, on_command, on_callback_query, dict(kwargs))
+        for platform, client in self._client_snapshot().items():
+            self._register_client_callbacks(platform, client)
+
+    def _register_client_callbacks(self, platform: str, client: BaseIMClient) -> None:
+        if self._registered_callbacks is None:
+            return
+        on_message, on_command, on_callback_query, kwargs = self._registered_callbacks
+        wrapped_kwargs = {key: self._wrap_additional_callback(platform, value) for key, value in kwargs.items()}
+        wrapped_kwargs["on_ready"] = self._wrap_on_ready(platform, kwargs.get("on_ready"))
+        wrapped_commands: Optional[Dict[str, Callable]] = None
+        if on_command is not None:
+            wrapped_commands = {}
+            for name, handler in on_command.items():
+                wrapped = self._wrap_context_callback(platform, handler)
+                if wrapped is not None:
+                    wrapped_commands[name] = cast(Callable, wrapped)
+        client.register_callbacks(
+            on_message=self._wrap_context_callback(platform, on_message),
+            on_command=wrapped_commands,
+            on_callback_query=self._wrap_callback_query(platform, on_callback_query),
+            **wrapped_kwargs,
+        )
 
     def _wrap_additional_callback(self, platform: str, callback: Optional[Callable]) -> Optional[Callable]:
         if callback is None:
@@ -164,15 +211,35 @@ class MultiIMClient(BaseIMClient):
                     "Platform '%s' ready (%d/%d)",
                     platform,
                     len(self._ready_platforms),
-                    len(self.clients),
+                    len(self._client_snapshot()),
                 )
-                if not self._ready_emitted and len(self._ready_platforms) >= len(self.clients):
+                client_count = len(self._client_snapshot())
+                if client_count > 0 and not self._ready_emitted and len(self._ready_platforms) >= client_count:
                     self._ready_emitted = True
                     should_fire = True
             if should_fire:
                 await callback(*args, **kwargs)
 
         return _wrapped
+
+    def _emit_empty_ready_once(self) -> None:
+        callback = getattr(self, "on_ready_callback", None)
+        if callback is None:
+            return
+        with self._ready_lock:
+            if self._ready_emitted or self.clients:
+                return
+            self._ready_emitted = True
+
+        async def _call_ready() -> None:
+            result = callback()
+            if inspect.isawaitable(result):
+                await result
+
+        try:
+            asyncio.run(_call_ready())
+        except Exception:
+            logger.exception("MultiIMClient empty-runtime on_ready callback failed")
 
     @staticmethod
     def _annotate_context(platform: str, context: MessageContext) -> None:
@@ -205,7 +272,8 @@ class MultiIMClient(BaseIMClient):
 
     def supports_message_editing(self, context: Optional[MessageContext] = None) -> bool:
         if context is None:
-            return all(client.supports_message_editing() for client in self.clients.values())
+            clients = self._client_snapshot()
+            return bool(clients) and all(client.supports_message_editing() for client in clients.values())
         return self.get_client_for_context(context).supports_message_editing(context)
 
     async def upload_markdown(
@@ -280,10 +348,11 @@ class MultiIMClient(BaseIMClient):
         return await self.clients[self.primary_platform].answer_callback(callback_id, text=text, show_alert=show_alert)
 
     def register_handlers(self):
-        for client in self.clients.values():
+        for client in self._client_snapshot().values():
             client.register_handlers()
 
     def run(self):
+        self._run_started.set()
         self._stop_requested.clear()
         with self._clients_lock:
             self._threads = {}
@@ -291,6 +360,8 @@ class MultiIMClient(BaseIMClient):
                 thread = threading.Thread(target=self._run_client, args=(platform, client), daemon=True)
                 thread.start()
                 self._threads[platform] = thread
+            if not self.clients:
+                self._emit_empty_ready_once()
 
         try:
             # Idle-loop until an explicit stop. The runtime stays alive even when
@@ -312,6 +383,7 @@ class MultiIMClient(BaseIMClient):
             self.stop()
             for thread in list(self._threads.values()):
                 thread.join(timeout=1.0)
+            self._run_started.clear()
 
     @staticmethod
     def _run_client(platform: str, client: BaseIMClient) -> None:
@@ -331,10 +403,15 @@ class MultiIMClient(BaseIMClient):
             if platform in self.clients:
                 logger.warning("add_client: platform %s already present; skipping", platform)
                 return
+            self._register_client_callbacks(platform, client)
             self.clients[platform] = client
+            if self.primary_platform not in self.clients:
+                self.primary_platform = platform
+                self.config = client.config
+                self.formatter = client.formatter
             # If the runtime isn't looping yet (pre-run / stopped), just register
             # the client — run() will start its thread. Otherwise start it now.
-            if not self._stop_requested.is_set():
+            if self._run_started.is_set() and not self._stop_requested.is_set():
                 thread = threading.Thread(target=self._run_client, args=(platform, client), daemon=True)
                 thread.start()
                 self._threads[platform] = thread
@@ -350,8 +427,15 @@ class MultiIMClient(BaseIMClient):
         with self._clients_lock:
             client = self.clients.pop(platform, None)
             thread = self._threads.pop(platform, None)
+            if platform == self.primary_platform and self.clients:
+                next_platform, next_client = next(iter(self.clients.items()))
+                self.primary_platform = next_platform
+                self.config = next_client.config
+                self.formatter = next_client.formatter
         if client is None:
             return None
+        with self._ready_lock:
+            self._ready_platforms.discard(platform)
 
         stop_attr = getattr(client, "stop", None)
         if callable(stop_attr) and not inspect.iscoroutinefunction(stop_attr):
@@ -369,13 +453,13 @@ class MultiIMClient(BaseIMClient):
     async def get_user_info(self, user_id: str) -> Dict[str, Any]:
         platform, raw_user_id = _split_scoped_key(str(user_id))
         platform = platform or _infer_user_platform(user_id)
-        client = self.clients.get(platform, self.clients[self.primary_platform])
+        client = self.clients.get(platform) or self._primary_client()
         return await client.get_user_info(raw_user_id)
 
     async def get_channel_info(self, channel_id: str) -> Dict[str, Any]:
         platform, raw_channel_id = _split_scoped_key(str(channel_id))
         platform = platform or _infer_channel_platform(channel_id)
-        client = self.clients.get(platform, self.clients[self.primary_platform])
+        client = self.clients.get(platform) or self._primary_client()
         return await client.get_channel_info(raw_channel_id)
 
     async def add_reaction(self, context: MessageContext, message_id: str, emoji: str) -> bool:
@@ -390,15 +474,21 @@ class MultiIMClient(BaseIMClient):
     async def clear_typing_indicator(self, context: MessageContext) -> bool:
         return await self.get_client_for_context(context).clear_typing_indicator(context)
 
+    async def delete_message(self, context: MessageContext, message_id: str) -> bool:
+        delete = getattr(self.get_client_for_context(context), "delete_message", None)
+        if not callable(delete):
+            return False
+        return await delete(context, message_id)
+
     async def send_dm(self, user_id: str, text: str, **kwargs):
         platform, raw_user_id = _split_scoped_key(str(user_id))
         platform = platform or _infer_user_platform(user_id)
-        client = self.clients.get(platform, self.clients[self.primary_platform])
+        client = self.clients.get(platform) or self._primary_client()
         return await client.send_dm(raw_user_id, text, **kwargs)
 
     def stop(self):
         self._stop_requested.set()
-        for client in self.clients.values():
+        for client in self._client_snapshot().values():
             stop_attr = getattr(client, "stop", None)
             if callable(stop_attr) and not inspect.iscoroutinefunction(stop_attr):
                 try:
@@ -412,7 +502,7 @@ class MultiIMClient(BaseIMClient):
         for thread in list(self._threads.values()):
             await asyncio.to_thread(thread.join, 2.0)
 
-        for client in self.clients.values():
+        for client in self._client_snapshot().values():
             if any(thread.is_alive() for thread in self._threads.values()):
                 break
             shutdown_attr = getattr(client, "shutdown", None)
@@ -426,4 +516,7 @@ class MultiIMClient(BaseIMClient):
                     logger.exception("Failed to shutdown IM client")
 
     def format_markdown(self, text: str) -> str:
-        return self.clients[self.primary_platform].format_markdown(text)
+        try:
+            return self._primary_client().format_markdown(text)
+        except ValueError:
+            return text

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -495,6 +495,11 @@ class MultiIMClient(BaseIMClient):
                     message = f"IM thread for {platform} did not stop within timeout"
                     logger.error("%s; hot-remove failed", message)
                     raise IMClientRemovalError(message)
+            verify_stopped = getattr(client, "verify_stopped", None)
+            if callable(verify_stopped) and not bool(verify_stopped()):
+                message = f"IM client for {platform} did not stop all runtime resources"
+                logger.error("%s; hot-remove failed", message)
+                raise IMClientRemovalError(message)
 
             ready_callback = None
             with self._clients_lock:

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -24,6 +24,10 @@ class MultiIMClient(BaseIMClient):
         self.clients = clients
         self.primary_platform = primary_platform
         self._threads: Dict[str, threading.Thread] = {}
+        # Guards mutations of ``clients`` / ``_threads`` so the run() monitor
+        # loop (IM worker thread) and runtime add/remove_client calls (the
+        # reconcile path, on the asyncio loop) can't see a half-updated map.
+        self._clients_lock = threading.RLock()
         self._stop_requested = threading.Event()
         self._ready_lock = threading.Lock()
         self._ready_platforms: set[str] = set()
@@ -281,22 +285,28 @@ class MultiIMClient(BaseIMClient):
 
     def run(self):
         self._stop_requested.clear()
-        self._threads = {}
-
-        for platform, client in self.clients.items():
-            thread = threading.Thread(target=self._run_client, args=(platform, client), daemon=True)
-            thread.start()
-            self._threads[platform] = thread
+        with self._clients_lock:
+            self._threads = {}
+            for platform, client in self.clients.items():
+                thread = threading.Thread(target=self._run_client, args=(platform, client), daemon=True)
+                thread.start()
+                self._threads[platform] = thread
 
         try:
+            # Idle-loop until an explicit stop. The runtime stays alive even when
+            # no platform threads remain — that is a valid state now: hot
+            # reconcile can disable every IM platform (workbench-only) or be
+            # mid-rebuild, and the runtime must keep running so a platform can be
+            # added back without restarting the service. (Previously this broke
+            # out when ``_threads`` emptied, which — via Controller._run_im_runtime
+            # calling loop.stop() — would tear the whole service down.)
             while not self._stop_requested.is_set():
-                for platform, thread in list(self._threads.items()):
-                    if thread.is_alive():
-                        continue
-                    logger.warning("IM runtime for %s exited", platform)
-                    self._threads.pop(platform, None)
-                if not self._threads:
-                    break
+                with self._clients_lock:
+                    for platform, thread in list(self._threads.items()):
+                        if thread.is_alive():
+                            continue
+                        logger.warning("IM runtime for %s exited", platform)
+                        self._threads.pop(platform, None)
                 time.sleep(0.5)
         finally:
             self.stop()
@@ -309,6 +319,52 @@ class MultiIMClient(BaseIMClient):
             client.run()
         except Exception:
             logger.exception("IM runtime for %s crashed", platform)
+
+    def add_client(self, platform: str, client: BaseIMClient) -> None:
+        """Start one platform's client (+ its runtime thread) at runtime.
+
+        Used by the hot-reconcile path to enable a platform without restarting
+        the service. A no-op if the platform is already present (callers rebuild
+        via remove_client + add_client for credential changes).
+        """
+        with self._clients_lock:
+            if platform in self.clients:
+                logger.warning("add_client: platform %s already present; skipping", platform)
+                return
+            self.clients[platform] = client
+            # If the runtime isn't looping yet (pre-run / stopped), just register
+            # the client — run() will start its thread. Otherwise start it now.
+            if not self._stop_requested.is_set():
+                thread = threading.Thread(target=self._run_client, args=(platform, client), daemon=True)
+                thread.start()
+                self._threads[platform] = thread
+        logger.info("Hot-added IM platform %s", platform)
+
+    def remove_client(self, platform: str) -> Optional[BaseIMClient]:
+        """Stop and drop one platform's client (+ join its thread) at runtime.
+
+        Blocking (signals the client's stop and joins its thread), so the
+        reconcile path calls this via ``asyncio.to_thread`` to avoid blocking the
+        loop. Returns the removed client, or ``None`` if it wasn't present.
+        """
+        with self._clients_lock:
+            client = self.clients.pop(platform, None)
+            thread = self._threads.pop(platform, None)
+        if client is None:
+            return None
+
+        stop_attr = getattr(client, "stop", None)
+        if callable(stop_attr) and not inspect.iscoroutinefunction(stop_attr):
+            try:
+                stop_attr()
+            except Exception:
+                logger.exception("Failed to stop IM client for %s", platform)
+        if thread is not None:
+            thread.join(timeout=5.0)
+            if thread.is_alive():
+                logger.warning("IM thread for %s did not stop within timeout (leaked)", platform)
+        logger.info("Hot-removed IM platform %s", platform)
+        return client
 
     async def get_user_info(self, user_id: str) -> Dict[str, Any]:
         platform, raw_user_id = _split_scoped_key(str(user_id))

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -28,6 +28,7 @@ class MultiIMClient(BaseIMClient):
         self.clients = clients
         self.primary_platform = primary_platform
         self._threads: Dict[str, threading.Thread] = {}
+        self._run_exceptions: Dict[str, BaseException] = {}
         self._run_started = threading.Event()
         # Guards mutations of ``clients`` / ``_threads`` so the run() monitor
         # loop (IM worker thread) and runtime add/remove_client calls (the
@@ -394,6 +395,7 @@ class MultiIMClient(BaseIMClient):
         self._stop_requested.clear()
         with self._clients_lock:
             self._threads = {}
+            self._run_exceptions = {}
             for platform, client in self.clients.items():
                 thread = threading.Thread(target=self._run_client, args=(platform, client), daemon=True)
                 thread.start()
@@ -410,6 +412,8 @@ class MultiIMClient(BaseIMClient):
             # out when ``_threads`` emptied, which — via Controller._run_im_runtime
             # calling loop.stop() — would tear the whole service down.)
             while not self._stop_requested.is_set():
+                should_exit = False
+                crash_exception: BaseException | None = None
                 with self._clients_lock:
                     for platform, thread in list(self._threads.items()):
                         if thread.is_alive():
@@ -426,7 +430,15 @@ class MultiIMClient(BaseIMClient):
                     ]
                     if active_platforms and not live_active_threads:
                         logger.error("All enabled IM runtime threads exited")
-                        break
+                        crash_exception = next(
+                            (self._run_exceptions[platform] for platform in active_platforms if platform in self._run_exceptions),
+                            None,
+                        )
+                        should_exit = True
+                if crash_exception is not None:
+                    raise crash_exception
+                if should_exit:
+                    break
                 time.sleep(0.5)
         finally:
             self.stop()
@@ -434,11 +446,12 @@ class MultiIMClient(BaseIMClient):
                 thread.join(timeout=1.0)
             self._run_started.clear()
 
-    @staticmethod
-    def _run_client(platform: str, client: BaseIMClient) -> None:
+    def _run_client(self, platform: str, client: BaseIMClient) -> None:
         try:
             client.run()
-        except Exception:
+        except Exception as exc:
+            with self._clients_lock:
+                self._run_exceptions[platform] = exc
             logger.exception("IM runtime for %s crashed", platform)
 
     def add_client(self, platform: str, client: BaseIMClient) -> None:
@@ -453,6 +466,7 @@ class MultiIMClient(BaseIMClient):
                 logger.warning("add_client: platform %s already present; skipping", platform)
                 return
             self._removing_platforms.discard(platform)
+            self._run_exceptions.pop(platform, None)
             self._register_client_callbacks(platform, client)
             self.clients[platform] = client
             if self.primary_platform not in self.clients:
@@ -502,9 +516,11 @@ class MultiIMClient(BaseIMClient):
                 raise IMClientRemovalError(message)
 
             ready_callback = None
+            emit_empty_ready = False
             with self._clients_lock:
                 self.clients.pop(platform, None)
                 self._threads.pop(platform, None)
+                self._run_exceptions.pop(platform, None)
                 self._removing_platforms.discard(platform)
                 if self.clients:
                     if self.primary_platform not in self.clients:
@@ -514,13 +530,16 @@ class MultiIMClient(BaseIMClient):
                         self.formatter = next_client.formatter
                 else:
                     self._use_workbench_fallback_runtime()
+                    emit_empty_ready = True
         except Exception:
             with self._clients_lock:
                 self._removing_platforms.discard(platform)
             raise
         with self._ready_lock:
             self._ready_platforms.discard(platform)
-        if self._mark_ready_if_complete():
+        if emit_empty_ready:
+            self._emit_empty_ready_once()
+        elif self._mark_ready_if_complete():
             ready_callback = self._aggregate_ready_callback()
         if ready_callback is not None:
             self._fire_aggregate_ready_from_thread(ready_callback)

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -383,6 +383,20 @@ class MultiIMClient(BaseIMClient):
     async def dismiss_form_message(self, context: MessageContext) -> None:
         await self.get_client_for_context(context).dismiss_form_message(context)
 
+    async def open_question_modal(
+        self,
+        trigger_id: Any,
+        context: MessageContext,
+        pending: Any,
+        callback_prefix: str = "claude_question",
+    ):
+        return await self.get_client_for_context(context).open_question_modal(
+            trigger_id=trigger_id,
+            context=context,
+            pending=pending,
+            callback_prefix=callback_prefix,
+        )
+
     async def answer_callback(self, callback_id: str, text: Optional[str] = None, show_alert: bool = False) -> bool:
         return await self.clients[self.primary_platform].answer_callback(callback_id, text=text, show_alert=show_alert)
 

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -22,10 +22,16 @@ class IMClientRemovalError(RuntimeError):
 class MultiIMClient(BaseIMClient):
     """Delegate inbound/outbound messaging across multiple IM clients."""
 
-    def __init__(self, clients: Dict[str, BaseIMClient], primary_platform: str):
+    def __init__(
+        self,
+        clients: Dict[str, BaseIMClient],
+        primary_platform: str,
+        auxiliary_clients: Optional[Dict[str, BaseIMClient]] = None,
+    ):
         if clients and primary_platform not in clients:
             raise ValueError(f"Primary platform '{primary_platform}' is not in enabled clients")
         self.clients = clients
+        self._auxiliary_clients = auxiliary_clients or {}
         self.primary_platform = primary_platform
         self._threads: Dict[str, threading.Thread] = {}
         self._run_exceptions: Dict[str, BaseException] = {}
@@ -65,6 +71,11 @@ class MultiIMClient(BaseIMClient):
         with self._clients_lock:
             return dict(self.clients)
 
+    def set_auxiliary_client(self, platform: str, client: BaseIMClient) -> None:
+        """Register a delivery-only client that is not part of the run loop."""
+        with self._clients_lock:
+            self._auxiliary_clients[platform] = client
+
     def _primary_client(self) -> BaseIMClient:
         with self._clients_lock:
             client = self.clients.get(self.primary_platform)
@@ -92,11 +103,15 @@ class MultiIMClient(BaseIMClient):
                 return context.platform
             ps = context.platform_specific or {}
             platform = ps.get("platform")
-            if isinstance(platform, str) and platform in self.clients:
+            if isinstance(platform, str) and (platform in self.clients or platform in self._auxiliary_clients):
                 return platform
         return self.primary_platform
 
     def get_client(self, platform: str) -> BaseIMClient:
+        with self._clients_lock:
+            client = self.clients.get(platform) or self._auxiliary_clients.get(platform)
+            if client is not None:
+                return client
         try:
             return self.clients[platform]
         except KeyError as exc:
@@ -120,6 +135,9 @@ class MultiIMClient(BaseIMClient):
 
     def get_client_for_context(self, context: Optional[MessageContext] = None) -> BaseIMClient:
         return self.get_client(self._resolve_platform(context))
+
+    def supports_question_modal(self, context: Optional[MessageContext] = None) -> bool:
+        return callable(getattr(self.get_client_for_context(context), "open_question_modal", None))
 
     def get_default_parse_mode(self) -> Optional[str]:
         try:
@@ -390,7 +408,14 @@ class MultiIMClient(BaseIMClient):
         pending: Any,
         callback_prefix: str = "claude_question",
     ):
-        return await self.get_client_for_context(context).open_question_modal(
+        client = self.get_client_for_context(context)
+        open_modal = getattr(client, "open_question_modal", None)
+        if not callable(open_modal):
+            return await self.send_message(
+                context,
+                "Modal UI is not available. Please reply with a custom message.",
+            )
+        return await open_modal(
             trigger_id=trigger_id,
             context=context,
             pending=pending,
@@ -563,13 +588,13 @@ class MultiIMClient(BaseIMClient):
     async def get_user_info(self, user_id: str) -> Dict[str, Any]:
         platform, raw_user_id = _split_scoped_key(str(user_id))
         platform = platform or _infer_user_platform(user_id)
-        client = self.clients.get(platform) or self._primary_client()
+        client = self.clients.get(platform) or self._auxiliary_clients.get(platform) or self._primary_client()
         return await client.get_user_info(raw_user_id)
 
     async def get_channel_info(self, channel_id: str) -> Dict[str, Any]:
         platform, raw_channel_id = _split_scoped_key(str(channel_id))
         platform = platform or _infer_channel_platform(channel_id)
-        client = self.clients.get(platform) or self._primary_client()
+        client = self.clients.get(platform) or self._auxiliary_clients.get(platform) or self._primary_client()
         return await client.get_channel_info(raw_channel_id)
 
     async def add_reaction(self, context: MessageContext, message_id: str, emoji: str) -> bool:
@@ -593,7 +618,7 @@ class MultiIMClient(BaseIMClient):
     async def send_dm(self, user_id: str, text: str, **kwargs):
         platform, raw_user_id = _split_scoped_key(str(user_id))
         platform = platform or _infer_user_platform(user_id)
-        client = self.clients.get(platform) or self._primary_client()
+        client = self.clients.get(platform) or self._auxiliary_clients.get(platform) or self._primary_client()
         return await client.send_dm(raw_user_id, text, **kwargs)
 
     def stop(self):

--- a/modules/im/multi.py
+++ b/modules/im/multi.py
@@ -33,6 +33,7 @@ class MultiIMClient(BaseIMClient):
         # loop (IM worker thread) and runtime add/remove_client calls (the
         # reconcile path, on the asyncio loop) can't see a half-updated map.
         self._clients_lock = threading.RLock()
+        self._removing_platforms: set[str] = set()
         self._stop_requested = threading.Event()
         self._ready_lock = threading.Lock()
         self._ready_platforms: set[str] = set()
@@ -42,10 +43,22 @@ class MultiIMClient(BaseIMClient):
             super().__init__(clients[primary_platform].config)
             self.formatter = clients[primary_platform].formatter
         else:
-            from config.v2_config import AvibeConfig
+            config, formatter = self._workbench_fallback_runtime()
+            super().__init__(config)
+            self.formatter = formatter
 
-            super().__init__(AvibeConfig())
-            self.formatter = None
+    @staticmethod
+    def _workbench_fallback_runtime() -> tuple[Any, Any]:
+        from .avibe import AvibeConfig
+        from .formatters.avibe_formatter import AvibeFormatter
+
+        return AvibeConfig(), AvibeFormatter()
+
+    def _use_workbench_fallback_runtime(self) -> None:
+        config, formatter = self._workbench_fallback_runtime()
+        self.primary_platform = "avibe"
+        self.config = config
+        self.formatter = formatter
 
     def _client_snapshot(self) -> Dict[str, BaseIMClient]:
         with self._clients_lock:
@@ -69,6 +82,8 @@ class MultiIMClient(BaseIMClient):
             if client is not None:
                 self.config = client.config
                 self.formatter = client.formatter
+            elif not self.clients:
+                self._use_workbench_fallback_runtime()
 
     def _resolve_platform(self, context: Optional[MessageContext] = None) -> str:
         if context is not None:
@@ -399,9 +414,17 @@ class MultiIMClient(BaseIMClient):
                     for platform, thread in list(self._threads.items()):
                         if thread.is_alive():
                             continue
+                        if platform in self._removing_platforms:
+                            continue
                         logger.warning("IM runtime for %s exited", platform)
                         self._threads.pop(platform, None)
-                    if self.clients and not self._threads:
+                    active_platforms = [platform for platform in self.clients if platform not in self._removing_platforms]
+                    live_active_threads = [
+                        platform
+                        for platform in active_platforms
+                        if (thread := self._threads.get(platform)) is not None and thread.is_alive()
+                    ]
+                    if active_platforms and not live_active_threads:
                         logger.error("All enabled IM runtime threads exited")
                         break
                 time.sleep(0.5)
@@ -429,6 +452,7 @@ class MultiIMClient(BaseIMClient):
             if platform in self.clients:
                 logger.warning("add_client: platform %s already present; skipping", platform)
                 return
+            self._removing_platforms.discard(platform)
             self._register_client_callbacks(platform, client)
             self.clients[platform] = client
             if self.primary_platform not in self.clients:
@@ -452,32 +476,43 @@ class MultiIMClient(BaseIMClient):
         """
         with self._clients_lock:
             client = self.clients.get(platform)
+            if client is not None:
+                self._removing_platforms.add(platform)
             thread = self._threads.get(platform)
         if client is None:
             return None
 
-        stop_attr = getattr(client, "stop", None)
-        if callable(stop_attr) and not inspect.iscoroutinefunction(stop_attr):
-            try:
-                stop_attr()
-            except Exception:
-                logger.exception("Failed to stop IM client for %s", platform)
-        if thread is not None:
-            thread.join(timeout=5.0)
-            if thread.is_alive():
-                message = f"IM thread for {platform} did not stop within timeout"
-                logger.error("%s; hot-remove failed", message)
-                raise IMClientRemovalError(message)
+        try:
+            stop_attr = getattr(client, "stop", None)
+            if callable(stop_attr) and not inspect.iscoroutinefunction(stop_attr):
+                try:
+                    stop_attr()
+                except Exception:
+                    logger.exception("Failed to stop IM client for %s", platform)
+            if thread is not None:
+                thread.join(timeout=5.0)
+                if thread.is_alive():
+                    message = f"IM thread for {platform} did not stop within timeout"
+                    logger.error("%s; hot-remove failed", message)
+                    raise IMClientRemovalError(message)
 
-        ready_callback = None
-        with self._clients_lock:
-            self.clients.pop(platform, None)
-            self._threads.pop(platform, None)
-            if platform == self.primary_platform and self.clients:
-                next_platform, next_client = next(iter(self.clients.items()))
-                self.primary_platform = next_platform
-                self.config = next_client.config
-                self.formatter = next_client.formatter
+            ready_callback = None
+            with self._clients_lock:
+                self.clients.pop(platform, None)
+                self._threads.pop(platform, None)
+                self._removing_platforms.discard(platform)
+                if self.clients:
+                    if self.primary_platform not in self.clients:
+                        next_platform, next_client = next(iter(self.clients.items()))
+                        self.primary_platform = next_platform
+                        self.config = next_client.config
+                        self.formatter = next_client.formatter
+                else:
+                    self._use_workbench_fallback_runtime()
+        except Exception:
+            with self._clients_lock:
+                self._removing_platforms.discard(platform)
+            raise
         with self._ready_lock:
             self._ready_platforms.discard(platform)
         if self._mark_ready_if_complete():

--- a/modules/im/telegram.py
+++ b/modules/im/telegram.py
@@ -318,6 +318,9 @@ class TelegramBot(BaseIMClient):
             await self._handle_message(message)
 
     async def _handle_message(self, message: dict[str, Any]) -> None:
+        if self._controller and hasattr(self._controller, "_refresh_config_from_disk"):
+            self._controller._refresh_config_from_disk()
+
         context = self._build_message_context(message)
         if context is None:
             return

--- a/modules/im/telegram.py
+++ b/modules/im/telegram.py
@@ -106,6 +106,7 @@ class TelegramBot(BaseIMClient):
         self._bot_user: Optional[dict[str, Any]] = None
         self._on_ready: Optional[Callable] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._poll_task: Optional[asyncio.Task[Any]] = None
         self._update_tasks: set[asyncio.Task[Any]] = set()
         self._message_callback_tasks: set[asyncio.Task[Any]] = set()
         self._update_scope_gates: dict[str, _TelegramUpdateScopeGate] = {}
@@ -166,9 +167,13 @@ class TelegramBot(BaseIMClient):
 
     def stop(self):
         self._stop_event.set()
+        loop = self._loop
+        poll_task = self._poll_task
+        if loop is not None and loop.is_running() and poll_task is not None and not poll_task.done():
+            loop.call_soon_threadsafe(poll_task.cancel)
 
     async def shutdown(self) -> None:
-        self._stop_event.set()
+        self.stop()
 
     async def _run(self) -> None:
         self._loop = asyncio.get_running_loop()
@@ -180,19 +185,30 @@ class TelegramBot(BaseIMClient):
 
             while not self._stop_event.is_set():
                 try:
-                    updates = await telegram_api.get_updates(
+                    self._poll_task = asyncio.create_task(telegram_api.get_updates(
                         self.config.bot_token,
                         self._offset,
                         proxy_url=self._proxy_url,
-                    )
+                    ))
+                    try:
+                        updates = await self._poll_task
+                    except asyncio.CancelledError:
+                        if self._stop_event.is_set():
+                            break
+                        raise
+                    finally:
+                        self._poll_task = None
                     for update in updates.get("result", []):
                         await self._wait_for_update_capacity()
                         self._offset = int(update["update_id"]) + 1
                         self._spawn_update_task(update)
                 except Exception as err:
+                    if self._stop_event.is_set():
+                        break
                     logger.warning("Telegram poll loop error: %s", err, exc_info=True)
                     await asyncio.sleep(2)
         finally:
+            self._poll_task = None
             await self._drain_background_tasks()
 
     def _spawn_update_task(self, update: dict[str, Any]) -> None:

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -484,6 +484,7 @@ class MultiSettingsManager:
     """Route settings operations to per-platform managers using scoped keys."""
 
     def __init__(self, platforms: list[str], settings_file: Optional[str] = None, primary_platform: str = "slack"):
+        self.settings_file = settings_file
         self.platform = primary_platform
         self.primary_platform = primary_platform
         self.sessions_store = SessionsStore()
@@ -500,6 +501,34 @@ class MultiSettingsManager:
             )
             for platform in platforms
         }
+        if primary_platform not in self.managers:
+            self.managers[primary_platform] = self._create_platform_manager(primary_platform)
+
+    def _create_platform_manager(self, platform: str) -> SettingsManager:
+        return SettingsManager(
+            settings_file=self.settings_file,
+            platform=platform,
+            sessions_store=self.sessions_store,
+            sessions_facade=self.sessions,
+        )
+
+    def add_platform(self, platform: str) -> SettingsManager:
+        manager = self.managers.get(platform)
+        if manager is None:
+            manager = self._create_platform_manager(platform)
+            self.managers[platform] = manager
+        return manager
+
+    def remove_platform(self, platform: str) -> None:
+        if platform == self.primary_platform:
+            return
+        self.managers.pop(platform, None)
+
+    def set_primary_platform(self, platform: str) -> None:
+        if platform not in self.managers:
+            self.add_platform(platform)
+        self.platform = platform
+        self.primary_platform = platform
 
     def get_store(self) -> SettingsStore:
         return self.managers[self.primary_platform].get_store()

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -618,18 +618,30 @@ def test_config_post_does_not_call_init_sessions():
     source = Path("vibe/ui_server.py").read_text(encoding="utf-8")
     module = ast.parse(source)
 
-    config_post = next(
-        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "config_post"
-    )
+    function_types = (ast.FunctionDef, ast.AsyncFunctionDef)
+    functions = {node.name: node for node in module.body if isinstance(node, function_types)}
+    pending = ["config_post"]
+    save_path_nodes = {}
+    while pending:
+        name = pending.pop()
+        if name in save_path_nodes:
+            continue
+        node = functions[name]
+        save_path_nodes[name] = node
+        for child in ast.walk(node):
+            if isinstance(child, ast.Name) and child.id in functions and child.id != name:
+                pending.append(child.id)
 
-    calls_init_sessions = False
-    for node in ast.walk(config_post):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            if isinstance(node.func.value, ast.Name) and node.func.value.id == "api" and node.func.attr == "init_sessions":
-                calls_init_sessions = True
-                break
+    assert "_save_config_and_runtime_decisions" in save_path_nodes
 
-    assert calls_init_sessions is False
+    calls_init_sessions = []
+    for name, function_node in save_path_nodes.items():
+        for node in ast.walk(function_node):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if isinstance(node.func.value, ast.Name) and node.func.value.id == "api" and node.func.attr == "init_sessions":
+                    calls_init_sessions.append(name)
+
+    assert calls_init_sessions == []
 
 
 def test_settings_platforms_apply_uses_parent_platform_identity():

--- a/tests/test_controller_config_reload.py
+++ b/tests/test_controller_config_reload.py
@@ -1,16 +1,18 @@
 from types import SimpleNamespace
 
-from config.v2_config import DiscordConfig, V2Config
+from config.v2_config import DiscordConfig, TelegramConfig, V2Config
 from core.controller import Controller
 
 
-def _config_payload(discord_payload: dict) -> dict:
+def _config_payload(discord_payload: dict | None = None, telegram_payload: dict | None = None) -> dict:
+    platform = "telegram" if telegram_payload is not None else "discord"
     return {
-        "platform": "discord",
-        "platforms": {"enabled": ["discord"], "primary": "discord"},
+        "platform": platform,
+        "platforms": {"enabled": [platform], "primary": platform},
         "mode": "self_host",
         "version": "v2",
-        "discord": discord_payload,
+        "discord": discord_payload or {},
+        "telegram": telegram_payload or {},
         "runtime": {"default_cwd": "_tmp", "log_level": "INFO"},
         "agents": {
             "default_backend": "opencode",
@@ -28,7 +30,7 @@ def test_refresh_config_updates_platform_message_settings(tmp_path, monkeypatch)
     controller = Controller.__new__(Controller)
     controller.config = V2Config.from_payload(
         _config_payload(
-            {
+            discord_payload={
                 "bot_token": "discord-token",
                 "require_mention": stale_discord_config.require_mention,
             }
@@ -39,7 +41,7 @@ def test_refresh_config_updates_platform_message_settings(tmp_path, monkeypatch)
 
     latest_config = V2Config.from_payload(
         _config_payload(
-            {
+            discord_payload={
                 "bot_token": "discord-token",
                 "require_mention": False,
             }
@@ -50,6 +52,44 @@ def test_refresh_config_updates_platform_message_settings(tmp_path, monkeypatch)
     controller._refresh_config_from_disk()
 
     assert stale_discord_config.require_mention is False
+
+
+def test_refresh_config_updates_telegram_option_only_settings(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+
+    stale_telegram_config = TelegramConfig(
+        bot_token="123456:test-token",
+        require_mention=True,
+        forum_auto_topic=True,
+    )
+    controller = Controller.__new__(Controller)
+    controller.config = V2Config.from_payload(
+        _config_payload(
+            telegram_payload={
+                "bot_token": "123456:test-token",
+                "require_mention": stale_telegram_config.require_mention,
+                "forum_auto_topic": stale_telegram_config.forum_auto_topic,
+            }
+        )
+    )
+    controller.im_clients = {"telegram": SimpleNamespace(config=stale_telegram_config)}
+    controller._config_mtime = None
+
+    latest_config = V2Config.from_payload(
+        _config_payload(
+            telegram_payload={
+                "bot_token": "123456:test-token",
+                "require_mention": False,
+                "forum_auto_topic": False,
+            }
+        )
+    )
+    latest_config.save()
+
+    controller._refresh_config_from_disk()
+
+    assert stale_telegram_config.require_mention is False
+    assert stale_telegram_config.forum_auto_topic is False
 
 
 def test_refresh_config_updates_remote_access_for_audio_asr(tmp_path, monkeypatch) -> None:

--- a/tests/test_controller_platform_reconcile.py
+++ b/tests/test_controller_platform_reconcile.py
@@ -150,6 +150,7 @@ def _controller(config):
     controller.im_client = MultiIMClient(dict(clients), controller.primary_platform)
     controller.im_clients = dict(clients)
     controller.im_clients["avibe"] = _Client("avibe")
+    controller._removed_im_clients = {}
     controller.settings_manager = MultiSettingsManager(
         Controller._settings_platforms_for(controller.enabled_platforms, controller.primary_platform),
         primary_platform=controller.primary_platform,
@@ -196,6 +197,26 @@ def test_reconcile_removes_platform_and_keeps_workbench_delivery(monkeypatch):
     assert "discord" not in controller.im_client.clients
     assert "discord" not in controller.im_clients
     assert "avibe" in controller.im_clients
+
+
+def test_reconcile_routes_removed_platform_context_to_noop_sink(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack", "discord"]))
+    slack = controller.im_clients["slack"]
+
+    asyncio.run(controller.reconcile_platforms(_config(["slack"])))
+
+    stale_context = MessageContext(user_id="u", channel_id="discord-channel", platform="discord")
+    removed_client = controller.get_im_client_for_context(stale_context)
+    platform_client = controller._get_im_client_for_platform("discord")
+
+    assert removed_client is platform_client
+    assert removed_client is not slack
+    assert asyncio.run(removed_client.send_message(stale_context, "late result")) == ""
+    assert asyncio.run(removed_client.send_message_with_buttons(stale_context, "late result", None)) == ""
+    assert asyncio.run(removed_client.send_typing_indicator(stale_context)) is False
+    assert asyncio.run(removed_client.clear_typing_indicator(stale_context)) is False
+    assert asyncio.run(removed_client.delete_message(stale_context, "ack-1")) is False
 
 
 def test_reconcile_rebuilds_enabled_platform_on_credential_change(monkeypatch):

--- a/tests/test_controller_platform_reconcile.py
+++ b/tests/test_controller_platform_reconcile.py
@@ -147,9 +147,13 @@ def _controller(config):
     clients = {platform: _Client(platform, getattr(config, platform)) for platform in controller.enabled_platforms}
     for platform, client in clients.items():
         client.formatter = _Formatter()
-    controller.im_client = MultiIMClient(dict(clients), controller.primary_platform)
     controller.im_clients = dict(clients)
     controller.im_clients["avibe"] = _Client("avibe")
+    controller.im_client = MultiIMClient(
+        dict(clients),
+        controller.primary_platform,
+        auxiliary_clients={"avibe": controller.im_clients["avibe"]},
+    )
     controller._removed_im_clients = {}
     controller.settings_manager = MultiSettingsManager(
         Controller._settings_platforms_for(controller.enabled_platforms, controller.primary_platform),
@@ -307,3 +311,31 @@ def test_reconcile_disable_all_keeps_empty_multi_runtime(monkeypatch):
     assert controller.im_client.clients == {}
     assert "avibe" in controller.im_clients
     assert controller.get_im_client_for_context(MessageContext(user_id="u", channel_id="c", platform="avibe")).name == "avibe"
+
+
+def test_reconcile_disable_all_keeps_multi_runtime_avibe_delivery(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack"]))
+    avibe = controller.im_clients["avibe"]
+    deleted: list[tuple[str, str]] = []
+    reactions: list[tuple[str, str, str]] = []
+
+    async def _delete_message(context, message_id):
+        deleted.append((context.platform, message_id))
+        return True
+
+    async def _remove_reaction(context, message_id, emoji):
+        reactions.append((context.platform, message_id, emoji))
+        return True
+
+    avibe.delete_message = _delete_message
+    avibe.remove_reaction = _remove_reaction
+
+    asyncio.run(controller.reconcile_platforms(_config([])))
+    context = MessageContext(user_id="u", channel_id="c", platform="avibe")
+
+    assert controller.im_client.get_client_for_context(context) is avibe
+    assert asyncio.run(controller.im_client.delete_message(context, "ack-1")) is True
+    assert asyncio.run(controller.im_client.remove_reaction(context, "ack-1", "eyes")) is True
+    assert deleted == [("avibe", "ack-1")]
+    assert reactions == [("avibe", "ack-1", "eyes")]

--- a/tests/test_controller_platform_reconcile.py
+++ b/tests/test_controller_platform_reconcile.py
@@ -212,8 +212,8 @@ def test_reconcile_routes_removed_platform_context_to_noop_sink(monkeypatch):
 
     assert removed_client is platform_client
     assert removed_client is not slack
-    assert asyncio.run(removed_client.send_message(stale_context, "late result")) == ""
-    assert asyncio.run(removed_client.send_message_with_buttons(stale_context, "late result", None)) == ""
+    assert asyncio.run(removed_client.send_message(stale_context, "late result")) is None
+    assert asyncio.run(removed_client.send_message_with_buttons(stale_context, "late result", None)) is None
     assert asyncio.run(removed_client.send_typing_indicator(stale_context)) is False
     assert asyncio.run(removed_client.clear_typing_indicator(stale_context)) is False
     assert asyncio.run(removed_client.delete_message(stale_context, "ack-1")) is False

--- a/tests/test_controller_platform_reconcile.py
+++ b/tests/test_controller_platform_reconcile.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from config.v2_config import DiscordConfig, LarkConfig, SlackConfig
+from core.controller import Controller
+from modules.agent_router import AgentRouter
+from modules.im.base import BaseIMClient, BaseIMConfig, MessageContext
+from modules.im.multi import MultiIMClient
+from modules.settings_manager import MultiSettingsManager
+
+
+@dataclass
+class _StubConfig(BaseIMConfig):
+    name: str = ""
+
+    def validate(self) -> None:
+        return None
+
+
+class _Formatter:
+    def format_error(self, text: str) -> str:
+        return text
+
+
+class _Client(BaseIMClient):
+    def __init__(self, name: str, config: BaseIMConfig | None = None):
+        super().__init__(config or _StubConfig(name=name))
+        self.name = name
+        self.stopped = False
+        self.settings_manager = None
+        self.controller = None
+
+    def set_settings_manager(self, settings_manager):
+        self.settings_manager = settings_manager
+
+    def set_controller(self, controller):
+        self.controller = controller
+
+    async def send_message(self, context, text, parse_mode=None, reply_to=None):
+        return self.name
+
+    async def send_message_with_buttons(self, context, text, keyboard, parse_mode=None):
+        return self.name
+
+    async def edit_message(self, context, message_id, text=None, keyboard=None, parse_mode=None):
+        return True
+
+    async def answer_callback(self, callback_id, text=None, show_alert=False):
+        return True
+
+    def register_handlers(self):
+        return None
+
+    def run(self):
+        return None
+
+    def stop(self):
+        self.stopped = True
+
+    async def get_user_info(self, user_id: str):
+        return {"id": user_id}
+
+    async def get_channel_info(self, channel_id: str):
+        return {"id": channel_id}
+
+    def format_markdown(self, text: str) -> str:
+        return text
+
+
+async def _noop(*args, **kwargs):
+    return None
+
+
+def _handler(**overrides):
+    methods = {
+        "handle_start",
+        "handle_new",
+        "handle_cwd",
+        "handle_set_cwd",
+        "handle_resume",
+        "handle_setup",
+        "handle_stop",
+        "handle_bind",
+        "handle_change_cwd_submission",
+        "handle_settings",
+        "handle_settings_update",
+        "handle_routing_update",
+        "handle_routing_modal_update",
+        "handle_callback_query",
+        "handle_resume_session_submission",
+    }
+    values = {name: _noop for name in methods}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _Descriptor:
+    def __init__(self, platform: str):
+        self.id = platform
+        self.config_key = platform
+        self.credential_fields = ("bot_token",)
+
+    def runtime_reconcile_field_names(self):
+        if self.id == "lark":
+            return ("app_id", "app_secret", "domain")
+        return ("bot_token",)
+
+    def get_config(self, config):
+        return getattr(config, self.id)
+
+    def create_client(self, config):
+        return _Client(self.id, self.get_config(config))
+
+    def create_formatter(self):
+        return _Formatter()
+
+
+def _config(
+    enabled: list[str],
+    *,
+    primary: str | None = None,
+    slack_token: str = "xoxb-old",
+    discord_token: str = "discord-old-token",
+    lark_secret: str = "lark-old-secret",
+):
+    primary = primary or (enabled[0] if enabled else "avibe")
+    return SimpleNamespace(
+        platform=primary,
+        platforms=SimpleNamespace(enabled=enabled, primary=primary),
+        enabled_platforms=lambda: list(enabled),
+        slack=SlackConfig(bot_token=slack_token),
+        discord=DiscordConfig(bot_token=discord_token),
+        lark=LarkConfig(app_id="cli_a", app_secret=lark_secret, domain="feishu"),
+        claude=SimpleNamespace(),
+        language="en",
+    )
+
+
+def _controller(config):
+    controller = Controller.__new__(Controller)
+    controller.config = config
+    controller.enabled_platforms = list(config.enabled_platforms())
+    controller.primary_platform = Controller._derive_primary_platform(config)
+    clients = {platform: _Client(platform, getattr(config, platform)) for platform in controller.enabled_platforms}
+    for platform, client in clients.items():
+        client.formatter = _Formatter()
+    controller.im_client = MultiIMClient(dict(clients), controller.primary_platform)
+    controller.im_clients = dict(clients)
+    controller.im_clients["avibe"] = _Client("avibe")
+    controller.settings_manager = MultiSettingsManager(
+        Controller._settings_platforms_for(controller.enabled_platforms, controller.primary_platform),
+        primary_platform=controller.primary_platform,
+    )
+    controller.platform_settings_managers = controller.settings_manager.managers
+    controller.sessions = controller.settings_manager.sessions
+    controller.agent_router = AgentRouter.from_file(None, platform=controller.primary_platform, default_backend="opencode")
+    controller.processing_indicator = SimpleNamespace(config=config)
+    controller.audio_asr_service = SimpleNamespace(config=config)
+    controller.claude_client = SimpleNamespace(config=config.claude, formatter=None)
+    controller.command_handler = _handler()
+    controller.settings_handler = _handler()
+    controller.message_handler = _handler()
+    controller.session_handler = _handler()
+    controller.agent_service = SimpleNamespace(agents={})
+    controller._reconcile_lock = None
+    controller._loop = None
+    return controller
+
+
+def test_reconcile_adds_platform_with_callbacks_before_start(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack"]))
+    controller._setup_callbacks()
+
+    result = asyncio.run(controller.reconcile_platforms(_config(["slack", "discord"])))
+
+    assert result["added"] == ["discord"]
+    assert "discord" in controller.im_client.clients
+    assert "discord" in controller.platform_settings_managers
+    assert controller.im_client.clients["discord"].on_message_callback is not None
+    assert controller.im_client.clients["discord"].settings_manager.platform == "discord"
+
+
+def test_reconcile_removes_platform_and_keeps_workbench_delivery(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack", "discord"]))
+    removed_client = controller.im_clients["discord"]
+
+    result = asyncio.run(controller.reconcile_platforms(_config(["slack"])))
+
+    assert result["removed"] == ["discord"]
+    assert removed_client.stopped is True
+    assert "discord" not in controller.im_client.clients
+    assert "discord" not in controller.im_clients
+    assert "avibe" in controller.im_clients
+
+
+def test_reconcile_rebuilds_enabled_platform_on_credential_change(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack"]))
+    old_client = controller.im_clients["slack"]
+
+    result = asyncio.run(controller.reconcile_platforms(_config(["slack"], slack_token="xoxb-new")))
+
+    assert result["rebuilt"] == ["slack"]
+    assert old_client.stopped is True
+    assert controller.im_clients["slack"] is not old_client
+    assert controller.im_clients["slack"].config.bot_token == "xoxb-new"
+
+
+def test_reconcile_noop_when_runtime_fields_do_not_change(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack"]))
+    original_client = controller.im_clients["slack"]
+
+    result = asyncio.run(controller.reconcile_platforms(_config(["slack"])))
+
+    assert result["added"] == []
+    assert result["removed"] == []
+    assert result["rebuilt"] == []
+    assert controller.im_clients["slack"] is original_client
+
+
+def test_reconcile_disable_all_keeps_empty_multi_runtime(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack"]))
+
+    result = asyncio.run(controller.reconcile_platforms(_config([])))
+
+    assert result["removed"] == ["slack"]
+    assert result["enabled"] == []
+    assert result["primary"] == "avibe"
+    assert controller.primary_platform == "avibe"
+    assert controller.im_client.clients == {}
+    assert "avibe" in controller.im_clients
+    assert controller.get_im_client_for_context(MessageContext(user_id="u", channel_id="c", platform="avibe")).name == "avibe"

--- a/tests/test_controller_platform_reconcile.py
+++ b/tests/test_controller_platform_reconcile.py
@@ -219,6 +219,31 @@ def test_reconcile_routes_removed_platform_context_to_noop_sink(monkeypatch):
     assert asyncio.run(removed_client.delete_message(stale_context, "ack-1")) is False
 
 
+def test_reconcile_routes_to_sink_while_platform_stop_is_in_progress(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack", "discord"]))
+    slack = controller.im_clients["slack"]
+    discord = controller.im_clients["discord"]
+    seen_during_stop: list[BaseIMClient] = []
+
+    def _remove_client(platform):
+        assert platform == "discord"
+        seen_during_stop.append(
+            controller.get_im_client_for_context(MessageContext(user_id="u", channel_id="c", platform=platform))
+        )
+        return discord
+
+    controller.im_client.remove_client = _remove_client
+
+    result = asyncio.run(controller.reconcile_platforms(_config(["slack"])))
+
+    assert result["removed"] == ["discord"]
+    assert seen_during_stop
+    assert seen_during_stop[0] is not discord
+    assert seen_during_stop[0] is not slack
+    assert asyncio.run(seen_during_stop[0].send_message(MessageContext(user_id="u", channel_id="c", platform="discord"), "late")) is None
+
+
 def test_reconcile_rebuilds_enabled_platform_on_credential_change(monkeypatch):
     monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
     controller = _controller(_config(["slack"]))

--- a/tests/test_controller_platform_reconcile.py
+++ b/tests/test_controller_platform_reconcile.py
@@ -232,6 +232,30 @@ def test_reconcile_rebuilds_enabled_platform_on_credential_change(monkeypatch):
     assert controller.im_clients["slack"].config.bot_token == "xoxb-new"
 
 
+def test_reconcile_rebuild_installs_sink_before_new_client(monkeypatch):
+    monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
+    controller = _controller(_config(["slack"]))
+    old_client = controller.im_clients["slack"]
+    seen_during_rebuild: list[BaseIMClient] = []
+
+    def _build_platform_client(platform, config):
+        seen_during_rebuild.append(
+            controller.get_im_client_for_context(MessageContext(user_id="u", channel_id="c", platform=platform))
+        )
+        return _Client(platform, getattr(config, platform))
+
+    controller._build_platform_client = _build_platform_client
+
+    result = asyncio.run(controller.reconcile_platforms(_config(["slack"], slack_token="xoxb-new")))
+
+    assert result["rebuilt"] == ["slack"]
+    assert old_client.stopped is True
+    assert len(seen_during_rebuild) == 1
+    assert seen_during_rebuild[0] is not old_client
+    assert seen_during_rebuild[0] is not controller.im_clients["slack"]
+    assert asyncio.run(seen_during_rebuild[0].send_message(MessageContext(user_id="u", channel_id="c", platform="slack"), "late")) is None
+
+
 def test_reconcile_noop_when_runtime_fields_do_not_change(monkeypatch):
     monkeypatch.setattr("core.controller.get_platform_descriptor", lambda platform: _Descriptor(platform))
     controller = _controller(_config(["slack"]))

--- a/tests/test_feishu_hot_stop.py
+++ b/tests/test_feishu_hot_stop.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+
+from config.v2_config import LarkConfig
+from modules.im.feishu import FeishuBot
+
+
+def test_feishu_stop_disconnects_nested_ws_client(monkeypatch):
+    import lark_oapi.ws.client as ws_client_module
+
+    loop = asyncio.new_event_loop()
+    disconnected = []
+
+    class _WsClient:
+        async def _disconnect(self):
+            disconnected.append(True)
+
+    bot = FeishuBot(LarkConfig(app_id="cli_a", app_secret="secret"))
+    bot._ws_client = _WsClient()
+    bot._loop = loop
+    monkeypatch.setattr(ws_client_module, "loop", loop)
+
+    try:
+        bot.stop()
+    finally:
+        loop.close()
+
+    assert disconnected == [True]
+
+
+def test_feishu_stop_stops_running_lark_ws_loop(monkeypatch):
+    import lark_oapi.ws.client as ws_client_module
+
+    loop = asyncio.new_event_loop()
+    disconnected = []
+
+    class _WsClient:
+        async def _disconnect(self):
+            disconnected.append(True)
+
+    def _run_loop() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    import threading
+
+    thread = threading.Thread(target=_run_loop, daemon=True)
+    thread.start()
+    try:
+        assert thread.is_alive()
+        bot = FeishuBot(LarkConfig(app_id="cli_a", app_secret="secret"))
+        bot._ws_client = _WsClient()
+        monkeypatch.setattr(ws_client_module, "loop", loop)
+
+        bot.stop()
+        thread.join(timeout=2)
+    finally:
+        if thread.is_alive():
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=2)
+        loop.close()
+
+    assert disconnected == [True]
+    assert thread.is_alive() is False

--- a/tests/test_feishu_hot_stop.py
+++ b/tests/test_feishu_hot_stop.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 
 from config.v2_config import LarkConfig
 from modules.im.feishu import FeishuBot
+from modules.im.multi import IMClientRemovalError, MultiIMClient
 
 
 def test_feishu_stop_disconnects_nested_ws_client(monkeypatch):
@@ -63,3 +65,38 @@ def test_feishu_stop_stops_running_lark_ws_loop(monkeypatch):
 
     assert disconnected == [True]
     assert thread.is_alive() is False
+
+
+def test_feishu_nested_ws_thread_leak_fails_hot_remove():
+    stop_outer = threading.Event()
+    stop_leaked_ws = threading.Event()
+    leaked_ws = threading.Thread(target=stop_leaked_ws.wait, daemon=True, name="feishu-ws-test")
+    leaked_ws.start()
+    outer = threading.Thread(target=stop_outer.wait, daemon=True, name="feishu-outer-test")
+    outer.start()
+
+    bot = FeishuBot(LarkConfig(app_id="cli_a", app_secret="secret"))
+    bot._ws_thread = leaked_ws
+    client = MultiIMClient({"lark": bot}, primary_platform="lark")
+    client._threads["lark"] = outer
+
+    def _stop_outer_only() -> None:
+        stop_outer.set()
+
+    bot.stop = _stop_outer_only
+
+    try:
+        try:
+            client.remove_client("lark")
+        except IMClientRemovalError as exc:
+            assert "did not stop all runtime resources" in str(exc)
+        else:
+            raise AssertionError("remove_client should fail when Feishu nested WS thread leaks")
+
+        assert client.clients["lark"] is bot
+        assert client._threads["lark"] is outer
+    finally:
+        stop_outer.set()
+        stop_leaked_ws.set()
+        outer.join(timeout=2)
+        leaked_ws.join(timeout=2)

--- a/tests/test_internal_client.py
+++ b/tests/test_internal_client.py
@@ -99,6 +99,36 @@ def test_dispatch_async_missing_socket_raises_unavailable(tmp_path):
         asyncio.run(internal_client.dispatch_async({"session_id": "s", "text": "x"}, socket_path=sock))
 
 
+def test_reconcile_platforms_round_trip(tmp_path):
+    app = FastAPI()
+    calls: list[bool] = []
+
+    @app.post("/internal/reconcile-platforms")
+    async def _reconcile():
+        calls.append(True)
+        return {"ok": True, "rebuilt": ["slack"]}
+
+    sock = tmp_path / "dispatch.sock"
+    sock.touch()
+
+    async def _go():
+        fake_transport = httpx.ASGITransport(app=app)
+        with patch("vibe.internal_client.httpx.AsyncHTTPTransport", return_value=fake_transport):
+            return await internal_client.reconcile_platforms(socket_path=sock)
+
+    result = asyncio.run(_go())
+
+    assert calls == [True]
+    assert result["status_code"] == 200
+    assert result["body"] == {"ok": True, "rebuilt": ["slack"]}
+
+
+def test_reconcile_platforms_missing_socket_raises_unavailable(tmp_path):
+    sock = tmp_path / "missing.sock"
+    with pytest.raises(internal_client.InternalServerUnavailable):
+        asyncio.run(internal_client.reconcile_platforms(socket_path=sock))
+
+
 def test_turn_state_os_error_raises_unavailable(tmp_path):
     """Socket files can exist on Docker Desktop bind mounts while connection
     operations raise platform ``OSError`` values (for example errno 95). The UI

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -205,6 +205,28 @@ def test_reconcile_platforms_endpoint_calls_controller(monkeypatch):
     assert calls == ["compat:v2-config"]
 
 
+def test_reconcile_platforms_endpoint_reports_controller_failure(monkeypatch):
+    controller = _build_controller_double()
+
+    async def reconcile_platforms(config):
+        raise RuntimeError("IM thread for discord did not stop within timeout")
+
+    controller.reconcile_platforms = reconcile_platforms
+    monkeypatch.setattr("config.v2_config.V2Config.load", lambda: "v2-config")
+    monkeypatch.setattr("config.v2_compat.to_app_config", lambda config: f"compat:{config}")
+    app = internal_server.create_app(controller)
+
+    async def _go():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.post("/internal/reconcile-platforms")
+
+    resp = asyncio.run(_go())
+
+    assert resp.status_code == 500
+    assert resp.json() == {"ok": False, "error": "IM thread for discord did not stop within timeout"}
+
+
 async def _dispatch_round_trip(body: dict) -> httpx.Response:
     app = internal_server.create_app(_build_controller_double())
     transport = httpx.ASGITransport(app=app)

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -156,6 +156,7 @@ def test_create_app_exposes_minimal_endpoints():
     # flow re-publishes its SSE chunks as ``show.dispatch``).
     assert ("/internal/health", ("GET",)) in routes
     assert ("/internal/dispatch_async", ("POST",)) in routes
+    assert ("/internal/reconcile-platforms", ("POST",)) in routes
     assert ("/internal/cancel/{session_id}", ("POST",)) in routes
     assert ("/internal/dispatch", ("POST",)) in routes
 
@@ -177,6 +178,31 @@ def test_health_endpoint():
     resp = asyncio.run(_health_round_trip())
     assert resp.status_code == 200
     assert resp.json() == {"ok": True, "service": "vibe-remote-internal", "version": 1}
+
+
+def test_reconcile_platforms_endpoint_calls_controller(monkeypatch):
+    controller = _build_controller_double()
+    calls = []
+
+    async def reconcile_platforms(config):
+        calls.append(config)
+        return {"ok": True, "added": ["discord"]}
+
+    controller.reconcile_platforms = reconcile_platforms
+    monkeypatch.setattr("config.v2_config.V2Config.load", lambda: "v2-config")
+    monkeypatch.setattr("config.v2_compat.to_app_config", lambda config: f"compat:{config}")
+    app = internal_server.create_app(controller)
+
+    async def _go():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.post("/internal/reconcile-platforms")
+
+    resp = asyncio.run(_go())
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "added": ["discord"]}
+    assert calls == ["compat:v2-config"]
 
 
 async def _dispatch_round_trip(body: dict) -> httpx.Response:

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -53,6 +53,20 @@ class _StubIMClient:
         return self._upload_id
 
 
+class _DropClient(_StubIMClient):
+    async def send_message(self, context, text, parse_mode=None, reply_to=None):
+        self.sent_messages.append((context.channel_id, text, parse_mode))
+        return None
+
+    async def send_message_with_buttons(self, context, text, keyboard, parse_mode=None):
+        self.sent_messages.append((context.channel_id, text, parse_mode))
+        return None
+
+    async def upload_markdown(self, context, title, content, filetype="markdown"):
+        self.uploaded_markdowns.append((context.channel_id, title, content, filetype))
+        return None
+
+
 class _NativeMarkdownIMClient(_StubIMClient):
     def __init__(self):
         super().__init__()
@@ -207,6 +221,28 @@ class MessageDispatcherResultFallbackTests(unittest.IsolatedAsyncioTestCase):
         context = MessageContext(user_id="U1", channel_id="C1", platform="slack")
         with mock.patch("core.message_dispatcher.persist_agent_message") as persist:
             result = await dispatcher.emit_agent_message(context, "notify", "heads up")
+        self.assertIsNone(result)
+        persist.assert_not_called()
+
+    async def test_removed_platform_notify_drop_is_not_persisted(self):
+        controller = _StubController(platform="discord", im_client=_DropClient())
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="U1", channel_id="C1", platform="discord")
+
+        with mock.patch("core.message_dispatcher.persist_agent_message") as persist:
+            result = await dispatcher.emit_agent_message(context, "notify", "late notify")
+
+        self.assertIsNone(result)
+        persist.assert_not_called()
+
+    async def test_removed_platform_result_drop_is_not_persisted(self):
+        controller = _StubController(platform="discord", im_client=_DropClient())
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="U1", channel_id="C1", platform="discord")
+
+        with mock.patch("core.message_dispatcher.persist_agent_message") as persist:
+            result = await dispatcher.emit_agent_message(context, "result", "late result")
+
         self.assertIsNone(result)
         persist.assert_not_called()
 

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -119,6 +119,16 @@ class _SlowStopClient(_StubClient):
         self.finish_stop.wait(timeout=5)
 
 
+class _CrashingClient(_StubClient):
+    def __init__(self, name: str, exc: BaseException):
+        super().__init__(name)
+        self.exc = exc
+
+    def run(self):
+        self.started.set()
+        raise self.exc
+
+
 def test_multi_settings_manager_routes_scoped_keys(tmp_path):
     manager = MultiSettingsManager(
         ["slack", "wechat"], settings_file=str(tmp_path / "settings.json"), primary_platform="slack"
@@ -208,6 +218,22 @@ def test_multi_im_client_remove_pending_platform_completes_ready():
     assert ready_calls == [True]
 
 
+def test_multi_im_client_remove_last_pending_platform_completes_empty_ready():
+    slack = _StubClient("slack")
+    client = MultiIMClient({"slack": slack}, primary_platform="slack")
+    ready_calls: list[bool] = []
+
+    async def on_ready():
+        ready_calls.append(True)
+
+    client.register_callbacks(on_ready=on_ready)
+
+    removed = client.remove_client("slack")
+
+    assert removed is slack
+    assert ready_calls == [True]
+
+
 def test_multi_im_client_run_returns_when_all_enabled_threads_exit():
     client = MultiIMClient({"slack": _StubClient("slack")}, primary_platform="slack")
     returned: list[bool] = []
@@ -223,6 +249,33 @@ def test_multi_im_client_run_returns_when_all_enabled_threads_exit():
 
     assert thread.is_alive() is False
     assert returned == [True]
+
+
+def test_multi_im_client_run_raises_single_platform_runtime_crash():
+    boom = RuntimeError("slack failed")
+    client = MultiIMClient({"slack": _CrashingClient("slack", boom)}, primary_platform="slack")
+
+    try:
+        client.run()
+    except RuntimeError as exc:
+        assert exc is boom
+    else:
+        raise AssertionError("MultiIMClient.run should raise the platform runtime crash")
+
+
+def test_multi_im_client_run_raises_multi_platform_runtime_crash_when_all_exit():
+    boom = RuntimeError("discord failed")
+    client = MultiIMClient(
+        {"slack": _StubClient("slack"), "discord": _CrashingClient("discord", boom)},
+        primary_platform="slack",
+    )
+
+    try:
+        client.run()
+    except RuntimeError as exc:
+        assert exc is boom
+    else:
+        raise AssertionError("MultiIMClient.run should raise the captured platform runtime crash")
 
 
 def test_multi_im_client_remove_client_keeps_maps_when_thread_will_not_stop():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -31,6 +33,7 @@ class _StubClient(BaseIMClient):
         self.sent = []
         self.removed = []
         self.dismissed = []
+        self.stopped = False
 
     async def send_message(self, context, text, parse_mode=None, reply_to=None):
         self.sent.append((context.platform, context.channel_id, text))
@@ -60,6 +63,9 @@ class _StubClient(BaseIMClient):
 
     def run(self):
         return None
+
+    def stop(self):
+        self.stopped = True
 
     async def get_user_info(self, user_id: str):
         return {"id": user_id, "name": self.name}
@@ -116,6 +122,59 @@ def test_multi_im_client_routes_send_by_context_platform():
 
     assert slack.sent == []
     assert wechat.sent == [("wechat", "c", "hello")]
+
+
+def test_multi_im_client_add_client_registers_callbacks_before_start():
+    client = MultiIMClient({}, primary_platform="avibe")
+    added = _StubClient("slack")
+    captured: list[str | None] = []
+
+    async def on_message(context: MessageContext, text: str):
+        captured.append(context.platform)
+
+    client.register_callbacks(on_message=on_message)
+    client.add_client("slack", added)
+
+    assert client.clients["slack"] is added
+    assert added.on_message_callback is not None
+    asyncio.run(added.on_message_callback(MessageContext(user_id="u", channel_id="c"), "hello"))
+    assert captured == ["slack"]
+
+
+def test_multi_im_client_remove_client_stops_and_drops_platform():
+    slack = _StubClient("slack")
+    wechat = _StubClient("wechat")
+    client = MultiIMClient({"slack": slack, "wechat": wechat}, primary_platform="slack")
+
+    removed = client.remove_client("slack")
+
+    assert removed is slack
+    assert slack.stopped is True
+    assert "slack" not in client.clients
+    assert client.primary_platform == "wechat"
+
+
+def test_multi_im_client_empty_runtime_stays_alive_until_stop():
+    client = MultiIMClient({}, primary_platform="avibe")
+    returned: list[bool] = []
+
+    def _run() -> None:
+        client.run()
+        returned.append(True)
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    assert client._run_started.wait(timeout=2)
+    time.sleep(0.05)
+    assert thread.is_alive() is True
+    assert returned == []
+
+    client.stop()
+    thread.join(timeout=2)
+
+    assert thread.is_alive() is False
+    assert returned == [True]
 
 
 def test_multi_im_client_routes_message_edit_capability_by_context_platform():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -10,7 +10,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from modules.im.base import BaseIMClient, BaseIMConfig, MessageContext
-from modules.im.multi import MultiIMClient
+from modules.im.multi import IMClientRemovalError, MultiIMClient
 from modules.settings_manager import MultiSettingsManager
 from config.v2_sessions import ActivePollInfo
 from core.processing_indicator import ProcessingIndicatorService
@@ -26,10 +26,13 @@ class _StubConfig(BaseIMConfig):
 
 
 class _StubClient(BaseIMClient):
-    def __init__(self, name: str, *, supports_editing: bool = True):
+    def __init__(self, name: str, *, supports_editing: bool = True, run_until_stopped: bool = False):
         super().__init__(_StubConfig())
         self.name = name
         self._supports_editing = supports_editing
+        self._run_until_stopped = run_until_stopped
+        self._stop_event = threading.Event()
+        self.started = threading.Event()
         self.sent = []
         self.removed = []
         self.dismissed = []
@@ -62,10 +65,14 @@ class _StubClient(BaseIMClient):
         return None
 
     def run(self):
+        self.started.set()
+        if self._run_until_stopped:
+            self._stop_event.wait()
         return None
 
     def stop(self):
         self.stopped = True
+        self._stop_event.set()
 
     async def get_user_info(self, user_id: str):
         return {"id": user_id, "name": self.name}
@@ -152,6 +159,67 @@ def test_multi_im_client_remove_client_stops_and_drops_platform():
     assert slack.stopped is True
     assert "slack" not in client.clients
     assert client.primary_platform == "wechat"
+
+
+def test_multi_im_client_remove_pending_platform_completes_ready():
+    slack = _StubClient("slack")
+    discord = _StubClient("discord")
+    client = MultiIMClient({"slack": slack, "discord": discord}, primary_platform="slack")
+    ready_calls: list[bool] = []
+
+    async def on_ready():
+        ready_calls.append(True)
+
+    client.register_callbacks(on_ready=on_ready)
+
+    assert slack.on_ready_callback is not None
+    asyncio.run(slack.on_ready_callback())
+    assert ready_calls == []
+
+    removed = client.remove_client("discord")
+
+    assert removed is discord
+    assert ready_calls == [True]
+
+
+def test_multi_im_client_run_returns_when_all_enabled_threads_exit():
+    client = MultiIMClient({"slack": _StubClient("slack")}, primary_platform="slack")
+    returned: list[bool] = []
+
+    def _run() -> None:
+        client.run()
+        returned.append(True)
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    thread.join(timeout=2)
+
+    assert thread.is_alive() is False
+    assert returned == [True]
+
+
+def test_multi_im_client_remove_client_keeps_maps_when_thread_will_not_stop():
+    stuck = _StubClient("slack", run_until_stopped=True)
+    client = MultiIMClient({"slack": stuck}, primary_platform="slack")
+    never_stop = threading.Event()
+    thread = threading.Thread(target=never_stop.wait, daemon=True)
+    thread.start()
+    client._threads["slack"] = thread
+
+    try:
+        try:
+            client.remove_client("slack")
+        except IMClientRemovalError:
+            pass
+        else:
+            raise AssertionError("remove_client should fail when the old runtime thread stays alive")
+
+        assert client.clients["slack"] is stuck
+        assert client._threads["slack"] is thread
+    finally:
+        never_stop.set()
+        thread.join(timeout=2)
 
 
 def test_multi_im_client_empty_runtime_stays_alive_until_stop():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -36,6 +36,7 @@ class _StubClient(BaseIMClient):
         self.sent = []
         self.removed = []
         self.dismissed = []
+        self.question_modals = []
         self.stopped = False
 
     async def send_message(self, context, text, parse_mode=None, reply_to=None):
@@ -57,6 +58,10 @@ class _StubClient(BaseIMClient):
 
     async def dismiss_form_message(self, context):
         self.dismissed.append((context.platform, context.message_id))
+
+    async def open_question_modal(self, trigger_id, context, pending, callback_prefix="claude_question"):
+        self.question_modals.append((trigger_id, context.platform, pending, callback_prefix))
+        return self.name
 
     async def answer_callback(self, callback_id, text=None, show_alert=False):
         return True
@@ -152,6 +157,28 @@ def test_multi_im_client_routes_send_by_context_platform():
 
     assert slack.sent == []
     assert wechat.sent == [("wechat", "c", "hello")]
+
+
+def test_multi_im_client_delegates_question_modal_by_context_platform():
+    slack = _StubClient("slack")
+    discord = _StubClient("discord")
+    client = MultiIMClient({"slack": slack, "discord": discord}, primary_platform="slack")
+    context = MessageContext(user_id="u", channel_id="c", platform="discord")
+    pending = {"questions": [{"header": "H", "question": "Q", "options": ["A"]}]}
+
+    assert hasattr(client, "open_question_modal")
+    result = asyncio.run(
+        client.open_question_modal(
+            trigger_id="trigger-1",
+            context=context,
+            pending=pending,
+            callback_prefix="test_question",
+        )
+    )
+
+    assert result == "discord"
+    assert slack.question_modals == []
+    assert discord.question_modals == [("trigger-1", "discord", pending, "test_question")]
 
 
 def test_multi_im_client_add_client_registers_callbacks_before_start():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -106,6 +106,19 @@ class _StubClient(BaseIMClient):
         return text
 
 
+class _SlowStopClient(_StubClient):
+    def __init__(self, name: str):
+        super().__init__(name, run_until_stopped=True)
+        self.stop_entered = threading.Event()
+        self.finish_stop = threading.Event()
+
+    def stop(self):
+        self.stopped = True
+        self.stop_entered.set()
+        self._stop_event.set()
+        self.finish_stop.wait(timeout=5)
+
+
 def test_multi_settings_manager_routes_scoped_keys(tmp_path):
     manager = MultiSettingsManager(
         ["slack", "wechat"], settings_file=str(tmp_path / "settings.json"), primary_platform="slack"
@@ -159,6 +172,19 @@ def test_multi_im_client_remove_client_stops_and_drops_platform():
     assert slack.stopped is True
     assert "slack" not in client.clients
     assert client.primary_platform == "wechat"
+
+
+def test_multi_im_client_remove_last_client_restores_workbench_formatter():
+    slack = _StubClient("slack")
+    client = MultiIMClient({"slack": slack}, primary_platform="slack")
+
+    removed = client.remove_client("slack")
+
+    assert removed is slack
+    assert client.clients == {}
+    assert client.primary_platform == "avibe"
+    assert client.formatter is not None
+    assert "Warning" in client.formatter.format_warning("heads up")
 
 
 def test_multi_im_client_remove_pending_platform_completes_ready():
@@ -222,9 +248,67 @@ def test_multi_im_client_remove_client_keeps_maps_when_thread_will_not_stop():
         thread.join(timeout=2)
 
 
+def test_multi_im_client_hot_remove_last_client_does_not_return_runtime():
+    slow = _SlowStopClient("slack")
+    client = MultiIMClient({"slack": slow}, primary_platform="slack")
+    returned: list[bool] = []
+    removal_errors: list[BaseException] = []
+
+    def _run() -> None:
+        client.run()
+        returned.append(True)
+
+    runtime_thread = threading.Thread(target=_run, daemon=True)
+    runtime_thread.start()
+    assert client._run_started.wait(timeout=2)
+    assert slow.started.wait(timeout=2)
+
+    def _remove() -> None:
+        try:
+            client.remove_client("slack")
+        except BaseException as exc:
+            removal_errors.append(exc)
+
+    remover = threading.Thread(target=_remove, daemon=True)
+    remover.start()
+    assert slow.stop_entered.wait(timeout=2)
+
+    deadline = time.monotonic() + 2
+    dead_platform_thread = False
+    while time.monotonic() < deadline:
+        with client._clients_lock:
+            platform_thread = client._threads.get("slack")
+        if platform_thread is not None and not platform_thread.is_alive():
+            dead_platform_thread = True
+            break
+        time.sleep(0.01)
+    assert dead_platform_thread is True
+
+    time.sleep(0.7)
+    assert runtime_thread.is_alive() is True
+    assert returned == []
+
+    slow.finish_stop.set()
+    remover.join(timeout=2)
+    assert remover.is_alive() is False
+    assert removal_errors == []
+    assert client.clients == {}
+    assert client.primary_platform == "avibe"
+    assert runtime_thread.is_alive() is True
+    assert returned == []
+
+    client.stop()
+    runtime_thread.join(timeout=2)
+    assert runtime_thread.is_alive() is False
+    assert returned == [True]
+
+
 def test_multi_im_client_empty_runtime_stays_alive_until_stop():
     client = MultiIMClient({}, primary_platform="avibe")
     returned: list[bool] = []
+
+    assert client.formatter is not None
+    assert "Error" in client.formatter.format_error("boom")
 
     def _run() -> None:
         client.run()

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -111,6 +111,10 @@ class _StubClient(BaseIMClient):
         return text
 
 
+class _ModalLessClient(_StubClient):
+    open_question_modal = None
+
+
 class _SlowStopClient(_StubClient):
     def __init__(self, name: str):
         super().__init__(name, run_until_stopped=True)
@@ -179,6 +183,18 @@ def test_multi_im_client_delegates_question_modal_by_context_platform():
     assert result == "discord"
     assert slack.question_modals == []
     assert discord.question_modals == [("trigger-1", "discord", pending, "test_question")]
+
+
+def test_multi_im_client_question_modal_falls_back_for_modal_less_platform():
+    wechat = _ModalLessClient("wechat")
+    client = MultiIMClient({"wechat": wechat}, primary_platform="wechat")
+    context = MessageContext(user_id="u", channel_id="c", platform="wechat")
+
+    result = asyncio.run(client.open_question_modal("trigger-1", context, {"questions": []}, "test_question"))
+
+    assert wechat.question_modals == []
+    assert result == "wechat"
+    assert wechat.sent == [("wechat", "c", "Modal UI is not available. Please reply with a custom message.")]
 
 
 def test_multi_im_client_add_client_registers_callbacks_before_start():

--- a/tests/test_platform_registry.py
+++ b/tests/test_platform_registry.py
@@ -14,6 +14,7 @@ from config.platform_registry import (
 from config.v2_config import PlatformsConfig, SlackConfig, V2Config
 from modules.im.avibe import AvibeBot
 from modules.im.factory import IMFactory
+from modules.im.multi import MultiIMClient
 from modules.im.slack import SlackBot
 
 
@@ -136,35 +137,37 @@ def test_create_clients_builds_real_platforms_but_skips_workbench() -> None:
 
 
 def test_create_client_returns_avibe_for_workbench_only_empty_enabled() -> None:
-    # Workbench-only config: no external IM platform is enabled, so the built
-    # client map is empty. ``create_client`` must return the in-process
-    # ``AvibeBot`` (mirroring the controller's avibe fallback) rather than
-    # constructing ``MultiIMClient({}, "avibe")``, which would raise because the
-    # primary is absent from the empty map.
+    # Workbench-only config: no external IM platform is enabled, so the IM
+    # runtime wrapper is empty and idles until stop.
     config = _config_with_enabled([])
     config.platforms = SimpleNamespace(enabled=[], primary="avibe")
 
     client = IMFactory.create_client(config)
 
-    assert isinstance(client, AvibeBot)
+    assert isinstance(client, MultiIMClient)
+    assert client.clients == {}
+    assert client.primary_platform == "avibe"
 
 
 def test_create_client_returns_avibe_for_legacy_avibe_only_enabled() -> None:
     # Older configs persisted the workbench-only state as ``["avibe"]`` instead
     # of an empty list. ``create_clients`` skips the workbench either way, so the
-    # singular helper must still resolve to the in-process ``AvibeBot``.
+    # singular helper must still resolve to an empty runtime wrapper.
     client = IMFactory.create_client(_config_with_enabled(["avibe"]))
 
-    assert isinstance(client, AvibeBot)
+    assert isinstance(client, MultiIMClient)
+    assert client.clients == {}
+    assert client.primary_platform == "avibe"
 
 
 def test_create_client_returns_single_real_client_when_one_platform_enabled() -> None:
-    # Sanity guard that the workbench-only short-circuit does not regress the
-    # ordinary single-platform path: a lone enabled platform returns that
-    # client directly (not wrapped in MultiIMClient).
+    # The runtime always uses the wrapper now, even for a lone enabled platform,
+    # so hot reconcile has one uniform add/remove surface.
     config = _config_with_enabled(["slack"])
     config.platforms = SimpleNamespace(enabled=["slack"], primary="slack")
 
     client = IMFactory.create_client(config)
 
-    assert isinstance(client, SlackBot)
+    assert isinstance(client, MultiIMClient)
+    assert isinstance(client.clients["slack"], SlackBot)
+    assert client.primary_platform == "slack"

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -188,6 +188,56 @@ def test_restart_job_prepares_show_runtime_after_service_start(monkeypatch, tmp_
     assert runtime.read_json(runtime.get_restart_status_path())["state"] == "succeeded"
 
 
+def test_restart_job_schedules_pending_followup_after_success(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
+    calls = []
+    scheduled: list[dict] = []
+
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda stop_ui=True: _fake_stop_runtime(calls))
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda start_ui=True: _fake_start_runtime(calls))
+    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: pid == 222)
+
+    original_schedule_restart = restart_supervisor.schedule_restart
+
+    def _schedule_restart(**kwargs):
+        scheduled.append(kwargs)
+        return {"job_id": "followup"}
+
+    restart_supervisor.mark_pending_restart(
+        trigger="web-ui-config-pending",
+        scope="service",
+        reason="restart_in_progress",
+        restart_job_id="jobpending",
+    )
+    monkeypatch.setattr(restart_supervisor, "schedule_restart", _schedule_restart)
+
+    try:
+        rc = restart_supervisor._run_restart_job(
+            job_id="jobpending",
+            delay_seconds=0,
+            vibe_path="/bin/vibe",
+            trigger="web-ui",
+            scope="service",
+        )
+    finally:
+        monkeypatch.setattr(restart_supervisor, "schedule_restart", original_schedule_restart)
+
+    assert rc == 0
+    assert scheduled == [
+        {
+            "delay_seconds": 0.0,
+            "vibe_path": "/bin/vibe",
+            "trigger": "web-ui-config-pending",
+            "scope": "service",
+        }
+    ]
+    assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
+
+
 def test_restart_job_aborts_when_stop_fails(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     paths.ensure_data_dirs()

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -14,6 +16,7 @@ from config import paths
 from core import chat_discovery
 from modules.agents.native_sessions import NativeResumeSession
 from modules.im import MessageContext
+from modules.im.multi import MultiIMClient
 from modules.im.telegram import TelegramBot
 from config.v2_config import TelegramConfig
 
@@ -1008,3 +1011,39 @@ def test_handle_callback_query_denies_unauthorized_protected_action() -> None:
 
     answer_mock.assert_awaited_once_with("cb-1", "Admin only", show_alert=True)
     bot.on_callback_query_callback.assert_not_awaited()
+
+
+def test_remove_client_cancels_telegram_long_poll_promptly(monkeypatch) -> None:
+    poll_started = threading.Event()
+    poll_cancelled = threading.Event()
+
+    async def _get_me(*args, **kwargs):
+        return {"result": {"id": 1, "username": "vibe_remote_bot"}}
+
+    async def _get_updates(*args, **kwargs):
+        poll_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            poll_cancelled.set()
+            raise
+
+    monkeypatch.setattr("modules.im.telegram.telegram_api.get_me", _get_me)
+    monkeypatch.setattr("modules.im.telegram.telegram_api.get_updates", _get_updates)
+
+    bot = TelegramBot(TelegramConfig(bot_token="123456:test-token"))
+    client = MultiIMClient({"telegram": bot}, primary_platform="telegram")
+    runtime_thread = threading.Thread(target=bot.run, daemon=True)
+    runtime_thread.start()
+    client._threads["telegram"] = runtime_thread
+
+    assert poll_started.wait(timeout=2)
+
+    started = time.monotonic()
+    removed = client.remove_client("telegram")
+    elapsed = time.monotonic() - started
+
+    assert removed is bot
+    assert elapsed < 2
+    assert runtime_thread.is_alive() is False
+    assert poll_cancelled.is_set()

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -82,6 +82,33 @@ def test_group_message_uses_channel_require_mention_override() -> None:
     assert bot.on_message_callback.await_args.args[1] == "hello team"
 
 
+def test_inbound_message_refreshes_config_before_reading_options() -> None:
+    bot = TelegramBot(TelegramConfig(bot_token="123456:test-token", require_mention=True))
+    bot._bot_user = {"id": 1, "username": "vibe_remote_bot"}
+    refresh_calls: list[bool] = []
+
+    def _refresh_config_from_disk() -> None:
+        refresh_calls.append(True)
+        bot.config.require_mention = False
+
+    bot.set_controller(SimpleNamespace(_refresh_config_from_disk=_refresh_config_from_disk))
+    bot.on_message_callback = AsyncMock()
+
+    asyncio.run(
+        bot._handle_message(
+            {
+                "message_id": 77,
+                "chat": {"id": -100123, "type": "group", "title": "Core Group"},
+                "from": {"id": 42},
+                "text": "hello team",
+            }
+        )
+    )
+
+    assert refresh_calls == [True]
+    bot.on_message_callback.assert_awaited_once()
+
+
 def test_group_mention_only_falls_through_as_empty_message() -> None:
     bot = TelegramBot(TelegramConfig(bot_token="123456:test-token", require_mention=True))
     bot._bot_user = {"id": 1, "username": "vibe_remote_bot"}

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -494,6 +494,37 @@ def test_config_post_schedules_service_restart_when_hot_reconcile_fails(monkeypa
     assert restart_calls == [True]
 
 
+def test_config_restart_fallback_marks_pending_restart_when_restart_in_flight(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    restart_status = {
+        "ok": None,
+        "state": "running",
+        "job_id": "job-in-flight",
+        "supervisor_pid": 4242,
+    }
+    runtime.write_json(runtime.get_restart_status_path(), restart_status)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("must not overlap restart jobs")),
+    )
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result["ok"] is True
+    assert result["code"] == "restart_pending_after_in_progress"
+    assert result["restart"] == restart_status
+    pending = runtime.read_json(restart_supervisor._pending_restart_path())
+    assert pending["restart_job_id"] == "job-in-flight"
+    assert pending["trigger"] == "web-ui-config-pending"
+    assert pending["scope"] == "service"
+
+
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):
     ui_dist = tmp_path / "dist"
     assets_dir = ui_dist / "assets"

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -431,6 +431,44 @@ def test_config_post_schedules_service_restart_when_hot_reconcile_unavailable(mo
     assert restart_calls == [True]
 
 
+def test_config_post_schedules_service_restart_when_hot_reconcile_fails(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from vibe import api
+    from vibe import internal_client
+
+    payload = _full_config_payload()
+    payload["platforms"] = {"enabled": ["discord"], "primary": "discord"}
+    api.save_config(payload)
+
+    async def _reconcile_platforms():
+        return {
+            "status_code": 500,
+            "body": {"ok": False, "error": "IM thread for discord did not stop within timeout"},
+        }
+
+    restart_calls = []
+    monkeypatch.setattr(internal_client, "reconcile_platforms", _reconcile_platforms)
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_service_restart_for_config_fallback",
+        lambda: restart_calls.append(True) or {"ok": True, "restart": {"job_id": "job-hot-failure"}},
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/config",
+        json={"discord": {"bot_token": "discord-new-token-12345"}},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    runtime = response.get_json()["platform_runtime"]
+    assert runtime["hot_reconciled"] is False
+    assert runtime["restart_scheduled"] is True
+    assert runtime["body"]["error"] == "IM thread for discord did not stop within timeout"
+    assert restart_calls == [True]
+
+
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):
     ui_dist = tmp_path / "dist"
     assets_dir = ui_dist / "assets"

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -376,6 +376,31 @@ def test_config_post_hot_reconciles_platform_runtime_credential_change(monkeypat
     assert reconcile_calls == [True]
 
 
+def test_platform_runtime_fields_changed_detects_primary_only_change():
+    from config.v2_config import V2Config
+
+    payload = _full_config_payload()
+    payload["platforms"] = {"enabled": ["discord", "slack"], "primary": "discord"}
+    payload["slack"] = {"bot_token": "xoxb-hot-token", "app_token": "xapp-hot-token"}
+    previous = V2Config.from_payload(payload)
+    current = V2Config.from_payload(
+        {
+            **payload,
+            "platform": "slack",
+            "platforms": {"enabled": ["discord", "slack"], "primary": "slack"},
+        }
+    )
+
+    assert (
+        ui_server._platform_runtime_fields_changed(
+            previous,
+            current,
+            {"platforms": {"enabled": ["discord", "slack"], "primary": "slack"}},
+        )
+        is True
+    )
+
+
 def test_config_post_non_platform_change_does_not_reconcile_platforms(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     from vibe import api

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -525,6 +525,35 @@ def test_config_restart_fallback_marks_pending_restart_when_restart_in_flight(mo
     assert pending["scope"] == "service"
 
 
+def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    restart_status = {
+        "ok": None,
+        "state": "running",
+        "job_id": "job-in-flight",
+        "supervisor_pid": 4242,
+    }
+    runtime.write_json(runtime.get_restart_status_path(), restart_status)
+    in_flight_results = iter([True, False])
+    scheduled: list[dict] = []
+
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight_results))
+    monkeypatch.setattr(restart_supervisor, "schedule_restart", lambda **kwargs: scheduled.append(kwargs) or {"job_id": "followup"})
+    monkeypatch.setattr(runtime, "read_status", lambda: {"service_pid": 11, "ui_pid": 22})
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result["ok"] is True
+    assert result["code"] == "restart_scheduled_after_in_flight_finished"
+    assert result["restart"] == {"job_id": "followup"}
+    assert scheduled == [{"delay_seconds": 0.0, "trigger": "web-ui-config", "scope": "service"}]
+    assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
+
+
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):
     ui_dist = tmp_path / "dist"
     assets_dir = ui_dist / "assets"

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -313,6 +313,124 @@ def test_config_routes_redact_platform_and_gateway_secrets(monkeypatch, tmp_path
         assert "client_secret" not in data["gateway"]
 
 
+def test_config_post_hot_reconciles_platform_enablement(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from vibe import api
+    from vibe import internal_client
+
+    payload = _full_config_payload()
+    payload["platforms"] = {"enabled": ["discord"], "primary": "discord"}
+    api.save_config(payload)
+
+    reconcile_calls = []
+    restart_calls = []
+
+    async def _reconcile_platforms():
+        reconcile_calls.append(True)
+        return {"status_code": 200, "body": {"ok": True, "added": ["slack"]}}
+
+    monkeypatch.setattr(internal_client, "reconcile_platforms", _reconcile_platforms)
+    monkeypatch.setattr(ui_server, "_schedule_service_restart_for_config_fallback", lambda: restart_calls.append(True) or {"ok": True})
+
+    next_payload = {
+        **payload,
+        "platforms": {"enabled": ["discord", "slack"], "primary": "discord"},
+        "slack": {"bot_token": "xoxb-hot-token", "app_token": "xapp-hot-token"},
+    }
+    client = app.test_client()
+    response = client.post("/api/config", json=next_payload, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["platform_runtime"]["hot_reconciled"] is True
+    assert reconcile_calls == [True]
+    assert restart_calls == []
+
+
+def test_config_post_hot_reconciles_platform_runtime_credential_change(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from vibe import api
+    from vibe import internal_client
+
+    payload = _full_config_payload()
+    payload["platforms"] = {"enabled": ["discord"], "primary": "discord"}
+    api.save_config(payload)
+
+    reconcile_calls = []
+
+    async def _reconcile_platforms():
+        reconcile_calls.append(True)
+        return {"status_code": 200, "body": {"ok": True, "rebuilt": ["discord"]}}
+
+    monkeypatch.setattr(internal_client, "reconcile_platforms", _reconcile_platforms)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/config",
+        json={"discord": {"bot_token": "discord-new-token-12345"}},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["platform_runtime"]["body"]["rebuilt"] == ["discord"]
+    assert reconcile_calls == [True]
+
+
+def test_config_post_non_platform_change_does_not_reconcile_platforms(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from vibe import api
+    from vibe import internal_client
+
+    payload = _full_config_payload()
+    payload["platforms"] = {"enabled": ["discord"], "primary": "discord"}
+    api.save_config(payload)
+
+    async def _reconcile_platforms():
+        raise AssertionError("platform reconcile should not run")
+
+    monkeypatch.setattr(internal_client, "reconcile_platforms", _reconcile_platforms)
+
+    client = app.test_client()
+    response = client.post("/api/config", json={"show_duration": False}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert "platform_runtime" not in response.get_json()
+
+
+def test_config_post_schedules_service_restart_when_hot_reconcile_unavailable(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    from vibe import api
+    from vibe import internal_client
+
+    payload = _full_config_payload()
+    payload["platforms"] = {"enabled": ["discord"], "primary": "discord"}
+    api.save_config(payload)
+
+    async def _reconcile_platforms():
+        raise internal_client.InternalServerUnavailable("missing socket")
+
+    restart_calls = []
+    monkeypatch.setattr(internal_client, "reconcile_platforms", _reconcile_platforms)
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_service_restart_for_config_fallback",
+        lambda: restart_calls.append(True) or {"ok": True, "restart": {"job_id": "job-hot-fallback"}},
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/config",
+        json={"platforms": {"enabled": ["discord", "slack"], "primary": "discord"}, "slack": {"bot_token": "xoxb-hot-token", "app_token": "xapp-hot-token"}},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    runtime = response.get_json()["platform_runtime"]
+    assert runtime["hot_reconciled"] is False
+    assert runtime["restart_scheduled"] is True
+    assert restart_calls == [True]
+
+
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):
     ui_dist = tmp_path / "dist"
     assets_dir = ui_dist / "assets"

--- a/tests/test_workbench_only_runtime.py
+++ b/tests/test_workbench_only_runtime.py
@@ -4,13 +4,11 @@ A workbench-only install enables no Slack/Discord/Telegram/Lark/WeChat
 platform. The Avibe Workbench (in-process Web UI) is the sole inbound surface.
 These tests cover the two delicate seams that make that work end-to-end:
 
-1. Controller ``_init_modules`` must register the in-process ``AvibeBot`` as the
-   SOLE IM client, anchor the primary platform to "avibe", and wire a settings
-   manager for it — without crashing on the empty enabled-platform set.
-2. ``AvibeBot.run`` must fire ``on_ready`` exactly once (so the controller starts
-   poll-restore / scheduled tasks / update checker) and then BLOCK so the
-   IM-runtime thread does not return, keeping the controller's ``run_forever``
-   alive until ``stop`` is called.
+1. Controller ``_init_modules`` must always use ``MultiIMClient`` for the IM
+   runtime, even when no external IM platforms are enabled. In workbench-only
+   mode that wrapper has zero runtime clients and stays alive via its idle loop.
+2. ``AvibeBot`` remains registered separately as the in-process delivery client
+   for Web UI replies, with a settings manager for "avibe".
 
 The has-IM path is exercised by the broader multi-platform suite; here we only
 assert the workbench-only behavior that previously raised.
@@ -22,6 +20,7 @@ import asyncio
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -30,7 +29,55 @@ from config.v2_compat import to_app_config
 from config.v2_config import V2Config
 from core.controller import Controller
 from modules.im.avibe import AvibeBot, AvibeConfig
-from modules.im.base import MessageContext
+from modules.im.base import BaseIMClient, BaseIMConfig, MessageContext
+from modules.im.multi import MultiIMClient
+
+
+@dataclass
+class _BootConfig(BaseIMConfig):
+    def validate(self) -> None:
+        return None
+
+
+class _BootClient(BaseIMClient):
+    def __init__(self, platform: str):
+        super().__init__(_BootConfig())
+        self.platform = platform
+        self.settings_manager = None
+        self.controller = None
+
+    def set_settings_manager(self, settings_manager):
+        self.settings_manager = settings_manager
+
+    def set_controller(self, controller):
+        self.controller = controller
+
+    async def send_message(self, context, text, parse_mode=None, reply_to=None):
+        return self.platform
+
+    async def send_message_with_buttons(self, context, text, keyboard, parse_mode=None):
+        return self.platform
+
+    async def edit_message(self, context, message_id, text=None, keyboard=None, parse_mode=None):
+        return True
+
+    async def answer_callback(self, callback_id, text=None, show_alert=False):
+        return True
+
+    def register_handlers(self):
+        return None
+
+    def run(self):
+        return None
+
+    async def get_user_info(self, user_id: str):
+        return {"id": user_id}
+
+    async def get_channel_info(self, channel_id: str):
+        return {"id": channel_id}
+
+    def format_markdown(self, text: str) -> str:
+        return text
 
 
 def _workbench_only_app_config():
@@ -49,20 +96,48 @@ def _workbench_only_app_config():
     return to_app_config(V2Config.from_payload(payload))
 
 
-def test_init_modules_registers_avibe_as_sole_client_for_workbench_only():
-    app_config = _workbench_only_app_config()
-    # The compat view of a workbench-only config exposes no enabled platforms.
-    assert app_config.enabled_platforms() == []
+def _boot_app_config(enabled: list[str]):
+    primary = enabled[0] if enabled else "avibe"
+    payload = {
+        "platform": primary,
+        "platforms": {"enabled": enabled, "primary": primary},
+        "mode": "self_host",
+        "version": "v2",
+        "runtime": {"default_cwd": "_tmp", "log_level": "INFO"},
+        "agents": {
+            "default_backend": "opencode",
+            "opencode": {"enabled": True, "cli_path": "opencode"},
+        },
+        "setup_completed": True,
+        "slack": {"bot_token": "xoxb-test", "app_token": "xapp-test"},
+        "discord": {"bot_token": "discord-token"},
+        "telegram": {"bot_token": "123456:test-token"},
+        "lark": {"app_id": "cli_a", "app_secret": "secret", "domain": "feishu"},
+        "wechat": {"bot_token": "wechat-token"},
+    }
+    return to_app_config(V2Config.from_payload(payload))
 
+
+def _init_controller_modules(app_config):
     controller = Controller.__new__(Controller)
     controller.config = app_config
     controller.enabled_platforms = list(app_config.enabled_platforms())
     controller.primary_platform = getattr(getattr(app_config, "platforms", None), "primary", app_config.platform)
-
     controller._init_modules()
+    return controller
+
+
+def test_init_modules_uses_empty_multi_runtime_for_workbench_only():
+    app_config = _workbench_only_app_config()
+    # The compat view of a workbench-only config exposes no enabled platforms.
+    assert app_config.enabled_platforms() == []
+
+    controller = _init_controller_modules(app_config)
 
     assert list(controller.im_clients.keys()) == ["avibe"]
-    assert isinstance(controller.im_client, AvibeBot)
+    assert isinstance(controller.im_clients["avibe"], AvibeBot)
+    assert isinstance(controller.im_client, MultiIMClient)
+    assert controller.im_client.clients == {}
     assert controller.primary_platform == "avibe"
     # The primary-anchored settings manager resolves (no KeyError on an empty
     # enabled-platform set) for both the no-context and avibe-context cases.
@@ -71,6 +146,36 @@ def test_init_modules_registers_avibe_as_sole_client_for_workbench_only():
     assert controller.get_settings_manager_for_context(avibe_ctx).platform == "avibe"
     # Agent routing has a route for the avibe primary.
     assert "avibe" in controller.agent_router.platform_routes
+
+
+def test_init_modules_boots_single_platform_with_multi_runtime(monkeypatch):
+    app_config = _boot_app_config(["slack"])
+    monkeypatch.setattr("core.controller.IMFactory.create_clients", lambda config: {"slack": _BootClient("slack")})
+
+    controller = _init_controller_modules(app_config)
+
+    assert isinstance(controller.im_client, MultiIMClient)
+    assert list(controller.im_client.clients.keys()) == ["slack"]
+    assert controller.primary_platform == "slack"
+    assert "avibe" in controller.im_clients
+    assert "slack" in controller.agent_router.platform_routes
+
+
+def test_init_modules_boots_four_platforms_with_multi_runtime(monkeypatch):
+    enabled = ["slack", "discord", "telegram", "lark"]
+    app_config = _boot_app_config(enabled)
+    monkeypatch.setattr(
+        "core.controller.IMFactory.create_clients",
+        lambda config: {platform: _BootClient(platform) for platform in enabled},
+    )
+
+    controller = _init_controller_modules(app_config)
+
+    assert isinstance(controller.im_client, MultiIMClient)
+    assert list(controller.im_client.clients.keys()) == enabled
+    assert controller.primary_platform == "slack"
+    assert "avibe" in controller.im_clients
+    assert set(enabled) <= set(controller.agent_router.platform_routes)
 
 
 def test_avibe_run_fires_on_ready_once_then_blocks_until_stop():

--- a/tests/test_workbench_only_runtime.py
+++ b/tests/test_workbench_only_runtime.py
@@ -148,6 +148,31 @@ def test_init_modules_uses_empty_multi_runtime_for_workbench_only():
     assert "avibe" in controller.agent_router.platform_routes
 
 
+def test_workbench_only_multi_runtime_routes_avibe_cleanup_to_avibe_client():
+    controller = _init_controller_modules(_workbench_only_app_config())
+    avibe = controller.im_clients["avibe"]
+    deleted: list[tuple[str, str]] = []
+    reactions: list[tuple[str, str, str]] = []
+
+    async def _delete_message(context, message_id):
+        deleted.append((context.platform, message_id))
+        return True
+
+    async def _remove_reaction(context, message_id, emoji):
+        reactions.append((context.platform, message_id, emoji))
+        return True
+
+    avibe.delete_message = _delete_message
+    avibe.remove_reaction = _remove_reaction
+    context = MessageContext(user_id="u", channel_id="c", platform="avibe")
+
+    assert controller.im_client.get_client_for_context(context) is avibe
+    assert asyncio.run(controller.im_client.delete_message(context, "ack-1")) is True
+    assert asyncio.run(controller.im_client.remove_reaction(context, "ack-1", "eyes")) is True
+    assert deleted == [("avibe", "ack-1")]
+    assert reactions == [("avibe", "ack-1", "eyes")]
+
+
 def test_init_modules_boots_single_platform_with_multi_runtime(monkeypatch):
     app_config = _boot_app_config(["slack"])
     monkeypatch.setattr("core.controller.IMFactory.create_clients", lambda config: {"slack": _BootClient("slack")})

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
-import { Check, ChevronUp, Loader2, Pencil, RotateCw } from 'lucide-react';
+import { Check, ChevronUp, Loader2, Pencil } from 'lucide-react';
 
 import { useApi } from '@/context/ApiContext';
-import { useStatus } from '@/context/StatusContext';
 import { useToast } from '@/context/ToastContext';
 import {
   getEnabledPlatforms,
@@ -53,7 +52,6 @@ const tileStyle = (id: string) =>
 export const SettingsPlatformsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
-  const { control } = useStatus();
   const { showToast } = useToast();
   const [config, setConfig] = useState<any>(null);
   // Platforms the user revealed to configure but has NOT enabled yet (no creds
@@ -65,7 +63,7 @@ export const SettingsPlatformsPage: React.FC = () => {
   const [busyPlatform, setBusyPlatform] = useState<string | null>(null);
   // The platform pending a disable confirmation (null = no dialog open).
   const [confirmDisableId, setConfirmDisableId] = useState<string | null>(null);
-  const [restartPhase, setRestartPhase] = useState<'idle' | 'saving' | 'restarting'>('idle');
+  const [restartPhase, setRestartPhase] = useState<'idle' | 'saving'>('idle');
 
   useEffect(() => {
     api.getConfig().then(setConfig).catch(() => {});
@@ -104,44 +102,37 @@ export const SettingsPlatformsPage: React.FC = () => {
     }
   };
 
-  // Persist the enabled set and restart. ``primary`` is intentionally omitted:
+  // Persist the enabled set. ``primary`` is intentionally omitted:
   // the backend normalizes it from ``enabled`` (first enabled, or the workbench
   // when empty), so the UI never chooses or sends one.
-  // Restart only the service (scope:'service') so the open Web UI survives the
-  // config change. If a prior restart is still in flight, the change is saved
-  // but the running restart may have already read the OLD config — so don't
-  // claim success; retry until this save gets its OWN dedicated restart
-  // (service-only restarts are quick, so a few short retries cover it). Only if
-  // it stays busy do we tell the user it's saved while a restart runs.
-  const requestServiceRestart = async (): Promise<boolean> => {
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      try {
-        await control('restart', { scope: 'service' });
-        showToast(t('platform.restartedSuccess'), 'success');
-        return true;
-      } catch (e) {
-        if ((e as { code?: string })?.code !== 'restart_in_progress') {
-          showToast(t('platform.restartFailed'), 'error');
-          return false;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1500));
-      }
+  const showApplyResult = (savedConfig: any) => {
+    const runtime = savedConfig?.platform_runtime;
+    if (runtime?.hot_reconciled) {
+      showToast(t('platform.appliedSuccess'), 'success');
+      return true;
     }
-    showToast(t('platform.restartInProgress'), 'warning');
-    return false;
+    if (runtime?.restart_scheduled) {
+      showToast(t('platform.restartedSuccess'), 'success');
+      return true;
+    }
+    if (runtime && runtime.hot_reconciled === false) {
+      showToast(t('platform.restartFailed'), 'error');
+      return false;
+    }
+    showToast(t('common.saved'), 'success');
+    return true;
   };
 
   const persistEnabled = async (nextEnabled: string[]) => {
     setRestartPhase('saving');
     try {
       try {
-        await saveConfig({ ...config, platforms: { enabled: nextEnabled } });
+        const savedConfig = await saveConfig({ ...config, platforms: { enabled: nextEnabled } });
+        showApplyResult(savedConfig);
       } catch {
         showToast(t('common.saveFailed'), 'error');
         return false;
       }
-      setRestartPhase('restarting');
-      await requestServiceRestart();
       return true;
     } finally {
       setRestartPhase('idle');
@@ -213,15 +204,21 @@ export const SettingsPlatformsPage: React.FC = () => {
         showToast(t('common.saved'), 'success');
         return;
       }
-      const nextEnabled = wasEnabled ? enabledPlatforms : [...enabledPlatforms, platform];
-      setRestartPhase('restarting');
+      if (wasEnabled) {
+        if (showApplyResult(savedConfig)) {
+          setRevealed((prev) => prev.filter((p) => p !== platform));
+          setOpenConfig((prev) => (prev === platform ? null : prev));
+        }
+        return;
+      }
+      const nextEnabled = [...enabledPlatforms, platform];
       try {
-        await saveConfig({ ...savedConfig, platforms: { enabled: nextEnabled } });
+        savedConfig = await saveConfig({ ...savedConfig, platforms: { enabled: nextEnabled } });
       } catch {
         showToast(t('platform.restartFailed'), 'error');
         return;
       }
-      if (await requestServiceRestart()) {
+      if (showApplyResult(savedConfig)) {
         setRevealed((prev) => prev.filter((p) => p !== platform));
         setOpenConfig((prev) => (prev === platform ? null : prev));
       }
@@ -256,18 +253,12 @@ export const SettingsPlatformsPage: React.FC = () => {
             aria-live="polite"
             className="sticky top-2 z-10 flex items-center gap-3 rounded-xl border border-cyan/35 bg-cyan/[0.08] px-4 py-3 shadow-[0_8px_24px_-8px_rgba(0,212,255,0.35)]"
           >
-            {restartPhase === 'saving' ? (
-              <Loader2 size={16} className="shrink-0 animate-spin text-cyan" />
-            ) : (
-              <RotateCw size={16} className="shrink-0 animate-spin text-cyan" strokeWidth={2.25} />
-            )}
+            <Loader2 size={16} className="shrink-0 animate-spin text-cyan" />
             <div className="min-w-0 flex-1">
               <div className="text-[13px] font-semibold text-foreground">
-                {restartPhase === 'saving' ? t('platform.applyingConfig') : t('platform.restartingService')}
+                {t('platform.applyingConfig')}
               </div>
-              <div className="mt-0.5 text-[11px] text-muted">
-                {restartPhase === 'saving' ? t('common.saving') : t('dashboard.restarting')}
-              </div>
+              <div className="mt-0.5 text-[11px] text-muted">{t('common.saving')}</div>
             </div>
           </div>
         )}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -739,6 +739,7 @@
     "configureBeforeEnable": "Configure and save this platform before enabling it.",
     "applyingConfig": "Applying configuration...",
     "restartingService": "Restarting service to apply changes...",
+    "appliedSuccess": "Configuration applied",
     "restartedSuccess": "Configuration applied and service restarted",
     "restartFailed": "Configuration saved, but service restart failed",
     "restartInProgress": "Saved. The service is busy restarting — toggle again shortly to make sure it takes effect.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -739,6 +739,7 @@
     "configureBeforeEnable": "请先配置并保存该平台，再启用它。",
     "applyingConfig": "正在应用配置...",
     "restartingService": "正在重启服务以使配置生效...",
+    "appliedSuccess": "配置已应用",
     "restartedSuccess": "配置已应用，服务已重启",
     "restartFailed": "配置已保存，但服务重启失败",
     "restartInProgress": "更改已保存。服务正忙于重启——请稍后再次切换以确保生效。",

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -216,6 +216,29 @@ async def dispatch_async(
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
 
 
+async def reconcile_platforms(
+    *,
+    socket_path: Optional[Path] = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Ask the controller to hot-apply the persisted platform configuration."""
+
+    target = (socket_path or default_socket_path()).expanduser().resolve()
+    if not target.exists():
+        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
+    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://localhost",
+            timeout=httpx.Timeout(timeout, connect=5.0),
+        ) as client:
+            resp = await client.post("/internal/reconcile-platforms")
+    except _SOCKET_ERRORS as exc:
+        raise InternalServerUnavailable(str(exc)) from exc
+    return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
+
+
 async def cancel_dispatch(session_id: str, *, socket_path: Optional[Path] = None) -> dict[str, Any]:
     """Ask the controller to cancel a running ``dispatch_turn`` for
     ``session_id``.

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -30,6 +30,46 @@ def _restart_log_path(job_id: str) -> Path:
     return paths.get_logs_dir() / f"restart-{timestamp}-{job_id}.log"
 
 
+def _pending_restart_path() -> Path:
+    return paths.get_runtime_dir() / "pending_restart.json"
+
+
+def mark_pending_restart(
+    *,
+    trigger: str,
+    scope: str = "service",
+    reason: str = "restart_in_progress",
+    restart_job_id: str | None = None,
+) -> dict:
+    payload = {
+        "trigger": trigger,
+        "scope": scope,
+        "reason": reason,
+        "restart_job_id": restart_job_id,
+        "created_at": _now_iso(),
+        "created_at_epoch": time.time(),
+    }
+    path = _pending_restart_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(path, payload)
+    return payload
+
+
+def _consume_pending_restart_for_job(job_id: str) -> dict | None:
+    path = _pending_restart_path()
+    payload = runtime.read_json(path)
+    if not isinstance(payload, dict):
+        return None
+    restart_job_id = payload.get("restart_job_id")
+    if restart_job_id and restart_job_id != job_id:
+        return None
+    try:
+        path.unlink()
+    except OSError:
+        logger.debug("Failed to remove pending restart marker", exc_info=True)
+    return payload
+
+
 def _prune_restart_logs(limit: int = _RESTART_LOG_RETENTION) -> None:
     try:
         logs = sorted(
@@ -339,6 +379,24 @@ def _run_restart_job(
                 write(f"Show Runtime preparation skipped: {exc}")
             finally:
                 mark_duration("prepare_show_runtime_seconds", prepare_started_at)
+
+        pending_restart = _consume_pending_restart_for_job(job_id)
+        if pending_restart is not None:
+            write(
+                "scheduling pending follow-up restart "
+                f"trigger={pending_restart.get('trigger')!r} scope={pending_restart.get('scope')!r}"
+            )
+            try:
+                schedule_restart(
+                    delay_seconds=0.0,
+                    vibe_path=vibe_path,
+                    trigger=str(pending_restart.get("trigger") or "pending-restart"),
+                    scope=str(pending_restart.get("scope") or "service"),
+                )
+            except Exception as exc:
+                payload["pending_restart"] = {"scheduled": False, "error": str(exc)}
+                _write_status(payload)
+                write(f"failed to schedule pending follow-up restart: {exc}")
 
         return 0
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2231,11 +2231,23 @@ def _restart_in_flight() -> bool:
 
 def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
     from vibe import runtime
-    from vibe.restart_supervisor import schedule_restart
+    from vibe.restart_supervisor import mark_pending_restart, schedule_restart
 
     with _RESTART_CONTROL_LOCK:
+        restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
         if _restart_in_flight():
-            return {"ok": False, "code": "restart_in_progress", "error": "a restart is already in progress"}
+            pending = mark_pending_restart(
+                trigger="web-ui-config-pending",
+                scope="service",
+                reason="restart_in_progress",
+                restart_job_id=restart_status.get("job_id"),
+            )
+            return {
+                "ok": True,
+                "pending_restart": pending,
+                "restart": restart_status,
+                "code": "restart_pending_after_in_progress",
+            }
         status = runtime.read_status()
         runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
         restart = schedule_restart(delay_seconds=0.0, trigger="web-ui-config", scope="service")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1039,6 +1039,7 @@ def _platform_runtime_fields_changed(previous: V2Config | None, current: V2Confi
         return False
     return (
         set(previous.platforms.enabled) != set(current.platforms.enabled)
+        or previous.platforms.primary != current.platforms.primary
         or _platform_runtime_signature(previous) != _platform_runtime_signature(current)
     )
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1014,6 +1014,35 @@ def _should_rotate_remote_session_secret(previous: V2Config | None, current: V2C
     return bool(previous_cloud.enabled and not current_cloud.enabled and current_cloud.session_secret)
 
 
+def _platform_runtime_signature(config: V2Config) -> dict[str, tuple[Any, ...]]:
+    from config.platform_registry import get_platform_descriptor
+
+    signatures: dict[str, tuple[Any, ...]] = {}
+    for platform in config.platforms.enabled:
+        descriptor = get_platform_descriptor(platform)
+        platform_config = descriptor.get_config(config)
+        signatures[platform] = (
+            tuple(getattr(platform_config, field, None) for field in descriptor.runtime_reconcile_field_names())
+            if platform_config is not None
+            else ()
+        )
+    return signatures
+
+
+def _platform_runtime_fields_changed(previous: V2Config | None, current: V2Config, payload: dict) -> bool:
+    from config.platform_registry import im_platform_descriptors
+
+    if previous is None:
+        return False
+    platform_config_keys = {descriptor.config_key for descriptor in im_platform_descriptors()}
+    if "platforms" not in payload and "platform" not in payload and not any(key in payload for key in platform_config_keys):
+        return False
+    return (
+        set(previous.platforms.enabled) != set(current.platforms.enabled)
+        or _platform_runtime_signature(previous) != _platform_runtime_signature(current)
+    )
+
+
 # Static PWA / icon assets must be reachable WITHOUT the remote-access auth
 # cookie. iOS "Add to Home Screen" fetches the apple-touch-icon + manifest in a
 # context that doesn't carry the session, so gating them makes the installed app
@@ -2199,6 +2228,36 @@ def _restart_in_flight() -> bool:
     return age < _RESTART_SEED_GRACE_SECONDS
 
 
+def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
+    from vibe import runtime
+    from vibe.restart_supervisor import schedule_restart
+
+    with _RESTART_CONTROL_LOCK:
+        if _restart_in_flight():
+            return {"ok": False, "code": "restart_in_progress", "error": "a restart is already in progress"}
+        status = runtime.read_status()
+        runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
+        restart = schedule_restart(delay_seconds=0.0, trigger="web-ui-config", scope="service")
+    return {"ok": True, "restart": restart}
+
+
+def _save_config_and_runtime_decisions(payload: dict) -> tuple[V2Config, bool, bool]:
+    from vibe import api
+    from vibe import remote_access
+
+    with CONFIG_LOCK:
+        previous_config = _load_remote_access_config()
+        config = api.save_config(payload)
+        should_reconcile_remote_access = False
+        if _remote_access_settings_changed(previous_config, config, payload):
+            if _should_rotate_remote_session_secret(previous_config, config, payload):
+                remote_access.rotate_session_secret(config)
+                config = V2Config.load()
+            should_reconcile_remote_access = True
+        should_reconcile_platforms = _platform_runtime_fields_changed(previous_config, config, payload)
+        return config, should_reconcile_remote_access, should_reconcile_platforms
+
+
 @app.route("/api/control", methods=["POST"])
 def control():
     from vibe import runtime
@@ -2253,29 +2312,47 @@ def control():
 
 
 @app.route("/api/config", methods=["POST"])
-def config_post():
+async def config_post():
     from vibe import api
+    from vibe import internal_client
     from vibe import remote_access
 
     payload = request.json or {}
     remote_access_runtime = None
-    should_reconcile_remote_access = False
-    with CONFIG_LOCK:
-        previous_config = _load_remote_access_config() if "remote_access" in payload else None
-        try:
-            config = api.save_config(payload)
-        except ValueError as exc:
-            message = str(exc)
-            return jsonify({"ok": False, "error": message, "message": message}), 400
-        if _remote_access_settings_changed(previous_config, config, payload):
-            if _should_rotate_remote_session_secret(previous_config, config, payload):
-                remote_access.rotate_session_secret(config)
-            should_reconcile_remote_access = True
+    try:
+        config, should_reconcile_remote_access, should_reconcile_platforms = await asyncio.to_thread(
+            _save_config_and_runtime_decisions,
+            payload,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        return jsonify({"ok": False, "error": message, "message": message}), 400
     if should_reconcile_remote_access:
-        remote_access_runtime = remote_access.reconcile()
+        remote_access_runtime = await asyncio.to_thread(remote_access.reconcile)
+    platform_runtime = None
+    if should_reconcile_platforms:
+        try:
+            result = await internal_client.reconcile_platforms()
+            platform_runtime = {
+                "ok": result.get("status_code") == 200 and bool((result.get("body") or {}).get("ok")),
+                "hot_reconciled": result.get("status_code") == 200 and bool((result.get("body") or {}).get("ok")),
+                "body": result.get("body") or {},
+            }
+        except internal_client.InternalServerUnavailable as exc:
+            platform_runtime = {"ok": False, "hot_reconciled": False, "error": str(exc)}
+        if not platform_runtime.get("ok"):
+            restart_result = await asyncio.to_thread(_schedule_service_restart_for_config_fallback)
+            platform_runtime["restart_scheduled"] = bool(restart_result.get("ok"))
+            if restart_result.get("ok"):
+                platform_runtime["restart"] = restart_result.get("restart")
+            else:
+                platform_runtime["restart_error"] = restart_result.get("error")
+                platform_runtime["restart_code"] = restart_result.get("code")
     response_payload = api.config_to_payload(config)
     if remote_access_runtime is not None:
         response_payload["remote_access_runtime"] = remote_access_runtime
+    if platform_runtime is not None:
+        response_payload["platform_runtime"] = platform_runtime
     return jsonify(response_payload)
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2233,24 +2233,40 @@ def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
     from vibe import runtime
     from vibe.restart_supervisor import mark_pending_restart, schedule_restart
 
+    def _schedule_restart() -> dict[str, Any]:
+        status = runtime.read_status()
+        runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
+        return schedule_restart(delay_seconds=0.0, trigger="web-ui-config", scope="service")
+
     with _RESTART_CONTROL_LOCK:
-        restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
         if _restart_in_flight():
+            restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
             pending = mark_pending_restart(
                 trigger="web-ui-config-pending",
                 scope="service",
                 reason="restart_in_progress",
                 restart_job_id=restart_status.get("job_id"),
             )
+            if not _restart_in_flight():
+                try:
+                    from vibe.restart_supervisor import _pending_restart_path
+
+                    _pending_restart_path().unlink(missing_ok=True)
+                except OSError:
+                    logger.debug("Failed to remove stale pending restart marker", exc_info=True)
+                restart = _schedule_restart()
+                return {
+                    "ok": True,
+                    "restart": restart,
+                    "code": "restart_scheduled_after_in_flight_finished",
+                }
             return {
                 "ok": True,
                 "pending_restart": pending,
                 "restart": restart_status,
                 "code": "restart_pending_after_in_progress",
             }
-        status = runtime.read_status()
-        runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
-        restart = schedule_restart(delay_seconds=0.0, trigger="web-ui-config", scope="service")
+        restart = _schedule_restart()
     return {"ok": True, "restart": restart}
 
 


### PR DESCRIPTION
## Capability

**Phase 2 of the restart rework — hot platform reconcile.** Platform enable / disable / credential changes now apply at **runtime with no service restart** (Phase 1, #566, made the restart UI-preserving; this removes the restart entirely for platform changes). Implemented mainly by **Codex (gpt-5.5 xhigh)** as the lead, on top of the MultiIMClient lifecycle foundation.

### What changed
- **`MultiIMClient`** (`modules/im/multi.py`): per-platform `add_client`/`remove_client` under a `_clients_lock`; `run()` idle-loops instead of exiting when no platform threads remain (an empty IM set is valid now).
- **`Controller.reconcile_platforms(new_config)`** (`core/controller.py`): diff the enabled set → add / remove / **credential rebuild (= remove + add)**; reconciles per-platform settings managers, agent routes, formatters, callbacks, and the derived `primary_platform`. The IM runtime is **always** a `MultiIMClient` wrapper (single, multi, or zero external platforms) so disabling every IM platform (workbench-only) keeps the runtime alive instead of letting `Controller._run_im_runtime` return → `loop.stop()` → service down. The always-on `AvibeBot` stays registered as the in-process delivery client (`im_clients["avibe"]`) but out of the IM run-loop.
- **Feishu hot-stop** (`modules/im/feishu.py`): lark-oapi exposes no public WS close, so the adapter now disconnects via the SDK's `_disconnect()` + stops the module loop (releasing the blocking `_select()`) + joins the nested `feishu-ws` thread, so Feishu can be hot-removed cleanly. (Residual risk: relies on a lark-oapi **private** API — a test guards against silent SDK drift.)
- **Internal command** `/internal/reconcile-platforms` (`core/internal_server.py` + `vibe/internal_client.py`); **`POST /api/config`** (`vibe/ui_server.py`) diffs platform enable/disable + runtime credentials → hot-reconcile via the internal socket, falling back to the Phase-1 service-only restart only if the socket is unavailable.
- **Platforms page** (`SettingsPlatformsPage.tsx` + i18n): no longer calls `control('restart')` for platform changes; shows "配置已应用" on hot apply, no restarting banner.

## Evidence layers

- **Unit**: 113 passed across the new/affected suites — `test_controller_platform_reconcile`, `test_feishu_hot_stop`, `test_internal_client`, `test_internal_server`, `test_multi_platform_runtime`, `test_workbench_only_runtime`, `test_platform_registry`, `test_ui_server_fastapi`. Covers reconcile diff (add/remove/credential-rebuild/no-op), disable-all-keeps-runtime-alive, the internal command, the `/api/config` reconcile-vs-restart decision, MultiIMClient add/remove, Feishu stop, and 4/1/0-platform boot shapes.
- **Build**: `npm run build` (tsc + vite) green; `ruff` clean on all changed Python.
- **Contract**: new internal endpoint + `reconcile_platforms`; `/api/config` response shape unchanged; Phase-1 restart path preserved as fallback.
- **Scenario**: no scenario catalog covers the platform-runtime path.
- **Residual manual checks (recommend in regression, all 5 IM platforms)**: toggle each platform on/off and edit a credential → takes effect with no restart and no Web-UI reload; disabling every IM platform leaves the service + workbench alive; Feishu disable cleanly stops its WS thread.

## Notes
- Built incrementally on Phase 1 (#566, merged). Plan: `docs/plans/hot-platform-reconcile.md`.
- Lead implementer: Codex gpt-5.5 (xhigh). This PR will go through the Codex review loop; findings are routed back to the Codex implementation session.
