### PR TITLE
fix(remote-access): keep loopback tunnel binds local

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -956,9 +956,25 @@ def test_effective_ui_bind_host_preserves_loopback_when_tunnel_disabled() -> Non
     assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
 
 
+def test_effective_ui_bind_host_preserves_loopback_when_tunnel_enabled() -> None:
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "127.0.0.1"
+
+    assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
+
+
 def test_effective_ui_bind_host_falls_back_to_loopback_when_setup_host_blank() -> None:
     config = _config()
     config.remote_access.vibe_cloud.enabled = False
+    config.ui.setup_host = ""
+
+    assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
+
+
+def test_effective_ui_bind_host_falls_back_to_loopback_when_tunnel_enabled_and_setup_host_blank() -> None:
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
     config.ui.setup_host = ""
 
     assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
@@ -972,12 +988,20 @@ def test_effective_ui_bind_host_uses_v6_wildcard_for_ipv6_setup_host() -> None:
     assert runtime.effective_ui_bind_host(config) == "::"
 
 
+def test_effective_ui_bind_host_preserves_v6_loopback_when_tunnel_enabled() -> None:
+    config = _config()
+    assert config.remote_access.vibe_cloud.enabled is True
+    config.ui.setup_host = "::1"
+
+    assert runtime.effective_ui_bind_host(config) == "::1"
+
+
 def test_effective_ui_bind_host_uses_v6_wildcard_for_bracketed_ipv6_loopback() -> None:
     config = _config()
     assert config.remote_access.vibe_cloud.enabled is True
     config.ui.setup_host = "[::1]"
 
-    assert runtime.effective_ui_bind_host(config) == "::"
+    assert runtime.effective_ui_bind_host(config) == "::1"
 
 
 def test_effective_ui_bind_host_prefers_requested_host_over_persisted_setup_host() -> None:
@@ -1000,13 +1024,13 @@ def test_effective_ui_bind_host_overrides_to_ipv4_wildcard_when_localhost_resolv
     monkeypatch,
 ) -> None:
     # Pairs with _origin_host_for_pairing returning 127.0.0.1 for "localhost":
-    # the bind family must be IPv4 so cloudflared can reach the UI.
+    # the bind host must be the same IPv4 loopback so cloudflared can reach the UI.
     monkeypatch.setattr(runtime, "resolve_localhost_family", lambda: "inet")
     config = _config()
     assert config.remote_access.vibe_cloud.enabled is True
     config.ui.setup_host = "localhost"
 
-    assert runtime.effective_ui_bind_host(config) == "0.0.0.0"
+    assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
 
 
 def test_effective_ui_bind_host_overrides_to_ipv6_wildcard_when_localhost_resolves_v6_only(
@@ -1020,7 +1044,7 @@ def test_effective_ui_bind_host_overrides_to_ipv6_wildcard_when_localhost_resolv
     assert config.remote_access.vibe_cloud.enabled is True
     config.ui.setup_host = "localhost"
 
-    assert runtime.effective_ui_bind_host(config) == "::"
+    assert runtime.effective_ui_bind_host(config) == "::1"
 
 
 def test_resolve_localhost_family_prefers_ipv4_when_both_resolve(monkeypatch) -> None:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -675,7 +675,7 @@ def _origin_host_for_pairing(config: V2Config) -> str:
     # "localhost" is ambiguous: cloudflared and the UI server resolve it
     # independently, so on a dual-stack host they can land on different
     # families (::1 vs 127.0.0.1) and surface as a 502. Hand cloudflared
-    # a literal loopback IP whose family matches the wildcard
+    # a literal loopback IP whose family matches the bind host that
     # ``effective_ui_bind_host`` chooses, so the two sides never disagree
     # and IPv6-only hosts still work.
     if host.lower() == "localhost":

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import logging
 import os
@@ -957,12 +958,12 @@ def resolve_localhost_family() -> str:
 def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) -> str:
     """Resolve the host the UI server should bind to.
 
-    When the Avibe Cloud tunnel is enabled, bind to a wildcard so the local
+    When the Avibe Cloud tunnel is enabled, keep loopback-only configs bound
+    to loopback. For non-loopback setup hosts, bind to a wildcard so the local
     ``cloudflared`` origin (which dials ``127.0.0.1``/``[::1]``) can reach the
     UI no matter which interface IP the user typed into ``ui.setup_host``
-    (loopback, Tailscale CGNAT, LAN). The host-trust middleware in
-    ``ui_server`` still rejects untrusted peers, so widening the bind does
-    not widen exposure.
+    (Tailscale CGNAT, LAN). The host-trust middleware in ``ui_server`` still
+    rejects untrusted peers, so widening the bind does not widen exposure.
 
     Why: If the user binds to a Tailscale or LAN IP and then enables the
     tunnel, ``cloudflared`` cannot reach the UI on its loopback origin and
@@ -975,17 +976,23 @@ def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) 
     setup_host = (requested_host if requested_host is not None else config.ui.setup_host) or "127.0.0.1"
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     if cloud is not None and cloud.enabled:
-        # Pick the wildcard family that matches the user's intent so an
-        # IPv6-only setup_host stays reachable on v6.
         normalized = setup_host.strip()
         if normalized.startswith("[") and normalized.endswith("]"):
             normalized = normalized[1:-1]
         # "localhost" is ambiguous on dual-stack hosts and may even be
-        # exclusively IPv6. Resolve once and pick the wildcard that
-        # matches the family _origin_host_for_pairing will hand
-        # cloudflared, so the two sides cannot disagree.
+        # exclusively IPv6. Resolve once and bind to a literal loopback that
+        # matches the family _origin_host_for_pairing will hand cloudflared,
+        # so the two sides cannot disagree without widening the local socket.
         if normalized.lower() == "localhost":
-            return "::" if resolve_localhost_family() == "inet6" else "0.0.0.0"
+            return "::1" if resolve_localhost_family() == "inet6" else "127.0.0.1"
+        try:
+            address = ipaddress.ip_address(normalized)
+        except ValueError:
+            address = None
+        if address is not None and address.is_loopback:
+            return address.compressed
+        # Pick the wildcard family that matches the user's non-loopback intent
+        # so IPv6 setup_host values stay reachable on v6.
         if normalized in {"::", "::0"} or ":" in normalized:
             return "::"
         return "0.0.0.0"


### PR DESCRIPTION
## Summary
- Keep the UI bound to loopback when Avibe Cloud remote access is enabled and `ui.setup_host` is still loopback, localhost, or blank.
- Preserve the existing wildcard bind behavior for explicit non-loopback LAN/Tailscale hosts so cloudflared can still reach the local origin.
- Update remote-access bind/origin tests for IPv4 loopback, IPv6 loopback, localhost, blank host, and non-loopback compatibility.

## Affected Capability
- Avibe Cloud remote-access UI bind host selection.

## Affected Scenario IDs
- N/A: no scenario catalog entry exists for remote-access bind host selection.

## Evidence Layers
- Unit: `tests/test_remote_access_vibe_cloud.py` bind/origin matrix.
- Contract: not applicable; no external API schema changed.
- Scenario: not applicable; no scenario catalog case exists.
- Residual manual checks: semantic probe confirmed loopback hosts bind to loopback while LAN/Tailscale hosts still bind wildcard.

## Validation
- `python3 -m pytest tests/test_remote_access_vibe_cloud.py tests/test_ui_server_reload.py -q`
- `python3 -m pytest tests/test_vibe_cli.py tests/test_restart_supervisor.py -q -k "ui or start_runtime"`
- `ruff check vibe/runtime.py vibe/remote_access.py tests/test_remote_access_vibe_cloud.py tests/test_ui_server_reload.py tests/test_vibe_cli.py tests/test_restart_supervisor.py`
- `git diff --check`
