### PR TITLE
feat(ui): workbench chat tweaks — harness markdown, mobile new-session, session reference, Show Page toggle, icon tooltips, subtitle

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -268,6 +268,14 @@ class ShowPageStore:
             status = conn.execute(
                 select(agent_sessions.c.status).where(agent_sessions.c.id == session_id)
             ).scalar_one_or_none()
+            if status is None:
+                # Unknown session — don't create an orphan page row not tied to any
+                # session lifecycle/archive cleanup (other session-scoped APIs also
+                # treat a missing session as absent).
+                raise ShowPageError(
+                    "Cannot create a Show Page for an unknown session.",
+                    code="session_not_found",
+                )
             if status == "archived":
                 raise ShowPageError(
                     "Cannot create a Show Page for an archived session.",

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -245,6 +245,54 @@ class ShowPageStore:
             )
         return page
 
+    def ensure_active(self, session_id: str) -> tuple[ShowPage, bool]:
+        """Atomically ensure a page for a NON-archived session; return (page, created).
+
+        The existing-row check, the archived check and the insert all run in ONE
+        transaction so (a) a concurrent archive can't race the create (TOCTOU),
+        and (b) ``created`` is derived from the insert itself — concurrent
+        first-ensures don't both report "created" (which would otherwise double-
+        send the visualize prompt or collide on the unique key). An existing page
+        is returned untouched (archive already took it offline).
+        """
+        session_id = validate_session_id(session_id)
+        now = _utc_now_iso()
+        with self.engine.begin() as conn:
+            existing = (
+                conn.execute(select(show_pages).where(show_pages.c.session_id == session_id).limit(1))
+                .mappings()
+                .first()
+            )
+            if existing is not None:
+                return _page_from_row(existing), False
+            status = conn.execute(
+                select(agent_sessions.c.status).where(agent_sessions.c.id == session_id)
+            ).scalar_one_or_none()
+            if status == "archived":
+                raise ShowPageError(
+                    "Cannot create a Show Page for an archived session.",
+                    code="session_archived",
+                )
+            result = conn.execute(
+                insert(show_pages)
+                .prefix_with("OR IGNORE")
+                .values(
+                    session_id=session_id,
+                    visibility=VISIBILITY_PRIVATE,
+                    share_id=None,
+                    offline_at=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+            created = bool(result.rowcount and result.rowcount > 0)
+            row = (
+                conn.execute(select(show_pages).where(show_pages.c.session_id == session_id).limit(1))
+                .mappings()
+                .first()
+            )
+        return _page_from_row(row), created
+
     def _is_archived(self, session_id: str) -> bool:
         with self.engine.connect() as conn:
             status = conn.execute(

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -816,7 +816,9 @@ def test_private_show_page_sets_show_event_write_cookie(monkeypatch, tmp_path):
     cookies = "\n".join(response.headers.getlist("set-cookie"))
     assert "vibe_show_event_token=token-ses123" in cookies
     assert "Path=/show/ses123/" in cookies
-    assert response.headers["content-security-policy"] == "frame-ancestors 'none'"
+    # 'self' (not 'none'): the workbench frames a private Show Page in the chat
+    # view (same origin); cross-origin framing stays blocked.
+    assert response.headers["content-security-policy"] == "frame-ancestors 'self'"
 
 
 def test_public_show_page_clears_show_event_write_cookie(monkeypatch, tmp_path):

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -30,6 +30,7 @@ import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { WorkbenchInboxProvider } from './context/WorkbenchInboxContext';
 import { WorkbenchProjectsProvider } from './context/WorkbenchProjectsContext';
+import { ComposerBridgeProvider } from './context/ComposerBridgeContext';
 import { AgentationToggle } from './components/AgentationToggle';
 import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -326,10 +327,12 @@ function App() {
           <ApiProvider>
             <WorkbenchInboxProvider>
               <WorkbenchProjectsProvider>
-                <BrowserRouter>
-                  <AppRoutes />
-                </BrowserRouter>
-                <AgentationToggle />
+                <ComposerBridgeProvider>
+                  <BrowserRouter>
+                    <AppRoutes />
+                  </BrowserRouter>
+                  <AgentationToggle />
+                </ComposerBridgeProvider>
               </WorkbenchProjectsProvider>
             </WorkbenchInboxProvider>
           </ApiProvider>

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -69,9 +69,17 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
   VariantProps<typeof buttonVariants> & { asChild?: boolean };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, title, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
-    return <Comp ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />;
+    // Icon-only buttons carry their label in `aria-label` (there's no visible
+    // text). Mirror it into `title` so hovering shows that label as a native
+    // tooltip — unless the caller passed an explicit title. Gives every
+    // icon-sized button a hover hint for free.
+    const ariaLabel = props['aria-label'];
+    const resolvedTitle = title ?? (size === 'icon' && typeof ariaLabel === 'string' ? ariaLabel : undefined);
+    return (
+      <Comp ref={ref} title={resolvedTitle} className={cn(buttonVariants({ variant, size }), className)} {...props} />
+    );
   }
 );
 Button.displayName = 'Button';

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -108,11 +108,18 @@ export const ChatPage: React.FC = () => {
     { disabled: !sessionId },
   );
 
+  // Loaded session (null while bootstrapping — ChatPage renders a loader until
+  // it's set). Lifted above the composer bridge + show-page logic that gate on it.
+  const [session, setSession] = useState<WorkbenchSession | null>(null);
+
   // Show Page toggle: swap the chat surface (transcript + composer, NOT the
   // header bar) for this session's Show Page in an iframe, and back. Declared
   // before the composer bridge target, which depends on showPageMode.
   const [showPageMode, setShowPageMode] = useState(false);
   const [showPageBusy, setShowPageBusy] = useState(false);
+  // Sessions whose first-open visualize prompt failed to send — retry it on the
+  // next toggle (the page row already exists, so `existed` alone won't re-prompt).
+  const showPagePromptRetryRef = useRef<Set<string>>(new Set());
   const [showPageUrl, setShowPageUrl] = useState<string | null>(null);
   useEffect(() => {
     // ChatPage is reused across :sessionId — clear all show-page state so the
@@ -130,12 +137,14 @@ export const ChatPage: React.FC = () => {
       composerRef.current?.insertSessionReference(refSessionId, title),
     [],
   );
-  // Null target hides that sidebar action — when no chat is open (no sessionId)
-  // OR while the Show Page iframe has replaced the composer (it's unmounted, so
-  // an insert would silently no-op).
+  // Null target hides that sidebar action unless the composer is actually
+  // mounted + insertable: a chat is open (sessionId), its session has loaded
+  // (before that ChatPage shows a loader — the composer isn't rendered yet), and
+  // the Show Page iframe hasn't replaced the composer. Otherwise an insert would
+  // silently no-op against a null composerRef.
   const composerTarget = useMemo<ComposerInsertTarget | null>(
-    () => (sessionId && !showPageMode ? { sessionId, insertSessionReference } : null),
-    [sessionId, showPageMode, insertSessionReference],
+    () => (sessionId && session != null && !showPageMode ? { sessionId, insertSessionReference } : null),
+    [sessionId, session, showPageMode, insertSessionReference],
   );
   useRegisterComposerTarget(composerTarget);
 
@@ -147,7 +156,6 @@ export const ChatPage: React.FC = () => {
     else navigate('/inbox');
   }, [location.key, navigate]);
 
-  const [session, setSession] = useState<WorkbenchSession | null>(null);
   const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
   const [defaultAgentName, setDefaultAgentName] = useState<string | null>(null);
   const [messages, setMessages] = useState<WorkbenchMessage[]>([]);
@@ -760,11 +768,17 @@ export const ChatPage: React.FC = () => {
             ? `/p/${encodeURIComponent(res.share_id)}/`
             : `/show/${encodeURIComponent(sid)}/`,
         );
-        // Only a freshly-created page needs the agent to build the visualization.
-        if (res.existed === false) {
-          void sendMessage(t('chat.showPage.prompt'));
-        }
         setShowPageMode(true);
+        // First open (or a prior prompt that failed to send) asks the agent to
+        // build the visualization. sendMessage returns false on a failed send;
+        // track it so the NEXT toggle retries — the page row exists after this,
+        // so `existed` alone would never re-prompt a created-but-unprompted page.
+        if (res.existed === false || showPagePromptRetryRef.current.has(sid)) {
+          void sendMessage(t('chat.showPage.prompt')).then((sent) => {
+            if (sent === false) showPagePromptRetryRef.current.add(sid);
+            else showPagePromptRetryRef.current.delete(sid);
+          });
+        }
       }
     } catch {
       // apiFetch already surfaced a toast; stay in chat view.
@@ -1032,10 +1046,10 @@ export const ChatPage: React.FC = () => {
           onToggleShowPage={toggleShowPage}
         />
 
-      {showPageMode && showPageUrl ? (
-        // The session's Show Page replaces the transcript + composer (the header
-        // bar stays). Same-origin (/show/<id>/ private or /p/<share>/ public) so
-        // it inherits the workbench's auth; URL is resolved from ensureShowPage.
+      {showPageMode && showPageUrl && (
+        // The session's Show Page (same-origin /show/<id>/ private or /p/<share>/
+        // public; URL resolved from ensureShowPage) fills the chat area while the
+        // header bar stays. The chat surface below is kept mounted but hidden.
         //
         // Sandbox is deliberately LIGHT: `allow-same-origin` is required (the page
         // authenticates with the workbench cookie + runs its own same-origin
@@ -1052,41 +1066,44 @@ export const ChatPage: React.FC = () => {
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
           className="min-h-0 w-full flex-1 border-0 bg-background"
         />
-      ) : (
-        <>
-          {error && (
-            <div className="mx-auto mt-3 w-full max-w-[1080px] rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
-              {error}
-            </div>
-          )}
-
-          <Transcript
-            messages={messages}
-            session={session}
-            working={working}
-            hasOlder={!!olderCursor}
-            loadingOlder={loadingOlder}
-            onLoadOlder={loadOlderMessages}
-            messageFontSize={messageFontSize}
-            onQuickReply={handleQuickReply}
-          />
-          <QueueStrip queue={queue} onRemove={removeQueued} onSendNow={sendQueueNow} />
-          {/* key by session so the composer remounts per session — its draft-seeding
-              + local value reset, instead of carrying across sessions (Codex P2). */}
-          <Compose
-            key={sessionId}
-            composerRef={composerRef}
-            onSend={(text, attachments, references) => sendMessage(text, attachments, undefined, references)}
-            onStop={stopMessage}
-            busy={working}
-            sessionId={sessionId ?? ''}
-            initialDraft={initialDraft}
-            onDraftChange={onDraftChange}
-            onSearchAgents={searchAgents}
-            onSearchSessions={searchSessions}
-          />
-        </>
       )}
+
+      {/* Chat surface stays MOUNTED while the Show Page is shown — just hidden —
+          so unsent composer text + staged attachments survive the toggle instead
+          of being discarded on unmount. */}
+      <div className={clsx('flex min-h-0 flex-1 flex-col', showPageMode && 'hidden')}>
+        {error && (
+          <div className="mx-auto mt-3 w-full max-w-[1080px] rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+            {error}
+          </div>
+        )}
+
+        <Transcript
+          messages={messages}
+          session={session}
+          working={working}
+          hasOlder={!!olderCursor}
+          loadingOlder={loadingOlder}
+          onLoadOlder={loadOlderMessages}
+          messageFontSize={messageFontSize}
+          onQuickReply={handleQuickReply}
+        />
+        <QueueStrip queue={queue} onRemove={removeQueued} onSendNow={sendQueueNow} />
+        {/* key by session so the composer remounts per session — its draft-seeding
+            + local value reset, instead of carrying across sessions (Codex P2). */}
+        <Compose
+          key={sessionId}
+          composerRef={composerRef}
+          onSend={(text, attachments, references) => sendMessage(text, attachments, undefined, references)}
+          onStop={stopMessage}
+          busy={working}
+          sessionId={sessionId ?? ''}
+          initialDraft={initialDraft}
+          onDraftChange={onDraftChange}
+          onSearchAgents={searchAgents}
+          onSearchSessions={searchSessions}
+        />
+      </div>
       </div>
       </FileViewerProvider>
     </ImageViewerProvider>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1096,6 +1096,39 @@ export const ChatPage: React.FC = () => {
 // Pending send-while-busy messages, shown between the transcript and the
 // composer (Codex-GUI style). Each can be dropped; "立即发送" interrupts the
 // running turn and flushes the whole queue now (the queue flushes merged).
+// One queued message. Its text is a single truncated line by default; clicking
+// it expands to the full wrapped text (and clicking again collapses it) so a
+// long queued prompt can be read without sending it.
+const QueueRow: React.FC<{ item: WorkbenchMessage; onRemove: (id: string) => void }> = ({ item, onRemove }) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="flex items-start gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className={clsx(
+          'min-w-0 flex-1 text-left text-[12px] text-foreground',
+          expanded ? 'whitespace-pre-wrap break-words' : 'truncate',
+        )}
+      >
+        {item.text}
+      </button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={() => onRemove(item.id)}
+        aria-label={t('chat.queue.remove')}
+        className="size-6 shrink-0 text-muted hover:text-destructive"
+      >
+        <X className="size-3.5" />
+      </Button>
+    </div>
+  );
+};
+
 const QueueStrip: React.FC<{
   queue: WorkbenchMessage[];
   onRemove: (id: string) => void;
@@ -1117,19 +1150,7 @@ const QueueStrip: React.FC<{
         </div>
         <div className="flex max-h-32 flex-col gap-1 overflow-y-auto">
           {queue.map((item) => (
-            <div key={item.id} className="flex items-center gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
-              <span className="flex-1 truncate text-[12px] text-foreground">{item.text}</span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                onClick={() => onRemove(item.id)}
-                aria-label={t('chat.queue.remove')}
-                className="size-6 shrink-0 text-muted hover:text-destructive"
-              >
-                <X className="size-3.5" />
-              </Button>
-            </div>
+            <QueueRow key={item.id} item={item} onRemove={onRemove} />
           ))}
         </div>
       </div>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -128,8 +128,10 @@ export const ChatPage: React.FC = () => {
   // chat view on session change so a freshly-opened chat starts in chat mode.
   const [showPageMode, setShowPageMode] = useState(false);
   const [showPageBusy, setShowPageBusy] = useState(false);
+  const [showPageUrl, setShowPageUrl] = useState<string | null>(null);
   useEffect(() => {
     setShowPageMode(false);
+    setShowPageUrl(null);
   }, [sessionId]);
 
   // Back returns to the page the user came from, not a hardcoded inbox.
@@ -734,22 +736,35 @@ export const ChatPage: React.FC = () => {
   // ensures the page exists; if it was just created, ask the agent to build the
   // visualization. Errors surface via the apiFetch toast layer.
   const toggleShowPage = useCallback(async () => {
-    if (!sessionId) return;
+    const sid = sessionId;
+    if (!sid) return;
     if (showPageMode) {
       setShowPageMode(false);
       return;
     }
     setShowPageBusy(true);
     try {
-      const res = await api.ensureShowPage(sessionId);
-      if (res?.ok && res.existed === false) {
-        void sendMessage('Please visualize this session as a Show Page.');
+      const res = await api.ensureShowPage(sid);
+      // Bail if the user switched chats while ensure was in flight — otherwise a
+      // stale resolve would flip the NEW chat into iframe mode + send its prompt.
+      if (sessionIdRef.current !== sid) return;
+      if (res?.ok) {
+        // Public pages are served under /p/<share_id>/; private under /show/<id>/.
+        setShowPageUrl(
+          res.visibility === 'public' && res.share_id
+            ? `/p/${encodeURIComponent(res.share_id)}/`
+            : `/show/${encodeURIComponent(sid)}/`,
+        );
+        // Only a freshly-created page needs the agent to build the visualization.
+        if (res.existed === false) {
+          void sendMessage('Please visualize this session as a Show Page.');
+        }
+        setShowPageMode(true);
       }
-      setShowPageMode(true);
     } catch {
       // apiFetch already surfaced a toast; stay in chat view.
     } finally {
-      setShowPageBusy(false);
+      if (sessionIdRef.current === sid) setShowPageBusy(false);
     }
   }, [sessionId, showPageMode, api, sendMessage]);
 
@@ -1009,12 +1024,13 @@ export const ChatPage: React.FC = () => {
           onToggleShowPage={toggleShowPage}
         />
 
-      {showPageMode && sessionId ? (
+      {showPageMode && showPageUrl ? (
         // The session's Show Page replaces the transcript + composer (the header
-        // bar stays). Same-origin /show/<id>/ inherits the workbench's auth.
+        // bar stays). Same-origin (/show/<id>/ private or /p/<share>/ public) so
+        // it inherits the workbench's auth; URL is resolved from ensureShowPage.
         <iframe
           title={t('chat.showPage.title')}
-          src={`/show/${encodeURIComponent(sessionId)}/`}
+          src={showPageUrl}
           className="min-h-0 w-full flex-1 border-0 bg-background"
         />
       ) : (

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1560,21 +1560,19 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
 
   // Agent / system replies AND the user's own messages render as markdown (users
   // routinely type lists / code / **emphasis** and expect it formatted). Only
-  // harness-triggered prompts (scheduled task / watch / webhook) stay verbatim —
-  // that row is a collapsed technical preview where the raw text is the point.
+  // Every message body renders as Markdown — including the expanded harness row
+  // (scheduled task / watch / webhook prompt), which used to stay verbatim.
+  // Harness prompts and the user's own messages keep soft breaks so their
+  // original line breaks stay visible (a harness prompt often mixes authored
+  // Markdown with line-oriented waiter output); agent/system replies are
+  // authored Markdown and must not get stray hard breaks.
   const bodyNode = message.text ? (
-    isHarness ? (
-      <div className="whitespace-pre-wrap break-words text-[13px] text-foreground">{message.text}</div>
-    ) : (
-      // Keep the user's own newlines visible (soft-break → <br>); agent/system
-      // replies are authored markdown and must not get stray hard breaks.
-      <Markdown
-        content={message.text}
-        softBreaks={isUser}
-        references={(message.content as { references?: MentionReference[] } | null)?.references}
-        className="vr-markdown--inherit-size"
-      />
-    )
+    <Markdown
+      content={message.text}
+      softBreaks={isUser || isHarness}
+      references={(message.content as { references?: MentionReference[] } | null)?.references}
+      className="vr-markdown--inherit-size"
+    />
   ) : messageAttachments.length === 0 ? (
     <div className="text-[13px] text-muted">—</div>
   ) : null;

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -108,31 +108,36 @@ export const ChatPage: React.FC = () => {
     { disabled: !sessionId },
   );
 
-  // Publish this chat's composer to the ComposerBridge while it's mounted, so
-  // the sidebar's "reference this session" action can insert a #<session>
-  // mention into the open chat's input. Null target (no sessionId) = no chat
-  // open, which hides that sidebar action.
+  // Show Page toggle: swap the chat surface (transcript + composer, NOT the
+  // header bar) for this session's Show Page in an iframe, and back. Declared
+  // before the composer bridge target, which depends on showPageMode.
+  const [showPageMode, setShowPageMode] = useState(false);
+  const [showPageBusy, setShowPageBusy] = useState(false);
+  const [showPageUrl, setShowPageUrl] = useState<string | null>(null);
+  useEffect(() => {
+    // ChatPage is reused across :sessionId — clear all show-page state so the
+    // next chat starts in chat view with a live (not stuck-busy) toggle.
+    setShowPageMode(false);
+    setShowPageUrl(null);
+    setShowPageBusy(false);
+  }, [sessionId]);
+
+  // Publish this chat's composer to the ComposerBridge so the sidebar's
+  // "reference this session" action can insert a #<session> mention into the
+  // open chat's input.
   const insertSessionReference = useCallback(
     (refSessionId: string, title?: string | null) =>
       composerRef.current?.insertSessionReference(refSessionId, title),
     [],
   );
+  // Null target hides that sidebar action — when no chat is open (no sessionId)
+  // OR while the Show Page iframe has replaced the composer (it's unmounted, so
+  // an insert would silently no-op).
   const composerTarget = useMemo<ComposerInsertTarget | null>(
-    () => (sessionId ? { sessionId, insertSessionReference } : null),
-    [sessionId, insertSessionReference],
+    () => (sessionId && !showPageMode ? { sessionId, insertSessionReference } : null),
+    [sessionId, showPageMode, insertSessionReference],
   );
   useRegisterComposerTarget(composerTarget);
-
-  // Show Page toggle: swap the chat surface (transcript + composer, NOT the
-  // header bar) for this session's Show Page in an iframe, and back. Resets to
-  // chat view on session change so a freshly-opened chat starts in chat mode.
-  const [showPageMode, setShowPageMode] = useState(false);
-  const [showPageBusy, setShowPageBusy] = useState(false);
-  const [showPageUrl, setShowPageUrl] = useState<string | null>(null);
-  useEffect(() => {
-    setShowPageMode(false);
-    setShowPageUrl(null);
-  }, [sessionId]);
 
   // Back returns to the page the user came from, not a hardcoded inbox.
   // location.key === 'default' means /chat was the first history entry (deep
@@ -757,16 +762,19 @@ export const ChatPage: React.FC = () => {
         );
         // Only a freshly-created page needs the agent to build the visualization.
         if (res.existed === false) {
-          void sendMessage('Please visualize this session as a Show Page.');
+          void sendMessage(t('chat.showPage.prompt'));
         }
         setShowPageMode(true);
       }
     } catch {
       // apiFetch already surfaced a toast; stay in chat view.
     } finally {
-      if (sessionIdRef.current === sid) setShowPageBusy(false);
+      // Always clear — the in-flight request is done regardless of which chat is
+      // now mounted (ChatPage is reused across sessions; a guarded clear would
+      // strand the shared busy flag on a session the user switched to).
+      setShowPageBusy(false);
     }
-  }, [sessionId, showPageMode, api, sendMessage]);
+  }, [sessionId, showPageMode, api, sendMessage, t]);
 
   // A quick-reply click sends the chosen label as a normal user turn, tagged with
   // the agent message it answers so the group can lock + highlight the choice on

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Bell, Bot, ChevronDown, Clock, Info, Loader2, MessageSquare, Pencil, UploadCloud, X } from 'lucide-react';
+import { AppWindow, ArrowLeft, Bell, Bot, ChevronDown, Clock, Info, Loader2, MessageSquare, Pencil, UploadCloud, X } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -122,6 +122,15 @@ export const ChatPage: React.FC = () => {
     [sessionId, insertSessionReference],
   );
   useRegisterComposerTarget(composerTarget);
+
+  // Show Page toggle: swap the chat surface (transcript + composer, NOT the
+  // header bar) for this session's Show Page in an iframe, and back. Resets to
+  // chat view on session change so a freshly-opened chat starts in chat mode.
+  const [showPageMode, setShowPageMode] = useState(false);
+  const [showPageBusy, setShowPageBusy] = useState(false);
+  useEffect(() => {
+    setShowPageMode(false);
+  }, [sessionId]);
 
   // Back returns to the page the user came from, not a hardcoded inbox.
   // location.key === 'default' means /chat was the first history entry (deep
@@ -721,6 +730,29 @@ export const ChatPage: React.FC = () => {
     [api, sessionId],
   );
 
+  // Toggle the chat surface ↔ the session's Show Page (iframe). The first open
+  // ensures the page exists; if it was just created, ask the agent to build the
+  // visualization. Errors surface via the apiFetch toast layer.
+  const toggleShowPage = useCallback(async () => {
+    if (!sessionId) return;
+    if (showPageMode) {
+      setShowPageMode(false);
+      return;
+    }
+    setShowPageBusy(true);
+    try {
+      const res = await api.ensureShowPage(sessionId);
+      if (res?.ok && res.existed === false) {
+        void sendMessage('Please visualize this session as a Show Page.');
+      }
+      setShowPageMode(true);
+    } catch {
+      // apiFetch already surfaced a toast; stay in chat view.
+    } finally {
+      setShowPageBusy(false);
+    }
+  }, [sessionId, showPageMode, api, sendMessage]);
+
   // A quick-reply click sends the chosen label as a normal user turn, tagged with
   // the agent message it answers so the group can lock + highlight the choice on
   // reload (the answered state is derived from this metadata).
@@ -972,39 +1004,54 @@ export const ChatPage: React.FC = () => {
           onPatch={patch}
           onBack={goBack}
           working={working}
+          showPageMode={showPageMode}
+          showPageBusy={showPageBusy}
+          onToggleShowPage={toggleShowPage}
         />
 
-      {error && (
-        <div className="mx-auto mt-3 w-full max-w-[1080px] rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
-          {error}
-        </div>
-      )}
+      {showPageMode && sessionId ? (
+        // The session's Show Page replaces the transcript + composer (the header
+        // bar stays). Same-origin /show/<id>/ inherits the workbench's auth.
+        <iframe
+          title={t('chat.showPage.title')}
+          src={`/show/${encodeURIComponent(sessionId)}/`}
+          className="min-h-0 w-full flex-1 border-0 bg-background"
+        />
+      ) : (
+        <>
+          {error && (
+            <div className="mx-auto mt-3 w-full max-w-[1080px] rounded-md border border-destructive/40 bg-destructive/[0.06] px-3 py-2 text-[12px] text-destructive">
+              {error}
+            </div>
+          )}
 
-      <Transcript
-        messages={messages}
-        session={session}
-        working={working}
-        hasOlder={!!olderCursor}
-        loadingOlder={loadingOlder}
-        onLoadOlder={loadOlderMessages}
-        messageFontSize={messageFontSize}
-        onQuickReply={handleQuickReply}
-      />
-      <QueueStrip queue={queue} onRemove={removeQueued} onSendNow={sendQueueNow} />
-      {/* key by session so the composer remounts per session — its draft-seeding
-          + local value reset, instead of carrying across sessions (Codex P2). */}
-      <Compose
-        key={sessionId}
-        composerRef={composerRef}
-        onSend={(text, attachments, references) => sendMessage(text, attachments, undefined, references)}
-        onStop={stopMessage}
-        busy={working}
-        sessionId={sessionId ?? ''}
-        initialDraft={initialDraft}
-        onDraftChange={onDraftChange}
-        onSearchAgents={searchAgents}
-        onSearchSessions={searchSessions}
-      />
+          <Transcript
+            messages={messages}
+            session={session}
+            working={working}
+            hasOlder={!!olderCursor}
+            loadingOlder={loadingOlder}
+            onLoadOlder={loadOlderMessages}
+            messageFontSize={messageFontSize}
+            onQuickReply={handleQuickReply}
+          />
+          <QueueStrip queue={queue} onRemove={removeQueued} onSendNow={sendQueueNow} />
+          {/* key by session so the composer remounts per session — its draft-seeding
+              + local value reset, instead of carrying across sessions (Codex P2). */}
+          <Compose
+            key={sessionId}
+            composerRef={composerRef}
+            onSend={(text, attachments, references) => sendMessage(text, attachments, undefined, references)}
+            onStop={stopMessage}
+            busy={working}
+            sessionId={sessionId ?? ''}
+            initialDraft={initialDraft}
+            onDraftChange={onDraftChange}
+            onSearchAgents={searchAgents}
+            onSearchSessions={searchSessions}
+          />
+        </>
+      )}
       </div>
       </FileViewerProvider>
     </ImageViewerProvider>
@@ -1098,9 +1145,12 @@ interface ChatHeaderBarProps {
   onPatch: (changes: Partial<WorkbenchSession>) => Promise<void>;
   onBack: () => void;
   working: boolean;
+  showPageMode: boolean;
+  showPageBusy: boolean;
+  onToggleShowPage: () => void;
 }
 
-const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working }) => {
+const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working, showPageMode, showPageBusy, onToggleShowPage }) => {
   const { t } = useTranslation();
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
   // Backend locks once a NATIVE conversation exists — a native can only be
@@ -1171,6 +1221,27 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
             IM-launched users often land straight in a chat. Renders only on iOS
             Safari + not-installed; null otherwise. */}
         <InstallHint />
+        {/* Show Page toggle: swaps the chat surface for the session's Show Page
+            (the header bar stays). First open initializes the page + prompts the
+            agent. Pushed to the far right of the header row. */}
+        <Button
+          type="button"
+          variant={showPageMode ? 'secondary' : 'ghost'}
+          size="icon"
+          onClick={onToggleShowPage}
+          disabled={showPageBusy}
+          aria-label={showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
+          title={showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
+          className="ml-auto size-7 shrink-0"
+        >
+          {showPageBusy ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : showPageMode ? (
+            <MessageSquare className="size-3.5" />
+          ) : (
+            <AppWindow className="size-3.5" />
+          )}
+        </Button>
       </div>
     </div>
   );

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
+import { useRegisterComposerTarget, type ComposerInsertTarget } from '../../context/ComposerBridgeContext';
 import type { VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
@@ -106,6 +107,21 @@ export const ChatPage: React.FC = () => {
     (files) => composerRef.current?.addFiles(files),
     { disabled: !sessionId },
   );
+
+  // Publish this chat's composer to the ComposerBridge while it's mounted, so
+  // the sidebar's "reference this session" action can insert a #<session>
+  // mention into the open chat's input. Null target (no sessionId) = no chat
+  // open, which hides that sidebar action.
+  const insertSessionReference = useCallback(
+    (refSessionId: string, title?: string | null) =>
+      composerRef.current?.insertSessionReference(refSessionId, title),
+    [],
+  );
+  const composerTarget = useMemo<ComposerInsertTarget | null>(
+    () => (sessionId ? { sessionId, insertSessionReference } : null),
+    [sessionId, insertSessionReference],
+  );
+  useRegisterComposerTarget(composerTarget);
 
   // Back returns to the page the user came from, not a hardcoded inbox.
   // location.key === 'default' means /chat was the first history entry (deep

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1036,9 +1036,20 @@ export const ChatPage: React.FC = () => {
         // The session's Show Page replaces the transcript + composer (the header
         // bar stays). Same-origin (/show/<id>/ private or /p/<share>/ public) so
         // it inherits the workbench's auth; URL is resolved from ensureShowPage.
+        //
+        // Sandbox is deliberately LIGHT: `allow-same-origin` is required (the page
+        // authenticates with the workbench cookie + runs its own same-origin
+        // fetches/WebSocket), and it intentionally also keeps the page able to
+        // reach the parent — a Show Page interacting with the surrounding
+        // workbench is a wanted (if not-yet-promoted) capability. Real isolation
+        // would need a separate origin, which we won't do (Show Pages are part of
+        // the product). The agent already has full machine access, so frontend
+        // isolation isn't the security boundary anyway. We still drop the exotic
+        // capabilities the page never needs (top navigation, pointer lock, etc.).
         <iframe
           title={t('chat.showPage.title')}
           src={showPageUrl}
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
           className="min-h-0 w-full flex-1 border-0 bg-background"
         />
       ) : (

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -126,6 +126,10 @@ export interface ComposerHandle {
   /** Stage + upload files from outside the composer — e.g. a chat-page-wide
    *  drag-and-drop that drops onto the transcript rather than the input row. */
   addFiles: (files: File[]) => void;
+  /** Insert a `#<session>` reference chip at the cursor (e.g. "reference this
+   *  session" from the sidebar). No-op when the mention editor isn't active
+   *  (the plain-textarea home composer). */
+  insertSessionReference: (sessionId: string, title?: string | null) => void;
 }
 
 // The chat-style input row: an auto-growing textarea + a Send/Stop icon button,
@@ -334,6 +338,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // deps array → always runs the latest uploadFiles closure for this session.
   useImperativeHandle(ref, () => ({
     addFiles: (files: File[]) => void uploadFiles(files),
+    insertSessionReference: (refSessionId: string, title?: string | null) => {
+      // Same node a typed `#` pick yields: trigger `#`, label = title||id, data
+      // carries the stable sessionId → serializes to `#<id>` + a session ref.
+      mentionRef.current?.insertMention('#', title?.trim() || refSessionId, { sessionId: refSessionId });
+    },
   }));
 
   const startRecording = async () => {

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -30,6 +30,7 @@ import {
   BeautifulMentionsPlugin,
   BeautifulMentionNode,
   $isBeautifulMentionNode,
+  useBeautifulMentions,
   type BeautifulMentionsItem,
   type BeautifulMentionsMenuProps,
   type BeautifulMentionsMenuItemProps,
@@ -55,6 +56,14 @@ export interface MentionEditorHandle {
   append: (text: string) => void;
   /** Replace the whole editor with plain text (restore on a failed send). */
   setText: (text: string) => void;
+  /** Insert a mention chip at the current cursor — same node a picker-selected
+   *  `@`/`#` yields — when triggered from outside the editor (e.g. "reference
+   *  this session" in the sidebar). */
+  insertMention: (
+    trigger: string,
+    value: string,
+    data?: Record<string, string | number | boolean | null>,
+  ) => void;
 }
 
 export interface MentionEditorProps {
@@ -223,6 +232,7 @@ function BootstrapPlugin({
   bridgeRef: Ref<MentionEditorHandle>;
 }) {
   const [editor] = useLexicalComposerContext();
+  const { insertMention: insertBeautifulMention } = useBeautifulMentions();
   const seeded = useRef(false);
 
   useImperativeHandle(
@@ -250,8 +260,13 @@ function BootstrapPlugin({
           root.append(paragraph);
           if (text) paragraph.selectStart().insertText(text);
         }),
+      // Insert at the live selection (Lexical keeps it across DOM blur), then
+      // focus so the user can keep typing. Produces the same node a typed
+      // `#`/`@` pick does, so serialization (#<id> + references) is identical.
+      insertMention: (trigger, value, data) =>
+        insertBeautifulMention({ trigger, value, data: data ?? {}, focus: true }),
     }),
-    [editor],
+    [editor, insertBeautifulMention],
   );
 
   useEffect(() => {

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -12,6 +12,7 @@ import {
   FolderPlus,
   Loader2,
   Pencil,
+  Plus,
   RotateCw,
   Settings2,
 } from 'lucide-react';
@@ -74,8 +75,11 @@ const MobileProjectRow: React.FC<{
   onToggle: () => void;
 }> = ({ project, open, state, onToggle }) => {
   const { t } = useTranslation();
-  const { renameProject, archiveProject } = useWorkbenchProjectsTree();
+  const navigate = useNavigate();
+  const { renameProject, archiveProject, createSessionForProject } = useWorkbenchProjectsTree();
   const [menuOpen, setMenuOpen] = useState(false);
+  // Guards against a double-tap creating two sessions before navigation unmounts.
+  const creatingSessionRef = useRef(false);
   const [renaming, setRenaming] = useState(false);
   const [draft, setDraft] = useState(project.display_name);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -161,6 +165,25 @@ const MobileProjectRow: React.FC<{
             </Button>
           </PopoverTrigger>
           <PopoverContent align="end" className="w-[200px] p-1">
+            {/* New session — first item, mobile only. Desktop surfaces this as
+                the per-project "+" button in the sidebar, so it stays out of the
+                desktop project menu; here the "+" doesn't fit, so it lives here. */}
+            <MenuItem
+              icon={Plus}
+              onClick={async () => {
+                setMenuOpen(false);
+                if (creatingSessionRef.current) return;
+                creatingSessionRef.current = true;
+                try {
+                  const session = await createSessionForProject(project.id);
+                  if (session) navigate(`/chat/${encodeURIComponent(session.id)}`);
+                } finally {
+                  creatingSessionRef.current = false;
+                }
+              }}
+            >
+              {t('newSession.title')}
+            </MenuItem>
             <MenuItem
               icon={Pencil}
               onClick={() => {

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -13,6 +13,7 @@ import {
   Folder,
   FolderOpen,
   FolderPlus,
+  Hash,
   Inbox,
   KeyRound,
   Loader2,
@@ -26,6 +27,7 @@ import type { LucideIcon } from 'lucide-react';
 
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
+import { useComposerInsertTarget } from '../../context/ComposerBridgeContext';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '../ui/popover';
@@ -200,6 +202,10 @@ const SessionRow: React.FC<{
   const navigate = useNavigate();
   const location = useLocation();
   const active = location.pathname === `/chat/${session.id}`;
+  // "Reference this session" shows only when a chat composer is mounted (a chat
+  // is open) AND this row isn't that open session — you can't reference yourself.
+  const insertTarget = useComposerInsertTarget();
+  const canReference = insertTarget != null && insertTarget.sessionId !== session.id;
   const [menuOpen, setMenuOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
@@ -303,6 +309,19 @@ const SessionRow: React.FC<{
         </button>
       </PopoverAnchor>
       <PopoverContent align="start" className="w-[176px] p-1">
+        {canReference && (
+          <button
+            type="button"
+            onClick={() => {
+              setMenuOpen(false);
+              insertTarget?.insertSessionReference(session.id, session.title);
+            }}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
+          >
+            <Hash className="size-3 text-muted" />
+            {t('workbench.sessionReference')}
+          </button>
+        )}
         <button
           type="button"
           onClick={() => {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -38,6 +38,8 @@ export type ApiContextType = {
   unsubscribeWebPush: (endpoint: string) => Promise<{ ok: boolean; disabled: boolean }>;
   sendWebPushTest: (payload?: { title?: string; body?: string; url?: string; endpoint?: string }) => Promise<WebPushTestResult>;
   setShowPageVisibility: (sessionId: string, visibility: string) => Promise<any>;
+  /** Create the session's Show Page if absent; resolves to `{ existed, ... }`. */
+  ensureShowPage: (sessionId: string) => Promise<any>;
   rotateShowPageShare: (sessionId: string) => Promise<any>;
   getBindCodes: () => Promise<any>;
   createBindCode: (type: string, expiresAt?: string) => Promise<any>;
@@ -1513,6 +1515,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     unsubscribeWebPush: (endpoint) => deleteJson('/api/web-push/subscriptions', { endpoint }),
     sendWebPushTest: (payload) => postJson('/api/web-push/test', payload ?? {}),
     setShowPageVisibility: (sessionId, visibility) => postJson(`/api/show-pages/${encodeURIComponent(sessionId)}/visibility`, { visibility }),
+    ensureShowPage: (sessionId) => postJson(`/api/show-pages/${encodeURIComponent(sessionId)}/ensure`, {}),
     rotateShowPageShare: (sessionId) => postJson(`/api/show-pages/${encodeURIComponent(sessionId)}/rotate-share`, {}),
     getBindCodes: () => getJson('/api/bind-codes'),
     createBindCode: (type, expiresAt) => postJson('/api/bind-codes', { type, expires_at: expiresAt }),

--- a/ui/src/context/ComposerBridgeContext.tsx
+++ b/ui/src/context/ComposerBridgeContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+/**
+ * Bridges the chat composer (mounted only inside ChatPage) to components that
+ * live outside it — e.g. the sidebar's "reference this session" action, which
+ * needs to drop a `#<session>` mention into the currently-open chat's input.
+ *
+ * `target` is the active chat composer, or `null` when no chat is open. That
+ * null/non-null state is exactly the "is the user on a Chat page?" gate the
+ * sidebar menu item needs — no separate route check required.
+ */
+export type ComposerInsertTarget = {
+  /** The session whose composer is currently mounted (the open chat). */
+  sessionId: string;
+  /** Insert a `#<session>` reference chip at the composer's cursor. */
+  insertSessionReference: (sessionId: string, title?: string | null) => void;
+};
+
+type ComposerBridge = {
+  target: ComposerInsertTarget | null;
+  setTarget: (target: ComposerInsertTarget | null) => void;
+};
+
+const ComposerBridgeContext = createContext<ComposerBridge | null>(null);
+
+export const ComposerBridgeProvider = ({ children }: { children: ReactNode }) => {
+  const [target, setTarget] = useState<ComposerInsertTarget | null>(null);
+  return (
+    <ComposerBridgeContext.Provider value={{ target, setTarget }}>{children}</ComposerBridgeContext.Provider>
+  );
+};
+
+/** Consumer side (sidebar session menu): the active composer target, or null. */
+export const useComposerInsertTarget = (): ComposerInsertTarget | null =>
+  useContext(ComposerBridgeContext)?.target ?? null;
+
+/**
+ * Producer side (ChatPage): publish `target` while this chat is mounted, clear
+ * it on unmount / session change. Only one ChatPage is mounted at a time, so a
+ * plain set-on-mount / clear-on-unmount is safe. `target` MUST be memoized by
+ * the caller (e.g. on sessionId) so the effect doesn't re-run every render.
+ */
+export const useRegisterComposerTarget = (target: ComposerInsertTarget | null): void => {
+  const setTarget = useContext(ComposerBridgeContext)?.setTarget;
+  useEffect(() => {
+    if (!setTarget) return;
+    setTarget(target);
+    return () => setTarget(null);
+  }, [setTarget, target]);
+};

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -536,7 +536,7 @@
   },
   "appShell": {
     "title": "Avibe OS",
-    "subtitle": "Agent OS",
+    "subtitle": "Agent OS · Workbench",
     "workspaceLabel": "Workspace",
     "openControlPanel": "Control Panel",
     "backToWorkbench": "Back to Workbench",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1755,6 +1755,11 @@
   "chat": {
     "back": "Back",
     "untitled": "Untitled session",
+    "showPage": {
+      "open": "View Show Page",
+      "backToChat": "Back to chat",
+      "title": "Show Page"
+    },
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",
     "noAgents": "No enabled agents. Create one on the Agents page.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1758,7 +1758,8 @@
     "showPage": {
       "open": "View Show Page",
       "backToChat": "Back to chat",
-      "title": "Show Page"
+      "title": "Show Page",
+      "prompt": "Please visualize this session as a Show Page."
     },
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -582,6 +582,7 @@
     "projectRenamePlaceholder": "New name",
     "sessionRename": "Rename",
     "sessionRenamePlaceholder": "Session name",
+    "sessionReference": "Reference this session",
     "sessionArchive": "Archive session",
     "archiveSession": {
       "title": "Archive this session permanently?",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -536,7 +536,7 @@
   },
   "appShell": {
     "title": "Avibe OS",
-    "subtitle": "Agent 操作系统",
+    "subtitle": "Agent操作系统 · 工作台",
     "workspaceLabel": "工作区",
     "openControlPanel": "控制面板",
     "backToWorkbench": "返回工作台",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -582,6 +582,7 @@
     "projectRenamePlaceholder": "新名字",
     "sessionRename": "重命名",
     "sessionRenamePlaceholder": "会话名称",
+    "sessionReference": "引用该会话",
     "sessionArchive": "归档会话",
     "archiveSession": {
       "title": "永久归档此会话？",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1754,6 +1754,11 @@
   "chat": {
     "back": "返回",
     "untitled": "未命名会话",
+    "showPage": {
+      "open": "查看 Show Page",
+      "backToChat": "返回对话",
+      "title": "Show Page"
+    },
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",
     "noAgents": "暂无已启用的 Agent。请先在 Agents 页创建。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1757,7 +1757,8 @@
     "showPage": {
       "open": "查看 Show Page",
       "backToChat": "返回对话",
-      "title": "Show Page"
+      "title": "Show Page",
+      "prompt": "Please visualize this session as a Show Page."
     },
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1008,26 +1008,20 @@ def ensure_show_page(session_id: str) -> dict:
     workbench can ALSO send the "visualize this session" prompt only on first
     creation. Mirrors the CLI ``vibe show path`` (ensure + return).
     """
-    from core.show_pages import ShowPageError, ShowPageStore, show_page_payload
+    from core.show_pages import ShowPageStore, show_page_payload
 
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        existed = store.get(session_id) is not None
-        # Don't materialize a fresh page row for an archived (terminal) session —
-        # /show/<id>/ serves private pages without re-checking archived state, so
-        # creating one would resurrect it. Mirrors update_visibility's guard. An
-        # already-existing page is returned as-is (archive took it offline).
-        if not existed and store._is_archived(session_id):
-            raise ShowPageError(
-                "Cannot create a Show Page for an archived session.",
-                code="session_archived",
-            )
-        page = store.ensure(session_id)
+        # Atomic: refuses to create a page for an archived session and reports
+        # whether IT created the row (so the UI only prompts the agent on a real
+        # first creation, not a concurrent ensure). Raises ShowPageError for an
+        # archived session — the route maps it to a 4xx.
+        page, created = store.ensure_active(session_id)
         payload = show_page_payload(page, config=config)
     finally:
         store.close()
-    return {"ok": True, "existed": existed, **_apply_session_meta([payload])[0]}
+    return {"ok": True, "existed": not created, **_apply_session_meta([payload])[0]}
 
 
 def rotate_show_page_share(session_id: str) -> dict:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1008,12 +1008,21 @@ def ensure_show_page(session_id: str) -> dict:
     workbench can ALSO send the "visualize this session" prompt only on first
     creation. Mirrors the CLI ``vibe show path`` (ensure + return).
     """
-    from core.show_pages import ShowPageStore, show_page_payload
+    from core.show_pages import ShowPageError, ShowPageStore, show_page_payload
 
     config = V2Config.load()
     store = ShowPageStore()
     try:
         existed = store.get(session_id) is not None
+        # Don't materialize a fresh page row for an archived (terminal) session —
+        # /show/<id>/ serves private pages without re-checking archived state, so
+        # creating one would resurrect it. Mirrors update_visibility's guard. An
+        # already-existing page is returned as-is (archive took it offline).
+        if not existed and store._is_archived(session_id):
+            raise ShowPageError(
+                "Cannot create a Show Page for an archived session.",
+                code="session_archived",
+            )
         page = store.ensure(session_id)
         payload = show_page_payload(page, config=config)
     finally:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1001,6 +1001,26 @@ def set_show_page_visibility(session_id: str, visibility: str) -> dict:
     return {"ok": True, **_apply_session_meta([payload])[0]}
 
 
+def ensure_show_page(session_id: str) -> dict:
+    """Create the session's Show Page if it doesn't exist yet; report which.
+
+    ``existed`` tells the caller whether the page was already initialized, so the
+    workbench can ALSO send the "visualize this session" prompt only on first
+    creation. Mirrors the CLI ``vibe show path`` (ensure + return).
+    """
+    from core.show_pages import ShowPageStore, show_page_payload
+
+    config = V2Config.load()
+    store = ShowPageStore()
+    try:
+        existed = store.get(session_id) is not None
+        page = store.ensure(session_id)
+        payload = show_page_payload(page, config=config)
+    finally:
+        store.close()
+    return {"ok": True, "existed": existed, **_apply_session_meta([payload])[0]}
+
+
 def rotate_show_page_share(session_id: str) -> dict:
     """Revoke the current public link and issue a new one (public pages only)."""
     from core.show_pages import ShowPageStore, show_page_payload

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6698,7 +6698,11 @@ def _rewrite_show_runtime_location(session_id: str, location: str, *, external_p
 
 def _with_show_event_write_cookie(response: Response, session_id: str, *, enabled: bool) -> Response:
     if enabled:
-        response.headers["Content-Security-Policy"] = "frame-ancestors 'none'"
+        # 'self' (not 'none') so the workbench can frame a private Show Page in the
+        # chat view — same origin as the page — while cross-origin clickjacking
+        # stays blocked. Direct navigation is unaffected (frame-ancestors only
+        # governs framing).
+        response.headers["Content-Security-Policy"] = "frame-ancestors 'self'"
         response.set_cookie(
             SHOW_EVENT_WRITE_TOKEN_COOKIE,
             show_event_write_token(session_id),

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2298,6 +2298,17 @@ def show_page_visibility_post(session_id):
         return _show_page_error_response(exc)
 
 
+@app.route("/api/show-pages/<session_id>/ensure", methods=["POST"])
+def show_page_ensure_post(session_id):
+    from core.show_pages import ShowPageError
+    from vibe import api
+
+    try:
+        return jsonify(api.ensure_show_page(session_id))
+    except ShowPageError as exc:
+        return _show_page_error_response(exc)
+
+
 @app.route("/api/show-pages/<session_id>/rotate-share", methods=["POST"])
 def show_page_rotate_share_post(session_id):
     from core.show_pages import ShowPageError


### PR DESCRIPTION
## What

A batch of workbench/chat UI detail tweaks (6 atomic commits):

1. **Markdown in expanded harness messages** — the collapsible system-trigger row (scheduled task / watch / webhook) now renders its expanded body through the shared `<Markdown>` renderer (soft breaks preserve the original line breaks) instead of verbatim plain text. The collapsed one-line preview is unchanged.
2. **"New session" in the mobile project menu** — added as the first item of the mobile `ProjectsPage` project `…` menu (desktop already has the per-project `+`). Mobile-only by construction; reuses `createSessionForProject` + navigates to the new chat.
3. **"Reference this session"** — new desktop sidebar session-row menu item that drops a `#<session>` mention at the open chat composer's cursor — the same node + `#<id>` marker + references sidecar a typed `#` pick yields, via a new `MentionEditorHandle.insertMention` (reuses `lexical-beautiful-mentions`' `insertMention`). A small `ComposerBridge` context publishes the mounted chat composer; the item shows only when a chat is open AND the row isn't that session. Mobile (separate tabs) is unaffected — it keeps the typed `#` flow.
4. **Subtitle copy** — app-shell brand subtitle → `Agent OS · Workbench` / `Agent操作系统 · 工作台`.
5. **Icon-button hover tooltips** — the `Button` primitive now defaults `title` to `aria-label` for `size="icon"` buttons, so every icon button (composer attach/mic/send, chat header, …) gets a native hover hint from one place.
6. **Show Page toggle in the chat header** — an `AppWindow` toggle at the right of the chat header bar swaps the chat surface (transcript + composer; the header bar stays) for the session's Show Page in a same-origin `/show/<id>/` iframe, and back. First open ensures the page exists and — only when just created — sends the agent an English prompt to build the visualization. New backend `POST /api/show-pages/<id>/ensure` (`api.ensure_show_page`) creates the page if absent and returns `existed`; the "has a show page" marker is simply the `show_pages` row keyed by `session_id`.

## Evidence

- **Build / lint:** `ui` `npm run build` (tsc + vite) green for every commit; `ruff check` green on the changed Python (`vibe/api.py`, `vibe/ui_server.py`).
- **Unit/contract/scenario:** none added — items 1–5 are UI-only, and the new `ensure` endpoint mirrors the existing `set_show_page_visibility` / `ShowPageStore.ensure` patterns (no new behavior to unit-cover beyond what `ShowPageStore` tests already exercise).
- **Residual manual checks (desktop + mobile chat page):** expanded harness message renders Markdown; mobile project menu "New session"; sidebar "Reference this session" inserts `#` only when a chat is open and not for the active session; subtitle copy; icon-button hover tooltips; Show Page toggle (init + agent prompt on first open, iframe loads same-origin, toggles back, resets on session switch).
