### PR TITLE
fix(workbench): even out the sidebar brand-to-search gap

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -239,7 +239,10 @@ export const AppShell: React.FC = () => {
       <aside className="fixed inset-y-0 left-0 z-30 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
         <div className="flex h-full flex-col justify-between gap-6 px-4 py-5">
           {/* Top: Brand + Workspace label + Nav list */}
-          <div className="flex min-h-0 flex-1 flex-col gap-6">
+          {/* Workbench mounts a search field right under the brand, so use the
+              same gap as the sidebar's own rows (gap-4) for an even rhythm; admin
+              keeps the wider gap-6 to separate the brand from its labelled nav. */}
+          <div className={clsx('flex min-h-0 flex-1 flex-col', shellMode === 'workbench' ? 'gap-4' : 'gap-6')}>
             <div className="flex items-center gap-2.5 px-1 py-2">
               <img
                 src={logoImg}


### PR DESCRIPTION
Page-feedback tweak: in the workbench sidebar the gap between the brand header and the search field felt wider than the gap between the search field and the Inbox below it.

Cause: the AppShell sidebar top group used `gap-6`, while the sidebar's own rows (search ↔ inbox ↔ …) use `gap-4`.

Fix: the workbench top group now uses `gap-4` so the brand → search → inbox rhythm is even. The admin shell keeps `gap-6` (there the brand sits above a labelled nav section, where the wider gap reads as intended).

## Evidence layers
- **Build (UI gate):** `npm run build` (tsc + vite) green.
- **Manual:** to verify in regression after merge.
- Unit / contract / scenario: n/a (frontend-only spacing).