### PR TITLE
fix(claude): settle EOF turns through terminal cleanup

### DIFF
--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -761,11 +761,10 @@ class ClaudeAgent(BaseAgent):
 
     async def _handle_receiver_eof(self, composite_key: str, context: MessageContext) -> None:
         """Settle a Claude receiver that ended without a ResultMessage."""
-        pending_requests = self._pending_requests.get(composite_key) or []
-        if not pending_requests:
+        pending_request = self._pop_pending_request(composite_key)
+        if pending_request is None:
             return
 
-        pending_request = pending_requests[0]
         pending_token = str(
             (getattr(getattr(pending_request, "context", None), "platform_specific", None) or {}).get(
                 AGENT_RUNTIME_TURN_TOKEN
@@ -773,10 +772,12 @@ class ClaudeAgent(BaseAgent):
             or ""
         )
         if not pending_token:
+            self._pending_requests.setdefault(composite_key, []).insert(0, pending_request)
             return
         logger.warning("Claude receiver ended without a result for session %s", composite_key)
         self._adopt_pending_turn_token(context, pending_request)
-        await self._clear_pending_reactions(composite_key, context)
+        await self._remove_specific_pending_reaction(composite_key, context, pending_request)
+        await self._remove_ack_reaction(pending_request)
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)
         self._mark_session_idle_if_no_pending_requests(composite_key)

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -273,6 +273,86 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(queries, [("first", runtime_key), ("third", runtime_key)])
         self.assertNotIn(runtime_key, agent._pending_requests)
 
+    async def test_handle_message_receiver_eof_without_result_settles_current_turn(self):
+        controller = _StubController()
+        runtime_key = "wechat_o9:/tmp/work"
+        mark_active_calls = []
+        mark_idle_calls = []
+        queries = []
+
+        class _Client:
+            _vibe_runtime_base_session_id = "wechat_o9"
+            _vibe_runtime_session_key = runtime_key
+
+            async def query(self, message, *, session_id):
+                queries.append((message, session_id))
+
+            async def disconnect(self):
+                return None
+
+            def receive_messages(self):
+                async def _iterate():
+                    if False:
+                        yield None
+
+                return _iterate()
+
+        client = _Client()
+        controller._get_session_key = lambda _context: "wechat-user"
+        controller.emit_agent_message = AsyncMock()
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(return_value=client),
+            mark_session_active=lambda key: mark_active_calls.append(key),
+            mark_session_idle=lambda key: mark_idle_calls.append(key),
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_args, **_kwargs: None,
+            clear_session_tracking=lambda key: mark_idle_calls.append(f"clear:{key}"),
+        )
+
+        agent = ClaudeAgent(controller)
+        service = AgentService(controller)
+        service.register(agent)
+        controller.agent_service = service
+        agent._prepare_message_with_files = lambda request: request.message
+        agent._delete_ack = AsyncMock()
+        agent._remove_ack_reaction = AsyncMock()
+
+        async def _emit(context, message_type, text, **_kwargs):
+            if message_type == "result":
+                service.release_runtime_turn(context)
+
+        controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        context = SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={})
+        request = SimpleNamespace(
+            context=context,
+            message="first",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id=runtime_key,
+            session_key="wechat-user",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            ack_message_id=None,
+            ack_reaction_message_id=None,
+            ack_reaction_emoji=None,
+            files=None,
+        )
+
+        await service.handle_message("claude", request)
+        receiver_task = controller.receiver_tasks.get(runtime_key)
+        if receiver_task is not None:
+            await asyncio.wait_for(receiver_task, timeout=1)
+
+        self.assertEqual(queries, [("first", runtime_key)])
+        self.assertEqual(mark_active_calls, [runtime_key])
+        self.assertIn(runtime_key, mark_idle_calls)
+        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True)
+        agent._remove_ack_reaction.assert_awaited_once_with(request)
+        self.assertNotIn(runtime_key, agent._pending_requests)
+        self.assertNotIn(runtime_key, controller.claude_sessions)
+        self.assertFalse(service._turn_gates[runtime_key].lock.locked())
+
     async def test_handle_stop_releases_runtime_turn_gate(self):
         controller = _StubController()
         runtime_key = "wechat_o9:/tmp/work"


### PR DESCRIPTION
## Summary
- replace PR #583's narrow idle guard with explicit EOF terminal cleanup on current master
- retire the current Claude pending turn when the receiver stream ends without a ResultMessage
- emit the existing terminal error result after runtime cleanup so Workbench waiters and the shared runtime gate are released through the #581 model

## Background
PR #583 identified the right leak class, but its branch does not contain PR #581 and the fix only marks the runtime session idle in the receiver finally. In the real `handle_message` path the current turn is still queued in `_pending_requests`, so that guard can no-op and miss the terminal cleanup model introduced by #581.

## Evidence layers
- unit: added a production-entry regression test for `AgentService.handle_message -> ClaudeAgent.handle_message -> receiver EOF`
- contract: covered runtime gate release via `tests/test_runtime_service_lock.py` and stream-token guard behavior via `tests/test_dispatcher_stream_chunk.py`
- scenario: no scenario catalog entry; this is a Claude runtime lifecycle regression
- residual manual checks: not run; focused automated lifecycle tests cover the changed path

## Validation
- `npm run build` in `ui/`
- `uv run pytest tests/test_claude_agent_sessions.py -q`
- `uv run pytest tests/test_runtime_service_lock.py tests/test_dispatcher_stream_chunk.py -q`
- `uv run pytest tests/test_claude_agent_sessions.py -k "synthetic_api_error or receiver_eof or handle_stop or auth_error" -q`
- `uv run ruff check modules/agents/claude_agent.py tests/test_claude_agent_sessions.py`

Fixes/Replacement for #583.
