### PR TITLE
fix(show): don't corrupt /@fs/ paths when rewriting public Show Page URLs

### DIFF
--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6557,7 +6557,21 @@ def _rewrite_public_show_runtime_private_paths(
         return content
     private_prefix = f"/show/{quote(session_id, safe='')}/"
     public_prefix = f"{external_prefix.rstrip('/')}/"
-    rewritten = text.replace(private_prefix, public_prefix)
+    # Only rewrite the private prefix where it is a genuine URL reference, not
+    # where the same "/show/<session>/" substring is embedded inside an absolute
+    # Vite /@fs/<realpath> filesystem path (e.g.
+    # /@fs/<home>/.avibe/show/<session>/src/App.tsx). A blind str.replace would
+    # also corrupt that fs path -> the module 404s and is served as index.html
+    # -> MIME error -> the app never mounts (blank public Show Page). A genuine
+    # URL reference of the prefix is preceded by a quote / paren / = / comma /
+    # whitespace / start, whereas the embedded fs occurrence is preceded by an
+    # alphanumeric path-component char (the "e" in ".avibe"); the negative
+    # lookbehind (note: "/" is deliberately NOT excluded) skips only the latter.
+    rewritten = re.sub(
+        r"(?<![A-Za-z0-9._~-])" + re.escape(private_prefix),
+        public_prefix,
+        text,
+    )
     if rewritten == text:
         return content
     _mark_show_runtime_document_no_store(headers)


### PR DESCRIPTION
## What

Fix blank **public** Show Page shares (`/p/<share-id>/`) caused by the public path-rewriter corrupting the filesystem portion of Vite `/@fs/` module URLs.

Fixes #574.

## Root cause

`_rewrite_public_show_runtime_private_paths` rewrote `/show/<session>/` → `/p/<share>/` with a blind `str.replace`. Vite serves app source modules via absolute `/@fs/<realpath>` URLs (emitted when the workspace root is a symlinked path whose realpath differs), e.g.:

```js
import App from "/show/<session>/@fs/<home>/.avibe/show/<session>/src/App.tsx";
```

`/show/<session>/` appears **twice**: the leading URL base (should be rewritten) and one embedded in the `/@fs/` filesystem path (must not be). The blind replace corrupted the fs path → the module 404'd and was served as `index.html` (`text/html`) → the browser MIME-rejected the ES module → React never mounted → blank page (stuck `avs-fallback-shell`). `curl` sees a healthy shell + 200 assets, so it's easy to misdiagnose.

## Fix

Rewrite only genuine URL references via a negative lookbehind; fs-path-embedded occurrences (preceded by an alphanumeric path-component char) are left intact:

```python
rewritten = re.sub(r"(?<![A-Za-z0-9._~-])" + re.escape(private_prefix), public_prefix, text)
```

## Verification

Applied to a running instance and traced the full module graph the way a browser loads it: `main.tsx` now imports `App` from the correct `/p/<share>/@fs/<home>/.avibe/show/<session>/src/App.tsx`, which serves `text/javascript`; `main.tsx → App.tsx → styles.css → @avibe/show-ui/* vendor chunks` all resolve with correct JS MIME types and the page mounts. No remaining corrupted `/@fs/` paths.

Reviewed for over-/under-rewrite regressions (sourcemaps, `url(...)`, import maps, absolute URLs): genuine URL refs are always preceded by a non-class delimiter; the only theoretical over-rewrite needs the home dir to literally be `/show/<session>/…`, which is not a realistic deployment.

## Note (optional follow-up)

A defense-in-depth complement is to launch the Show Runtime with a canonicalized (`realpath`) workspace root so Vite stops emitting `/@fs/<realpath>` URLs in the first place — but the rewriter should be robust regardless, which is what this PR does.
