### PR TITLE
feat(workbench): Show Page share control + presentation toggle

### DIFF
--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -21,6 +21,7 @@ import clsx from 'clsx';
 import { useApi } from '../context/ApiContext';
 import { useToast } from '../context/ToastContext';
 import { copyTextToClipboard } from '../lib/utils';
+import { copyHref, displayLink } from '../lib/showPageLinks';
 import { SearchField } from './settings/SettingsPrimitives';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
@@ -58,28 +59,6 @@ const STATUS: Record<
   offline: { Icon: CloudOff, badge: 'secondary', tone: 'muted', dot: 'bg-muted', tile: 'border-border-strong bg-foreground/[0.04]', iconColor: 'text-muted' },
 };
 
-// Same-origin path a Show Page is served at locally — usable even when Avibe
-// Cloud is off, where the cloud-qualified urls in the payload are null.
-function localPath(page: ShowPage): string | null {
-  if (page.visibility === 'private') return `/show/${encodeURIComponent(page.session_id)}/`;
-  if (page.visibility === 'public' && page.share_id) return `/p/${encodeURIComponent(page.share_id)}/`;
-  return null;
-}
-
-function liveHref(page: ShowPage): string | null {
-  return page.active_url || localPath(page);
-}
-
-function copyHref(page: ShowPage): string | null {
-  const href = liveHref(page);
-  if (!href) return null;
-  return href.startsWith('http') ? href : window.location.origin + href;
-}
-
-function displayLink(page: ShowPage): string | null {
-  const href = liveHref(page);
-  return href ? href.replace(/^https?:\/\//, '') : null;
-}
 
 interface RowProps {
   page: ShowPage;

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { AppWindow, ArrowLeft, Bell, Bot, ChevronDown, Clock, Info, Loader2, MessageSquare, Pencil, UploadCloud, X } from 'lucide-react';
+import { ArrowLeft, Bell, Bot, ChevronDown, Clock, Info, Loader2, MessageSquare, Pencil, Presentation, UploadCloud, X } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -15,6 +15,7 @@ import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { formatLocalDateTime } from '../../lib/relativeTime';
 import { useFileDrop } from '../../lib/useFileDrop';
 import { AgentRoutePicker } from './AgentRoutePicker';
+import { ShowPageShareControl } from './ShowPageShareControl';
 import { InstallHint } from '../InstallHint';
 import { Button } from '../ui/button';
 import { ChatImage } from '../ui/chat-image';
@@ -1274,48 +1275,58 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
           <ArrowLeft className="size-3.5" />
         </Button>
         <TitleField key={session.id} title={session.title} onCommit={(title) => onPatch({ title })} />
-        <AgentRoutePicker
-          value={session}
-          agents={agents}
-          onChange={onPatch}
-          disabled={pickerDisabled}
-          allowedBackends={pinnedBackend ? [pinnedBackend] : undefined}
-          defaultLabel={
-            canClearToDefault
-              ? defaultAgent
-                ? t('newSession.defaultAgentNamed', { name: defaultAgent.name })
-                : t('newSession.defaultAgent')
-              : undefined
-          }
-          defaultRoute={defaultRoute}
-          isDefaultRoute={inheritsDefault}
-          compactMobile
-        />
+        {/* Hidden while the Show Page is open so the view gets the full width. */}
+        {!showPageMode && (
+          <AgentRoutePicker
+            value={session}
+            agents={agents}
+            onChange={onPatch}
+            disabled={pickerDisabled}
+            allowedBackends={pinnedBackend ? [pinnedBackend] : undefined}
+            defaultLabel={
+              canClearToDefault
+                ? defaultAgent
+                  ? t('newSession.defaultAgentNamed', { name: defaultAgent.name })
+                  : t('newSession.defaultAgent')
+                : undefined
+            }
+            defaultRoute={defaultRoute}
+            isDefaultRoute={inheritsDefault}
+            compactMobile
+          />
+        )}
         {/* Chat hides the brand header, so mount the install nudge here too —
             IM-launched users often land straight in a chat. Renders only on iOS
             Safari + not-installed; null otherwise. */}
         <InstallHint />
-        {/* Show Page toggle: swaps the chat surface for the session's Show Page
-            (the header bar stays). First open initializes the page + prompts the
-            agent. Pushed to the far right of the header row. */}
-        <Button
-          type="button"
-          variant={showPageMode ? 'secondary' : 'ghost'}
-          size="icon"
-          onClick={onToggleShowPage}
-          disabled={showPageBusy}
-          aria-label={showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
-          title={showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
-          className="ml-auto size-7 shrink-0"
-        >
-          {showPageBusy ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : showPageMode ? (
-            <MessageSquare className="size-3.5" />
-          ) : (
-            <AppWindow className="size-3.5" />
-          )}
-        </Button>
+        {/* Right-aligned actions. The Show Page toggle swaps the chat surface for
+            this session's Show Page (the header bar stays); first open initializes
+            the page + prompts the agent. It shows its label on desktop and stays
+            icon-only on mobile. In Show Page mode a Share control sits beside the
+            back-to-chat button. */}
+        <div className="ml-auto flex items-center gap-1.5">
+          {showPageMode && <ShowPageShareControl sessionId={session.id} />}
+          <Button
+            type="button"
+            variant={showPageMode ? 'secondary' : 'ghost'}
+            onClick={onToggleShowPage}
+            disabled={showPageBusy}
+            aria-label={showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
+            title={showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
+            className="h-7 shrink-0 gap-1.5 px-2"
+          >
+            {showPageBusy ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : showPageMode ? (
+              <MessageSquare className="size-3.5" />
+            ) : (
+              <Presentation className="size-3.5" />
+            )}
+            <span className="hidden text-xs font-medium md:inline">
+              {showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
+            </span>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -12,6 +12,7 @@ import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
+import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 import { formatLocalDateTime } from '../../lib/relativeTime';
 import { useFileDrop } from '../../lib/useFileDrop';
 import { AgentRoutePicker } from './AgentRoutePicker';
@@ -791,6 +792,14 @@ export const ChatPage: React.FC = () => {
     }
   }, [sessionId, showPageMode, api, sendMessage, t]);
 
+  // When the share control resolves the page (open) or flips its visibility, the
+  // serving route changes (private → /show/, public → /p/). Re-point the iframe
+  // so it never stays on a route that now 404s.
+  const handleShowPagePayload = useCallback((next: ShowPageLinkInfo) => {
+    const path = localPath(next);
+    if (path) setShowPageUrl(path);
+  }, []);
+
   // A quick-reply click sends the chosen label as a normal user turn, tagged with
   // the agent message it answers so the group can lock + highlight the choice on
   // reload (the answered state is derived from this metadata).
@@ -1045,6 +1054,7 @@ export const ChatPage: React.FC = () => {
           showPageMode={showPageMode}
           showPageBusy={showPageBusy}
           onToggleShowPage={toggleShowPage}
+          onShowPageVisibilityChange={handleShowPagePayload}
         />
 
       {showPageMode && showPageUrl && (
@@ -1223,9 +1233,10 @@ interface ChatHeaderBarProps {
   showPageMode: boolean;
   showPageBusy: boolean;
   onToggleShowPage: () => void;
+  onShowPageVisibilityChange?: (payload: ShowPageLinkInfo) => void;
 }
 
-const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working, showPageMode, showPageBusy, onToggleShowPage }) => {
+const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working, showPageMode, showPageBusy, onToggleShowPage, onShowPageVisibilityChange }) => {
   const { t } = useTranslation();
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
   // Backend locks once a NATIVE conversation exists — a native can only be
@@ -1304,8 +1315,9 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
             the page + prompts the agent. It shows its label on desktop and stays
             icon-only on mobile. In Show Page mode a Share control sits beside the
             back-to-chat button. */}
+        {/* Back-to-chat (or Visualize when in chat) stays leftmost; the Share
+            control sits to its right, only while the Show Page is open. */}
         <div className="ml-auto flex items-center gap-1.5">
-          {showPageMode && <ShowPageShareControl sessionId={session.id} />}
           <Button
             type="button"
             variant={showPageMode ? 'secondary' : 'ghost'}
@@ -1326,6 +1338,9 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
               {showPageMode ? t('chat.showPage.backToChat') : t('chat.showPage.open')}
             </span>
           </Button>
+          {showPageMode && (
+            <ShowPageShareControl sessionId={session.id} onPayloadChange={onShowPageVisibilityChange} />
+          )}
         </div>
       </div>
     </div>

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Copy, Loader2, Share2 } from 'lucide-react';
 
@@ -32,6 +32,9 @@ export const ShowPageShareControl: React.FC<{
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
+  // Monotonic guard: a slow ensure() must not overwrite a newer visibility
+  // result (or a link rotated elsewhere). Only the latest request applies.
+  const reqSeq = useRef(0);
 
   useEffect(() => {
     if (payload) onPayloadChange?.(payload);
@@ -48,12 +51,17 @@ export const ShowPageShareControl: React.FC<{
   // admin Show Pages page) is reflected; keep the last payload visible while
   // refreshing so reopening doesn't flash a spinner.
   const refresh = () => {
+    const seq = ++reqSeq.current;
     setLoading(!payload);
     api
       .ensureShowPage(sessionId)
-      .then((res: ShowPagePayload) => setPayload(res))
+      .then((res: ShowPagePayload) => {
+        if (seq === reqSeq.current) setPayload(res);
+      })
       .catch(() => undefined)
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (seq === reqSeq.current) setLoading(false);
+      });
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -62,12 +70,17 @@ export const ShowPageShareControl: React.FC<{
   };
 
   const toggleVisibility = (nextPublic: boolean) => {
+    const seq = ++reqSeq.current;
     setBusy(true);
     api
       .setShowPageVisibility(sessionId, nextPublic ? 'public' : 'private')
-      .then((res: ShowPagePayload) => setPayload(res))
+      .then((res: ShowPagePayload) => {
+        if (seq === reqSeq.current) setPayload(res);
+      })
       .catch(() => undefined)
-      .finally(() => setBusy(false));
+      .finally(() => {
+        if (seq === reqSeq.current) setBusy(false);
+      });
   };
 
   const copyLink = async () => {

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Copy, Loader2, Share2 } from 'lucide-react';
+
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { Switch } from '../ui/switch';
+import { useApi } from '../../context/ApiContext';
+
+type ShowPagePayload = {
+  visibility: string;
+  active_url: string | null;
+  public_url: string | null;
+  private_url: string | null;
+  url_available: boolean;
+  url_guidance: string | null;
+  share_id: string | null;
+};
+
+// Share affordance shown only while the Show Page is open (the in-chat view).
+// A popover with the page link (copy + native share) and a public/private
+// toggle that flips visibility in place via the existing show-pages API.
+export const ShowPageShareControl: React.FC<{ sessionId: string }> = ({ sessionId }) => {
+  const { t } = useTranslation();
+  const api = useApi();
+  const [open, setOpen] = useState(false);
+  const [payload, setPayload] = useState<ShowPagePayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const isPublic = payload?.visibility === 'public';
+  const link = payload?.active_url ?? payload?.private_url ?? '';
+  const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    // Lazily resolve the page (idempotent ensure) the first time the popover
+    // opens, so the link + current visibility are always fresh.
+    if (next && !payload && !loading) {
+      setLoading(true);
+      api
+        .ensureShowPage(sessionId)
+        .then((res: ShowPagePayload) => setPayload(res))
+        .catch(() => undefined)
+        .finally(() => setLoading(false));
+    }
+  };
+
+  const toggleVisibility = (nextPublic: boolean) => {
+    setBusy(true);
+    api
+      .setShowPageVisibility(sessionId, nextPublic ? 'public' : 'private')
+      .then((res: ShowPagePayload) => setPayload(res))
+      .catch(() => undefined)
+      .finally(() => setBusy(false));
+  };
+
+  const copyLink = async () => {
+    if (!link) return;
+    let ok = false;
+    try {
+      await navigator.clipboard.writeText(link);
+      ok = true;
+    } catch {
+      const field = document.getElementById('show-share-link');
+      if (field instanceof HTMLInputElement) {
+        field.select();
+        ok = document.execCommand('copy');
+      }
+    }
+    if (!ok) return;
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  const nativeShare = async () => {
+    if (!link) return;
+    try {
+      await navigator.share({ title: t('chat.showPage.title'), url: link });
+    } catch {
+      // user dismissed the share sheet, or it is unavailable — no-op
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 shrink-0"
+          aria-label={t('chat.showPage.share')}
+          title={t('chat.showPage.share')}
+        >
+          <Share2 className="size-3.5" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 space-y-3">
+        <div className="text-sm font-medium">{t('chat.showPage.shareTitle')}</div>
+
+        {loading ? (
+          <div className="flex items-center gap-2 py-2 text-sm text-muted">
+            <Loader2 className="size-4 animate-spin" />
+            {t('common.loading')}
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-1.5">
+              <Input
+                id="show-share-link"
+                readOnly
+                value={link}
+                onFocus={(e) => e.currentTarget.select()}
+                className="h-8 flex-1 text-xs"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="size-8 shrink-0"
+                onClick={copyLink}
+                aria-label={t('chat.showPage.copyLink')}
+                title={t('chat.showPage.copyLink')}
+              >
+                {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              </Button>
+              {canNativeShare && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="size-8 shrink-0"
+                  onClick={nativeShare}
+                  aria-label={t('chat.showPage.nativeShare')}
+                  title={t('chat.showPage.nativeShare')}
+                >
+                  <Share2 className="size-3.5" />
+                </Button>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-sm">
+                  {isPublic ? t('chat.showPage.visibilityPublic') : t('chat.showPage.visibilityPrivate')}
+                </div>
+                <div className="text-xs text-muted">
+                  {isPublic ? t('chat.showPage.publicDesc') : t('chat.showPage.privateDesc')}
+                </div>
+              </div>
+              <Switch
+                checked={isPublic}
+                disabled={busy}
+                onCheckedChange={toggleVisibility}
+                label={t('chat.showPage.visibilityPublic')}
+              />
+            </div>
+
+            {isPublic && payload && !payload.url_available && payload.url_guidance && (
+              <div className="rounded-md border border-border px-2.5 py-2 text-xs text-muted">
+                {payload.url_guidance}
+              </div>
+            )}
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -8,7 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Switch } from '../ui/switch';
 import { useApi } from '../../context/ApiContext';
 import { copyTextToClipboard } from '../../lib/utils';
-import { copyHref, displayLink, type ShowPageLinkInfo } from '../../lib/showPageLinks';
+import { copyHref, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 
 type ShowPagePayload = ShowPageLinkInfo & {
   url_available: boolean;
@@ -44,9 +44,10 @@ export const ShowPageShareControl: React.FC<{
 
   const offline = payload?.visibility === 'offline' || payload?.offline === true;
   const isPublic = payload?.visibility === 'public';
-  // Falls back to the same-origin route when Avibe Cloud is off (payload urls null).
+  // Absolute, copyable href; falls back to the same-origin route when Avibe
+  // Cloud is off (payload urls null). The field shows this full url so a manual
+  // select/copy yields the same link as the Copy button.
   const link = payload ? copyHref(payload) ?? '' : '';
-  const shownLink = payload ? displayLink(payload) ?? '' : '';
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
 
   // Re-fetch on every open so a visibility/share change made elsewhere (e.g. the
@@ -122,6 +123,8 @@ export const ShowPageShareControl: React.FC<{
             <Loader2 className="size-4 animate-spin" />
             {t('common.loading')}
           </div>
+        ) : !payload ? (
+          <p className="py-1 text-sm text-muted">{t('chat.showPage.loadError')}</p>
         ) : offline ? (
           <p className="py-1 text-sm text-muted">{t('chat.showPage.offlineNote')}</p>
         ) : (
@@ -130,7 +133,7 @@ export const ShowPageShareControl: React.FC<{
               <Input
                 id="show-share-link"
                 readOnly
-                value={shownLink}
+                value={link}
                 onFocus={(e) => e.currentTarget.select()}
                 className="h-8 flex-1 text-xs"
               />
@@ -179,9 +182,9 @@ export const ShowPageShareControl: React.FC<{
               />
             </div>
 
-            {isPublic && payload && !payload.url_available && payload.url_guidance && (
+            {payload && isPublic && !payload.url_available && (
               <div className="rounded-md border border-border px-2.5 py-2 text-xs text-muted">
-                {payload.url_guidance}
+                {t('chat.showPage.publicUnavailable')}
               </div>
             )}
           </>

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Copy, Loader2, Share2 } from 'lucide-react';
 
@@ -7,21 +7,24 @@ import { Input } from '../ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Switch } from '../ui/switch';
 import { useApi } from '../../context/ApiContext';
+import { copyTextToClipboard } from '../../lib/utils';
+import { copyHref, displayLink, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 
-type ShowPagePayload = {
-  visibility: string;
-  active_url: string | null;
-  public_url: string | null;
-  private_url: string | null;
+type ShowPagePayload = ShowPageLinkInfo & {
   url_available: boolean;
   url_guidance: string | null;
-  share_id: string | null;
+  offline: boolean;
 };
 
 // Share affordance shown only while the Show Page is open (the in-chat view).
 // A popover with the page link (copy + native share) and a public/private
 // toggle that flips visibility in place via the existing show-pages API.
-export const ShowPageShareControl: React.FC<{ sessionId: string }> = ({ sessionId }) => {
+export const ShowPageShareControl: React.FC<{
+  sessionId: string;
+  // Lets the chat view re-point the iframe at the route that now serves the
+  // page when visibility flips (private↔public swap the serving route).
+  onPayloadChange?: (payload: ShowPageLinkInfo) => void;
+}> = ({ sessionId, onPayloadChange }) => {
   const { t } = useTranslation();
   const api = useApi();
   const [open, setOpen] = useState(false);
@@ -30,22 +33,32 @@ export const ShowPageShareControl: React.FC<{ sessionId: string }> = ({ sessionI
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
 
+  useEffect(() => {
+    if (payload) onPayloadChange?.(payload);
+  }, [payload, onPayloadChange]);
+
+  const offline = payload?.visibility === 'offline' || payload?.offline === true;
   const isPublic = payload?.visibility === 'public';
-  const link = payload?.active_url ?? payload?.private_url ?? '';
+  // Falls back to the same-origin route when Avibe Cloud is off (payload urls null).
+  const link = payload ? copyHref(payload) ?? '' : '';
+  const shownLink = payload ? displayLink(payload) ?? '' : '';
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+
+  // Re-fetch on every open so a visibility/share change made elsewhere (e.g. the
+  // admin Show Pages page) is reflected; keep the last payload visible while
+  // refreshing so reopening doesn't flash a spinner.
+  const refresh = () => {
+    setLoading(!payload);
+    api
+      .ensureShowPage(sessionId)
+      .then((res: ShowPagePayload) => setPayload(res))
+      .catch(() => undefined)
+      .finally(() => setLoading(false));
+  };
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
-    // Lazily resolve the page (idempotent ensure) the first time the popover
-    // opens, so the link + current visibility are always fresh.
-    if (next && !payload && !loading) {
-      setLoading(true);
-      api
-        .ensureShowPage(sessionId)
-        .then((res: ShowPagePayload) => setPayload(res))
-        .catch(() => undefined)
-        .finally(() => setLoading(false));
-    }
+    if (next) refresh();
   };
 
   const toggleVisibility = (nextPublic: boolean) => {
@@ -59,20 +72,10 @@ export const ShowPageShareControl: React.FC<{ sessionId: string }> = ({ sessionI
 
   const copyLink = async () => {
     if (!link) return;
-    let ok = false;
-    try {
-      await navigator.clipboard.writeText(link);
-      ok = true;
-    } catch {
-      const field = document.getElementById('show-share-link');
-      if (field instanceof HTMLInputElement) {
-        field.select();
-        ok = document.execCommand('copy');
-      }
+    if (await copyTextToClipboard(link)) {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
     }
-    if (!ok) return;
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 2000);
   };
 
   const nativeShare = async () => {
@@ -106,13 +109,15 @@ export const ShowPageShareControl: React.FC<{ sessionId: string }> = ({ sessionI
             <Loader2 className="size-4 animate-spin" />
             {t('common.loading')}
           </div>
+        ) : offline ? (
+          <p className="py-1 text-sm text-muted">{t('chat.showPage.offlineNote')}</p>
         ) : (
           <>
             <div className="flex items-center gap-1.5">
               <Input
                 id="show-share-link"
                 readOnly
-                value={link}
+                value={shownLink}
                 onFocus={(e) => e.currentTarget.select()}
                 className="h-8 flex-1 text-xs"
               />
@@ -121,6 +126,7 @@ export const ShowPageShareControl: React.FC<{ sessionId: string }> = ({ sessionI
                 variant="outline"
                 size="icon"
                 className="size-8 shrink-0"
+                disabled={!link}
                 onClick={copyLink}
                 aria-label={t('chat.showPage.copyLink')}
                 title={t('chat.showPage.copyLink')}
@@ -133,6 +139,7 @@ export const ShowPageShareControl: React.FC<{ sessionId: string }> = ({ sessionI
                   variant="outline"
                   size="icon"
                   className="size-8 shrink-0"
+                  disabled={!link}
                   onClick={nativeShare}
                   aria-label={t('chat.showPage.nativeShare')}
                   title={t('chat.showPage.nativeShare')}

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -32,8 +32,10 @@ export const ShowPageShareControl: React.FC<{
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState(false);
-  // Monotonic guard: a slow ensure() must not overwrite a newer visibility
-  // result (or a link rotated elsewhere). Only the latest request applies.
+  // A visibility mutation is authoritative: it always applies its result and
+  // clears its own busy state, and it invalidates any refresh read issued
+  // before it resolved. A refresh (read) only applies if no newer request has
+  // superseded it. reqSeq orders the reads; a mutation bumps it on resolve.
   const reqSeq = useRef(0);
 
   useEffect(() => {
@@ -59,9 +61,7 @@ export const ShowPageShareControl: React.FC<{
         if (seq === reqSeq.current) setPayload(res);
       })
       .catch(() => undefined)
-      .finally(() => {
-        if (seq === reqSeq.current) setLoading(false);
-      });
+      .finally(() => setLoading(false));
   };
 
   const handleOpenChange = (next: boolean) => {
@@ -70,17 +70,17 @@ export const ShowPageShareControl: React.FC<{
   };
 
   const toggleVisibility = (nextPublic: boolean) => {
-    const seq = ++reqSeq.current;
     setBusy(true);
     api
       .setShowPageVisibility(sessionId, nextPublic ? 'public' : 'private')
       .then((res: ShowPagePayload) => {
-        if (seq === reqSeq.current) setPayload(res);
+        // Authoritative server state: always apply it, and invalidate any
+        // in-flight refresh read so a stale read can't revert us afterwards.
+        setPayload(res);
+        reqSeq.current += 1;
       })
       .catch(() => undefined)
-      .finally(() => {
-        if (seq === reqSeq.current) setBusy(false);
-      });
+      .finally(() => setBusy(false));
   };
 
   const copyLink = async () => {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1759,10 +1759,18 @@
     "back": "Back",
     "untitled": "Untitled session",
     "showPage": {
-      "open": "View Show Page",
+      "open": "Visualize",
       "backToChat": "Back to chat",
       "title": "Show Page",
-      "prompt": "Please visualize this session as a Show Page."
+      "prompt": "Please visualize this session as a Show Page.",
+      "share": "Share",
+      "shareTitle": "Share this Show Page",
+      "copyLink": "Copy link",
+      "nativeShare": "Share…",
+      "visibilityPublic": "Public",
+      "visibilityPrivate": "Private",
+      "publicDesc": "Anyone with the link can view",
+      "privateDesc": "Only you can view"
     },
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1771,7 +1771,9 @@
       "visibilityPrivate": "Private",
       "publicDesc": "Anyone with the link can view",
       "privateDesc": "Only you can view",
-      "offlineNote": "This Show Page is offline and can't be shared right now."
+      "offlineNote": "This Show Page is offline and can't be shared right now.",
+      "publicUnavailable": "Connect Avibe Cloud to get a public link others can open.",
+      "loadError": "Couldn't load this Show Page."
     },
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1770,7 +1770,8 @@
       "visibilityPublic": "Public",
       "visibilityPrivate": "Private",
       "publicDesc": "Anyone with the link can view",
-      "privateDesc": "Only you can view"
+      "privateDesc": "Only you can view",
+      "offlineNote": "This Show Page is offline and can't be shared right now."
     },
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1758,10 +1758,18 @@
     "back": "返回",
     "untitled": "未命名会话",
     "showPage": {
-      "open": "查看 Show Page",
-      "backToChat": "返回对话",
+      "open": "可视化",
+      "backToChat": "回聊天",
       "title": "Show Page",
-      "prompt": "Please visualize this session as a Show Page."
+      "prompt": "Please visualize this session as a Show Page.",
+      "share": "分享",
+      "shareTitle": "分享这个 Show Page",
+      "copyLink": "复制链接",
+      "nativeShare": "系统分享",
+      "visibilityPublic": "公开",
+      "visibilityPrivate": "私有",
+      "publicDesc": "任何人都可以通过链接查看",
+      "privateDesc": "只有你能查看"
     },
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1769,7 +1769,8 @@
       "visibilityPublic": "公开",
       "visibilityPrivate": "私有",
       "publicDesc": "任何人都可以通过链接查看",
-      "privateDesc": "只有你能查看"
+      "privateDesc": "只有你能查看",
+      "offlineNote": "这个 Show Page 已离线，暂时无法分享。"
     },
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1770,7 +1770,9 @@
       "visibilityPrivate": "私有",
       "publicDesc": "任何人都可以通过链接查看",
       "privateDesc": "只有你能查看",
-      "offlineNote": "这个 Show Page 已离线，暂时无法分享。"
+      "offlineNote": "这个 Show Page 已离线，暂时无法分享。",
+      "publicUnavailable": "连接 Avibe Cloud 后才能获得别人可打开的公开链接。",
+      "loadError": "无法加载这个 Show Page。"
     },
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",

--- a/ui/src/lib/showPageLinks.ts
+++ b/ui/src/lib/showPageLinks.ts
@@ -1,0 +1,36 @@
+// Show Page link helpers shared by the admin Show Pages list and the in-chat
+// share control. Avibe Cloud-qualified urls in the payload are null on a local
+// install (no remote access configured), so fall back to the same-origin route
+// the page is actually served at locally.
+
+export type ShowPageLinkInfo = {
+  session_id: string;
+  visibility: string;
+  active_url: string | null;
+  share_id: string | null;
+};
+
+// Same-origin path a Show Page is served at locally. Null when the page is
+// offline (or public without a share id), where there is no live route.
+export function localPath(page: ShowPageLinkInfo): string | null {
+  if (page.visibility === 'private') return `/show/${encodeURIComponent(page.session_id)}/`;
+  if (page.visibility === 'public' && page.share_id) return `/p/${encodeURIComponent(page.share_id)}/`;
+  return null;
+}
+
+export function liveHref(page: ShowPageLinkInfo): string | null {
+  return page.active_url || localPath(page);
+}
+
+// Absolute, copyable/shareable href (origin-qualifies the same-origin fallback).
+export function copyHref(page: ShowPageLinkInfo): string | null {
+  const href = liveHref(page);
+  if (!href) return null;
+  return href.startsWith('http') ? href : window.location.origin + href;
+}
+
+// Protocol-stripped form for compact display.
+export function displayLink(page: ShowPageLinkInfo): string | null {
+  const href = liveHref(page);
+  return href ? href.replace(/^https?:\/\//, '') : null;
+}


### PR DESCRIPTION
## What

Improves the **Show Page header** (the in-chat Show Page view, from #577/#584):

- **Toggle icon → `Presentation`**, with a **desktop text label** (`Visualize` / `Back to chat`); stays **icon-only on mobile**.
- **Hide the agent route picker while the Show Page is open** so the view gets the full header width.
- **New Share control** next to back-to-chat (only in Show Page mode): a **popover** with
  - the page **link** (read-only field + **Copy**, plus a **native share** button that opens the iOS/system share sheet when `navigator.share` is available),
  - a **Public / Private** `Switch` that flips visibility **in place** via the existing API,
  - the backend `url_guidance` surfaced when a public link isn't reachable yet (Avibe Cloud not connected).

## Design notes

- **Pure frontend.** Reuses `POST /api/show-pages/<id>/ensure` + `/visibility` and the `show_page_payload` URLs (`active_url` / `public_url` / `url_available` / `url_guidance`). No backend changes.
- Reuses design-system primitives: `Popover`, `Switch`, `Input`, `Button` (no re-rolled controls). New `ShowPageShareControl` is a self-contained reusable component.
- Clipboard copy has an `execCommand` fallback and only flips to "Copied" on real success (same pattern as #584).

## Evidence layers

- **Build (UI gate):** `npm run build` (tsc + vite) green; both i18n JSON valid.
- **Manual:** rendered the three states (chat header, Show Page header, open share popover) with the real lucide icons + theme values for design review.
- Unit / contract / scenario: n/a (frontend-only; UI CI gates on build, not pytest).