### PR TITLE
Support native Agent Session forks

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -1038,7 +1038,10 @@ class Controller:
     def _agent_run_target_payload(context: MessageContext) -> dict[str, Any]:
         payload = context.platform_specific or {}
         target = payload.get("agent_run_target")
-        return target if isinstance(target, dict) else {}
+        if isinstance(target, dict):
+            return target
+        session_target = payload.get("agent_session_target")
+        return session_target if isinstance(session_target, dict) else {}
 
     def get_opencode_overrides(self, context: MessageContext) -> tuple[Optional[str], Optional[str], Optional[str]]:
         """Get OpenCode agent, model, and reasoning effort overrides for this channel.

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -22,6 +22,7 @@ from modules.agents.claude_process_reaper import (
     reap_duplicate_claude_resume_processes,
 )
 from core.avibe_cloud import avibe_cloud_url_available
+from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 
 from .base import BaseHandler
@@ -589,6 +590,9 @@ class SessionHandler(BaseHandler):
         stored_claude_session_id = self.sessions.get_claude_session_id(session_key, base_session_id)
         if not subagent_name and not routing_subagent:
             stored_claude_session_id = self._reserved_native_session_id(context) or stored_claude_session_id
+        fork_source_claude_session_id: Optional[str] = None
+        if not stored_claude_session_id and not subagent_name and not routing_subagent:
+            fork_source_claude_session_id = pending_native_fork_source(context, "claude")
 
         # Read routing overrides via get_channel_routing which correctly
         # resolves DM users from the users store (not the stale channels store).
@@ -602,6 +606,10 @@ class SessionHandler(BaseHandler):
 
         explicit_model = subagent_model or routing_model_for_backend(routing, "claude")
         explicit_effort = subagent_reasoning_effort or routing_reasoning_effort_for_backend(routing, "claude")
+        session_target = payload.get("agent_session_target")
+        if isinstance(session_target, dict):
+            explicit_model = subagent_model or session_target.get("model") or explicit_model
+            explicit_effort = subagent_reasoning_effort or session_target.get("reasoning_effort") or explicit_effort
 
         if not effective_agent:
             # Claude SDK model changes are control requests; only send one when
@@ -678,11 +686,12 @@ class SessionHandler(BaseHandler):
                 base_session_id=base_session_id,
                 working_path=working_path,
                 session_key=session_key,
-                stored_claude_session_id=stored_claude_session_id,
+                stored_claude_session_id=fork_source_claude_session_id or stored_claude_session_id,
                 effective_agent=effective_agent,
                 explicit_model=explicit_model,
                 explicit_effort=explicit_effort,
                 agent_system_prompt=agent_system_prompt,
+                fork_session=bool(fork_source_claude_session_id),
             )
             if not create_future.done():
                 create_future.set_result(client)
@@ -711,6 +720,7 @@ class SessionHandler(BaseHandler):
         explicit_model: Optional[str],
         explicit_effort: Optional[str],
         agent_system_prompt: Optional[str],
+        fork_session: bool = False,
     ) -> ClaudeSDKClient:
 
         # Ensure working directory exists
@@ -794,6 +804,7 @@ class SessionHandler(BaseHandler):
             "cwd": working_path,
             "system_prompt": final_system_prompt,
             "resume": stored_claude_session_id if stored_claude_session_id else None,
+            "fork_session": bool(fork_session and stored_claude_session_id),
             "extra_args": extra_args,
             "setting_sources": ["user", "project", "local"],  # Load all setting sources (user, project CLAUDE.md, local overrides)
             "sandbox": CLAUDE_REMOTE_SANDBOX,
@@ -822,6 +833,7 @@ class SessionHandler(BaseHandler):
         logger.info(f"  Working directory: {working_path}")
         logger.info(f"  Resume session ID: {stored_claude_session_id}")
         logger.info(f"  Options.resume: {options.resume}")
+        logger.info(f"  Options.fork_session: {getattr(options, 'fork_session', False)}")
         if effective_agent:
             logger.info(f"  Subagent: {effective_agent}")
         if effective_model:
@@ -872,7 +884,12 @@ class SessionHandler(BaseHandler):
         self.claude_sessions[composite_key] = client
         self.claude_system_prompts[composite_key] = final_system_prompt
         setattr(client, "_vibe_current_model", effective_model)
-        self.bind_claude_runtime_session(client, base_session_id, composite_key, stored_claude_session_id)
+        self.bind_claude_runtime_session(
+            client,
+            base_session_id,
+            composite_key,
+            None if fork_session else stored_claude_session_id,
+        )
         self.touch_session_activity(composite_key)
         logger.info(f"Created new Claude SDK client for {base_session_id} at {working_path}")
 

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -594,6 +594,7 @@ def _build_session_context(
             "reasoning_effort": session_row.get("reasoning_effort"),
             "native_session_id": session_row.get("native_session_id"),
             "workdir": session_row.get("workdir"),
+            "metadata": session_row.get("metadata") or {},
             # Carry the stored anchor so SessionHandler.get_base_session_id reuses it
             # instead of computing ``avibe_<id>`` — otherwise, after a restart, new
             # dispatches look up the native-session map under the wrong anchor and

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -167,6 +167,7 @@ class ResolvedSessionIdTarget:
     reasoning_effort: Optional[str] = None
     workdir: Optional[str] = None
     session_anchor: Optional[str] = None
+    metadata: Optional[dict[str, Any]] = None
     suppress_delivery: bool = False
 
 
@@ -265,6 +266,7 @@ def resolve_session_id_target(session_id: str, *, db_path: Optional[Path] = None
         native_session_id=str(row["native_session_id"] or ""),
         workdir=row["workdir"],
         session_anchor=str(row["session_anchor"] or ""),
+        metadata=session_metadata if isinstance(session_metadata, dict) else {},
         suppress_delivery=suppress_delivery,
     )
 
@@ -1823,9 +1825,11 @@ class ScheduledTaskService:
         channel_id = session_target_context["channel_id"]
         if platform == "avibe" and session_id:
             channel_id = session_id
-        from core.services.session_fork import fork_metadata_from_request
+        from core.services.session_fork import fork_metadata_from_request, fork_metadata_from_session_metadata
 
         native_session_fork = fork_metadata_from_request(metadata)
+        if native_session_fork is None and target_info and not str(target_info.native_session_id or "").strip():
+            native_session_fork = fork_metadata_from_session_metadata(getattr(target_info, "metadata", None))
 
         return MessageContext(
             user_id=session_target_context["user_id"],
@@ -1874,6 +1878,7 @@ class ScheduledTaskService:
                         "native_session_fork": native_session_fork,
                         "workdir": target_info.workdir,
                         "session_anchor": target_info.session_anchor,
+                        "metadata": getattr(target_info, "metadata", None) or {},
                         "suppress_delivery": target_info.suppress_delivery,
                     }
                     if target_info

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -373,6 +373,7 @@ class TaskExecutionRequest:
     session_policy: Optional[str] = None
     callback_session_id: Optional[str] = None
     callback_status: Optional[str] = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -401,6 +402,7 @@ class TaskExecutionRequest:
             session_policy=payload.get("session_policy"),
             callback_session_id=payload.get("callback_session_id"),
             callback_status=payload.get("callback_status"),
+            metadata=payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
         )
 
 
@@ -772,6 +774,7 @@ class TaskExecutionStore:
         source_actor: Optional[str] = None,
         parent_run_id: Optional[str] = None,
         callback_session_id: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> TaskExecutionRequest:
         return self.enqueue(
             TaskExecutionRequest(
@@ -794,6 +797,7 @@ class TaskExecutionStore:
                 model=model,
                 reasoning_effort=reasoning_effort,
                 session_policy=session_policy,
+                metadata=dict(metadata or {}),
             )
         )
 
@@ -1536,6 +1540,7 @@ class ScheduledTaskService:
                     message=request.message,
                     execution_id=request.id,
                     agent_name=request.agent_name,
+                    metadata=request.metadata,
                 )
                 error = result.error
                 should_complete = result.complete_on_return
@@ -1611,6 +1616,7 @@ class ScheduledTaskService:
         execution_id: str,
         session_id: Optional[str] = None,
         agent_name: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> AgentRunExecutionResult:
         """Execute one direct Agent Run and wait for the real terminal result.
 
@@ -1637,6 +1643,7 @@ class ScheduledTaskService:
             session_id=session_id,
             agent_name=agent_name,
             target_info=target_info,
+            metadata=metadata,
         )
 
         gate = getattr(self.controller, "session_turn_gate", None)
@@ -1792,6 +1799,7 @@ class ScheduledTaskService:
         session_id: Optional[str] = None,
         agent_name: Optional[str] = None,
         target_info: Optional[ResolvedSessionIdTarget] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> MessageContext:
         platform = target.platform
         self.validate_platform(platform)
@@ -1815,6 +1823,9 @@ class ScheduledTaskService:
         channel_id = session_target_context["channel_id"]
         if platform == "avibe" and session_id:
             channel_id = session_id
+        from core.services.session_fork import fork_metadata_from_request
+
+        native_session_fork = fork_metadata_from_request(metadata)
 
         return MessageContext(
             user_id=session_target_context["user_id"],
@@ -1860,6 +1871,7 @@ class ScheduledTaskService:
                         "model": target_info.model,
                         "reasoning_effort": target_info.reasoning_effort,
                         "native_session_id": target_info.native_session_id,
+                        "native_session_fork": native_session_fork,
                         "workdir": target_info.workdir,
                         "session_anchor": target_info.session_anchor,
                         "suppress_delivery": target_info.suppress_delivery,

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -8,6 +8,7 @@ adapters to call their native fork API on the first turn.
 from __future__ import annotations
 
 import json
+import secrets
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -102,7 +103,9 @@ def reserve_forked_session(
             target_agent_id = override_agent.id if override_agent else row["agent_id"]
             target_agent_name = override_agent.name if override_agent else row["agent_name"]
             target_backend = override_agent.backend if override_agent else source_backend
-            target_variant = str(row["agent_variant"] or target_backend)
+            target_variant = target_backend if override_agent else str(row["agent_variant"] or target_backend)
+            now = utc_now_iso()
+            target_anchor = _fork_session_anchor(row["session_anchor"], source_session_id=str(row["id"]), now=now)
             target_model = _clean_optional(model) if model is not None else row["model"]
             target_effort = (
                 _clean_optional(reasoning_effort)
@@ -110,7 +113,6 @@ def reserve_forked_session(
                 else row["reasoning_effort"]
             )
 
-            now = utc_now_iso()
             metadata = _load_metadata(row["metadata_json"])
             metadata.update(
                 {
@@ -124,9 +126,10 @@ def reserve_forked_session(
             session_id = create_agent_session_row(
                 conn,
                 scope_id=row["scope_id"],
-                # A fork is an independent Avibe Session, so it needs a fresh
-                # anchor even when it stays under the same scope.
-                session_anchor=None,
+                # Keep IM delivery stable while satisfying the per-scope anchor
+                # uniqueness invariant. resolve_session_id_target strips the
+                # suffix after ":" when deriving the IM thread id.
+                session_anchor=target_anchor,
                 agent_id=target_agent_id,
                 agent_name=target_agent_name,
                 agent_backend=target_backend,
@@ -180,6 +183,23 @@ def fork_metadata_from_request(metadata: dict[str, Any] | None) -> dict[str, Any
     }
 
 
+def fork_metadata_from_session_metadata(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return pending fork metadata persisted on a fork target Session row."""
+
+    if not isinstance(metadata, dict):
+        return None
+    source_backend = _clean_optional(metadata.get("fork_source_backend"))
+    source_native = _clean_optional(metadata.get("fork_source_native_session_id"))
+    source_session = _clean_optional(metadata.get("fork_source_session_id"))
+    if not (source_backend and source_native and source_session):
+        return None
+    return {
+        "source_session_id": source_session,
+        "source_native_session_id": source_native,
+        "source_backend": source_backend,
+    }
+
+
 def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
     """Native source id if this turn should fork instead of start fresh."""
 
@@ -193,6 +213,8 @@ def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
     if str(target.get("native_session_id") or "").strip():
         return None
     fork = target.get("native_session_fork")
+    if not isinstance(fork, dict):
+        fork = fork_metadata_from_session_metadata(target.get("metadata"))
     if not isinstance(fork, dict):
         return None
     if str(fork.get("source_backend") or "").strip() != backend:
@@ -214,3 +236,11 @@ def _clean_optional(value: Any) -> Optional[str]:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _fork_session_anchor(value: Any, *, source_session_id: str, now: str) -> Optional[str]:
+    anchor = _clean_optional(value)
+    if not anchor or anchor == source_session_id:
+        return None
+    suffix = "".join(ch for ch in f"{source_session_id}_{now}" if ch.isalnum())
+    return f"{anchor}:fork_{suffix}_{secrets.token_hex(3)}"

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -1,0 +1,216 @@
+"""Fork Avibe Agent Sessions.
+
+This module owns the Avibe-level fork contract: validate the source Session,
+copy its row into a new pending Session, and carry enough metadata for backend
+adapters to call their native fork API on the first turn.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from config import paths
+
+
+class SessionForkError(ValueError):
+    """Raised when a Session cannot be forked."""
+
+
+@dataclass(frozen=True)
+class SessionForkSpec:
+    source_session_id: str
+    source_native_session_id: str
+    source_backend: str
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "source_session_id": self.source_session_id,
+            "source_native_session_id": self.source_native_session_id,
+            "source_backend": self.source_backend,
+        }
+
+
+@dataclass(frozen=True)
+class SessionForkResult:
+    session_id: str
+    agent_name: Optional[str]
+    agent_id: Optional[str]
+    agent_backend: str
+    model: Optional[str]
+    reasoning_effort: Optional[str]
+    fork: SessionForkSpec
+
+
+def reserve_forked_session(
+    *,
+    source_session_id: str,
+    agent_name: Optional[str] = None,
+    model: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> SessionForkResult:
+    """Copy an existing Agent Session row into a new pending fork target.
+
+    ``agent_name`` may switch to another enabled Avibe Agent only when that
+    Agent uses the same backend as the source. ``model`` and
+    ``reasoning_effort`` are simple per-session overrides. The new row's native
+    id stays empty until the backend adapter successfully forks the native
+    session.
+    """
+
+    from sqlalchemy import select
+
+    from core.vibe_agents import VibeAgentStore
+    from storage.agent_session_rows import create_agent_session_row, utc_now_iso
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
+    from storage.models import agent_sessions
+
+    path = db_path or paths.get_sqlite_state_path()
+    if db_path is None:
+        ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(paths.get_state_dir()))
+    engine = create_sqlite_engine(path)
+    agent_store = VibeAgentStore(path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == str(source_session_id)).limit(1)
+            ).mappings().first()
+            if row is None:
+                raise SessionForkError(f"agent session id not found: {source_session_id}")
+            if str(row["status"] or "") == "archived":
+                raise SessionForkError(f"agent session is archived: {source_session_id}")
+
+            source_backend = str(row["agent_backend"] or "").strip()
+            if source_backend not in {"codex", "claude", "opencode"}:
+                raise SessionForkError(f"session backend cannot be forked: {source_backend or 'unknown'}")
+            source_native = str(row["native_session_id"] or "").strip()
+            if not source_native:
+                raise SessionForkError(
+                    f"agent session has no native session id to fork: {source_session_id}"
+                )
+
+            override_agent = agent_store.require_enabled(agent_name) if agent_name else None
+            if override_agent is not None and override_agent.backend != source_backend:
+                raise SessionForkError(
+                    "agent backend does not match the source session backend"
+                )
+
+            target_agent_id = override_agent.id if override_agent else row["agent_id"]
+            target_agent_name = override_agent.name if override_agent else row["agent_name"]
+            target_backend = override_agent.backend if override_agent else source_backend
+            target_variant = str(row["agent_variant"] or target_backend)
+            target_model = _clean_optional(model) if model is not None else row["model"]
+            target_effort = (
+                _clean_optional(reasoning_effort)
+                if reasoning_effort is not None
+                else row["reasoning_effort"]
+            )
+
+            now = utc_now_iso()
+            metadata = _load_metadata(row["metadata_json"])
+            metadata.update(
+                {
+                    "created_via": "session_fork",
+                    "fork_source_session_id": str(row["id"]),
+                    "fork_source_native_session_id": source_native,
+                    "fork_source_backend": source_backend,
+                    "fork_created_at": now,
+                }
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=row["scope_id"],
+                # A fork is an independent Avibe Session, so it needs a fresh
+                # anchor even when it stays under the same scope.
+                session_anchor=None,
+                agent_id=target_agent_id,
+                agent_name=target_agent_name,
+                agent_backend=target_backend,
+                agent_variant=target_variant,
+                model=target_model,
+                reasoning_effort=target_effort,
+                workdir=row["workdir"],
+                native_session_id="",
+                title=row["title"],
+                metadata=metadata,
+                now=now,
+                require_workdir=False,
+            )
+
+        fork = SessionForkSpec(
+            source_session_id=str(source_session_id),
+            source_native_session_id=source_native,
+            source_backend=source_backend,
+        )
+        return SessionForkResult(
+            session_id=session_id,
+            agent_name=str(target_agent_name).strip() if target_agent_name else None,
+            agent_id=str(target_agent_id).strip() if target_agent_id else None,
+            agent_backend=target_backend,
+            model=target_model,
+            reasoning_effort=target_effort,
+            fork=fork,
+        )
+    finally:
+        agent_store.close()
+        engine.dispose()
+
+
+def fork_metadata_from_request(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return normalized pending fork metadata from an Agent Run record."""
+
+    if not isinstance(metadata, dict):
+        return None
+    fork = metadata.get("session_fork")
+    if not isinstance(fork, dict):
+        return None
+    source_backend = _clean_optional(fork.get("source_backend"))
+    source_native = _clean_optional(fork.get("source_native_session_id"))
+    source_session = _clean_optional(fork.get("source_session_id"))
+    if not (source_backend and source_native and source_session):
+        return None
+    return {
+        "source_session_id": source_session,
+        "source_native_session_id": source_native,
+        "source_backend": source_backend,
+    }
+
+
+def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
+    """Native source id if this turn should fork instead of start fresh."""
+
+    payload = getattr(context, "platform_specific", None) or {}
+    target = payload.get("agent_session_target")
+    if not isinstance(target, dict):
+        return None
+    target_backend = str(target.get("agent_backend") or "").strip()
+    if target_backend and target_backend != backend:
+        return None
+    if str(target.get("native_session_id") or "").strip():
+        return None
+    fork = target.get("native_session_fork")
+    if not isinstance(fork, dict):
+        return None
+    if str(fork.get("source_backend") or "").strip() != backend:
+        return None
+    source_native = str(fork.get("source_native_session_id") or "").strip()
+    return source_native or None
+
+
+def _load_metadata(value: Any) -> dict[str, Any]:
+    try:
+        loaded = json.loads(value or "{}")
+    except (TypeError, ValueError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _clean_optional(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from core.avibe_cloud import avibe_cloud_url_available
+from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 from modules.agents.base import AgentRequest, BaseAgent
 from modules.agents.subagent_router import SubagentDefinition, load_codex_subagent
@@ -586,6 +587,42 @@ class CodexAgent(BaseAgent):
         self._remember_thread_developer_instructions(request.base_session_id, thread_id, developer_instructions)
         return thread_id
 
+    async def _fork_thread(
+        self,
+        transport: CodexTransport,
+        request: AgentRequest,
+        source_thread_id: str,
+    ) -> str:
+        """Fork an existing Codex thread and bind the new thread id."""
+        self.ensure_agent_session_id(request)
+        _, effective_model, _, _ = self._resolve_codex_agent_settings(request)
+        params: Dict[str, Any] = {
+            "threadId": source_thread_id,
+            "cwd": request.working_path,
+            "approvalPolicy": "never",
+            "sandbox": "danger-full-access",
+        }
+        developer_instructions = self._build_thread_developer_instructions(request)
+        if developer_instructions:
+            params["developerInstructions"] = developer_instructions
+        if effective_model:
+            params["model"] = effective_model
+
+        resp = await transport.send_request("thread/fork", params)
+        thread_id = resp.get("id", "")
+        if not thread_id:
+            thread_obj = resp.get("thread")
+            if isinstance(thread_obj, dict):
+                thread_id = thread_obj.get("id", "")
+        if not thread_id:
+            raise RuntimeError("Codex thread/fork returned no thread id")
+
+        self._session_mgr.set_thread_id(request.base_session_id, thread_id)
+        self.bind_agent_session_id(request, thread_id)
+        self._remember_thread_developer_instructions(request.base_session_id, thread_id, developer_instructions)
+        logger.info("Forked Codex thread %s from %s for session %s", thread_id, source_thread_id, request.base_session_id)
+        return thread_id
+
     def _resolve_codex_agent_settings(
         self,
         request: AgentRequest,
@@ -704,6 +741,10 @@ class CodexAgent(BaseAgent):
             )
             logger.info("Resumed Codex thread %s for session %s", thread_id, request.base_session_id)
             return thread_id
+
+        fork_source = pending_native_fork_source(request.context, self.name)
+        if fork_source:
+            return await self._fork_thread(transport, request, fork_source)
 
         # No associated thread yet (genuinely first turn) — start fresh.
         return await self._start_thread(transport, request)

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -743,6 +743,19 @@ class OpenCodeServerManager:
                     raise RuntimeError(f"Failed to create session: {resp.status} {text}")
                 return await resp.json()
 
+    async def fork_session(self, source_session_id: str, directory: str) -> Dict[str, Any]:
+        async with self._request_scope():
+            session = await self._get_http_session()
+            async with session.post(
+                f"{self.base_url}/session/{source_session_id}/fork",
+                json={},
+                headers={"x-opencode-directory": directory},
+            ) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise RuntimeError(f"Failed to fork session: {resp.status} {text}")
+                return await resp.json()
+
     async def send_message(
         self,
         session_id: str,

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -12,6 +12,7 @@ import os
 import time
 from typing import Dict, Optional, Tuple
 
+from core.services.session_fork import pending_native_fork_source
 from modules.agents.base import AgentRequest, BaseAgent
 
 from .server import OpenCodeServerManager
@@ -248,14 +249,29 @@ class OpenCodeSessionManager:
         )
 
         if not session_id:
+            fork_source = pending_native_fork_source(request.context, self._agent_name)
             try:
-                session_data = await server.create_session(
-                    directory=request.working_path,
-                )
+                if fork_source:
+                    session_data = await server.fork_session(
+                        fork_source,
+                        directory=request.working_path,
+                    )
+                else:
+                    session_data = await server.create_session(
+                        directory=request.working_path,
+                    )
                 session_id = session_data.get("id")
                 if session_id:
                     self.bind_agent_session_id(request, anchor, session_id)
-                    logger.info(f"Created OpenCode session {session_id} for {request.base_session_id}")
+                    if fork_source:
+                        logger.info(
+                            "Forked OpenCode session %s from %s for %s",
+                            session_id,
+                            fork_source,
+                            request.base_session_id,
+                        )
+                    else:
+                        logger.info(f"Created OpenCode session {session_id} for {request.base_session_id}")
             except Exception as e:
                 logger.error(f"Failed to create OpenCode session: {e}", exc_info=True)
                 return None

--- a/storage/background.py
+++ b/storage/background.py
@@ -651,7 +651,10 @@ class SQLiteBackgroundTaskStore:
         if cancel_requested_at is not None:
             values["cancel_requested_at"] = cancel_requested_at
         if metadata is not None:
-            values["metadata_json"] = _json_dumps(metadata)
+            existing = self.get_run(run_id) or {}
+            merged = dict(existing.get("metadata") or {})
+            merged.update(metadata)
+            values["metadata_json"] = _json_dumps(merged)
         if callback_status is not None:
             values["callback_status"] = callback_status
         if callback_error is not None:
@@ -698,7 +701,10 @@ class SQLiteBackgroundTaskStore:
             "updated_at": now,
         }
         if metadata is not None:
-            values["metadata_json"] = _json_dumps(metadata)
+            existing = self.get_run(run_id) or {}
+            merged = dict(existing.get("metadata") or {})
+            merged.update(metadata)
+            values["metadata_json"] = _json_dumps(merged)
         with self.engine.begin() as conn:
             result = conn.execute(
                 update(agent_runs)
@@ -726,6 +732,10 @@ class SQLiteBackgroundTaskStore:
                     .values(status="canceled", completed_at=now, updated_at=now)
                 )
                 return False
+            metadata = _json_loads(row["metadata_json"], {})
+            if not isinstance(metadata, dict):
+                metadata = {}
+            metadata["workbench_queue_holds_run"] = False
             result = conn.execute(
                 update(agent_runs)
                 .where(agent_runs.c.id == run_id)
@@ -734,7 +744,7 @@ class SQLiteBackgroundTaskStore:
                     status="running",
                     started_at=now,
                     updated_at=now,
-                    metadata_json=_json_dumps({"workbench_queue_holds_run": False}),
+                    metadata_json=_json_dumps(metadata),
                 )
             )
             return bool(result.rowcount)
@@ -1026,6 +1036,7 @@ class SQLiteBackgroundTaskStore:
 
     @staticmethod
     def _run_from_row(row: Any) -> dict[str, Any]:
+        metadata = _json_loads(row["metadata_json"], {})
         return {
             "id": row["id"],
             "request_type": row["run_type"],
@@ -1068,7 +1079,8 @@ class SQLiteBackgroundTaskStore:
             "started_at": row["started_at"],
             "completed_at": row["completed_at"],
             "updated_at": row["updated_at"],
-            "metadata": _json_loads(row["metadata_json"], {}),
+            "metadata": metadata,
+            "session_fork": metadata.get("session_fork") if isinstance(metadata, dict) else None,
             "ok": None if row["completed_at"] is None else normalize_run_status(row["status"]) == "succeeded",
         }
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -169,6 +169,57 @@ def test_session_handler_keeps_sdk_default_for_default_claude_binary(monkeypatch
     assert captured["options"].cli_path is None
 
 
+def test_session_handler_sets_claude_fork_session_for_pending_native_fork(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+    class _ForkSessions(_Sessions):
+        @staticmethod
+        def get_claude_session_id(settings_key, base_session_id):
+            return None
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    controller.settings_manager.sessions = _ForkSessions()
+    handler = SessionHandler(controller)
+    context = MessageContext(
+        user_id="scheduled",
+        channel_id="ses-target",
+        platform="avibe",
+        platform_specific={
+            "agent_session_target": {
+                "id": "ses-target",
+                "agent_backend": "claude",
+                "native_session_id": "",
+                "model": "claude-sonnet-4-5",
+                "reasoning_effort": "high",
+                "native_session_fork": {
+                    "source_session_id": "ses-source",
+                    "source_native_session_id": "claude-source",
+                    "source_backend": "claude",
+                },
+            }
+        },
+    )
+
+    client = _run_session(handler, context)
+
+    assert captured["connected"] is True
+    assert captured["options"].resume == "claude-source"
+    assert captured["options"].fork_session is True
+    assert captured["options"].extra_args == {"model": "claude-sonnet-4-5"}
+    assert captured["options"].effort == "high"
+    assert not hasattr(client, "_vibe_native_session_id")
+
+
 def test_session_handler_disallows_remote_unsafe_claude_tools(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, Any] = {}
 

--- a/tests/test_cli_agent_run_schema.py
+++ b/tests/test_cli_agent_run_schema.py
@@ -308,9 +308,11 @@ def test_agent_run_fork_session_reserves_new_session_and_persists_metadata(tmp_p
     finally:
         engine.dispose()
     assert row["agent_name"] == "reviewer"
+    assert row["agent_variant"] == "codex"
     assert row["native_session_id"] == ""
     assert row["model"] == "gpt-5.2"
     assert row["reasoning_effort"] == "low"
+    assert row["session_anchor"] == payload["session_id"]
 
 
 def test_agent_run_fork_rejects_cross_backend_agent(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli_agent_run_schema.py
+++ b/tests/test_cli_agent_run_schema.py
@@ -195,6 +195,152 @@ def _read_session_workdir(db_path: Path, session_id: str):
         ).scalar_one()
 
 
+def _seed_bound_session(db_path: Path, tmp_path: Path) -> str:
+    from storage.agent_session_rows import create_agent_session_row
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state()
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            scope_id = upsert_scope(
+                conn,
+                platform="avibe",
+                scope_type="project",
+                native_id="proj_fork_cli",
+                now="2026-06-16T00:00:00Z",
+            )
+            conn.execute(
+                scope_settings.insert().values(
+                    scope_id=scope_id,
+                    enabled=1,
+                    role=None,
+                    workdir=str(tmp_path),
+                    agent_name="worker",
+                    agent_backend="codex",
+                    agent_variant="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    require_mention=None,
+                    settings_version=1,
+                    settings_json="{}",
+                    created_at="2026-06-16T00:00:00Z",
+                    updated_at="2026-06-16T00:00:00Z",
+                )
+            )
+            return create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                session_anchor=None,
+                agent_backend="codex",
+                agent_variant="codex",
+                agent_id="agent-worker",
+                agent_name="worker",
+                model="gpt-5",
+                reasoning_effort="medium",
+                workdir=str(tmp_path),
+                native_session_id="thread-source",
+            )
+    finally:
+        engine.dispose()
+
+
+def test_agent_run_fork_session_reserves_new_session_and_persists_metadata(tmp_path: Path, capsys) -> None:
+    from sqlalchemy import select
+
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import agent_sessions
+
+    state_home = tmp_path / "home"
+    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+        ensure_sqlite_state()
+        db_path = state_home / "state" / "vibe.sqlite"
+        source_session_id = _seed_bound_session(db_path, tmp_path)
+        agent_store = cli.VibeAgentStore(db_path)
+        agent_store.create(name="reviewer", backend="codex", model="gpt-5.1", reasoning_effort="high")
+        request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
+        args = _parse_agent_run(
+            [
+                "--fork-session",
+                source_session_id,
+                "--agent",
+                "reviewer",
+                "--model",
+                "gpt-5.2",
+                "--reasoning-effort",
+                "low",
+                "--async",
+                "--message",
+                "continue from here",
+            ]
+        )
+
+        with (
+            patch("vibe.cli._agent_store", return_value=agent_store),
+            patch("vibe.cli._task_request_store", return_value=request_store),
+            patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+            patch("vibe.cli._primary_platform", return_value="slack"),
+        ):
+            result = cli.cmd_agent_run(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["session_policy"] == "fork"
+    assert payload["forked_from_session_id"] == source_session_id
+    assert payload["session_id"] != source_session_id
+
+    run = request_store.get_run(payload["run_id"])
+    assert run is not None
+    assert run["metadata"]["session_fork"]["source_native_session_id"] == "thread-source"
+    assert run["model"] == "gpt-5.2"
+    assert run["reasoning_effort"] == "low"
+
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == payload["session_id"])
+            ).mappings().one()
+    finally:
+        engine.dispose()
+    assert row["agent_name"] == "reviewer"
+    assert row["native_session_id"] == ""
+    assert row["model"] == "gpt-5.2"
+    assert row["reasoning_effort"] == "low"
+
+
+def test_agent_run_fork_rejects_cross_backend_agent(tmp_path: Path, capsys) -> None:
+    from storage.importer import ensure_sqlite_state
+
+    state_home = tmp_path / "home"
+    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+        ensure_sqlite_state()
+        db_path = state_home / "state" / "vibe.sqlite"
+        source_session_id = _seed_bound_session(db_path, tmp_path)
+        agent_store = cli.VibeAgentStore(db_path)
+        agent_store.create(name="claude-worker", backend="claude")
+        request_store = cli.TaskExecutionStore(tmp_path / "task_requests")
+        args = _parse_agent_run(
+            ["--fork-session", source_session_id, "--agent", "claude-worker", "--async", "--message", "hi"]
+        )
+
+        with (
+            patch("vibe.cli._agent_store", return_value=agent_store),
+            patch("vibe.cli._task_request_store", return_value=request_store),
+            patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+        ):
+            result = cli.cmd_agent_run(args)
+
+    assert result == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out or captured.err)
+    assert payload["code"] == "session_fork_failed"
+
+
 def test_agent_run_private_session_workdir_follows_invocation_cwd(tmp_path: Path, capsys, monkeypatch) -> None:
     """A private (no --deliver-key) reservation snapshots the CLI invocation's
     cwd as the new session's workdir — like every other CLI tool — instead of

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1219,6 +1219,64 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(method, "thread/resume")
         self.assertEqual(params["threadId"], "native-reserved")
 
+    async def test_start_or_resume_thread_forks_pending_native_source(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model="gpt-5.2",
+            vibe_agent_reasoning_effort="high",
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        method, params = transport.send_request.await_args.args
+        self.assertEqual(method, "thread/fork")
+        self.assertEqual(params["threadId"], "thread-source")
+        self.assertEqual(params["cwd"], "/tmp/work")
+        self.assertEqual(params["approvalPolicy"], "never")
+        self.assertEqual(params["sandbox"], "danger-full-access")
+        self.assertEqual(params["model"], "gpt-5.2")
+        self.assertNotIn("effort", params)
+        agent.sessions.bind_agent_session.assert_called_once_with(
+            "avibe::project::proj_1",
+            "codex",
+            "ses-target",
+            "thread-fork",
+        )
+
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the
         # reserved MAIN native.

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -335,6 +335,12 @@ def test_dispatch_forwards_session_routing_into_platform_specific(monkeypatch, t
             agent_name="contract-bot",
             model="claude-sonnet-4-6",
             reasoning_effort="high",
+            metadata={
+                "created_via": "session_fork",
+                "fork_source_session_id": "ses-source",
+                "fork_source_native_session_id": "thread-source",
+                "fork_source_backend": "claude",
+            },
         )
     session_id = session["id"]
 
@@ -373,6 +379,7 @@ def test_dispatch_forwards_session_routing_into_platform_specific(monkeypatch, t
     # restart instead of a computed avibe_<id> (Codex P2). Workbench sessions
     # self-anchor to their id.
     assert target.get("session_anchor") == session_id
+    assert target.get("metadata", {}).get("fork_source_native_session_id") == "thread-source"
 
 
 def test_dispatch_async_starts_turn_and_returns_202(monkeypatch, tmp_path):

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -69,6 +69,45 @@ def test_opencode_create_session_does_not_pass_vibe_title() -> None:
     server.create_session.assert_awaited_once_with(directory="/repo")
 
 
+def test_opencode_forks_pending_native_source() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(fork_session=AsyncMock(return_value={"id": "oc-fork"}), create_session=AsyncMock())
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+            },
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo")
+    server.create_session.assert_not_awaited()
+    sessions.bind_agent_session_by_id.assert_called_once_with(
+        "ses-fork",
+        "oc-fork",
+        workdir="/repo",
+        vibe_agent_id=None,
+        vibe_agent_name=None,
+        vibe_agent_backend=None,
+    )
+
+
 def test_opencode_reserved_agent_session_id_is_not_replaced() -> None:
     sessions = SimpleNamespace(
         get_agent_session_id=Mock(return_value="oc-session-1"),

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -699,6 +699,59 @@ def test_build_context_carries_pending_native_fork_metadata() -> None:
 
     session_target = context.platform_specific["agent_session_target"]
     assert session_target["native_session_id"] == ""
+    assert session_target["metadata"] == {}
+    assert session_target["native_session_fork"] == {
+        "source_session_id": "ses-source",
+        "source_native_session_id": "thread-source",
+        "source_backend": "codex",
+    }
+
+
+def test_build_context_restores_pending_fork_from_session_metadata_when_run_metadata_missing() -> None:
+    controller = SimpleNamespace(
+        platform_settings_managers={},
+        im_clients={"avibe": SimpleNamespace()},
+        get_im_client_for_context=lambda _context: SimpleNamespace(
+            should_use_thread_for_reply=lambda: True,
+            should_use_thread_for_dm_session=lambda: False,
+        ),
+    )
+    service = ScheduledTaskService(controller=controller, store=ScheduledTaskStore(Path("/tmp/nonexistent-scheduled.json")))
+    target = ParsedSessionKey(platform="avibe", scope_type="project", scope_id="proj_890721e64fc8")
+    target_info = SimpleNamespace(
+        session_id="ses-target",
+        agent_id="agent-1",
+        agent_name="worker",
+        agent_backend="codex",
+        agent_variant="codex",
+        model="gpt-5",
+        reasoning_effort="high",
+        native_session_id="",
+        workdir="/tmp/work",
+        session_anchor="ses-target",
+        metadata={
+            "created_via": "session_fork",
+            "fork_source_session_id": "ses-source",
+            "fork_source_native_session_id": "thread-source",
+            "fork_source_backend": "codex",
+        },
+        suppress_delivery=False,
+    )
+
+    context = asyncio.run(
+        service._build_context(
+            target,
+            execution_id="exec-1",
+            trigger_kind="agent_run",
+            session_id="ses-target",
+            agent_name="worker",
+            target_info=target_info,
+            metadata={},
+        )
+    )
+
+    session_target = context.platform_specific["agent_session_target"]
+    assert session_target["metadata"]["fork_source_native_session_id"] == "thread-source"
     assert session_target["native_session_fork"] == {
         "source_session_id": "ses-source",
         "source_native_session_id": "thread-source",

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -654,6 +654,58 @@ def test_build_context_avibe_keys_on_session_id_not_project() -> None:
     assert context.platform_specific["session_key_external"] == "avibe::project::proj_890721e64fc8"
 
 
+def test_build_context_carries_pending_native_fork_metadata() -> None:
+    controller = SimpleNamespace(
+        platform_settings_managers={},
+        im_clients={"avibe": SimpleNamespace()},
+        get_im_client_for_context=lambda _context: SimpleNamespace(
+            should_use_thread_for_reply=lambda: True,
+            should_use_thread_for_dm_session=lambda: False,
+        ),
+    )
+    service = ScheduledTaskService(controller=controller, store=ScheduledTaskStore(Path("/tmp/nonexistent-scheduled.json")))
+    target = ParsedSessionKey(platform="avibe", scope_type="project", scope_id="proj_890721e64fc8")
+    target_info = SimpleNamespace(
+        session_id="ses-target",
+        agent_id="agent-1",
+        agent_name="worker",
+        agent_backend="codex",
+        agent_variant="codex",
+        model="gpt-5",
+        reasoning_effort="high",
+        native_session_id="",
+        workdir="/tmp/work",
+        session_anchor="ses-target",
+        suppress_delivery=False,
+    )
+
+    context = asyncio.run(
+        service._build_context(
+            target,
+            execution_id="exec-1",
+            trigger_kind="agent_run",
+            session_id="ses-target",
+            agent_name="worker",
+            target_info=target_info,
+            metadata={
+                "session_fork": {
+                    "source_session_id": "ses-source",
+                    "source_native_session_id": "thread-source",
+                    "source_backend": "codex",
+                }
+            },
+        )
+    )
+
+    session_target = context.platform_specific["agent_session_target"]
+    assert session_target["native_session_id"] == ""
+    assert session_target["native_session_fork"] == {
+        "source_session_id": "ses-source",
+        "source_native_session_id": "thread-source",
+        "source_backend": "codex",
+    }
+
+
 def test_build_context_clears_provisional_anchor_for_cross_scope_delivery() -> None:
     settings_manager = SimpleNamespace(get_store=lambda: SimpleNamespace(get_user=lambda *_args, **_kwargs: None))
     controller = SimpleNamespace(
@@ -1580,6 +1632,88 @@ def test_busy_avibe_agent_run_returns_to_queued_and_is_held_by_workbench_queue(m
     assert (run.get("metadata") or {}).get("workbench_queue_holds_run") is True
     assert submitted == [(session_id, "run behind active workbench turn", request.id)]
     assert handler_calls == []
+
+
+def test_busy_avibe_agent_run_requeue_preserves_session_fork_metadata(monkeypatch, tmp_path) -> None:
+    session_id = _make_avibe_session(monkeypatch, tmp_path)
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id=session_id,
+        message="run behind active workbench turn",
+        agent_name="codex",
+        metadata={
+            "session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "thread-source",
+                "source_backend": "codex",
+            }
+        },
+    )
+    submitted: list[tuple] = []
+
+    async def _submit_scheduled(sid, ctx, text):
+        submitted.append((sid, text, ctx.platform_specific["agent_session_target"]["native_session_fork"]))
+        return "enqueued"
+
+    async def _handle_scheduled_message(context, message, parsed_session_key=None):
+        raise AssertionError("busy workbench runs should not dispatch directly")
+
+    gate = SimpleNamespace(submit_scheduled=_submit_scheduled, in_flight={session_id: object()})
+    controller = _avibe_controller_double(gate=gate, handle_scheduled_message=_handle_scheduled_message)
+    service = ScheduledTaskService(
+        controller=controller,
+        store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=request_store,
+    )
+
+    async def _exercise() -> None:
+        await service._drain_requests()
+        execution = service._inflight_executions.get(request.id)
+        assert execution is not None
+        await execution
+
+    asyncio.run(_exercise())
+
+    run = request_store.get_run(request.id)
+    assert run is not None
+    assert run["metadata"]["session_fork"]["source_native_session_id"] == "thread-source"
+    assert run["metadata"]["workbench_queue_holds_run"] is True
+    assert submitted[0][2]["source_native_session_id"] == "thread-source"
+
+
+def test_workbench_queue_flush_recovery_preserves_session_fork_metadata(monkeypatch, tmp_path) -> None:
+    session_id = _make_avibe_session(monkeypatch, tmp_path)
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id=session_id,
+        message="recover fork after queue flush",
+        agent_name="codex",
+        metadata={
+            "session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "thread-source",
+                "source_backend": "codex",
+            },
+            "workbench_queue_holds_run": True,
+        },
+    )
+
+    sqlite_store = request_store._sqlite
+    assert sqlite_store is not None
+    assert sqlite_store.claim_queued_run_for_workbench(request.id) is True
+
+    flushed = request_store.get_run(request.id)
+    assert flushed is not None
+    assert flushed["status"] == "running"
+    assert flushed["metadata"]["workbench_queue_holds_run"] is False
+    assert flushed["metadata"]["session_fork"]["source_native_session_id"] == "thread-source"
+
+    request_store.recover_processing()
+    claimed = request_store.claim(request.id)
+
+    assert claimed is not None
+    assert claimed.metadata["workbench_queue_holds_run"] is False
+    assert claimed.metadata["session_fork"]["source_native_session_id"] == "thread-source"
 
 
 def test_drain_requests_reserves_watch_create_per_run_before_session_validation(tmp_path: Path) -> None:

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -5,7 +5,13 @@ from pathlib import Path
 import pytest
 from sqlalchemy import select
 
-from core.services.session_fork import SessionForkError, pending_native_fork_source, reserve_forked_session
+from core.services.session_fork import (
+    SessionForkError,
+    fork_metadata_from_session_metadata,
+    pending_native_fork_source,
+    reserve_forked_session,
+)
+from core.scheduled_tasks import resolve_session_id_target
 from core.vibe_agents import VibeAgentStore
 from modules.im import MessageContext
 from storage.agent_session_rows import create_agent_session_row
@@ -94,12 +100,86 @@ def test_reserve_forked_session_copies_row_and_applies_overrides(tmp_path: Path)
 
     assert row["agent_name"] == "reviewer"
     assert row["agent_backend"] == "codex"
+    assert row["agent_variant"] == "codex"
     assert row["model"] == "gpt-5.2"
     assert row["reasoning_effort"] == "low"
     assert row["workdir"] == str(tmp_path)
     assert row["native_session_id"] == ""
     assert row["session_anchor"] == result.session_id
     assert row["title"] == "Source"
+
+
+def test_reserve_forked_session_keeps_im_anchor_and_resets_variant_for_agent_override(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    SQLiteSessionsService(db_path).close()
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            scope_id = upsert_scope(
+                conn,
+                platform="slack",
+                scope_type="channel",
+                native_id="C123",
+                now="2026-06-16T00:00:00Z",
+            )
+            conn.execute(
+                scope_settings.insert().values(
+                    scope_id=scope_id,
+                    enabled=1,
+                    role=None,
+                    workdir=str(tmp_path),
+                    agent_name="worker",
+                    agent_backend="codex",
+                    agent_variant="reviewer",
+                    model=None,
+                    reasoning_effort=None,
+                    require_mention=None,
+                    settings_version=1,
+                    settings_json="{}",
+                    created_at="2026-06-16T00:00:00Z",
+                    updated_at="2026-06-16T00:00:00Z",
+                )
+            )
+            source_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                session_anchor="slack_171717.123",
+                agent_backend="codex",
+                agent_variant="reviewer",
+                agent_id="agent-worker",
+                agent_name="worker",
+                workdir=str(tmp_path),
+                native_session_id="thread-source",
+            )
+    finally:
+        engine.dispose()
+    store = VibeAgentStore(db_path)
+    try:
+        store.create(name="auditor", backend="codex")
+    finally:
+        store.close()
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        agent_name="auditor",
+        db_path=db_path,
+    )
+
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    assert row["agent_name"] == "auditor"
+    assert row["agent_variant"] == "codex"
+    assert row["session_anchor"].startswith("slack_171717.123:fork_")
+
+    resolved = resolve_session_id_target(result.session_id, db_path=db_path)
+    assert resolved.session_key.to_key() == "slack::channel::C123::thread::171717.123"
 
 
 def test_reserve_forked_session_rejects_backend_change(tmp_path: Path) -> None:
@@ -164,3 +244,41 @@ def test_pending_native_fork_source_requires_empty_target_native() -> None:
     ctx.platform_specific["agent_session_target"]["agent_backend"] = "codex"
     ctx.platform_specific["agent_session_target"]["native_session_id"] = "thread-existing"
     assert pending_native_fork_source(ctx, "codex") is None
+
+
+def test_pending_native_fork_source_uses_target_session_metadata() -> None:
+    ctx = MessageContext(
+        user_id="U1",
+        channel_id="C1",
+        platform_specific={
+            "agent_session_target": {
+                "id": "ses-target",
+                "agent_backend": "codex",
+                "native_session_id": "",
+                "metadata": {
+                    "created_via": "session_fork",
+                    "fork_source_session_id": "ses-source",
+                    "fork_source_native_session_id": "thread-source",
+                    "fork_source_backend": "codex",
+                },
+            }
+        },
+    )
+
+    assert pending_native_fork_source(ctx, "codex") == "thread-source"
+
+
+def test_fork_metadata_from_session_metadata_uses_pending_row_fields() -> None:
+    metadata = {
+        "created_via": "session_fork",
+        "fork_source_session_id": "ses-source",
+        "fork_source_native_session_id": "thread-source",
+        "fork_source_backend": "codex",
+    }
+
+    assert fork_metadata_from_session_metadata(metadata) == {
+        "source_session_id": "ses-source",
+        "source_native_session_id": "thread-source",
+        "source_backend": "codex",
+    }
+    assert fork_metadata_from_session_metadata({"created_via": "session_fork"}) is None

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from core.services.session_fork import SessionForkError, pending_native_fork_source, reserve_forked_session
+from core.vibe_agents import VibeAgentStore
+from modules.im import MessageContext
+from storage.agent_session_rows import create_agent_session_row
+from storage.db import create_sqlite_engine
+from storage.models import agent_sessions, scope_settings
+from storage.sessions_service import SQLiteSessionsService
+from storage.settings_service import upsert_scope
+
+
+def _seed_source_session(db_path: Path, tmp_path: Path) -> str:
+    SQLiteSessionsService(db_path).close()
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            scope_id = upsert_scope(
+                conn,
+                platform="avibe",
+                scope_type="project",
+                native_id="proj_fork",
+                now="2026-06-16T00:00:00Z",
+            )
+            conn.execute(
+                scope_settings.insert().values(
+                    scope_id=scope_id,
+                    enabled=1,
+                    role=None,
+                    workdir=str(tmp_path),
+                    agent_name="worker",
+                    agent_backend="codex",
+                    agent_variant="codex",
+                    model="gpt-5",
+                    reasoning_effort="medium",
+                    require_mention=None,
+                    settings_version=1,
+                    settings_json="{}",
+                    created_at="2026-06-16T00:00:00Z",
+                    updated_at="2026-06-16T00:00:00Z",
+                )
+            )
+            return create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                session_anchor=None,
+                agent_backend="codex",
+                agent_variant="codex",
+                agent_id="agent-worker",
+                agent_name="worker",
+                model="gpt-5",
+                reasoning_effort="medium",
+                workdir=str(tmp_path),
+                native_session_id="thread-source",
+                title="Source",
+                metadata={"created_via": "test"},
+            )
+    finally:
+        engine.dispose()
+
+
+def test_reserve_forked_session_copies_row_and_applies_overrides(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    store = VibeAgentStore(db_path)
+    try:
+        store.create(name="reviewer", backend="codex", model="gpt-5.1", reasoning_effort="high")
+    finally:
+        store.close()
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        agent_name="reviewer",
+        model="gpt-5.2",
+        reasoning_effort="low",
+        db_path=db_path,
+    )
+
+    assert result.session_id != source_id
+    assert result.fork.source_native_session_id == "thread-source"
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    assert row["agent_name"] == "reviewer"
+    assert row["agent_backend"] == "codex"
+    assert row["model"] == "gpt-5.2"
+    assert row["reasoning_effort"] == "low"
+    assert row["workdir"] == str(tmp_path)
+    assert row["native_session_id"] == ""
+    assert row["session_anchor"] == result.session_id
+    assert row["title"] == "Source"
+
+
+def test_reserve_forked_session_rejects_backend_change(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    store = VibeAgentStore(db_path)
+    try:
+        store.create(name="claude-worker", backend="claude")
+    finally:
+        store.close()
+
+    with pytest.raises(SessionForkError, match="backend"):
+        reserve_forked_session(
+            source_session_id=source_id,
+            agent_name="claude-worker",
+            db_path=db_path,
+        )
+
+
+def test_reserve_forked_session_agent_override_keeps_source_model_when_not_overridden(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    store = VibeAgentStore(db_path)
+    try:
+        store.create(name="reviewer", backend="codex", model="agent-model", reasoning_effort="agent-effort")
+    finally:
+        store.close()
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        agent_name="reviewer",
+        db_path=db_path,
+    )
+
+    assert result.agent_name == "reviewer"
+    assert result.model == "gpt-5"
+    assert result.reasoning_effort == "medium"
+
+
+def test_pending_native_fork_source_requires_empty_target_native() -> None:
+    ctx = MessageContext(
+        user_id="U1",
+        channel_id="C1",
+        platform_specific={
+            "agent_session_target": {
+                "id": "ses-target",
+                "agent_backend": "codex",
+                "native_session_id": "",
+                "native_session_fork": {
+                    "source_session_id": "ses-source",
+                    "source_native_session_id": "thread-source",
+                    "source_backend": "codex",
+                },
+            }
+        },
+    )
+
+    assert pending_native_fork_source(ctx, "codex") == "thread-source"
+    assert pending_native_fork_source(ctx, "claude") is None
+    ctx.platform_specific["agent_session_target"]["agent_backend"] = "claude"
+    assert pending_native_fork_source(ctx, "codex") is None
+    ctx.platform_specific["agent_session_target"]["agent_backend"] = "codex"
+    ctx.platform_specific["agent_session_target"]["native_session_id"] = "thread-existing"
+    assert pending_native_fork_source(ctx, "codex") is None

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -2565,6 +2565,7 @@ def cmd_agent_import(args):
 
 def _validate_run_session_policy(args, *, help_command: str) -> str:
     session_id = (getattr(args, "session_id", None) or "").strip()
+    fork_session = (getattr(args, "fork_session", None) or "").strip()
     create_session = bool(getattr(args, "create_session", False))
     create_per_run = bool(getattr(args, "create_session_per_run", False))
     if bool(getattr(args, "async_run", False)) and getattr(args, "wait_timeout", None) is not None:
@@ -2579,6 +2580,23 @@ def _validate_run_session_policy(args, *, help_command: str) -> str:
             "--callback-session-id requires --async",
             code="callback_requires_async",
             hint="Callback delivery happens after an asynchronous run completes.",
+            help_command=help_command,
+        )
+    if fork_session and (session_id or create_session or create_per_run):
+        raise TaskCliError(
+            "use --fork-session without --session-id or session creation flags",
+            code="conflicting_session_policy",
+            hint="Fork creates a new Session from the source Session.",
+            help_command=help_command,
+        )
+    if not fork_session and (
+        (getattr(args, "model", None) or "").strip()
+        or (getattr(args, "reasoning_effort", None) or "").strip()
+    ):
+        raise TaskCliError(
+            "--model and --reasoning-effort are only valid with --fork-session",
+            code="fork_override_without_fork",
+            hint="Use --agent, --model, and --reasoning-effort as overrides when forking a Session.",
             help_command=help_command,
         )
     if session_id and (create_session or create_per_run):
@@ -2600,6 +2618,8 @@ def _validate_run_session_policy(args, *, help_command: str) -> str:
             hint="Use --create-session for a one-shot agent run.",
             help_command=help_command,
         )
+    if fork_session:
+        return "fork"
     if create_session:
         return "create"
     if session_id:
@@ -2793,6 +2813,33 @@ def _reserve_cli_session(*, agent, deliver_key: Optional[str], workdir: Optional
     return session_id
 
 
+def _reserve_forked_cli_session(
+    *,
+    source_session_id: str,
+    agent_name: Optional[str],
+    model: Optional[str],
+    reasoning_effort: Optional[str],
+):
+    from core.services.session_fork import SessionForkError, reserve_forked_session
+
+    try:
+        return reserve_forked_session(
+            source_session_id=source_session_id,
+            agent_name=agent_name or None,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            db_path=paths.get_sqlite_state_path(),
+        )
+    except SessionForkError as exc:
+        raise TaskCliError(
+            str(exc),
+            code="session_fork_failed",
+            hint="Fork requires a bound source Session and, when overriding --agent, the same backend.",
+            help_command="vibe agent run --help",
+            details={"source_session_id": source_session_id},
+        ) from exc
+
+
 def _reserve_definition_session(*, agent_name: Optional[str], deliver_key: str, help_command: str) -> str:
     from core.services import sessions as sessions_service
 
@@ -2838,7 +2885,7 @@ def cmd_agent_run(args):
                 hint="Pass --agent with the Avibe Agent name to run.",
                 help_command="vibe agent run --help",
             )
-        if session_policy == "none" and (args.deliver_key or args.post_to):
+        if session_policy in {"none", "fork"} and (args.deliver_key or args.post_to):
             raise TaskCliError(
                 "delivery options require --session-id or --create-session",
                 code="delivery_target_without_session_policy",
@@ -2847,12 +2894,30 @@ def cmd_agent_run(args):
             )
         session_id = (args.session_id or "").strip() or None
         session_key = ""
+        if session_policy == "fork" and (args.cwd or "").strip():
+            raise TaskCliError(
+                "--cwd only applies when this run creates a blank session",
+                code="cwd_with_fork_session",
+                hint="A fork copies the source Session working directory.",
+                help_command="vibe agent run --help",
+            )
         run_cwd = _resolve_run_cwd(args, session_policy=session_policy, help_command="vibe agent run --help")
         agent = _agent_store().require_enabled(agent_name) if agent_name else None
+        fork_result = None
         if session_policy == "create":
             session_id = _reserve_cli_session(agent=agent, deliver_key=args.deliver_key, workdir=run_cwd)
         elif session_policy == "none":
             session_id = _reserve_cli_session(agent=agent, deliver_key=None, workdir=run_cwd)
+        elif session_policy == "fork":
+            fork_result = _reserve_forked_cli_session(
+                source_session_id=(args.fork_session or "").strip(),
+                agent_name=agent_name or None,
+                model=args.model,
+                reasoning_effort=args.reasoning_effort,
+            )
+            session_id = fork_result.session_id
+            if agent_name:
+                agent = _agent_store().require_enabled(agent_name)
         if session_id:
             target = resolve_session_id_target(session_id)
             session_key = target.session_key.to_key()
@@ -2878,8 +2943,10 @@ def cmd_agent_run(args):
             agent_name=agent.name if agent else None,
             agent_id=agent.id if agent else None,
             agent_backend=agent.backend if agent else None,
-            model=agent.model if agent else None,
-            reasoning_effort=agent.reasoning_effort if agent else None,
+            model=fork_result.model if fork_result else (agent.model if agent else None),
+            reasoning_effort=(
+                fork_result.reasoning_effort if fork_result else (agent.reasoning_effort if agent else None)
+            ),
             session_policy=session_policy,
             session_key=session_key,
             session_id=session_id,
@@ -2887,6 +2954,11 @@ def cmd_agent_run(args):
             deliver_key=args.deliver_key,
             message=message,
             callback_session_id=callback_session_id,
+            metadata={
+                "session_fork": fork_result.fork.to_metadata(),
+            }
+            if fork_result
+            else None,
         )
         payload = {
             "accepted": True,
@@ -2908,6 +2980,10 @@ def cmd_agent_run(args):
                 "callback_session_id": callback_session_id,
             },
         }
+        if fork_result:
+            payload["forked_from_session_id"] = fork_result.fork.source_session_id
+        if fork_result:
+            payload["run"]["forked_from_session_id"] = fork_result.fork.source_session_id
         if not args.async_run:
             payload["run"] = _wait_for_run_result(request_store, request.id, wait_timeout=args.wait_timeout)
         _print_cli_payload("agent_run", **payload)
@@ -5812,9 +5888,12 @@ def build_parser():
     )
     agent_run_parser.add_argument("--agent", help="Avibe Agent name")
     agent_run_parser.add_argument("--session-id", help="Existing Agent Session ID to continue")
+    agent_run_parser.add_argument("--fork-session", help="Existing Agent Session ID to fork into a new Session")
     agent_run_parser.add_argument("--create-session", action="store_true", help="Create a new Avibe Session ID before running")
     agent_run_parser.add_argument("--create-session-per-run", action="store_true", help="Create a new Avibe Session ID for each definition run")
     agent_run_parser.add_argument("--deliver-key", help="Scope ID used as delivery target when creating or sending to a target")
+    agent_run_parser.add_argument("--model", help="Model override for the new forked Session")
+    agent_run_parser.add_argument("--reasoning-effort", help="Reasoning effort override for the new forked Session")
     agent_run_parser.add_argument(
         "--cwd",
         help=(


### PR DESCRIPTION
## Summary

- add `vibe agent run --fork-session` to reserve a copied Avibe Agent Session and run in the forked target
- carry native fork metadata through Agent Run execution, workbench queue/recovery, and session target context
- wire native forks for Codex `thread/fork`, Claude `fork_session`, and OpenCode `/session/{id}/fork`

## Evidence

- Unit: session fork validation, CLI run schema, scheduled/workbench queue metadata preservation
- Contract: Codex, Claude, and OpenCode adapter tests cover first-turn native fork binding
- Scenario: fork existing session, reject backend-changing agent override, override agent/model/reasoning on same backend
- Manual: verified Codex app-server schema exposes stable `thread/fork`

## Notes

- No scenario catalog entry was found for this backend capability.
