### PR TITLE
fix(remote-access): make standalone PWA login work (OAuth state desync) + friendly error page

### DIFF
--- a/docs/plans/pwa-oauth-login-state-desync.md
+++ b/docs/plans/pwa-oauth-login-state-desync.md
@@ -51,10 +51,13 @@ Stop requiring `cookie.state == url.state`. Recover the PKCE secrets by the
   - if neither yields a record → existing one-shot retry, then the friendly
     re-login page.
 
-Server-side store: per-file under `~/.avibe/runtime/oauth_handshakes/<r>.json`,
-`0600`, single-use (deleted on read), pruned by TTL. Single UI process, so no
-cross-process coordination needed; on-disk so an in-flight login survives a UI
-restart.
+Server-side store: an **in-memory** dict keyed by the state id (`vibe/remote_access.py`),
+single-use (`pop` under a lock), TTL-pruned, with a size cap. The UI server is a
+single process that handles both the redirect and the callback, so memory is shared
+and admission/single-use are trivially atomic under one lock. It is deliberately
+*not* on disk — the handshake is short-lived and a mid-flow restart just means the
+user logs in again; keeping it in memory removes the disk/inode DoS surface and the
+file-cleanup/atomic-rename machinery entirely.
 
 ## Security
 
@@ -98,12 +101,21 @@ while giving the same binding. Its one assumption (iOS keeps the persistent devi
 cookie stable across the excursion) is verified on the regression PWA; if that ever
 fails, the `localStorage`-nonce variant is the fallback.
 
-### Review round 2 (Codex P2s)
+### Hardening the unauthenticated path (Codex review)
 
-- **Bounded store** — the handshake store is written on every unauthenticated
-  redirect, so it now caps live entries (`OAUTH_HANDSHAKE_MAX_ENTRIES`) and sheds
-  *new* writes when full (preserving in-flight logins), preventing inode exhaustion
-  from a burst of unauthenticated requests.
+The login-start redirect and `/auth/callback` are reachable without a session, so
+unauthenticated floods are the root of the resource-growth concerns. Addressed at
+the highest layer plus backstops:
+
+- **Root: per-client rate limit** on the unauthenticated `/auth` path (`ui_server.py`,
+  fixed window keyed by the Cloudflare-forwarded IP). A flood is `429`'d at the door,
+  so the downstream store and diagnostics stay bounded; a real login spends only a
+  couple of requests, far under the budget.
+- **In-memory store with a size cap** — no disk/inode surface; the cap sheds new
+  entries when full (preserving in-flight logins) as a backstop.
+- **Rate-limited diagnostics** — every unauthenticated-reachable failure log goes
+  through a per-key throttle; the capacity warning is throttled; the success-recovery
+  line is `debug`.
 - **i18n** — the re-login page copy lives in `vibe/i18n` (`remote_access.oauth_error.*`,
   en + zh) and renders in the browser's `Accept-Language` (the only server-readable
   locale signal pre-auth; the SPA keeps its language only in localStorage).

--- a/docs/plans/pwa-oauth-login-state-desync.md
+++ b/docs/plans/pwa-oauth-login-state-desync.md
@@ -63,7 +63,34 @@ an instance is enforced by the avibe.bot backend** (`isEmailAuthorizedForInstanc
 the local instance only trusts backend-issued tokens (audience/issuer/nonce
 checked at exchange). The `state` remains HMAC-signed and single-use, so it cannot
 be forged or replayed. The cookie's state-equality was a defense-in-depth layer
-that is simply unavailable (and counter-productive) in standalone PWAs.
+that is unavailable (and counter-productive) in standalone PWAs.
+
+Codex review (gpt-5.5, xhigh) hardening applied:
+
+- **Store-fallback requires a valid same-origin handshake cookie to be present**
+  (its state may differ — that's the PWA desync — but it must parse/verify). This
+  proves the browser actually started a login on this instance, so a bare
+  `code+state` callback URL can't be replayed in a browser that never did. The PWA
+  always carries such a cookie, so the fix still works.
+- **`pop_oauth_handshake` is atomic single-use** via `os.replace` to a unique
+  private name before reading, so concurrent callbacks for one `rid` can't both
+  consume the same record.
+
+### Known limitation / follow-up
+
+The fallback still binds finalization to *a* same-origin login attempt, not to the
+*specific* browser tab that approved consent (the cookie/jar that would provide
+that binding is exactly what desyncs on iOS). On an instance that authorizes
+**multiple** identities, an attacker who holds a valid `code+state` for their own
+authorized identity could induce a victim's browser (which has visited the
+instance) to hit that callback and be logged in as the attacker — a login-CSRF.
+
+Bounded today: Avibe instances are single-identity (one authorized email), so no
+second identity exists to mount this. The complete fix, for when multi-identity
+matters, is a same-origin binding the desync can't break: the login-start page
+writes a random nonce to `localStorage`, the store keeps its hash, and a JS
+finalizer on the callback page POSTs `{code, state, nonce}` — tracked as a
+follow-up rather than blocking this PWA fix.
 
 ## Testing
 

--- a/docs/plans/pwa-oauth-login-state-desync.md
+++ b/docs/plans/pwa-oauth-login-state-desync.md
@@ -98,6 +98,16 @@ while giving the same binding. Its one assumption (iOS keeps the persistent devi
 cookie stable across the excursion) is verified on the regression PWA; if that ever
 fails, the `localStorage`-nonce variant is the fallback.
 
+### Review round 2 (Codex P2s)
+
+- **Bounded store** — the handshake store is written on every unauthenticated
+  redirect, so it now caps live entries (`OAUTH_HANDSHAKE_MAX_ENTRIES`) and sheds
+  *new* writes when full (preserving in-flight logins), preventing inode exhaustion
+  from a burst of unauthenticated requests.
+- **i18n** — the re-login page copy lives in `vibe/i18n` (`remote_access.oauth_error.*`,
+  en + zh) and renders in the browser's `Accept-Language` (the only server-readable
+  locale signal pre-auth; the SPA keeps its language only in localStorage).
+
 ## Testing
 
 - Unit (`tests/test_ui_remote_access_auth.py`):

--- a/docs/plans/pwa-oauth-login-state-desync.md
+++ b/docs/plans/pwa-oauth-login-state-desync.md
@@ -76,21 +76,27 @@ Codex review (gpt-5.5, xhigh) hardening applied:
   private name before reading, so concurrent callbacks for one `rid` can't both
   consume the same record.
 
-### Known limitation / follow-up
+### Per-browser binding for the store-fallback (login-CSRF closed)
 
-The fallback still binds finalization to *a* same-origin login attempt, not to the
-*specific* browser tab that approved consent (the cookie/jar that would provide
-that binding is exactly what desyncs on iOS). On an instance that authorizes
-**multiple** identities, an attacker who holds a valid `code+state` for their own
-authorized identity could induce a victim's browser (which has visited the
-instance) to hit that callback and be logged in as the attacker — a login-CSRF.
+A bare `code+state` callback URL must not log a *different* browser in. The
+store-fallback is therefore bound to a **stable per-browser device cookie**
+(`__Host-vibe_oauth_device`):
 
-Bounded today: Avibe instances are single-identity (one authorized email), so no
-second identity exists to mount this. The complete fix, for when multi-identity
-matters, is a same-origin binding the desync can't break: the login-start page
-writes a random nonce to `localStorage`, the store keeps its hash, and a JS
-finalizer on the callback page POSTs `{code, state, nonce}` — tracked as a
-follow-up rather than blocking this PWA fix.
+- The login redirect sets it once (reused on later flows, 180-day TTL). Unlike the
+  per-flow handshake *state*, it is not regenerated per `GET /`, so it stays
+  consistent across the iOS authorize excursion.
+- The handshake record stores `hmac(session_secret, device_id)`. The callback's
+  store-fallback only proceeds when the request's device cookie hashes to that
+  value — proving it is the same browser that started the flow.
+- An attacker cannot present a victim's device cookie (HttpOnly, Secure,
+  per-browser), so inducing a victim to hit an attacker's `code+state` callback no
+  longer logs the victim in as the attacker.
+
+This was chosen over a `localStorage`-nonce + JS-finalizer flow because it needs no
+interstitial pages, no client JS, and no change to the normal-browser login UX —
+while giving the same binding. Its one assumption (iOS keeps the persistent device
+cookie stable across the excursion) is verified on the regression PWA; if that ever
+fails, the `localStorage`-nonce variant is the fallback.
 
 ## Testing
 

--- a/docs/plans/pwa-oauth-login-state-desync.md
+++ b/docs/plans/pwa-oauth-login-state-desync.md
@@ -1,0 +1,82 @@
+# Fix: PWA login always fails with `invalid_oauth_state`
+
+## Background
+
+Installed (standalone) PWAs on iOS deterministically fail Avibe Cloud remote-access
+login: after approving the avibe.bot consent screen, the user lands on
+`/auth/callback` and gets `invalid_oauth_state` every time. Normal browsers work.
+
+## Root cause (evidence-backed, from the master regression env)
+
+Topology: the PWA and `/auth/callback` are both on the tunnel host
+(`test-app.avibe.bot`); the authorize/token endpoints are on `avibe.bot` (parent
+domain, cross-origin but same registrable domain → same-site).
+
+Diagnostic logging on the callback (regression) showed, on every PWA failure:
+
+```
+cookie_parsed=True  cookie_state_rid=<A>  url_state_rid=<B>  url_state_valid=True   (A != B)
+handshake_cookie_present=True  sec_fetch_site=same-site  ua=...iPhone OS 18_7...
+```
+
+So the handshake cookie **is** delivered and valid, and the callback URL's `state`
+is **also** a valid token we signed — but they are **two different states**.
+
+Why: iOS standalone PWAs open the cross-origin avibe.bot authorize page in a
+separate in-app-browser context, while the PWA's main webview independently
+re-mints its own `GET /` → state + handshake cookie. The cookie the callback reads
+therefore belongs to a *different* `GET /` generation than the consent the user
+actually approved. The existing check `cookie.state == url.state` is the wrong
+invariant in this multi-context environment.
+
+(An earlier hypothesis — the cookie was a session cookie dropped across the
+excursion — was disproven by `handshake_cookie_present=True`. Adding `Max-Age`
+only changed the symptom from "absent" to "present-but-stale".)
+
+## Fix
+
+Stop requiring `cookie.state == url.state`. Recover the PKCE secrets by the
+**signature-verified URL state** instead:
+
+- `GET /` (`_redirect_to_vibe_cloud_login`): generate `state` (signed, with random
+  id `r`), `nonce`, `code_verifier`. Persist `{nonce, code_verifier, next}`
+  **server-side keyed by `r`** (single-use, 5-min TTL), in addition to the existing
+  cookie.
+- `/auth/callback`: verify the URL `state` signature, then:
+  - **cookie-first** — if the cookie is present and its state matches the URL state,
+    use the cookie's secrets (unchanged strong per-browser binding for normal
+    browsers);
+  - **store-fallback** — otherwise look up the server-side handshake by the URL
+    state's `r` (the iOS PWA / cookie-desync case);
+  - if neither yields a record → existing one-shot retry, then the friendly
+    re-login page.
+
+Server-side store: per-file under `~/.avibe/runtime/oauth_handshakes/<r>.json`,
+`0600`, single-use (deleted on read), pruned by TTL. Single UI process, so no
+cross-process coordination needed; on-disk so an in-flight login survives a UI
+restart.
+
+## Security
+
+The change does not weaken the real gate: **which identity may complete OAuth for
+an instance is enforced by the avibe.bot backend** (`isEmailAuthorizedForInstance`);
+the local instance only trusts backend-issued tokens (audience/issuer/nonce
+checked at exchange). The `state` remains HMAC-signed and single-use, so it cannot
+be forged or replayed. The cookie's state-equality was a defense-in-depth layer
+that is simply unavailable (and counter-productive) in standalone PWAs.
+
+## Testing
+
+- Unit (`tests/test_ui_remote_access_auth.py`):
+  - new: valid-but-mismatched cookie + matching server-side record → callback
+    completes via the store, using the record's verifier/nonce (not the stale
+    cookie's).
+  - new: login redirect persists the handshake cookie (`Max-Age`).
+  - existing cookie-path / retry / legacy-state / sanitization cases stay green.
+- Manual: iOS standalone PWA login on the master regression env (`test-app.avibe.bot`).
+
+## Rollout
+
+1. Deploy to the master regression env; confirm PWA login succeeds (and the
+   `recovered via server-side handshake` info log fires).
+2. codex review (auth-path change) → open PR.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,25 @@ def _isolate_vibe_remote_home(request, tmp_path, monkeypatch):
         return
     monkeypatch.delenv("AVIBE_HOME", raising=False)
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_oauth_runtime_state():
+    """Reset module-level in-memory OAuth caches between tests.
+
+    The handshake store, diagnostic-log throttles, and the unauthenticated /auth
+    rate limiter live in process memory (not under the isolated VIBE_REMOTE_HOME),
+    so without this they would leak across tests sharing a pytest process — e.g. the
+    rate limiter accumulating across files and spuriously 429-ing an unrelated test.
+    """
+    try:
+        from vibe import remote_access, ui_server
+    except Exception:
+        yield
+        return
+    caches = (remote_access._oauth_handshakes, ui_server._oauth_diag_log_state, ui_server._auth_ratelimit)
+    for cache in caches:
+        cache.clear()
+    yield
+    for cache in caches:
+        cache.clear()

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1189,6 +1189,71 @@ def test_oauth_handshake_store_is_single_use_and_expires(monkeypatch, tmp_path):
     assert remote_access.pop_oauth_handshake(None) is None
 
 
+def test_remote_callback_refuses_store_fallback_without_cookie(monkeypatch, tmp_path):
+    # Defense-in-depth: a callback URL (code+state) must not become a cross-browser
+    # bearer login. With NO same-origin handshake cookie present, the server-side
+    # store must not be used to complete login, even though a record exists for the
+    # signed state. The PWA fix only relaxes the *state-equality* of a present cookie.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    secret = config.remote_access.vibe_cloud.session_secret
+    client = app.test_client()
+
+    rid = "victimrid0001"
+    state_url = ui_server._make_oauth_state(secret, next_target="/dashboard", rid=rid)
+    remote_access.store_oauth_handshake(rid, nonce="n", code_verifier="v", next_target="/dashboard")
+
+    exchanged = []
+    monkeypatch.setattr(
+        remote_access, "exchange_oauth_code", lambda *a, **k: exchanged.append(a) or {"claims": {}}
+    )
+
+    # No oauth handshake cookie on the client.
+    response = client.get(
+        f"/auth/callback?code=test-code&state={state_url}",
+        base_url="https://alex.avibe.bot",
+        follow_redirects=False,
+    )
+
+    # Never exchanged the code, and never redirected the browser to the target.
+    assert exchanged == []
+    assert response.headers.get("Location") != "/dashboard"
+
+
+def test_oauth_handshake_pop_is_atomic_single_use_under_concurrency(monkeypatch, tmp_path):
+    import threading
+    from unittest import mock
+
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    remote_access.store_oauth_handshake("race-rid000", nonce="n", code_verifier="v", next_target="/")
+
+    barrier = threading.Barrier(2)
+    orig_replace = remote_access.os.replace
+
+    def delayed_replace(src, dst):
+        try:
+            barrier.wait(timeout=5)
+        except threading.BrokenBarrierError:
+            pass
+        return orig_replace(src, dst)
+
+    results = []
+
+    def worker():
+        results.append(remote_access.pop_oauth_handshake("race-rid000"))
+
+    with mock.patch.object(remote_access.os, "replace", delayed_replace):
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    # The atomic claim guarantees exactly one racer gets the record.
+    assert sum(1 for r in results if r is not None) == 1
+
+
 def test_remote_callback_accepts_html_escaped_state_separator(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1233,6 +1233,34 @@ def test_oauth_handshake_store_caps_entries(monkeypatch, tmp_path):
     assert remote_access.pop_oauth_handshake("rid-0") is not None
 
 
+def test_oauth_handshake_cap_holds_under_concurrency(monkeypatch, tmp_path):
+    # Atomic admission: a concurrent burst must not blow past the cap. Without the
+    # lock, many threads could pass the count check before any writes.
+    import threading
+
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    monkeypatch.setattr(remote_access, "OAUTH_HANDSHAKE_MAX_ENTRIES", 5)
+
+    barrier = threading.Barrier(20)
+
+    def worker(i):
+        try:
+            barrier.wait(timeout=5)
+        except threading.BrokenBarrierError:
+            pass
+        remote_access.store_oauth_handshake(f"rid-{i:03d}", nonce="n", code_verifier="v", next_target="/")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    live = list((paths.get_runtime_dir() / "oauth_handshakes").glob("*.json"))
+    assert len(live) <= 5
+
+
 def test_oauth_diag_log_is_rate_limited(monkeypatch):
     # The unauthenticated callback failure path must not grow the log without bound:
     # repeated hits within the window emit once, with the suppressed count folded in.

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import ipaddress
-import json
 import socket
 import asyncio
 from collections import namedtuple
 
 import httpx
+import pytest
 
-from config import paths
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from config.v2_config import CONFIG_LOCK
 from tests.ui_server_test_helpers import csrf_headers
@@ -1204,12 +1203,9 @@ def test_oauth_handshake_store_is_single_use_and_expires(monkeypatch, tmp_path):
     # Single-use: a second pop finds nothing.
     assert remote_access.pop_oauth_handshake("rid-abc") is None
 
-    # An expired record is treated as absent (and removed).
+    # An expired record is treated as absent.
     remote_access.store_oauth_handshake("rid-exp", nonce="n", code_verifier="v", next_target="/x")
-    record_path = paths.get_runtime_dir() / "oauth_handshakes" / "rid-exp.json"
-    data = json.loads(record_path.read_text())
-    data["exp"] = 0
-    record_path.write_text(json.dumps(data))
+    remote_access._oauth_handshakes["rid-exp"]["exp"] = 0
     assert remote_access.pop_oauth_handshake("rid-exp") is None
 
     # Invalid ids are rejected, never touching the filesystem.
@@ -1257,8 +1253,28 @@ def test_oauth_handshake_cap_holds_under_concurrency(monkeypatch, tmp_path):
     for t in threads:
         t.join()
 
-    live = list((paths.get_runtime_dir() / "oauth_handshakes").glob("*.json"))
-    assert len(live) <= 5
+    assert len(remote_access._oauth_handshakes) <= 5
+
+
+def test_unauthenticated_auth_requests_are_rate_limited(monkeypatch, tmp_path):
+    # Root-level bound: a flood of unauthenticated login-start requests from one
+    # client is 429'd, instead of each one doing handshake/cookie/log work.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    monkeypatch.setattr(ui_server, "_AUTH_RATELIMIT_MAX_PER_WINDOW", 3)
+    client = app.test_client()
+
+    statuses = [
+        client.get(
+            "/dashboard",
+            base_url="https://alex.avibe.bot",
+            environ_base={"REMOTE_ADDR": "203.0.113.77"},
+            follow_redirects=False,
+        ).status_code
+        for _ in range(5)
+    ]
+    assert statuses[:3] == [302, 302, 302]  # within budget -> redirect to login
+    assert statuses[3:] == [429, 429]  # over budget -> throttled
 
 
 def test_oauth_diag_log_is_rate_limited(monkeypatch):

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import ipaddress
+import json
 import socket
 import asyncio
 from collections import namedtuple
 
 import httpx
 
+from config import paths
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from config.v2_config import CONFIG_LOCK
 from tests.ui_server_test_helpers import csrf_headers
@@ -114,6 +116,22 @@ def test_remote_host_redirects_to_vibe_cloud_login(monkeypatch, tmp_path):
     assert state_payload is not None
     assert state_payload["next"] == "/dashboard"
     assert state_payload["retry"] is False
+
+
+def test_login_redirect_sets_persistent_handshake_cookie(monkeypatch, tmp_path):
+    # iOS standalone PWAs drop session-scoped cookies (no Max-Age) across the
+    # cross-origin authorize excursion, so the callback can't read the handshake
+    # back and deterministically fails with invalid_oauth_state. The handshake
+    # cookie must be persistent. Regression guard for the PWA login dead-end.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+
+    with app.test_request_context("/dashboard", base_url="https://alex.avibe.bot"):
+        response = ui_server._redirect_to_vibe_cloud_login(config)
+
+    set_cookie = response.headers["Set-Cookie"]
+    assert set_cookie.startswith(f"{ui_server.REMOTE_OAUTH_COOKIE_NAME}=")
+    assert f"Max-Age={ui_server.REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS}" in set_cookie
 
 
 def test_remote_setup_route_requires_vibe_cloud_login(monkeypatch, tmp_path):
@@ -994,7 +1012,11 @@ def test_remote_callback_rejects_nonce_mismatch(monkeypatch, tmp_path):
     response = client.get(f"/auth/callback?code=test-code&state={state}", base_url="https://alex.avibe.bot")
 
     assert response.status_code == 400
-    assert response.get_json()["error"] == "invalid_oauth_nonce"
+    assert "text/html" in response.headers["Content-Type"]
+    assert "invalid_oauth_nonce" in response.text
+    assert "Sign in again" in response.text
+    # Re-login button points back at the original destination from the handshake.
+    assert 'href="/dashboard"' in response.text
 
 
 def test_remote_callback_rejects_when_remote_access_is_disabled(monkeypatch, tmp_path):
@@ -1064,19 +1086,107 @@ def test_remote_callback_does_not_restart_oauth_twice(monkeypatch, tmp_path):
 
     response = client.get(f"/auth/callback?code=test-code&state={state}", base_url="https://alex.avibe.bot")
 
+    # Auto-retry already spent: render the friendly re-login page, not raw JSON.
     assert response.status_code == 400
-    assert response.get_json()["error"] == "invalid_oauth_state"
+    assert "text/html" in response.headers["Content-Type"]
+    assert "invalid_oauth_state" in response.text
+    assert "Sign in again" in response.text
+    # Retry recovers the original destination from the signed state param.
+    assert 'href="/show/ses123/"' in response.text
 
 
-def test_remote_callback_preserves_invalid_state_response_for_legacy_state(monkeypatch, tmp_path):
+def test_remote_callback_renders_relogin_page_for_legacy_state(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     _save_config(tmp_path)
     client = app.test_client()
 
     response = client.get("/auth/callback?code=test-code&state=state-1", base_url="https://alex.avibe.bot")
 
+    # Undecodable state has no recoverable destination, so the retry button
+    # falls back to the home page.
     assert response.status_code == 400
-    assert response.get_json()["error"] == "invalid_oauth_state"
+    assert "text/html" in response.headers["Content-Type"]
+    assert "invalid_oauth_state" in response.text
+    assert "Sign in again" in response.text
+    assert 'href="/"' in response.text
+
+
+def test_remote_callback_recovers_via_store_when_cookie_state_desyncs(monkeypatch, tmp_path):
+    # iOS standalone PWA: the handshake cookie carries a *different* (but valid)
+    # state than the one the user approved, because the cross-origin authorize step
+    # runs in a separate in-app-browser context. The callback must still complete by
+    # recovering the PKCE secrets from the server-side store, keyed by the signed URL
+    # state. Regression guard for the deterministic PWA invalid_oauth_state dead-end.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    secret = config.remote_access.vibe_cloud.session_secret
+    client = app.test_client()
+
+    # The flow the user actually approved: a signed state plus its server-side record.
+    rid = "approvedrid000"
+    state_url = ui_server._make_oauth_state(secret, next_target="/dashboard", rid=rid)
+    remote_access.store_oauth_handshake(
+        rid, nonce="nonce-approved", code_verifier="verifier-approved", next_target="/dashboard"
+    )
+
+    # A stale-but-valid cookie from a *different* GET / generation (different state).
+    stale_cookie = ui_server._make_oauth_cookie(
+        secret,
+        {
+            "state": ui_server._make_oauth_state(secret, next_target="/", rid="stalerid0000"),
+            "nonce": "nonce-stale",
+            "code_verifier": "verifier-stale",
+            "next": "/",
+            "exp": int(ui_server.datetime.now().timestamp()) + 300,
+        },
+    )
+    client.set_cookie(ui_server.REMOTE_OAUTH_COOKIE_NAME, stale_cookie, domain="alex.avibe.bot")
+
+    captured = {}
+
+    def exchange(cfg, code, verifier):
+        captured["verifier"] = verifier
+        return {"claims": {"email": "alex@example.com", "sub": "user-1", "nonce": "nonce-approved"}}
+
+    monkeypatch.setattr(remote_access, "exchange_oauth_code", exchange)
+
+    response = client.get(
+        f"/auth/callback?code=test-code&state={state_url}",
+        base_url="https://alex.avibe.bot",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/dashboard"
+    # Used the server-side record's verifier, not the stale cookie's.
+    assert captured["verifier"] == "verifier-approved"
+    # Handshake is single-use: consumed by the callback.
+    assert remote_access.pop_oauth_handshake(rid) is None
+
+
+def test_oauth_handshake_store_is_single_use_and_expires(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    remote_access.store_oauth_handshake("rid-abc", nonce="n", code_verifier="v", next_target="/x")
+    first = remote_access.pop_oauth_handshake("rid-abc")
+    assert first is not None
+    assert first["code_verifier"] == "v"
+    assert first["next"] == "/x"
+    # Single-use: a second pop finds nothing.
+    assert remote_access.pop_oauth_handshake("rid-abc") is None
+
+    # An expired record is treated as absent (and removed).
+    remote_access.store_oauth_handshake("rid-exp", nonce="n", code_verifier="v", next_target="/x")
+    record_path = paths.get_runtime_dir() / "oauth_handshakes" / "rid-exp.json"
+    data = json.loads(record_path.read_text())
+    data["exp"] = 0
+    record_path.write_text(json.dumps(data))
+    assert remote_access.pop_oauth_handshake("rid-exp") is None
+
+    # Invalid ids are rejected, never touching the filesystem.
+    assert remote_access.pop_oauth_handshake("bad/rid") is None
+    assert remote_access.pop_oauth_handshake(None) is None
 
 
 def test_remote_callback_accepts_html_escaped_state_separator(monkeypatch, tmp_path):

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1277,6 +1277,47 @@ def test_unauthenticated_auth_requests_are_rate_limited(monkeypatch, tmp_path):
     assert statuses[3:] == [429, 429]  # over budget -> throttled
 
 
+def test_auth_rate_limit_ignores_untrusted_forwarded_ip(monkeypatch, tmp_path):
+    # A direct (non-loopback) peer can't dodge the limit by rotating CF-Connecting-IP:
+    # the forwarded IP is trusted only from the loopback tunnel peer, so such a peer
+    # is keyed by its real address and the rotating header is ignored.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    monkeypatch.setattr(ui_server, "_AUTH_RATELIMIT_MAX_PER_WINDOW", 3)
+    client = app.test_client()
+
+    statuses = [
+        client.get(
+            "/dashboard",
+            base_url="https://alex.avibe.bot",
+            environ_base={"REMOTE_ADDR": "203.0.113.90"},
+            headers={"CF-Connecting-IP": f"9.9.9.{i}"},  # rotated each request
+            follow_redirects=False,
+        ).status_code
+        for i in range(5)
+    ]
+    assert statuses[:3] == [302, 302, 302]
+    assert statuses[3:] == [429, 429]  # still limited despite the rotating header
+
+
+def test_auth_rate_limit_table_is_bounded(monkeypatch, tmp_path):
+    # The limiter's own table is hard-capped (LRU eviction), so a burst of distinct
+    # clients can't drive unbounded in-process memory growth.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    monkeypatch.setattr(ui_server, "_AUTH_RATELIMIT_MAX_TRACKED_CLIENTS", 3)
+    client = app.test_client()
+
+    for i in range(10):  # 10 distinct peers
+        client.get(
+            "/dashboard",
+            base_url="https://alex.avibe.bot",
+            environ_base={"REMOTE_ADDR": f"198.51.100.{i}"},
+            follow_redirects=False,
+        )
+    assert len(ui_server._auth_ratelimit) <= 3
+
+
 def test_oauth_diag_log_is_rate_limited(monkeypatch):
     # The unauthenticated callback failure path must not grow the log without bound:
     # repeated hits within the window emit once, with the suppressed count folded in.

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1233,6 +1233,26 @@ def test_oauth_handshake_store_caps_entries(monkeypatch, tmp_path):
     assert remote_access.pop_oauth_handshake("rid-0") is not None
 
 
+def test_oauth_diag_log_is_rate_limited(monkeypatch):
+    # The unauthenticated callback failure path must not grow the log without bound:
+    # repeated hits within the window emit once, with the suppressed count folded in.
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(ui_server.time, "monotonic", lambda: clock["t"])
+    ui_server._oauth_diag_log_state.pop("test_key", None)
+
+    emitted = []
+    monkeypatch.setattr(ui_server.logger, "warning", lambda msg, *a: emitted.append(msg % a if a else msg))
+
+    for _ in range(5):
+        ui_server._log_oauth_diag("test_key", "boom x=%s", 1)
+    assert len(emitted) == 1  # only the first hit in the window is logged
+
+    clock["t"] += ui_server._OAUTH_DIAG_LOG_INTERVAL_SECONDS + 1
+    ui_server._log_oauth_diag("test_key", "boom x=%s", 1)
+    assert len(emitted) == 2
+    assert "suppressed" in emitted[1]  # the 4 suppressed hits are reported
+
+
 def test_oauth_error_page_localizes_from_accept_language(monkeypatch, tmp_path):
     # The re-login page copy must come from vibe/i18n and honor the browser's
     # Accept-Language (the only server-readable locale signal pre-auth).

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -134,6 +134,26 @@ def test_login_redirect_sets_persistent_handshake_cookie(monkeypatch, tmp_path):
     assert f"Max-Age={ui_server.REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS}" in set_cookie
 
 
+def test_login_redirect_sets_stable_device_binding_cookie(monkeypatch, tmp_path):
+    # The store-fallback recovery is bound to this persistent per-browser device
+    # cookie, which (unlike the per-flow handshake state) survives the iOS authorize
+    # excursion. The login redirect must seed it, long-lived.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+
+    with app.test_request_context("/dashboard", base_url="https://alex.avibe.bot"):
+        response = ui_server._redirect_to_vibe_cloud_login(config)
+
+    device_cookies = [
+        c for c in response.headers.getlist("Set-Cookie")
+        if c.startswith(f"{ui_server.REMOTE_OAUTH_DEVICE_COOKIE_NAME}=")
+    ]
+    assert len(device_cookies) == 1
+    assert f"Max-Age={ui_server.REMOTE_OAUTH_DEVICE_TTL_SECONDS}" in device_cookies[0]
+    assert "HttpOnly" in device_cookies[0]
+    assert "Secure" in device_cookies[0]
+
+
 def test_remote_setup_route_requires_vibe_cloud_login(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
@@ -1122,11 +1142,17 @@ def test_remote_callback_recovers_via_store_when_cookie_state_desyncs(monkeypatc
     secret = config.remote_access.vibe_cloud.session_secret
     client = app.test_client()
 
-    # The flow the user actually approved: a signed state plus its server-side record.
+    # The flow the user actually approved: a signed state plus its server-side record,
+    # bound to this browser's stable device id.
     rid = "approvedrid000"
+    device_id = "device-abc-123"
     state_url = ui_server._make_oauth_state(secret, next_target="/dashboard", rid=rid)
     remote_access.store_oauth_handshake(
-        rid, nonce="nonce-approved", code_verifier="verifier-approved", next_target="/dashboard"
+        rid,
+        nonce="nonce-approved",
+        code_verifier="verifier-approved",
+        next_target="/dashboard",
+        device_hash=ui_server._oauth_device_hash(secret, device_id),
     )
 
     # A stale-but-valid cookie from a *different* GET / generation (different state).
@@ -1141,6 +1167,8 @@ def test_remote_callback_recovers_via_store_when_cookie_state_desyncs(monkeypatc
         },
     )
     client.set_cookie(ui_server.REMOTE_OAUTH_COOKIE_NAME, stale_cookie, domain="alex.avibe.bot")
+    # The device cookie is stable across the excursion and matches the record's bind.
+    client.set_cookie(ui_server.REMOTE_OAUTH_DEVICE_COOKIE_NAME, device_id, domain="alex.avibe.bot")
 
     captured = {}
 
@@ -1189,11 +1217,11 @@ def test_oauth_handshake_store_is_single_use_and_expires(monkeypatch, tmp_path):
     assert remote_access.pop_oauth_handshake(None) is None
 
 
-def test_remote_callback_refuses_store_fallback_without_cookie(monkeypatch, tmp_path):
-    # Defense-in-depth: a callback URL (code+state) must not become a cross-browser
-    # bearer login. With NO same-origin handshake cookie present, the server-side
-    # store must not be used to complete login, even though a record exists for the
-    # signed state. The PWA fix only relaxes the *state-equality* of a present cookie.
+def test_remote_callback_refuses_store_fallback_without_device_binding(monkeypatch, tmp_path):
+    # Login-CSRF block: a code+state callback URL must not complete in a browser that
+    # isn't the one that started the flow. The store record is bound to the attacker's
+    # device id; the victim's browser presents its own (different) device cookie plus a
+    # stale handshake cookie, so the store-fallback must refuse — no token exchange.
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     secret = config.remote_access.vibe_cloud.session_secret
@@ -1201,14 +1229,33 @@ def test_remote_callback_refuses_store_fallback_without_cookie(monkeypatch, tmp_
 
     rid = "victimrid0001"
     state_url = ui_server._make_oauth_state(secret, next_target="/dashboard", rid=rid)
-    remote_access.store_oauth_handshake(rid, nonce="n", code_verifier="v", next_target="/dashboard")
+    remote_access.store_oauth_handshake(
+        rid,
+        nonce="n",
+        code_verifier="v",
+        next_target="/dashboard",
+        device_hash=ui_server._oauth_device_hash(secret, "attacker-device"),
+    )
+
+    # Victim browser: a valid-but-stale handshake cookie and its OWN device cookie.
+    stale_cookie = ui_server._make_oauth_cookie(
+        secret,
+        {
+            "state": ui_server._make_oauth_state(secret, next_target="/", rid="victimst0000"),
+            "nonce": "x",
+            "code_verifier": "x",
+            "next": "/",
+            "exp": int(ui_server.datetime.now().timestamp()) + 300,
+        },
+    )
+    client.set_cookie(ui_server.REMOTE_OAUTH_COOKIE_NAME, stale_cookie, domain="alex.avibe.bot")
+    client.set_cookie(ui_server.REMOTE_OAUTH_DEVICE_COOKIE_NAME, "victim-device", domain="alex.avibe.bot")
 
     exchanged = []
     monkeypatch.setattr(
         remote_access, "exchange_oauth_code", lambda *a, **k: exchanged.append(a) or {"claims": {}}
     )
 
-    # No oauth handshake cookie on the client.
     response = client.get(
         f"/auth/callback?code=test-code&state={state_url}",
         base_url="https://alex.avibe.bot",

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1217,6 +1217,43 @@ def test_oauth_handshake_store_is_single_use_and_expires(monkeypatch, tmp_path):
     assert remote_access.pop_oauth_handshake(None) is None
 
 
+def test_oauth_handshake_store_caps_entries(monkeypatch, tmp_path):
+    # The store is written on every unauthenticated redirect; a hard cap prevents
+    # unbounded inode growth under a burst. At capacity, new writes are shed and
+    # existing in-flight entries are preserved.
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    monkeypatch.setattr(remote_access, "OAUTH_HANDSHAKE_MAX_ENTRIES", 3)
+
+    for i in range(3):
+        remote_access.store_oauth_handshake(f"rid-{i}", nonce="n", code_verifier="v", next_target="/")
+    remote_access.store_oauth_handshake("rid-overflow", nonce="n", code_verifier="v", next_target="/")
+
+    assert remote_access.pop_oauth_handshake("rid-overflow") is None
+    assert remote_access.pop_oauth_handshake("rid-0") is not None
+
+
+def test_oauth_error_page_localizes_from_accept_language(monkeypatch, tmp_path):
+    # The re-login page copy must come from vibe/i18n and honor the browser's
+    # Accept-Language (the only server-readable locale signal pre-auth).
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    client = app.test_client()
+
+    response = client.get(
+        "/auth/callback?code=test-code&state=state-1",
+        base_url="https://alex.avibe.bot",
+        headers={"Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8"},
+    )
+
+    assert response.status_code == 400
+    body = response.text
+    assert '<html lang="zh"' in body
+    assert "登录会话已过期" in body  # invalid_oauth_state_title (zh)
+    assert "重新登录" in body  # sign_in_again (zh)
+    assert "Your sign-in session expired" not in body  # not the English copy
+
+
 def test_remote_callback_refuses_store_fallback_without_device_binding(monkeypatch, tmp_path):
     # Login-CSRF block: a code+state callback URL must not complete in a browser that
     # isn't the one that started the flow. The store record is bound to the attacker's

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -397,5 +397,19 @@
     "routingChoosePrefix": "Choose a value for",
     "routingSaving": "Saving routing settings...",
     "routingCanceled": "Routing update canceled."
+  },
+  "remote_access": {
+    "oauth_error": {
+      "sign_in_again": "Sign in again",
+      "cookie_hint": "Still stuck after trying again? Make sure your browser allows cookies for this site.",
+      "default_title": "Let's sign you in again",
+      "default_body": "Your sign-in didn't finish. Please try again.",
+      "invalid_oauth_state_title": "Your sign-in session expired",
+      "invalid_oauth_state_body": "The secure login link expired or couldn't be matched to this browser. This usually happens when a sign-in link sits unused for a few minutes, or is opened in a different tab or window. Start over and you'll be right back in.",
+      "oauth_exchange_failed_title": "We couldn't finish signing you in",
+      "oauth_exchange_failed_body": "Avibe Cloud didn't complete the sign-in just now. This is usually temporary — please try again.",
+      "invalid_oauth_nonce_title": "We couldn't verify this sign-in",
+      "invalid_oauth_nonce_body": "This sign-in attempt couldn't be verified, so we stopped to keep your account secure. Start over to continue."
+    }
   }
 }

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -397,5 +397,19 @@
     "routingChoosePrefix": "请选择",
     "routingSaving": "正在保存 Agent 路由设置...",
     "routingCanceled": "已取消更新 Agent 路由设置。"
+  },
+  "remote_access": {
+    "oauth_error": {
+      "sign_in_again": "重新登录",
+      "cookie_hint": "重试后仍然卡住?请确认浏览器允许本站使用 Cookie。",
+      "default_title": "重新登录一下",
+      "default_body": "登录未完成,请重试。",
+      "invalid_oauth_state_title": "登录会话已过期",
+      "invalid_oauth_state_body": "安全登录链接已过期,或无法与当前浏览器匹配。这通常是因为登录链接闲置了几分钟,或在另一个标签页/窗口中打开。重新登录即可继续。",
+      "oauth_exchange_failed_title": "登录未能完成",
+      "oauth_exchange_failed_body": "Avibe Cloud 刚才没能完成登录,这通常是暂时的,请重试。",
+      "invalid_oauth_nonce_title": "无法验证此次登录",
+      "invalid_oauth_nonce_body": "本次登录未能通过验证,为保护你的账户已中止。请重新登录以继续。"
+    }
   }
 }

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -930,17 +930,28 @@ def store_oauth_handshake(rid: str, *, nonce: str, code_verifier: str, next_targ
 
 
 def pop_oauth_handshake(rid: str | None) -> dict[str, Any] | None:
-    """Return and delete (single-use) the handshake for ``rid``; None if absent/expired."""
+    """Return and delete (single-use) the handshake for ``rid``; None if absent/expired.
+
+    The claim is atomic: the record file is ``os.replace``d to a unique private name
+    before it is read, so under concurrent callbacks for the same ``rid`` exactly one
+    racer wins and the others get ``None``.
+    """
     if not rid or not _OAUTH_HANDSHAKE_RID_RE.match(rid):
         return None
-    path = _oauth_handshake_dir() / f"{rid}.json"
+    directory = _oauth_handshake_dir()
+    path = directory / f"{rid}.json"
+    claim = directory / f".{rid}.{os.getpid()}.{secrets.token_hex(8)}.claim"
     try:
-        raw = path.read_text(encoding="utf-8")
+        os.replace(path, claim)  # atomic single-use claim — only one racer can win
+    except OSError:
+        return None
+    try:
+        raw = claim.read_text(encoding="utf-8")
     except OSError:
         return None
     finally:
         try:
-            path.unlink()
+            claim.unlink()
         except OSError:
             pass
     try:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -880,6 +880,14 @@ OAUTH_HANDSHAKE_TTL_SECONDS = 300
 # logins) and is far above any realistic concurrent-login count.
 OAUTH_HANDSHAKE_MAX_ENTRIES = 2048
 _OAUTH_HANDSHAKE_RID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
+# Serializes prune+capacity-check+write so the cap is enforced atomically under a
+# concurrent burst (count-then-write without a lock could blow past the cap).
+_OAUTH_STORE_LOCK = threading.Lock()
+# Throttle the "at capacity" warning: under a sustained flood it would otherwise be
+# emitted on every shed write and grow the log unbounded — the very thing the cap
+# is meant to prevent.
+_OAUTH_STORE_CAPACITY_WARN_INTERVAL_SECONDS = 60.0
+_oauth_store_capacity_warned_at = 0.0
 
 
 def _oauth_handshake_dir() -> Path:
@@ -905,6 +913,15 @@ def _prune_oauth_handshakes(directory: Path) -> int:
     return survivors
 
 
+def _warn_oauth_store_at_capacity() -> None:
+    """Log the capacity-shed warning at most once per interval (call under the lock)."""
+    global _oauth_store_capacity_warned_at
+    now = time.monotonic()
+    if now - _oauth_store_capacity_warned_at >= _OAUTH_STORE_CAPACITY_WARN_INTERVAL_SECONDS:
+        _oauth_store_capacity_warned_at = now
+        logger.warning("oauth handshake store at capacity (>= %d); shedding writes", OAUTH_HANDSHAKE_MAX_ENTRIES)
+
+
 def store_oauth_handshake(
     rid: str, *, nonce: str, code_verifier: str, next_target: str, device_hash: str | None = None
 ) -> None:
@@ -917,16 +934,6 @@ def store_oauth_handshake(
     if not _OAUTH_HANDSHAKE_RID_RE.match(rid or ""):
         return
     directory = _oauth_handshake_dir()
-    try:
-        directory.mkdir(parents=True, exist_ok=True)
-        directory.chmod(0o700)
-    except OSError:
-        pass
-    # Prune expired records first; if the store is still at capacity (i.e. flooded
-    # with fresh entries), shed this write rather than grow unbounded on disk.
-    if _prune_oauth_handshakes(directory) >= OAUTH_HANDSHAKE_MAX_ENTRIES:
-        logger.warning("oauth handshake store at capacity (>= %d); skipping write", OAUTH_HANDSHAKE_MAX_ENTRIES)
-        return
     payload = {
         "nonce": nonce,
         "code_verifier": code_verifier,
@@ -935,19 +942,32 @@ def store_oauth_handshake(
         "exp": int(time.time()) + OAUTH_HANDSHAKE_TTL_SECONDS,
     }
     final = directory / f"{rid}.json"
-    tmp = directory / f".{rid}.{os.getpid()}.tmp"
-    try:
-        tmp.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+    tmp = directory / f".{rid}.{os.getpid()}.{secrets.token_hex(6)}.tmp"
+    # Hold the lock across prune + capacity-check + write so admission is atomic:
+    # otherwise a concurrent burst could all pass the check and blow past the cap.
+    with _OAUTH_STORE_LOCK:
         try:
-            tmp.chmod(0o600)
+            directory.mkdir(parents=True, exist_ok=True)
+            directory.chmod(0o700)
         except OSError:
             pass
-        os.replace(tmp, final)
-    except OSError:
+        # Prune expired records first; if the store is still at capacity (i.e. a
+        # flood of fresh entries), shed this write rather than grow unbounded.
+        if _prune_oauth_handshakes(directory) >= OAUTH_HANDSHAKE_MAX_ENTRIES:
+            _warn_oauth_store_at_capacity()
+            return
         try:
-            tmp.unlink()
+            tmp.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+            try:
+                tmp.chmod(0o600)
+            except OSError:
+                pass
+            os.replace(tmp, final)
         except OSError:
-            pass
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
 
 
 def pop_oauth_handshake(rid: str | None) -> dict[str, Any] | None:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -864,53 +864,39 @@ def exchange_oauth_code(config: V2Config, code: str, code_verifier: str) -> dict
 
 # --- OAuth handshake store -------------------------------------------------
 #
-# The login handshake (PKCE ``code_verifier`` + ``nonce``) is normally carried in
-# a short-lived cookie. iOS standalone PWAs run the cross-origin authorize step in
-# a separate in-app-browser context, so the cookie the callback reads belongs to a
-# *different* ``GET /`` generation than the consent the user approved, and
-# ``cookie.state == url.state`` never holds. We therefore also persist the
-# handshake server-side, keyed by the signed state's random id, so the callback
-# can recover it by the (signature-verified) state in the callback URL. The id is
-# unguessable and single-use; the verifier never leaves the machine.
+# The login handshake (PKCE ``code_verifier`` + ``nonce`` + device binding) lives
+# only between the login-start redirect and the ``/auth/callback`` of one flow
+# (~5 min). iOS standalone PWAs run the cross-origin authorize step in a separate
+# in-app-browser context, so the handshake *cookie* the callback reads can belong
+# to a different ``GET /`` generation than the consent the user approved; we
+# therefore also keep the handshake here, keyed by the signed state's random id, so
+# the callback can recover it by the (signature-verified) state in the callback URL.
+#
+# Kept in process memory, not on disk: the UI server is a single process that
+# handles both the redirect and the callback, the data is short-lived, and a
+# mid-flow restart just means the user logs in again. This avoids a disk/inode DoS
+# surface entirely and makes single-use + the cap trivially atomic under one lock.
 
 OAUTH_HANDSHAKE_TTL_SECONDS = 300
-# Hard cap on live handshake files. The store is written on every unauthenticated
-# redirect, so without a bound a burst of unauthenticated requests could exhaust
-# inodes within the TTL. The cap sheds *new* writes when full (preserving in-flight
-# logins) and is far above any realistic concurrent-login count.
+# Cap on live handshakes — bounds memory under a burst of unauthenticated login
+# starts; sheds new entries when full (preserving in-flight logins). Far above any
+# realistic concurrent-login count. (The unauthenticated /auth rate limiter is the
+# primary bound; this is a backstop.)
 OAUTH_HANDSHAKE_MAX_ENTRIES = 2048
 _OAUTH_HANDSHAKE_RID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
-# Serializes prune+capacity-check+write so the cap is enforced atomically under a
-# concurrent burst (count-then-write without a lock could blow past the cap).
+# Guards prune + capacity-check + insert/pop so admission and single-use are atomic.
 _OAUTH_STORE_LOCK = threading.Lock()
-# Throttle the "at capacity" warning: under a sustained flood it would otherwise be
-# emitted on every shed write and grow the log unbounded — the very thing the cap
-# is meant to prevent.
+_oauth_handshakes: dict[str, dict[str, Any]] = {}
+# Throttle the "at capacity" warning so it can't itself grow the log under the flood
+# it reports.
 _OAUTH_STORE_CAPACITY_WARN_INTERVAL_SECONDS = 60.0
 _oauth_store_capacity_warned_at = 0.0
 
 
-def _oauth_handshake_dir() -> Path:
-    return paths.get_runtime_dir() / "oauth_handshakes"
-
-
-def _prune_oauth_handshakes(directory: Path) -> int:
-    """Delete expired records; return the number of surviving (live) entries."""
-    cutoff = time.time() - OAUTH_HANDSHAKE_TTL_SECONDS
-    survivors = 0
-    try:
-        entries = list(directory.glob("*.json"))
-    except OSError:
-        return 0
-    for entry in entries:
-        try:
-            if entry.stat().st_mtime < cutoff:
-                entry.unlink()
-            else:
-                survivors += 1
-        except OSError:
-            pass
-    return survivors
+def _prune_oauth_handshakes(now: int) -> None:
+    """Drop expired handshakes. Caller must hold ``_OAUTH_STORE_LOCK``."""
+    for rid in [rid for rid, record in _oauth_handshakes.items() if record.get("exp", 0) <= now]:
+        _oauth_handshakes.pop(rid, None)
 
 
 def _warn_oauth_store_at_capacity() -> None:
@@ -925,80 +911,42 @@ def _warn_oauth_store_at_capacity() -> None:
 def store_oauth_handshake(
     rid: str, *, nonce: str, code_verifier: str, next_target: str, device_hash: str | None = None
 ) -> None:
-    """Persist a login handshake keyed by the signed state's random id ``rid``.
+    """Persist a login handshake in memory, keyed by the signed state's random id.
 
-    Single-use, ``OAUTH_HANDSHAKE_TTL_SECONDS`` TTL. Written atomically with
-    owner-only permissions under the runtime dir. Invalid ids are ignored.
+    Single-use, ``OAUTH_HANDSHAKE_TTL_SECONDS`` TTL. Invalid ids are ignored.
     ``device_hash`` binds a later store-fallback recovery to the originating browser.
     """
     if not _OAUTH_HANDSHAKE_RID_RE.match(rid or ""):
         return
-    directory = _oauth_handshake_dir()
-    payload = {
+    now = int(time.time())
+    record = {
         "nonce": nonce,
         "code_verifier": code_verifier,
         "next": next_target,
         "device_hash": device_hash,
-        "exp": int(time.time()) + OAUTH_HANDSHAKE_TTL_SECONDS,
+        "exp": now + OAUTH_HANDSHAKE_TTL_SECONDS,
     }
-    final = directory / f"{rid}.json"
-    tmp = directory / f".{rid}.{os.getpid()}.{secrets.token_hex(6)}.tmp"
-    # Hold the lock across prune + capacity-check + write so admission is atomic:
-    # otherwise a concurrent burst could all pass the check and blow past the cap.
     with _OAUTH_STORE_LOCK:
-        try:
-            directory.mkdir(parents=True, exist_ok=True)
-            directory.chmod(0o700)
-        except OSError:
-            pass
-        # Prune expired records first; if the store is still at capacity (i.e. a
-        # flood of fresh entries), shed this write rather than grow unbounded.
-        if _prune_oauth_handshakes(directory) >= OAUTH_HANDSHAKE_MAX_ENTRIES:
+        _prune_oauth_handshakes(now)
+        # At capacity (a flood of fresh entries): shed this one rather than grow
+        # unbounded, but keep in-flight logins. Re-storing an existing id is allowed
+        # (it doesn't grow the store).
+        if len(_oauth_handshakes) >= OAUTH_HANDSHAKE_MAX_ENTRIES and rid not in _oauth_handshakes:
             _warn_oauth_store_at_capacity()
             return
-        try:
-            tmp.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
-            try:
-                tmp.chmod(0o600)
-            except OSError:
-                pass
-            os.replace(tmp, final)
-        except OSError:
-            try:
-                tmp.unlink()
-            except OSError:
-                pass
+        _oauth_handshakes[rid] = record
 
 
 def pop_oauth_handshake(rid: str | None) -> dict[str, Any] | None:
-    """Return and delete (single-use) the handshake for ``rid``; None if absent/expired.
+    """Return and remove (single-use) the handshake for ``rid``; None if absent/expired.
 
-    The claim is atomic: the record file is ``os.replace``d to a unique private name
-    before it is read, so under concurrent callbacks for the same ``rid`` exactly one
-    racer wins and the others get ``None``.
+    ``dict.pop`` under the lock is atomic, so concurrent callbacks for the same
+    ``rid`` get exactly one winner.
     """
     if not rid or not _OAUTH_HANDSHAKE_RID_RE.match(rid):
         return None
-    directory = _oauth_handshake_dir()
-    path = directory / f"{rid}.json"
-    claim = directory / f".{rid}.{os.getpid()}.{secrets.token_hex(8)}.claim"
-    try:
-        os.replace(path, claim)  # atomic single-use claim — only one racer can win
-    except OSError:
+    with _OAUTH_STORE_LOCK:
+        record = _oauth_handshakes.pop(rid, None)
+    if record is None or record.get("exp", 0) <= int(time.time()):
         return None
-    try:
-        raw = claim.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    finally:
-        try:
-            claim.unlink()
-        except OSError:
-            pass
-    try:
-        payload = json.loads(raw)
-    except (ValueError, TypeError):
-        return None
-    if not isinstance(payload, dict) or int(payload.get("exp", 0)) <= int(time.time()):
-        return None
-    return payload
+    return record

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -857,3 +857,96 @@ def exchange_oauth_code(config: V2Config, code: str, code_verifier: str) -> dict
     if not claims.get("email_verified"):
         raise ValueError("email_not_verified")
     return {"claims": claims, "token": token_payload}
+
+
+# --- OAuth handshake store -------------------------------------------------
+#
+# The login handshake (PKCE ``code_verifier`` + ``nonce``) is normally carried in
+# a short-lived cookie. iOS standalone PWAs run the cross-origin authorize step in
+# a separate in-app-browser context, so the cookie the callback reads belongs to a
+# *different* ``GET /`` generation than the consent the user approved, and
+# ``cookie.state == url.state`` never holds. We therefore also persist the
+# handshake server-side, keyed by the signed state's random id, so the callback
+# can recover it by the (signature-verified) state in the callback URL. The id is
+# unguessable and single-use; the verifier never leaves the machine.
+
+OAUTH_HANDSHAKE_TTL_SECONDS = 300
+_OAUTH_HANDSHAKE_RID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
+
+
+def _oauth_handshake_dir() -> Path:
+    return paths.get_runtime_dir() / "oauth_handshakes"
+
+
+def _prune_oauth_handshakes(directory: Path) -> None:
+    cutoff = time.time() - OAUTH_HANDSHAKE_TTL_SECONDS
+    try:
+        entries = list(directory.glob("*.json"))
+    except OSError:
+        return
+    for entry in entries:
+        try:
+            if entry.stat().st_mtime < cutoff:
+                entry.unlink()
+        except OSError:
+            pass
+
+
+def store_oauth_handshake(rid: str, *, nonce: str, code_verifier: str, next_target: str) -> None:
+    """Persist a login handshake keyed by the signed state's random id ``rid``.
+
+    Single-use, ``OAUTH_HANDSHAKE_TTL_SECONDS`` TTL. Written atomically with
+    owner-only permissions under the runtime dir. Invalid ids are ignored.
+    """
+    if not _OAUTH_HANDSHAKE_RID_RE.match(rid or ""):
+        return
+    directory = _oauth_handshake_dir()
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        directory.chmod(0o700)
+    except OSError:
+        pass
+    _prune_oauth_handshakes(directory)
+    payload = {
+        "nonce": nonce,
+        "code_verifier": code_verifier,
+        "next": next_target,
+        "exp": int(time.time()) + OAUTH_HANDSHAKE_TTL_SECONDS,
+    }
+    final = directory / f"{rid}.json"
+    tmp = directory / f".{rid}.{os.getpid()}.tmp"
+    try:
+        tmp.write_text(json.dumps(payload, separators=(",", ":")), encoding="utf-8")
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        os.replace(tmp, final)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def pop_oauth_handshake(rid: str | None) -> dict[str, Any] | None:
+    """Return and delete (single-use) the handshake for ``rid``; None if absent/expired."""
+    if not rid or not _OAUTH_HANDSHAKE_RID_RE.match(rid):
+        return None
+    path = _oauth_handshake_dir() / f"{rid}.json"
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    finally:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict) or int(payload.get("exp", 0)) <= int(time.time()):
+        return None
+    return payload

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -892,11 +892,14 @@ def _prune_oauth_handshakes(directory: Path) -> None:
             pass
 
 
-def store_oauth_handshake(rid: str, *, nonce: str, code_verifier: str, next_target: str) -> None:
+def store_oauth_handshake(
+    rid: str, *, nonce: str, code_verifier: str, next_target: str, device_hash: str | None = None
+) -> None:
     """Persist a login handshake keyed by the signed state's random id ``rid``.
 
     Single-use, ``OAUTH_HANDSHAKE_TTL_SECONDS`` TTL. Written atomically with
     owner-only permissions under the runtime dir. Invalid ids are ignored.
+    ``device_hash`` binds a later store-fallback recovery to the originating browser.
     """
     if not _OAUTH_HANDSHAKE_RID_RE.match(rid or ""):
         return
@@ -911,6 +914,7 @@ def store_oauth_handshake(rid: str, *, nonce: str, code_verifier: str, next_targ
         "nonce": nonce,
         "code_verifier": code_verifier,
         "next": next_target,
+        "device_hash": device_hash,
         "exp": int(time.time()) + OAUTH_HANDSHAKE_TTL_SECONDS,
     }
     final = directory / f"{rid}.json"

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import ipaddress
 import json
+import logging
 import ntpath
 import os
 import platform
@@ -31,6 +32,8 @@ from jwt import PyJWKClient
 from config import paths
 from config.v2_config import V2Config
 from vibe import api, runtime
+
+logger = logging.getLogger(__name__)
 
 CLOUDFLARED_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/latest/download"
 SESSION_COOKIE_NAME = "__Host-vibe_remote_session"
@@ -871,6 +874,11 @@ def exchange_oauth_code(config: V2Config, code: str, code_verifier: str) -> dict
 # unguessable and single-use; the verifier never leaves the machine.
 
 OAUTH_HANDSHAKE_TTL_SECONDS = 300
+# Hard cap on live handshake files. The store is written on every unauthenticated
+# redirect, so without a bound a burst of unauthenticated requests could exhaust
+# inodes within the TTL. The cap sheds *new* writes when full (preserving in-flight
+# logins) and is far above any realistic concurrent-login count.
+OAUTH_HANDSHAKE_MAX_ENTRIES = 2048
 _OAUTH_HANDSHAKE_RID_RE = re.compile(r"\A[A-Za-z0-9_-]{1,64}\Z")
 
 
@@ -878,18 +886,23 @@ def _oauth_handshake_dir() -> Path:
     return paths.get_runtime_dir() / "oauth_handshakes"
 
 
-def _prune_oauth_handshakes(directory: Path) -> None:
+def _prune_oauth_handshakes(directory: Path) -> int:
+    """Delete expired records; return the number of surviving (live) entries."""
     cutoff = time.time() - OAUTH_HANDSHAKE_TTL_SECONDS
+    survivors = 0
     try:
         entries = list(directory.glob("*.json"))
     except OSError:
-        return
+        return 0
     for entry in entries:
         try:
             if entry.stat().st_mtime < cutoff:
                 entry.unlink()
+            else:
+                survivors += 1
         except OSError:
             pass
+    return survivors
 
 
 def store_oauth_handshake(
@@ -909,7 +922,11 @@ def store_oauth_handshake(
         directory.chmod(0o700)
     except OSError:
         pass
-    _prune_oauth_handshakes(directory)
+    # Prune expired records first; if the store is still at capacity (i.e. flooded
+    # with fresh entries), shed this write rather than grow unbounded on disk.
+    if _prune_oauth_handshakes(directory) >= OAUTH_HANDSHAKE_MAX_ENTRIES:
+        logger.warning("oauth handshake store at capacity (>= %d); skipping write", OAUTH_HANDSHAKE_MAX_ENTRIES)
+        return
     payload = {
         "nonce": nonce,
         "code_verifier": code_verifier,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2645,7 +2645,8 @@ def remote_access_auth_callback():
         result = remote_access.exchange_oauth_code(config, _oauth_callback_arg("code") or "", code_verifier)
         claims = result["claims"]
     except Exception as exc:
-        logger.warning("vibe cloud oauth code exchange failed: %s", exc)
+        # Unauthenticated-reachable (valid handshake + bad code), so rate-limited.
+        _log_oauth_diag("exchange_failed", "vibe cloud oauth code exchange failed: %s", exc)
         return _oauth_callback_error_response("oauth_exchange_failed", next_target=next_target)
     if claims.get("nonce") != handshake_nonce:
         return _oauth_callback_error_response("invalid_oauth_nonce", next_target=next_target)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1487,6 +1487,52 @@ def _oauth_callback_error_response(error: str, *, next_target: Any, status: int 
     return response
 
 
+# --- Unauthenticated /auth rate limiting -----------------------------------
+#
+# The login-start redirect and /auth/callback are reachable without a session, so
+# a flood of unauthenticated requests is the *root* of the resource-growth concerns
+# on this path. A per-client fixed-window limiter bounds that flood at the door, so
+# the downstream handshake store and diagnostics stay bounded without each needing
+# its own guard. (The per-store cap and per-log throttles remain as cheap backstops.)
+_AUTH_RATELIMIT_WINDOW_SECONDS = 60.0
+_AUTH_RATELIMIT_MAX_PER_WINDOW = 60  # a real login spends a handful; this only stops floods
+_AUTH_RATELIMIT_MAX_TRACKED_CLIENTS = 4096
+_auth_ratelimit_lock = threading.Lock()
+_auth_ratelimit: dict[str, list[float]] = {}  # client -> [window_start_monotonic, count]
+
+
+def _auth_client_id() -> str:
+    """Client identity for rate limiting: the Cloudflare-forwarded IP when present
+    (remote traffic always arrives via the tunnel), else the connecting peer."""
+    return (request.headers.get("CF-Connecting-IP") or request.remote_addr or "unknown").strip()
+
+
+def _auth_rate_limited() -> bool:
+    """True when the caller has exceeded the unauthenticated /auth request budget."""
+    client = _auth_client_id()
+    now = time.monotonic()
+    with _auth_ratelimit_lock:
+        if len(_auth_ratelimit) > _AUTH_RATELIMIT_MAX_TRACKED_CLIENTS:
+            for stale in [c for c, (ws, _c) in _auth_ratelimit.items() if now - ws >= _AUTH_RATELIMIT_WINDOW_SECONDS]:
+                _auth_ratelimit.pop(stale, None)
+        window_start, count = _auth_ratelimit.get(client, (0.0, 0))
+        if now - window_start >= _AUTH_RATELIMIT_WINDOW_SECONDS:
+            _auth_ratelimit[client] = [now, 1]
+            return False
+        if count >= _AUTH_RATELIMIT_MAX_PER_WINDOW:
+            return True
+        _auth_ratelimit[client] = [window_start, count + 1]
+        return False
+
+
+def _auth_rate_limit_response():
+    """Minimal 429 for an abusive unauthenticated /auth client (no per-request work)."""
+    response = Response("Too Many Requests", status=429, mimetype="text/plain; charset=utf-8")
+    response.headers["Retry-After"] = str(int(_AUTH_RATELIMIT_WINDOW_SECONDS))
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
 @app.before_request
 def start_api_request_timer():
     if request.path.startswith("/api/"):
@@ -1528,6 +1574,10 @@ def enforce_remote_access_cookie():
             g.remote_session_renew = (str(payload.get("email", "")), str(payload.get("sub", "")))
         return None
     if request.method == "GET":
+        # Bound unauthenticated login-start floods at the door (this writes a
+        # handshake + sets cookies); a real user spends only a couple per login.
+        if _auth_rate_limited():
+            return _auth_rate_limit_response()
         return _redirect_to_vibe_cloud_login(config)
     return jsonify({"ok": False, "error": "remote_access_login_required"}), 401
 
@@ -2596,6 +2646,9 @@ def remote_access_auth_callback():
     cloud = config.remote_access.vibe_cloud
     if not cloud.enabled:
         return jsonify({"error": "remote_access_disabled"}), 400
+    # Unauthenticated endpoint: bound floods before any store lookup / logging.
+    if _auth_rate_limited():
+        return _auth_rate_limit_response()
     url_state_token = _oauth_callback_arg("state")
     cookie_state = _read_oauth_cookie(cloud.session_secret, request.cookies.get(REMOTE_OAUTH_COOKIE_NAME))
     url_state = _read_oauth_state(cloud.session_secret, url_state_token)
@@ -2619,7 +2672,7 @@ def remote_access_auth_callback():
         # the same browser that started the flow — so a bare code+state callback URL
         # can't be replayed in another browser (closes login-CSRF). The PWA carries the
         # device cookie unchanged across the excursion, so recovery still succeeds.
-        logger.info("oauth callback recovered via server-side handshake (device-bound, desynced cookie context)")
+        logger.debug("oauth callback recovered via server-side handshake (device-bound, desynced cookie context)")
         code_verifier = store_record["code_verifier"]
         handshake_nonce = store_record.get("nonce")
         next_target = store_record.get("next")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2532,7 +2532,13 @@ def remote_access_auth_callback():
         code_verifier = cookie_state["code_verifier"]
         handshake_nonce = cookie_state.get("nonce")
         next_target = cookie_state.get("next")
-    elif store_record is not None:
+    elif cookie_state is not None and store_record is not None:
+        # Store-fallback for the iOS standalone PWA case. Require a *valid* same-origin
+        # handshake cookie to be present (even though its state differs): that proves
+        # this browser actually started a login on this instance, so the callback URL
+        # alone can't be replayed in a browser that never did (closes the cookie-absent
+        # bearer-login vector). The PWA always carries such a cookie — only its state
+        # desyncs because authorize ran in a separate in-app-browser context.
         logger.info("oauth callback recovered via server-side handshake (cookie-less or desynced context)")
         code_verifier = store_record["code_verifier"]
         handshake_nonce = store_record.get("nonce")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3,6 +3,7 @@ import asyncio
 import gzip
 import hashlib
 import hmac
+import html
 import ipaddress
 import json
 import logging
@@ -113,6 +114,12 @@ CSRF_COOKIE_NAME = "vibe_csrf_token"
 CSRF_HEADER_NAME = "X-Vibe-CSRF-Token"
 REMOTE_OAUTH_COOKIE_NAME = "__Host-vibe_remote_oauth"
 REMOTE_OAUTH_RETRY_PARAM = "__vibe_oauth_retry"
+# Lifetime of the short-lived OAuth handshake (signed state + PKCE cookie). The
+# cookie MUST carry an explicit Max-Age: iOS standalone PWAs drop session-scoped
+# cookies (no Max-Age) across the cross-origin authorize excursion / app
+# backgrounding, which silently breaks the callback. A persistent cookie with a
+# short TTL survives. The signed payload's own `exp` enforces the real validity.
+REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS = 300
 MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 LOG_SOURCES = (
     ("service", "vibe_remote.log", lambda: paths.get_logs_dir() / "vibe_remote.log"),
@@ -1100,13 +1107,13 @@ def _b64url_decode(value: str) -> bytes:
     return base64.urlsafe_b64decode(f"{value}{padding}")
 
 
-def _make_oauth_state(secret: str, *, next_target: str, retry: bool = False) -> str:
+def _make_oauth_state(secret: str, *, next_target: str, retry: bool = False, rid: str | None = None) -> str:
     payload = {
         "v": 1,
-        "r": secrets.token_urlsafe(18),
+        "r": rid or secrets.token_urlsafe(18),
         "next": next_target,
         "retry": bool(retry),
-        "exp": int(datetime.now().timestamp()) + 300,
+        "exp": int(datetime.now().timestamp()) + REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS,
     }
     payload_text = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
     signature = _b64url_encode(hmac.new(secret.encode("utf-8"), payload_text.encode("ascii"), hashlib.sha256).digest())
@@ -1132,6 +1139,21 @@ def _read_oauth_state(secret: str, value: str | None) -> dict[str, Any] | None:
     if int(payload.get("exp", 0)) <= int(datetime.now().timestamp()):
         return None
     return payload
+
+
+def _peek_oauth_state_rid(token: str | None) -> str | None:
+    """Best-effort extract a vr1 state token's random id, for diagnostics only.
+
+    Does NOT verify the HMAC — purely to compare which state a request carries.
+    The ``r`` field is a single-use random nonce, not a secret.
+    """
+    if not token or not token.startswith("vr1."):
+        return None
+    try:
+        payload = json.loads(_b64url_decode(token.split(".")[1]).decode("utf-8"))
+        return (str(payload.get("r", ""))[:12]) or None
+    except Exception:
+        return None
 
 
 def _safe_remote_redirect_target(value: Any) -> str:
@@ -1176,12 +1198,19 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
     code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
     raw_next = request.full_path if request.query_string else request.path
     next_target = _strip_oauth_retry_param(raw_next)
+    rid = secrets.token_urlsafe(18)
     state = _make_oauth_state(
         cloud.session_secret,
         next_target=next_target,
         retry=request.args.get(REMOTE_OAUTH_RETRY_PARAM) == "1",
+        rid=rid,
     )
     nonce = secrets.token_urlsafe(24)
+    # Persist the handshake server-side keyed by the state id, so the callback can
+    # recover the PKCE secrets by the signed URL state even when the cookie desyncs
+    # (iOS standalone PWA runs authorize in a separate in-app-browser context). The
+    # cookie below is kept as the strong per-browser binding for normal browsers.
+    remote_access.store_oauth_handshake(rid, nonce=nonce, code_verifier=code_verifier, next_target=next_target)
     oauth_cookie = _make_oauth_cookie(
         cloud.session_secret,
         {
@@ -1189,7 +1218,7 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
             "nonce": nonce,
             "code_verifier": code_verifier,
             "next": next_target,
-            "exp": int(datetime.now().timestamp()) + 300,
+            "exp": int(datetime.now().timestamp()) + REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS,
         },
     )
     response = Response(status=302)
@@ -1201,6 +1230,7 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
         secure=True,
         samesite="Lax",
         path="/",
+        max_age=REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS,
     )
     return response
 
@@ -1212,6 +1242,167 @@ def _restart_vibe_cloud_login_from_state(config: V2Config, state: str | None):
         return None
     next_target = _safe_remote_redirect_target(payload.get("next"))
     response = redirect(_add_oauth_retry_param(next_target))
+    response.delete_cookie(REMOTE_OAUTH_COOKIE_NAME, path="/", secure=True, samesite="Lax")
+    return response
+
+
+# Human-readable copy for the OAuth callback error page, keyed by error code.
+# Each entry is ``(headline, body)``. Codes not listed fall back to a generic
+# "try again" message so an unexpected failure still renders a usable page.
+_OAUTH_ERROR_PAGE_COPY: dict[str, tuple[str, str]] = {
+    "invalid_oauth_state": (
+        "Your sign-in session expired",
+        "The secure login link expired or couldn't be matched to this browser. "
+        "This usually happens when a sign-in link sits unused for a few minutes, "
+        "or is opened in a different tab or window. Start over and you'll be right back in.",
+    ),
+    "oauth_exchange_failed": (
+        "We couldn't finish signing you in",
+        "Avibe Cloud didn't complete the sign-in just now. This is usually "
+        "temporary — please try again.",
+    ),
+    "invalid_oauth_nonce": (
+        "We couldn't verify this sign-in",
+        "This sign-in attempt couldn't be verified, so we stopped to keep your "
+        "account secure. Start over to continue.",
+    ),
+}
+
+
+def _render_oauth_error_html(error: str, *, retry_href: str) -> str:
+    """Render a branded, self-contained re-login page for a failed OAuth callback.
+
+    Replaces the old raw-JSON dead-end: the user sees a plain-language reason and
+    a single "Sign in again" button that navigates to ``retry_href`` (a sanitized
+    same-origin path), which re-enters the login flow via the auth gate.
+    """
+    title, message = _OAUTH_ERROR_PAGE_COPY.get(
+        error,
+        ("Let's sign you in again", "Your sign-in didn't finish. Please try again."),
+    )
+    safe_title = html.escape(title)
+    safe_message = html.escape(message)
+    safe_href = html.escape(retry_href or "/", quote=True)
+    safe_code = html.escape(error)
+    hint = ""
+    if error == "invalid_oauth_state":
+        hint = (
+            '<p class="oauth-error-hint">Still stuck after trying again? Make sure '
+            "your browser allows cookies for this site.</p>"
+        )
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
+    <title>{safe_title}</title>
+    <style>
+      :root {{
+        color-scheme: light;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f6f7f9;
+        color: #172033;
+      }}
+      body {{ margin: 0; min-height: 100vh; }}
+      .oauth-error-shell {{
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 32px 18px;
+        box-sizing: border-box;
+      }}
+      .oauth-error-panel {{
+        width: min(460px, 100%);
+        border: 1px solid rgba(23, 32, 51, 0.12);
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.96);
+        padding: clamp(28px, 6vw, 40px);
+        box-shadow: 0 24px 80px rgba(23, 32, 51, 0.10);
+        box-sizing: border-box;
+        text-align: center;
+      }}
+      .oauth-error-eyebrow {{
+        color: #526078;
+        font-size: 13px;
+        font-weight: 760;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }}
+      .oauth-error-panel h1 {{
+        margin: 14px 0 0;
+        font-size: clamp(24px, 6vw, 32px);
+        line-height: 1.12;
+        letter-spacing: 0;
+      }}
+      .oauth-error-panel p {{
+        margin: 14px 0 0;
+        line-height: 1.65;
+        color: #526078;
+      }}
+      .oauth-error-hint {{ font-size: 13px; }}
+      .oauth-error-actions {{ margin-top: 26px; }}
+      .oauth-error-button {{
+        display: inline-block;
+        height: 44px;
+        padding: 0 24px;
+        border-radius: 12px;
+        background: #0f172a;
+        color: #fff;
+        font: 700 15px/44px Inter, ui-sans-serif, system-ui;
+        text-decoration: none;
+      }}
+      .oauth-error-button:hover {{ background: #1e293b; }}
+      .oauth-error-code {{
+        margin-top: 22px;
+        font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        color: #94a3b8;
+      }}
+    </style>
+  </head>
+  <body>
+    <main class="oauth-error-shell">
+      <section class="oauth-error-panel">
+        <div class="oauth-error-eyebrow">Avibe</div>
+        <h1>{safe_title}</h1>
+        <p>{safe_message}</p>
+        {hint}
+        <div class="oauth-error-actions">
+          <a class="oauth-error-button" href="{safe_href}">Sign in again</a>
+        </div>
+        <div class="oauth-error-code">{safe_code}</div>
+      </section>
+    </main>
+  </body>
+</html>
+"""
+
+
+def _oauth_callback_error_response(error: str, *, next_target: Any, status: int = 400):
+    """Build the HTML re-login response for a failed OAuth callback.
+
+    Clears any stale handshake cookie so "Sign in again" starts a clean flow, and
+    strips the auto-retry marker from ``next_target`` so the retry gets a fresh
+    attempt (plus one silent auto-retry) instead of immediately failing again.
+    """
+    # Diagnostic only: whether the handshake cookie reached us at all is the key
+    # signal for cookie-loss cases (e.g. iOS standalone PWA). No token values are
+    # logged — only presence and a few non-secret request hints.
+    logger.warning(
+        "oauth callback rejected: error=%s handshake_cookie_present=%s ua=%r sec_fetch_site=%s",
+        error,
+        bool(request.cookies.get(REMOTE_OAUTH_COOKIE_NAME)),
+        (request.headers.get("User-Agent") or "")[:140],
+        request.headers.get("Sec-Fetch-Site") or "",
+    )
+    retry_href = _strip_oauth_retry_param(next_target if isinstance(next_target, str) else "/")
+    response = Response(
+        _render_oauth_error_html(error, retry_href=retry_href),
+        status=status,
+        mimetype="text/html; charset=utf-8",
+    )
+    response.headers["Cache-Control"] = "no-store"
     response.delete_cookie(REMOTE_OAUTH_COOKIE_NAME, path="/", secure=True, samesite="Lax")
     return response
 
@@ -2325,21 +2516,53 @@ def remote_access_auth_callback():
     cloud = config.remote_access.vibe_cloud
     if not cloud.enabled:
         return jsonify({"error": "remote_access_disabled"}), 400
-    oauth_state = _read_oauth_cookie(cloud.session_secret, request.cookies.get(REMOTE_OAUTH_COOKIE_NAME))
-    if not oauth_state or oauth_state.get("state") != _oauth_callback_arg("state"):
-        retry_response = _restart_vibe_cloud_login_from_state(config, _oauth_callback_arg("state"))
+    url_state_token = _oauth_callback_arg("state")
+    cookie_state = _read_oauth_cookie(cloud.session_secret, request.cookies.get(REMOTE_OAUTH_COOKIE_NAME))
+    url_state = _read_oauth_state(cloud.session_secret, url_state_token)
+    # Single-use: consume any server-side handshake for this verified state id, even
+    # when we ultimately use the cookie, so the store stays clean.
+    store_record = remote_access.pop_oauth_handshake(url_state.get("r")) if url_state else None
+
+    # Prefer the cookie when it matches the URL state (strong per-browser binding,
+    # the normal-browser path). Fall back to the server-side handshake when the
+    # cookie is missing or carries a different state — the iOS standalone PWA case,
+    # where the authorize step runs in a separate in-app-browser context and the
+    # cookie desyncs from the state the user actually approved.
+    if cookie_state and cookie_state.get("state") == url_state_token:
+        code_verifier = cookie_state["code_verifier"]
+        handshake_nonce = cookie_state.get("nonce")
+        next_target = cookie_state.get("next")
+    elif store_record is not None:
+        logger.info("oauth callback recovered via server-side handshake (cookie-less or desynced context)")
+        code_verifier = store_record["code_verifier"]
+        handshake_nonce = store_record.get("nonce")
+        next_target = store_record.get("next")
+    else:
+        # Neither the cookie nor the server-side store yielded the handshake.
+        logger.warning(
+            "oauth state check failed: cookie_parsed=%s cookie_state_rid=%s url_state_rid=%s url_state_valid=%s",
+            cookie_state is not None,
+            _peek_oauth_state_rid(cookie_state.get("state")) if cookie_state else None,
+            _peek_oauth_state_rid(url_state_token),
+            url_state is not None,
+        )
+        retry_response = _restart_vibe_cloud_login_from_state(config, url_state_token)
         if retry_response is not None:
             return retry_response
-        return jsonify({"error": "invalid_oauth_state"}), 400
+        # Auto-retry exhausted (or the state is undecodable): show the re-login page,
+        # recovering the original destination from the signed state when possible.
+        next_target = url_state.get("next") if url_state else "/"
+        return _oauth_callback_error_response("invalid_oauth_state", next_target=next_target)
     try:
-        result = remote_access.exchange_oauth_code(config, _oauth_callback_arg("code") or "", oauth_state["code_verifier"])
+        result = remote_access.exchange_oauth_code(config, _oauth_callback_arg("code") or "", code_verifier)
         claims = result["claims"]
     except Exception as exc:
-        return jsonify({"error": "oauth_exchange_failed", "detail": str(exc)}), 400
-    if claims.get("nonce") != oauth_state.get("nonce"):
-        return jsonify({"error": "invalid_oauth_nonce"}), 400
+        logger.warning("vibe cloud oauth code exchange failed: %s", exc)
+        return _oauth_callback_error_response("oauth_exchange_failed", next_target=next_target)
+    if claims.get("nonce") != handshake_nonce:
+        return _oauth_callback_error_response("invalid_oauth_nonce", next_target=next_target)
     response = Response(status=302)
-    response.headers["Location"] = _safe_remote_redirect_target(oauth_state.get("next"))
+    response.headers["Location"] = _safe_remote_redirect_target(next_target)
     response.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
         remote_access.make_session_cookie(config, str(claims.get("email", "")), str(claims.get("sub", ""))),

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1432,6 +1432,31 @@ def _render_oauth_error_html(error: str, *, retry_href: str, lang: str = "en") -
 """
 
 
+_OAUTH_DIAG_LOG_INTERVAL_SECONDS = 60.0
+_oauth_diag_log_lock = threading.Lock()
+# key -> [window_start_monotonic, suppressed_count]
+_oauth_diag_log_state: dict[str, list[float]] = {}
+
+
+def _log_oauth_diag(key: str, message: str, *args: Any) -> None:
+    """Emit an unauthenticated-reachable OAuth diagnostic at WARNING, rate-limited
+    per ``key`` (~once / ``_OAUTH_DIAG_LOG_INTERVAL_SECONDS``).
+
+    The OAuth callback is reachable without auth, so a flood of invalid callbacks
+    would otherwise grow the (unrotated) service log without bound. Suppressed hits
+    are counted and folded into the next emitted line so the signal isn't lost.
+    """
+    now = time.monotonic()
+    with _oauth_diag_log_lock:
+        window_start, suppressed = _oauth_diag_log_state.get(key, (0.0, 0))
+        if window_start and now - window_start < _OAUTH_DIAG_LOG_INTERVAL_SECONDS:
+            _oauth_diag_log_state[key] = [window_start, suppressed + 1]
+            return
+        _oauth_diag_log_state[key] = [now, 0]
+    extra = f" [+{int(suppressed)} suppressed in {int(_OAUTH_DIAG_LOG_INTERVAL_SECONDS)}s]" if suppressed else ""
+    logger.warning(message + extra, *args)
+
+
 def _oauth_callback_error_response(error: str, *, next_target: Any, status: int = 400):
     """Build the HTML re-login response for a failed OAuth callback.
 
@@ -1441,8 +1466,10 @@ def _oauth_callback_error_response(error: str, *, next_target: Any, status: int 
     """
     # Diagnostic only: whether the handshake cookie reached us at all is the key
     # signal for cookie-loss cases (e.g. iOS standalone PWA). No token values are
-    # logged — only presence and a few non-secret request hints.
-    logger.warning(
+    # logged — only presence and a few non-secret request hints. Rate-limited
+    # because this path is unauthenticated and could be flooded.
+    _log_oauth_diag(
+        "callback_rejected",
         "oauth callback rejected: error=%s handshake_cookie_present=%s ua=%r sec_fetch_site=%s",
         error,
         bool(request.cookies.get(REMOTE_OAUTH_COOKIE_NAME)),
@@ -2598,7 +2625,9 @@ def remote_access_auth_callback():
         next_target = store_record.get("next")
     else:
         # Neither the cookie nor the server-side store yielded the handshake.
-        logger.warning(
+        # Rate-limited: this branch is unauthenticated-reachable.
+        _log_oauth_diag(
+            "state_check_failed",
             "oauth state check failed: cookie_parsed=%s cookie_state_rid=%s url_state_rid=%s url_state_valid=%s",
             cookie_state is not None,
             _peek_oauth_state_rid(cookie_state.get("state")) if cookie_state else None,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -40,6 +40,7 @@ from core.show_pages import (
 )
 from core.show_session_events import show_event_payload_session_mismatch
 from modules.agents.catalog import AGENT_BACKENDS, supports_runtime_refresh
+from vibe.i18n import get_supported_languages, t
 from vibe.runtime import get_ui_dist_path, get_working_dir
 from vibe.sentry_integration import init_sentry
 
@@ -1298,52 +1299,52 @@ def _restart_vibe_cloud_login_from_state(config: V2Config, state: str | None):
     return response
 
 
-# Human-readable copy for the OAuth callback error page, keyed by error code.
-# Each entry is ``(headline, body)``. Codes not listed fall back to a generic
-# "try again" message so an unexpected failure still renders a usable page.
-_OAUTH_ERROR_PAGE_COPY: dict[str, tuple[str, str]] = {
-    "invalid_oauth_state": (
-        "Your sign-in session expired",
-        "The secure login link expired or couldn't be matched to this browser. "
-        "This usually happens when a sign-in link sits unused for a few minutes, "
-        "or is opened in a different tab or window. Start over and you'll be right back in.",
-    ),
-    "oauth_exchange_failed": (
-        "We couldn't finish signing you in",
-        "Avibe Cloud didn't complete the sign-in just now. This is usually "
-        "temporary — please try again.",
-    ),
-    "invalid_oauth_nonce": (
-        "We couldn't verify this sign-in",
-        "This sign-in attempt couldn't be verified, so we stopped to keep your "
-        "account secure. Start over to continue.",
-    ),
-}
+# Error codes with dedicated copy in vibe/i18n (remote_access.oauth_error.*); any
+# other code falls back to the generic "default_*" strings so an unexpected failure
+# still renders a usable page.
+_OAUTH_ERROR_PAGE_CODES = {"invalid_oauth_state", "oauth_exchange_failed", "invalid_oauth_nonce"}
 
 
-def _render_oauth_error_html(error: str, *, retry_href: str) -> str:
+def _request_ui_language() -> str:
+    """Best-effort UI language for a pre-auth page, from the Accept-Language header.
+
+    The Web UI persists its language only in localStorage (not a server-readable
+    cookie), so Accept-Language is the available signal here — and it matches what
+    the SPA's own navigator-based detection would pick. Falls back to English.
+    """
+    supported = set(get_supported_languages())
+    for part in (request.headers.get("Accept-Language") or "").split(","):
+        tag = part.split(";")[0].strip().lower()
+        if not tag:
+            continue
+        if tag in supported:
+            return tag
+        primary = tag.split("-")[0]
+        if primary in supported:
+            return primary
+    return "en"
+
+
+def _render_oauth_error_html(error: str, *, retry_href: str, lang: str = "en") -> str:
     """Render a branded, self-contained re-login page for a failed OAuth callback.
 
-    Replaces the old raw-JSON dead-end: the user sees a plain-language reason and
-    a single "Sign in again" button that navigates to ``retry_href`` (a sanitized
-    same-origin path), which re-enters the login flow via the auth gate.
+    Replaces the old raw-JSON dead-end: the user sees a plain-language reason and a
+    single re-login button that navigates to ``retry_href`` (a sanitized same-origin
+    path), which re-enters the login flow via the auth gate. Copy is served from
+    ``vibe/i18n`` in ``lang``.
     """
-    title, message = _OAUTH_ERROR_PAGE_COPY.get(
-        error,
-        ("Let's sign you in again", "Your sign-in didn't finish. Please try again."),
-    )
-    safe_title = html.escape(title)
-    safe_message = html.escape(message)
+    key = error if error in _OAUTH_ERROR_PAGE_CODES else "default"
+    safe_lang = html.escape(lang, quote=True)
+    safe_title = html.escape(t(f"remote_access.oauth_error.{key}_title", lang))
+    safe_message = html.escape(t(f"remote_access.oauth_error.{key}_body", lang))
+    safe_button = html.escape(t("remote_access.oauth_error.sign_in_again", lang))
     safe_href = html.escape(retry_href or "/", quote=True)
     safe_code = html.escape(error)
     hint = ""
     if error == "invalid_oauth_state":
-        hint = (
-            '<p class="oauth-error-hint">Still stuck after trying again? Make sure '
-            "your browser allows cookies for this site.</p>"
-        )
+        hint = f'<p class="oauth-error-hint">{html.escape(t("remote_access.oauth_error.cookie_hint", lang))}</p>'
     return f"""<!doctype html>
-<html lang="en">
+<html lang="{safe_lang}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -1421,7 +1422,7 @@ def _render_oauth_error_html(error: str, *, retry_href: str) -> str:
         <p>{safe_message}</p>
         {hint}
         <div class="oauth-error-actions">
-          <a class="oauth-error-button" href="{safe_href}">Sign in again</a>
+          <a class="oauth-error-button" href="{safe_href}">{safe_button}</a>
         </div>
         <div class="oauth-error-code">{safe_code}</div>
       </section>
@@ -1450,7 +1451,7 @@ def _oauth_callback_error_response(error: str, *, next_target: Any, status: int 
     )
     retry_href = _strip_oauth_retry_param(next_target if isinstance(next_target, str) else "/")
     response = Response(
-        _render_oauth_error_html(error, retry_href=retry_href),
+        _render_oauth_error_html(error, retry_href=retry_href, lang=_request_ui_language()),
         status=status,
         mimetype="text/html; charset=utf-8",
     )

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -16,6 +16,7 @@ import socket
 import subprocess
 import threading
 import time
+from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -1498,13 +1499,23 @@ _AUTH_RATELIMIT_WINDOW_SECONDS = 60.0
 _AUTH_RATELIMIT_MAX_PER_WINDOW = 60  # a real login spends a handful; this only stops floods
 _AUTH_RATELIMIT_MAX_TRACKED_CLIENTS = 4096
 _auth_ratelimit_lock = threading.Lock()
-_auth_ratelimit: dict[str, list[float]] = {}  # client -> [window_start_monotonic, count]
+# Bounded LRU of client -> [window_start_monotonic, count]; the least-recently-seen
+# entry is evicted once the table is full, so the table can't grow without bound.
+_auth_ratelimit: OrderedDict[str, list[float]] = OrderedDict()
 
 
 def _auth_client_id() -> str:
-    """Client identity for rate limiting: the Cloudflare-forwarded IP when present
-    (remote traffic always arrives via the tunnel), else the connecting peer."""
-    return (request.headers.get("CF-Connecting-IP") or request.remote_addr or "unknown").strip()
+    """Client identity for rate limiting.
+
+    Trust the Cloudflare-forwarded client IP only when the request arrived via the
+    local tunnel (loopback peer = cloudflared). A direct peer reaching the origin
+    port could otherwise set/rotate ``CF-Connecting-IP`` to dodge the limit, so for
+    such peers we key on the real connecting address instead.
+    """
+    forwarded = (request.headers.get("CF-Connecting-IP") or "").strip()
+    if forwarded and _is_loopback_peer():
+        return f"cf:{forwarded}"
+    return f"peer:{(request.remote_addr or 'unknown').strip()}"
 
 
 def _auth_rate_limited() -> bool:
@@ -1512,16 +1523,20 @@ def _auth_rate_limited() -> bool:
     client = _auth_client_id()
     now = time.monotonic()
     with _auth_ratelimit_lock:
-        if len(_auth_ratelimit) > _AUTH_RATELIMIT_MAX_TRACKED_CLIENTS:
-            for stale in [c for c, (ws, _c) in _auth_ratelimit.items() if now - ws >= _AUTH_RATELIMIT_WINDOW_SECONDS]:
-                _auth_ratelimit.pop(stale, None)
-        window_start, count = _auth_ratelimit.get(client, (0.0, 0))
-        if now - window_start >= _AUTH_RATELIMIT_WINDOW_SECONDS:
+        bucket = _auth_ratelimit.get(client)
+        if bucket is None or now - bucket[0] >= _AUTH_RATELIMIT_WINDOW_SECONDS:
+            # New or rolled-over window. Hard-bound the table before admitting a
+            # genuinely new client (evict the least-recently-seen).
+            if client not in _auth_ratelimit:
+                while len(_auth_ratelimit) >= _AUTH_RATELIMIT_MAX_TRACKED_CLIENTS:
+                    _auth_ratelimit.popitem(last=False)
             _auth_ratelimit[client] = [now, 1]
+            _auth_ratelimit.move_to_end(client)
             return False
-        if count >= _AUTH_RATELIMIT_MAX_PER_WINDOW:
+        if bucket[1] >= _AUTH_RATELIMIT_MAX_PER_WINDOW:
             return True
-        _auth_ratelimit[client] = [window_start, count + 1]
+        bucket[1] += 1
+        _auth_ratelimit.move_to_end(client)
         return False
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -120,6 +120,14 @@ REMOTE_OAUTH_RETRY_PARAM = "__vibe_oauth_retry"
 # backgrounding, which silently breaks the callback. A persistent cookie with a
 # short TTL survives. The signed payload's own `exp` enforces the real validity.
 REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS = 300
+# Stable, per-browser binding id. Unlike the per-flow handshake state (which the
+# iOS standalone PWA desyncs), this cookie is set once and reused, so it stays
+# consistent across the cross-origin authorize excursion. The callback's
+# server-side store-fallback is bound to hmac(secret, device_id), which an
+# attacker cannot supply for a victim's browser — this closes the login-CSRF that
+# a bare code+state callback URL would otherwise allow.
+REMOTE_OAUTH_DEVICE_COOKIE_NAME = "__Host-vibe_oauth_device"
+REMOTE_OAUTH_DEVICE_TTL_SECONDS = 180 * 24 * 60 * 60
 MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 LOG_SOURCES = (
     ("service", "vibe_remote.log", lambda: paths.get_logs_dir() / "vibe_remote.log"),
@@ -1077,6 +1085,30 @@ def _oauth_cookie_signature(secret: str, payload: str) -> str:
     return hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
 
 
+def _oauth_device_hash(secret: str, device_id: str) -> str:
+    return hmac.new(secret.encode("utf-8"), f"device:{device_id}".encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _oauth_device_id() -> str:
+    """The caller's stable per-browser binding id from its device cookie (or None)."""
+    return request.cookies.get(REMOTE_OAUTH_DEVICE_COOKIE_NAME) or ""
+
+
+def _oauth_store_record_device_bound(secret: str, record: dict[str, Any] | None) -> bool:
+    """True when the request's device cookie matches the handshake record's binding.
+
+    The store-fallback (cookie-state desync path) is only safe when we can prove the
+    callback comes from the same browser that started the flow. The device cookie is
+    that proof: it is stable across the iOS authorize excursion and an attacker
+    cannot present a victim's value.
+    """
+    expected = (record or {}).get("device_hash")
+    device_id = _oauth_device_id()
+    if not expected or not device_id:
+        return False
+    return hmac.compare_digest(str(expected), _oauth_device_hash(secret, device_id))
+
+
 def _make_oauth_cookie(secret: str, payload: dict[str, Any]) -> str:
     payload_text = quote(json.dumps(payload, separators=(",", ":")), safe="")
     signature = _oauth_cookie_signature(secret, payload_text)
@@ -1206,11 +1238,22 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
         rid=rid,
     )
     nonce = secrets.token_urlsafe(24)
+    # Stable per-browser binding id: reuse the existing device cookie so it stays
+    # consistent across the iOS authorize excursion (it is NOT regenerated per flow,
+    # unlike the handshake state), generating one only on first use.
+    device_id = _oauth_device_id() or secrets.token_urlsafe(24)
     # Persist the handshake server-side keyed by the state id, so the callback can
     # recover the PKCE secrets by the signed URL state even when the cookie desyncs
     # (iOS standalone PWA runs authorize in a separate in-app-browser context). The
-    # cookie below is kept as the strong per-browser binding for normal browsers.
-    remote_access.store_oauth_handshake(rid, nonce=nonce, code_verifier=code_verifier, next_target=next_target)
+    # device_hash binds that recovery to this browser; the cookie below stays the
+    # strong per-browser binding for normal browsers.
+    remote_access.store_oauth_handshake(
+        rid,
+        nonce=nonce,
+        code_verifier=code_verifier,
+        next_target=next_target,
+        device_hash=_oauth_device_hash(cloud.session_secret, device_id),
+    )
     oauth_cookie = _make_oauth_cookie(
         cloud.session_secret,
         {
@@ -1231,6 +1274,15 @@ def _redirect_to_vibe_cloud_login(config: V2Config):
         samesite="Lax",
         path="/",
         max_age=REMOTE_OAUTH_HANDSHAKE_TTL_SECONDS,
+    )
+    response.set_cookie(
+        REMOTE_OAUTH_DEVICE_COOKIE_NAME,
+        device_id,
+        httponly=True,
+        secure=True,
+        samesite="Lax",
+        path="/",
+        max_age=REMOTE_OAUTH_DEVICE_TTL_SECONDS,
     )
     return response
 
@@ -2532,14 +2584,14 @@ def remote_access_auth_callback():
         code_verifier = cookie_state["code_verifier"]
         handshake_nonce = cookie_state.get("nonce")
         next_target = cookie_state.get("next")
-    elif cookie_state is not None and store_record is not None:
-        # Store-fallback for the iOS standalone PWA case. Require a *valid* same-origin
-        # handshake cookie to be present (even though its state differs): that proves
-        # this browser actually started a login on this instance, so the callback URL
-        # alone can't be replayed in a browser that never did (closes the cookie-absent
-        # bearer-login vector). The PWA always carries such a cookie — only its state
-        # desyncs because authorize ran in a separate in-app-browser context.
-        logger.info("oauth callback recovered via server-side handshake (cookie-less or desynced context)")
+    elif store_record is not None and _oauth_store_record_device_bound(cloud.session_secret, store_record):
+        # Store-fallback for the iOS standalone PWA case, where the handshake cookie's
+        # state desyncs (authorize ran in a separate in-app-browser context). Gated on
+        # the stable device cookie matching the handshake record, which proves this is
+        # the same browser that started the flow — so a bare code+state callback URL
+        # can't be replayed in another browser (closes login-CSRF). The PWA carries the
+        # device cookie unchanged across the excursion, so recovery still succeeds.
+        logger.info("oauth callback recovered via server-side handshake (device-bound, desynced cookie context)")
         code_verifier = store_record["code_verifier"]
         handshake_nonce = store_record.get("nonce")
         next_target = store_record.get("next")


### PR DESCRIPTION
## Capability

Avibe Cloud **remote-access login now works from an installed (standalone) PWA**, and failed OAuth callbacks render a branded **re-login page** instead of raw JSON.

## Problem

On iOS standalone PWAs, login **deterministically** failed with `{"error":"invalid_oauth_state"}`. Normal browsers were fine.

## Root cause (confirmed on the master regression env)

The PWA + `/auth/callback` live on the tunnel host; the avibe.bot authorize step is cross-origin. iOS runs that authorize step in a **separate in-app-browser context**, and the PWA main webview re-mints its own `GET /` state, so the handshake cookie the callback reads belongs to a **different generation** than the consent the user approved. Diagnostic logging showed `cookie_parsed=True, url_state_valid=True, cookie_state_rid != url_state_rid` — i.e. two validly-signed states. The old `cookie.state == url.state` equality is the wrong invariant for that multi-context environment.

## Fix

- **Server-side handshake store** (`vibe/remote_access.py`): persist `{nonce, code_verifier, next, device_hash}` keyed by the signed state's random id — single-use (atomic `os.replace` claim), `0600`, 5-min TTL, pruned.
- **`/auth/callback` is cookie-first, store-fallback** (`vibe/ui_server.py`): normal browsers still use the matched handshake cookie (unchanged); when the cookie's state desyncs (PWA), recover the PKCE secrets from the store by the **signature-verified URL state**.
- **Per-browser binding** closes login-CSRF: the store-fallback only proceeds when a stable `__Host-vibe_oauth_device` cookie (set once, reused, 180d) hashes to the record's `device_hash`. It is not regenerated per flow, so it survives the iOS excursion; an attacker can't present a victim's value, so a bare `code+state` URL can't log a victim in.
- **Branded re-login page** replaces the raw-JSON dead-ends for `invalid_oauth_state` / `oauth_exchange_failed` / `invalid_oauth_nonce`.

Plan + full rationale: `docs/plans/pwa-oauth-login-state-desync.md`.

## Security

Which identity may complete OAuth is gated by the avibe.bot backend per instance (`isEmailAuthorizedForInstance`); tokens are validated (audience/issuer/nonce/instance/email_verified) at exchange; state stays HMAC-signed + single-use. The device binding restores per-browser binding for the cookie-less path. Reviewed by codex (gpt-5.5, xhigh); its High (cookieless fallback) and Low (non-atomic pop) findings are both addressed.

## Evidence layers

- **Unit/contract** (`tests/test_ui_remote_access_auth.py`, 108 passed, ruff clean): store single-use + TTL + atomic concurrent pop; desync recovery via device-bound store-fallback; mismatched-device fallback refused (login-CSRF block); login redirect seeds the persistent device + handshake cookies; re-login page renders for each error code; existing cookie-path / retry / legacy-state / sanitization cases stay green.
- **Scenario**: the `auth_setup` catalog covers **agent-backend** provider auth (codex/claude/opencode), a different surface from the remote-access Cloud login gate — not applicable here.
- **Manual**: iOS standalone PWA (iPhone OS 18.7) login verified end-to-end on the master regression env (`test-app.avibe.bot`), including the device-cookie-stable-across-excursion assumption.