### PR TITLE
fix(workbench): dismiss Show Page share popover on outside tap (mobile)

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -130,6 +130,11 @@ export const ChatPage: React.FC = () => {
   // next toggle (the page row already exists, so `existed` alone won't re-prompt).
   const showPagePromptRetryRef = useRef<Set<string>>(new Set());
   const [showPageUrl, setShowPageUrl] = useState<string | null>(null);
+  // True while the share popover is open. The popover floats over the Show Page
+  // iframe; making the iframe inert lets an outside tap there reach the parent
+  // document so the (non-modal) popover dismisses, without modal-blocking the
+  // sibling header buttons (which would then need two taps).
+  const [shareOpen, setShareOpen] = useState(false);
   useEffect(() => {
     // ChatPage is reused across :sessionId — clear all show-page state so the
     // next chat starts in chat view with a live (not stuck-busy) toggle.
@@ -1333,6 +1338,7 @@ export const ChatPage: React.FC = () => {
           showPageBusy={showPageBusy}
           onToggleShowPage={toggleShowPage}
           onShowPageVisibilityChange={handleShowPagePayload}
+          onShareOpenChange={setShareOpen}
         />
 
       {showPageMode && showPageUrl && (
@@ -1354,7 +1360,7 @@ export const ChatPage: React.FC = () => {
           src={showPageUrl}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
           allow="clipboard-write"
-          className="min-h-0 w-full flex-1 border-0 bg-background"
+          className={clsx('min-h-0 w-full flex-1 border-0 bg-background', shareOpen && 'pointer-events-none')}
         />
       )}
 
@@ -1519,9 +1525,10 @@ interface ChatHeaderBarProps {
   showPageBusy: boolean;
   onToggleShowPage: () => void;
   onShowPageVisibilityChange?: (payload: ShowPageLinkInfo) => void;
+  onShareOpenChange?: (open: boolean) => void;
 }
 
-const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working, showPageMode, showPageBusy, onToggleShowPage, onShowPageVisibilityChange }) => {
+const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working, showPageMode, showPageBusy, onToggleShowPage, onShowPageVisibilityChange, onShareOpenChange }) => {
   const { t } = useTranslation();
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
   // Backend locks once a NATIVE conversation exists — a native can only be
@@ -1630,7 +1637,11 @@ const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultA
             </span>
           </Button>
           {showPageMode && (
-            <ShowPageShareControl sessionId={session.id} onPayloadChange={onShowPageVisibilityChange} />
+            <ShowPageShareControl
+              sessionId={session.id}
+              onPayloadChange={onShowPageVisibilityChange}
+              onOpenChange={onShareOpenChange}
+            />
           )}
         </div>
       </div>

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -24,7 +24,11 @@ export const ShowPageShareControl: React.FC<{
   // Lets the chat view re-point the iframe at the route that now serves the
   // page when visibility flips (private↔public swap the serving route).
   onPayloadChange?: (payload: ShowPageLinkInfo) => void;
-}> = ({ sessionId, onPayloadChange }) => {
+  // The popover floats over the Show Page iframe; the chat view makes the iframe
+  // inert while it is open so an outside tap there falls through to the parent
+  // document and Radix can dismiss (a tap inside an iframe never reaches us).
+  onOpenChange?: (open: boolean) => void;
+}> = ({ sessionId, onPayloadChange, onOpenChange }) => {
   const { t } = useTranslation();
   const api = useApi();
   const [open, setOpen] = useState(false);
@@ -67,6 +71,7 @@ export const ShowPageShareControl: React.FC<{
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
+    onOpenChange?.(next);
     if (next) refresh();
   };
 
@@ -101,13 +106,8 @@ export const ShowPageShareControl: React.FC<{
     }
   };
 
-  // modal: the popover floats over the Show Page iframe; without it an outside
-  // tap lands inside the iframe (a separate browsing context) and never reaches
-  // the parent document, so Radix can't detect it to dismiss. modal adds a
-  // viewport guard above the iframe that captures the tap (mobile, where the
-  // iframe fills most of the screen, hit this; desktop has parent chrome around).
   return (
-    <Popover open={open} onOpenChange={handleOpenChange} modal>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           type="button"

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -101,8 +101,13 @@ export const ShowPageShareControl: React.FC<{
     }
   };
 
+  // modal: the popover floats over the Show Page iframe; without it an outside
+  // tap lands inside the iframe (a separate browsing context) and never reaches
+  // the parent document, so Radix can't detect it to dismiss. modal adds a
+  // viewport guard above the iframe that captures the tap (mobile, where the
+  // iframe fills most of the screen, hit this; desktop has parent chrome around).
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
+    <Popover open={open} onOpenChange={handleOpenChange} modal>
       <PopoverTrigger asChild>
         <Button
           type="button"

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -46,6 +46,11 @@ export const ShowPageShareControl: React.FC<{
     if (payload) onPayloadChange?.(payload);
   }, [payload, onPayloadChange]);
 
+  // If we unmount while open (a route/session change tears down Show Page mode),
+  // Radix won't fire onOpenChange, so report closed here — otherwise the chat
+  // view would keep the iframe inert (pointer-events:none) on the next Show Page.
+  useEffect(() => () => onOpenChange?.(false), [onOpenChange]);
+
   const offline = payload?.visibility === 'offline' || payload?.offline === true;
   const isPublic = payload?.visibility === 'public';
   // Absolute, copyable href; falls back to the same-origin route when Avibe


### PR DESCRIPTION
**Bug:** on mobile, opening the Show Page **share** popover and then tapping a blank area did not dismiss it — only re-tapping the share button closed it.

**Cause:** in Show Page mode the popover (Radix, portaled to the parent document) floats over the Show Page **iframe**, which fills most of the mobile screen. A tap on that "blank" area lands *inside the iframe* — a separate browsing context — so it never reaches the parent document where Radix's `DismissableLayer` listens for the outside `pointerdown`. Hence no dismiss.

**Fix (non-modal + inert iframe):** keep the popover **non-modal** (so a tap on a sibling header button — e.g. Back-to-chat — dismisses it *and* activates the button in one tap), and make the Show Page **iframe `pointer-events: none` while the popover is open**. An outside tap over the iframe then falls through to the parent document and Radix dismisses. The control reports its open state up via `onOpenChange`; ChatPage toggles the iframe inert.

> An earlier revision used Radix `modal`, but that disabled *all* outside pointer events and made sibling header buttons require two taps (flagged in review) — replaced by the inert-iframe approach.

## Evidence layers
- **Build (UI gate):** `npm run build` (tsc + vite) green.
- **Manual:** to verify on mobile in regression after merge (open share → tap outside / tap Back-to-chat both work in one tap).
- Unit / contract / scenario: n/a (frontend interaction).