### PR TITLE
fix(claude): release idle "active" flag so leaked sessions get reaped

### DIFF
--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -685,6 +685,18 @@ class ClaudeAgent(BaseAgent):
         # inside the loop.
         finally:
             self._suppressed_synthetic_results.discard(composite_key)
+            # Guaranteed release of the per-turn "active" flag. The success path
+            # only marks idle when a ResultMessage arrives AND no pending request
+            # remains; the except blocks cover cancel/error. But if the receiver
+            # generator is simply exhausted (stream closed without a terminal
+            # ResultMessage, or a pending request was never drained), none of
+            # those run and the session stays pinned in ``active_sessions``
+            # forever — which permanently exempts it from idle eviction. This
+            # guard is safe because ``_mark_session_idle_if_no_pending_requests``
+            # is a no-op while a turn is still queued, so an in-flight follow-up
+            # is never wrongly demoted to idle.
+            if composite_key:
+                self._mark_session_idle_if_no_pending_requests(composite_key)
 
     async def _handle_synthetic_api_error_message(
         self,

--- a/modules/session_manager.py
+++ b/modules/session_manager.py
@@ -116,23 +116,3 @@ class SessionManager:
         if user_id not in self.sessions:
             return False
         return self.sessions[user_id].is_executing
-    
-    async def cleanup_inactive_sessions(self, inactive_hours: int = 24):
-        """Clean up inactive sessions"""
-        async with self._lock:
-            current_time = datetime.now()
-            to_remove = []
-            
-            for user_id, session in self.sessions.items():
-                time_diff = current_time - session.last_activity
-                if time_diff.total_seconds() > inactive_hours * 3600:
-                    to_remove.append(user_id)
-            
-            for user_id in to_remove:
-                session = self.sessions[user_id]
-                # Cleanup Claude SDK clients before removing session
-                await session.cleanup_clients()
-                del self.sessions[user_id]
-                logger.info(f"Cleaned up inactive session for user {user_id}")
-            
-            return len(to_remove)

--- a/tests/test_session_idle_eviction.py
+++ b/tests/test_session_idle_eviction.py
@@ -1,0 +1,90 @@
+"""Regression test for the active-session state leak (fix/active-session-leak).
+
+``ClaudeAgent._receive_messages`` must release the per-turn ``active`` flag in
+its ``finally`` even when the receive stream is exhausted WITHOUT a terminal
+ResultMessage (and with no other turn queued). Before the fix this path left
+the session pinned active forever, which permanently exempted it from idle
+eviction (``SessionHandler.evict_idle_sessions`` skips active sessions), so the
+resident Claude CLI process survived until the next service restart.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agents.claude_agent import ClaudeAgent
+
+
+def _empty_stream_client():
+    """A Claude SDK client whose receive stream ends without any message."""
+
+    class _Client:
+        def receive_messages(self):
+            async def _iterate():
+                return
+                yield  # pragma: no cover - makes this an async generator
+
+            return _iterate()
+
+    return _Client()
+
+
+def _agent_controller():
+    controller = SimpleNamespace(
+        config=SimpleNamespace(platform="slack"),
+        im_client=SimpleNamespace(formatter=None),
+        settings_manager=SimpleNamespace(sessions=None),
+        session_manager=SimpleNamespace(),
+        receiver_tasks={},
+        claude_sessions={},
+        claude_client=SimpleNamespace(_is_skip_message=lambda message: False),
+    )
+    controller._get_session_key = lambda context: "session-key"
+    return controller
+
+
+class ReceiverReleasesActiveTests(unittest.IsolatedAsyncioTestCase):
+    async def test_exhausted_stream_without_result_marks_idle(self):
+        controller = _agent_controller()
+        mark_idle_calls = []
+        controller.session_handler = SimpleNamespace(
+            mark_session_idle=lambda key: mark_idle_calls.append(key),
+        )
+        agent = ClaudeAgent(controller)
+        context = SimpleNamespace(user_id="U1", channel_id="C1")
+        composite_key = "session-1:/tmp/work"
+
+        await agent._receive_messages(
+            _empty_stream_client(), "session-1", "/tmp/work", context, composite_key=composite_key
+        )
+
+        # The guaranteed-release guard in the finally must have fired.
+        self.assertEqual(mark_idle_calls, [composite_key])
+
+    async def test_exhausted_stream_keeps_active_when_request_queued(self):
+        controller = _agent_controller()
+        mark_idle_calls = []
+        controller.session_handler = SimpleNamespace(
+            mark_session_idle=lambda key: mark_idle_calls.append(key),
+        )
+        agent = ClaudeAgent(controller)
+        context = SimpleNamespace(user_id="U1", channel_id="C1")
+        composite_key = "session-1:/tmp/work"
+        # A follow-up turn is still queued; the finally guard must be a no-op so
+        # an in-flight request is never wrongly demoted to idle.
+        agent._pending_requests[composite_key] = [SimpleNamespace(started_at=None)]
+
+        await agent._receive_messages(
+            _empty_stream_client(), "session-1", "/tmp/work", context, composite_key=composite_key
+        )
+
+        self.assertEqual(mark_idle_calls, [])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Problem

Claude sessions are kept resident between turns (one persistent `stream-json` CLI process per Avibe session). The per-turn `active_sessions` flag is set in `ClaudeAgent.handle_message`, but it is released only on three paths:

- the in-loop `ResultMessage` handler — and only when no follow-up request is queued, and
- the receiver's `except asyncio.CancelledError` / `except Exception` blocks.

When the receiver generator is simply **exhausted** (stream closed without a terminal `ResultMessage`, or a pending request was never drained), none of those run. The session then stays pinned in `active_sessions` forever. Since `SessionHandler.evict_idle_sessions` skips anything still in `active_sessions`, such a session is **never idle-evicted** and its CLI process survives until the service restarts — observed in the wild as Claude processes idle for hours while normally tracked sessions are reaped at ~`idle_timeout_seconds` (default 600s).

## Fix

`_receive_messages`' `finally` now calls `_mark_session_idle_if_no_pending_requests(composite_key)`. It is a no-op while a turn is still queued, so an in-flight follow-up is never wrongly demoted to idle; otherwise it guarantees the per-turn `active` flag is released on every receiver termination — including the stream-exhausted path that previously had no release.

## Dead-code cleanup

Remove `SessionManager.cleanup_inactive_sessions` (a 24h sweep). It had no callers and was misleading — real idle reaping is driven by `idle_timeout_seconds`.

## Tests

`tests/test_session_idle_eviction.py` (drives the real `_receive_messages`):

- stream exhausted without a result → session marked idle
- stream exhausted while a turn is queued → stays active (no false demotion)

Both negative-verified: the first fails on the pre-patch code and passes with the patch. The touched area (agent/session/handler tests, incl. `test_claude_cli_path.py`) is green.

---

Note: an earlier revision also tightened `evict_idle_sessions` to treat a session as active only while its receiver task is alive (defense in depth against other leak sources). That was **dropped** because it conflicts with the deliberate TOCTOU re-check in `test_evict_idle_sessions_rechecks_active_state_before_cleanup` (a session that becomes active mid-sweep must not be evicted) and could race-evict a session whose receiver task isn't registered yet. The `finally` guard above fixes the reported leak without changing the eviction contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
