### PR TITLE
fix(workbench): clarify forked session copy

### DIFF
--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -117,13 +117,15 @@ def reserve_forked_session(
                 if reasoning_effort is not None
                 else row["reasoning_effort"]
             )
+            source_title = str(row["title"] or "").strip()
+            target_title = _forked_session_title(source_title)
 
             metadata = _load_metadata(row["metadata_json"])
             metadata.update(
                 {
                     "created_via": "session_fork",
                     "fork_source_session_id": str(row["id"]),
-                    "fork_source_session_title": str(row["title"] or ""),
+                    "fork_source_session_title": source_title,
                     "fork_source_message_id": source_message_id,
                     "fork_source_native_session_id": source_native,
                     "fork_source_backend": source_backend,
@@ -145,7 +147,7 @@ def reserve_forked_session(
                 reasoning_effort=target_effort,
                 workdir=row["workdir"],
                 native_session_id="",
-                title=row["title"],
+                title=target_title,
                 metadata=metadata,
                 now=now,
                 require_workdir=False,
@@ -244,6 +246,10 @@ def _clean_optional(value: Any) -> Optional[str]:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _forked_session_title(source_title: str) -> str:
+    return f"Fork {source_title}" if source_title else "Fork"
 
 
 def _latest_source_message_id(conn: Any, source_session_id: str) -> Optional[str]:

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -62,6 +62,11 @@ Current session id: `{default_session_id}`. Treat this as the authoritative Avib
 
 """
 
+_FORKED_SESSION_PROMPT = """\
+This Agent Session was forked from `{source_session_id}`. The authoritative Avibe session id for this fork is `{default_session_id}`. If copied source context mentions another Avibe session id, treat it as historical source-context only and use `{default_session_id}` for Show Pages, Harness commands, tasks, watches, callbacks, and session updates.
+
+"""
+
 _SHOW_PAGES_PROMPT = """\
 
 ## Show Pages
@@ -257,6 +262,27 @@ def _extract_default_session_id(context: MessageContext) -> str:
     return str(default_session_id)
 
 
+def _extract_fork_source_session_id(context: MessageContext) -> Optional[str]:
+    platform_specific = context.platform_specific or {}
+    target = platform_specific.get("agent_session_target")
+    if not isinstance(target, dict):
+        return None
+
+    fork = target.get("native_session_fork")
+    if isinstance(fork, dict):
+        source_session_id = str(fork.get("source_session_id") or "").strip()
+        if source_session_id:
+            return source_session_id
+
+    metadata = target.get("metadata")
+    if isinstance(metadata, dict):
+        source_session_id = str(metadata.get("fork_source_session_id") or "").strip()
+        if source_session_id:
+            return source_session_id
+
+    return None
+
+
 def _is_web_platform(platform: str) -> bool:
     return platform.strip().lower() in {"avibe", "web"}
 
@@ -339,7 +365,15 @@ def get_enabled_agents_for_prompt(controller: Any) -> Optional[list[AgentPromptI
 
 
 def _build_session_start_prompt(context: MessageContext) -> str:
-    return _SESSION_START_PROMPT.format(default_session_id=_extract_default_session_id(context))
+    default_session_id = _extract_default_session_id(context)
+    prompt = _SESSION_START_PROMPT.format(default_session_id=default_session_id)
+    source_session_id = _extract_fork_source_session_id(context)
+    if source_session_id and source_session_id != default_session_id:
+        prompt += _FORKED_SESSION_PROMPT.format(
+            default_session_id=default_session_id,
+            source_session_id=source_session_id,
+        )
+    return prompt
 
 
 def _build_harness_prompt(

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -283,6 +283,17 @@ def _extract_fork_source_session_id(context: MessageContext) -> Optional[str]:
     return None
 
 
+def build_forked_session_correction_prompt(context: MessageContext) -> Optional[str]:
+    default_session_id = _extract_default_session_id(context)
+    source_session_id = _extract_fork_source_session_id(context)
+    if source_session_id and source_session_id != default_session_id:
+        return _FORKED_SESSION_PROMPT.format(
+            default_session_id=default_session_id,
+            source_session_id=source_session_id,
+        )
+    return None
+
+
 def _is_web_platform(platform: str) -> bool:
     return platform.strip().lower() in {"avibe", "web"}
 
@@ -367,12 +378,9 @@ def get_enabled_agents_for_prompt(controller: Any) -> Optional[list[AgentPromptI
 def _build_session_start_prompt(context: MessageContext) -> str:
     default_session_id = _extract_default_session_id(context)
     prompt = _SESSION_START_PROMPT.format(default_session_id=default_session_id)
-    source_session_id = _extract_fork_source_session_id(context)
-    if source_session_id and source_session_id != default_session_id:
-        prompt += _FORKED_SESSION_PROMPT.format(
-            default_session_id=default_session_id,
-            source_session_id=source_session_id,
-        )
+    fork_correction = build_forked_session_correction_prompt(context)
+    if fork_correction:
+        prompt += fork_correction
     return prompt
 
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -11,7 +11,11 @@ from typing import Any, Dict, Optional
 
 from core.avibe_cloud import avibe_cloud_url_available
 from core.services.session_fork import pending_native_fork_source
-from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
+from core.system_prompt_injection import (
+    build_forked_session_correction_prompt,
+    build_system_prompt_injection,
+    get_enabled_agents_for_prompt,
+)
 from modules.agents.base import AgentRequest, BaseAgent
 from modules.agents.subagent_router import SubagentDefinition, load_codex_subagent
 from modules.agents.codex.event_handler import CodexEventHandler
@@ -75,6 +79,7 @@ class CodexAgent(BaseAgent):
         self._session_locks: Dict[str, asyncio.Lock] = {}
         # base_session_id → (thread_id, developer_instructions)
         self._thread_developer_instructions: Dict[str, tuple[str, str]] = {}
+        self._fork_correction_pending_base_sessions: set[str] = set()
 
     # ------------------------------------------------------------------
     # BaseAgent interface
@@ -624,15 +629,20 @@ class CodexAgent(BaseAgent):
         if effective_model:
             params["model"] = effective_model
 
-        resp = await transport.send_request("thread/fork", params)
-        thread_id = resp.get("id", "")
-        if not thread_id:
-            thread_obj = resp.get("thread")
-            if isinstance(thread_obj, dict):
-                thread_id = thread_obj.get("id", "")
-        if not thread_id:
-            raise RuntimeError("Codex thread/fork returned no thread id")
+        self._mark_fork_correction_pending(request.base_session_id)
+        try:
+            resp = await transport.send_request("thread/fork", params)
+            thread_id = resp.get("id", "")
+            if not thread_id:
+                thread_obj = resp.get("thread")
+                if isinstance(thread_obj, dict):
+                    thread_id = thread_obj.get("id", "")
+            if not thread_id:
+                raise RuntimeError("Codex thread/fork returned no thread id")
 
+            await self._inject_forked_session_correction(transport, request, thread_id)
+        finally:
+            self._clear_fork_correction_pending(request.base_session_id)
         self._session_mgr.set_thread_id(request.base_session_id, thread_id)
         self.bind_agent_session_id(request, thread_id)
         self._remember_thread_developer_instructions(request.base_session_id, thread_id, developer_instructions)
@@ -873,6 +883,36 @@ class CodexAgent(BaseAgent):
 
         return "\n\n".join(part for part in instruction_parts if part) or None
 
+    async def _inject_forked_session_correction(
+        self,
+        transport: CodexTransport,
+        request: AgentRequest,
+        thread_id: str,
+    ) -> None:
+        """Append a fork correction as Codex model-visible developer history.
+
+        Codex accepts ``developerInstructions`` on ``thread/fork``, but the fork
+        also copies the source thread's previous developer messages. Appending a
+        fresh developer item makes the target session id authoritative without
+        creating a user turn.
+        """
+        correction = build_forked_session_correction_prompt(request.context)
+        if not correction:
+            return
+        await transport.send_request(
+            "thread/inject_items",
+            {
+                "threadId": thread_id,
+                "items": [
+                    {
+                        "type": "message",
+                        "role": "developer",
+                        "content": [{"type": "input_text", "text": correction}],
+                    }
+                ],
+            },
+        )
+
     async def _refresh_thread_developer_instructions_if_needed(
         self,
         transport: CodexTransport,
@@ -925,6 +965,20 @@ class CodexAgent(BaseAgent):
     def _clear_thread_developer_instructions(self, base_session_id: str) -> None:
         if hasattr(self, "_thread_developer_instructions"):
             self._thread_developer_instructions.pop(base_session_id, None)
+
+    def _fork_correction_pending_sessions(self) -> set[str]:
+        if not hasattr(self, "_fork_correction_pending_base_sessions"):
+            self._fork_correction_pending_base_sessions = set()
+        return self._fork_correction_pending_base_sessions
+
+    def _mark_fork_correction_pending(self, base_session_id: str) -> None:
+        self._fork_correction_pending_sessions().add(base_session_id)
+
+    def _clear_fork_correction_pending(self, base_session_id: str) -> None:
+        self._fork_correction_pending_sessions().discard(base_session_id)
+
+    def is_fork_correction_pending(self, base_session_id: str) -> bool:
+        return base_session_id in self._fork_correction_pending_sessions()
 
     async def _start_turn(
         self,

--- a/modules/agents/codex/event_handler.py
+++ b/modules/agents/codex/event_handler.py
@@ -101,6 +101,14 @@ class CodexEventHandler:
     async def _on_thread_started(self, params: dict[str, Any], request: AgentRequest) -> None:
         thread_obj = params.get("thread", {})
         thread_id = thread_obj.get("id", "") if isinstance(thread_obj, dict) else ""
+        is_fork_correction_pending = getattr(self._agent, "is_fork_correction_pending", None)
+        if callable(is_fork_correction_pending) and is_fork_correction_pending(request.base_session_id):
+            logger.debug(
+                "Skipping Codex thread/started auto-bind for pending fork correction: session=%s thread=%s",
+                request.base_session_id,
+                thread_id,
+            )
+            return
         if thread_id:
             self._agent._session_mgr.set_thread_id(request.base_session_id, thread_id)
             self._agent.bind_agent_session_id(request, thread_id)

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -218,6 +218,12 @@ def test_session_handler_sets_claude_fork_session_for_pending_native_fork(monkey
     assert captured["options"].extra_args == {"model": "claude-sonnet-4-5"}
     assert captured["options"].effort == "high"
     assert not hasattr(client, "_vibe_native_session_id")
+    prompt_value = captured["options"].system_prompt
+    prompt = prompt_value["append"] if isinstance(prompt_value, dict) else prompt_value
+    assert "Current session id: `ses-target`" in prompt
+    assert "This Agent Session was forked from `ses-source`." in prompt
+    assert "The authoritative Avibe session id for this fork is `ses-target`." in prompt
+    assert "use `ses-target` for Show Pages" in prompt
 
 
 def test_session_handler_disallows_remote_unsafe_claude_tools(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1229,6 +1229,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             bind_agent_session=Mock(return_value="ses-target"),
         )
         agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
         request = SimpleNamespace(
             working_path="/tmp/work",
             context=SimpleNamespace(
@@ -1262,7 +1263,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         thread_id = await agent._start_or_resume_thread(transport, request)
 
         self.assertEqual(thread_id, "thread-fork")
-        method, params = transport.send_request.await_args.args
+        method, params = transport.send_request.await_args_list[0].args
         self.assertEqual(method, "thread/fork")
         self.assertEqual(params["threadId"], "thread-source")
         self.assertEqual(params["cwd"], "/tmp/work")
@@ -1278,12 +1279,79 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             developer_instructions,
         )
         self.assertIn("use `ses-target` for Show Pages", developer_instructions)
+        inject_method, inject_params = transport.send_request.await_args_list[1].args
+        self.assertEqual(inject_method, "thread/inject_items")
+        self.assertEqual(inject_params["threadId"], "thread-fork")
+        self.assertEqual(inject_params["items"][0]["type"], "message")
+        self.assertEqual(inject_params["items"][0]["role"], "developer")
+        correction_text = inject_params["items"][0]["content"][0]["text"]
+        self.assertIn("This Agent Session was forked from `ses-source`.", correction_text)
+        self.assertIn(
+            "The authoritative Avibe session id for this fork is `ses-target`.",
+            correction_text,
+        )
         agent.sessions.bind_agent_session.assert_called_once_with(
             "avibe::project::proj_1",
             "codex",
             "ses-target",
             "thread-fork",
         )
+
+    async def test_start_or_resume_thread_does_not_bind_failed_fork_correction(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(
+            send_request=AsyncMock(
+                side_effect=[
+                    {"thread": {"id": "thread-fork"}},
+                    RuntimeError("inject failed"),
+                ]
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "inject failed"):
+            await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(transport.send_request.await_count, 2)
+        agent._session_mgr.set_thread_id.assert_not_called()
+        agent.sessions.bind_agent_session.assert_not_called()
+        self.assertFalse(agent.is_fork_correction_pending("ses-target"))
 
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1270,6 +1270,14 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(params["sandbox"], "danger-full-access")
         self.assertEqual(params["model"], "gpt-5.2")
         self.assertNotIn("effort", params)
+        developer_instructions = params["developerInstructions"]
+        self.assertIn("Current session id: `ses-target`", developer_instructions)
+        self.assertIn("This Agent Session was forked from `ses-source`.", developer_instructions)
+        self.assertIn(
+            "The authoritative Avibe session id for this fork is `ses-target`.",
+            developer_instructions,
+        )
+        self.assertIn("use `ses-target` for Show Pages", developer_instructions)
         agent.sessions.bind_agent_session.assert_called_once_with(
             "avibe::project::proj_1",
             "codex",

--- a/tests/test_codex_event_handler.py
+++ b/tests/test_codex_event_handler.py
@@ -124,6 +124,25 @@ class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.context.platform_specific["agent_session_id"], "sesk8m4q2p7x")
         agent.controller.emit_agent_message.assert_not_awaited()
 
+    async def test_thread_started_does_not_bind_while_fork_correction_is_pending(self):
+        agent = _StubAgent()
+        agent.is_fork_correction_pending = Mock(return_value=True)
+        agent.bind_agent_session_id = Mock(wraps=agent.bind_agent_session_id)
+        handler = CodexEventHandler(agent)
+        request = SimpleNamespace(
+            base_session_id="session-1",
+            session_key="slack::channel::C1",
+            working_path="/repo",
+            context=SimpleNamespace(platform_specific={}),
+        )
+
+        await handler._on_thread_started({"thread": {"id": "thread-1"}}, request)
+
+        agent.is_fork_correction_pending.assert_called_once_with("session-1")
+        agent._session_mgr.set_thread_id.assert_not_called()
+        agent.bind_agent_session_id.assert_not_called()
+        self.assertNotIn("agent_session_id", request.context.platform_specific)
+
     async def test_retrying_error_is_suppressed(self):
         agent = _StubAgent()
         handler = CodexEventHandler(agent)

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -674,6 +674,145 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
     assert calls[0]["reasoning_effort"] == "high"
 
 
+def test_opencode_fork_prompt_marks_target_session_id_authoritative():
+    calls = []
+
+    class _Server:
+        async def ensure_running(self):
+            return None
+
+        async def list_messages(self, session_id, directory):
+            return []
+
+        async def prompt_async(self, **kwargs):
+            calls.append(kwargs)
+
+        async def mark_run_active(self, session_id):
+            return None
+
+        async def mark_run_inactive(self, session_id):
+            return None
+
+        def get_default_agent_from_config(self):
+            return None
+
+        def get_agent_model_from_config(self, _agent):
+            return None
+
+        def get_agent_reasoning_effort_from_config(self, _agent):
+            return None
+
+    class _SessionManager:
+        async def ensure_working_dir(self, path):
+            return None
+
+        async def get_or_create_session_id(self, request, server):
+            return "oc-fork"
+
+        def set_request_session(self, *args):
+            return None
+
+        def mark_initialized(self, session_id):
+            return False
+
+    class _Sessions:
+        def add_active_poll(self, **kwargs):
+            return None
+
+        def remove_active_poll(self, session_id):
+            return None
+
+    class _PollLoop:
+        async def run_prompt_poll(self, *args, **kwargs):
+            return "done", True
+
+    async def _get_server():
+        return _Server()
+
+    async def _async_noop():
+        return None
+
+    class _Controller:
+        def __init__(self):
+            self.config = type(
+                "Config",
+                (),
+                {
+                    "platform": "avibe",
+                    "reply_enhancements": True,
+                    "show_pages_prompt": True,
+                    "remote_access": None,
+                    "language": "en",
+                    "opencode": type(
+                        "OpenCodeConfig",
+                        (),
+                        {
+                            "default_model": None,
+                            "default_provider": None,
+                            "default_reasoning_effort": None,
+                        },
+                    )(),
+                },
+            )()
+            self.im_client = _StubClient("avibe")
+            self.settings_manager = type("Settings", (), {"sessions": _Sessions()})()
+            self.sessions = self.settings_manager.sessions
+            self.processing_indicator = type("Processing", (), {"snapshot_request": lambda self, request: {}})()
+
+        def get_opencode_overrides(self, context):
+            return None, None, None
+
+    agent = OpenCodeAgent.__new__(OpenCodeAgent)
+    agent.controller = _Controller()
+    agent.config = agent.controller.config
+    agent.im_client = agent.controller.im_client
+    agent.settings_manager = agent.controller.settings_manager
+    agent.sessions = agent.controller.sessions
+    agent.opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+    agent._session_manager = _SessionManager()
+    agent._poll_loop = _PollLoop()
+    agent._get_server = _get_server
+    agent._delete_ack = lambda request: _async_noop()
+    agent._remove_ack_reaction = lambda request: _async_noop()
+    agent.emit_result_message = lambda *args, **kwargs: _async_noop()
+
+    async def _run():
+        request = AgentRequest(
+            context=MessageContext(
+                user_id="u",
+                channel_id="ses-target",
+                platform="avibe",
+                platform_specific={
+                    "agent_session_id": "ses-target",
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "opencode",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "oc-source",
+                            "source_backend": "opencode",
+                        },
+                    },
+                },
+            ),
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="ses-target",
+            composite_session_id="ses-target:/tmp/work",
+            session_key="avibe::ses-target",
+        )
+        await agent._process_message(request)
+
+    asyncio.run(_run())
+
+    system = calls[0]["system"]
+    assert "Current session id: `ses-target`" in system
+    assert "This Agent Session was forked from `ses-source`." in system
+    assert "The authoritative Avibe session id for this fork is `ses-target`." in system
+    assert "use `ses-target` for Show Pages" in system
+
+
 def test_opencode_normal_text_matching_legacy_question_prefix_is_processed():
     processed = []
 

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -230,13 +230,17 @@ def test_link_inbound_is_noop_when_already_linked(monkeypatch, tmp_path):
 # ------------------------------------------------------------ title prompt
 
 
-def _injection_for(session_id, *, platform="avibe"):
+def _injection_for(session_id, *, platform="avibe", platform_specific=None):
     from core.system_prompt_injection import build_system_prompt_injection
     from modules.im.base import MessageContext
 
+    payload = {"agent_session_id": session_id}
+    if platform_specific:
+        payload.update(platform_specific)
+
     ctx = MessageContext(
         user_id="u", channel_id="c", platform=platform,
-        platform_specific={"agent_session_id": session_id},
+        platform_specific=payload,
     )
     return build_system_prompt_injection(context=ctx)
 
@@ -261,6 +265,48 @@ def test_im_title_prompt_is_not_injected():
     assert "## Session Title" not in out
     assert "vibe session update sesim --title" not in out
     assert "Current Session Reminder" in out  # the reminder itself still renders
+
+
+def test_forked_session_prompt_marks_target_session_id_authoritative():
+    out = _injection_for(
+        "sestarget",
+        platform_specific={
+            "agent_session_target": {
+                "id": "sestarget",
+                "native_session_fork": {
+                    "source_session_id": "sessource",
+                    "source_native_session_id": "native-source",
+                    "source_backend": "codex",
+                },
+            },
+        },
+    )
+
+    assert "Current session id: `sestarget`" in out
+    assert "This Agent Session was forked from `sessource`." in out
+    assert "The authoritative Avibe session id for this fork is `sestarget`." in out
+    assert "If copied source context mentions another Avibe session id" in out
+    assert "use `sestarget` for Show Pages, Harness commands, tasks, watches, callbacks, and session updates" in out
+
+
+def test_forked_session_prompt_can_use_persisted_metadata():
+    out = _injection_for(
+        "sestarget",
+        platform_specific={
+            "agent_session_target": {
+                "id": "sestarget",
+                "metadata": {
+                    "created_via": "session_fork",
+                    "fork_source_session_id": "sessource",
+                    "fork_source_native_session_id": "native-source",
+                    "fork_source_backend": "opencode",
+                },
+            },
+        },
+    )
+
+    assert "This Agent Session was forked from `sessource`." in out
+    assert "The authoritative Avibe session id for this fork is `sestarget`." in out
 
 
 # ------------------------------------------------ live session.activity endpoint

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -136,9 +136,39 @@ def test_reserve_forked_session_copies_row_and_applies_overrides(tmp_path: Path)
     assert row["workdir"] == str(tmp_path)
     assert row["native_session_id"] == ""
     assert row["session_anchor"] == result.session_id
-    assert row["title"] == "Source"
+    assert row["title"] == "Fork Source"
     assert metadata["fork_source_message_id"] == visible_message["id"]
     assert metadata["fork_source_session_title"] == "Source"
+
+
+def test_reserve_forked_session_uses_generic_title_for_untitled_source(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(title=None)
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(source_session_id=source_id, db_path=db_path)
+
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    metadata = json.loads(row["metadata_json"])
+    assert row["title"] == "Fork"
+    assert metadata["fork_source_session_title"] == ""
 
 
 def test_reserve_forked_session_keeps_im_anchor_and_resets_variant_for_agent_override(tmp_path: Path) -> None:

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -213,7 +213,7 @@ def test_fork_session_creates_new_workbench_session(isolated_state, tmp_path):
     assert payload["id"] != session_id
     assert payload["scope_id"] == scope_id
     assert payload["project_id"] == "proj_stream"
-    assert payload["title"] == "Source session"
+    assert payload["title"] == "Fork Source session"
     assert payload["agent_backend"] == "claude"
     assert payload["agent_name"] == "worker"
     assert payload["native_session_id"] == ""

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1804,7 +1804,7 @@
     "missingSessionId": "Missing session id in the URL.",
     "transcriptEmpty": "Type a message below to start the conversation",
     "forkedEmptyTitle": "Forked session ready",
-    "forkedEmptyBody": "The native agent context was forked from the source session. This transcript starts clean and will only show new messages sent here.",
+    "forkedEmptyBody": "This session has been forked from the source context. The previous messages are preserved, so you can continue the conversation here.",
     "forkedFromPrefix": "Forked from",
     "forkedSource": "Open source session",
     "scrollToBottom": "Scroll to latest",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1804,7 +1804,7 @@
     "missingSessionId": "Missing session id in the URL.",
     "transcriptEmpty": "Type a message below to start the conversation",
     "forkedEmptyTitle": "Forked session ready",
-    "forkedEmptyBody": "This session has been forked from the source context. The previous messages are preserved, so you can continue the conversation here.",
+    "forkedEmptyBody": "This session has been forked from the source context. The visible transcript starts clean, and the source context is preserved so you can continue the conversation here.",
     "forkedFromPrefix": "Forked from",
     "forkedSource": "Open source session",
     "scrollToBottom": "Scroll to latest",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1803,7 +1803,7 @@
     "missingSessionId": "URL 缺少 session id。",
     "transcriptEmpty": "在下方输入消息开始对话",
     "forkedEmptyTitle": "Fork 会话已创建",
-    "forkedEmptyBody": "已从原会话上下文分叉，历史消息均已保留，继续对话即可",
+    "forkedEmptyBody": "已从原会话上下文分叉，当前对话记录从空白开始，原会话上下文已保留，继续对话即可",
     "forkedFromPrefix": "Fork 自",
     "forkedSource": "打开源会话",
     "scrollToBottom": "回到最新",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1803,7 +1803,7 @@
     "missingSessionId": "URL 缺少 session id。",
     "transcriptEmpty": "在下方输入消息开始对话",
     "forkedEmptyTitle": "Fork 会话已创建",
-    "forkedEmptyBody": "底层 Agent 上下文已从源会话 fork 过来。这里的聊天记录从空白开始，只显示此会话里的新消息。",
+    "forkedEmptyBody": "已从原会话上下文分叉，历史消息均已保留，继续对话即可",
     "forkedFromPrefix": "Fork 自",
     "forkedSource": "打开源会话",
     "scrollToBottom": "回到最新",


### PR DESCRIPTION
## Summary
- rename forked Workbench sessions with a `Fork` prefix while keeping source-title metadata intact
- update the forked empty-chat copy to avoid "native/bottom agent" wording, clarify that the visible transcript starts clean, and explain that source context is preserved
- mark the fork target Avibe session id as authoritative in shared prompt injection so copied source context cannot keep using the old session id
- cover titled/untitled fork targets plus Codex, Claude, and OpenCode fork prompt propagation in tests

## Validation
- `npm run build` in `ui/`
- `uv run ruff check core/services/session_fork.py tests/test_session_fork.py`
- `uv run pytest tests/test_session_fork.py -q`
- `jq empty ui/src/i18n/en.json ui/src/i18n/zh.json`
- `uv run ruff check core/system_prompt_injection.py tests/test_session_cli.py tests/test_codex_agent.py tests/test_claude_cli_path.py tests/test_multi_platform_runtime.py`
- `uv run pytest tests/test_reply_enhancer_platform.py tests/test_session_cli.py tests/test_codex_agent.py::CodexAgentPayloadTests tests/test_claude_cli_path.py tests/test_multi_platform_runtime.py::test_opencode_prompt_disables_question_tool_for_all_platforms tests/test_multi_platform_runtime.py::test_opencode_fork_prompt_marks_target_session_id_authoritative -q`
- `uv run ruff check tests/test_ui_session_stream.py core/system_prompt_injection.py tests/test_session_cli.py tests/test_codex_agent.py tests/test_claude_cli_path.py tests/test_multi_platform_runtime.py`
- `uv run pytest tests/test_ui_session_stream.py::test_fork_session_creates_new_workbench_session tests/test_session_cli.py::test_forked_session_prompt_marks_target_session_id_authoritative tests/test_codex_agent.py::CodexAgentPayloadTests::test_start_or_resume_thread_forks_pending_native_source tests/test_claude_cli_path.py::test_session_handler_sets_claude_fork_session_for_pending_native_fork tests/test_multi_platform_runtime.py::test_opencode_fork_prompt_marks_target_session_id_authoritative -q`
- `git diff --check`

## Risks / follow-ups
- No migration is needed; this only affects newly forked session titles, localized copy, and the prompt injected into forked sessions.
