### PR TITLE
fix(opencode): align custom provider runtime models

### DIFF
--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -22,6 +22,7 @@ from .message_processor import OpenCodeMessageProcessorMixin
 from .poll_loop import OpenCodePollLoop
 from .server import OpenCodeServerManager
 from .session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
+from .utils import find_opencode_model_info
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,9 @@ def _opencode_model_supports_variant(model_info: dict | None, variant: str | Non
     variants = model_info.get("variants")
     if isinstance(variants, dict) and variant in variants:
         return True
+    capabilities = model_info.get("capabilities")
+    if variants is None and "variants" not in model_info and isinstance(capabilities, dict):
+        return capabilities.get("reasoning") is True
     return False
 
 
@@ -50,9 +54,14 @@ def _opencode_model_has_no_variants(model_info: dict | None) -> bool:
     if not isinstance(model_info, dict):
         return False
     capabilities = model_info.get("capabilities")
-    if isinstance(capabilities, dict) and capabilities.get("reasoning") is False:
-        return True
+    if isinstance(capabilities, dict):
+        if capabilities.get("reasoning") is True:
+            return False
+        if capabilities.get("reasoning") is False:
+            return True
     variants = model_info.get("variants")
+    if variants is None and "variants" not in model_info:
+        return True
     return isinstance(variants, dict) and not variants
 
 
@@ -78,22 +87,15 @@ def resolve_opencode_reasoning_effort(
     if not isinstance(model_catalog, dict):
         return requested_effort
 
-    for provider in model_catalog.get("providers", []) or []:
-        if not isinstance(provider, dict) or provider.get("id") != provider_id:
-            continue
-        models = provider.get("models")
-        if not isinstance(models, dict):
+    model_info = find_opencode_model_info(model_catalog, provider_id, model_id)
+    if requested_effort:
+        if _opencode_model_supports_variant(model_info, requested_effort):
             return requested_effort
-        model_info = models.get(model_id)
-        if requested_effort:
-            if _opencode_model_supports_variant(model_info, requested_effort):
-                return requested_effort
-            if isinstance(model_info, dict):
-                return "default"
-            return requested_effort
-        if _opencode_model_has_no_variants(model_info):
+        if isinstance(model_info, dict):
             return "default"
         return requested_effort
+    if _opencode_model_has_no_variants(model_info):
+        return "default"
     return requested_effort
 
 

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -37,6 +37,66 @@ def resolve_opencode_model_dict(model_str: str | None, default_provider: str | N
     return None
 
 
+def _opencode_model_supports_variant(model_info: dict | None, variant: str | None) -> bool:
+    if not isinstance(model_info, dict) or not isinstance(variant, str) or not variant.strip():
+        return False
+    variants = model_info.get("variants")
+    if isinstance(variants, dict) and variant in variants:
+        return True
+    return False
+
+
+def _opencode_model_has_no_variants(model_info: dict | None) -> bool:
+    if not isinstance(model_info, dict):
+        return False
+    capabilities = model_info.get("capabilities")
+    if isinstance(capabilities, dict) and capabilities.get("reasoning") is False:
+        return True
+    variants = model_info.get("variants")
+    return isinstance(variants, dict) and not variants
+
+
+def resolve_opencode_reasoning_effort(
+    model_dict: dict[str, str] | None,
+    requested_effort: str | None,
+    model_catalog: dict | None,
+) -> str | None:
+    """Return the variant OpenCode should receive for this model.
+
+    OpenCode stores the last selected run variant per provider/model. When avibe
+    overrides the model to a non-reasoning model, omitting ``variant`` lets that
+    saved value leak into the new request. Send OpenCode's explicit ``default``
+    variant for models that do not support the requested effort.
+    """
+
+    if not model_dict:
+        return requested_effort
+    provider_id = model_dict.get("providerID")
+    model_id = model_dict.get("modelID")
+    if not provider_id or not model_id:
+        return requested_effort
+    if not isinstance(model_catalog, dict):
+        return requested_effort
+
+    for provider in model_catalog.get("providers", []) or []:
+        if not isinstance(provider, dict) or provider.get("id") != provider_id:
+            continue
+        models = provider.get("models")
+        if not isinstance(models, dict):
+            return requested_effort
+        model_info = models.get(model_id)
+        if requested_effort:
+            if _opencode_model_supports_variant(model_info, requested_effort):
+                return requested_effort
+            if isinstance(model_info, dict):
+                return "default"
+            return requested_effort
+        if _opencode_model_has_no_variants(model_info):
+            return "default"
+        return requested_effort
+    return requested_effort
+
+
 class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
     """OpenCode Server API integration via HTTP."""
 
@@ -265,6 +325,16 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 reasoning_effort = server.get_agent_reasoning_effort_from_config(agent_to_use)
             if not reasoning_effort:
                 reasoning_effort = getattr(opencode_cfg, "default_reasoning_effort", None)
+            if model_dict:
+                try:
+                    model_catalog = await server.get_available_models(request.working_path)
+                    reasoning_effort = resolve_opencode_reasoning_effort(
+                        model_dict,
+                        reasoning_effort,
+                        model_catalog,
+                    )
+                except Exception as err:
+                    logger.debug("Failed to resolve OpenCode model variant support: %s", err)
 
             baseline_message_ids: set[str] = set()
             try:

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -44,33 +44,57 @@ def _parse_provider_id(model_key: Optional[str]) -> Optional[str]:
     return provider_id or None
 
 
+def get_opencode_provider_id(provider: dict | None) -> str:
+    if not isinstance(provider, dict):
+        return ""
+    provider_id = provider.get("id") or provider.get("provider_id") or provider.get("name") or ""
+    return provider_id if isinstance(provider_id, str) else ""
+
+
+def _opencode_model_entry_id(model_entry: Any) -> str:
+    if isinstance(model_entry, str):
+        return model_entry
+    if not isinstance(model_entry, dict):
+        return ""
+    model_id = model_entry.get("id") or model_entry.get("modelID") or model_entry.get("model_id") or ""
+    return model_id if isinstance(model_id, str) else ""
+
+
+def find_opencode_model_info(
+    opencode_models: dict | None,
+    provider_id: str | None,
+    model_id: str | None,
+) -> dict | None:
+    if not provider_id or not model_id or not isinstance(opencode_models, dict):
+        return None
+
+    for provider in opencode_models.get("providers", []) or []:
+        if get_opencode_provider_id(provider) != provider_id:
+            continue
+
+        models = provider.get("models", {}) if isinstance(provider, dict) else {}
+        if isinstance(models, dict):
+            model_info = models.get(model_id)
+            if isinstance(model_info, dict):
+                return model_info
+            return {} if model_info is not None else None
+        if isinstance(models, list):
+            for entry in models:
+                if _opencode_model_entry_id(entry) == model_id:
+                    return entry if isinstance(entry, dict) else {}
+        return None
+    return None
+
+
 def _find_model_variants(opencode_models: dict, target_model: Optional[str]) -> Dict[str, Any]:
     target_provider, target_model_id = _parse_model_key(target_model)
     if not target_provider or not target_model_id or not isinstance(opencode_models, dict):
         return {}
-    providers_data = opencode_models.get("providers", [])
-    for provider in providers_data:
-        provider_id = provider.get("id") or provider.get("provider_id") or provider.get("name")
-        if provider_id != target_provider:
-            continue
-
-        models = provider.get("models", {})
-        model_info: Optional[dict] = None
-        if isinstance(models, dict):
-            candidate = models.get(target_model_id)
-            if isinstance(candidate, dict):
-                model_info = candidate
-        elif isinstance(models, list):
-            for entry in models:
-                if isinstance(entry, dict) and entry.get("id") == target_model_id:
-                    model_info = entry
-                    break
-
-        if isinstance(model_info, dict):
-            variants = model_info.get("variants", {})
-            if isinstance(variants, dict):
-                return variants
-        break
+    model_info = find_opencode_model_info(opencode_models, target_provider, target_model_id)
+    if isinstance(model_info, dict):
+        variants = model_info.get("variants", {})
+        if isinstance(variants, dict):
+            return variants
     return {}
 
 
@@ -212,7 +236,7 @@ def build_opencode_model_option_items(
 
     providers: List[Tuple[str, dict]] = []
     for provider in providers_data:
-        provider_id = provider.get("id") or provider.get("provider_id") or provider.get("name") or ""
+        provider_id = get_opencode_provider_id(provider)
         if not provider_id:
             continue
         providers.append((provider_id, provider))

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -17,7 +17,7 @@ from core.message_dispatcher import ConsolidatedMessageDispatcher
 from core.processing_indicator import ProcessingIndicatorService
 from modules.agents.base import AgentRequest
 from modules.agents.service import AgentService
-from modules.agents.opencode.agent import OpenCodeAgent
+from modules.agents.opencode.agent import OpenCodeAgent, resolve_opencode_reasoning_effort
 from modules.agents.opencode.poll_loop import OpenCodePollLoop
 
 
@@ -678,6 +678,81 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
     assert calls[0]["tools"] == {"question": False}
     assert calls[0]["model"] == {"providerID": "openai", "modelID": "gpt-5.4"}
     assert calls[0]["reasoning_effort"] == "high"
+
+
+def test_opencode_resets_saved_variant_for_non_reasoning_model():
+    catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "glm-5.2": {
+                        "capabilities": {"reasoning": False},
+                        "variants": {},
+                    }
+                },
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "glm", "modelID": "glm-5.2"},
+            None,
+            catalog,
+        )
+        == "default"
+    )
+
+
+def test_opencode_keeps_supported_reasoning_variant():
+    catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {
+                    "gpt-5.4": {
+                        "capabilities": {"reasoning": True},
+                        "variants": {"high": {"reasoningEffort": "high"}},
+                    }
+                },
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "openai", "modelID": "gpt-5.4"},
+            "high",
+            catalog,
+        )
+        == "high"
+    )
+
+
+def test_opencode_resets_unsupported_reasoning_variant():
+    catalog = {
+        "providers": [
+            {
+                "id": "anthropic",
+                "models": {
+                    "claude-opus-4-5": {
+                        "capabilities": {"reasoning": True},
+                        "variants": {"low": {"effort": "low"}},
+                    }
+                },
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "anthropic", "modelID": "claude-opus-4-5"},
+            "max",
+            catalog,
+        )
+        == "default"
+    )
 
 
 def test_opencode_fork_prompt_marks_target_session_id_authoritative():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -705,6 +705,81 @@ def test_opencode_resets_saved_variant_for_non_reasoning_model():
     )
 
 
+def test_opencode_resets_saved_variant_for_model_without_variant_metadata():
+    catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "glm-5.2": {
+                        "id": "glm-5.2",
+                        "name": "GLM 5.2",
+                    }
+                },
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "glm", "modelID": "glm-5.2"},
+            None,
+            catalog,
+        )
+        == "default"
+    )
+
+
+def test_opencode_keeps_unspecified_variant_when_catalog_says_reasoning_supported():
+    catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {
+                    "gpt-5.4": {
+                        "id": "gpt-5.4",
+                        "capabilities": {"reasoning": True},
+                    }
+                },
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "openai", "modelID": "gpt-5.4"},
+            None,
+            catalog,
+        )
+        is None
+    )
+
+
+def test_opencode_resets_saved_variant_for_list_model_catalog():
+    catalog = {
+        "providers": [
+            {
+                "provider_id": "glm",
+                "models": [
+                    {
+                        "id": "glm-5.2",
+                        "name": "GLM 5.2",
+                    }
+                ],
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "glm", "modelID": "glm-5.2"},
+            None,
+            catalog,
+        )
+        == "default"
+    )
+
+
 def test_opencode_keeps_supported_reasoning_variant():
     catalog = {
         "providers": [
@@ -714,6 +789,57 @@ def test_opencode_keeps_supported_reasoning_variant():
                     "gpt-5.4": {
                         "capabilities": {"reasoning": True},
                         "variants": {"high": {"reasoningEffort": "high"}},
+                    }
+                },
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "openai", "modelID": "gpt-5.4"},
+            "high",
+            catalog,
+        )
+        == "high"
+    )
+
+
+def test_opencode_keeps_supported_reasoning_variant_for_list_model_catalog():
+    catalog = {
+        "providers": [
+            {
+                "name": "openai",
+                "models": [
+                    {
+                        "id": "gpt-5.4",
+                        "capabilities": {"reasoning": True},
+                        "variants": {"high": {"reasoningEffort": "high"}},
+                    }
+                ],
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "openai", "modelID": "gpt-5.4"},
+            "high",
+            catalog,
+        )
+        == "high"
+    )
+
+
+def test_opencode_keeps_requested_variant_when_catalog_says_reasoning_supported():
+    catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {
+                    "gpt-5.4": {
+                        "id": "gpt-5.4",
+                        "capabilities": {"reasoning": True},
                     }
                 },
             }

--- a/tests/test_opencode_config_reconciler.py
+++ b/tests/test_opencode_config_reconciler.py
@@ -140,6 +140,29 @@ def test_user_models_do_not_resurrect_live_deleted_models():
     )["provider"]["deepseek"]["models"] == {"keep-model": {"id": "keep-model"}}
 
 
+def test_empty_user_models_block_drops_live_models():
+    assert _reconcile(
+        {
+            "provider": {
+                "deepseek": {
+                    "options": {"baseURL": "https://api.deepseek.com"},
+                    "models": {},
+                }
+            }
+        },
+        {
+            "provider": {
+                "deepseek": {
+                    "options": {"baseURL": "https://api.deepseek.com"},
+                    "models": {
+                        "deleted-model": {"id": "deleted-model"},
+                    },
+                }
+            }
+        },
+    )["provider"]["deepseek"]["models"] == {}
+
+
 def test_provider_absent_from_user_config_is_dropped_unless_auth_or_local():
     assert set(
         _reconcile(

--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -268,14 +268,14 @@ def test_upsert_provider_model_allows_provider_native_slash(tmp_path: Path) -> N
     )
 
 
-def test_remove_provider_model_prunes_empty_model_block_but_keeps_options(tmp_path: Path) -> None:
+def test_remove_provider_model_keeps_empty_model_tombstone_and_options(tmp_path: Path) -> None:
     upsert_opencode_provider_base_url("deepseek", "https://api.deepseek.com", home=tmp_path)
     upsert_opencode_provider_model("deepseek", "deepseek-v4-flash", home=tmp_path)
 
     remove_opencode_provider_model("deepseek", "deepseek-v4-flash", home=tmp_path)
 
     config = _read_config(get_opencode_config_paths(tmp_path)[0])
-    assert "models" not in config["provider"]["deepseek"]
+    assert config["provider"]["deepseek"]["models"] == {}
     assert config["provider"]["deepseek"]["options"]["baseURL"] == "https://api.deepseek.com"
 
 

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -712,6 +712,17 @@ def test_delete_provider_model_only_removes_user_managed_models(fake_model_env) 
     assert read_opencode_provider_user_models("deepseek", home=home) == {}
 
 
+def test_delete_provider_model_keeps_empty_models_tombstone(fake_model_env) -> None:
+    _server, home = fake_model_env
+    _save_model("deepseek", {"model_id": "deepseek-v4-flash"})
+
+    result = _delete_model("deepseek", "deepseek-v4-flash")
+
+    assert result["ok"] is True
+    config = _read_opencode_config(home)
+    assert config["provider"]["deepseek"]["models"] == {}
+
+
 def test_delete_provider_model_rejects_builtin_model(fake_model_env) -> None:
     result = _delete_model("deepseek", "deepseek-chat")
     assert result == {"ok": False, "message": "Only user-managed models can be removed"}

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -843,7 +843,7 @@ def remove_opencode_provider_model(
         return probe.path
     models.pop(model_id, None)
     if not models:
-        provider_config.pop("models", None)
+        provider_config["models"] = {}
 
     _prune_empty_provider_config(config, provider_id)
     return _write_opencode_config(config, probe.path)


### PR DESCRIPTION
## Summary
- reset stale OpenCode run variants when switching to custom models that do not support reasoning variants
- preserve an explicit empty `models: {}` tombstone after removing the last user-managed provider model so OpenCode refreshes cannot resurrect deleted models
- add focused coverage for custom provider runtime variant selection and provider-model deletion semantics

## Scenarios
- OpenCode custom Anthropic-compatible provider `glm/glm-5.2`: connectivity test passes and actual sessions should not inherit a saved `medium` reasoning variant from another model.
- OpenCode Provider Settings: deleting the last manually added model should keep it deleted after OpenCode config refresh/restart.

## Evidence
- Unit/contract: `python3 -m pytest tests/test_opencode_config_reconciler.py tests/test_opencode_server.py tests/test_save_opencode_provider_auth.py tests/test_opencode_provider_base_url.py tests/test_multi_platform_runtime.py`
- Lint: `ruff check modules/agents/opencode/agent.py vibe/opencode_config.py tests/test_opencode_config_reconciler.py tests/test_save_opencode_provider_auth.py tests/test_opencode_provider_base_url.py tests/test_multi_platform_runtime.py`
- Manual residual: inspected regression OpenCode catalog/session evidence only; regression state was not mutated.
