### PR TITLE
Fix stale backend session cleanup on new session

### DIFF
--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -318,6 +318,19 @@ class SessionsStore:
         if user_id not in self.state.active_slack_threads:
             self.state.active_slack_threads[user_id] = {}
 
+    @staticmethod
+    def _count_session_mappings(agent_maps: Dict[str, Any]) -> int:
+        return sum(len(thread_map) for thread_map in agent_maps.values() if isinstance(thread_map, dict))
+
+    def _sync_session_mappings_for_user(self, user_id: str) -> None:
+        fresh_maps = self._service.load_state().session_mappings.get(user_id, {})
+        self.state.session_mappings[user_id] = {
+            str(agent_name): dict(thread_map)
+            for agent_name, thread_map in fresh_maps.items()
+            if isinstance(thread_map, dict)
+        }
+        self._ensure_user_namespace(user_id)
+
     def get_agent_map(self, user_id: str, agent_name: str) -> Dict[str, str]:
         """Get mapping of thread_id -> session_id for a user and agent."""
         self.maybe_reload()
@@ -422,28 +435,25 @@ class SessionsStore:
 
     def remove_agent_session(self, user_id: str, agent_name: str, thread_id: str) -> bool:
         self._ensure_service()
+        self._ensure_user_namespace(user_id)
+        before = self._count_session_mappings(self.state.session_mappings[user_id])
         removed = self._service.delete_agent_session(
             scope_key=user_id,
             agent_name=agent_name,
             session_anchor=thread_id,
         )
-        agent_map = self.get_agent_map(user_id, agent_name)
-        if thread_id in agent_map:
-            del agent_map[thread_id]
-            removed = True
-        return removed
+        self._sync_session_mappings_for_user(user_id)
+        after = self._count_session_mappings(self.state.session_mappings[user_id])
+        return bool(removed or after < before)
 
     def clear_agent_sessions(self, user_id: str, agent_name: str | None = None) -> int:
         self._ensure_service()
-        removed = self._service.delete_agent_sessions(scope_key=user_id, agent_name=agent_name)
         self._ensure_user_namespace(user_id)
-        if agent_name is None:
-            count = sum(len(agent_map) for agent_map in self.state.session_mappings[user_id].values())
-            self.state.session_mappings[user_id] = {}
-            return max(removed, count)
-        count = len(self.state.session_mappings[user_id].get(agent_name, {}))
-        self.state.session_mappings[user_id][agent_name] = {}
-        return max(removed, count)
+        before = self._count_session_mappings(self.state.session_mappings[user_id])
+        removed = self._service.delete_agent_sessions(scope_key=user_id, agent_name=agent_name)
+        self._sync_session_mappings_for_user(user_id)
+        after = self._count_session_mappings(self.state.session_mappings[user_id])
+        return max(removed, max(before - after, 0))
 
     def clear_session_base(self, user_id: str, base_session_id: str) -> int:
         self._ensure_service()

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -455,7 +455,7 @@ class SQLiteSessionsService:
             result = conn.execute(
                 agent_sessions.delete()
                 .where(agent_sessions.c.scope_id == scope_id)
-                .where(agent_sessions.c.agent_variant == (str(agent_name) or "default"))
+                .where(_agent_session_name_predicate(str(agent_name) or "default"))
                 .where(agent_sessions.c.session_anchor == str(session_anchor))
             )
             return bool(result.rowcount)
@@ -474,7 +474,7 @@ class SQLiteSessionsService:
                 return 0
             stmt = agent_sessions.delete().where(agent_sessions.c.scope_id == scope_id)
             if agent_name is not None:
-                stmt = stmt.where(agent_sessions.c.agent_variant == (str(agent_name) or "default"))
+                stmt = stmt.where(_agent_session_name_predicate(str(agent_name) or "default"))
             if session_anchor_prefix is not None:
                 prefix = str(session_anchor_prefix)
                 prefix_pattern = f"{_escape_sql_like(prefix)}:%"
@@ -1064,6 +1064,14 @@ _ROUTING_SENTINEL_VARIANTS = {"", "default", *_BACKEND_AGENT_NAMES}
 
 def _agent_backend(agent_name: str) -> str:
     return agent_name if agent_name in _BACKEND_AGENT_NAMES else "unknown"
+
+
+def _agent_session_name_predicate(agent_name: str) -> Any:
+    requested = str(agent_name) or "default"
+    backend = _agent_backend(requested)
+    if backend != "unknown":
+        return (agent_sessions.c.agent_backend == backend) | (agent_sessions.c.agent_variant == requested)
+    return agent_sessions.c.agent_variant == requested
 
 
 def _new_session_id(used: set[str]) -> str:

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -9,9 +9,10 @@ from sqlalchemy import select
 from config import paths
 from config.v2_sessions import ActivePollInfo, SessionState, SessionsStore
 from modules.sessions_facade import SessionsFacade
+from storage.agent_session_rows import create_agent_session_row
 from storage.db import create_sqlite_engine
 from storage.models import agent_sessions
-from storage.sessions_service import SQLiteSessionsService
+from storage.sessions_service import SQLiteSessionsService, resolve_scope_from_legacy_key
 from storage.settings_service import upsert_scope
 
 
@@ -584,6 +585,158 @@ def test_sqlite_sessions_service_delete_agent_sessions_escapes_anchor_prefix(tmp
         assert mappings == {"slack_1A2X3:/repo": "unrelated"}
     finally:
         service.close()
+
+
+def test_delete_agent_sessions_by_backend_removes_custom_variant_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "telegram::-100123", now="2026-06-18T07:30:00Z")
+            assert scope_id is not None
+            create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="opencode",
+                agent_variant="reviewer",
+                session_anchor="telegram_-100123",
+                native_session_id="oc-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+            create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="claude",
+                agent_variant="worker",
+                session_anchor="telegram_-100123:claude",
+                native_session_id="claude-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+            create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="helper",
+                session_anchor="telegram_-100123:codex",
+                native_session_id="codex-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+
+        removed = service.delete_agent_sessions(scope_key="telegram::-100123", agent_name="opencode")
+
+        assert removed == 1
+        assert service.find_session_for_anchor(scope_key="telegram::-100123", session_anchor="telegram_-100123") is None
+        assert (
+            service.find_session_for_anchor(scope_key="telegram::-100123", session_anchor="telegram_-100123:claude")
+            is not None
+        )
+        assert (
+            service.find_session_for_anchor(scope_key="telegram::-100123", session_anchor="telegram_-100123:codex")
+            is not None
+        )
+    finally:
+        service.close()
+
+
+def test_delete_agent_session_by_backend_removes_custom_variant_row(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "telegram::-100123", now="2026-06-18T07:30:00Z")
+            assert scope_id is not None
+            create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="opencode",
+                agent_variant="reviewer",
+                session_anchor="telegram_-100123",
+                native_session_id="oc-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+
+        removed = service.delete_agent_session(
+            scope_key="telegram::-100123",
+            agent_name="opencode",
+            session_anchor="telegram_-100123",
+        )
+
+        assert removed is True
+        assert service.find_session_for_anchor(scope_key="telegram::-100123", session_anchor="telegram_-100123") is None
+    finally:
+        service.close()
+
+
+def test_sessions_store_clear_backend_prunes_cached_custom_variant_rows(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    try:
+        with store._service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "telegram::-100123", now="2026-06-18T07:30:00Z")
+            assert scope_id is not None
+            create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="opencode",
+                agent_variant="reviewer",
+                session_anchor="telegram_-100123",
+                native_session_id="oc-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+
+        store.load()
+        assert store.state.session_mappings["telegram::-100123"]["reviewer"]["telegram_-100123"] == "oc-native"
+
+        removed = store.clear_agent_sessions("telegram::-100123", "opencode")
+        store.save()
+
+        assert removed == 1
+        assert "reviewer" not in store.state.session_mappings["telegram::-100123"]
+        assert (
+            store.find_session_for_anchor("telegram::-100123", "telegram_-100123")
+            is None
+        )
+    finally:
+        store.close()
+
+
+def test_sessions_store_remove_backend_session_prunes_cached_custom_variant_row(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    try:
+        with store._service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "telegram::-100123", now="2026-06-18T07:30:00Z")
+            assert scope_id is not None
+            create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="opencode",
+                agent_variant="reviewer",
+                session_anchor="telegram_-100123",
+                native_session_id="oc-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+
+        store.load()
+        assert store.state.session_mappings["telegram::-100123"]["reviewer"]["telegram_-100123"] == "oc-native"
+
+        removed = store.remove_agent_session("telegram::-100123", "opencode", "telegram_-100123")
+        store.save()
+
+        assert removed is True
+        assert "reviewer" not in store.state.session_mappings["telegram::-100123"]
+        assert (
+            store.find_session_for_anchor("telegram::-100123", "telegram_-100123")
+            is None
+        )
+    finally:
+        store.close()
 
 
 def test_sessions_store_lifecycle_updates_in_memory_state(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Clear agent session rows by backend when the requested agent name is a built-in backend.
- Prevent Telegram `/new` from leaving stale OpenCode custom-variant rows that can override Claude routing on the next message.
- Add regression coverage for batch and single-row backend clears, including non-target backend preservation.

## Evidence
- Unit: `uv run pytest -q tests/test_sqlite_sessions_store.py tests/test_agent_run_target.py tests/test_command_handler_user_names.py::CommandHandlerUserNameTests::test_new_command_sends_fresh_session_confirmation tests/test_command_handler_user_names.py::CommandHandlerUserNameTests::test_telegram_new_command_creates_topic_session_when_supported`
- Lint: `uv run ruff check storage/sessions_service.py tests/test_sqlite_sessions_store.py`
- Review: reviewer subagent returned `NO FINDINGS`; suggested residual test gaps were added before commit.

## Residual Checks
- Verified the dispatch semantics remain unchanged: existing session rows still pin a thread to its current backend.
- Verified the fix is scoped to cleanup semantics: backend clears now remove rows for that backend even when `agent_variant` is a custom agent name.
