### PR TITLE
feat(workbench): chat text-selection quote/ask toolbar

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -15,8 +15,10 @@ import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 import { formatLocalDateTime } from '../../lib/relativeTime';
 import { useFileDrop } from '../../lib/useFileDrop';
+import { quoteText } from '../../lib/quoteText';
 import { AgentRoutePicker } from './AgentRoutePicker';
 import { ShowPageShareControl } from './ShowPageShareControl';
+import { SelectionQuoteToolbar } from './SelectionQuoteToolbar';
 import { InstallHint } from '../InstallHint';
 import { Button } from '../ui/button';
 import { ChatImage } from '../ui/chat-image';
@@ -145,6 +147,28 @@ export const ChatPage: React.FC = () => {
     (refSessionId: string, title?: string | null) =>
       composerRef.current?.insertSessionReference(refSessionId, title),
     [],
+  );
+
+  // Chat-selection toolbar actions. "Quote" appends the quoted selection to the
+  // current composer; "Ask in a new session" forks this session and seeds the
+  // fork's draft with the same quote, then navigates to it.
+  const quoteSelectionToComposer = useCallback(
+    (text: string) => composerRef.current?.appendText(quoteText(text)),
+    [],
+  );
+  const askInNewSession = useCallback(
+    async (text: string) => {
+      if (!sessionId) return;
+      try {
+        const forked = await api.forkSession(sessionId);
+        if (!forked?.id) return;
+        await api.setSessionDraft(forked.id, quoteText(text));
+        navigate(`/chat/${encodeURIComponent(forked.id)}`);
+      } catch {
+        // forkSession / setSessionDraft surface their own errors via the toast layer.
+      }
+    },
+    [sessionId, api, navigate],
   );
   // Null target hides that sidebar action unless the composer is actually
   // mounted + insertable: a chat is open (sessionId), its session has loaded
@@ -1384,6 +1408,8 @@ export const ChatPage: React.FC = () => {
           highlightedId={highlightedId}
           messageFontSize={messageFontSize}
           onQuickReply={handleQuickReply}
+          onQuoteSelection={quoteSelectionToComposer}
+          onAskInNewSession={askInNewSession}
         />
         <QueueStrip queue={queue} onRemove={removeQueued} onSendNow={sendQueueNow} />
         {/* key by session so the composer remounts per session — its draft-seeding
@@ -1723,6 +1749,10 @@ interface TranscriptProps {
   highlightedId: string | null;
   messageFontSize: number;
   onQuickReply: (messageId: string, choice: string) => boolean | void | Promise<boolean | void>;
+  // Chat-selection toolbar: quote the selection into the composer, or fork +
+  // ask in a new session seeded with the quote.
+  onQuoteSelection: (text: string) => void;
+  onAskInNewSession: (text: string) => void;
 }
 
 const Transcript: React.FC<TranscriptProps> = ({
@@ -1741,6 +1771,8 @@ const Transcript: React.FC<TranscriptProps> = ({
   highlightedId,
   messageFontSize,
   onQuickReply,
+  onQuoteSelection,
+  onAskInNewSession,
 }) => {
   const { t } = useTranslation();
   const forkSourceSessionId =
@@ -2030,7 +2062,10 @@ const Transcript: React.FC<TranscriptProps> = ({
   }
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
-      <div ref={scrollRef} onScroll={handleScroll} className="min-h-0 flex-1 overflow-y-auto px-4 py-5 [overflow-anchor:none] md:px-8">
+      <SelectionQuoteToolbar containerRef={scrollRef} onQuote={onQuoteSelection} onAskInNew={onAskInNewSession} />
+      {/* [-webkit-touch-callout:none] suppresses the iOS selection callout so our
+          toolbar is the selection UI on mobile (we re-offer Copy there). */}
+      <div ref={scrollRef} onScroll={handleScroll} className="min-h-0 flex-1 overflow-y-auto px-4 py-5 [overflow-anchor:none] [-webkit-touch-callout:none] md:px-8">
         <div ref={contentRef} className="mx-auto flex w-full max-w-[1080px] flex-col gap-3">
           {forkSourceBanner}
           {loadingOlder && (

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -2062,7 +2062,13 @@ const Transcript: React.FC<TranscriptProps> = ({
   }
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
-      <SelectionQuoteToolbar containerRef={scrollRef} onQuote={onQuoteSelection} onAskInNew={onAskInNewSession} />
+      <SelectionQuoteToolbar
+        containerRef={scrollRef}
+        onQuote={onQuoteSelection}
+        // Forking needs a bound native session (mirrors the sidebar's fork gate);
+        // omit the action otherwise so it isn't offered just to 409.
+        onAskInNew={session.native_session_id ? onAskInNewSession : undefined}
+      />
       {/* [-webkit-touch-callout:none] suppresses the iOS selection callout so our
           toolbar is the selection UI on mobile (we re-offer Copy there). */}
       <div ref={scrollRef} onScroll={handleScroll} className="min-h-0 flex-1 overflow-y-auto px-4 py-5 [overflow-anchor:none] [-webkit-touch-callout:none] md:px-8">

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Bell, Bot, ChevronDown, Clock, GitFork, Info, Loader2, Messa
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
+import { useToast } from '../../context/ToastContext';
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { useRegisterComposerTarget, type ComposerInsertTarget } from '../../context/ComposerBridgeContext';
 import type { VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
@@ -94,6 +95,7 @@ export const ChatPage: React.FC = () => {
   const { sessionId } = useParams<{ sessionId: string }>();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const location = useLocation();
   // Deep-link target: the search palette routes to /chat/<session>?msg=<message>
   // (P3 contract). When set, the jump effect below scrolls to + briefly
@@ -162,13 +164,20 @@ export const ChatPage: React.FC = () => {
       try {
         const forked = await api.forkSession(sessionId);
         if (!forked?.id) return;
-        await api.setSessionDraft(forked.id, quoteText(text));
+        // setSessionDraft returns {ok:false} for a non-OK response (it doesn't
+        // throw), so check it before navigating — don't strand the user in a
+        // fork with an empty composer and a lost selection.
+        const saved = await api.setSessionDraft(forked.id, quoteText(text));
+        if (!saved?.ok) {
+          showToast(t('chat.selection.askFailed'), 'error');
+          return;
+        }
         navigate(`/chat/${encodeURIComponent(forked.id)}`);
       } catch {
-        // forkSession / setSessionDraft surface their own errors via the toast layer.
+        showToast(t('chat.selection.askFailed'), 'error');
       }
     },
-    [sessionId, api, navigate],
+    [sessionId, api, navigate, showToast, t],
   );
   // Null target hides that sidebar action unless the composer is actually
   // mounted + insertable: a chat is open (sessionId), its session has loaded

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -130,6 +130,10 @@ export interface ComposerHandle {
    *  session" from the sidebar). No-op when the mention editor isn't active
    *  (the plain-textarea home composer). */
   insertSessionReference: (sessionId: string, title?: string | null) => void;
+  /** Append text to the end of the composer (e.g. a quoted chat selection),
+   *  with a separating space when the composer is non-empty. No-op when the
+   *  mention editor isn't active (the plain-textarea home composer). */
+  appendText: (text: string) => void;
 }
 
 // The chat-style input row: an auto-growing textarea + a Send/Stop icon button,
@@ -343,6 +347,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       // carries the stable sessionId → serializes to `#<id>` + a session ref.
       mentionRef.current?.insertMention('#', title?.trim() || refSessionId, { sessionId: refSessionId });
     },
+    appendText: (text: string) => mentionRef.current?.append(text),
   }));
 
   const startRecording = async () => {

--- a/ui/src/components/workbench/SelectionQuoteToolbar.tsx
+++ b/ui/src/components/workbench/SelectionQuoteToolbar.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Check, Copy, GitFork, TextQuote } from 'lucide-react';
+
+import { copyTextToClipboard } from '../../lib/utils';
+
+type SelectionState = { text: string; top: number; bottom: number; left: number };
+
+const TOOLBAR_H = 38;
+const GAP = 8;
+
+// A floating toolbar that appears over a text selection inside the chat
+// transcript. "Quote" appends the (quoted) selection to the current composer;
+// "Ask in a new session" forks + prefills the fork's draft; "Copy" (mobile
+// only) replaces the native callout that the transcript suppresses there.
+export const SelectionQuoteToolbar: React.FC<{
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  onQuote: (text: string) => void;
+  onAskInNew: (text: string) => void;
+}> = ({ containerRef, onQuote, onAskInNew }) => {
+  const { t } = useTranslation();
+  const [sel, setSel] = useState<SelectionState | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    let timer = 0;
+    const recompute = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+        setSel(null);
+        return;
+      }
+      const text = selection.toString().trim();
+      const range = selection.getRangeAt(0);
+      if (!text || !container.contains(range.commonAncestorContainer)) {
+        setSel(null);
+        return;
+      }
+      const rect = range.getBoundingClientRect();
+      if (!rect.width && !rect.height) {
+        setSel(null);
+        return;
+      }
+      setSel({ text, top: rect.top, bottom: rect.bottom, left: rect.left + rect.width / 2 });
+    };
+    // Debounce so the toolbar appears when the selection settles, not on every
+    // intermediate range while dragging the selection / handles.
+    const onSelectionChange = () => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(recompute, 150);
+    };
+    // A scrolled transcript makes the cached rect stale — hide immediately.
+    const onScroll = () => {
+      window.clearTimeout(timer);
+      setSel(null);
+    };
+    document.addEventListener('selectionchange', onSelectionChange);
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      window.clearTimeout(timer);
+      document.removeEventListener('selectionchange', onSelectionChange);
+      container.removeEventListener('scroll', onScroll);
+    };
+  }, [containerRef]);
+
+  if (!sel) return null;
+
+  const dismiss = () => {
+    window.getSelection()?.removeAllRanges();
+    setSel(null);
+    setCopied(false);
+  };
+  const runQuote = () => {
+    onQuote(sel.text);
+    dismiss();
+  };
+  const runAskInNew = () => {
+    onAskInNew(sel.text);
+    dismiss();
+  };
+  const runCopy = () => {
+    const text = sel.text;
+    void copyTextToClipboard(text).then((ok) => {
+      if (ok) {
+        setCopied(true);
+        window.setTimeout(dismiss, 800);
+      }
+    });
+  };
+
+  const above = sel.top > TOOLBAR_H + GAP + 8;
+  const top = above ? sel.top - TOOLBAR_H - GAP : sel.bottom + GAP;
+  const left = Math.min(Math.max(sel.left, 96), window.innerWidth - 96);
+
+  const itemClass =
+    'flex items-center gap-1.5 px-3 py-2 text-[13px] font-medium text-foreground transition-colors hover:bg-foreground/[0.06]';
+
+  return createPortal(
+    <div
+      role="toolbar"
+      // Keep the selection alive when the toolbar is pressed (desktop). On touch
+      // the handlers use the captured `sel.text`, so a collapse is harmless too.
+      onMouseDown={(e) => e.preventDefault()}
+      style={{ position: 'fixed', top, left, transform: 'translateX(-50%)', zIndex: 60 }}
+      className="flex items-center overflow-hidden rounded-lg border border-border-strong bg-surface-2 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.7)]"
+    >
+      <button type="button" className={itemClass} onClick={runQuote}>
+        <TextQuote className="size-3.5 text-muted" />
+        {t('chat.selection.quote')}
+      </button>
+      <span className="h-5 w-px bg-border" />
+      <button type="button" className={itemClass} onClick={runAskInNew}>
+        <GitFork className="size-3.5 text-muted" />
+        {t('chat.selection.askInNew')}
+      </button>
+      {/* Copy is mobile-only: the transcript suppresses the native iOS callout
+          there, so we re-offer copy ourselves. Desktop keeps Cmd/Ctrl+C. */}
+      <span className="h-5 w-px bg-border md:hidden" />
+      <button type="button" className={`${itemClass} md:hidden`} onClick={runCopy}>
+        {copied ? <Check className="size-3.5 text-mint" /> : <Copy className="size-3.5 text-muted" />}
+        {t('chat.selection.copy')}
+      </button>
+    </div>,
+    document.body,
+  );
+};

--- a/ui/src/components/workbench/SelectionQuoteToolbar.tsx
+++ b/ui/src/components/workbench/SelectionQuoteToolbar.tsx
@@ -110,6 +110,21 @@ export const SelectionQuoteToolbar: React.FC<{
     });
   };
 
+  // Activate on pointerup (mouse + touch) and Enter/Space (keyboard). The
+  // pointerdown preventDefault keeps the text selection alive (and on touch
+  // cancels the synthetic click we don't use), so onClick is intentionally
+  // avoided — it wouldn't fire on touch yet would double-fire on mouse.
+  const activate = (run: () => void) => ({
+    onPointerDown: (e: React.PointerEvent) => e.preventDefault(),
+    onPointerUp: () => run(),
+    onKeyDown: (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        run();
+      }
+    },
+  });
+
   const above = sel.top > TOOLBAR_H + GAP + EDGE;
   const top = above ? sel.top - TOOLBAR_H - GAP : sel.bottom + GAP;
   // Clamp by the on-screen (capped) width so a toolbar wider than the viewport
@@ -126,14 +141,14 @@ export const SelectionQuoteToolbar: React.FC<{
       style={{ position: 'fixed', top, left, maxWidth: 'calc(100vw - 16px)', transform: 'translateX(-50%)', zIndex: 60 }}
       className="flex items-center overflow-x-auto rounded-lg border border-border-strong bg-surface-2 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.7)]"
     >
-      <Button variant="ghost" className={itemClass} onPointerDown={(e) => { e.preventDefault(); runQuote(); }}>
+      <Button variant="ghost" className={itemClass} {...activate(runQuote)}>
         <TextQuote className="size-3.5 text-muted" />
         {t('chat.selection.quote')}
       </Button>
       {onAskInNew && (
         <>
           <span className="h-5 w-px bg-border" />
-          <Button variant="ghost" className={itemClass} onPointerDown={(e) => { e.preventDefault(); runAsk(); }}>
+          <Button variant="ghost" className={itemClass} {...activate(runAsk)}>
             <GitFork className="size-3.5 text-muted" />
             {t('chat.selection.askInNew')}
           </Button>
@@ -142,7 +157,7 @@ export const SelectionQuoteToolbar: React.FC<{
       {isTouch && (
         <>
           <span className="h-5 w-px bg-border" />
-          <Button variant="ghost" className={itemClass} onPointerDown={(e) => { e.preventDefault(); runCopy(); }}>
+          <Button variant="ghost" className={itemClass} {...activate(runCopy)}>
             {copied ? <Check className="size-3.5 text-mint" /> : <Copy className="size-3.5 text-muted" />}
             {t('chat.selection.copy')}
           </Button>

--- a/ui/src/components/workbench/SelectionQuoteToolbar.tsx
+++ b/ui/src/components/workbench/SelectionQuoteToolbar.tsx
@@ -1,27 +1,40 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { Check, Copy, GitFork, TextQuote } from 'lucide-react';
 
+import { Button } from '../ui/button';
 import { copyTextToClipboard } from '../../lib/utils';
 
 type SelectionState = { text: string; top: number; bottom: number; left: number };
 
-const TOOLBAR_H = 38;
+const TOOLBAR_H = 36;
 const GAP = 8;
+const EDGE = 8;
 
 // A floating toolbar that appears over a text selection inside the chat
 // transcript. "Quote" appends the (quoted) selection to the current composer;
-// "Ask in a new session" forks + prefills the fork's draft; "Copy" (mobile
-// only) replaces the native callout that the transcript suppresses there.
+// "Ask in a new session" forks + prefills the fork's draft (only offered when
+// the session is forkable); "Copy" replaces the native callout that the
+// transcript suppresses on touch devices.
 export const SelectionQuoteToolbar: React.FC<{
   containerRef: React.RefObject<HTMLDivElement | null>;
   onQuote: (text: string) => void;
-  onAskInNew: (text: string) => void;
+  // Omitted when the session can't be forked yet (no native id) — the action is
+  // hidden rather than offered just to 409.
+  onAskInNew?: (text: string) => void;
 }> = ({ containerRef, onQuote, onAskInNew }) => {
   const { t } = useTranslation();
   const [sel, setSel] = useState<SelectionState | null>(null);
   const [copied, setCopied] = useState(false);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+  // Touch devices get a Copy action because the transcript suppresses the native
+  // selection callout there (a coarse pointer covers phones AND tablets/iPads,
+  // unlike a width breakpoint).
+  const [isTouch] = useState(
+    () => typeof window !== 'undefined' && !!window.matchMedia?.('(pointer: coarse)').matches,
+  );
 
   useEffect(() => {
     const container = containerRef.current;
@@ -66,6 +79,12 @@ export const SelectionQuoteToolbar: React.FC<{
     };
   }, [containerRef]);
 
+  // Measure the rendered toolbar so we can clamp it on-screen by its real width
+  // (the label widths vary by locale + how many actions are shown).
+  useLayoutEffect(() => {
+    if (sel && toolbarRef.current) setWidth(toolbarRef.current.offsetWidth);
+  }, [sel, onAskInNew, isTouch]);
+
   if (!sel) return null;
 
   const dismiss = () => {
@@ -77,8 +96,8 @@ export const SelectionQuoteToolbar: React.FC<{
     onQuote(sel.text);
     dismiss();
   };
-  const runAskInNew = () => {
-    onAskInNew(sel.text);
+  const runAsk = () => {
+    onAskInNew?.(sel.text);
     dismiss();
   };
   const runCopy = () => {
@@ -91,15 +110,16 @@ export const SelectionQuoteToolbar: React.FC<{
     });
   };
 
-  const above = sel.top > TOOLBAR_H + GAP + 8;
+  const above = sel.top > TOOLBAR_H + GAP + EDGE;
   const top = above ? sel.top - TOOLBAR_H - GAP : sel.bottom + GAP;
-  const left = Math.min(Math.max(sel.left, 96), window.innerWidth - 96);
+  const half = width / 2;
+  const left = Math.min(Math.max(sel.left, EDGE + half), window.innerWidth - EDGE - half);
 
-  const itemClass =
-    'flex items-center gap-1.5 px-3 py-2 text-[13px] font-medium text-foreground transition-colors hover:bg-foreground/[0.06]';
+  const itemClass = 'h-9 gap-1.5 rounded-none px-3 text-[13px] font-medium';
 
   return createPortal(
     <div
+      ref={toolbarRef}
       role="toolbar"
       // Keep the selection alive when the toolbar is pressed (desktop). On touch
       // the handlers use the captured `sel.text`, so a collapse is harmless too.
@@ -107,22 +127,28 @@ export const SelectionQuoteToolbar: React.FC<{
       style={{ position: 'fixed', top, left, transform: 'translateX(-50%)', zIndex: 60 }}
       className="flex items-center overflow-hidden rounded-lg border border-border-strong bg-surface-2 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.7)]"
     >
-      <button type="button" className={itemClass} onClick={runQuote}>
+      <Button variant="ghost" className={itemClass} onClick={runQuote}>
         <TextQuote className="size-3.5 text-muted" />
         {t('chat.selection.quote')}
-      </button>
-      <span className="h-5 w-px bg-border" />
-      <button type="button" className={itemClass} onClick={runAskInNew}>
-        <GitFork className="size-3.5 text-muted" />
-        {t('chat.selection.askInNew')}
-      </button>
-      {/* Copy is mobile-only: the transcript suppresses the native iOS callout
-          there, so we re-offer copy ourselves. Desktop keeps Cmd/Ctrl+C. */}
-      <span className="h-5 w-px bg-border md:hidden" />
-      <button type="button" className={`${itemClass} md:hidden`} onClick={runCopy}>
-        {copied ? <Check className="size-3.5 text-mint" /> : <Copy className="size-3.5 text-muted" />}
-        {t('chat.selection.copy')}
-      </button>
+      </Button>
+      {onAskInNew && (
+        <>
+          <span className="h-5 w-px bg-border" />
+          <Button variant="ghost" className={itemClass} onClick={runAsk}>
+            <GitFork className="size-3.5 text-muted" />
+            {t('chat.selection.askInNew')}
+          </Button>
+        </>
+      )}
+      {isTouch && (
+        <>
+          <span className="h-5 w-px bg-border" />
+          <Button variant="ghost" className={itemClass} onClick={runCopy}>
+            {copied ? <Check className="size-3.5 text-mint" /> : <Copy className="size-3.5 text-muted" />}
+            {t('chat.selection.copy')}
+          </Button>
+        </>
+      )}
     </div>,
     document.body,
   );

--- a/ui/src/components/workbench/SelectionQuoteToolbar.tsx
+++ b/ui/src/components/workbench/SelectionQuoteToolbar.tsx
@@ -112,7 +112,9 @@ export const SelectionQuoteToolbar: React.FC<{
 
   const above = sel.top > TOOLBAR_H + GAP + EDGE;
   const top = above ? sel.top - TOOLBAR_H - GAP : sel.bottom + GAP;
-  const half = width / 2;
+  // Clamp by the on-screen (capped) width so a toolbar wider than the viewport
+  // centers + scrolls internally instead of pushing an edge off-screen.
+  const half = Math.min(width, window.innerWidth - 2 * EDGE) / 2;
   const left = Math.min(Math.max(sel.left, EDGE + half), window.innerWidth - EDGE - half);
 
   const itemClass = 'h-9 gap-1.5 rounded-none px-3 text-[13px] font-medium';
@@ -121,20 +123,17 @@ export const SelectionQuoteToolbar: React.FC<{
     <div
       ref={toolbarRef}
       role="toolbar"
-      // Keep the selection alive when the toolbar is pressed (desktop). On touch
-      // the handlers use the captured `sel.text`, so a collapse is harmless too.
-      onMouseDown={(e) => e.preventDefault()}
-      style={{ position: 'fixed', top, left, transform: 'translateX(-50%)', zIndex: 60 }}
-      className="flex items-center overflow-hidden rounded-lg border border-border-strong bg-surface-2 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.7)]"
+      style={{ position: 'fixed', top, left, maxWidth: 'calc(100vw - 16px)', transform: 'translateX(-50%)', zIndex: 60 }}
+      className="flex items-center overflow-x-auto rounded-lg border border-border-strong bg-surface-2 shadow-[0_12px_30px_-8px_rgba(0,0,0,0.7)]"
     >
-      <Button variant="ghost" className={itemClass} onClick={runQuote}>
+      <Button variant="ghost" className={itemClass} onPointerDown={(e) => { e.preventDefault(); runQuote(); }}>
         <TextQuote className="size-3.5 text-muted" />
         {t('chat.selection.quote')}
       </Button>
       {onAskInNew && (
         <>
           <span className="h-5 w-px bg-border" />
-          <Button variant="ghost" className={itemClass} onClick={runAsk}>
+          <Button variant="ghost" className={itemClass} onPointerDown={(e) => { e.preventDefault(); runAsk(); }}>
             <GitFork className="size-3.5 text-muted" />
             {t('chat.selection.askInNew')}
           </Button>
@@ -143,7 +142,7 @@ export const SelectionQuoteToolbar: React.FC<{
       {isTouch && (
         <>
           <span className="h-5 w-px bg-border" />
-          <Button variant="ghost" className={itemClass} onClick={runCopy}>
+          <Button variant="ghost" className={itemClass} onPointerDown={(e) => { e.preventDefault(); runCopy(); }}>
             {copied ? <Check className="size-3.5 text-mint" /> : <Copy className="size-3.5 text-muted" />}
             {t('chat.selection.copy')}
           </Button>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1777,6 +1777,11 @@
   "chat": {
     "back": "Back",
     "untitled": "Untitled session",
+    "selection": {
+      "quote": "Quote",
+      "askInNew": "Ask in a new session",
+      "copy": "Copy"
+    },
     "showPage": {
       "open": "Visualize",
       "backToChat": "Back to chat",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1780,7 +1780,8 @@
     "selection": {
       "quote": "Quote",
       "askInNew": "Ask in a new session",
-      "copy": "Copy"
+      "copy": "Copy",
+      "askFailed": "Couldn't start a new session from the selection."
     },
     "showPage": {
       "open": "Visualize",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1776,6 +1776,11 @@
   "chat": {
     "back": "返回",
     "untitled": "未命名会话",
+    "selection": {
+      "quote": "引用",
+      "askInNew": "在新会话询问",
+      "copy": "复制"
+    },
     "showPage": {
       "open": "可视化",
       "backToChat": "回聊天",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1779,7 +1779,8 @@
     "selection": {
       "quote": "引用",
       "askInNew": "在新会话询问",
-      "copy": "复制"
+      "copy": "复制",
+      "askFailed": "无法从选中内容新建会话，请重试。"
     },
     "showPage": {
       "open": "可视化",

--- a/ui/src/lib/quoteText.ts
+++ b/ui/src/lib/quoteText.ts
@@ -1,0 +1,11 @@
+// Wrap a chat selection in quotes for the composer / a forked draft. Text that
+// contains any CJK ideograph (pure Chinese OR mixed Chinese+Latin) uses the
+// Chinese corner brackets 「」; pure Latin/ASCII text uses straight double
+// quotes. Mixed text counts as Chinese — any CJK character flips to 「」.
+// Ranges: CJK Ext A (3400–4DBF), CJK Unified (4E00–9FFF), CJK Compat (F900–FAFF).
+const CJK = /[㐀-䶿一-鿿豈-﫿]/;
+
+export function quoteText(text: string): string {
+  const trimmed = text.trim();
+  return CJK.test(trimmed) ? `「${trimmed}」` : `"${trimmed}"`;
+}

--- a/ui/src/lib/quoteText.ts
+++ b/ui/src/lib/quoteText.ts
@@ -1,11 +1,11 @@
 // Wrap a chat selection in quotes for the composer / a forked draft. Text that
-// contains any CJK ideograph (pure Chinese OR mixed Chinese+Latin) uses the
-// Chinese corner brackets 「」; pure Latin/ASCII text uses straight double
-// quotes. Mixed text counts as Chinese — any CJK character flips to 「」.
-// Ranges: CJK Ext A (3400–4DBF), CJK Unified (4E00–9FFF), CJK Compat (F900–FAFF).
-const CJK = /[㐀-䶿一-鿿豈-﫿]/;
+// contains any Han ideograph (pure Chinese OR mixed Chinese+Latin, including
+// supplementary-plane Ext-B+ characters) uses the Chinese corner brackets 「」;
+// pure Latin/ASCII text uses straight double quotes. Mixed text counts as
+// Chinese — any Han character flips to 「」.
+const HAN = /\p{Script=Han}/u;
 
 export function quoteText(text: string): string {
   const trimmed = text.trim();
-  return CJK.test(trimmed) ? `「${trimmed}」` : `"${trimmed}"`;
+  return HAN.test(trimmed) ? `「${trimmed}」` : `"${trimmed}"`;
 }


### PR DESCRIPTION
Selecting text inside a chat bubble shows a small floating toolbar over the selection.

## Actions
- **Quote** — wraps the selection in quotes and **appends** it to the current composer (always, empty or not). Quote style follows the text: any CJK ideograph (Chinese, or mixed Chinese+Latin) → corner brackets `「…」`; pure Latin/ASCII → `"…"`.
- **Ask in a new session** — **forks** the current session and seeds the fork's draft with the same quote, then navigates to it (reuses `forkSession` + per-session draft seeding).
- **Copy** *(mobile only)* — the transcript sets `-webkit-touch-callout: none` so the iOS native selection callout is suppressed and our toolbar is the selection UI on touch; we re-offer Copy since the native one is gone. Desktop keeps `Cmd/Ctrl+C` and the native context menu (Copy button is `md:hidden`).

## Implementation
- New `SelectionQuoteToolbar` (selectionchange-driven, debounced, portaled to `body`, repositions above/below the selection, hides on scroll/clear/action) rendered inside `Transcript`.
- `ComposerHandle.appendText(text)` (reuses the mention editor's `append`); `quoteText()` helper for the CJK/Latin quote choice.
- No backend changes.

## Mobile note
Web pages can't inject items into the iOS/Android native selection menu, so Option A (suppress the native callout + render our own toolbar, partial selection preserved) is used. iOS callout suppression is the reliable lever; **real-device verification in regression is the true test** (a mock can't exercise the native callout).

## Evidence layers
- **Build (UI gate):** `npm run build` (tsc + vite) green; both i18n JSON valid.
- **Manual:** desktop selection → toolbar → quote/ask verified by build + design mock (approved); mobile callout-suppression + Copy to verify on a real device in regression.
- Unit / contract / scenario: n/a (frontend interaction).