### PR TITLE
fix(agent-routing): ignore legacy scope backend fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,9 @@ Agent routing model:
 - global default: the enabled Vibe Agent recorded in SQLite `state_meta.default_agent_name`
 - backend availability and CLI path: `agents.<backend>.enabled` and `agents.<backend>.cli_path`
 - per-channel overrides: configured via the Web UI Agent Settings / channel settings
-- legacy compatibility: `agents.default_backend` may still appear in old JSON payloads, but new routing code must not treat it as the product default
+- legacy compatibility: `agents.default_backend` and scope-level `routing.agent_backend` /
+  `scope_settings.agent_backend` may still appear in old JSON/API payloads, but new routing
+  code must not treat them as the product default or scope route selector
 
 Source-of-truth rule:
 

--- a/core/controller.py
+++ b/core/controller.py
@@ -1004,8 +1004,8 @@ class Controller:
         """Unified agent resolution with dynamic override support.
 
         Priority:
-        1. explicit Vibe Agent selected by the Scope
-        2. migration fallback from legacy Scope agent_backend
+        1. explicit/session Vibe Agent target
+        2. existing session backend snapshot
         3. default Vibe Agent route
         4. AgentService.default_agent / first registered backend compatibility fallback
         """
@@ -1023,22 +1023,9 @@ class Controller:
         if target_backend and str(target_backend) in {"opencode", "claude", "codex"}:
             return str(target_backend)
 
-        settings_key = self._get_settings_key(context)
-        settings_manager = self.get_settings_manager_for_context(context)
-        routing = settings_manager.get_channel_routing(settings_key)
         vibe_agent = self.resolve_vibe_agent_for_context(context, required=False)
         if vibe_agent:
             return vibe_agent.backend
-
-        if routing and routing.agent_backend:
-            # Migration fallback for scopes saved before Agent became the unified
-            # selection. New Scope settings should select agent_name instead.
-            if routing.agent_backend in self.agent_service.agents:
-                return routing.agent_backend
-            logger.warning(
-                f"Scope routing specifies legacy backend '{routing.agent_backend}' but it is not registered."
-            )
-            return routing.agent_backend
 
         return self._fallback_registered_agent_backend()
 
@@ -1072,9 +1059,7 @@ class Controller:
         try:
             if agent_name:
                 return self.vibe_agent_store.require_enabled(agent_name)
-            legacy_backend = (target.get("agent_backend") if target else None) or (
-                routing.agent_backend if routing else None
-            )
+            legacy_backend = target.get("agent_backend") if target else None
             if legacy_backend:
                 agent = self.vibe_agent_store.get_builtin_default_agent_for_backend(legacy_backend)
                 if agent is not None:

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -236,11 +236,8 @@ class MessageHandler(BaseHandler):
                     override_agent_name=requested_vibe_agent,
                     required=False,
                 )
-            elif callable(resolve_vibe_agent):
-                routing_agent_backend = getattr(routing, "agent_backend", None) if routing else None
-                routing_agent_name = getattr(routing, "agent_name", None) if routing else None
-                if not session_agent_backend and (routing_agent_name or not routing_agent_backend):
-                    vibe_agent = resolve_vibe_agent(context, required=False)
+            elif callable(resolve_vibe_agent) and not session_agent_backend:
+                vibe_agent = resolve_vibe_agent(context, required=False)
             if vibe_agent:
                 agent_name = vibe_agent.backend
             elif session_agent_backend:

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 class _ScopeAgentTarget(NamedTuple):
     agent_name: Optional[str]
-    agent_backend: Optional[str]
 
 
 def _utc_now_iso() -> str:
@@ -1682,13 +1681,8 @@ class ScheduledTaskService:
         ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(config_paths.get_state_dir()))
         agent_store = VibeAgentStore()
         try:
-            scope_target = self._resolve_scope_agent_target(deliver_key) if not agent_name else _ScopeAgentTarget(None, None)
+            scope_target = self._resolve_scope_agent_target(deliver_key) if not agent_name else _ScopeAgentTarget(None)
             resolved_agent_name = agent_name or scope_target.agent_name
-            if not resolved_agent_name and scope_target.agent_backend:
-                raise ValueError(
-                    "scope routing still references a legacy backend without an Agent; "
-                    "choose an Agent before creating sessions for this Scope"
-                )
             agent = agent_store.require_enabled(resolved_agent_name) if resolved_agent_name else agent_store.get_default_agent()
         finally:
             agent_store.close()
@@ -1716,7 +1710,7 @@ class ScheduledTaskService:
         try:
             target = parse_session_key(deliver_key)
         except ValueError:
-            return _ScopeAgentTarget(None, None)
+            return _ScopeAgentTarget(None)
         from config import paths as config_paths
         from storage.settings_service import make_scope_id
 
@@ -1725,17 +1719,16 @@ class ScheduledTaskService:
         try:
             with engine.connect() as conn:
                 value = conn.execute(
-                    select(scope_settings.c.agent_name, scope_settings.c.agent_backend)
+                    select(scope_settings.c.agent_name)
                     .where(scope_settings.c.scope_id == scope_id)
                     .limit(1)
                 ).first()
         finally:
             engine.dispose()
         if value is None:
-            return _ScopeAgentTarget(None, None)
+            return _ScopeAgentTarget(None)
         agent_name = str(value.agent_name).strip() if value.agent_name else None
-        agent_backend = str(value.agent_backend).strip() if value.agent_backend else None
-        return _ScopeAgentTarget(agent_name, agent_backend)
+        return _ScopeAgentTarget(agent_name)
 
     async def _execute_request(
         self,

--- a/core/services/agent_run_target.py
+++ b/core/services/agent_run_target.py
@@ -381,7 +381,6 @@ def _resolve_agent_target(
     """Resolve the concrete Vibe Agent/backend before a Session row exists."""
 
     scope_agent_name = _optional_str(scope_row.get("agent_name")) if scope_row else None
-    scope_backend = _supported_backend(scope_row.get("agent_backend")) if scope_row else None
     resolver = getattr(controller, "resolve_vibe_agent_for_context", None)
     if scope_agent_name and callable(resolver):
         try:
@@ -393,18 +392,8 @@ def _resolve_agent_target(
             agent = None
         if agent is not None:
             target = _agent_target_from_vibe_agent(agent, scope_row=scope_row)
-            if target is not None and (scope_backend is None or target.agent_backend == scope_backend):
+            if target is not None:
                 return target
-
-    if scope_backend:
-        return ResolvedAgentTarget(
-            agent_id=None,
-            agent_name=scope_agent_name,
-            agent_backend=scope_backend,
-            agent_variant=_agent_variant_for_backend(scope_backend, scope_row),
-            model=_optional_str(scope_row.get("model")) if scope_row else None,
-            reasoning_effort=_optional_str(scope_row.get("reasoning_effort")) if scope_row else None,
-        )
 
     if callable(resolver):
         try:
@@ -449,13 +438,16 @@ def _agent_target_from_vibe_agent(agent: Any, *, scope_row: Optional[dict[str, A
     backend = _supported_backend(getattr(agent, "backend", None))
     if not backend:
         return None
-    scope_model = _optional_str(scope_row.get("model")) if scope_row else None
-    scope_effort = _optional_str(scope_row.get("reasoning_effort")) if scope_row else None
+    scope_backend = _supported_backend(scope_row.get("agent_backend")) if scope_row else None
+    apply_scope_overrides = scope_backend is None or scope_backend == backend
+    compatible_scope_row = scope_row if apply_scope_overrides else None
+    scope_model = _optional_str(scope_row.get("model")) if scope_row and apply_scope_overrides else None
+    scope_effort = _optional_str(scope_row.get("reasoning_effort")) if scope_row and apply_scope_overrides else None
     return ResolvedAgentTarget(
         agent_id=_optional_str(getattr(agent, "id", None)),
         agent_name=_optional_str(getattr(agent, "name", None)),
         agent_backend=backend,
-        agent_variant=_agent_variant_for_backend(backend, scope_row),
+        agent_variant=_agent_variant_for_backend(backend, compatible_scope_row),
         model=scope_model or _optional_str(getattr(agent, "model", None)),
         reasoning_effort=scope_effort or _optional_str(getattr(agent, "reasoning_effort", None)),
     )

--- a/docs/CODEX_SETUP.md
+++ b/docs/CODEX_SETUP.md
@@ -36,7 +36,7 @@ No additional flag is required to bypass approvals—the bot always adds `--dang
 
 Configure routing via the platform **Agent Settings** UI: pick Codex for the Slack channel, Discord channel, Telegram chat, or other scope you want.
 
-Each routed scope gets its own agent override. Unrouted scopes fall back to the configured default backend.
+Each routed scope stores a Vibe Agent name. Unrouted scopes fall back to the configured default Vibe Agent.
 
 ## 4. Restart the bot and test
 

--- a/docs/DYNAMIC_ROUTING_DESIGN.md
+++ b/docs/DYNAMIC_ROUTING_DESIGN.md
@@ -1,5 +1,12 @@
 # Dynamic Channel Routing Design
 
+> Historical design note: this document describes the pre-Agent-catalog backend
+> routing model. Current Avibe routing is Agent-based: scopes select
+> `routing.agent_name`, new sessions inherit the default Vibe Agent when no
+> scope Agent is set, and `scope_settings.agent_backend` / `routing.agent_backend`
+> are retained only as legacy compatibility fields. Existing Agent Sessions keep
+> their own `agent_sessions.agent_backend` snapshot.
+
 ## Overview
 
 Replace static file-based routing with dynamic per-channel routing configuration that users can change via Slack menus.

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -138,7 +138,9 @@ channels["C123"] = {
     "require_mention": channels.get("C123", {}).get("require_mention"),
     "routing": {
         **(channels.get("C123", {}).get("routing") or {}),
-        "agent_backend": "codex",
+        "agent_name": "codex",
+        "model": "gpt-5.4",
+        "reasoning_effort": "high",
         "codex_model": "gpt-5.4",
         "codex_reasoning_effort": "high",
     },
@@ -252,7 +254,6 @@ Important config payload shape:
     "log_level": "INFO"
   },
   "agents": {
-    "default_backend": "opencode",
     "opencode": {
       "enabled": true,
       "cli_path": "opencode",
@@ -313,6 +314,9 @@ Important config payload shape:
   "reply_enhancements": true
 }
 ```
+
+`agents.default_backend` may still appear in legacy read-back payloads. Do not
+set it for new default-Agent changes; use the Agent catalog/default Agent instead.
 
 Discord server access belongs to `/settings`, not `/config`. Store enabled
 servers under `guilds`, next to channel settings:
@@ -388,7 +392,7 @@ Channel entry shape:
   "require_mention": null,
   "require_bind": null,
   "routing": {
-    "agent_backend": "codex",
+    "agent_name": "codex",
     "model": "gpt-5.4",
     "reasoning_effort": "high",
     "opencode_agent": null,
@@ -411,9 +415,10 @@ Field meanings:
 - `custom_cwd`: scope-level working directory override; empty string or `null` means use global default
 - `require_mention`: `null` inherits the platform default, `true` requires mention, `false` disables mention gating for that channel
 - `require_bind`: `null`/`false` lets any channel member use the bot (current default); `true` gates the channel to bound users only — messages from unbound senders are silently ignored (no denial reply), while the bot's own replies stay visible to everyone. Enforced in the shared auth pipeline, so it applies on every platform. Bind is platform-wide, so `require_bind` means "is this sender a bound user", not a per-channel allowlist.
-- `routing.agent_backend`: `opencode`, `claude`, `codex`, or `null` to inherit default
-- `routing.model`: canonical scope-level model override for the selected backend
-- `routing.reasoning_effort`: canonical scope-level reasoning override for the selected backend
+- `routing.agent_name`: Vibe Agent name for this scope, or `null` to inherit the default Agent
+- `routing.agent_backend`: legacy compatibility field accepted on input/read-back; do not use it as the route selector for new changes
+- `routing.model`: canonical scope-level model override for the selected Agent backend
+- `routing.reasoning_effort`: canonical scope-level reasoning override for the selected Agent backend
 - `routing.<backend>_agent`: backend-specific subagent
 - `routing.<backend>_model` / `routing.<backend>_reasoning_effort`: legacy aliases accepted on input and derived on read-back; do not treat them as independent state
 
@@ -450,7 +455,7 @@ User entry shape:
   "show_message_types": ["assistant"],
   "custom_cwd": "/path/to/repo",
   "routing": {
-    "agent_backend": "claude",
+    "agent_name": "claude",
     "model": "claude-sonnet-4-6",
     "reasoning_effort": "high",
     "opencode_agent": null,
@@ -561,15 +566,16 @@ When the restart is initiated by an agent from an active conversation, use the C
 
 ## Scope and Precedence Rules
 
-### Backend selection
+### Agent selection
 
-Backend resolution priority is:
+Agent resolution priority is:
 
-1. scope-level routing override from `/settings` or `/api/users`
-2. platform router fallback
-3. global default backend from `/config`
+1. existing Agent Session backend snapshot, when the message belongs to an existing session/thread
+2. scope-level `routing.agent_name` from `/settings` or `/api/users`, for new sessions
+3. global default Vibe Agent from the Agent catalog
+4. registered backend compatibility fallback, only when no enabled default Agent is available
 
-If the user names a specific channel or DM and wants a specific backend, use the scope API, not global `/config`.
+If the user names a specific channel or DM and wants a specific Agent, use the scope API, not global `/config`. Do not set a global default backend; new routing is Agent-based.
 
 ### Working directory
 
@@ -620,7 +626,7 @@ Merged channel entry:
   "custom_cwd": null,
   "require_mention": null,
   "routing": {
-    "agent_backend": "codex",
+    "agent_name": "codex",
     "model": "gpt-5.4",
     "reasoning_effort": "high",
     "opencode_agent": null,
@@ -640,7 +646,7 @@ Merged channel entry:
 
 Use `/settings` and set:
 
-- `routing.agent_backend = "opencode"`
+- `routing.agent_name = "opencode"`
 - `routing.opencode_agent = "<agent>"`
 - `routing.model = "<model>"` if requested
 - `routing.reasoning_effort = "<effort>"` if requested
@@ -651,7 +657,7 @@ If the user wants OpenCode-native defaults, providers, MCP servers, skills, plug
 
 Use `/settings` for a channel or `/api/users` for a DM user and set:
 
-- `routing.agent_backend = "claude"`
+- `routing.agent_name = "claude"`
 - `routing.claude_agent = "<agent>"` if requested
 - `routing.model = "<model>"`
 - `routing.reasoning_effort = "<effort>"`
@@ -817,11 +823,11 @@ Operational guidance:
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively
 
-## Backend Capability Matrix
+## Agent Backend Capability Matrix
 
-Current Avibe routing support is:
+Current Avibe Agent capabilities are:
 
-| Backend | Channel/User backend select | Subagent | Model | Reasoning |
+| Backend | Select through Vibe Agent | Subagent | Model | Reasoning |
 | --- | --- | --- | --- | --- |
 | OpenCode | yes | yes | yes | yes |
 | Claude | yes | yes | yes | yes |
@@ -880,7 +886,7 @@ Relevant docs:
 - plugins: `https://opencode.ai/docs/plugins/`
 - MCP servers: `https://opencode.ai/docs/mcp-servers/`
 
-Inside Avibe, OpenCode scope routing controls backend choice, subagent, model, and reasoning effort. Use `POST /opencode/setup-permission` only for the specific permission helper.
+Inside Avibe, a scope can select an OpenCode-backed Vibe Agent and then set subagent, model, and reasoning effort overrides. Use `POST /opencode/setup-permission` only for the specific permission helper.
 
 ### Claude Code
 
@@ -901,7 +907,7 @@ Relevant docs:
 
 - subagents: `https://docs.anthropic.com/en/docs/claude-code/sub-agents`
 
-Inside Avibe, Claude scope routing controls backend choice, model, subagent, and reasoning effort.
+Inside Avibe, a scope can select a Claude-backed Vibe Agent and then set model, subagent, and reasoning effort overrides.
 
 ### Codex
 
@@ -926,7 +932,7 @@ Relevant docs:
 - CLI overview: `https://developers.openai.com/codex/cli`
 - subagents: `https://developers.openai.com/codex/subagents`
 
-Inside Avibe, Codex scope routing controls backend choice, subagent, model, and reasoning effort.
+Inside Avibe, a scope can select a Codex-backed Vibe Agent and then set subagent, model, and reasoning effort overrides.
 
 ## CLI Reference
 

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -138,7 +138,9 @@ channels["C123"] = {
     "require_mention": channels.get("C123", {}).get("require_mention"),
     "routing": {
         **(channels.get("C123", {}).get("routing") or {}),
-        "agent_backend": "codex",
+        "agent_name": "codex",
+        "model": "gpt-5.4",
+        "reasoning_effort": "high",
         "codex_model": "gpt-5.4",
         "codex_reasoning_effort": "high",
     },
@@ -252,7 +254,6 @@ Important config payload shape:
     "log_level": "INFO"
   },
   "agents": {
-    "default_backend": "opencode",
     "opencode": {
       "enabled": true,
       "cli_path": "opencode",
@@ -313,6 +314,9 @@ Important config payload shape:
   "reply_enhancements": true
 }
 ```
+
+`agents.default_backend` may still appear in legacy read-back payloads. Do not
+set it for new default-Agent changes; use the Agent catalog/default Agent instead.
 
 Discord server access belongs to `/settings`, not `/config`. Store enabled
 servers under `guilds`, next to channel settings:
@@ -388,7 +392,7 @@ Channel entry shape:
   "require_mention": null,
   "require_bind": null,
   "routing": {
-    "agent_backend": "codex",
+    "agent_name": "codex",
     "model": "gpt-5.4",
     "reasoning_effort": "high",
     "opencode_agent": null,
@@ -411,9 +415,10 @@ Field meanings:
 - `custom_cwd`: scope-level working directory override; empty string or `null` means use global default
 - `require_mention`: `null` inherits the platform default, `true` requires mention, `false` disables mention gating for that channel
 - `require_bind`: `null`/`false` lets any channel member use the bot (current default); `true` gates the channel to bound users only — messages from unbound senders are silently ignored (no denial reply), while the bot's own replies stay visible to everyone. Enforced in the shared auth pipeline, so it applies on every platform. Bind is platform-wide, so `require_bind` means "is this sender a bound user", not a per-channel allowlist.
-- `routing.agent_backend`: `opencode`, `claude`, `codex`, or `null` to inherit default
-- `routing.model`: canonical scope-level model override for the selected backend
-- `routing.reasoning_effort`: canonical scope-level reasoning override for the selected backend
+- `routing.agent_name`: Vibe Agent name for this scope, or `null` to inherit the default Agent
+- `routing.agent_backend`: legacy compatibility field accepted on input/read-back; do not use it as the route selector for new changes
+- `routing.model`: canonical scope-level model override for the selected Agent backend
+- `routing.reasoning_effort`: canonical scope-level reasoning override for the selected Agent backend
 - `routing.<backend>_agent`: backend-specific subagent
 - `routing.<backend>_model` / `routing.<backend>_reasoning_effort`: legacy aliases accepted on input and derived on read-back; do not treat them as independent state
 
@@ -450,7 +455,7 @@ User entry shape:
   "show_message_types": ["assistant"],
   "custom_cwd": "/path/to/repo",
   "routing": {
-    "agent_backend": "claude",
+    "agent_name": "claude",
     "model": "claude-sonnet-4-6",
     "reasoning_effort": "high",
     "opencode_agent": null,
@@ -561,15 +566,16 @@ When the restart is initiated by an agent from an active conversation, use the C
 
 ## Scope and Precedence Rules
 
-### Backend selection
+### Agent selection
 
-Backend resolution priority is:
+Agent resolution priority is:
 
-1. scope-level routing override from `/settings` or `/api/users`
-2. platform router fallback
-3. global default backend from `/config`
+1. existing Agent Session backend snapshot, when the message belongs to an existing session/thread
+2. scope-level `routing.agent_name` from `/settings` or `/api/users`, for new sessions
+3. global default Vibe Agent from the Agent catalog
+4. registered backend compatibility fallback, only when no enabled default Agent is available
 
-If the user names a specific channel or DM and wants a specific backend, use the scope API, not global `/config`.
+If the user names a specific channel or DM and wants a specific Agent, use the scope API, not global `/config`. Do not set a global default backend; new routing is Agent-based.
 
 ### Working directory
 
@@ -620,7 +626,7 @@ Merged channel entry:
   "custom_cwd": null,
   "require_mention": null,
   "routing": {
-    "agent_backend": "codex",
+    "agent_name": "codex",
     "model": "gpt-5.4",
     "reasoning_effort": "high",
     "opencode_agent": null,
@@ -640,7 +646,7 @@ Merged channel entry:
 
 Use `/settings` and set:
 
-- `routing.agent_backend = "opencode"`
+- `routing.agent_name = "opencode"`
 - `routing.opencode_agent = "<agent>"`
 - `routing.model = "<model>"` if requested
 - `routing.reasoning_effort = "<effort>"` if requested
@@ -651,7 +657,7 @@ If the user wants OpenCode-native defaults, providers, MCP servers, skills, plug
 
 Use `/settings` for a channel or `/api/users` for a DM user and set:
 
-- `routing.agent_backend = "claude"`
+- `routing.agent_name = "claude"`
 - `routing.claude_agent = "<agent>"` if requested
 - `routing.model = "<model>"`
 - `routing.reasoning_effort = "<effort>"`
@@ -815,11 +821,11 @@ Operational guidance:
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively
 
-## Backend Capability Matrix
+## Agent Backend Capability Matrix
 
-Current Avibe routing support is:
+Current Avibe Agent capabilities are:
 
-| Backend | Channel/User backend select | Subagent | Model | Reasoning |
+| Backend | Select through Vibe Agent | Subagent | Model | Reasoning |
 | --- | --- | --- | --- | --- |
 | OpenCode | yes | yes | yes | yes |
 | Claude | yes | yes | yes | yes |
@@ -878,7 +884,7 @@ Relevant docs:
 - plugins: `https://opencode.ai/docs/plugins/`
 - MCP servers: `https://opencode.ai/docs/mcp-servers/`
 
-Inside Avibe, OpenCode scope routing controls backend choice, subagent, model, and reasoning effort. Use `POST /opencode/setup-permission` only for the specific permission helper.
+Inside Avibe, a scope can select an OpenCode-backed Vibe Agent and then set subagent, model, and reasoning effort overrides. Use `POST /opencode/setup-permission` only for the specific permission helper.
 
 ### Claude Code
 
@@ -899,7 +905,7 @@ Relevant docs:
 
 - subagents: `https://docs.anthropic.com/en/docs/claude-code/sub-agents`
 
-Inside Avibe, Claude scope routing controls backend choice, model, subagent, and reasoning effort.
+Inside Avibe, a scope can select a Claude-backed Vibe Agent and then set model, subagent, and reasoning effort overrides.
 
 ### Codex
 
@@ -924,7 +930,7 @@ Relevant docs:
 - CLI overview: `https://developers.openai.com/codex/cli`
 - subagents: `https://developers.openai.com/codex/subagents`
 
-Inside Avibe, Codex scope routing controls backend choice, subagent, model, and reasoning effort.
+Inside Avibe, a scope can select a Codex-backed Vibe Agent and then set subagent, model, and reasoning effort overrides.
 
 ## CLI Reference
 

--- a/tests/test_agent_run_target.py
+++ b/tests/test_agent_run_target.py
@@ -188,6 +188,45 @@ def test_new_im_session_uses_resolved_vibe_agent(tmp_path):
     assert session["reasoning_effort"] == "high"
 
 
+def test_new_im_session_ignores_legacy_scope_backend(tmp_path):
+    workdir = tmp_path / "channel"
+    controller = _controller(tmp_path)
+    with controller.sqlite_engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="slack",
+            scope_type="channel",
+            native_id="C123",
+            now="2026-06-04T05:00:00Z",
+        )
+        _seed_scope_settings(
+            conn,
+            scope_id,
+            workdir=str(workdir),
+            agent_backend="opencode",
+            agent_variant="reviewer",
+        )
+
+    ctx = MessageContext(user_id="U1", channel_id="C123", platform="slack", thread_id="171717.123")
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="slack_171717.123",
+    )
+
+    assert target.agent_id == "agent-codex-default"
+    assert target.agent_name == "codex"
+    assert target.agent_backend == "codex"
+    assert target.agent_variant == "codex"
+    with controller.sqlite_engine.connect() as conn:
+        session = sessions_service.get_session(conn, target.agent_session_id)
+    assert session["agent_id"] == "agent-codex-default"
+    assert session["agent_name"] == "codex"
+    assert session["agent_backend"] == "codex"
+    assert session["agent_variant"] == "codex"
+
+
 def test_new_im_session_falls_back_to_default_vibe_agent(tmp_path):
     workdir = tmp_path / "channel"
     controller = _controller(tmp_path)
@@ -264,6 +303,18 @@ def test_new_im_session_without_scope_settings_snapshots_default_cwd(tmp_path):
 def test_opencode_bind_reuses_scoped_agent_variant_session(tmp_path):
     workdir = tmp_path / "channel"
     controller = _controller(tmp_path)
+    opencode_agent = SimpleNamespace(
+        id="agent-opencode-reviewer",
+        name="Code Reviewer",
+        backend="opencode",
+        model=None,
+        reasoning_effort=None,
+    )
+
+    default_resolver = controller.resolve_vibe_agent_for_context
+    controller.resolve_vibe_agent_for_context = lambda _context, override_agent_name=None, required=False: (
+        opencode_agent if override_agent_name == "Code Reviewer" else default_resolver(_context, required=required)
+    )
     with controller.sqlite_engine.begin() as conn:
         scope_id = upsert_scope(
             conn,

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -1393,12 +1393,12 @@ def test_resolve_agent_for_target_allows_unresolved_legacy_scope_backend_without
     assert agent.name == default_agent.name
 
 
-def test_resolve_agent_for_target_rejects_unresolved_legacy_scope_backend_for_session_creation(
+def test_resolve_agent_for_target_ignores_unresolved_legacy_scope_backend_for_session_creation(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = cli.VibeAgentStore(db_path)
-    agent_store.ensure_default_agent(backend="claude")
+    default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
     agent_store.close()
     from storage.importer import ensure_sqlite_state
@@ -1431,18 +1431,16 @@ def test_resolve_agent_for_target_rejects_unresolved_legacy_scope_backend_for_se
     with (
         patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
         patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
-        pytest.raises(cli.TaskCliError) as exc,
     ):
-        cli._resolve_agent_for_target(
+        agent = cli._resolve_agent_for_target(
             agent_name=None,
             session_id=None,
             session_key="slack::channel::C123",
             help_command="vibe task add --help",
-            reject_unresolved_legacy_scope_backend=True,
         )
 
-    assert exc.value.code == "legacy_scope_backend_unresolved"
-    assert exc.value.details == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
+    assert agent is not None
+    assert agent.name == default_agent.name
 
 
 def test_reserve_definition_session_uses_canonicalized_scope_agent(tmp_path: Path) -> None:
@@ -1492,11 +1490,12 @@ def test_reserve_definition_session_uses_canonicalized_scope_agent(tmp_path: Pat
     assert target.agent_id
 
 
-def test_reserve_definition_session_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+def test_reserve_definition_session_ignores_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = cli.VibeAgentStore(db_path)
-    agent_store.ensure_default_agent(backend="claude")
+    default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
+    agent_store.close()
     from storage.importer import ensure_sqlite_state
     from storage.models import scope_settings
     from storage.settings_service import upsert_scope
@@ -1528,22 +1527,22 @@ def test_reserve_definition_session_rejects_unresolved_legacy_scope_backend(tmp_
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
         patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
         patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
-        pytest.raises(cli.TaskCliError) as exc,
     ):
-        cli._reserve_definition_session(
+        session_id = cli._reserve_definition_session(
             agent_name=None,
             deliver_key="slack::channel::C123",
             help_command="vibe task add --help",
         )
+        target = cli.resolve_session_id_target(session_id, db_path=db_path)
 
-    assert exc.value.code == "legacy_scope_backend_unresolved"
-    assert exc.value.details == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
+    assert target.agent_backend == default_agent.backend
+    assert target.agent_name == default_agent.name
 
 
-def test_task_add_create_per_run_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+def test_task_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_path: Path, capsys) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = cli.VibeAgentStore(db_path)
-    agent_store.ensure_default_agent(backend="claude")
+    default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
     agent_store.close()
     from storage.importer import ensure_sqlite_state
@@ -1589,11 +1588,12 @@ def test_task_add_create_per_run_rejects_unresolved_legacy_scope_backend(tmp_pat
         patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
     ):
-        result, payload = _capture_stderr_json(cli.cmd_task_add, args)
+        result = cli.cmd_task_add(args)
 
-    assert result == 1
-    assert payload["code"] == "legacy_scope_backend_unresolved"
-    assert payload["details"] == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["task"]["agent_name"] == default_agent.name
 
 
 def test_task_add_rejects_deprecated_prompt_argument() -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -157,10 +157,10 @@ def test_watch_add_rejects_missing_cwd() -> None:
     assert payload["code"] == "invalid_watch_cwd"
 
 
-def test_watch_add_create_per_run_rejects_unresolved_legacy_scope_backend(tmp_path: Path) -> None:
+def test_watch_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_path: Path, capsys) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = cli.VibeAgentStore(db_path)
-    agent_store.ensure_default_agent(backend="claude")
+    default_agent = agent_store.ensure_default_agent(backend="claude")
     agent_store.create(name="codex", backend="opencode")
     agent_store.close()
     from storage.importer import ensure_sqlite_state
@@ -203,14 +203,14 @@ def test_watch_add_create_per_run_rejects_unresolved_legacy_scope_backend(tmp_pa
         patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
         patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(args[0], args[1], args[2])),
     ):
-        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+        result = cli.cmd_watch_add(args)
 
-    assert result == 1
-    assert payload["code"] == "legacy_scope_backend_unresolved"
-    assert payload["details"] == {"deliver_key": "slack::channel::C123", "agent_backend": "codex"}
-    with sqlite3.connect(db_path) as conn:
-        assert conn.execute("select count(*) from agent_sessions").fetchone()[0] == 0
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["watch"]["agent_name"] == default_agent.name
 
 
 def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:

--- a/tests/test_controller_vibe_agent_routing.py
+++ b/tests/test_controller_vibe_agent_routing.py
@@ -36,40 +36,44 @@ def test_resolve_vibe_agent_for_context_uses_catalog_default_when_scope_has_no_a
     assert controller.resolve_vibe_agent_for_context(_context(), required=False) is default_agent
 
 
-def test_resolve_vibe_agent_for_context_maps_legacy_backend_to_builtin_agent() -> None:
+def test_resolve_vibe_agent_for_context_ignores_legacy_scope_backend() -> None:
     controller = _StubController()
-    builtin_agent = SimpleNamespace(name="opencode", backend="opencode")
+    default_agent = SimpleNamespace(name="reviewer", backend="codex")
     controller.primary_platform = "slack"
     controller._get_settings_key = lambda context: context.channel_id
     controller.vibe_agent_store = SimpleNamespace(
         require=lambda name: (_ for _ in ()).throw(ValueError(f"agent '{name}' not found")),
-        get_builtin_default_agent_for_backend=lambda backend: builtin_agent if backend == "opencode" else None,
-        get_default_agent=lambda: SimpleNamespace(name="reviewer", backend="codex"),
+        get_builtin_default_agent_for_backend=lambda backend: (_ for _ in ()).throw(
+            AssertionError("scope backend should not be mapped to an Agent")
+        ),
+        get_default_agent=lambda: default_agent,
     )
     controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
         get_channel_routing=lambda settings_key: SimpleNamespace(agent_name=None, agent_backend="opencode")
     )
 
-    assert controller.resolve_vibe_agent_for_context(_context(), required=False) is builtin_agent
+    assert controller.resolve_vibe_agent_for_context(_context(), required=False) is default_agent
 
 
-def test_resolve_agent_for_context_uses_legacy_backend_builtin_agent() -> None:
+def test_resolve_agent_for_context_ignores_legacy_scope_backend() -> None:
     controller = _StubController()
-    builtin_agent = SimpleNamespace(name="opencode", backend="opencode")
+    default_agent = SimpleNamespace(name="reviewer", backend="codex")
     controller.primary_platform = "slack"
     controller._get_settings_key = lambda context: context.channel_id
     controller.agent_service = SimpleNamespace(agents={"opencode": object(), "codex": object()})
     controller.vibe_agent_store = SimpleNamespace(
         require=lambda name: (_ for _ in ()).throw(ValueError(f"agent '{name}' not found")),
-        get_builtin_default_agent_for_backend=lambda backend: builtin_agent if backend == "opencode" else None,
-        get_default_agent=lambda: SimpleNamespace(name="reviewer", backend="codex"),
+        get_builtin_default_agent_for_backend=lambda backend: (_ for _ in ()).throw(
+            AssertionError("scope backend should not be mapped to an Agent")
+        ),
+        get_default_agent=lambda: default_agent,
     )
     controller.get_settings_manager_for_context = lambda context: SimpleNamespace(
         get_channel_routing=lambda settings_key: SimpleNamespace(agent_name=None, agent_backend="opencode")
     )
     controller.agent_router = SimpleNamespace(resolve=lambda platform, settings_key: "claude")
 
-    assert controller.resolve_agent_for_context(_context()) == "opencode"
+    assert controller.resolve_agent_for_context(_context()) == "codex"
 
 
 def test_resolve_agent_for_context_uses_default_agent_not_router_default() -> None:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1096,7 +1096,7 @@ def test_runtime_session_reservation_uses_canonicalized_scope_agent(tmp_path: Pa
     assert target.agent_id
 
 
-def test_runtime_session_reservation_rejects_unresolved_legacy_scope_backend(
+def test_runtime_session_reservation_ignores_unresolved_legacy_scope_backend(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -1111,7 +1111,7 @@ def test_runtime_session_reservation_rejects_unresolved_legacy_scope_backend(
 
     agent_store = VibeAgentStore(db_path)
     try:
-        agent_store.ensure_default_agent(backend="claude")
+        default_agent = agent_store.ensure_default_agent(backend="claude")
         agent_store.create(name="codex", backend="opencode")
     finally:
         agent_store.close()
@@ -1146,8 +1146,11 @@ def test_runtime_session_reservation_rejects_unresolved_legacy_scope_backend(
         request_store=TaskExecutionStore(tmp_path / "task_requests"),
     )
 
-    with pytest.raises(ValueError, match="legacy backend without an Agent"):
-        service._reserve_runtime_session(agent_name=None, deliver_key="slack::channel::C123")
+    session_id = service._reserve_runtime_session(agent_name=None, deliver_key="slack::channel::C123")
+    target = resolve_session_id_target(session_id, db_path=db_path)
+
+    assert target.agent_backend == default_agent.backend
+    assert target.agent_name == default_agent.name
 
 
 def test_runtime_session_reservation_uses_default_agent_without_scope_agent(

--- a/ui/src/components/Workbench.tsx
+++ b/ui/src/components/Workbench.tsx
@@ -12,7 +12,7 @@ import { AgentRoutePicker } from './workbench/AgentRoutePicker';
 // Mirrors design.pen DnkGJ "Workbench" canvas: a centered hero panel +
 // suggestion chips with the shared chat Composer below it. The Composer is
 // wired to create a new session under the most-recently-active project using
-// the default backend, then routes to /chat/<id> with the typed message
+// the default Agent, then routes to /chat/<id> with the typed message
 // pre-seeded. No project? The send surfaces the NewProjectDialog so the user
 // gets unstuck without bouncing pages. The create flow lives in the shared
 // useNewSession hook — one source of truth with the mobile NewSessionSheet.

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -105,9 +105,8 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
 
   const selectedVibeAgent = vibeAgents.find((agent) => agent.name === value.routing.agent_name) || null;
   const defaultVibeAgent = vibeAgents.find((agent) => agent.name === defaultAgentName) || null;
-  const legacyBackend = value.routing.agent_backend || null;
-  const inheritedVibeAgent = selectedVibeAgent || (!legacyBackend ? defaultVibeAgent : null);
-  const effectiveBackend = selectedVibeAgent?.backend || legacyBackend || defaultVibeAgent?.backend || 'opencode';
+  const inheritedVibeAgent = selectedVibeAgent || defaultVibeAgent;
+  const effectiveBackend = selectedVibeAgent?.backend || defaultVibeAgent?.backend || 'opencode';
   const effectiveModel = value.routing.model || inheritedVibeAgent?.model || '';
 
   const getOpenCodeReasoningOptions = (modelKey: string) => {

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -643,7 +643,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       const effectiveCwd = (raw.custom_cwd ?? '') || defaultCwd;
       const routing = raw.routing || {};
       const selectedAgent = routing.agent_name ? agentByName[routing.agent_name] : null;
-      const backend = selectedAgent?.backend || routing.agent_backend || defaultAgent?.backend || 'opencode';
+      const backend = selectedAgent?.backend || defaultAgent?.backend || 'opencode';
 
       if (backend === 'opencode' && config.agents?.opencode?.enabled) {
         neededOpenCodeCwds.add(effectiveCwd);

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -575,7 +575,7 @@ export const UserList: React.FC = () => {
       const cwd = u.config.custom_cwd || defaultCwd;
       const routing = u.config.routing || {};
       const selectedAgent = routing.agent_name ? agentByName[routing.agent_name] : null;
-      const backend = selectedAgent?.backend || routing.agent_backend || defaultAgent?.backend || 'opencode';
+      const backend = selectedAgent?.backend || defaultAgent?.backend || 'opencode';
       if (backend === 'opencode' && config.agents?.opencode?.enabled && !opencodeOptionsByCwd[cwd]) loadOpenCodeOptions(cwd);
       if (backend === 'claude' && config.agents?.claude?.enabled && !claudeAgentsByCwd[cwd]) loadClaudeAgents(cwd);
       if (backend === 'codex' && config.agents?.codex?.enabled && !codexAgentsByCwd[cwd]) loadCodexAgents(cwd);

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1373,31 +1373,29 @@ def _validate_agent_name_arg(agent_name: Optional[str]) -> Optional[str]:
 
 class _ScopeRoutingTarget(NamedTuple):
     agent_name: Optional[str]
-    agent_backend: Optional[str]
 
 
 def _resolve_scope_routing_target(session_key: str) -> _ScopeRoutingTarget:
     if not session_key:
-        return _ScopeRoutingTarget(None, None)
+        return _ScopeRoutingTarget(None)
     try:
         parsed = parse_session_key(session_key)
     except ValueError:
-        return _ScopeRoutingTarget(None, None)
+        return _ScopeRoutingTarget(None)
     scope_id = make_scope_id(parsed.platform, parsed.scope_type, parsed.scope_id)
     _ensure_cli_sqlite_state()
     engine = create_sqlite_engine(paths.get_sqlite_state_path())
     try:
         with engine.connect() as conn:
             row = conn.execute(
-                select(scope_settings.c.agent_name, scope_settings.c.agent_backend)
+                select(scope_settings.c.agent_name)
                 .where(scope_settings.c.scope_id == scope_id)
                 .limit(1)
             ).first()
             if row is None:
-                return _ScopeRoutingTarget(None, None)
+                return _ScopeRoutingTarget(None)
             agent_name = str(row.agent_name).strip() if row.agent_name else None
-            agent_backend = str(row.agent_backend).strip() if row.agent_backend else None
-            return _ScopeRoutingTarget(agent_name, agent_backend)
+            return _ScopeRoutingTarget(agent_name)
     finally:
         engine.dispose()
 
@@ -1406,28 +1404,12 @@ def _resolve_scope_agent_name(session_key: str) -> Optional[str]:
     return _resolve_scope_routing_target(session_key).agent_name
 
 
-def _raise_unresolved_legacy_scope_backend(
-    *,
-    scope_target: _ScopeRoutingTarget,
-    deliver_key: str,
-    help_command: str,
-) -> None:
-    raise TaskCliError(
-        "scope routing still references a legacy backend without an Agent",
-        code="legacy_scope_backend_unresolved",
-        hint="Open the Scope routing settings and choose an Agent before creating sessions for this Scope.",
-        help_command=help_command,
-        details={"deliver_key": deliver_key, "agent_backend": scope_target.agent_backend},
-    )
-
-
 def _resolve_agent_for_target(
     *,
     agent_name: Optional[str],
     session_id: Optional[str],
     session_key: str,
     help_command: str,
-    reject_unresolved_legacy_scope_backend: bool = False,
 ):
     store = _agent_store()
     try:
@@ -1459,12 +1441,6 @@ def _resolve_agent_for_target(
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
                 return store.require_enabled(scope_target.agent_name)
-            if scope_target.agent_backend and reject_unresolved_legacy_scope_backend:
-                _raise_unresolved_legacy_scope_backend(
-                    scope_target=scope_target,
-                    deliver_key=session_key,
-                    help_command=help_command,
-                )
 
         return store.get_default_agent()
     finally:
@@ -1478,22 +1454,16 @@ def _resolve_agent_for_session_reservation(
     help_command: str,
 ) -> Optional[VibeAgent]:
     resolved_agent_name = agent_name
-    scope_target = _ScopeRoutingTarget(None, None)
+    scope_target = _ScopeRoutingTarget(None)
     if not resolved_agent_name:
         scope_target = _resolve_scope_routing_target(deliver_key)
         resolved_agent_name = scope_target.agent_name
-    if not resolved_agent_name:
-        if scope_target.agent_backend:
-            _raise_unresolved_legacy_scope_backend(
-                scope_target=scope_target,
-                deliver_key=deliver_key,
-                help_command=help_command,
-            )
-        return None
 
     store = _agent_store()
     try:
-        return store.require_enabled(resolved_agent_name)
+        if resolved_agent_name:
+            return store.require_enabled(resolved_agent_name)
+        return store.get_default_agent()
     finally:
         store.close()
 
@@ -1720,7 +1690,6 @@ def cmd_task_add(args):
             session_id=session_id,
             session_key=session_key or getattr(args, "deliver_key", None) or "",
             help_command="vibe task add --help",
-            reject_unresolved_legacy_scope_backend=session_policy != "existing",
         )
         agent_name = agent.name if agent else None
         if session_policy == "create_once":
@@ -2049,7 +2018,6 @@ def cmd_task_update(args):
                 session_id=None,
                 session_key=deliver_key or "",
                 help_command="vibe task update --help",
-                reject_unresolved_legacy_scope_backend=True,
             )
             agent_name = agent.name if agent else None
         elif agent_name is not None or session_id or session_key:
@@ -3335,7 +3303,6 @@ def cmd_watch_add(args):
             session_id=session_id,
             session_key=session_key or getattr(args, "deliver_key", None) or "",
             help_command="vibe watch add --help",
-            reject_unresolved_legacy_scope_backend=session_policy != "existing",
         )
         agent_name = agent.name if agent else None
         if session_policy == "create_once":
@@ -3613,7 +3580,6 @@ def cmd_watch_update(args):
                 session_id=None,
                 session_key=deliver_key or "",
                 help_command="vibe watch update --help",
-                reject_unresolved_legacy_scope_backend=True,
             )
             agent_name = agent.name if agent else None
         elif agent_name is not None or session_id or session_key:


### PR DESCRIPTION
## Summary
- stop treating scope-level legacy `agent_backend` as a runtime route selector for new messages, tasks, and watches
- keep existing Agent Session backend snapshots authoritative, while new sessions use `routing.agent_name` or the default Vibe Agent
- update Web UI option-loading behavior and Avibe operation docs/skills to describe Agent-based routing instead of default backend routing

## What changed
`scope_settings.agent_backend` is now compatibility metadata, not a scope route source. It may still be present in imported/read-back payloads, and it is only consulted to avoid applying stale model/subagent overrides to the wrong backend. It no longer creates backend-only sessions or blocks default-Agent fallback.

Existing `agent_sessions.agent_backend` remains unchanged: that is the session snapshot and is still the source of truth for an already-created session/thread.

## Tests
- `uv run pytest tests/test_agent_run_target.py tests/test_controller_vibe_agent_routing.py tests/test_cli_task_command.py tests/test_cli_watch_command.py tests/test_scheduled_tasks.py -q`
- `uv run ruff check core/controller.py core/handlers/message_handler.py core/scheduled_tasks.py core/services/agent_run_target.py vibe/cli.py tests/test_agent_run_target.py tests/test_cli_task_command.py tests/test_cli_watch_command.py tests/test_controller_vibe_agent_routing.py tests/test_scheduled_tasks.py`
- `npm run build` in `ui/`
- `git diff --check`

## Notes
- `npm ci` was needed in this isolated worktree before building `ui/dist` for the editable package/test workflow.
- The Vite build still reports the existing large chunk warning.
