### PR TITLE
fix(agents): serialize runtime session turns

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1509,38 +1509,55 @@ class AgentAuthService:
 
     async def _refresh_backend_runtime(self, backend: str) -> None:
         agent_service = getattr(self.controller, "agent_service", None)
-        refresh_runtime_config = getattr(agent_service, "refresh_runtime_config", None)
-        runtime_config = None
-        if callable(refresh_runtime_config):
-            runtime_config = self._load_backend_runtime_config(backend)
-            if runtime_config is None:
-                await self._unregister_disabled_backend_agent(backend)
-                return
-            if runtime_config is not None and self._register_missing_backend_agent(backend, runtime_config):
-                return
-            if runtime_config is not None and await refresh_runtime_config(backend, runtime_config):
-                active_default = self._revalidate_runtime_default_backend(self._load_saved_default_backend())
-                self._sync_builtin_default_agents(active_default)
-                return
-
-        agent = getattr(agent_service, "agents", {}).get(backend) if agent_service else None
-        refresh_config = getattr(agent, "refresh_runtime_config", None)
-        if callable(refresh_config):
-            if runtime_config is None:
+        runtime_tokens: dict[str, str] = {}
+        snapshot_tokens = getattr(agent_service, "runtime_turn_tokens_for_backend", None)
+        if callable(snapshot_tokens):
+            runtime_tokens = snapshot_tokens(backend)
+        try:
+            refresh_runtime_config = getattr(agent_service, "refresh_runtime_config", None)
+            runtime_config = None
+            if callable(refresh_runtime_config):
                 runtime_config = self._load_backend_runtime_config(backend)
-            if runtime_config is None:
+                if runtime_config is None:
+                    await self._unregister_disabled_backend_agent(backend)
+                    return
+                if runtime_config is not None and self._register_missing_backend_agent(backend, runtime_config):
+                    return
+                if runtime_config is not None and await refresh_runtime_config(backend, runtime_config):
+                    active_default = self._revalidate_runtime_default_backend(self._load_saved_default_backend())
+                    self._sync_builtin_default_agents(active_default)
+                    return
+
+            agent = getattr(agent_service, "agents", {}).get(backend) if agent_service else None
+            refresh_config = getattr(agent, "refresh_runtime_config", None)
+            if callable(refresh_config):
+                if runtime_config is None:
+                    runtime_config = self._load_backend_runtime_config(backend)
+                if runtime_config is None:
+                    return
+                await refresh_config(runtime_config)
                 return
-            await refresh_config(runtime_config)
-            return
-        if backend == "opencode":
-            await self._refresh_opencode_server()
-            return
-        refresh = getattr(agent, "refresh_auth_state", None)
-        if callable(refresh):
-            await refresh()
+            if backend == "opencode":
+                await self._refresh_opencode_server()
+                return
+            refresh = getattr(agent, "refresh_auth_state", None)
+            if callable(refresh):
+                await refresh()
+        finally:
+            release_tokens = getattr(agent_service, "release_runtime_turn_tokens", None)
+            if callable(release_tokens):
+                release_tokens(runtime_tokens)
+            else:
+                release_turns = getattr(agent_service, "release_runtime_turns_for_backend", None)
+                if callable(release_turns):
+                    release_turns(backend)
 
     async def _clear_backend_sessions_for_context(self, backend: str, context: MessageContext) -> None:
         agent_service = getattr(self.controller, "agent_service", None)
+        clear_backend_sessions = getattr(agent_service, "clear_backend_sessions", None)
+        if callable(clear_backend_sessions):
+            await clear_backend_sessions(backend, self._get_settings_key(context))
+            return
         agent = getattr(agent_service, "agents", {}).get(backend) if agent_service else None
         clear_sessions = getattr(agent, "clear_sessions", None)
         if not callable(clear_sessions):

--- a/core/controller.py
+++ b/core/controller.py
@@ -678,7 +678,7 @@ class Controller:
 
         # Register callbacks with the IM client
         self.im_client.register_callbacks(
-            on_message=self._dispatch_to_controller_loop_background(_on_im_message),
+            on_message=self._dispatch_im_message_to_controller_loop(_on_im_message),
             on_command=command_handlers,
             on_callback_query=self._dispatch_to_controller_loop(self.message_handler.handle_callback_query),
             on_settings_update=self._dispatch_to_controller_loop(self.settings_handler.handle_settings_update),
@@ -710,11 +710,43 @@ class Controller:
 
         return _wrapped
 
+    def _dispatch_im_message_to_controller_loop(self, callback):
+        tracked_platforms = {"telegram", "wechat"}
+
+        async def _wrapped(context, *args, **kwargs):
+            platform = str(
+                getattr(context, "platform", None)
+                or (getattr(context, "platform_specific", None) or {}).get("platform")
+                or ""
+            )
+            if platform in tracked_platforms:
+                return await self._run_on_controller_loop(callback, context, *args, **kwargs)
+            self._schedule_controller_callback(callback, context, *args, **kwargs)
+            return None
+
+        return _wrapped
+
     def _dispatch_to_controller_loop_background(self, callback):
         async def _wrapped(*args, **kwargs):
             self._schedule_controller_callback(callback, *args, **kwargs)
 
         return _wrapped
+
+    async def _run_on_controller_loop(self, callback, *args, **kwargs):
+        loop = self._loop
+        if loop is None:
+            return await callback(*args, **kwargs)
+
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if current_loop is loop:
+            return await callback(*args, **kwargs)
+
+        future = asyncio.run_coroutine_threadsafe(callback(*args, **kwargs), loop)
+        return await asyncio.wrap_future(future)
 
     def _schedule_controller_callback(self, callback, *args, **kwargs) -> None:
         async def _runner():

--- a/core/controller.py
+++ b/core/controller.py
@@ -714,17 +714,32 @@ class Controller:
         tracked_platforms = {"telegram", "wechat"}
 
         async def _wrapped(context, *args, **kwargs):
-            platform = str(
-                getattr(context, "platform", None)
-                or (getattr(context, "platform_specific", None) or {}).get("platform")
-                or ""
-            )
+            platform = self._platform_for_im_callback_context(context)
             if platform in tracked_platforms:
                 return await self._run_on_controller_loop(callback, context, *args, **kwargs)
             self._schedule_controller_callback(callback, context, *args, **kwargs)
             return None
 
         return _wrapped
+
+    def _platform_for_im_callback_context(self, context) -> str:
+        platform = str(
+            getattr(context, "platform", None)
+            or (getattr(context, "platform_specific", None) or {}).get("platform")
+            or ""
+        ).strip()
+        if platform:
+            return platform
+        im_client = getattr(self, "im_client", None)
+        primary_platform = str(getattr(im_client, "primary_platform", "") or "").strip()
+        if primary_platform:
+            return primary_platform
+        module = str(getattr(type(im_client), "__module__", "") or "")
+        if module.startswith("modules.im.wechat"):
+            return "wechat"
+        if module.startswith("modules.im.telegram"):
+            return "telegram"
+        return ""
 
     def _dispatch_to_controller_loop_background(self, callback):
         async def _wrapped(*args, **kwargs):

--- a/core/controller.py
+++ b/core/controller.py
@@ -1,6 +1,7 @@
 """Core controller that coordinates between modules and handlers"""
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import threading
@@ -677,7 +678,7 @@ class Controller:
 
         # Register callbacks with the IM client
         self.im_client.register_callbacks(
-            on_message=self._dispatch_to_controller_loop(_on_im_message),
+            on_message=self._dispatch_to_controller_loop_background(_on_im_message),
             on_command=command_handlers,
             on_callback_query=self._dispatch_to_controller_loop(self.message_handler.handle_callback_query),
             on_settings_update=self._dispatch_to_controller_loop(self.settings_handler.handle_settings_update),
@@ -708,6 +709,44 @@ class Controller:
             return await asyncio.wrap_future(future)
 
         return _wrapped
+
+    def _dispatch_to_controller_loop_background(self, callback):
+        async def _wrapped(*args, **kwargs):
+            self._schedule_controller_callback(callback, *args, **kwargs)
+
+        return _wrapped
+
+    def _schedule_controller_callback(self, callback, *args, **kwargs) -> None:
+        async def _runner():
+            await callback(*args, **kwargs)
+
+        loop = self._loop
+        if loop is None:
+            task = asyncio.create_task(_runner())
+            task.add_done_callback(self._log_background_callback_result)
+            return
+
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+
+        if current_loop is loop:
+            task = loop.create_task(_runner())
+            task.add_done_callback(self._log_background_callback_result)
+            return
+
+        future = asyncio.run_coroutine_threadsafe(_runner(), loop)
+        future.add_done_callback(self._log_background_callback_result)
+
+    @staticmethod
+    def _log_background_callback_result(future) -> None:
+        try:
+            future.result()
+        except (asyncio.CancelledError, concurrent.futures.CancelledError):
+            return
+        except Exception:
+            logger.error("Background IM message callback failed", exc_info=True)
 
     def _run_im_runtime(self) -> None:
         try:

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -121,6 +121,23 @@ class ConsolidatedMessageDispatcher:
         if callable(mark):
             mark(context)
 
+    def _release_runtime_turn(self, context: MessageContext) -> None:
+        service = getattr(self.controller, "agent_service", None)
+        release = getattr(service, "release_runtime_turn", None)
+        if callable(release):
+            release(context)
+
+    def _is_current_runtime_turn(self, context: MessageContext) -> bool:
+        service = getattr(self.controller, "agent_service", None)
+        matches = getattr(service, "emit_matches_runtime_turn", None)
+        if not callable(matches):
+            return True
+        try:
+            return bool(matches(context))
+        except Exception:
+            logger.debug("runtime turn guard failed open", exc_info=True)
+            return True
+
     def _t(self, key: str, **kwargs) -> str:
         translator = getattr(self.controller, "_t", None)
         if callable(translator):
@@ -479,6 +496,9 @@ class ConsolidatedMessageDispatcher:
         # ``getattr`` keeps it a no-op for controllers without the hook (mirrors
         # ``_signal_turn_complete``).
         if canonical_type == "result":
+            if not self._is_current_runtime_turn(context):
+                logger.info("Dropping stale result emit for superseded runtime turn in %s", self._get_session_key(context))
+                return None
             # Settle the avibe dot for the ACTIVE turn's terminal result (idle, or
             # failed on is_error) via the turn owner, which applies the active-turn
             # guard + skips non-avibe contexts. ``getattr`` keeps it a no-op for stub
@@ -486,6 +506,7 @@ class ConsolidatedMessageDispatcher:
             manager = getattr(self.controller, "session_turns", None)
             if manager is not None:
                 manager.on_terminal_result(context, is_error=is_error)
+            self._release_runtime_turn(context)
         text = strip_silent_blocks(text)
         # ``level="silent"`` is the explicit visibility control (orthogonal to type):
         # the message already settled the dot above (for a terminal result), so here
@@ -765,6 +786,14 @@ class ConsolidatedMessageDispatcher:
 
         if canonical_type not in {"system", "assistant", "toolcall"}:
             canonical_type = "assistant"
+
+        if not self._is_current_runtime_turn(context):
+            logger.info(
+                "Dropping stale %s emit for superseded runtime turn in %s",
+                canonical_type,
+                self._get_session_key(context),
+            )
+            return None
 
         # Persist the intermediate log row BEFORE the mute filter so muted
         # assistant / tool_call messages still land in the store (product

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -501,12 +501,11 @@ class ConsolidatedMessageDispatcher:
                 return None
             # Settle the avibe dot for the ACTIVE turn's terminal result (idle, or
             # failed on is_error) via the turn owner, which applies the active-turn
-            # guard + skips non-avibe contexts. ``getattr`` keeps it a no-op for stub
-            # controllers without the owner.
+            # guard + skips non-avibe contexts. Runtime gate release happens after
+            # the result path clears/persists/streams its own state.
             manager = getattr(self.controller, "session_turns", None)
             if manager is not None:
                 manager.on_terminal_result(context, is_error=is_error)
-            self._release_runtime_turn(context)
         text = strip_silent_blocks(text)
         # ``level="silent"`` is the explicit visibility control (orthogonal to type):
         # the message already settled the dot above (for a terminal result), so here
@@ -514,19 +513,23 @@ class ConsolidatedMessageDispatcher:
         # streaming — no user-facing bubble, regardless of body. An empty/stripped
         # body (e.g. a ``<silent>`` directive reduced to nothing) is silent too.
         if level == "silent" or not text or not text.strip():
-            if canonical_type == "result":
-                # A terminal result — even silent/empty — still means the turn
-                # finished: release the streaming SSE waiter so it closes now
-                # instead of hanging until the safety timeout, with no visible chunk.
-                await self._clear_consolidated_state(context)
-                self._record_agent_run_terminal_result(
-                    context,
-                    text,
-                    None,
-                    is_error=is_error,
-                )
-                self._signal_turn_complete(context)
-            return None
+            try:
+                if canonical_type == "result":
+                    # A terminal result — even silent/empty — still means the turn
+                    # finished: release the streaming SSE waiter so it closes now
+                    # instead of hanging until the safety timeout, with no visible chunk.
+                    await self._clear_consolidated_state(context)
+                    self._record_agent_run_terminal_result(
+                        context,
+                        text,
+                        None,
+                        is_error=is_error,
+                    )
+                    self._signal_turn_complete(context)
+                return None
+            finally:
+                if canonical_type == "result":
+                    self._release_runtime_turn(context)
 
         # Resolve the delivery target once. Routed / post_to / thread replies
         # land in a different channel than the source context, and the persisted
@@ -559,24 +562,28 @@ class ConsolidatedMessageDispatcher:
         persists_without_delivery = target_context.platform == "avibe"
 
         if (context.platform_specific or {}).get("suppress_delivery"):
-            message_id = f"suppressed:{(context.platform_specific or {}).get('task_execution_id') or canonical_type}"
-            terminal_status = None
-            if (
-                canonical_type == "result"
-                and (context.platform_specific or {}).get("task_trigger_kind") == "agent_run"
-            ):
-                terminal_status = "failed" if is_error else "succeeded"
-            if canonical_type == "result" or (context.platform_specific or {}).get("task_trigger_kind") != "agent_run":
-                self._record_suppressed_run_message(
-                    context,
-                    text,
-                    message_id,
-                    terminal_status=terminal_status,
-                )
-            if canonical_type == "result":
-                await self._clear_consolidated_state(context)
-                self._signal_turn_complete(context)
-            return message_id
+            try:
+                message_id = f"suppressed:{(context.platform_specific or {}).get('task_execution_id') or canonical_type}"
+                terminal_status = None
+                if (
+                    canonical_type == "result"
+                    and (context.platform_specific or {}).get("task_trigger_kind") == "agent_run"
+                ):
+                    terminal_status = "failed" if is_error else "succeeded"
+                if canonical_type == "result" or (context.platform_specific or {}).get("task_trigger_kind") != "agent_run":
+                    self._record_suppressed_run_message(
+                        context,
+                        text,
+                        message_id,
+                        terminal_status=terminal_status,
+                    )
+                if canonical_type == "result":
+                    await self._clear_consolidated_state(context)
+                    self._signal_turn_complete(context)
+                return message_id
+            finally:
+                if canonical_type == "result":
+                    self._release_runtime_turn(context)
 
         if canonical_type == "notify":
             try:
@@ -593,105 +600,38 @@ class ConsolidatedMessageDispatcher:
             return None
 
         if canonical_type == "result":
-            primary_message_id: Optional[str] = None
-            scheduled_anchor_message_id: Optional[str] = None
-            delivered_as_attachment = False
+            try:
+                primary_message_id: Optional[str] = None
+                scheduled_anchor_message_id: Optional[str] = None
+                delivered_as_attachment = False
 
-            # ``enhanced`` (extracted file links + quick-reply buttons) was
-            # computed above for persistence; reuse it for delivery.
-            display_text = enhanced.text if enhanced.text.strip() else text
+                # ``enhanced`` (extracted file links + quick-reply buttons) was
+                # computed above for persistence; reuse it for delivery.
+                display_text = enhanced.text if enhanced.text.strip() else text
 
-            if self._result_within_limit(context, display_text):
-                try:
-                    primary_message_id = await self._send_result_inline(
-                        im_client,
-                        target_context,
-                        display_text,
-                        enhanced.buttons if enhanced else [],
-                        parse_mode,
-                    )
-                    scheduled_anchor_message_id = primary_message_id
-                except Exception as err:
-                    if enhanced and enhanced.buttons and self._supports_quick_replies(context):
-                        logger.warning("Failed to send result with quick replies, falling back: %s", err)
-                        try:
-                            primary_message_id = await im_client.send_message(
-                                target_context, display_text, parse_mode=parse_mode
-                            )
-                            scheduled_anchor_message_id = primary_message_id
-                        except Exception as fallback_err:
-                            logger.error("Failed to send fallback result message: %s", fallback_err)
-                    else:
-                        logger.error("Failed to send result message: %s", err)
-            elif self._should_split_long_result(context):
-                try:
-                    primary_message_id = await self._send_split_result_messages(
-                        im_client,
-                        target_context,
-                        display_text,
-                        enhanced.buttons if enhanced else [],
-                        parse_mode,
-                    )
-                    scheduled_anchor_message_id = primary_message_id
-                except Exception as err:
-                    logger.error("Failed to send split result messages: %s", err)
-            else:
-                summary = self._build_result_summary(display_text, self._get_result_max_chars(context))
-                try:
-                    primary_message_id = await im_client.send_message(target_context, summary, parse_mode=parse_mode)
-                    scheduled_anchor_message_id = primary_message_id
-                except Exception as err:
-                    logger.error("Failed to send result summary: %s", err)
-
-                if (
-                    context.platform
-                    or (context.platform_specific or {}).get("platform")
-                    or self.controller.config.platform
-                ) in {"slack", "discord", "telegram", "lark"} and hasattr(im_client, "upload_markdown"):
+                if self._result_within_limit(context, display_text):
                     try:
-                        attachment_message_id = await im_client.upload_markdown(
+                        primary_message_id = await self._send_result_inline(
+                            im_client,
                             target_context,
-                            title="result.md",
-                            content=display_text,
-                            filetype="markdown",
+                            display_text,
+                            enhanced.buttons if enhanced else [],
+                            parse_mode,
                         )
-                        if primary_message_id is None:
-                            primary_message_id = attachment_message_id
-                            delivered_as_attachment = True
-                            if self._attachment_id_can_anchor_delivery(context):
-                                scheduled_anchor_message_id = attachment_message_id
+                        scheduled_anchor_message_id = primary_message_id
                     except Exception as err:
-                        logger.warning(f"Failed to upload result attachment: {err}")
-                        await im_client.send_message(
-                            target_context,
-                            self._t("error.resultAttachmentUploadFailed"),
-                            parse_mode=parse_mode,
-                        )
-
-            # --- Fallback: card content rejected (e.g. table over limit) ---
-            if primary_message_id is None and display_text:
-                logger.warning("All direct result sends failed; attempting fallback delivery")
-                file_uploaded = False
-
-                # Fallback 1: upload full content as .md file.
-                if hasattr(im_client, "upload_markdown"):
-                    try:
-                        primary_message_id = await im_client.upload_markdown(
-                            target_context,
-                            title="result.md",
-                            content=display_text,
-                            filetype="markdown",
-                        )
-                        file_uploaded = True
-                        delivered_as_attachment = True
-                        if self._attachment_id_can_anchor_delivery(context):
-                            scheduled_anchor_message_id = primary_message_id
-                        logger.info("Result delivered as .md file attachment (fallback)")
-                    except Exception as upload_err:
-                        logger.warning("upload_markdown fallback failed: %s", upload_err)
-
-                # Fallback 2: split into multiple messages.
-                if not file_uploaded:
+                        if enhanced and enhanced.buttons and self._supports_quick_replies(context):
+                            logger.warning("Failed to send result with quick replies, falling back: %s", err)
+                            try:
+                                primary_message_id = await im_client.send_message(
+                                    target_context, display_text, parse_mode=parse_mode
+                                )
+                                scheduled_anchor_message_id = primary_message_id
+                            except Exception as fallback_err:
+                                logger.error("Failed to send fallback result message: %s", fallback_err)
+                        else:
+                            logger.error("Failed to send result message: %s", err)
+                elif self._should_split_long_result(context):
                     try:
                         primary_message_id = await self._send_split_result_messages(
                             im_client,
@@ -701,88 +641,158 @@ class ConsolidatedMessageDispatcher:
                             parse_mode,
                         )
                         scheduled_anchor_message_id = primary_message_id
-                        logger.info("Result delivered via split messages (fallback)")
-                    except Exception as split_err:
-                        logger.error("Split message fallback also failed: %s", split_err)
-
-            # Explain attachment-only delivery or total failure once all attempts settle.
-            try:
-                if delivered_as_attachment:
-                    notice = self._t("info.resultDeliveredAsAttachment")
-                elif primary_message_id is None and display_text:
-                    notice = self._t("error.resultDeliveryFailed")
+                    except Exception as err:
+                        logger.error("Failed to send split result messages: %s", err)
                 else:
-                    notice = None
-                if notice:
-                    await im_client.send_message(target_context, notice, parse_mode="markdown")
-            except Exception:
-                logger.error("Failed to send delivery status notification")
+                    summary = self._build_result_summary(display_text, self._get_result_max_chars(context))
+                    try:
+                        primary_message_id = await im_client.send_message(target_context, summary, parse_mode=parse_mode)
+                        scheduled_anchor_message_id = primary_message_id
+                    except Exception as err:
+                        logger.error("Failed to send result summary: %s", err)
 
-            # Upload extracted file attachments
-            if enhanced and enhanced.files:
-                await self._upload_file_links(im_client, target_context, enhanced.files)
+                    if (
+                        context.platform
+                        or (context.platform_specific or {}).get("platform")
+                        or self.controller.config.platform
+                    ) in {"slack", "discord", "telegram", "lark"} and hasattr(im_client, "upload_markdown"):
+                        try:
+                            attachment_message_id = await im_client.upload_markdown(
+                                target_context,
+                                title="result.md",
+                                content=display_text,
+                                filetype="markdown",
+                            )
+                            if primary_message_id is None:
+                                primary_message_id = attachment_message_id
+                                delivered_as_attachment = True
+                                if self._attachment_id_can_anchor_delivery(context):
+                                    scheduled_anchor_message_id = attachment_message_id
+                        except Exception as err:
+                            logger.warning(f"Failed to upload result attachment: {err}")
+                            await im_client.send_message(
+                                target_context,
+                                self._t("error.resultAttachmentUploadFailed"),
+                                parse_mode=parse_mode,
+                            )
 
-            if scheduled_anchor_message_id:
+                # --- Fallback: card content rejected (e.g. table over limit) ---
+                if primary_message_id is None and display_text:
+                    logger.warning("All direct result sends failed; attempting fallback delivery")
+                    file_uploaded = False
+
+                    # Fallback 1: upload full content as .md file.
+                    if hasattr(im_client, "upload_markdown"):
+                        try:
+                            primary_message_id = await im_client.upload_markdown(
+                                target_context,
+                                title="result.md",
+                                content=display_text,
+                                filetype="markdown",
+                            )
+                            file_uploaded = True
+                            delivered_as_attachment = True
+                            if self._attachment_id_can_anchor_delivery(context):
+                                scheduled_anchor_message_id = primary_message_id
+                            logger.info("Result delivered as .md file attachment (fallback)")
+                        except Exception as upload_err:
+                            logger.warning("upload_markdown fallback failed: %s", upload_err)
+
+                    # Fallback 2: split into multiple messages.
+                    if not file_uploaded:
+                        try:
+                            primary_message_id = await self._send_split_result_messages(
+                                im_client,
+                                target_context,
+                                display_text,
+                                enhanced.buttons if enhanced else [],
+                                parse_mode,
+                            )
+                            scheduled_anchor_message_id = primary_message_id
+                            logger.info("Result delivered via split messages (fallback)")
+                        except Exception as split_err:
+                            logger.error("Split message fallback also failed: %s", split_err)
+
+                # Explain attachment-only delivery or total failure once all attempts settle.
                 try:
-                    self.controller.session_handler.finalize_scheduled_delivery(context, scheduled_anchor_message_id)
-                except Exception as err:
-                    logger.warning("Failed to finalize scheduled delivery anchor: %s", err)
+                    if delivered_as_attachment:
+                        notice = self._t("info.resultDeliveredAsAttachment")
+                    elif primary_message_id is None and display_text:
+                        notice = self._t("error.resultDeliveryFailed")
+                    else:
+                        notice = None
+                    if notice:
+                        await im_client.send_message(target_context, notice, parse_mode="markdown")
+                except Exception:
+                    logger.error("Failed to send delivery status notification")
 
-            # Final result closes the current turn: clear consolidated
-            # assistant/tool/system message state so the next user turn starts
-            # a fresh log message instead of appending to the previous one.
-            await self._clear_consolidated_state(context)
+                # Upload extracted file attachments
+                if enhanced and enhanced.files:
+                    await self._upload_file_links(im_client, target_context, enhanced.files)
 
-            self._record_agent_run_terminal_result(
-                context,
-                display_text,
-                primary_message_id,
-                is_error=is_error,
-            )
+                if scheduled_anchor_message_id:
+                    try:
+                        self.controller.session_handler.finalize_scheduled_delivery(context, scheduled_anchor_message_id)
+                    except Exception as err:
+                        logger.warning("Failed to finalize scheduled delivery anchor: %s", err)
 
-            # Persist the delivered result (cleaned text == what was shown).
-            # avibe always persists (SSE is its delivery); for IM a result that
-            # failed every send/upload (primary_message_id is None) is NOT
-            # recorded, matching the old outbound mirror's success-only rule.
-            if persists_without_delivery or primary_message_id is not None:
-                # A failed terminal result persists as type='error' so it shows in
-                # the transcript/inbox like any terminal message but is NOT counted
-                # as an unread agent reply (unread queries are result-only). Codex P2.
-                result_type = "error" if is_error else "result"
-                if target_context.platform == "avibe":
-                    # Keep the ``file://`` links in the persisted avibe text so the
-                    # workbench media-proxy rewrite (in ``persist_agent_message``)
-                    # can turn them into inline images / file cards. ``persist_text``
-                    # already has them stripped to plain labels for IM delivery.
-                    # Also carry the parsed quick-reply labels so the workbench can
-                    # render the button group (IM channels render native buttons
-                    # from the same ``enhanced.buttons``).
-                    avibe_enhanced = process_reply(
-                        text, include_quick_replies=quick_replies_on, keep_file_links=True
-                    )
-                    avibe_text = avibe_enhanced.text or persist_text
-                    persist_agent_message(
-                        target_context,
-                        result_type,
-                        avibe_text,
-                        quick_replies=[b.text for b in avibe_enhanced.buttons] or None,
+                # Final result closes the current turn: clear consolidated
+                # assistant/tool/system message state so the next user turn starts
+                # a fresh log message instead of appending to the previous one.
+                await self._clear_consolidated_state(context)
+
+                self._record_agent_run_terminal_result(
+                    context,
+                    display_text,
+                    primary_message_id,
+                    is_error=is_error,
+                )
+
+                # Persist the delivered result (cleaned text == what was shown).
+                # avibe always persists (SSE is its delivery); for IM a result that
+                # failed every send/upload (primary_message_id is None) is NOT
+                # recorded, matching the old outbound mirror's success-only rule.
+                if persists_without_delivery or primary_message_id is not None:
+                    # A failed terminal result persists as type='error' so it shows in
+                    # the transcript/inbox like any terminal message but is NOT counted
+                    # as an unread agent reply (unread queries are result-only). Codex P2.
+                    result_type = "error" if is_error else "result"
+                    if target_context.platform == "avibe":
+                        # Keep the ``file://`` links in the persisted avibe text so the
+                        # workbench media-proxy rewrite (in ``persist_agent_message``)
+                        # can turn them into inline images / file cards. ``persist_text``
+                        # already has them stripped to plain labels for IM delivery.
+                        # Also carry the parsed quick-reply labels so the workbench can
+                        # render the button group (IM channels render native buttons
+                        # from the same ``enhanced.buttons``).
+                        avibe_enhanced = process_reply(
+                            text, include_quick_replies=quick_replies_on, keep_file_links=True
+                        )
+                        avibe_text = avibe_enhanced.text or persist_text
+                        persist_agent_message(
+                            target_context,
+                            result_type,
+                            avibe_text,
+                            quick_replies=[b.text for b in avibe_enhanced.buttons] or None,
+                        )
+                    else:
+                        persist_agent_message(target_context, result_type, persist_text)
+
+                if primary_message_id and display_text:
+                    # Stream the delivered result to live consumers (avibe SSE).
+                    await _stream_chunk(
+                        self.controller, context, text=display_text, message_id=primary_message_id, kind="result"
                     )
                 else:
-                    persist_agent_message(target_context, result_type, persist_text)
+                    # A terminal result still completes the turn even if every IM
+                    # delivery path failed and therefore produced no durable message id.
+                    # Without this release, direct agent_run and avibe turn waiters keep
+                    # waiting forever despite the backend having already finished.
+                    self._signal_turn_complete(context)
 
-            if primary_message_id and display_text:
-                # Stream the delivered result to live consumers (avibe SSE).
-                await _stream_chunk(
-                    self.controller, context, text=display_text, message_id=primary_message_id, kind="result"
-                )
-            else:
-                # A terminal result still completes the turn even if every IM
-                # delivery path failed and therefore produced no durable message id.
-                # Without this release, direct agent_run and avibe turn waiters keep
-                # waiting forever despite the backend having already finished.
-                self._signal_turn_complete(context)
-
-            return primary_message_id
+                return primary_message_id
+            finally:
+                self._release_runtime_turn(context)
 
         if canonical_type not in {"system", "assistant", "toolcall"}:
             canonical_type = "assistant"

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -496,6 +496,10 @@ class BaseAgent(ABC):
         """Clear session state for a given session scope key. Returns cleared count."""
         return 0
 
+    def runtime_turn_keys_for_session_key(self, session_key: str) -> set[str]:
+        """Return runtime turn gate keys owned by the session scope."""
+        return set()
+
     async def prepare_resume_binding(
         self,
         *,

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -113,6 +113,18 @@ class BaseAgent(ABC):
         """Return runtime identities scoped to a persisted Avibe settings key."""
         return set()
 
+    def mark_runtime_turn_started(self, context: Any) -> None:
+        """Mark the current gated turn as accepted by the backend runtime.
+
+        AgentService uses this to distinguish a startup-window stop (backend has
+        not accepted the turn yet) from a stale stop after the backend lost an
+        accepted turn.
+        """
+        service = getattr(self.controller, "agent_service", None)
+        mark_started = getattr(service, "mark_runtime_turn_started", None)
+        if callable(mark_started):
+            mark_started(context)
+
     def ensure_agent_session_id(
         self,
         request: AgentRequest,

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -105,6 +105,14 @@ class BaseAgent(ABC):
         backend_key = str(payload.get("backend_composite_session_id") or "").strip()
         return backend_key or request.composite_session_id
 
+    def runtime_turn_keys(self) -> set[str]:
+        """Return all currently known runtime identities for this backend."""
+        return set()
+
+    def runtime_turn_keys_for_session_key(self, session_key: str) -> set[str]:
+        """Return runtime identities scoped to a persisted Avibe settings key."""
+        return set()
+
     def ensure_agent_session_id(
         self,
         request: AgentRequest,

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -15,6 +15,10 @@ from core.reply_enhancer import strip_silent_blocks
 
 logger = logging.getLogger(__name__)
 
+AGENT_RUNTIME_TURN_KEY = "agent_runtime_turn_key"
+AGENT_RUNTIME_TURN_TOKEN = "agent_runtime_turn_token"
+AGENT_TURN_TOKEN = "turn_token"
+
 
 @dataclass
 class AgentRequest:
@@ -94,6 +98,12 @@ class BaseAgent(ABC):
 
     def _get_formatter(self, context: MessageContext):
         return getattr(self._get_im_client(context), "formatter", self.im_client.formatter)
+
+    def runtime_turn_key(self, request: AgentRequest) -> str:
+        """Return the backend runtime identity that must run one turn at a time."""
+        payload = getattr(request.context, "platform_specific", None) or {}
+        backend_key = str(payload.get("backend_composite_session_id") or "").strip()
+        return backend_key or request.composite_session_id
 
     def ensure_agent_session_id(
         self,
@@ -407,7 +417,10 @@ class BaseAgent(ABC):
         should NOT override it.  The guard (check-then-clear) is idempotent so
         calling it more than once is harmless.
         """
-        await self.controller.processing_indicator.finish(request)
+        service = getattr(self.controller, "processing_indicator", None)
+        if service is None:
+            return
+        await service.finish(request)
 
     async def emit_result_message(
         self,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -37,8 +37,16 @@ class ClaudeAgent(BaseAgent):
         self._pending_assistant_message: dict[str, str] = {}
         self._native_session_ids: dict[str, str] = {}
         self._suppressed_synthetic_results: set[str] = set()
-        # Store reaction info per session as a queue (FIFO) for cleanup after result
-        # Each entry is (reaction_message_id, emoji)
+        # A Claude SDK client is a single streaming transport.  It does not attach
+        # a turn id to ResultMessage events, so Avibe must not write a second
+        # prompt into the same runtime session until the first prompt reaches a
+        # terminal result.  Web Chat has its own gate, but IM/scheduled callers can
+        # reach this adapter directly; keep the invariant at the backend boundary.
+        self._runtime_turn_locks: dict[str, asyncio.Lock] = {}
+        self._runtime_turn_lock_keys: dict[str, tuple[str, ...]] = {}
+        # Store reaction info per runtime session for cleanup after terminal
+        # result. Under the runtime turn gate there is normally one active entry;
+        # the list shape remains for defensive cleanup of older queued state.
         self._pending_reactions: dict[str, list[tuple[str, str]]] = {}
         self._pending_requests: dict[str, list[AgentRequest]] = {}
 
@@ -68,6 +76,10 @@ class ClaudeAgent(BaseAgent):
         context = request.context
         runtime_base_session_id = request.base_session_id
         runtime_session_key = request.composite_session_id
+        expected_runtime_key = self._expected_runtime_session_key(request)
+        held_expected_key: str | None = None
+        active_runtime_key: str | None = None
+        turn_registered = False
 
         # Question callback handling (disabled - SDK doesn't support AskUserQuestion response)
         # if self.ENABLE_ASK_USER_QUESTION and request.message.startswith("claude_question:"):
@@ -75,6 +87,8 @@ class ClaudeAgent(BaseAgent):
         #     return
 
         try:
+            await self._acquire_runtime_turn_lock(expected_runtime_key)
+            held_expected_key = expected_runtime_key
             client = await self.session_handler.get_or_create_claude_session(
                 context,
                 subagent_name=request.subagent_name,
@@ -87,6 +101,13 @@ class ClaudeAgent(BaseAgent):
             )
             runtime_base_session_id = getattr(client, "_vibe_runtime_base_session_id", runtime_base_session_id)
             runtime_session_key = getattr(client, "_vibe_runtime_session_key", runtime_session_key)
+            if runtime_session_key != expected_runtime_key:
+                await self._acquire_runtime_turn_lock(runtime_session_key)
+            active_runtime_key = runtime_session_key
+            self._runtime_turn_lock_keys[runtime_session_key] = tuple(
+                dict.fromkeys((expected_runtime_key, runtime_session_key))
+            )
+            held_expected_key = None
             mark_session_active = getattr(self.session_handler, "mark_session_active", None)
             if callable(mark_session_active):
                 mark_session_active(runtime_session_key)
@@ -105,10 +126,6 @@ class ClaudeAgent(BaseAgent):
             message = self._prepare_message_with_files(request)
 
             await client.query(message, session_id=runtime_session_key)
-            logger.info(f"Sent message to Claude for session {runtime_session_key}")
-
-            await self._delete_ack(context, request)
-
             if (
                 runtime_session_key not in self.receiver_tasks
                 or self.receiver_tasks[runtime_session_key].done()
@@ -122,8 +139,27 @@ class ClaudeAgent(BaseAgent):
                         composite_key=runtime_session_key,
                     )
                 )
+            turn_registered = True
+            logger.info(f"Sent message to Claude for session {runtime_session_key}")
+
+            await self._delete_ack(context, request)
+        except asyncio.CancelledError:
+            if not turn_registered:
+                await self._remove_specific_pending_reaction(runtime_session_key, context, request)
+                self._remove_pending_request(runtime_session_key, request)
+                self._mark_session_idle_if_no_pending_requests(runtime_session_key)
+                await self._delete_ack(context, request)
+                if active_runtime_key:
+                    self._release_runtime_turn(active_runtime_key)
+                elif held_expected_key:
+                    self._release_runtime_turn_lock(held_expected_key)
+            raise
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
+            if not turn_registered and active_runtime_key:
+                self._release_runtime_turn(active_runtime_key or runtime_session_key)
+            elif not turn_registered and held_expected_key:
+                self._release_runtime_turn_lock(held_expected_key)
             # Clean up the specific reaction for this request (not FIFO)
             await self._remove_specific_pending_reaction(runtime_session_key, context, request)
             self._remove_pending_request(runtime_session_key, request)
@@ -157,6 +193,33 @@ class ClaudeAgent(BaseAgent):
             await self.controller.emit_agent_message(context, "result", "", is_error=True)
         finally:
             await self._delete_ack(context, request)
+
+    async def _acquire_runtime_turn_lock(self, composite_key: str) -> None:
+        if not composite_key:
+            return
+        lock = self._runtime_turn_locks.get(composite_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._runtime_turn_locks[composite_key] = lock
+        await lock.acquire()
+
+    def _release_runtime_turn(self, composite_key: str) -> None:
+        if not composite_key:
+            return
+        lock_keys = self._runtime_turn_lock_keys.pop(composite_key, None) or (composite_key,)
+        for lock_key in reversed(lock_keys):
+            self._release_runtime_turn_lock(lock_key)
+
+    def _release_runtime_turn_lock(self, composite_key: str) -> None:
+        lock = self._runtime_turn_locks.get(composite_key)
+        if lock is not None and lock.locked():
+            lock.release()
+
+    @staticmethod
+    def _expected_runtime_session_key(request: AgentRequest) -> str:
+        payload = getattr(request.context, "platform_specific", None) or {}
+        backend_key = str(payload.get("backend_composite_session_id") or "").strip()
+        return backend_key or request.composite_session_id
 
     async def _handle_question_callback(self, request: AgentRequest) -> None:
         """Handle question-related callbacks (button clicks, modal submissions).
@@ -309,6 +372,7 @@ class ClaudeAgent(BaseAgent):
         if not preserve_pending_request_state:
             self._pending_reactions.pop(composite_key, None)
             self._pending_requests.pop(composite_key, None)
+            self._release_runtime_turn(composite_key)
         cleanup = getattr(self.session_handler, "cleanup_session", None)
         if callable(cleanup):
             await cleanup(composite_key, current_receiver_task=current_receiver_task)
@@ -339,6 +403,8 @@ class ClaudeAgent(BaseAgent):
         try:
             if hasattr(client, "interrupt"):
                 await client.interrupt()
+                stopped_request = self._pop_pending_request(composite_key)
+                self._adopt_pending_turn_token(request.context, stopped_request)
                 # A user-initiated stop is terminal but intentional, so it carries
                 # NO user-facing message: a single SILENT result settles the dot to
                 # idle + releases the SSE waiter through the outbound chokepoint
@@ -348,6 +414,8 @@ class ClaudeAgent(BaseAgent):
                 await self.controller.emit_agent_message(
                     request.context, "result", "", level="silent"
                 )
+                self._mark_session_idle_if_no_pending_requests(composite_key)
+                await self._cleanup_runtime_session(composite_key)
                 return True
             else:
                 request.stop_failure_reason = "unsupported"
@@ -455,6 +523,7 @@ class ClaudeAgent(BaseAgent):
                             if callable(mark_session_idle):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
+                            self._release_runtime_turn(composite_key)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
                             return
@@ -538,6 +607,7 @@ class ClaudeAgent(BaseAgent):
                             if callable(mark_session_idle):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
+                            self._release_runtime_turn(composite_key)
                             return
                         continue
 
@@ -565,6 +635,7 @@ class ClaudeAgent(BaseAgent):
                             if callable(mark_session_idle):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
+                            self._release_runtime_turn(composite_key)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
                             return
@@ -610,6 +681,7 @@ class ClaudeAgent(BaseAgent):
                         session = await self.session_manager.get_or_create_session(context.user_id, context.channel_id)
                         if session and is_idle:
                             session.session_active[composite_key] = False
+                        self._release_runtime_turn(composite_key)
                         continue
 
                     # Ignore UserMessage/tool results; toolcalls are emitted from ToolUseBlock.
@@ -627,6 +699,7 @@ class ClaudeAgent(BaseAgent):
                 mark_session_idle(composite_key)
             logger.info("Claude receiver cancelled for session %s", composite_key)
             await self._clear_pending_reactions(composite_key, context)
+            self._release_runtime_turn(composite_key)
             raise
         except Exception as e:
             composite_key = composite_key or f"{base_session_id}:{working_path}"
@@ -675,6 +748,7 @@ class ClaudeAgent(BaseAgent):
                 # the 600s stream timeout and then settle idle. No-op off-workbench
                 # (Codex P2).
                 await self.controller.emit_agent_message(context, "result", "", is_error=True)
+            self._release_runtime_turn(composite_key)
         # NOTE: no `finally` cleanup of pending reactions here.
         # When the receiver ends normally (stream exhausted after a result),
         # new messages may have already queued their reactions via
@@ -713,6 +787,7 @@ class ClaudeAgent(BaseAgent):
         self._suppressed_synthetic_results.add(composite_key)
         self._discard_pending_reaction(composite_key)
         self._mark_session_idle_if_no_pending_requests(composite_key)
+        self._release_runtime_turn(composite_key)
         return True
 
     def _consume_suppressed_synthetic_result(self, composite_key: str, message, text: Optional[str]) -> bool:
@@ -748,7 +823,8 @@ class ClaudeAgent(BaseAgent):
     async def _remove_pending_reaction(self, composite_key: str, context: MessageContext) -> None:
         """Remove the oldest stored reaction for a session after result is sent.
 
-        Uses FIFO queue to handle multiple messages in the same session.
+        The backend turn gate normally leaves at most one pending reaction, but
+        keep FIFO cleanup for defensive compatibility with older queued state.
         """
         reactions = self._pending_reactions.get(composite_key)
         if reactions:
@@ -783,14 +859,13 @@ class ClaudeAgent(BaseAgent):
     def _adopt_pending_turn_token(context: MessageContext, pending_request: Optional[AgentRequest]) -> None:
         """Copy the pending turn's ``turn_token`` onto the reused receiver context.
 
-        Claude runs one long-lived receiver per session, so the context captured
-        when it started carries the FIRST turn's ``turn_token``. The streaming
-        completion guard in ``core.message_dispatcher._stream_chunk`` correlates a
-        ``result`` emit to the live turn sink by that token; without this the
-        current turn's result would carry a stale token and be rejected, hanging
-        the SSE stream until the safety timeout. Pulling the token from the
-        FIFO-matched pending request realigns it. No-op when there's no pending
-        request or it carries no token (fail-open: completion stays ungated)."""
+        Claude runs one long-lived receiver per runtime session, so the context
+        captured when it started can carry an older turn's ``turn_token``. The
+        streaming completion guard in ``core.message_dispatcher._stream_chunk``
+        correlates a ``result`` emit to the live turn sink by that token; without
+        this, later turns could be rejected as stale. Pulling the token from the
+        current pending request realigns it. No-op when there's no pending request
+        or it carries no token (fail-open: completion stays ungated)."""
         if pending_request is None:
             return
         src = getattr(pending_request, "context", None)
@@ -805,13 +880,11 @@ class ClaudeAgent(BaseAgent):
         """Retire a terminal auth-failure turn from the pending FIFO.
 
         The auth error IS this turn's (failed) result, so pop its pending request:
-        leaving the failed entry desyncs request↔result pairing, so the NEXT
-        successful turn would FIFO-pop this stale request and adopt its old
+        leaving the failed entry would make the next result adopt the old
         ``turn_token`` — then ``_stream_chunk`` rejects the live turn's completion
         and Stop sticks until the safety timeout. Adopt the failed turn's own token
-        and release its Chat stream now. Called from every auth-failure terminal
-        path (result / system / assistant); the dot was already settled and the
-        recovery notify persisted by ``maybe_emit_auth_recovery_message``."""
+        and release its Chat stream now. Called from auth-failure terminal paths
+        after the recovery notify has been persisted."""
         failed_request = self._pop_pending_request(composite_key)
         self._adopt_pending_turn_token(context, failed_request)
         _mark = getattr(self.controller, "mark_turn_complete", None)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -43,6 +43,7 @@ class ClaudeAgent(BaseAgent):
         self._pending_assistant_message: dict[str, str] = {}
         self._native_session_ids: dict[str, str] = {}
         self._suppressed_synthetic_results: set[str] = set()
+        self._suppress_receiver_runtime_release: set[str] = set()
         # Store reaction info per runtime session for cleanup after terminal
         # result. Under the runtime turn gate there is normally one active entry;
         # the list shape remains for defensive cleanup of older queued state.
@@ -140,8 +141,6 @@ class ClaudeAgent(BaseAgent):
             raise
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
-            if not turn_registered:
-                self._release_service_runtime_turn(context)
             # Clean up the specific reaction for this request (not FIFO)
             await self._remove_specific_pending_reaction(runtime_session_key, context, request)
             self._remove_pending_request(runtime_session_key, request)
@@ -172,7 +171,10 @@ class ClaudeAgent(BaseAgent):
             # empty terminal error result turns the dot red AND releases the
             # web-Chat stream waiter (the visible error was sent + persisted
             # above), instead of waiting out the safety timeout. No-op off-workbench.
-            await self.controller.emit_agent_message(context, "result", "", is_error=True)
+            try:
+                await self.controller.emit_agent_message(context, "result", "", is_error=True)
+            finally:
+                self._release_service_runtime_turn(context)
         finally:
             await self._delete_ack(context, request)
 
@@ -216,6 +218,17 @@ class ClaudeAgent(BaseAgent):
         await self.session_manager.clear_session(session_key)
 
         return len(sessions_to_clear) or len(session_bases_to_clear)
+
+    def runtime_turn_keys_for_session_key(self, session_key: str) -> set[str]:
+        agent_map = self.sessions.list_agent_sessions(session_key, self.name)
+        session_bases_to_clear = set(agent_map.keys())
+        runtime_keys = set()
+        session_ids = set(self.claude_sessions.keys()) | set(self.receiver_tasks.keys())
+        for composite_id in session_ids:
+            base_part = composite_id.split(":", 1)[0] if ":" in composite_id else composite_id
+            if base_part in session_bases_to_clear:
+                runtime_keys.add(composite_id)
+        return runtime_keys
 
     async def refresh_auth_state(self) -> None:
         """Reconnect Claude runtime so future requests load fresh auth."""
@@ -390,20 +403,28 @@ class ClaudeAgent(BaseAgent):
             except Exception:
                 logger.debug("Failed to clear Claude stop processing indicator", exc_info=True)
 
+        self._suppress_receiver_runtime_release.add(composite_key)
+        try:
+            self._mark_session_idle_if_no_pending_requests(composite_key)
+            await self._cleanup_runtime_session(composite_key)
+        except Exception as err:
+            logger.error("Failed to clean up stopped Claude session %s: %s", composite_key, err, exc_info=True)
+            self._release_service_runtime_turn(request.context)
+            raise
+        finally:
+            self._suppress_receiver_runtime_release.discard(composite_key)
+
         try:
             # A user-initiated stop is terminal but intentional, so it carries
             # NO user-facing message: a single SILENT result settles the dot to
             # idle + releases the SSE waiter through the outbound chokepoint
-            # WITHOUT a bubble. Done HERE, before /internal/cancel cancels the
-            # _run_turn task (the cancelled branch can't safely emit during
-            # cancellation).
+            # WITHOUT a bubble. Emit only after cleanup so the next turn cannot
+            # acquire the gate and reuse a client that this stop is still
+            # disconnecting.
             await self.controller.emit_agent_message(request.context, "result", "", level="silent")
         except Exception as err:
             logger.error("Failed to emit Claude stop result for session %s: %s", composite_key, err, exc_info=True)
             self._release_service_runtime_turn(request.context)
-        finally:
-            self._mark_session_idle_if_no_pending_requests(composite_key)
-            await self._cleanup_runtime_session(composite_key)
 
         return True
 
@@ -668,7 +689,8 @@ class ClaudeAgent(BaseAgent):
                 mark_session_idle(composite_key)
             logger.info("Claude receiver cancelled for session %s", composite_key)
             await self._clear_pending_reactions(composite_key, context)
-            self._release_service_runtime_turn(context)
+            if composite_key not in self._suppress_receiver_runtime_release:
+                self._release_service_runtime_turn(context)
             raise
         except Exception as e:
             composite_key = composite_key or f"{base_session_id}:{working_path}"

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -114,6 +114,7 @@ class ClaudeAgent(BaseAgent):
             message = self._prepare_message_with_files(request)
 
             await client.query(message, session_id=runtime_session_key)
+            self.mark_runtime_turn_started(context)
             if (
                 runtime_session_key not in self.receiver_tasks
                 or self.receiver_tasks[runtime_session_key].done()
@@ -207,8 +208,7 @@ class ClaudeAgent(BaseAgent):
 
         sessions_to_clear = []
         for composite_id in list(self.claude_sessions.keys()):
-            base_part = composite_id.split(":")[0] if ":" in composite_id else composite_id
-            if base_part in session_bases_to_clear:
+            if self._runtime_key_matches_session_base(composite_id, session_bases_to_clear):
                 sessions_to_clear.append(composite_id)
 
         for composite_id in sessions_to_clear:
@@ -224,13 +224,19 @@ class ClaudeAgent(BaseAgent):
         session_bases_to_clear = set(agent_map.keys())
         runtime_keys = set()
         for composite_id in self.runtime_turn_keys():
-            base_part = composite_id.split(":", 1)[0] if ":" in composite_id else composite_id
-            if base_part in session_bases_to_clear:
+            if self._runtime_key_matches_session_base(composite_id, session_bases_to_clear):
                 runtime_keys.add(composite_id)
         return runtime_keys
 
     def runtime_turn_keys(self) -> set[str]:
         return set(self.claude_sessions.keys()) | set(self.receiver_tasks.keys())
+
+    @staticmethod
+    def _runtime_key_matches_session_base(runtime_key: str, session_bases: set[str]) -> bool:
+        for session_base in session_bases:
+            if runtime_key == session_base or runtime_key.startswith(f"{session_base}:"):
+                return True
+        return False
 
     async def refresh_auth_state(self) -> None:
         """Reconnect Claude runtime so future requests load fresh auth."""
@@ -775,15 +781,15 @@ class ClaudeAgent(BaseAgent):
         self._pending_assistant_message.pop(composite_key, None)
         self._mark_session_idle_if_no_pending_requests(composite_key)
 
+        await self._cleanup_runtime_session(
+            composite_key,
+            current_receiver_task=asyncio.current_task(),
+            preserve_pending_request_state=True,
+        )
         try:
             await self.controller.emit_agent_message(context, "result", "", is_error=True)
         finally:
             self._release_service_runtime_turn(context)
-            await self._cleanup_runtime_session(
-                composite_key,
-                current_receiver_task=asyncio.current_task(),
-                preserve_pending_request_state=True,
-            )
 
     async def _handle_synthetic_api_error_message(
         self,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -6,7 +6,13 @@ from typing import Callable, Optional
 from core.agent_auth_service import classify_auth_error
 from modules.claude_sdk_compat import TextBlock, ToolUseBlock, is_claude_sdk_buffer_error
 
-from modules.agents.base import AgentRequest, BaseAgent
+from modules.agents.base import (
+    AGENT_RUNTIME_TURN_KEY,
+    AGENT_RUNTIME_TURN_TOKEN,
+    AGENT_TURN_TOKEN,
+    AgentRequest,
+    BaseAgent,
+)
 
 # NOTE: AskUserQuestion support is disabled because Claude Code SDK cannot
 # respond to it programmatically. See: https://github.com/anthropics/claude-code/issues/10168
@@ -37,13 +43,6 @@ class ClaudeAgent(BaseAgent):
         self._pending_assistant_message: dict[str, str] = {}
         self._native_session_ids: dict[str, str] = {}
         self._suppressed_synthetic_results: set[str] = set()
-        # A Claude SDK client is a single streaming transport.  It does not attach
-        # a turn id to ResultMessage events, so Avibe must not write a second
-        # prompt into the same runtime session until the first prompt reaches a
-        # terminal result.  Web Chat has its own gate, but IM/scheduled callers can
-        # reach this adapter directly; keep the invariant at the backend boundary.
-        self._runtime_turn_locks: dict[str, asyncio.Lock] = {}
-        self._runtime_turn_lock_keys: dict[str, tuple[str, ...]] = {}
         # Store reaction info per runtime session for cleanup after terminal
         # result. Under the runtime turn gate there is normally one active entry;
         # the list shape remains for defensive cleanup of older queued state.
@@ -76,9 +75,6 @@ class ClaudeAgent(BaseAgent):
         context = request.context
         runtime_base_session_id = request.base_session_id
         runtime_session_key = request.composite_session_id
-        expected_runtime_key = self._expected_runtime_session_key(request)
-        held_expected_key: str | None = None
-        active_runtime_key: str | None = None
         turn_registered = False
 
         # Question callback handling (disabled - SDK doesn't support AskUserQuestion response)
@@ -87,8 +83,6 @@ class ClaudeAgent(BaseAgent):
         #     return
 
         try:
-            await self._acquire_runtime_turn_lock(expected_runtime_key)
-            held_expected_key = expected_runtime_key
             client = await self.session_handler.get_or_create_claude_session(
                 context,
                 subagent_name=request.subagent_name,
@@ -101,13 +95,6 @@ class ClaudeAgent(BaseAgent):
             )
             runtime_base_session_id = getattr(client, "_vibe_runtime_base_session_id", runtime_base_session_id)
             runtime_session_key = getattr(client, "_vibe_runtime_session_key", runtime_session_key)
-            if runtime_session_key != expected_runtime_key:
-                await self._acquire_runtime_turn_lock(runtime_session_key)
-            active_runtime_key = runtime_session_key
-            self._runtime_turn_lock_keys[runtime_session_key] = tuple(
-                dict.fromkeys((expected_runtime_key, runtime_session_key))
-            )
-            held_expected_key = None
             mark_session_active = getattr(self.session_handler, "mark_session_active", None)
             if callable(mark_session_active):
                 mark_session_active(runtime_session_key)
@@ -149,17 +136,12 @@ class ClaudeAgent(BaseAgent):
                 self._remove_pending_request(runtime_session_key, request)
                 self._mark_session_idle_if_no_pending_requests(runtime_session_key)
                 await self._delete_ack(context, request)
-                if active_runtime_key:
-                    self._release_runtime_turn(active_runtime_key)
-                elif held_expected_key:
-                    self._release_runtime_turn_lock(held_expected_key)
+                self._release_service_runtime_turn(context)
             raise
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
-            if not turn_registered and active_runtime_key:
-                self._release_runtime_turn(active_runtime_key or runtime_session_key)
-            elif not turn_registered and held_expected_key:
-                self._release_runtime_turn_lock(held_expected_key)
+            if not turn_registered:
+                self._release_service_runtime_turn(context)
             # Clean up the specific reaction for this request (not FIFO)
             await self._remove_specific_pending_reaction(runtime_session_key, context, request)
             self._remove_pending_request(runtime_session_key, request)
@@ -194,32 +176,11 @@ class ClaudeAgent(BaseAgent):
         finally:
             await self._delete_ack(context, request)
 
-    async def _acquire_runtime_turn_lock(self, composite_key: str) -> None:
-        if not composite_key:
-            return
-        lock = self._runtime_turn_locks.get(composite_key)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._runtime_turn_locks[composite_key] = lock
-        await lock.acquire()
-
-    def _release_runtime_turn(self, composite_key: str) -> None:
-        if not composite_key:
-            return
-        lock_keys = self._runtime_turn_lock_keys.pop(composite_key, None) or (composite_key,)
-        for lock_key in reversed(lock_keys):
-            self._release_runtime_turn_lock(lock_key)
-
-    def _release_runtime_turn_lock(self, composite_key: str) -> None:
-        lock = self._runtime_turn_locks.get(composite_key)
-        if lock is not None and lock.locked():
-            lock.release()
-
-    @staticmethod
-    def _expected_runtime_session_key(request: AgentRequest) -> str:
-        payload = getattr(request.context, "platform_specific", None) or {}
-        backend_key = str(payload.get("backend_composite_session_id") or "").strip()
-        return backend_key or request.composite_session_id
+    def _release_service_runtime_turn(self, context: MessageContext) -> None:
+        service = getattr(self.controller, "agent_service", None)
+        release = getattr(service, "release_runtime_turn", None)
+        if callable(release):
+            release(context)
 
     async def _handle_question_callback(self, request: AgentRequest) -> None:
         """Handle question-related callbacks (button clicks, modal submissions).
@@ -372,7 +333,6 @@ class ClaudeAgent(BaseAgent):
         if not preserve_pending_request_state:
             self._pending_reactions.pop(composite_key, None)
             self._pending_requests.pop(composite_key, None)
-            self._release_runtime_turn(composite_key)
         cleanup = getattr(self.session_handler, "cleanup_session", None)
         if callable(cleanup):
             await cleanup(composite_key, current_receiver_task=current_receiver_task)
@@ -523,7 +483,6 @@ class ClaudeAgent(BaseAgent):
                             if callable(mark_session_idle):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
-                            self._release_runtime_turn(composite_key)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
                             return
@@ -607,7 +566,6 @@ class ClaudeAgent(BaseAgent):
                             if callable(mark_session_idle):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
-                            self._release_runtime_turn(composite_key)
                             return
                         continue
 
@@ -635,7 +593,6 @@ class ClaudeAgent(BaseAgent):
                             if callable(mark_session_idle):
                                 mark_session_idle(composite_key)
                             await self._clear_pending_reactions(composite_key, context)
-                            self._release_runtime_turn(composite_key)
                             self._last_assistant_text.pop(composite_key, None)
                             self._pending_assistant_message.pop(composite_key, None)
                             return
@@ -681,7 +638,6 @@ class ClaudeAgent(BaseAgent):
                         session = await self.session_manager.get_or_create_session(context.user_id, context.channel_id)
                         if session and is_idle:
                             session.session_active[composite_key] = False
-                        self._release_runtime_turn(composite_key)
                         continue
 
                     # Ignore UserMessage/tool results; toolcalls are emitted from ToolUseBlock.
@@ -699,7 +655,7 @@ class ClaudeAgent(BaseAgent):
                 mark_session_idle(composite_key)
             logger.info("Claude receiver cancelled for session %s", composite_key)
             await self._clear_pending_reactions(composite_key, context)
-            self._release_runtime_turn(composite_key)
+            self._release_service_runtime_turn(context)
             raise
         except Exception as e:
             composite_key = composite_key or f"{base_session_id}:{working_path}"
@@ -748,7 +704,7 @@ class ClaudeAgent(BaseAgent):
                 # the 600s stream timeout and then settle idle. No-op off-workbench
                 # (Codex P2).
                 await self.controller.emit_agent_message(context, "result", "", is_error=True)
-            self._release_runtime_turn(composite_key)
+            self._release_service_runtime_turn(context)
         # NOTE: no `finally` cleanup of pending reactions here.
         # When the receiver ends normally (stream exhausted after a result),
         # new messages may have already queued their reactions via
@@ -787,7 +743,6 @@ class ClaudeAgent(BaseAgent):
         self._suppressed_synthetic_results.add(composite_key)
         self._discard_pending_reaction(composite_key)
         self._mark_session_idle_if_no_pending_requests(composite_key)
-        self._release_runtime_turn(composite_key)
         return True
 
     def _consume_suppressed_synthetic_result(self, composite_key: str, message, text: Optional[str]) -> bool:
@@ -857,24 +812,31 @@ class ClaudeAgent(BaseAgent):
 
     @staticmethod
     def _adopt_pending_turn_token(context: MessageContext, pending_request: Optional[AgentRequest]) -> None:
-        """Copy the pending turn's ``turn_token`` onto the reused receiver context.
+        """Copy the pending turn tokens onto the reused receiver context.
 
         Claude runs one long-lived receiver per runtime session, so the context
-        captured when it started can carry an older turn's ``turn_token``. The
-        streaming completion guard in ``core.message_dispatcher._stream_chunk``
-        correlates a ``result`` emit to the live turn sink by that token; without
-        this, later turns could be rejected as stale. Pulling the token from the
-        current pending request realigns it. No-op when there's no pending request
-        or it carries no token (fail-open: completion stays ungated)."""
+        captured when it started can carry an older turn's tokens. The web stream
+        guard uses ``turn_token`` and the shared backend runtime gate uses
+        ``agent_runtime_turn_token``; both must follow the FIFO-matched pending
+        request before any assistant/tool/result emit.
+        """
         if pending_request is None:
             return
         src = getattr(pending_request, "context", None)
-        token = (getattr(src, "platform_specific", None) or {}).get("turn_token") if src is not None else None
-        if not token:
+        src_payload = (getattr(src, "platform_specific", None) or {}) if src is not None else {}
+        token = src_payload.get(AGENT_TURN_TOKEN)
+        runtime_key = src_payload.get(AGENT_RUNTIME_TURN_KEY)
+        runtime_token = src_payload.get(AGENT_RUNTIME_TURN_TOKEN)
+        if not (token or runtime_key or runtime_token):
             return
         if context.platform_specific is None:
             context.platform_specific = {}
-        context.platform_specific["turn_token"] = token
+        if token:
+            context.platform_specific[AGENT_TURN_TOKEN] = token
+        if runtime_key:
+            context.platform_specific[AGENT_RUNTIME_TURN_KEY] = runtime_key
+        if runtime_token:
+            context.platform_specific[AGENT_RUNTIME_TURN_TOKEN] = runtime_token
 
     def _retire_failed_auth_turn(self, composite_key: str, context: MessageContext) -> None:
         """Retire a terminal auth-failure turn from the pending FIFO.

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -223,16 +223,18 @@ class ClaudeAgent(BaseAgent):
         agent_map = self.sessions.list_agent_sessions(session_key, self.name)
         session_bases_to_clear = set(agent_map.keys())
         runtime_keys = set()
-        session_ids = set(self.claude_sessions.keys()) | set(self.receiver_tasks.keys())
-        for composite_id in session_ids:
+        for composite_id in self.runtime_turn_keys():
             base_part = composite_id.split(":", 1)[0] if ":" in composite_id else composite_id
             if base_part in session_bases_to_clear:
                 runtime_keys.add(composite_id)
         return runtime_keys
 
+    def runtime_turn_keys(self) -> set[str]:
+        return set(self.claude_sessions.keys()) | set(self.receiver_tasks.keys())
+
     async def refresh_auth_state(self) -> None:
         """Reconnect Claude runtime so future requests load fresh auth."""
-        session_ids = set(self.claude_sessions.keys()) | set(self.receiver_tasks.keys())
+        session_ids = self.runtime_turn_keys()
 
         for composite_id in session_ids:
             await self._cleanup_runtime_session(composite_id)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -360,31 +360,17 @@ class ClaudeAgent(BaseAgent):
             return False
 
         client = self.claude_sessions[composite_key]
+        if not hasattr(client, "interrupt"):
+            request.stop_failure_reason = "unsupported"
+            await self.controller.emit_agent_message(
+                request.context,
+                "notify",
+                "⚠️ This Claude session cannot be interrupted; consider /new.",
+            )
+            return False
+
         try:
-            if hasattr(client, "interrupt"):
-                await client.interrupt()
-                stopped_request = self._pop_pending_request(composite_key)
-                self._adopt_pending_turn_token(request.context, stopped_request)
-                # A user-initiated stop is terminal but intentional, so it carries
-                # NO user-facing message: a single SILENT result settles the dot to
-                # idle + releases the SSE waiter through the outbound chokepoint
-                # WITHOUT a bubble. Done HERE, before /internal/cancel cancels the
-                # _run_turn task (the cancelled branch can't safely emit during
-                # cancellation). A genuine interrupt FAILURE below still notifies.
-                await self.controller.emit_agent_message(
-                    request.context, "result", "", level="silent"
-                )
-                self._mark_session_idle_if_no_pending_requests(composite_key)
-                await self._cleanup_runtime_session(composite_key)
-                return True
-            else:
-                request.stop_failure_reason = "unsupported"
-                await self.controller.emit_agent_message(
-                    request.context,
-                    "notify",
-                    "⚠️ This Claude session cannot be interrupted; consider /new.",
-                )
-                return False
+            await client.interrupt()
         except Exception as err:
             request.stop_failure_reason = "interrupt_failed"
             logger.error(f"Failed to interrupt Claude session {composite_key}: {err}")
@@ -394,6 +380,32 @@ class ClaudeAgent(BaseAgent):
                 "⚠️ Failed to interrupt Claude session. Please try /new.",
             )
             return False
+
+        stopped_request = self._pop_pending_request(composite_key)
+        self._adopt_pending_turn_token(request.context, stopped_request)
+        if stopped_request is not None:
+            try:
+                await self._remove_specific_pending_reaction(composite_key, request.context, stopped_request)
+                await self._remove_ack_reaction(stopped_request)
+            except Exception:
+                logger.debug("Failed to clear Claude stop processing indicator", exc_info=True)
+
+        try:
+            # A user-initiated stop is terminal but intentional, so it carries
+            # NO user-facing message: a single SILENT result settles the dot to
+            # idle + releases the SSE waiter through the outbound chokepoint
+            # WITHOUT a bubble. Done HERE, before /internal/cancel cancels the
+            # _run_turn task (the cancelled branch can't safely emit during
+            # cancellation).
+            await self.controller.emit_agent_message(request.context, "result", "", level="silent")
+        except Exception as err:
+            logger.error("Failed to emit Claude stop result for session %s: %s", composite_key, err, exc_info=True)
+            self._release_service_runtime_turn(request.context)
+        finally:
+            self._mark_session_idle_if_no_pending_requests(composite_key)
+            await self._cleanup_runtime_session(composite_key)
+
+        return True
 
     async def _receive_messages(
         self,
@@ -645,6 +657,7 @@ class ClaudeAgent(BaseAgent):
                 except Exception as e:
                     logger.error(f"Error processing message from Claude: {e}", exc_info=True)
                     continue
+            await self._handle_receiver_eof(composite_key, context)
         except asyncio.CancelledError:
             # Receiver task was explicitly cancelled (e.g. /stop, /clear,
             # or a new message replacing the session).  Clean up reactions
@@ -715,6 +728,45 @@ class ClaudeAgent(BaseAgent):
         # inside the loop.
         finally:
             self._suppressed_synthetic_results.discard(composite_key)
+
+    async def _handle_receiver_eof(self, composite_key: str, context: MessageContext) -> None:
+        """Settle a Claude receiver that ended without a ResultMessage."""
+        pending_requests = self._pending_requests.get(composite_key) or []
+        if not pending_requests:
+            return
+
+        pending_request = pending_requests[0]
+        context_token = str((getattr(context, "platform_specific", None) or {}).get(AGENT_RUNTIME_TURN_TOKEN) or "")
+        pending_token = str(
+            (getattr(getattr(pending_request, "context", None), "platform_specific", None) or {}).get(
+                AGENT_RUNTIME_TURN_TOKEN
+            )
+            or ""
+        )
+        if not context_token or not pending_token:
+            return
+        if context_token and pending_token and context_token != pending_token:
+            logger.info(
+                "Ignoring Claude receiver EOF for %s because a newer runtime turn is pending",
+                composite_key,
+            )
+            return
+        logger.warning("Claude receiver ended without a result for session %s", composite_key)
+        self._adopt_pending_turn_token(context, pending_request)
+        await self._clear_pending_reactions(composite_key, context)
+        self._last_assistant_text.pop(composite_key, None)
+        self._pending_assistant_message.pop(composite_key, None)
+        self._mark_session_idle_if_no_pending_requests(composite_key)
+
+        try:
+            await self.controller.emit_agent_message(context, "result", "", is_error=True)
+        finally:
+            self._release_service_runtime_turn(context)
+            await self._cleanup_runtime_session(
+                composite_key,
+                current_receiver_task=asyncio.current_task(),
+                preserve_pending_request_state=True,
+            )
 
     async def _handle_synthetic_api_error_message(
         self,
@@ -882,14 +934,14 @@ class ClaudeAgent(BaseAgent):
 
         Used on error paths to remove the current request's reaction instead of FIFO.
         """
-        if not request.ack_reaction_message_id:
+        target_id = getattr(request, "ack_reaction_message_id", None)
+        target_emoji = getattr(request, "ack_reaction_emoji", None)
+        if not target_id:
             return
         reactions = self._pending_reactions.get(composite_key)
         if not reactions:
             return
         # Find and remove the matching reaction
-        target_id = request.ack_reaction_message_id
-        target_emoji = request.ack_reaction_emoji
         for i, (msg_id, emoji) in enumerate(reactions):
             if msg_id == target_id and emoji == target_emoji:
                 reactions.pop(i)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -758,20 +758,13 @@ class ClaudeAgent(BaseAgent):
             return
 
         pending_request = pending_requests[0]
-        context_token = str((getattr(context, "platform_specific", None) or {}).get(AGENT_RUNTIME_TURN_TOKEN) or "")
         pending_token = str(
             (getattr(getattr(pending_request, "context", None), "platform_specific", None) or {}).get(
                 AGENT_RUNTIME_TURN_TOKEN
             )
             or ""
         )
-        if not context_token or not pending_token:
-            return
-        if context_token and pending_token and context_token != pending_token:
-            logger.info(
-                "Ignoring Claude receiver EOF for %s because a newer runtime turn is pending",
-                composite_key,
-            )
+        if not pending_token:
             return
         logger.warning("Claude receiver ended without a result for session %s", composite_key)
         self._adopt_pending_turn_token(context, pending_request)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -270,6 +270,13 @@ class CodexAgent(BaseAgent):
 
         return count
 
+    def runtime_turn_keys_for_session_key(self, session_key: str) -> set[str]:
+        runtime_keys = set()
+        for base_session_id in self._session_mgr.get_sessions_by_session_key(session_key):
+            cwd = self._session_mgr.get_cwd(base_session_id)
+            runtime_keys.add(f"{base_session_id}:{cwd}" if cwd else base_session_id)
+        return runtime_keys
+
     async def refresh_auth_state(self) -> None:
         """Drop app-server runtime state so future turns pick up fresh auth."""
         if not hasattr(self, "_transport_last_activity"):

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -270,12 +270,21 @@ class CodexAgent(BaseAgent):
 
         return count
 
+    def runtime_turn_keys(self) -> set[str]:
+        return {
+            self._runtime_turn_key_for_base_session(base_session_id)
+            for base_session_id in self._session_mgr.all_base_sessions()
+        }
+
     def runtime_turn_keys_for_session_key(self, session_key: str) -> set[str]:
-        runtime_keys = set()
-        for base_session_id in self._session_mgr.get_sessions_by_session_key(session_key):
-            cwd = self._session_mgr.get_cwd(base_session_id)
-            runtime_keys.add(f"{base_session_id}:{cwd}" if cwd else base_session_id)
-        return runtime_keys
+        return {
+            self._runtime_turn_key_for_base_session(base_session_id)
+            for base_session_id in self._session_mgr.get_sessions_by_session_key(session_key)
+        }
+
+    def _runtime_turn_key_for_base_session(self, base_session_id: str) -> str:
+        cwd = self._session_mgr.get_cwd(base_session_id)
+        return f"{base_session_id}:{cwd}" if cwd else base_session_id
 
     async def refresh_auth_state(self) -> None:
         """Drop app-server runtime state so future turns pick up fresh auth."""

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -929,6 +929,7 @@ class CodexAgent(BaseAgent):
             raise RuntimeError("Codex turn/start returned no turn id")
 
         turn_state = self._turn_registry.finalize_turn_start_response(turn_id, request)
+        self._mark_runtime_turn_started(getattr(request, "context", None))
         bind_generated_image_snapshot = getattr(event_handler, "bind_generated_image_snapshot", None)
         if callable(bind_generated_image_snapshot):
             bind_generated_image_snapshot(thread_id, turn_id, request.base_session_id)
@@ -940,6 +941,12 @@ class CodexAgent(BaseAgent):
             "registered" if turn_state else "already-finished",
         )
         return thread_id
+
+    def _mark_runtime_turn_started(self, context: Any) -> None:
+        service = getattr(getattr(self, "controller", None), "agent_service", None)
+        mark_started = getattr(service, "mark_runtime_turn_started", None)
+        if callable(mark_started):
+            mark_started(context)
 
     # ------------------------------------------------------------------
     # Input building

--- a/modules/agents/codex/event_handler.py
+++ b/modules/agents/codex/event_handler.py
@@ -79,13 +79,20 @@ class CodexEventHandler:
             logger.debug("Unhandled Codex notification: %s", method)
 
     def _release_stream_turn(self, context) -> None:
-        """Release any web-Chat SSE stream waiting on this turn so it closes
-        promptly. Token-guarded in the controller (a superseded turn won't
-        close a newer turn's stream); no-op for IM/CLI turns and for
-        controllers that don't expose streaming completion."""
+        """Release turn state for terminal paths that do not emit a result.
+
+        Result emits settle both the web-Chat SSE stream and the shared backend
+        runtime gate through the outbound dispatcher. Interrupted/stale backend
+        notifications intentionally skip a visible result, so they need the same
+        release here. Both release calls are token-guarded by their owners.
+        """
         mark = getattr(self._agent.controller, "mark_turn_complete", None)
         if callable(mark):
             mark(context)
+        service = getattr(self._agent.controller, "agent_service", None)
+        release = getattr(service, "release_runtime_turn", None)
+        if callable(release):
+            release(context)
 
     # ------------------------------------------------------------------
     # Notification handlers

--- a/modules/agents/codex/session.py
+++ b/modules/agents/codex/session.py
@@ -53,6 +53,10 @@ class CodexSessionManager:
         """Return base_session_ids associated with a given working directory."""
         return [bid for bid, stored_cwd in self._cwds.items() if stored_cwd == cwd]
 
+    def get_cwd(self, base_session_id: str) -> Optional[str]:
+        """Return the working directory tracked for a base session."""
+        return self._cwds.get(base_session_id)
+
     def get_sessions_by_session_key(self, session_key: str) -> list[str]:
         """Return base_session_ids associated with a given session_key."""
         return [bid for bid, sk in self._session_keys.items() if sk == session_key]

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -480,6 +480,12 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 self.sessions.remove_active_poll(opencode_session_id)
         return terminated
 
+    def runtime_turn_keys_for_session_key(self, session_key: str) -> set[str]:
+        return {
+            f"{base_id}:{req_info[1]}"
+            for base_id, req_info in self._session_manager.list_for_session_key(session_key).items()
+        }
+
     async def _delete_ack(self, request: AgentRequest) -> None:
         service = getattr(self.controller, "processing_indicator", None)
         if service is not None:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -486,6 +486,12 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             for base_id, req_info in self._session_manager.list_for_session_key(session_key).items()
         }
 
+    def runtime_turn_keys(self) -> set[str]:
+        return {
+            f"{base_id}:{req_info[1]}"
+            for base_id, req_info in self._session_manager.list_all().items()
+        }
+
     async def _delete_ack(self, request: AgentRequest) -> None:
         service = getattr(self.controller, "processing_indicator", None)
         if service is not None:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -312,6 +312,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             )
             await server.mark_run_active(session_id)
             run_registered = True
+            self.mark_runtime_turn_started(request.context)
 
             logger.info(
                 "Starting OpenCode poll loop for %s (thread=%s, cwd=%s)",

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -73,6 +73,13 @@ class OpenCodeSessionManager:
                 matches[base_id] = info
         return matches
 
+    def list_for_session_key(self, session_key: str) -> Dict[str, RequestSessionTuple]:
+        return {
+            base_id: info
+            for base_id, info in self._request_sessions.items()
+            if len(info) >= 3 and info[2] == session_key
+        }
+
     def _set_request_agent_session_id(self, request: AgentRequest, agent_session_id: Optional[str]) -> None:
         if not agent_session_id:
             return

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -80,6 +80,9 @@ class OpenCodeSessionManager:
             if len(info) >= 3 and info[2] == session_key
         }
 
+    def list_all(self) -> Dict[str, RequestSessionTuple]:
+        return dict(self._request_sessions)
+
     def _set_request_agent_session_id(self, request: AgentRequest, agent_session_id: Optional[str]) -> None:
         if not agent_session_id:
             return

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -65,9 +65,14 @@ class AgentService:
     async def clear_sessions(self, session_key: str) -> Dict[str, int]:
         cleared: Dict[str, int] = {}
         for name, agent in self.agents.items():
+            runtime_key_getter = getattr(agent, "runtime_turn_keys_for_session_key", None)
+            runtime_keys = runtime_key_getter(session_key) if callable(runtime_key_getter) else set()
+            runtime_tokens = self._runtime_turn_tokens(runtime_keys)
             count = await agent.clear_sessions(session_key)
             if count:
                 cleared[name] = count
+            for runtime_key, runtime_token in runtime_tokens.items():
+                self.release_runtime_turn_key(runtime_key, runtime_token)
         return cleared
 
     async def handle_stop(self, agent_name: str, request: AgentRequest) -> bool:
@@ -87,6 +92,17 @@ class AgentService:
         gate = self._turn_gates.get(runtime_key)
         if gate is None or gate.token != runtime_token:
             return
+        self.release_runtime_turn_key(runtime_key, runtime_token)
+
+    def release_runtime_turn_key(self, runtime_key: str, runtime_token: str | None = None) -> None:
+        runtime_key = str(runtime_key or "").strip()
+        if not runtime_key:
+            return
+        gate = self._turn_gates.get(runtime_key)
+        if gate is None:
+            return
+        if runtime_token is not None and gate.token != runtime_token:
+            return
         gate.token = ""
         if gate.lock.locked():
             gate.lock.release()
@@ -104,6 +120,14 @@ class AgentService:
         if runtime_key not in self._turn_gates:
             self._turn_gates[runtime_key] = _RuntimeTurnGate()
         return self._turn_gates[runtime_key]
+
+    def _runtime_turn_tokens(self, runtime_keys: set[str]) -> dict[str, str]:
+        tokens = {}
+        for runtime_key in runtime_keys:
+            gate = self._turn_gates.get(runtime_key)
+            if gate is not None and gate.token:
+                tokens[runtime_key] = gate.token
+        return tokens
 
     @staticmethod
     def _stamp_runtime_turn(request: AgentRequest, runtime_key: str, runtime_token: str) -> None:

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -43,17 +43,18 @@ class AgentService:
         await gate.lock.acquire()
         gate.token = uuid.uuid4().hex
         gate.backend = agent.name
+        gate.running = True
         self._stamp_runtime_turn(request, runtime_key, gate.token)
-        # INBOUND status chokepoint (one of exactly two — the other is the outbound
-        # MessageDispatcher.emit_agent_message). Every turn, every source (chat /
-        # scheduled / Show Page), every backend funnels through here, so this is the
-        # single place that marks an avibe session "running". The matching idle /
-        # failed is written by the outbound terminal result. Non-avibe turns carry
-        # no workbench session id and are skipped.
-        manager = getattr(self.controller, "session_turns", None)
-        if manager is not None:
-            manager.on_running(request.context)
         try:
+            # INBOUND status chokepoint (one of exactly two — the other is the outbound
+            # MessageDispatcher.emit_agent_message). Every turn, every source (chat /
+            # scheduled / Show Page), every backend funnels through here, so this is the
+            # single place that marks an avibe session "running". The matching idle /
+            # failed is written by the outbound terminal result. Non-avibe turns carry
+            # no workbench session id and are skipped.
+            manager = getattr(self.controller, "session_turns", None)
+            if manager is not None:
+                manager.on_running(request.context)
             await agent.handle_message(request)
         except asyncio.CancelledError:
             self.release_runtime_turn(request.context)
@@ -116,7 +117,13 @@ class AgentService:
         if gate is not None and gate.token:
             self._stamp_runtime_turn(request, runtime_key, gate.token)
         handled = await agent.handle_stop(request)
-        if not handled and getattr(request, "stop_failure_reason", None) in STALE_STOP_REASONS:
+        if (
+            not handled
+            and getattr(request, "stop_failure_reason", None) in STALE_STOP_REASONS
+            and gate is not None
+            and gate.token
+            and not gate.running
+        ):
             self.release_runtime_turn(request.context)
         return handled
 
@@ -142,6 +149,7 @@ class AgentService:
             return
         gate.token = ""
         gate.backend = ""
+        gate.running = False
         if gate.lock.locked():
             gate.lock.release()
 
@@ -218,3 +226,4 @@ class _RuntimeTurnGate:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     token: str = ""
     backend: str = ""
+    running: bool = False

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -57,9 +57,18 @@ class AgentService:
             raise
         except Exception:
             # The message handler converts backend exceptions into a terminal
-            # error result using the same context. Keep the gate current so that
-            # result is delivered and releases the runtime turn through the
-            # shared dispatcher path.
+            # error result using the same context. Try that shared terminal path
+            # here too; if delivery itself is broken, the finally below still
+            # releases this turn's token so later prompts cannot hang forever.
+            try:
+                emit = getattr(self.controller, "emit_agent_message", None)
+                if callable(emit):
+                    try:
+                        await emit(request.context, "result", "", is_error=True, level="silent")
+                    except Exception:
+                        logger.debug("Failed to emit terminal result for backend exception", exc_info=True)
+            finally:
+                self.release_runtime_turn(request.context)
             raise
 
     async def clear_sessions(self, session_key: str) -> Dict[str, int]:

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -14,6 +14,8 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
+STALE_STOP_REASONS = {"not_active", "runtime_unavailable"}
+
 
 class AgentService:
     """Registry and dispatcher for agent implementations."""
@@ -40,6 +42,7 @@ class AgentService:
         gate = self._get_turn_gate(runtime_key)
         await gate.lock.acquire()
         gate.token = uuid.uuid4().hex
+        gate.backend = agent.name
         self._stamp_runtime_turn(request, runtime_key, gate.token)
         # INBOUND status chokepoint (one of exactly two — the other is the outbound
         # MessageDispatcher.emit_agent_message). Every turn, every source (chat /
@@ -73,16 +76,38 @@ class AgentService:
 
     async def clear_sessions(self, session_key: str) -> Dict[str, int]:
         cleared: Dict[str, int] = {}
-        for name, agent in self.agents.items():
-            runtime_key_getter = getattr(agent, "runtime_turn_keys_for_session_key", None)
-            runtime_keys = runtime_key_getter(session_key) if callable(runtime_key_getter) else set()
-            runtime_tokens = self._runtime_turn_tokens(runtime_keys)
-            count = await agent.clear_sessions(session_key)
+        for name in list(self.agents.keys()):
+            count = await self.clear_backend_sessions(name, session_key)
             if count:
                 cleared[name] = count
-            for runtime_key, runtime_token in runtime_tokens.items():
-                self.release_runtime_turn_key(runtime_key, runtime_token)
         return cleared
+
+    async def clear_backend_sessions(self, agent_name: str, session_key: str) -> int:
+        agent = self.get(agent_name)
+        runtime_key_getter = getattr(agent, "runtime_turn_keys_for_session_key", None)
+        runtime_keys = runtime_key_getter(session_key) if callable(runtime_key_getter) else set()
+        runtime_tokens = self._runtime_turn_tokens(runtime_keys, backend=agent.name)
+        count = await agent.clear_sessions(session_key)
+        for runtime_key, runtime_token in runtime_tokens.items():
+            self.release_runtime_turn_key(runtime_key, runtime_token)
+        return count
+
+    def release_runtime_turns_for_backend(self, agent_name: str) -> None:
+        runtime_tokens = self.runtime_turn_tokens_for_backend(agent_name)
+        self.release_runtime_turn_tokens(runtime_tokens)
+
+    def runtime_turn_tokens_for_backend(self, agent_name: str) -> dict[str, str]:
+        agent = self.agents.get(agent_name)
+        backend = agent.name if agent is not None else agent_name
+        return {
+            runtime_key: gate.token
+            for runtime_key, gate in self._turn_gates.items()
+            if gate.backend == backend and gate.token
+        }
+
+    def release_runtime_turn_tokens(self, runtime_tokens: dict[str, str]) -> None:
+        for runtime_key, runtime_token in runtime_tokens.items():
+            self.release_runtime_turn_key(runtime_key, runtime_token)
 
     async def handle_stop(self, agent_name: str, request: AgentRequest) -> bool:
         agent = self.get(agent_name)
@@ -90,7 +115,10 @@ class AgentService:
         gate = self._turn_gates.get(runtime_key)
         if gate is not None and gate.token:
             self._stamp_runtime_turn(request, runtime_key, gate.token)
-        return await agent.handle_stop(request)
+        handled = await agent.handle_stop(request)
+        if not handled and getattr(request, "stop_failure_reason", None) in STALE_STOP_REASONS:
+            self.release_runtime_turn(request.context)
+        return handled
 
     def release_runtime_turn(self, context: Any) -> None:
         payload = getattr(context, "platform_specific", None) or {}
@@ -113,6 +141,7 @@ class AgentService:
         if runtime_token is not None and gate.token != runtime_token:
             return
         gate.token = ""
+        gate.backend = ""
         if gate.lock.locked():
             gate.lock.release()
 
@@ -141,12 +170,15 @@ class AgentService:
             or "default"
         )
 
-    def _runtime_turn_tokens(self, runtime_keys: set[str]) -> dict[str, str]:
+    def _runtime_turn_tokens(self, runtime_keys: set[str], *, backend: str | None = None) -> dict[str, str]:
         tokens = {}
         for runtime_key in runtime_keys:
             gate = self._turn_gates.get(runtime_key)
-            if gate is not None and gate.token:
-                tokens[runtime_key] = gate.token
+            if gate is None or not gate.token:
+                continue
+            if backend is not None and gate.backend != backend:
+                continue
+            tokens[runtime_key] = gate.token
         return tokens
 
     @staticmethod
@@ -173,11 +205,16 @@ class AgentService:
         refresh = getattr(agent, "refresh_runtime_config", None)
         if not callable(refresh):
             return False
-        await refresh(runtime_config)
-        return True
+        runtime_tokens = self.runtime_turn_tokens_for_backend(agent.name)
+        try:
+            await refresh(runtime_config)
+            return True
+        finally:
+            self.release_runtime_turn_tokens(runtime_tokens)
 
 
 @dataclass
 class _RuntimeTurnGate:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     token: str = ""
+    backend: str = ""

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -43,7 +43,7 @@ class AgentService:
         await gate.lock.acquire()
         gate.token = uuid.uuid4().hex
         gate.backend = agent.name
-        gate.running = True
+        gate.runtime_started = False
         self._stamp_runtime_turn(request, runtime_key, gate.token)
         try:
             # INBOUND status chokepoint (one of exactly two — the other is the outbound
@@ -122,10 +122,21 @@ class AgentService:
             and getattr(request, "stop_failure_reason", None) in STALE_STOP_REASONS
             and gate is not None
             and gate.token
-            and not gate.running
+            and gate.runtime_started
         ):
             self.release_runtime_turn(request.context)
         return handled
+
+    def mark_runtime_turn_started(self, context: Any) -> None:
+        payload = getattr(context, "platform_specific", None) or {}
+        runtime_key = str(payload.get(AGENT_RUNTIME_TURN_KEY) or "").strip()
+        runtime_token = str(payload.get(AGENT_RUNTIME_TURN_TOKEN) or "").strip()
+        if not runtime_key or not runtime_token:
+            return
+        gate = self._turn_gates.get(runtime_key)
+        if gate is None or gate.token != runtime_token:
+            return
+        gate.runtime_started = True
 
     def release_runtime_turn(self, context: Any) -> None:
         payload = getattr(context, "platform_specific", None) or {}
@@ -149,7 +160,7 @@ class AgentService:
             return
         gate.token = ""
         gate.backend = ""
-        gate.running = False
+        gate.runtime_started = False
         if gate.lock.locked():
             gate.lock.release()
 
@@ -226,4 +237,4 @@ class _RuntimeTurnGate:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     token: str = ""
     backend: str = ""
-    running: bool = False
+    runtime_started: bool = False

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -1,7 +1,16 @@
 import logging
+import asyncio
+import uuid
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
-from .base import AgentRequest, BaseAgent
+from .base import (
+    AGENT_RUNTIME_TURN_KEY,
+    AGENT_RUNTIME_TURN_TOKEN,
+    AGENT_TURN_TOKEN,
+    AgentRequest,
+    BaseAgent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +22,7 @@ class AgentService:
         self.controller = controller
         self.agents: Dict[str, BaseAgent] = {}
         self.default_agent = "claude"
+        self._turn_gates: dict[str, _RuntimeTurnGate] = {}
 
     def register(self, agent: BaseAgent):
         self.agents[agent.name] = agent
@@ -26,6 +36,11 @@ class AgentService:
 
     async def handle_message(self, agent_name: str, request: AgentRequest):
         agent = self.get(agent_name)
+        runtime_key = agent.runtime_turn_key(request)
+        gate = self._get_turn_gate(runtime_key)
+        await gate.lock.acquire()
+        gate.token = uuid.uuid4().hex
+        self._stamp_runtime_turn(request, runtime_key, gate.token)
         # INBOUND status chokepoint (one of exactly two — the other is the outbound
         # MessageDispatcher.emit_agent_message). Every turn, every source (chat /
         # scheduled / Show Page), every backend funnels through here, so this is the
@@ -35,7 +50,17 @@ class AgentService:
         manager = getattr(self.controller, "session_turns", None)
         if manager is not None:
             manager.on_running(request.context)
-        await agent.handle_message(request)
+        try:
+            await agent.handle_message(request)
+        except asyncio.CancelledError:
+            self.release_runtime_turn(request.context)
+            raise
+        except Exception:
+            # The message handler converts backend exceptions into a terminal
+            # error result using the same context. Keep the gate current so that
+            # result is delivered and releases the runtime turn through the
+            # shared dispatcher path.
+            raise
 
     async def clear_sessions(self, session_key: str) -> Dict[str, int]:
         cleared: Dict[str, int] = {}
@@ -47,7 +72,48 @@ class AgentService:
 
     async def handle_stop(self, agent_name: str, request: AgentRequest) -> bool:
         agent = self.get(agent_name)
+        runtime_key = agent.runtime_turn_key(request)
+        gate = self._turn_gates.get(runtime_key)
+        if gate is not None and gate.token:
+            self._stamp_runtime_turn(request, runtime_key, gate.token)
         return await agent.handle_stop(request)
+
+    def release_runtime_turn(self, context: Any) -> None:
+        payload = getattr(context, "platform_specific", None) or {}
+        runtime_key = str(payload.get(AGENT_RUNTIME_TURN_KEY) or "").strip()
+        runtime_token = str(payload.get(AGENT_RUNTIME_TURN_TOKEN) or "").strip()
+        if not runtime_key or not runtime_token:
+            return
+        gate = self._turn_gates.get(runtime_key)
+        if gate is None or gate.token != runtime_token:
+            return
+        gate.token = ""
+        if gate.lock.locked():
+            gate.lock.release()
+
+    def emit_matches_runtime_turn(self, context: Any) -> bool:
+        payload = getattr(context, "platform_specific", None) or {}
+        runtime_key = str(payload.get(AGENT_RUNTIME_TURN_KEY) or "").strip()
+        runtime_token = str(payload.get(AGENT_RUNTIME_TURN_TOKEN) or "").strip()
+        if not runtime_key or not runtime_token:
+            return True
+        gate = self._turn_gates.get(runtime_key)
+        return gate is not None and gate.token == runtime_token
+
+    def _get_turn_gate(self, runtime_key: str) -> "_RuntimeTurnGate":
+        if runtime_key not in self._turn_gates:
+            self._turn_gates[runtime_key] = _RuntimeTurnGate()
+        return self._turn_gates[runtime_key]
+
+    @staticmethod
+    def _stamp_runtime_turn(request: AgentRequest, runtime_key: str, runtime_token: str) -> None:
+        if request.context.platform_specific is None:
+            request.context.platform_specific = {}
+        request.context.platform_specific[AGENT_RUNTIME_TURN_KEY] = runtime_key
+        request.context.platform_specific[AGENT_RUNTIME_TURN_TOKEN] = runtime_token
+        if request.context.platform_specific.get(AGENT_TURN_TOKEN):
+            return
+        request.context.platform_specific[AGENT_TURN_TOKEN] = runtime_token
 
     async def refresh_runtime_config(self, agent_name: str, runtime_config: Any) -> bool:
         """Refresh a backend's live runtime state from the latest config.
@@ -65,3 +131,9 @@ class AgentService:
             return False
         await refresh(runtime_config)
         return True
+
+
+@dataclass
+class _RuntimeTurnGate:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    token: str = ""

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -36,7 +36,7 @@ class AgentService:
 
     async def handle_message(self, agent_name: str, request: AgentRequest):
         agent = self.get(agent_name)
-        runtime_key = agent.runtime_turn_key(request)
+        runtime_key = self._runtime_turn_key(agent, request)
         gate = self._get_turn_gate(runtime_key)
         await gate.lock.acquire()
         gate.token = uuid.uuid4().hex
@@ -86,7 +86,7 @@ class AgentService:
 
     async def handle_stop(self, agent_name: str, request: AgentRequest) -> bool:
         agent = self.get(agent_name)
-        runtime_key = agent.runtime_turn_key(request)
+        runtime_key = self._runtime_turn_key(agent, request)
         gate = self._turn_gates.get(runtime_key)
         if gate is not None and gate.token:
             self._stamp_runtime_turn(request, runtime_key, gate.token)
@@ -129,6 +129,17 @@ class AgentService:
         if runtime_key not in self._turn_gates:
             self._turn_gates[runtime_key] = _RuntimeTurnGate()
         return self._turn_gates[runtime_key]
+
+    @staticmethod
+    def _runtime_turn_key(agent: BaseAgent, request: AgentRequest) -> str:
+        runtime_key = getattr(agent, "runtime_turn_key", None)
+        if callable(runtime_key):
+            return runtime_key(request)
+        return (
+            str(getattr(request, "composite_session_id", "") or "").strip()
+            or str(getattr(request, "base_session_id", "") or "").strip()
+            or "default"
+        )
 
     def _runtime_turn_tokens(self, runtime_keys: set[str]) -> dict[str, str]:
         tokens = {}

--- a/modules/im/wechat.py
+++ b/modules/im/wechat.py
@@ -970,7 +970,8 @@ class WeChatBot(BaseIMClient):
             channel_id=user_id,
             thread_id=None,
             message_id=None,
-            platform_specific={"is_dm": True, "context_token": context_token},
+            platform="wechat",
+            platform_specific={"platform": "wechat", "is_dm": True, "context_token": context_token},
         )
         try:
             return await self.send_message(context, text)
@@ -1294,7 +1295,9 @@ class WeChatBot(BaseIMClient):
             channel_id=from_user,  # WeChat DM: channel == user
             thread_id=None,  # No threads in WeChat
             message_id=message_id,
+            platform="wechat",
             platform_specific={
+                "platform": "wechat",
                 "message": msg,
                 "is_dm": True,  # Always DM for personal messaging
                 "context_token": context_token,

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -998,6 +998,35 @@ class AgentAuthServiceTests(unittest.IsolatedAsyncioTestCase):
         agent.refresh_runtime_config.assert_awaited_once_with(runtime_config)
         agent.refresh_auth_state.assert_not_awaited()
 
+    async def test_refresh_backend_runtime_releases_runtime_tokens_after_refresh(self):
+        controller = _StubController()
+        runtime_tokens = {"session:/repo": "token-1"}
+        controller.agent_service.runtime_turn_tokens_for_backend = Mock(return_value=runtime_tokens)
+        controller.agent_service.release_runtime_turn_tokens = Mock()
+        controller.agent_service.refresh_runtime_config = AsyncMock(return_value=True)
+        controller.agent_service.agents["codex"] = SimpleNamespace()
+        service = AgentAuthService(controller)
+        runtime_config = object()
+        service._load_backend_runtime_config = Mock(return_value=runtime_config)
+
+        await service._refresh_backend_runtime("codex")
+
+        controller.agent_service.runtime_turn_tokens_for_backend.assert_called_once_with("codex")
+        controller.agent_service.refresh_runtime_config.assert_awaited_once_with("codex", runtime_config)
+        controller.agent_service.release_runtime_turn_tokens.assert_called_once_with(runtime_tokens)
+
+    async def test_clear_backend_sessions_for_context_routes_through_agent_service(self):
+        controller = _StubController()
+        controller.agent_service.clear_backend_sessions = AsyncMock(return_value=1)
+        controller.agent_service.agents["codex"] = SimpleNamespace(clear_sessions=AsyncMock())
+        service = AgentAuthService(controller)
+        context = MessageContext(user_id="U1", channel_id="C1")
+
+        await service._clear_backend_sessions_for_context("codex", context)
+
+        controller.agent_service.clear_backend_sessions.assert_awaited_once_with("codex", "C1")
+        controller.agent_service.agents["codex"].clear_sessions.assert_not_awaited()
+
     async def test_refresh_backend_runtime_registers_codex_when_enabled_after_startup(self):
         from config.v2_compat import CodexCompatConfig
         from modules.agents.service import AgentService

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -29,6 +29,24 @@ class _RuntimeAgent:
         return False
 
 
+class _ClearingRuntimeAgent:
+    name = "codex"
+
+    def __init__(self, runtime_keys: set[str], on_clear=None):
+        self.runtime_keys = runtime_keys
+        self.clear_calls: list[str] = []
+        self.on_clear = on_clear
+
+    async def clear_sessions(self, session_key):
+        self.clear_calls.append(session_key)
+        if self.on_clear is not None:
+            await self.on_clear()
+        return 1
+
+    def runtime_turn_keys_for_session_key(self, _session_key):
+        return self.runtime_keys
+
+
 class _Controller:
     def __init__(self):
         self.session_turns = None
@@ -123,5 +141,56 @@ def test_agent_service_runtime_guard_drops_stale_emits_after_next_turn_starts() 
 
         assert service.emit_matches_runtime_turn(second.context)
         assert not service.emit_matches_runtime_turn(first.context)
+
+    asyncio.run(_run())
+
+
+def test_agent_service_clear_sessions_releases_cleared_runtime_gates() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        agent = _ClearingRuntimeAgent({"session:/repo", "session:/other"})
+        service.register(agent)
+
+        for runtime_key in ("session:/repo", "session:/other", "unrelated:/repo"):
+            gate = service._get_turn_gate(runtime_key)
+            await gate.lock.acquire()
+            gate.token = f"{runtime_key}-token"
+
+        cleared = await service.clear_sessions("scope-1")
+
+        assert cleared == {"codex": 1}
+        assert agent.clear_calls == ["scope-1"]
+        assert not service._turn_gates["session:/repo"].lock.locked()
+        assert not service._turn_gates["session:/other"].lock.locked()
+        assert service._turn_gates["unrelated:/repo"].lock.locked()
+
+        service.release_runtime_turn_key("unrelated:/repo")
+
+    asyncio.run(_run())
+
+
+def test_agent_service_clear_sessions_does_not_release_new_turn_token() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        runtime_key = "session:/repo"
+        gate = service._get_turn_gate(runtime_key)
+        await gate.lock.acquire()
+        gate.token = "old-token"
+
+        async def _on_clear():
+            service.release_runtime_turn_key(runtime_key, "old-token")
+            await gate.lock.acquire()
+            gate.token = "new-token"
+
+        agent = _ClearingRuntimeAgent({runtime_key}, on_clear=_on_clear)
+        service.register(agent)
+
+        cleared = await service.clear_sessions("scope-1")
+
+        assert cleared == {"codex": 1}
+        assert service._turn_gates[runtime_key].lock.locked()
+        assert service._turn_gates[runtime_key].token == "new-token"
+
+        service.release_runtime_turn_key(runtime_key, "new-token")
 
     asyncio.run(_run())

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -79,6 +79,11 @@ class _Controller:
         self.session_turns = None
 
 
+class _FailingTurnManager:
+    def on_running(self, _context):
+        raise RuntimeError("status failed")
+
+
 def _request(message: str, runtime_key: str = "session:/repo"):
     return SimpleNamespace(
         context=SimpleNamespace(platform_specific={}),
@@ -300,12 +305,35 @@ def test_agent_service_releases_runtime_gate_for_stale_stop() -> None:
         await gate.lock.acquire()
         gate.token = "stop-token"
         gate.backend = "claude"
+        gate.running = False
 
         handled = await service.handle_stop("claude", request)
 
         assert handled is False
         assert not gate.lock.locked()
         assert request.context.platform_specific["agent_runtime_turn_token"] == "stop-token"
+
+    asyncio.run(_run())
+
+
+def test_agent_service_keeps_runtime_gate_for_startup_window_stop() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        agent = _StopRuntimeAgent("not_active")
+        service.register(agent)
+        request = _request("stop")
+        gate = service._get_turn_gate("session:/repo")
+        await gate.lock.acquire()
+        gate.token = "stop-token"
+        gate.backend = "codex"
+        gate.running = True
+
+        handled = await service.handle_stop("claude", request)
+
+        assert handled is False
+        assert gate.lock.locked()
+        assert gate.token == "stop-token"
+        service.release_runtime_turn_key("session:/repo", "stop-token")
 
     asyncio.run(_run())
 
@@ -320,12 +348,38 @@ def test_agent_service_keeps_runtime_gate_for_interrupt_failure_stop() -> None:
         await gate.lock.acquire()
         gate.token = "stop-token"
         gate.backend = "claude"
+        gate.running = True
 
         handled = await service.handle_stop("claude", request)
 
         assert handled is False
         assert gate.lock.locked()
         service.release_runtime_turn_key("session:/repo", "stop-token")
+
+    asyncio.run(_run())
+
+
+def test_agent_service_releases_gate_when_on_running_fails() -> None:
+    async def _run():
+        controller = _Controller()
+        controller.session_turns = _FailingTurnManager()
+        service = AgentService(controller=controller)
+        agent = _RuntimeAgent()
+        service.register(agent)
+        request = _request("hello")
+
+        try:
+            await service.handle_message("claude", request)
+        except RuntimeError as err:
+            assert str(err) == "status failed"
+        else:
+            raise AssertionError("on_running failure should escape")
+
+        gate = service._turn_gates["session:/repo"]
+        assert not gate.lock.locked()
+        assert gate.token == ""
+        assert gate.running is False
+        assert agent.started == []
 
     asyncio.run(_run())
 

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -29,6 +29,11 @@ class _RuntimeAgent:
         return False
 
 
+class _RaisingRuntimeAgent(_RuntimeAgent):
+    async def handle_message(self, _request):
+        raise RuntimeError("backend failed")
+
+
 class _ClearingRuntimeAgent:
     name = "codex"
 
@@ -192,5 +197,30 @@ def test_agent_service_clear_sessions_does_not_release_new_turn_token() -> None:
         assert service._turn_gates[runtime_key].token == "new-token"
 
         service.release_runtime_turn_key(runtime_key, "new-token")
+
+    asyncio.run(_run())
+
+
+def test_agent_service_releases_gate_when_exception_terminal_emit_fails() -> None:
+    async def _run():
+        controller = _Controller()
+
+        async def _emit(*_args, **_kwargs):
+            raise RuntimeError("send failed")
+
+        controller.emit_agent_message = _emit
+        service = AgentService(controller=controller)
+        agent = _RaisingRuntimeAgent()
+        service.register(agent)
+        request = _request("boom")
+
+        try:
+            await service.handle_message("claude", request)
+        except RuntimeError as err:
+            assert str(err) == "backend failed"
+        else:
+            raise AssertionError("backend exception should escape")
+
+        assert not service._turn_gates["session:/repo"].lock.locked()
 
     asyncio.run(_run())

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -51,6 +51,28 @@ class _ClearingRuntimeAgent:
     def runtime_turn_keys_for_session_key(self, _session_key):
         return self.runtime_keys
 
+    def runtime_turn_keys(self):
+        return self.runtime_keys
+
+
+class _StopRuntimeAgent(_RuntimeAgent):
+    def __init__(self, reason: str):
+        super().__init__()
+        self.reason = reason
+
+    async def handle_stop(self, request):
+        request.stop_failure_reason = self.reason
+        return False
+
+
+class _RefreshingRuntimeAgent(_ClearingRuntimeAgent):
+    def __init__(self, runtime_keys: set[str]):
+        super().__init__(runtime_keys)
+        self.refresh_calls: list[object] = []
+
+    async def refresh_runtime_config(self, runtime_config):
+        self.refresh_calls.append(runtime_config)
+
 
 class _Controller:
     def __init__(self):
@@ -180,6 +202,7 @@ def test_agent_service_clear_sessions_releases_cleared_runtime_gates() -> None:
             gate = service._get_turn_gate(runtime_key)
             await gate.lock.acquire()
             gate.token = f"{runtime_key}-token"
+            gate.backend = "codex"
 
         cleared = await service.clear_sessions("scope-1")
 
@@ -201,11 +224,13 @@ def test_agent_service_clear_sessions_does_not_release_new_turn_token() -> None:
         gate = service._get_turn_gate(runtime_key)
         await gate.lock.acquire()
         gate.token = "old-token"
+        gate.backend = "codex"
 
         async def _on_clear():
             service.release_runtime_turn_key(runtime_key, "old-token")
             await gate.lock.acquire()
             gate.token = "new-token"
+            gate.backend = "codex"
 
         agent = _ClearingRuntimeAgent({runtime_key}, on_clear=_on_clear)
         service.register(agent)
@@ -217,6 +242,90 @@ def test_agent_service_clear_sessions_does_not_release_new_turn_token() -> None:
         assert service._turn_gates[runtime_key].token == "new-token"
 
         service.release_runtime_turn_key(runtime_key, "new-token")
+
+    asyncio.run(_run())
+
+
+def test_agent_service_clear_backend_sessions_does_not_release_other_backend_gate() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        runtime_key = "session:/repo"
+        gate = service._get_turn_gate(runtime_key)
+        await gate.lock.acquire()
+        gate.token = "claude-token"
+        gate.backend = "claude"
+        agent = _ClearingRuntimeAgent({runtime_key})
+        service.register(agent)
+
+        count = await service.clear_backend_sessions("codex", "scope-1")
+
+        assert count == 1
+        assert gate.lock.locked()
+        assert gate.token == "claude-token"
+        service.release_runtime_turn_key(runtime_key, "claude-token")
+
+    asyncio.run(_run())
+
+
+def test_agent_service_refresh_runtime_config_releases_backend_gates() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        runtime_key = "session:/repo"
+        gate = service._get_turn_gate(runtime_key)
+        await gate.lock.acquire()
+        gate.token = "refresh-token"
+        gate.backend = "codex"
+        agent = _RefreshingRuntimeAgent({runtime_key})
+        service.register(agent)
+        runtime_config = object()
+
+        handled = await service.refresh_runtime_config("codex", runtime_config)
+
+        assert handled is True
+        assert agent.refresh_calls == [runtime_config]
+        assert not gate.lock.locked()
+        assert gate.token == ""
+        assert gate.backend == ""
+
+    asyncio.run(_run())
+
+
+def test_agent_service_releases_runtime_gate_for_stale_stop() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        agent = _StopRuntimeAgent("not_active")
+        service.register(agent)
+        request = _request("stop")
+        gate = service._get_turn_gate("session:/repo")
+        await gate.lock.acquire()
+        gate.token = "stop-token"
+        gate.backend = "claude"
+
+        handled = await service.handle_stop("claude", request)
+
+        assert handled is False
+        assert not gate.lock.locked()
+        assert request.context.platform_specific["agent_runtime_turn_token"] == "stop-token"
+
+    asyncio.run(_run())
+
+
+def test_agent_service_keeps_runtime_gate_for_interrupt_failure_stop() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        agent = _StopRuntimeAgent("interrupt_failed")
+        service.register(agent)
+        request = _request("stop")
+        gate = service._get_turn_gate("session:/repo")
+        await gate.lock.acquire()
+        gate.token = "stop-token"
+        gate.backend = "claude"
+
+        handled = await service.handle_stop("claude", request)
+
+        assert handled is False
+        assert gate.lock.locked()
+        service.release_runtime_turn_key("session:/repo", "stop-token")
 
     asyncio.run(_run())
 

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -130,6 +130,26 @@ def test_agent_service_allows_distinct_runtime_keys_in_parallel() -> None:
     asyncio.run(_run())
 
 
+def test_agent_service_falls_back_to_request_runtime_key_for_legacy_agent_stubs() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        handled = []
+
+        async def _handle_message(request):
+            handled.append(request)
+
+        service.register(SimpleNamespace(name="legacy", handle_message=_handle_message))
+        request = _request("hello", "legacy:/repo")
+
+        await service.handle_message("legacy", request)
+
+        assert handled == [request]
+        assert request.context.platform_specific["agent_runtime_turn_key"] == "legacy:/repo"
+        service.release_runtime_turn(request.context)
+
+    asyncio.run(_run())
+
+
 def test_agent_service_runtime_guard_drops_stale_emits_after_next_turn_starts() -> None:
     async def _run():
         service = AgentService(controller=_Controller())

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -7,6 +7,41 @@ from unittest.mock import AsyncMock
 from modules.agents.service import AgentService
 
 
+class _RuntimeAgent:
+    name = "claude"
+
+    def __init__(self, release_first: asyncio.Event | None = None):
+        self.started: list[str] = []
+        self.release_first = release_first
+
+    def runtime_turn_key(self, request):
+        return request.composite_session_id
+
+    async def handle_message(self, request):
+        self.started.append(request.message)
+        if request.message == "first" and self.release_first is not None:
+            await self.release_first.wait()
+
+    async def clear_sessions(self, _session_key):
+        return 0
+
+    async def handle_stop(self, _request):
+        return False
+
+
+class _Controller:
+    def __init__(self):
+        self.session_turns = None
+
+
+def _request(message: str, runtime_key: str = "session:/repo"):
+    return SimpleNamespace(
+        context=SimpleNamespace(platform_specific={}),
+        message=message,
+        composite_session_id=runtime_key,
+    )
+
+
 def test_agent_service_dispatches_runtime_config_refresh() -> None:
     service = AgentService(controller=SimpleNamespace())
     runtime_config = object()
@@ -25,3 +60,68 @@ def test_agent_service_reports_missing_runtime_refresh_contract() -> None:
 
     assert asyncio.run(service.refresh_runtime_config("codex", object())) is False
     assert asyncio.run(service.refresh_runtime_config("claude", object())) is False
+
+
+def test_agent_service_serializes_same_runtime_until_terminal_release() -> None:
+    async def _run():
+        controller = _Controller()
+        service = AgentService(controller=controller)
+        controller.agent_service = service
+        release_first = asyncio.Event()
+        agent = _RuntimeAgent(release_first)
+        service.register(agent)
+
+        first_request = _request("first")
+        first = asyncio.create_task(service.handle_message("claude", first_request))
+        await asyncio.sleep(0)
+        assert agent.started == ["first"]
+
+        second_request = _request("second")
+        second = asyncio.create_task(service.handle_message("claude", second_request))
+        await asyncio.sleep(0.05)
+        assert agent.started == ["first"]
+
+        service.release_runtime_turn(first_request.context)
+        release_first.set()
+        await asyncio.wait_for(first, timeout=3)
+        await asyncio.wait_for(second, timeout=3)
+
+        assert agent.started == ["first", "second"]
+
+    asyncio.run(_run())
+
+
+def test_agent_service_allows_distinct_runtime_keys_in_parallel() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        agent = _RuntimeAgent()
+        service.register(agent)
+
+        await asyncio.gather(
+            service.handle_message("claude", _request("one", "one:/repo")),
+            service.handle_message("claude", _request("two", "two:/repo")),
+        )
+
+        assert sorted(agent.started) == ["one", "two"]
+
+    asyncio.run(_run())
+
+
+def test_agent_service_runtime_guard_drops_stale_emits_after_next_turn_starts() -> None:
+    async def _run():
+        service = AgentService(controller=_Controller())
+        agent = _RuntimeAgent()
+        service.register(agent)
+        first = _request("first")
+        second = _request("second")
+
+        await service.handle_message("claude", first)
+        assert service.emit_matches_runtime_turn(first.context)
+        service.release_runtime_turn(first.context)
+
+        await service.handle_message("claude", second)
+
+        assert service.emit_matches_runtime_turn(second.context)
+        assert not service.emit_matches_runtime_turn(first.context)
+
+    asyncio.run(_run())

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -251,6 +251,36 @@ def test_agent_service_clear_sessions_does_not_release_new_turn_token() -> None:
     asyncio.run(_run())
 
 
+def test_agent_service_marks_runtime_started_from_matching_context_only() -> None:
+    service = AgentService(controller=_Controller())
+    runtime_key = "session:/repo"
+    gate = service._get_turn_gate(runtime_key)
+    gate.token = "runtime-token"
+    gate.backend = "claude"
+    context = SimpleNamespace(
+        platform_specific={
+            "agent_runtime_turn_key": runtime_key,
+            "agent_runtime_turn_token": "runtime-token",
+        }
+    )
+
+    service.mark_runtime_turn_started(context)
+
+    assert gate.runtime_started is True
+
+    stale_context = SimpleNamespace(
+        platform_specific={
+            "agent_runtime_turn_key": runtime_key,
+            "agent_runtime_turn_token": "old-token",
+        }
+    )
+    gate.runtime_started = False
+
+    service.mark_runtime_turn_started(stale_context)
+
+    assert gate.runtime_started is False
+
+
 def test_agent_service_clear_backend_sessions_does_not_release_other_backend_gate() -> None:
     async def _run():
         service = AgentService(controller=_Controller())
@@ -305,7 +335,7 @@ def test_agent_service_releases_runtime_gate_for_stale_stop() -> None:
         await gate.lock.acquire()
         gate.token = "stop-token"
         gate.backend = "claude"
-        gate.running = False
+        gate.runtime_started = True
 
         handled = await service.handle_stop("claude", request)
 
@@ -326,7 +356,7 @@ def test_agent_service_keeps_runtime_gate_for_startup_window_stop() -> None:
         await gate.lock.acquire()
         gate.token = "stop-token"
         gate.backend = "codex"
-        gate.running = True
+        gate.runtime_started = False
 
         handled = await service.handle_stop("claude", request)
 
@@ -348,7 +378,7 @@ def test_agent_service_keeps_runtime_gate_for_interrupt_failure_stop() -> None:
         await gate.lock.acquire()
         gate.token = "stop-token"
         gate.backend = "claude"
-        gate.running = True
+        gate.runtime_started = True
 
         handled = await service.handle_stop("claude", request)
 
@@ -378,7 +408,7 @@ def test_agent_service_releases_gate_when_on_running_fails() -> None:
         gate = service._turn_gates["session:/repo"]
         assert not gate.lock.locked()
         assert gate.token == ""
-        assert gate.running is False
+        assert gate.runtime_started is False
         assert agent.started == []
 
     asyncio.run(_run())

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -99,6 +99,207 @@ class _StubController:
 
 
 class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_handle_message_serializes_queries_for_same_runtime_session(self):
+        controller = _StubController()
+        runtime_key = "wechat_o9:/tmp/work"
+        first_query_started = asyncio.Event()
+        release_result = asyncio.Event()
+        queries: list[tuple[str, str]] = []
+
+        class ResultMessage:
+            subtype = "success"
+            result = "done"
+            duration_ms = 1
+
+        class _Client:
+            _vibe_runtime_base_session_id = "wechat_o9"
+            _vibe_runtime_session_key = runtime_key
+
+            async def query(self, message, *, session_id):
+                queries.append((message, session_id))
+                if len(queries) == 1:
+                    first_query_started.set()
+
+            def receive_messages(self):
+                async def _iterate():
+                    await release_result.wait()
+                    yield ResultMessage()
+
+                return _iterate()
+
+        client = _Client()
+        controller._get_session_key = lambda _context: "wechat-user"
+        controller.emit_agent_message = AsyncMock()
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(return_value=client),
+            mark_session_active=lambda _key: None,
+            mark_session_idle=lambda _key: None,
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_args, **_kwargs: None,
+        )
+
+        agent = ClaudeAgent(controller)
+        agent._prepare_message_with_files = lambda request: request.message
+        agent._delete_ack = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+
+        def _request(message: str):
+            return SimpleNamespace(
+                context=SimpleNamespace(
+                    user_id="U1",
+                    channel_id="C1",
+                    platform_specific={"turn_token": message},
+                ),
+                message=message,
+                working_path="/tmp/work",
+                base_session_id="wechat_o9",
+                composite_session_id=runtime_key,
+                session_key="wechat-user",
+                subagent_name=None,
+                subagent_model=None,
+                subagent_reasoning_effort=None,
+                ack_message_id=None,
+                ack_reaction_message_id=None,
+                ack_reaction_emoji=None,
+                files=None,
+            )
+
+        first = asyncio.create_task(agent.handle_message(_request("first")))
+        await asyncio.wait_for(first_query_started.wait(), timeout=3)
+        await asyncio.sleep(0)
+        second = asyncio.create_task(agent.handle_message(_request("second")))
+        await asyncio.sleep(0.05)
+
+        self.assertEqual(
+            queries,
+            [("first", runtime_key)],
+            "the second prompt must not be written into the same Claude runtime before the first result",
+        )
+
+        release_result.set()
+        await asyncio.wait_for(first, timeout=3)
+        await asyncio.wait_for(second, timeout=3)
+
+        self.assertEqual(queries, [("first", runtime_key), ("second", runtime_key)])
+
+    async def test_cancelled_waiter_does_not_leak_runtime_session_lock(self):
+        controller = _StubController()
+        runtime_key = "wechat_o9:/tmp/work"
+        first_query_started = asyncio.Event()
+        release_result = asyncio.Event()
+        queries: list[tuple[str, str]] = []
+
+        class ResultMessage:
+            subtype = "success"
+            result = "done"
+            duration_ms = 1
+
+        class _Client:
+            _vibe_runtime_base_session_id = "wechat_o9"
+            _vibe_runtime_session_key = runtime_key
+
+            async def query(self, message, *, session_id):
+                queries.append((message, session_id))
+                if len(queries) == 1:
+                    first_query_started.set()
+
+            def receive_messages(self):
+                async def _iterate():
+                    await release_result.wait()
+                    yield ResultMessage()
+
+                return _iterate()
+
+        client = _Client()
+        controller._get_session_key = lambda _context: "wechat-user"
+        controller.emit_agent_message = AsyncMock()
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(return_value=client),
+            mark_session_active=lambda _key: None,
+            mark_session_idle=lambda _key: None,
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_args, **_kwargs: None,
+        )
+
+        agent = ClaudeAgent(controller)
+        agent._prepare_message_with_files = lambda request: request.message
+        agent._delete_ack = AsyncMock()
+        agent.emit_result_message = AsyncMock()
+
+        def _request(message: str):
+            return SimpleNamespace(
+                context=SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={}),
+                message=message,
+                working_path="/tmp/work",
+                base_session_id="wechat_o9",
+                composite_session_id=runtime_key,
+                session_key="wechat-user",
+                subagent_name=None,
+                subagent_model=None,
+                subagent_reasoning_effort=None,
+                ack_message_id=None,
+                ack_reaction_message_id=None,
+                ack_reaction_emoji=None,
+                files=None,
+            )
+
+        first = asyncio.create_task(agent.handle_message(_request("first")))
+        await asyncio.wait_for(first_query_started.wait(), timeout=3)
+        blocked = asyncio.create_task(agent.handle_message(_request("cancelled")))
+        await asyncio.sleep(0.05)
+        blocked.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await blocked
+
+        release_result.set()
+        await asyncio.wait_for(first, timeout=3)
+
+        third = asyncio.create_task(agent.handle_message(_request("third")))
+        await asyncio.wait_for(third, timeout=3)
+
+        self.assertEqual(queries, [("first", runtime_key), ("third", runtime_key)])
+        self.assertNotIn(runtime_key, agent._pending_requests)
+
+    async def test_handle_stop_releases_runtime_turn_gate(self):
+        controller = _StubController()
+        controller.emit_agent_message = AsyncMock()
+        runtime_key = "wechat_o9:/tmp/work"
+        interrupted = False
+
+        class _Client:
+            async def interrupt(self):
+                nonlocal interrupted
+                interrupted = True
+
+            async def disconnect(self):
+                return None
+
+        agent = ClaudeAgent(controller)
+        pending_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        agent._pending_requests[runtime_key] = [pending_request]
+        await agent._acquire_runtime_turn_lock(runtime_key)
+        agent._runtime_turn_lock_keys[runtime_key] = (runtime_key,)
+        controller.claude_sessions[runtime_key] = _Client()
+
+        request = SimpleNamespace(
+            context=SimpleNamespace(platform_specific={}),
+            composite_session_id=runtime_key,
+            stop_failure_reason=None,
+        )
+
+        handled = await agent.handle_stop(request)
+
+        self.assertTrue(handled)
+        self.assertTrue(interrupted)
+        self.assertNotIn(runtime_key, agent._pending_requests)
+        self.assertNotIn(runtime_key, controller.claude_sessions)
+        controller.session_handler.cleanup_session.assert_awaited_once_with(
+            runtime_key,
+            current_receiver_task=None,
+        )
+        self.assertFalse(agent._runtime_turn_locks[runtime_key].locked())
+        self.assertEqual(request.context.platform_specific["turn_token"], "T1")
+
     async def test_result_keeps_claude_session_active_when_requests_are_queued(self):
         controller = _StubController()
         mark_idle_calls = []

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -397,6 +397,129 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         )
         controller.processing_indicator.finish.assert_awaited_once_with(pending_request)
 
+    async def test_handle_stop_keeps_runtime_gate_until_cleanup_finishes(self):
+        controller = _StubController()
+        runtime_key = "wechat_o9:/tmp/work"
+        disconnect_started = asyncio.Event()
+        allow_disconnect = asyncio.Event()
+        emit_called = asyncio.Event()
+
+        class _Client:
+            async def interrupt(self):
+                return None
+
+            async def disconnect(self):
+                disconnect_started.set()
+                await allow_disconnect.wait()
+
+        async def _receiver():
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                raise
+
+        agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+        controller.processing_indicator = SimpleNamespace(finish=AsyncMock())
+
+        async def _emit(context, message_type, text, **_kwargs):
+            emit_called.set()
+            if message_type == "result":
+                service.release_runtime_turn(context)
+
+        controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "T1",
+                    "agent_runtime_turn_key": runtime_key,
+                    "agent_runtime_turn_token": "R1",
+                }
+            ),
+            ack_reaction_message_id="m1",
+            ack_reaction_emoji=":eyes:",
+        )
+        agent._pending_requests[runtime_key] = [pending_request]
+        agent._pending_reactions[runtime_key] = [("m1", ":eyes:")]
+        gate = service._get_turn_gate(runtime_key)
+        await gate.lock.acquire()
+        gate.token = "R1"
+        controller.claude_sessions[runtime_key] = _Client()
+        controller.receiver_tasks[runtime_key] = asyncio.create_task(_receiver())
+
+        request = SimpleNamespace(
+            context=SimpleNamespace(platform_specific={}),
+            message="stop",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id=runtime_key,
+            session_key="wechat-user",
+            stop_failure_reason=None,
+        )
+
+        stop_task = asyncio.create_task(service.handle_stop("claude", request))
+        await asyncio.wait_for(disconnect_started.wait(), timeout=3)
+        await asyncio.sleep(0)
+
+        self.assertTrue(service._turn_gates[runtime_key].lock.locked())
+        self.assertFalse(emit_called.is_set())
+
+        allow_disconnect.set()
+        handled = await asyncio.wait_for(stop_task, timeout=3)
+
+        self.assertTrue(handled)
+        self.assertTrue(emit_called.is_set())
+        self.assertFalse(service._turn_gates[runtime_key].lock.locked())
+
+    async def test_setup_failure_emits_terminal_result_before_runtime_gate_release(self):
+        controller = _StubController()
+        runtime_key = "wechat_o9:/tmp/work"
+        controller.emit_agent_message = AsyncMock()
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(side_effect=RuntimeError("setup failed")),
+            mark_session_active=lambda _key: None,
+            mark_session_idle=lambda _key: None,
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_args, **_kwargs: None,
+        )
+        agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+        agent._delete_ack = AsyncMock()
+        agent._remove_ack_reaction = AsyncMock()
+
+        observed_gate_current = []
+
+        async def _emit(context, message_type, text, **_kwargs):
+            if message_type == "result":
+                observed_gate_current.append(service.emit_matches_runtime_turn(context))
+                service.release_runtime_turn(context)
+
+        controller.emit_agent_message.side_effect = _emit
+        request = SimpleNamespace(
+            context=SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={}),
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id=runtime_key,
+            session_key="wechat-user",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            ack_message_id=None,
+            ack_reaction_message_id=None,
+            ack_reaction_emoji=None,
+            files=None,
+        )
+
+        await service.handle_message("claude", request)
+
+        self.assertEqual(observed_gate_current, [True])
+        self.assertFalse(service._turn_gates[runtime_key].lock.locked())
+
     async def test_result_keeps_claude_session_active_when_requests_are_queued(self):
         controller = _StubController()
         mark_idle_calls = []

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1443,6 +1443,71 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(composite_key, controller.claude_sessions)
         self.assertNotIn(composite_key, agent._pending_requests)
 
+    async def test_receiver_eof_adopts_pending_turn_token_when_context_is_stale(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "telegram::user::U1"
+        agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+
+        async def _emit(context, message_type, text, **_kwargs):
+            if message_type == "result":
+                service.release_runtime_turn(context)
+
+        controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        composite_key = "session-1:/tmp/work"
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={
+                "turn_token": "old-turn",
+                "agent_runtime_turn_key": composite_key,
+                "agent_runtime_turn_token": "old-runtime",
+            },
+        )
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "current-turn",
+                    "agent_runtime_turn_key": composite_key,
+                    "agent_runtime_turn_token": "current-runtime",
+                }
+            ),
+            ack_reaction_message_id=None,
+            ack_reaction_emoji=None,
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        gate = service._get_turn_gate(composite_key)
+        await gate.lock.acquire()
+        gate.token = "current-runtime"
+
+        class _Client:
+            async def disconnect(self):
+                return None
+
+            def receive_messages(self):
+                async def _iterate():
+                    if False:
+                        yield None
+
+                return _iterate()
+
+        client = _Client()
+        controller.claude_sessions[composite_key] = client
+        receiver_task = asyncio.create_task(
+            agent._receive_messages(client, "session-1", "/tmp/work", context, composite_key=composite_key)
+        )
+        controller.receiver_tasks[composite_key] = receiver_task
+
+        await asyncio.wait_for(receiver_task, timeout=1)
+
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        self.assertEqual(context.platform_specific["turn_token"], "current-turn")
+        self.assertEqual(context.platform_specific["agent_runtime_turn_token"], "current-runtime")
+        self.assertFalse(service._turn_gates[composite_key].lock.locked())
+        self.assertNotIn(composite_key, agent._pending_requests)
+
     async def test_assistant_auth_error_prefers_oauth_recovery_message(self):
         controller = _StubController()
         controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -765,6 +765,29 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(session_key, controller.claude_sessions)
         self.assertEqual(controller.session_manager.cleared, ["wechat-user"])
 
+    async def test_clear_sessions_cancels_subagent_runtime_keys_for_cleared_session(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        session_key = "wechat_o9:reviewer:/tmp/work"
+        client = _StubClient()
+        controller.claude_sessions[session_key] = client
+
+        cleared = await agent.clear_sessions("wechat-user")
+
+        self.assertEqual(cleared, 1)
+        self.assertTrue(client.disconnected)
+        self.assertNotIn(session_key, controller.claude_sessions)
+
+    async def test_runtime_turn_keys_for_session_key_matches_subagent_runtime_keys(self):
+        controller = _StubController()
+        agent = ClaudeAgent(controller)
+        controller.claude_sessions["wechat_o9:reviewer:/tmp/work"] = _StubClient()
+        controller.claude_sessions["other:/tmp/work"] = _StubClient()
+
+        keys = agent.runtime_turn_keys_for_session_key("wechat-user")
+
+        self.assertEqual(keys, {"wechat_o9:reviewer:/tmp/work"})
+
     async def test_clear_sessions_swallows_receiver_task_failure(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)
@@ -1442,6 +1465,70 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(service._turn_gates[composite_key].lock.locked())
         self.assertNotIn(composite_key, controller.claude_sessions)
         self.assertNotIn(composite_key, agent._pending_requests)
+
+    async def test_receiver_eof_cleans_runtime_before_terminal_emit_releases_gate(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "telegram::user::U1"
+        agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+        composite_key = "session-1:/tmp/work"
+        release_seen_state: dict[str, bool] = {}
+
+        async def _emit(context, message_type, text, **_kwargs):
+            if message_type == "result":
+                release_seen_state["client_present"] = composite_key in controller.claude_sessions
+                release_seen_state["receiver_present"] = composite_key in controller.receiver_tasks
+                service.release_runtime_turn(context)
+
+        controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={
+                "agent_runtime_turn_key": composite_key,
+                "agent_runtime_turn_token": "R1",
+            },
+        )
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "T1",
+                    "agent_runtime_turn_key": composite_key,
+                    "agent_runtime_turn_token": "R1",
+                }
+            ),
+            ack_reaction_message_id=None,
+            ack_reaction_emoji=None,
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        gate = service._get_turn_gate(composite_key)
+        await gate.lock.acquire()
+        gate.token = "R1"
+
+        class _Client:
+            async def disconnect(self):
+                return None
+
+            def receive_messages(self):
+                async def _iterate():
+                    if False:
+                        yield None
+
+                return _iterate()
+
+        client = _Client()
+        controller.claude_sessions[composite_key] = client
+        receiver_task = asyncio.create_task(
+            agent._receive_messages(client, "session-1", "/tmp/work", context, composite_key=composite_key)
+        )
+        controller.receiver_tasks[composite_key] = receiver_task
+
+        await asyncio.wait_for(receiver_task, timeout=1)
+
+        self.assertEqual(release_seen_state, {"client_present": False, "receiver_present": False})
+        self.assertFalse(service._turn_gates[composite_key].lock.locked())
 
     async def test_receiver_eof_adopts_pending_turn_token_when_context_is_stale(self):
         controller = _StubController()

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from modules.agents.base import BaseAgent
 from modules.agents.claude_agent import ClaudeAgent
+from modules.agents.service import AgentService
 
 
 class _StubSessions:
@@ -139,9 +140,15 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         )
 
         agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
         agent._prepare_message_with_files = lambda request: request.message
         agent._delete_ack = AsyncMock()
-        agent.emit_result_message = AsyncMock()
+        async def _emit_result(context, *_args, **_kwargs):
+            service.release_runtime_turn(context)
+
+        agent.emit_result_message = AsyncMock(side_effect=_emit_result)
 
         def _request(message: str):
             return SimpleNamespace(
@@ -164,10 +171,10 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
                 files=None,
             )
 
-        first = asyncio.create_task(agent.handle_message(_request("first")))
+        first = asyncio.create_task(service.handle_message("claude", _request("first")))
         await asyncio.wait_for(first_query_started.wait(), timeout=3)
         await asyncio.sleep(0)
-        second = asyncio.create_task(agent.handle_message(_request("second")))
+        second = asyncio.create_task(service.handle_message("claude", _request("second")))
         await asyncio.sleep(0.05)
 
         self.assertEqual(
@@ -222,9 +229,15 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         )
 
         agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
         agent._prepare_message_with_files = lambda request: request.message
         agent._delete_ack = AsyncMock()
-        agent.emit_result_message = AsyncMock()
+        async def _emit_result(context, *_args, **_kwargs):
+            service.release_runtime_turn(context)
+
+        agent.emit_result_message = AsyncMock(side_effect=_emit_result)
 
         def _request(message: str):
             return SimpleNamespace(
@@ -243,9 +256,9 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
                 files=None,
             )
 
-        first = asyncio.create_task(agent.handle_message(_request("first")))
+        first = asyncio.create_task(service.handle_message("claude", _request("first")))
         await asyncio.wait_for(first_query_started.wait(), timeout=3)
-        blocked = asyncio.create_task(agent.handle_message(_request("cancelled")))
+        blocked = asyncio.create_task(service.handle_message("claude", _request("cancelled")))
         await asyncio.sleep(0.05)
         blocked.cancel()
         with self.assertRaises(asyncio.CancelledError):
@@ -254,7 +267,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         release_result.set()
         await asyncio.wait_for(first, timeout=3)
 
-        third = asyncio.create_task(agent.handle_message(_request("third")))
+        third = asyncio.create_task(service.handle_message("claude", _request("third")))
         await asyncio.wait_for(third, timeout=3)
 
         self.assertEqual(queries, [("first", runtime_key), ("third", runtime_key)])
@@ -262,7 +275,6 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_handle_stop_releases_runtime_turn_gate(self):
         controller = _StubController()
-        controller.emit_agent_message = AsyncMock()
         runtime_key = "wechat_o9:/tmp/work"
         interrupted = False
 
@@ -275,19 +287,41 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
                 return None
 
         agent = ClaudeAgent(controller)
-        pending_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+
+        async def _emit(context, message_type, text, **_kwargs):
+            if message_type == "result":
+                service.release_runtime_turn(context)
+
+        controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "T1",
+                    "agent_runtime_turn_key": runtime_key,
+                    "agent_runtime_turn_token": "R1",
+                }
+            )
+        )
         agent._pending_requests[runtime_key] = [pending_request]
-        await agent._acquire_runtime_turn_lock(runtime_key)
-        agent._runtime_turn_lock_keys[runtime_key] = (runtime_key,)
+        gate = service._get_turn_gate(runtime_key)
+        await gate.lock.acquire()
+        gate.token = "R1"
         controller.claude_sessions[runtime_key] = _Client()
 
         request = SimpleNamespace(
             context=SimpleNamespace(platform_specific={}),
+            message="stop",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
             composite_session_id=runtime_key,
+            session_key="wechat-user",
             stop_failure_reason=None,
         )
 
-        handled = await agent.handle_stop(request)
+        handled = await service.handle_stop("claude", request)
 
         self.assertTrue(handled)
         self.assertTrue(interrupted)
@@ -297,8 +331,9 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             runtime_key,
             current_receiver_task=None,
         )
-        self.assertFalse(agent._runtime_turn_locks[runtime_key].locked())
+        self.assertFalse(service._turn_gates[runtime_key].lock.locked())
         self.assertEqual(request.context.platform_specific["turn_token"], "T1")
+        self.assertEqual(request.context.platform_specific["agent_runtime_turn_token"], "R1")
 
     async def test_result_keeps_claude_session_active_when_requests_are_queued(self):
         controller = _StubController()
@@ -359,9 +394,21 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         context = SimpleNamespace(
             user_id="U1",
             channel_id="C1",
-            platform_specific={"turn_token": "T1"},
+            platform_specific={
+                "turn_token": "T1",
+                "agent_runtime_turn_key": composite_key,
+                "agent_runtime_turn_token": "R1",
+            },
         )
-        pending_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T2"}))
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "T2",
+                    "agent_runtime_turn_key": composite_key,
+                    "agent_runtime_turn_token": "R2",
+                }
+            )
+        )
         agent._pending_requests[composite_key] = [pending_request]
 
         class FakeToolUseBlock:
@@ -398,6 +445,8 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             parse_mode="markdown",
         )
         self.assertEqual(context.platform_specific["turn_token"], "T2")
+        self.assertEqual(context.platform_specific["agent_runtime_turn_key"], composite_key)
+        self.assertEqual(context.platform_specific["agent_runtime_turn_token"], "R2")
         self.assertEqual(agent._pending_requests[composite_key], [pending_request])
 
     async def test_handle_message_uses_runtime_session_key_for_claude_tracking(self):

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -290,6 +290,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         service = AgentService(controller)
         service.register(agent)
         controller.agent_service = service
+        controller.processing_indicator = SimpleNamespace(finish=AsyncMock())
 
         async def _emit(context, message_type, text, **_kwargs):
             if message_type == "result":
@@ -303,9 +304,12 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
                     "agent_runtime_turn_key": runtime_key,
                     "agent_runtime_turn_token": "R1",
                 }
-            )
+            ),
+            ack_reaction_message_id="m1",
+            ack_reaction_emoji=":eyes:",
         )
         agent._pending_requests[runtime_key] = [pending_request]
+        agent._pending_reactions[runtime_key] = [("m1", ":eyes:")]
         gate = service._get_turn_gate(runtime_key)
         await gate.lock.acquire()
         gate.token = "R1"
@@ -334,6 +338,64 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(service._turn_gates[runtime_key].lock.locked())
         self.assertEqual(request.context.platform_specific["turn_token"], "T1")
         self.assertEqual(request.context.platform_specific["agent_runtime_turn_token"], "R1")
+        controller.processing_indicator.finish.assert_awaited_once_with(pending_request)
+
+    async def test_handle_stop_cleans_up_when_silent_result_emit_fails(self):
+        controller = _StubController()
+        runtime_key = "wechat_o9:/tmp/work"
+
+        class _Client:
+            async def interrupt(self):
+                return None
+
+            async def disconnect(self):
+                return None
+
+        agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+        controller.processing_indicator = SimpleNamespace(finish=AsyncMock())
+        controller.emit_agent_message = AsyncMock(side_effect=RuntimeError("send failed"))
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "T1",
+                    "agent_runtime_turn_key": runtime_key,
+                    "agent_runtime_turn_token": "R1",
+                }
+            ),
+            ack_reaction_message_id="m1",
+            ack_reaction_emoji=":eyes:",
+        )
+        agent._pending_requests[runtime_key] = [pending_request]
+        agent._pending_reactions[runtime_key] = [("m1", ":eyes:")]
+        gate = service._get_turn_gate(runtime_key)
+        await gate.lock.acquire()
+        gate.token = "R1"
+        controller.claude_sessions[runtime_key] = _Client()
+
+        request = SimpleNamespace(
+            context=SimpleNamespace(platform_specific={}),
+            message="stop",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id=runtime_key,
+            session_key="wechat-user",
+            stop_failure_reason=None,
+        )
+
+        handled = await service.handle_stop("claude", request)
+
+        self.assertTrue(handled)
+        self.assertIsNone(request.stop_failure_reason)
+        self.assertNotIn(runtime_key, controller.claude_sessions)
+        self.assertFalse(service._turn_gates[runtime_key].lock.locked())
+        controller.session_handler.cleanup_session.assert_awaited_once_with(
+            runtime_key,
+            current_receiver_task=None,
+        )
+        controller.processing_indicator.finish.assert_awaited_once_with(pending_request)
 
     async def test_result_keeps_claude_session_active_when_requests_are_queued(self):
         controller = _StubController()
@@ -438,16 +500,12 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             agent._get_formatter = lambda _context: _Formatter()
             await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
 
-        controller.emit_agent_message.assert_awaited_once_with(
-            context,
-            "toolcall",
-            "Bash(pwd)",
-            parse_mode="markdown",
-        )
+        first_emit = controller.emit_agent_message.await_args_list[0]
+        self.assertEqual(first_emit.args, (context, "toolcall", "Bash(pwd)"))
+        self.assertEqual(first_emit.kwargs, {"parse_mode": "markdown"})
         self.assertEqual(context.platform_specific["turn_token"], "T2")
         self.assertEqual(context.platform_specific["agent_runtime_turn_key"], composite_key)
         self.assertEqual(context.platform_specific["agent_runtime_turn_token"], "R2")
-        self.assertEqual(agent._pending_requests[composite_key], [pending_request])
 
     async def test_handle_message_uses_runtime_session_key_for_claude_tracking(self):
         controller = _StubController()
@@ -1198,6 +1256,69 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
         self.assertNotIn(composite_key, controller.receiver_tasks)
         self.assertNotIn(composite_key, controller.claude_sessions)
+
+    async def test_receiver_eof_without_result_releases_runtime_gate(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "telegram::user::U1"
+        agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+
+        async def _emit(context, message_type, text, **_kwargs):
+            if message_type == "result":
+                service.release_runtime_turn(context)
+
+        controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        composite_key = "session-1:/tmp/work"
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={
+                "agent_runtime_turn_key": composite_key,
+                "agent_runtime_turn_token": "R1",
+            },
+        )
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "T1",
+                    "agent_runtime_turn_key": composite_key,
+                    "agent_runtime_turn_token": "R1",
+                }
+            ),
+            ack_reaction_message_id=None,
+            ack_reaction_emoji=None,
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        gate = service._get_turn_gate(composite_key)
+        await gate.lock.acquire()
+        gate.token = "R1"
+
+        class _Client:
+            async def disconnect(self):
+                return None
+
+            def receive_messages(self):
+                async def _iterate():
+                    if False:
+                        yield None
+
+                return _iterate()
+
+        client = _Client()
+        controller.claude_sessions[composite_key] = client
+        receiver_task = asyncio.create_task(
+            agent._receive_messages(client, "session-1", "/tmp/work", context, composite_key=composite_key)
+        )
+        controller.receiver_tasks[composite_key] = receiver_task
+
+        await asyncio.wait_for(receiver_task, timeout=1)
+
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        self.assertFalse(service._turn_gates[composite_key].lock.locked())
+        self.assertNotIn(composite_key, controller.claude_sessions)
+        self.assertNotIn(composite_key, agent._pending_requests)
 
     async def test_assistant_auth_error_prefers_oauth_recovery_message(self):
         controller = _StubController()

--- a/tests/test_codex_event_handler.py
+++ b/tests/test_codex_event_handler.py
@@ -303,6 +303,33 @@ class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
         agent.emit_result_message.assert_not_awaited()
         agent._remove_ack_reaction.assert_not_awaited()
 
+    async def test_interrupted_completion_releases_runtime_gate_without_result(self):
+        agent = _StubAgent()
+        release_runtime_turn = Mock()
+        agent.controller.agent_service = SimpleNamespace(release_runtime_turn=release_runtime_turn)
+        handler = CodexEventHandler(agent)
+        context = SimpleNamespace(
+            platform_specific={
+                "agent_runtime_turn_key": "session-1:/repo",
+                "agent_runtime_turn_token": "R1",
+            }
+        )
+        request = SimpleNamespace(base_session_id="session-1", context=context, started_at=0)
+        agent._turn_registry.register_turn("turn-1", request)
+
+        await handler._on_turn_completed(
+            {
+                "turn": {
+                    "id": "turn-1",
+                    "status": "interrupted",
+                }
+            },
+            request,
+        )
+
+        agent.emit_result_message.assert_not_awaited()
+        release_runtime_turn.assert_called_once_with(context)
+
     async def test_auth_recovery_message_suppresses_plain_notify(self):
         agent = _StubAgent()
         agent.controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)

--- a/tests/test_controller_dispatch_loop.py
+++ b/tests/test_controller_dispatch_loop.py
@@ -4,6 +4,7 @@ import asyncio
 import threading
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -46,7 +47,7 @@ def test_dispatch_to_controller_loop_runs_callback_on_controller_loop():
     assert result["value"] == "hello"
 
 
-def test_dispatch_to_controller_loop_background_returns_before_callback_finishes():
+def test_dispatch_im_message_to_controller_loop_backgrounds_untracked_platforms():
     controller = Controller.__new__(Controller)
     loop = asyncio.new_event_loop()
     controller._loop = loop
@@ -54,15 +55,17 @@ def test_dispatch_to_controller_loop_background_returns_before_callback_finishes
     callback_can_finish = threading.Event()
     result: dict[str, object] = {}
 
-    async def callback(value: str) -> None:
+    async def callback(context, value: str) -> None:
         result["thread"] = threading.current_thread().name
         result["loop"] = asyncio.get_running_loop()
+        result["platform"] = context.platform
         result["value"] = value
         callback_started.set()
         await asyncio.to_thread(callback_can_finish.wait)
         result["finished"] = True
 
-    wrapped = Controller._dispatch_to_controller_loop_background(controller, callback)
+    wrapped = Controller._dispatch_im_message_to_controller_loop(controller, callback)
+    context = SimpleNamespace(platform="slack", platform_specific={"platform": "slack"})
 
     def _loop_runner() -> None:
         asyncio.set_event_loop(loop)
@@ -72,7 +75,7 @@ def test_dispatch_to_controller_loop_background_returns_before_callback_finishes
     loop_thread.start()
 
     async def _invoke() -> None:
-        await asyncio.wait_for(wrapped("hello"), timeout=0.2)
+        await asyncio.wait_for(wrapped(context, "hello"), timeout=0.2)
 
     try:
         asyncio.run(_invoke())
@@ -90,6 +93,58 @@ def test_dispatch_to_controller_loop_background_returns_before_callback_finishes
 
     assert result["finished"] is True
     assert result["thread"] == "controller-loop"
+    assert result["platform"] == "slack"
+    assert result["value"] == "hello"
+
+
+def test_dispatch_im_message_to_controller_loop_waits_for_tracked_platforms():
+    controller = Controller.__new__(Controller)
+    loop = asyncio.new_event_loop()
+    controller._loop = loop
+    callback_started = threading.Event()
+    callback_can_finish = threading.Event()
+    result: dict[str, object] = {}
+
+    async def callback(context, value: str) -> str:
+        result["thread"] = threading.current_thread().name
+        result["loop"] = asyncio.get_running_loop()
+        result["platform"] = context.platform
+        result["value"] = value
+        callback_started.set()
+        await asyncio.to_thread(callback_can_finish.wait)
+        result["finished"] = True
+        return "done"
+
+    wrapped = Controller._dispatch_im_message_to_controller_loop(controller, callback)
+    context = SimpleNamespace(platform="telegram", platform_specific={"platform": "telegram"})
+
+    def _loop_runner() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=_loop_runner, name="controller-loop", daemon=True)
+    loop_thread.start()
+
+    async def _invoke() -> str:
+        task = asyncio.create_task(wrapped(context, "hello"))
+        await asyncio.to_thread(callback_started.wait)
+        await asyncio.sleep(0)
+        assert not task.done()
+        callback_can_finish.set()
+        return await asyncio.wait_for(task, timeout=1)
+
+    try:
+        output = asyncio.run(_invoke())
+    finally:
+        callback_can_finish.set()
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2)
+        loop.close()
+
+    assert output == "done"
+    assert result["finished"] is True
+    assert result["thread"] == "controller-loop"
+    assert result["platform"] == "telegram"
     assert result["value"] == "hello"
 
 

--- a/tests/test_controller_dispatch_loop.py
+++ b/tests/test_controller_dispatch_loop.py
@@ -148,6 +148,56 @@ def test_dispatch_im_message_to_controller_loop_waits_for_tracked_platforms():
     assert result["value"] == "hello"
 
 
+def test_dispatch_im_message_to_controller_loop_waits_for_standalone_wechat_without_context_platform():
+    controller = Controller.__new__(Controller)
+    loop = asyncio.new_event_loop()
+    controller._loop = loop
+    controller.im_client = type("WeChatBot", (), {"__module__": "modules.im.wechat"})()
+    callback_started = threading.Event()
+    callback_can_finish = threading.Event()
+    result: dict[str, object] = {}
+
+    async def callback(context, value: str) -> str:
+        result["thread"] = threading.current_thread().name
+        result["loop"] = asyncio.get_running_loop()
+        result["value"] = value
+        callback_started.set()
+        await asyncio.to_thread(callback_can_finish.wait)
+        result["finished"] = True
+        return "done"
+
+    wrapped = Controller._dispatch_im_message_to_controller_loop(controller, callback)
+    context = SimpleNamespace(platform="", platform_specific={})
+
+    def _loop_runner() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=_loop_runner, name="controller-loop", daemon=True)
+    loop_thread.start()
+
+    async def _invoke() -> str:
+        task = asyncio.create_task(wrapped(context, "hello"))
+        await asyncio.to_thread(callback_started.wait)
+        await asyncio.sleep(0)
+        assert not task.done()
+        callback_can_finish.set()
+        return await asyncio.wait_for(task, timeout=1)
+
+    try:
+        output = asyncio.run(_invoke())
+    finally:
+        callback_can_finish.set()
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2)
+        loop.close()
+
+    assert output == "done"
+    assert result["finished"] is True
+    assert result["thread"] == "controller-loop"
+    assert result["value"] == "hello"
+
+
 def test_cleanup_sync_stops_watch_service_on_stopped_loop() -> None:
     controller = Controller.__new__(Controller)
     loop = asyncio.new_event_loop()

--- a/tests/test_controller_dispatch_loop.py
+++ b/tests/test_controller_dispatch_loop.py
@@ -46,6 +46,53 @@ def test_dispatch_to_controller_loop_runs_callback_on_controller_loop():
     assert result["value"] == "hello"
 
 
+def test_dispatch_to_controller_loop_background_returns_before_callback_finishes():
+    controller = Controller.__new__(Controller)
+    loop = asyncio.new_event_loop()
+    controller._loop = loop
+    callback_started = threading.Event()
+    callback_can_finish = threading.Event()
+    result: dict[str, object] = {}
+
+    async def callback(value: str) -> None:
+        result["thread"] = threading.current_thread().name
+        result["loop"] = asyncio.get_running_loop()
+        result["value"] = value
+        callback_started.set()
+        await asyncio.to_thread(callback_can_finish.wait)
+        result["finished"] = True
+
+    wrapped = Controller._dispatch_to_controller_loop_background(controller, callback)
+
+    def _loop_runner() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=_loop_runner, name="controller-loop", daemon=True)
+    loop_thread.start()
+
+    async def _invoke() -> None:
+        await asyncio.wait_for(wrapped("hello"), timeout=0.2)
+
+    try:
+        asyncio.run(_invoke())
+        assert callback_started.wait(timeout=1)
+        assert "finished" not in result
+        callback_can_finish.set()
+        deadline = loop.time() + 2
+        while "finished" not in result and loop.time() < deadline:
+            threading.Event().wait(0.01)
+    finally:
+        callback_can_finish.set()
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2)
+        loop.close()
+
+    assert result["finished"] is True
+    assert result["thread"] == "controller-loop"
+    assert result["value"] == "hello"
+
+
 def test_cleanup_sync_stops_watch_service_on_stopped_loop() -> None:
     controller = Controller.__new__(Controller)
     loop = asyncio.new_event_loop()

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -272,6 +272,38 @@ class MessageDispatcherResultFallbackTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(controller.im_client.sent_messages, [])
         persist.assert_not_called()
 
+    async def test_result_releases_runtime_gate_after_result_cleanup(self):
+        controller = _StubController(platform="slack")
+        events = []
+
+        class _AgentService:
+            @staticmethod
+            def emit_matches_runtime_turn(_context):
+                return True
+
+            @staticmethod
+            def release_runtime_turn(_context):
+                events.append("release")
+
+        controller.agent_service = _AgentService()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+
+        async def _clear_consolidated_state(_context):
+            events.append("clear")
+
+        dispatcher._clear_consolidated_state = _clear_consolidated_state
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={"agent_runtime_turn_key": "s:/repo", "agent_runtime_turn_token": "tok"},
+        )
+
+        with mock.patch("core.message_dispatcher.persist_agent_message"):
+            await dispatcher.emit_agent_message(context, "result", "done")
+
+        self.assertEqual(events, ["clear", "release"])
+
     async def test_muted_log_message_still_persists(self):
         """assistant / tool_call rows persist BEFORE the mute filter, so a muted
         process log still lands in the store (product requirement)."""

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -97,6 +97,7 @@ class _StubController:
         )()
         self.session_handler = _StubSessionHandler()
         self.im_client = im_client or _StubIMClient(fail_first_send=fail_first_send, upload_id=upload_id)
+        self.agent_service = None
 
     def _get_settings_key(self, context):
         return context.channel_id
@@ -244,6 +245,31 @@ class MessageDispatcherResultFallbackTests(unittest.IsolatedAsyncioTestCase):
             result = await dispatcher.emit_agent_message(context, "result", "late result")
 
         self.assertIsNone(result)
+        persist.assert_not_called()
+
+    async def test_stale_runtime_result_is_dropped_before_delivery_and_persistence(self):
+        controller = _StubController(platform="slack")
+        controller.agent_service = type(
+            "AgentService",
+            (),
+            {
+                "emit_matches_runtime_turn": staticmethod(lambda _context: False),
+                "release_runtime_turn": staticmethod(lambda _context: None),
+            },
+        )()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={"agent_runtime_turn_key": "s:/repo", "agent_runtime_turn_token": "old"},
+        )
+
+        with mock.patch("core.message_dispatcher.persist_agent_message") as persist:
+            message_id = await dispatcher.emit_agent_message(context, "result", "late result")
+
+        self.assertIsNone(message_id)
+        self.assertEqual(controller.im_client.sent_messages, [])
         persist.assert_not_called()
 
     async def test_muted_log_message_still_persists(self):


### PR DESCRIPTION
## Summary
- serialize backend runtime turns in AgentService, keyed by the backend composite session id when present, so Workbench, IM, scheduled/watch, and backend adapters share the same bottom-layer gate
- drop stale assistant/toolcall/result emits in the shared MessageDispatcher before delivery or transcript persistence, and release the runtime gate on terminal result
- keep Claude's reused receiver aligned with the active turn tokens, release Codex no-result terminal paths through the same shared gate, and close cleanup gaps for stop, EOF, setup failure, and scoped clear paths

## Evidence
- Unit: `pytest tests/test_agent_service.py tests/test_claude_agent_sessions.py tests/test_codex_agent.py tests/test_codex_event_handler.py tests/test_opencode_server.py tests/test_message_dispatcher_result_fallback.py tests/test_dispatcher_stream_chunk.py -q`
- Unit: `pytest tests/test_controller_agent_status.py tests/test_agent_service.py -q`
- Unit: `pytest tests/test_agent_service.py tests/test_controller_agent_status.py tests/test_claude_agent_sessions.py tests/test_message_dispatcher_result_fallback.py tests/test_dispatcher_stream_chunk.py -q`
- Unit: `pytest tests/test_message_handler_typing.py tests/test_internal_server.py::test_cancel_does_not_flush_queue tests/test_internal_server.py::test_cancel_releases_stale_turn_when_backend_not_active tests/test_internal_server.py::test_cancel_keeps_turn_when_backend_interrupt_failed tests/test_internal_server.py::test_scheduled_gate_cancel_stops_scheduled_run tests/test_internal_server.py::test_dispatch_async_enqueues_during_busy_turn tests/test_internal_server.py::test_async_dispatch_flushes_queue_on_turn_end tests/test_internal_server.py::test_scheduled_gate_busy_enqueues_and_leaves_chat_turn_untouched tests/test_internal_server.py::test_dispatch_turn_registers_sink_for_dispatcher_hook -q`
- Contract: N/A
- Scenario: N/A
- Lint: `ruff check modules/agents/base.py modules/agents/service.py modules/agents/claude_agent.py modules/agents/codex/agent.py modules/agents/codex/session.py modules/agents/opencode/agent.py modules/agents/opencode/session.py tests/test_agent_service.py tests/test_claude_agent_sessions.py`
- Diff hygiene: `git diff --check`
- Residual manual checks: no live Avibe restart or IM smoke test in this session
