### PR TITLE
fix(workbench): trailing space after quote + stagger selection toolbar on touch

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -160,7 +160,8 @@ export const ChatPage: React.FC = () => {
   // current composer; "Ask in a new session" forks this session and seeds the
   // fork's draft with the same quote, then navigates to it.
   const quoteSelectionToComposer = useCallback(
-    (text: string) => composerRef.current?.appendText(quoteText(text)),
+    // Trailing space so the user's next typed text is separated from the quote.
+    (text: string) => composerRef.current?.appendText(quoteText(text) + ' '),
     [],
   );
   const askInNewSession = useCallback(
@@ -172,7 +173,8 @@ export const ChatPage: React.FC = () => {
         // setSessionDraft returns {ok:false} for a non-OK response (it doesn't
         // throw), so check it before navigating — don't strand the user in a
         // fork with an empty composer and a lost selection.
-        const saved = await api.setSessionDraft(forked.id, quoteText(text));
+        // Trailing space so typing continues separated from the quote.
+        const saved = await api.setSessionDraft(forked.id, quoteText(text) + ' ');
         if (!saved?.ok) {
           showToast(t('chat.selection.askFailed'), 'error');
           return;
@@ -2089,9 +2091,7 @@ const Transcript: React.FC<TranscriptProps> = ({
         // omit the action otherwise so it isn't offered just to 409.
         onAskInNew={session.native_session_id ? onAskInNewSession : undefined}
       />
-      {/* [-webkit-touch-callout:none] suppresses the iOS selection callout so our
-          toolbar is the selection UI on mobile (we re-offer Copy there). */}
-      <div ref={scrollRef} onScroll={handleScroll} className="min-h-0 flex-1 overflow-y-auto px-4 py-5 [overflow-anchor:none] [-webkit-touch-callout:none] md:px-8">
+      <div ref={scrollRef} onScroll={handleScroll} className="min-h-0 flex-1 overflow-y-auto px-4 py-5 [overflow-anchor:none] md:px-8">
         <div ref={contentRef} className="mx-auto flex w-full max-w-[1080px] flex-col gap-3">
           {forkSourceBanner}
           {loadingOlder && (

--- a/ui/src/components/workbench/SelectionQuoteToolbar.tsx
+++ b/ui/src/components/workbench/SelectionQuoteToolbar.tsx
@@ -15,8 +15,8 @@ const EDGE = 8;
 // A floating toolbar that appears over a text selection inside the chat
 // transcript. "Quote" appends the (quoted) selection to the current composer;
 // "Ask in a new session" forks + prefills the fork's draft (only offered when
-// the session is forkable); "Copy" replaces the native callout that the
-// transcript suppresses on touch devices.
+// the session is forkable); "Copy" is a touch-only convenience — the OS
+// selection menu can't be suppressed, so on touch we stagger below it.
 export const SelectionQuoteToolbar: React.FC<{
   containerRef: React.RefObject<HTMLDivElement | null>;
   onQuote: (text: string) => void;
@@ -29,9 +29,9 @@ export const SelectionQuoteToolbar: React.FC<{
   const [copied, setCopied] = useState(false);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
-  // Touch devices get a Copy action because the transcript suppresses the native
-  // selection callout there (a coarse pointer covers phones AND tablets/iPads,
-  // unlike a width breakpoint).
+  // Touch (coarse pointer — covers phones AND tablets/iPads, unlike a width
+  // breakpoint) gets a Copy convenience; the OS selection menu still shows, so
+  // we stagger our toolbar below it rather than try to fight it.
   const [isTouch] = useState(
     () => typeof window !== 'undefined' && !!window.matchMedia?.('(pointer: coarse)').matches,
   );
@@ -125,8 +125,13 @@ export const SelectionQuoteToolbar: React.FC<{
     },
   });
 
-  const above = sel.top > TOOLBAR_H + GAP + EDGE;
-  const top = above ? sel.top - TOOLBAR_H - GAP : sel.bottom + GAP;
+  // The OS selection menu can't be queried or suppressed, but on touch it sits
+  // ABOVE the selection by default — so place ours BELOW to stagger (avoid the
+  // OS menu overlapping + covering ours). Desktop has no OS menu: prefer above.
+  const roomAbove = sel.top > TOOLBAR_H + GAP + EDGE;
+  const roomBelow = window.innerHeight - sel.bottom > TOOLBAR_H + GAP + EDGE;
+  const below = isTouch ? roomBelow || !roomAbove : !roomAbove;
+  const top = below ? sel.bottom + GAP : sel.top - TOOLBAR_H - GAP;
   // Clamp by the on-screen (capped) width so a toolbar wider than the viewport
   // centers + scrolls internally instead of pushing an edge off-screen.
   const half = Math.min(width, window.innerWidth - 2 * EDGE) / 2;

--- a/ui/src/components/workbench/SelectionQuoteToolbar.tsx
+++ b/ui/src/components/workbench/SelectionQuoteToolbar.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
-import { Check, Copy, GitFork, TextQuote } from 'lucide-react';
+import { GitFork, TextQuote } from 'lucide-react';
 
 import { Button } from '../ui/button';
-import { copyTextToClipboard } from '../../lib/utils';
 
 type SelectionState = { text: string; top: number; bottom: number; left: number };
 
@@ -15,8 +14,8 @@ const EDGE = 8;
 // A floating toolbar that appears over a text selection inside the chat
 // transcript. "Quote" appends the (quoted) selection to the current composer;
 // "Ask in a new session" forks + prefills the fork's draft (only offered when
-// the session is forkable); "Copy" is a touch-only convenience — the OS
-// selection menu can't be suppressed, so on touch we stagger below it.
+// the session is forkable). On touch the OS native selection menu also shows
+// (it can't be suppressed), so we stagger this toolbar clear of it.
 export const SelectionQuoteToolbar: React.FC<{
   containerRef: React.RefObject<HTMLDivElement | null>;
   onQuote: (text: string) => void;
@@ -26,12 +25,10 @@ export const SelectionQuoteToolbar: React.FC<{
 }> = ({ containerRef, onQuote, onAskInNew }) => {
   const { t } = useTranslation();
   const [sel, setSel] = useState<SelectionState | null>(null);
-  const [copied, setCopied] = useState(false);
   const toolbarRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
-  // Touch (coarse pointer — covers phones AND tablets/iPads, unlike a width
-  // breakpoint) gets a Copy convenience; the OS selection menu still shows, so
-  // we stagger our toolbar below it rather than try to fight it.
+  // Touch (coarse pointer — phones AND tablets/iPads) is where the OS selection
+  // menu coexists, so it drives the stagger-positioning below.
   const [isTouch] = useState(
     () => typeof window !== 'undefined' && !!window.matchMedia?.('(pointer: coarse)').matches,
   );
@@ -80,7 +77,7 @@ export const SelectionQuoteToolbar: React.FC<{
   }, [containerRef]);
 
   // Measure the rendered toolbar so we can clamp it on-screen by its real width
-  // (the label widths vary by locale + how many actions are shown).
+  // (label widths vary by locale + whether Ask is shown).
   useLayoutEffect(() => {
     if (sel && toolbarRef.current) setWidth(toolbarRef.current.offsetWidth);
   }, [sel, onAskInNew, isTouch]);
@@ -90,7 +87,6 @@ export const SelectionQuoteToolbar: React.FC<{
   const dismiss = () => {
     window.getSelection()?.removeAllRanges();
     setSel(null);
-    setCopied(false);
   };
   const runQuote = () => {
     onQuote(sel.text);
@@ -99,15 +95,6 @@ export const SelectionQuoteToolbar: React.FC<{
   const runAsk = () => {
     onAskInNew?.(sel.text);
     dismiss();
-  };
-  const runCopy = () => {
-    const text = sel.text;
-    void copyTextToClipboard(text).then((ok) => {
-      if (ok) {
-        setCopied(true);
-        window.setTimeout(dismiss, 800);
-      }
-    });
   };
 
   // Activate on pointerup (mouse + touch) and Enter/Space (keyboard). The
@@ -125,12 +112,21 @@ export const SelectionQuoteToolbar: React.FC<{
     },
   });
 
-  // The OS selection menu can't be queried or suppressed, but on touch it sits
-  // ABOVE the selection by default — so place ours BELOW to stagger (avoid the
-  // OS menu overlapping + covering ours). Desktop has no OS menu: prefer above.
   const roomAbove = sel.top > TOOLBAR_H + GAP + EDGE;
   const roomBelow = window.innerHeight - sel.bottom > TOOLBAR_H + GAP + EDGE;
-  const below = isTouch ? roomBelow || !roomAbove : !roomAbove;
+  let below: boolean;
+  if (isTouch) {
+    // The OS selection menu can't be queried or suppressed, but it sits toward
+    // screen center: BELOW a selection in the top half, ABOVE one in the bottom
+    // half. Stagger ours toward the nearer edge (the opposite side) so the two
+    // don't overlap. Fall back if that edge is clipped.
+    below = (sel.top + sel.bottom) / 2 >= window.innerHeight / 2;
+    if (below && !roomBelow) below = false;
+    else if (!below && !roomAbove) below = true;
+  } else {
+    // Desktop has no OS selection menu — just prefer above, flip if no room.
+    below = !roomAbove;
+  }
   const top = below ? sel.bottom + GAP : sel.top - TOOLBAR_H - GAP;
   // Clamp by the on-screen (capped) width so a toolbar wider than the viewport
   // centers + scrolls internally instead of pushing an edge off-screen.
@@ -156,15 +152,6 @@ export const SelectionQuoteToolbar: React.FC<{
           <Button variant="ghost" className={itemClass} {...activate(runAsk)}>
             <GitFork className="size-3.5 text-muted" />
             {t('chat.selection.askInNew')}
-          </Button>
-        </>
-      )}
-      {isTouch && (
-        <>
-          <span className="h-5 w-px bg-border" />
-          <Button variant="ghost" className={itemClass} {...activate(runCopy)}>
-            {copied ? <Check className="size-3.5 text-mint" /> : <Copy className="size-3.5 text-muted" />}
-            {t('chat.selection.copy')}
           </Button>
         </>
       )}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1781,7 +1781,6 @@
     "selection": {
       "quote": "Quote",
       "askInNew": "Ask in a new session",
-      "copy": "Copy",
       "askFailed": "Couldn't start a new session from the selection."
     },
     "showPage": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1780,7 +1780,6 @@
     "selection": {
       "quote": "引用",
       "askInNew": "在新会话询问",
-      "copy": "复制",
       "askFailed": "无法从选中内容新建会话，请重试。"
     },
     "showPage": {


### PR DESCRIPTION
Two follow-ups to the chat text-selection toolbar (#599).

## 1. Trailing space after the quote
The Quote action (and the forked-session draft prefill) now append a trailing space after the quoted text, so when the user keeps typing there's a gap between the quote and their text.

## 2. Stagger the toolbar clear of the OS selection menu (touch)
On mobile the OS native selection menu (Copy / Look Up / …) **cannot be suppressed while keeping the selection** — `-webkit-touch-callout: none` only affects long-press link callouts, not the selection edit menu, and `-webkit-user-select: none` would kill selection entirely. Its position also isn't exposed to the page. But it sits **above** the selection by default, and it was overlapping + covering our toolbar (which also positioned above), making our actions untappable.

Fix: on touch, place our toolbar **below** the selection so it's staggered clear of the OS menu (both can show; they no longer overlap). Desktop (no OS menu) keeps the above preference. Removed the misleading no-op callout CSS.

> Coexisting with the OS menu means its Copy is also available; our touch-only Copy button is now somewhat redundant — kept for now (one tap, next to our other actions), easy to drop if preferred.

## Evidence layers
- **Build (UI gate):** `npm run build` (tsc + vite) green.
- **Manual:** to verify on a real device in regression (selection menu + our toolbar staggered, both tappable; quote trailing space).
- Unit / contract / scenario: n/a (frontend interaction).