### PR TITLE
fix(watch): detach background stdin

### DIFF
--- a/core/watches.py
+++ b/core/watches.py
@@ -659,6 +659,7 @@ class ManagedWatchService:
             process = await asyncio.create_subprocess_shell(
                 watch.shell_command,
                 cwd=watch.cwd or None,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 **isolated_subprocess_kwargs(),
@@ -667,6 +668,7 @@ class ManagedWatchService:
             process = await asyncio.create_subprocess_exec(
                 *watch.command,
                 cwd=watch.cwd or None,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 **isolated_subprocess_kwargs(),

--- a/tests/test_service_logging_handlers.py
+++ b/tests/test_service_logging_handlers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import subprocess
 import sys
@@ -58,6 +59,29 @@ def test_start_service_disables_stdout_logging_for_background_process(monkeypatc
     assert captured["stderr_name"] == "service_stderr.log"
     assert isinstance(captured["env"], dict)
     assert captured["env"]["VIBE_DISABLE_STDOUT_LOGGING"] == "1"
+
+
+def test_spawn_background_detaches_stdin(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(runtime.paths, "get_runtime_dir", lambda: tmp_path)
+
+    class FakePopen:
+        pid = 12345
+
+        def __init__(self, args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+
+    process = runtime.spawn_service_background_process(["python3", "service.py"], "stdout.log", "stderr.log")
+
+    assert process.pid == 12345
+    stdin = captured["kwargs"]["stdin"]
+    assert stdin.name == os.devnull
+    assert stdin.closed is True
+    assert captured["kwargs"]["start_new_session"] is True
 
 
 def test_main_import_does_not_load_controller() -> None:

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -17,6 +17,14 @@ from core.watches import ManagedWatchService, ManagedWatchStore, WatchRuntimeSta
 from storage.background import SQLiteBackgroundTaskStore
 
 
+class _FakeProcess:
+    pid = 1234
+    returncode = 0
+
+    async def communicate(self):
+        return b"ok\n", b""
+
+
 def test_managed_watch_store_round_trip(tmp_path: Path) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     watch = store.add_watch(
@@ -72,6 +80,88 @@ def test_managed_watch_store_preserves_zero_values_on_reload(tmp_path: Path) -> 
     assert saved.timeout_seconds == 0
     assert saved.lifetime_timeout_seconds == 0
     assert saved.retry_delay_seconds == 0
+
+
+def test_managed_watch_exec_detaches_waiter_stdin(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=TaskExecutionStore(tmp_path / "task_requests"),
+        runtime_store=runtime_store,
+    )
+    watch = store.add_watch(
+        name="Watch Python",
+        session_key="slack::channel::C123",
+        command=["python3", "-c", "print('ok')"],
+        shell_command=None,
+        prefix=None,
+        cwd=None,
+        mode="once",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=30,
+        post_to=None,
+        deliver_key=None,
+    )
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    result = asyncio.run(service._run_cycle(watch, timeout_seconds=5))
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["stdin"] == asyncio.subprocess.DEVNULL
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.PIPE
+
+
+def test_managed_watch_shell_detaches_waiter_stdin(tmp_path: Path, monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=TaskExecutionStore(tmp_path / "task_requests"),
+        runtime_store=runtime_store,
+    )
+    watch = store.add_watch(
+        name="Watch Shell",
+        session_key="slack::channel::C123",
+        command=[],
+        shell_command="python3 -c 'print(\"ok\")'",
+        prefix=None,
+        cwd=None,
+        mode="once",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=30,
+        post_to=None,
+        deliver_key=None,
+    )
+
+    async def fake_create_subprocess_shell(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return _FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", fake_create_subprocess_shell)
+
+    result = asyncio.run(service._run_cycle(watch, timeout_seconds=5))
+
+    assert result.exit_code == 0
+    assert captured["kwargs"]["stdin"] == asyncio.subprocess.DEVNULL
+    assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == asyncio.subprocess.PIPE
 
 
 def test_managed_watch_store_uses_sqlite_when_path_is_default(tmp_path: Path, monkeypatch) -> None:

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -569,17 +569,22 @@ def spawn_background(args, pid_path, stdout_name: str, stderr_name: str, env: di
     stdout_path.parent.mkdir(parents=True, exist_ok=True)
     stdout = stdout_path.open("ab")
     stderr = stderr_path.open("ab")
-    process = subprocess.Popen(
-        args,
-        stdout=stdout,
-        stderr=stderr,
-        start_new_session=True,
-        cwd=str(get_working_dir()),
-        close_fds=True,
-        env=env,
-    )
-    stdout.close()
-    stderr.close()
+    stdin = open(os.devnull, "rb")
+    try:
+        process = subprocess.Popen(
+            args,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            start_new_session=True,
+            cwd=str(get_working_dir()),
+            close_fds=True,
+            env=env,
+        )
+    finally:
+        stdin.close()
+        stdout.close()
+        stderr.close()
     pid_path.write_text(str(process.pid), encoding="utf-8")
     return process.pid
 
@@ -595,9 +600,11 @@ def spawn_service_background_process(
     stdout_path.parent.mkdir(parents=True, exist_ok=True)
     stdout = stdout_path.open("ab")
     stderr = stderr_path.open("ab")
+    stdin = open(os.devnull, "rb")
     try:
         process = subprocess.Popen(
             args,
+            stdin=stdin,
             stdout=stdout,
             stderr=stderr,
             start_new_session=True,
@@ -606,6 +613,7 @@ def spawn_service_background_process(
             env=env,
         )
     finally:
+        stdin.close()
         stdout.close()
         stderr.close()
     return process


### PR DESCRIPTION
## Summary
- detach stdin for managed watch waiter subprocesses so Python waiters do not inherit a revoked service fd
- detach stdin when Avibe launches background service processes
- add regression coverage for watch exec/shell runners and service background spawn

## Validation
- `npm ci && npm run build` in `ui/` to satisfy editable package build includes
- `uv run pytest tests/test_watches.py tests/test_service_logging_handlers.py`
- `uv run ruff check core/watches.py vibe/runtime.py tests/test_watches.py tests/test_service_logging_handlers.py`
- local `ManagedWatchService._run_cycle` smoke with a Python waiter

## Risks / follow-ups
- Existing installed Avibe services need this version deployed/restarted before current `vibe watch` Python waiters inherit the fix. Until then, shell waiters can work around the issue with `exec </dev/null`.
