### PR TITLE
fix(workbench): search trigger height + Show Page access dropdown

### DIFF
--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -5,7 +5,7 @@ import { Check, Copy, Loader2, Share2 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
-import { Switch } from '../ui/switch';
+import { Select } from '../ui/select';
 import { useApi } from '../../context/ApiContext';
 import { copyTextToClipboard } from '../../lib/utils';
 import { copyHref, type ShowPageLinkInfo } from '../../lib/showPageLinks';
@@ -70,10 +70,10 @@ export const ShowPageShareControl: React.FC<{
     if (next) refresh();
   };
 
-  const toggleVisibility = (nextPublic: boolean) => {
+  const setVisibilityTo = (next: string) => {
     setBusy(true);
     api
-      .setShowPageVisibility(sessionId, nextPublic ? 'public' : 'private')
+      .setShowPageVisibility(sessionId, next)
       .then((res: ShowPagePayload) => {
         // Authoritative server state: always apply it, and invalidate any
         // in-flight refresh read so a stale read can't revert us afterwards.
@@ -165,21 +165,24 @@ export const ShowPageShareControl: React.FC<{
               )}
             </div>
 
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0">
-                <div className="text-sm">
-                  {isPublic ? t('chat.showPage.visibilityPublic') : t('chat.showPage.visibilityPrivate')}
-                </div>
-                <div className="text-xs text-muted">
-                  {isPublic ? t('chat.showPage.publicDesc') : t('chat.showPage.privateDesc')}
-                </div>
+            <div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm">{t('chat.showPage.access')}</span>
+                <Select
+                  value={isPublic ? 'public' : 'private'}
+                  disabled={busy}
+                  onChange={(e) => setVisibilityTo(e.target.value)}
+                  wrapperClassName="w-auto"
+                  className="h-8 text-sm"
+                  aria-label={t('chat.showPage.access')}
+                >
+                  <option value="private">{t('chat.showPage.visibilityPrivate')}</option>
+                  <option value="public">{t('chat.showPage.visibilityPublic')}</option>
+                </Select>
               </div>
-              <Switch
-                checked={isPublic}
-                disabled={busy}
-                onCheckedChange={toggleVisibility}
-                label={t('chat.showPage.visibilityPublic')}
-              />
+              <p className="mt-1.5 text-xs text-muted">
+                {isPublic ? t('chat.showPage.publicDesc') : t('chat.showPage.privateDesc')}
+              </p>
             </div>
 
             {payload && isPublic && !payload.url_available && (

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -723,11 +723,11 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
         type="button"
         variant="ghost"
         onClick={onOpenSearch}
-        className="h-auto w-full justify-start gap-2 rounded-lg border border-border-strong bg-foreground/[0.03] px-[11px] py-[9px] text-left font-normal transition hover:bg-foreground/[0.05]"
+        className="h-auto w-full justify-start gap-2 rounded-lg border border-border-strong bg-foreground/[0.03] px-3 py-2.5 text-left font-normal transition hover:bg-foreground/[0.05]"
       >
         <Search className="size-3.5 shrink-0 text-muted" />
         <span className="flex-1 truncate text-[13px] text-muted">{t('workbench.search.entry')}</span>
-        <kbd className="shrink-0 rounded-[5px] border border-border bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted">
+        <kbd className="shrink-0 rounded-[5px] border border-border bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[11px] font-medium leading-none text-muted">
           ⌘K
         </kbd>
       </Button>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1786,6 +1786,7 @@
       "shareTitle": "Share this Show Page",
       "copyLink": "Copy link",
       "nativeShare": "Share…",
+      "access": "Access",
       "visibilityPublic": "Public",
       "visibilityPrivate": "Private",
       "publicDesc": "Anyone with the link can view",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1785,6 +1785,7 @@
       "shareTitle": "分享这个 Show Page",
       "copyLink": "复制链接",
       "nativeShare": "系统分享",
+      "access": "权限",
       "visibilityPublic": "公开",
       "visibilityPrivate": "私有",
       "publicDesc": "任何人都可以通过链接查看",


### PR DESCRIPTION
Two workbench UI tweaks from page feedback on the chat view.

## 1. Sidebar search trigger height
The "Search messages ⌘K" field read taller than the Inbox entry: the ⌘K `kbd` inflated the row (default line-height made it taller than the label) and the field used different padding (`px-[11px] py-[9px]` vs the inbox's `px-3 py-2.5`). Now the field matches the inbox box metrics and the kbd gets `leading-none`, so both rows are the same height. Radius / border / shadow already matched.

## 2. Show Page share — access dropdown
The public/private `Switch` was unclear: a switch labelled **Private** in the off state gave no hint that turning it on meant **Public**. Replaced with a Google-Docs-style row — an **Access** label + a `Select` dropdown (**Private / Public**) — with the selected option's description below. Reuses the existing `Select` primitive; visibility still flips in place via the same API.

## Evidence layers
- **Build (UI gate):** `npm run build` (tsc + vite) green; both i18n JSON valid.
- **Manual:** rendered a dark-theme mock comparing search/inbox heights and the new access dropdown.
- Unit / contract / scenario: n/a (frontend-only; UI CI gates on build).