### PR TITLE
fix(prompt): stabilize web session title prompt

### DIFF
--- a/core/message_context.py
+++ b/core/message_context.py
@@ -1,0 +1,21 @@
+"""Shared helpers for MessageContext-derived metadata."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from modules.im import MessageContext
+
+
+def resolve_context_platform(
+    context: Optional[MessageContext],
+    *,
+    fallback_platform: Optional[str] = None,
+    default: str = "",
+) -> str:
+    """Resolve a MessageContext platform using the common precedence order."""
+    platform = fallback_platform or default
+    if context is not None:
+        payload = context.platform_specific or {}
+        platform = context.platform or payload.get("platform") or platform
+    return str(platform or default)

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
 from config import paths
+from core.message_context import resolve_context_platform
 from modules.im import MessageContext
 from storage.db import create_sqlite_engine
 from storage.background import SQLiteBackgroundTaskStore
@@ -292,7 +293,7 @@ def build_session_key_for_context(
     fallback_platform: Optional[str] = None,
 ) -> ParsedSessionKey:
     payload = context.platform_specific or {}
-    platform = context.platform or payload.get("platform") or fallback_platform or ""
+    platform = resolve_context_platform(context, fallback_platform=fallback_platform)
     is_dm = bool(payload.get("is_dm", False))
     scope_type = "user" if is_dm else "channel"
     scope_id = context.user_id if is_dm else context.channel_id

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -217,14 +217,13 @@ _SESSION_END_PROMPT = """\
 Current session id: `{default_session_id}`. Before using Show Page or Harness commands, target this exact session unless the user explicitly asks to target a different one.
 """
 
-# Appended to the session reminder ONLY when the session has no user-chosen title
-# (empty, or a title_source other than "user" — i.e. auto-generated or not yet set).
-# Nudges the agent to set a short, human-scannable title via the CLI so sessions are
-# easy to find in `vibe session list`. A CLI update lands as title_source="user", so
-# the nudge stops on the next turn — it naturally fires at most once per session.
-_SESSION_TITLE_NUDGE = """\
-This session's title is {title_state}. If you can tell what it's about, set a concise title (≤10 chars) once, silently — don't mention it to the user:
+_SESSION_TITLE_PROMPT = """\
+
+## Session Title
+When the topic of this conversation is clear, you may silently set one concise, human-scannable title for the current Session:
 `vibe session update {default_session_id} --title "<short title>"`
+
+Do not mention the title update unless the user asks, and do not repeatedly rename the same Session.
 """
 
 
@@ -252,6 +251,22 @@ def _extract_default_session_id(context: MessageContext) -> str:
     if not default_session_id:
         raise ValueError("agent_session_id is required before building avibe capability prompt")
     return str(default_session_id)
+
+
+def _resolve_context_platform(
+    context: Optional[MessageContext],
+    *,
+    fallback_platform: Optional[str] = None,
+) -> str:
+    platform = fallback_platform or "<platform>"
+    if context is not None:
+        platform_specific = context.platform_specific or {}
+        platform = context.platform or platform_specific.get("platform") or platform
+    return str(platform or "<platform>")
+
+
+def _is_web_platform(platform: str) -> bool:
+    return platform.strip().lower() in {"avibe", "web"}
 
 
 def _coerce_agent_prompt_info(agent: Any) -> AgentPromptInfo:
@@ -357,46 +372,16 @@ def _build_show_pages_prompt(context: MessageContext, *, avibe_cloud_guidance: s
     )
 
 
-def _lookup_session_title(session_id: str) -> Optional[tuple[str, Optional[str]]]:
-    """Return ``(title, title_source)`` for a session, or ``None`` if it can't be
-    read. Best-effort: a lookup failure must never break prompt injection."""
-    try:
-        from core.services import sessions as sessions_service
-        from storage.db import create_sqlite_engine
-
-        engine = create_sqlite_engine(paths.get_sqlite_state_path())
-        with engine.connect() as conn:
-            row = sessions_service.get_session(conn, session_id)
-        title = str(row.get("title") or "").strip()
-        metadata = row.get("metadata") if isinstance(row.get("metadata"), dict) else {}
-        return title, metadata.get("title_source")
-    except Exception:
-        logger.debug("session title lookup for prompt nudge failed", exc_info=True)
-        return None
-
-
-def _build_session_end_prompt(context: MessageContext) -> str:
+def _build_session_end_prompt(
+    context: MessageContext,
+    *,
+    fallback_platform: Optional[str] = None,
+) -> str:
     default_session_id = _extract_default_session_id(context)
     prompt = _SESSION_END_PROMPT.format(default_session_id=default_session_id)
-    looked_up = _lookup_session_title(default_session_id)
-    if looked_up is not None:
-        # Lazy import: keep this module's load storage-free so the agent-setup /
-        # session-handler import chain never transitively pulls in sqlite
-        # (test_native_session_lightweight_imports_do_not_require_sqlite).
-        from storage.workbench_sessions_service import DELIBERATE_TITLE_SOURCES
-
-        title, title_source = looked_up
-        # Nudge only when the title is NOT deliberately owned. DELIBERATE_TITLE_SOURCES
-        # = {"user", "agent"} covers a title set OR cleared on purpose (update_session
-        # stamps the source even for an empty title) — never re-nudge those, or we'd
-        # undo a deliberate clear / re-prompt an agent that already named it. Auto
-        # sources ("backend", "derived_first_prompt") and a never-touched session (no
-        # title_source) still nudge.
-        if title_source not in DELIBERATE_TITLE_SOURCES:
-            title_state = "not set yet" if not title else f'"{title}" (auto-generated)'
-            prompt += "\n" + _SESSION_TITLE_NUDGE.format(
-                title_state=title_state, default_session_id=default_session_id
-            )
+    platform = _resolve_context_platform(context, fallback_platform=fallback_platform)
+    if _is_web_platform(platform):
+        prompt += _SESSION_TITLE_PROMPT.format(default_session_id=default_session_id)
     return prompt
 
 
@@ -405,10 +390,7 @@ def _build_user_preferences_prompt(
     *,
     fallback_platform: Optional[str] = None,
 ) -> str:
-    platform = fallback_platform or "<platform>"
-    if context is not None:
-        platform_specific = context.platform_specific or {}
-        platform = context.platform or platform_specific.get("platform") or fallback_platform or "<platform>"
+    platform = _resolve_context_platform(context, fallback_platform=fallback_platform)
     return _USER_PREFERENCES_PROMPT.format(
         preferences_path=f"`{paths.get_user_preferences_path()}`",
         platform=platform,
@@ -451,7 +433,7 @@ def build_system_prompt_injection(
     if include_user_preferences:
         prompt += _build_user_preferences_prompt(context, fallback_platform=fallback_platform)
     if context is not None:
-        prompt += _build_session_end_prompt(context)
+        prompt += _build_session_end_prompt(context, fallback_platform=fallback_platform)
     return prompt
 
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -220,7 +220,10 @@ Current session id: `{default_session_id}`. Before using Show Page or Harness co
 _SESSION_TITLE_PROMPT = """\
 
 ## Session Title
-When the topic of this conversation is clear, you may silently set one concise, human-scannable title for the current Session:
+When the topic of this Web conversation is clear, you may silently set one concise, human-scannable title for the current Session once. Before setting it, inspect the Session:
+`vibe session get {default_session_id}`
+
+If `metadata.title_source` is `user` or `agent`, leave the title unchanged; that means the title was deliberately set or cleared. Otherwise, set it once:
 `vibe session update {default_session_id} --title "<short title>"`
 
 Do not mention the title update unless the user asks, and do not repeatedly rename the same Session.

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -12,6 +12,7 @@ from typing import Any, Iterable, Optional
 
 from config import paths
 from core.avibe_cloud import AVIBE_CLOUD_CONNECT_GUIDANCE
+from core.message_context import resolve_context_platform
 from modules.im import MessageContext
 
 logger = logging.getLogger(__name__)
@@ -256,18 +257,6 @@ def _extract_default_session_id(context: MessageContext) -> str:
     return str(default_session_id)
 
 
-def _resolve_context_platform(
-    context: Optional[MessageContext],
-    *,
-    fallback_platform: Optional[str] = None,
-) -> str:
-    platform = fallback_platform or "<platform>"
-    if context is not None:
-        platform_specific = context.platform_specific or {}
-        platform = context.platform or platform_specific.get("platform") or platform
-    return str(platform or "<platform>")
-
-
 def _is_web_platform(platform: str) -> bool:
     return platform.strip().lower() in {"avibe", "web"}
 
@@ -382,7 +371,7 @@ def _build_session_end_prompt(
 ) -> str:
     default_session_id = _extract_default_session_id(context)
     prompt = _SESSION_END_PROMPT.format(default_session_id=default_session_id)
-    platform = _resolve_context_platform(context, fallback_platform=fallback_platform)
+    platform = resolve_context_platform(context, fallback_platform=fallback_platform, default="<platform>")
     if _is_web_platform(platform):
         prompt += _SESSION_TITLE_PROMPT.format(default_session_id=default_session_id)
     return prompt
@@ -393,7 +382,7 @@ def _build_user_preferences_prompt(
     *,
     fallback_platform: Optional[str] = None,
 ) -> str:
-    platform = _resolve_context_platform(context, fallback_platform=fallback_platform)
+    platform = resolve_context_platform(context, fallback_platform=fallback_platform, default="<platform>")
     return _USER_PREFERENCES_PROMPT.format(
         preferences_path=f"`{paths.get_user_preferences_path()}`",
         platform=platform,

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -204,6 +204,19 @@ def test_build_session_key_for_context_uses_fallback_platform() -> None:
     assert parsed.to_key(include_thread=False) == "slack::channel::C123"
 
 
+def test_build_session_key_for_context_uses_platform_specific_platform() -> None:
+    context = MessageContext(
+        user_id="U123",
+        channel_id="C123",
+        thread_id="171717.123",
+        platform_specific={"platform": "telegram", "is_dm": False},
+    )
+
+    parsed = build_session_key_for_context(context, fallback_platform="slack")
+
+    assert parsed.to_key(include_thread=False) == "telegram::channel::C123"
+
+
 def test_scheduled_task_store_uses_sqlite_when_path_is_default(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
     store = ScheduledTaskStore()

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -245,7 +245,11 @@ def test_web_title_prompt_is_fixed_and_uses_session_id():
     out = _injection_for("sesweb")
     assert "## Session Title" in out
     # the command carries the REAL session id (not a <id> placeholder)
+    assert "vibe session get sesweb" in out
     assert 'vibe session update sesweb --title "<short title>"' in out
+    assert "metadata.title_source" in out
+    assert "`user` or `agent`" in out
+    assert "leave the title unchanged" in out
     assert "may silently set one concise, human-scannable title" in out
     assert "do not repeatedly rename the same Session" in out
     assert "not set yet" not in out

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -227,61 +227,36 @@ def test_link_inbound_is_noop_when_already_linked(monkeypatch, tmp_path):
     assert sid == "sesim"
 
 
-# ------------------------------------------------------------ title nudge prompt
+# ------------------------------------------------------------ title prompt
 
 
-def _injection_for(session_id):
+def _injection_for(session_id, *, platform="avibe"):
     from core.system_prompt_injection import build_system_prompt_injection
     from modules.im.base import MessageContext
 
     ctx = MessageContext(
-        user_id="u", channel_id="c", platform="avibe",
+        user_id="u", channel_id="c", platform=platform,
         platform_specific={"agent_session_id": session_id},
     )
     return build_system_prompt_injection(context=ctx)
 
 
-def test_title_nudge_when_empty(monkeypatch, tmp_path):
-    engine = _setup(monkeypatch, tmp_path)
-    _seed(engine, "sesnone", title="")
-    out = _injection_for("sesnone")
+def test_web_title_prompt_is_fixed_and_uses_session_id():
+    out = _injection_for("sesweb")
+    assert "## Session Title" in out
     # the command carries the REAL session id (not a <id> placeholder)
-    assert 'vibe session update sesnone --title "<short title>"' in out
-    assert "not set yet" in out
-    assert "silently" in out  # only update once, without disturbing the user
+    assert 'vibe session update sesweb --title "<short title>"' in out
+    assert "may silently set one concise, human-scannable title" in out
+    assert "do not repeatedly rename the same Session" in out
+    assert "not set yet" not in out
+    assert "auto-generated" not in out
 
 
-def test_title_nudge_when_auto_generated(monkeypatch, tmp_path):
-    engine = _setup(monkeypatch, tmp_path)
-    _seed(engine, "sesauto", title="Some auto title", title_source="backend")
-    out = _injection_for("sesauto")
-    assert "vibe session update sesauto --title" in out
-    assert "auto-generated" in out
-
-
-def test_no_title_nudge_when_user_set(monkeypatch, tmp_path):
-    engine = _setup(monkeypatch, tmp_path)
-    _seed(engine, "sesuser", title="Release review", title_source="user")
-    out = _injection_for("sesuser")
-    assert "vibe session update sesuser --title" not in out
+def test_im_title_prompt_is_not_injected():
+    out = _injection_for("sesim", platform="slack")
+    assert "## Session Title" not in out
+    assert "vibe session update sesim --title" not in out
     assert "Current Session Reminder" in out  # the reminder itself still renders
-
-
-def test_no_title_nudge_when_user_cleared(monkeypatch, tmp_path):
-    # A user who deliberately cleared the title (empty + title_source="user") must
-    # NOT be nudged, or the agent would undo the clear next turn (Codex P2).
-    engine = _setup(monkeypatch, tmp_path)
-    _seed(engine, "sescleared", title="", title_source="user")
-    out = _injection_for("sescleared")
-    assert "vibe session update sescleared --title" not in out
-
-
-def test_no_title_nudge_when_agent_set(monkeypatch, tmp_path):
-    # Once the agent names it (title_source="agent"), the nudge stops — fires once.
-    engine = _setup(monkeypatch, tmp_path)
-    _seed(engine, "sesagent", title="CLI design", title_source="agent")
-    out = _injection_for("sesagent")
-    assert "vibe session update sesagent --title" not in out
 
 
 # ------------------------------------------------ live session.activity endpoint


### PR DESCRIPTION
## Summary
- make the Session Title prompt Web-only and stable across same-session turns
- stop reading session title/title_source while building injected prompts
- update title prompt tests for Web vs IM behavior

## Tests
- python3 -m pytest tests/test_session_cli.py tests/test_reply_enhancer_platform.py::ReplyEnhancerPlatformTests::test_prompt_includes_harness_architecture_and_memory_context
- python3 -m ruff check core/system_prompt_injection.py tests/test_session_cli.py

## Evidence layers
- Unit: focused prompt/session CLI tests
- Contract: prompt-injection Web vs IM behavior assertions
- Scenario: not applicable
- Manual: residual cache impact reviewed by code path
