### PR TITLE
feat(show-pages): redesign empty Show Page placeholder

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -721,23 +721,87 @@ createRoot(document.getElementById("root")!).render(
 
 
 def _default_app_tsx() -> str:
-    return """import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+    # Placeholder shown while the agent has not authored the page yet. The Vite
+    # runtime hot-swaps this with the real page as soon as the agent rewrites
+    # src/App.tsx, so the copy reassures the user it will update automatically
+    # and offers the same prompt we auto-send, in case they want to nudge.
+    return """import { useState } from "react"
+import { Button } from "@/components/ui/button"
 import { ThemeProvider } from "@avibe/show-ui/theme"
 
+const NUDGE_PROMPT = "Please visualize this session as a Show Page."
+
+const COPY = {
+  en: {
+    badge: "Show Page",
+    title: "Building your Show Page",
+    body: "Your agent is turning this session into a visual page. It will appear here automatically once it is ready, no refresh needed.",
+    nudge: "Taking a while? Send this to your agent:",
+    copy: "Copy",
+    copied: "Copied",
+  },
+  zh: {
+    badge: "Show Page",
+    title: "正在生成 Show Page",
+    body: "Agent 正在把这次会话整理成一个可视化页面，完成后会自动显示在这里，不用刷新。",
+    nudge: "等太久了？把这句话发给 Agent 催一下：",
+    copy: "复制",
+    copied: "已复制",
+  },
+}
+
+function pickCopy() {
+  const lang = (typeof navigator !== "undefined" && navigator.language) || "en"
+  return lang.toLowerCase().startsWith("zh") ? COPY.zh : COPY.en
+}
+
 export default function App() {
+  const t = pickCopy()
+  const [copied, setCopied] = useState(false)
+
+  async function copyPrompt() {
+    try {
+      await navigator.clipboard.writeText(NUDGE_PROMPT)
+    } catch {
+      const field = document.getElementById("show-nudge-prompt")
+      if (field instanceof HTMLInputElement) {
+        field.select()
+        document.execCommand("copy")
+      }
+    }
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 2000)
+  }
+
   return (
     <ThemeProvider preset="zinc">
-      <main className="page">
-        <Card className="panel">
-          <CardHeader>
-            <CardTitle>Ready to visualize</CardTitle>
-            <CardDescription>This Show Page is served by the managed React runtime.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button onClick={() => void fetch("./api/health")}>Call handler</Button>
-          </CardContent>
-        </Card>
+      <main className="show-shell">
+        <section className="show-card">
+          <div className="show-pulse" aria-hidden="true">
+            <span className="show-pulse-ring" />
+            <span className="show-pulse-ring delay" />
+            <span className="show-pulse-core" />
+          </div>
+          <span className="show-badge">{t.badge}</span>
+          <h1 className="show-title">{t.title}</h1>
+          <p className="show-body">{t.body}</p>
+          <div className="show-nudge">
+            <label className="show-nudge-label" htmlFor="show-nudge-prompt">
+              {t.nudge}
+            </label>
+            <div className="show-nudge-row">
+              <input
+                id="show-nudge-prompt"
+                className="show-nudge-input"
+                value={NUDGE_PROMPT}
+                readOnly
+              />
+              <Button className="show-nudge-copy" onClick={() => void copyPrompt()}>
+                {copied ? t.copied : t.copy}
+              </Button>
+            </div>
+          </div>
+        </section>
       </main>
     </ThemeProvider>
   )
@@ -746,22 +810,153 @@ export default function App() {
 
 
 def _default_styles_css() -> str:
-    return """body {
-  margin: 0;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: #f6f7f9;
-  color: hsl(var(--avs-foreground));
+    return """:root {
+  color-scheme: light;
 }
 
-.page {
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: hsl(var(--avs-foreground));
+  background:
+    radial-gradient(130% 130% at 50% -20%, hsl(var(--avs-ring) / 0.10), transparent 55%),
+    hsl(var(--avs-muted));
+}
+
+.show-shell {
   min-height: 100vh;
   display: grid;
   place-items: center;
   padding: 24px;
+  box-sizing: border-box;
 }
 
-.panel {
-  width: min(560px, 100%);
+.show-card {
+  width: min(440px, 100%);
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 14px;
+  padding: clamp(28px, 6vw, 44px);
+  border: 1px solid hsl(var(--avs-border));
+  border-radius: calc(var(--avs-radius, 0.5rem) + 10px);
+  background: hsl(var(--avs-background));
+  box-shadow: 0 24px 70px -32px hsl(var(--avs-foreground) / 0.30);
+}
+
+.show-pulse {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  display: grid;
+  place-items: center;
+}
+
+.show-pulse-core {
+  width: 13px;
+  height: 13px;
+  border-radius: 999px;
+  background: hsl(var(--avs-ring));
+  box-shadow: 0 0 0 4px hsl(var(--avs-ring) / 0.14);
+}
+
+.show-pulse-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  border: 2px solid hsl(var(--avs-ring));
+  opacity: 0;
+  animation: show-ping 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+.show-pulse-ring.delay {
+  animation-delay: 0.9s;
+}
+
+.show-badge {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: hsl(var(--avs-muted-foreground));
+}
+
+.show-title {
+  margin: 0;
+  font-size: clamp(20px, 4.5vw, 24px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.show-body {
+  margin: 0;
+  max-width: 34ch;
+  line-height: 1.6;
+  color: hsl(var(--avs-muted-foreground));
+}
+
+.show-nudge {
+  width: 100%;
+  margin-top: 6px;
+  padding-top: 18px;
+  border-top: 1px solid hsl(var(--avs-border));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  text-align: left;
+}
+
+.show-nudge-label {
+  font-size: 13px;
+  color: hsl(var(--avs-muted-foreground));
+}
+
+.show-nudge-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.show-nudge-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 38px;
+  padding: 0 12px;
+  border: 1px solid hsl(var(--avs-border));
+  border-radius: 8px;
+  background: hsl(var(--avs-muted));
+  color: hsl(var(--avs-foreground));
+  font-size: 13px;
+}
+
+.show-nudge-input:focus-visible {
+  outline: 2px solid hsl(var(--avs-ring));
+  outline-offset: 1px;
+}
+
+.show-nudge-copy {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+@keyframes show-ping {
+  0% {
+    transform: scale(0.4);
+    opacity: 0.55;
+  }
+  100% {
+    transform: scale(1.05);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .show-pulse-ring {
+    animation: none;
+    opacity: 0;
+  }
 }
 """
 

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -721,11 +721,13 @@ createRoot(document.getElementById("root")!).render(
 
 
 def _default_app_tsx() -> str:
-    # Placeholder shown while the agent has not authored the page yet. The Vite
-    # runtime hot-swaps this with the real page as soon as the agent rewrites
-    # src/App.tsx, so the copy reassures the user it will update automatically
-    # and offers the same prompt we auto-send, in case they want to nudge.
-    return """import { useState } from "react"
+    # Placeholder shown while the agent has not authored the page yet. On the
+    # private /show/ surface the Vite runtime hot-swaps this with the real page
+    # as soon as the agent rewrites src/App.tsx, so the copy says it appears
+    # automatically; the public /p/ surface serves a static build with HMR
+    # disabled, so there the copy asks the viewer to refresh instead. We also
+    # offer the same prompt we auto-send, in case the user wants to nudge.
+    return """import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ThemeProvider } from "@avibe/show-ui/theme"
 
@@ -733,17 +735,21 @@ const NUDGE_PROMPT = "Please visualize this session as a Show Page."
 
 const COPY = {
   en: {
+    lang: "en",
     badge: "Show Page",
     title: "Building your Show Page",
-    body: "Your agent is turning this session into a visual page. It will appear here automatically once it is ready, no refresh needed.",
+    bodyLive: "Your agent is turning this session into a visual page. It will appear here automatically once it is ready.",
+    bodyStatic: "Your agent is turning this session into a visual page. Refresh this page once it is ready to see it.",
     nudge: "Taking a while? Send this to your agent:",
     copy: "Copy",
     copied: "Copied",
   },
   zh: {
+    lang: "zh",
     badge: "Show Page",
     title: "正在生成 Show Page",
-    body: "Agent 正在把这次会话整理成一个可视化页面，完成后会自动显示在这里，不用刷新。",
+    bodyLive: "Agent 正在把这次会话整理成一个可视化页面，完成后会自动显示在这里，不用刷新。",
+    bodyStatic: "Agent 正在把这次会话整理成一个可视化页面，完成后刷新一下页面就能看到。",
     nudge: "等太久了？把这句话发给 Agent 催一下：",
     copy: "复制",
     copied: "已复制",
@@ -755,20 +761,35 @@ function pickCopy() {
   return lang.toLowerCase().startsWith("zh") ? COPY.zh : COPY.en
 }
 
+// The private /show/ surface keeps Vite HMR, so the real page hot-swaps in on
+// its own. The public /p/ surface serves a static build (HMR disabled), so a
+// viewer there has to refresh to pick up the agent's page.
+function isLiveSurface() {
+  return typeof window !== "undefined" && window.location.pathname.includes("/show/")
+}
+
 export default function App() {
   const t = pickCopy()
   const [copied, setCopied] = useState(false)
+  const live = isLiveSurface()
+
+  useEffect(() => {
+    document.documentElement.lang = t.lang
+  }, [t.lang])
 
   async function copyPrompt() {
+    let ok = false
     try {
       await navigator.clipboard.writeText(NUDGE_PROMPT)
+      ok = true
     } catch {
       const field = document.getElementById("show-nudge-prompt")
       if (field instanceof HTMLInputElement) {
         field.select()
-        document.execCommand("copy")
+        ok = document.execCommand("copy")
       }
     }
+    if (!ok) return
     setCopied(true)
     window.setTimeout(() => setCopied(false), 2000)
   }
@@ -784,7 +805,7 @@ export default function App() {
           </div>
           <span className="show-badge">{t.badge}</span>
           <h1 className="show-title">{t.title}</h1>
-          <p className="show-body">{t.body}</p>
+          <p className="show-body">{live ? t.bodyLive : t.bodyStatic}</p>
           <div className="show-nudge">
             <label className="show-nudge-label" htmlFor="show-nudge-prompt">
               {t.nudge}

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -244,7 +244,9 @@ def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
     assert 'eventsPath: injected.eventsPath ?? "__show/events"' in main_tsx
     assert 'streamPath: injected.streamPath ?? "__show/events?stream=1"' in main_tsx
     assert 'writeToken: injected.writeToken ?? readCookie("vibe_show_event_token")' in main_tsx
-    assert "Ready to visualize" in (page_dir / "src" / "App.tsx").read_text(encoding="utf-8")
+    app_tsx = (page_dir / "src" / "App.tsx").read_text(encoding="utf-8")
+    assert "Building your Show Page" in app_tsx
+    assert "Please visualize this session as a Show Page." in app_tsx
     assert (page_dir / "api" / "health.ts").exists()
 
 

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1064,6 +1064,7 @@ export const ChatPage: React.FC = () => {
           title={t('chat.showPage.title')}
           src={showPageUrl}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
+          allow="clipboard-write"
           className="min-h-0 w-full flex-1 border-0 bg-background"
         />
       )}


### PR DESCRIPTION
## What

Redesign the **empty Show Page placeholder** — what renders in the in-chat Show Page iframe (and the Vite-served app) before the agent has authored any content.

**Before:** a bare shadcn card reading *"Ready to visualize / This Show Page is served by the managed React runtime"* plus a dev-only "Call handler" button. To an end user this reads as an unfinished dev shell.

**After:** a user-facing waiting state —
- animated progress pulse (blue ring, `prefers-reduced-motion` safe)
- reassuring copy: the agent is building the page and it appears here automatically when ready (Vite HMR swaps in the real `App.tsx` — no refresh)
- a secondary, **copyable nudge** showing the same prompt we auto-send, for when the user wants to prod the agent
- bilingual (follows `navigator.language`: zh / en)
- styled with the show-ui `--avs-*` theme tokens in real CSS (the Show runtime has no Tailwind, so utility classes would no-op)

**Scope:** only the generated scaffold (`_default_app_tsx` + `_default_styles_css`). The runtime-down **recovery** page (`show_page_runtime_recovery_html`, served when the managed runtime doesn't respond) is intentionally unchanged.

## Evidence layers

- **Unit:** updated the `tests/test_show_pages.py` scaffold assertion to the new placeholder markers; ran the group that pins these strings — `test_show_pages.py + test_ui_show_pages.py + test_reply_enhancer_platform.py` → **164 passed**. The recovery-path assertions (`"Ready to visualize"` / `"Copy prompt"` over the served fallback) stay green because that page is untouched. `ruff` clean.
- **Manual:** rendered the placeholder with the exact regression theme values at desktop + mobile widths, EN + ZH.
- Contract / scenario: n/a (no scenario catalog applies).