### PR TITLE
fix(opencode): tighten provider runtime options

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -21,7 +21,11 @@ from modules.claude_sdk_compat import (
     ClaudeSDKClient,
 )
 from modules.agents.catalog import WEB_OAUTH_BACKENDS
-from modules.agents.opencode.message_processor import extract_opencode_response_text
+from modules.agents.opencode.message_processor import (
+    extract_opencode_response_text,
+    is_empty_terminal_opencode_message,
+)
+from modules.agents.opencode.utils import resolve_opencode_reasoning_effort
 from modules.im import InlineButton, InlineKeyboard, MessageContext
 from vibe.i18n import t as i18n_t
 from vibe.opencode_config import remove_opencode_provider_api_key
@@ -381,6 +385,9 @@ class AgentAuthService:
     def _t(self, key: str, **kwargs) -> str:
         lang = getattr(self.controller, "_get_lang", lambda: getattr(self.controller.config, "language", "en"))()
         return i18n_t(key, lang, **kwargs)
+
+    def _lang(self) -> str:
+        return getattr(self.controller, "_get_lang", lambda: getattr(self.controller.config, "language", "en"))()
 
     def _resolve_backend_config(self, backend: str):
         """Return the backend's config object regardless of controller shape.
@@ -2226,7 +2233,7 @@ class AgentAuthService:
         provider is unhealthy or silently mask which provider works — so
         each provider card gets its own probe.
 
-        Flow: create a temp session → ``send_message("Hi", model=...)``
+        Flow: create a temp session → ``prompt_async("Hi", model=...)``
         → poll messages until the assistant message either completes
         with text or surfaces an ``info.error`` block → abort the
         session. The session record stays on disk (OpenCode doesn't
@@ -2325,11 +2332,24 @@ class AgentAuthService:
                 pass
 
             try:
-                await server.send_message(
-                    session_id,
-                    directory,
-                    "Hi",
+                catalog = await server.get_available_models(directory)
+            except Exception:  # noqa: BLE001
+                catalog = None
+            model_dict = {"providerID": provider_id, "modelID": chosen_model}
+            reasoning_effort = resolve_opencode_reasoning_effort(
+                model_dict,
+                None,
+                catalog if isinstance(catalog, dict) else None,
+            )
+
+            try:
+                await server.prompt_async(
+                    session_id=session_id,
+                    directory=directory,
+                    text="Hi",
                     model={"providerID": provider_id, "modelID": chosen_model},
+                    reasoning_effort=reasoning_effort,
+                    tools={"question": False},
                 )
             except Exception as err:  # noqa: BLE001
                 detail = str(err)
@@ -2384,6 +2404,21 @@ class AgentAuthService:
                         terminal,
                         allow_non_text_fallback=True,
                     )
+                    if not final_text and is_empty_terminal_opencode_message(terminal):
+                        lang = self._lang()
+                        return {
+                            "ok": False,
+                            "error": "empty_response",
+                            "detail": i18n_t(
+                                "error.opencodeEmptyResponse",
+                                lang,
+                                provider=provider_id,
+                                model=chosen_model,
+                                variant=reasoning_effort or i18n_t("common.default", lang),
+                            ),
+                            "duration_ms": int((time.monotonic() - started) * 1000),
+                            "model": chosen_model,
+                        }
                     break
                 await asyncio.sleep(poll_interval)
             else:

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2299,6 +2299,7 @@ class AgentAuthService:
         directory = os.path.expanduser("~")
         started = time.monotonic()
         session_id: str | None = None
+        active_registered = False
         try:
             try:
                 created = await server.create_session(directory, title="vibe-test-probe")
@@ -2351,6 +2352,8 @@ class AgentAuthService:
                     reasoning_effort=reasoning_effort,
                     tools={"question": False},
                 )
+                await server.mark_run_active(session_id)
+                active_registered = True
             except Exception as err:  # noqa: BLE001
                 detail = str(err)
                 return {
@@ -2461,6 +2464,8 @@ class AgentAuthService:
                     await server.abort_session(session_id, directory)
                 except Exception:  # noqa: BLE001
                     pass
+            if active_registered and session_id:
+                await server.mark_run_inactive(session_id)
 
     async def cancel_web_flow(self, flow_id: str) -> dict[str, Any]:
         async with self._web_flow_lock:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -22,7 +22,7 @@ from .message_processor import OpenCodeMessageProcessorMixin
 from .poll_loop import OpenCodePollLoop
 from .server import OpenCodeServerManager
 from .session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
-from .utils import find_opencode_model_info
+from .utils import resolve_opencode_reasoning_effort
 
 logger = logging.getLogger(__name__)
 
@@ -36,67 +36,6 @@ def resolve_opencode_model_dict(model_str: str | None, default_provider: str | N
     if isinstance(default_provider, str) and default_provider.strip():
         return {"providerID": default_provider.strip(), "modelID": model_str}
     return None
-
-
-def _opencode_model_supports_variant(model_info: dict | None, variant: str | None) -> bool:
-    if not isinstance(model_info, dict) or not isinstance(variant, str) or not variant.strip():
-        return False
-    variants = model_info.get("variants")
-    if isinstance(variants, dict) and variant in variants:
-        return True
-    capabilities = model_info.get("capabilities")
-    if variants is None and "variants" not in model_info and isinstance(capabilities, dict):
-        return capabilities.get("reasoning") is True
-    return False
-
-
-def _opencode_model_has_no_variants(model_info: dict | None) -> bool:
-    if not isinstance(model_info, dict):
-        return False
-    capabilities = model_info.get("capabilities")
-    if isinstance(capabilities, dict):
-        if capabilities.get("reasoning") is True:
-            return False
-        if capabilities.get("reasoning") is False:
-            return True
-    variants = model_info.get("variants")
-    if variants is None and "variants" not in model_info:
-        return True
-    return isinstance(variants, dict) and not variants
-
-
-def resolve_opencode_reasoning_effort(
-    model_dict: dict[str, str] | None,
-    requested_effort: str | None,
-    model_catalog: dict | None,
-) -> str | None:
-    """Return the variant OpenCode should receive for this model.
-
-    OpenCode stores the last selected run variant per provider/model. When avibe
-    overrides the model to a non-reasoning model, omitting ``variant`` lets that
-    saved value leak into the new request. Send OpenCode's explicit ``default``
-    variant for models that do not support the requested effort.
-    """
-
-    if not model_dict:
-        return requested_effort
-    provider_id = model_dict.get("providerID")
-    model_id = model_dict.get("modelID")
-    if not provider_id or not model_id:
-        return requested_effort
-    if not isinstance(model_catalog, dict):
-        return requested_effort
-
-    model_info = find_opencode_model_info(model_catalog, provider_id, model_id)
-    if requested_effort:
-        if _opencode_model_supports_variant(model_info, requested_effort):
-            return requested_effort
-        if isinstance(model_info, dict):
-            return "default"
-        return requested_effort
-    if _opencode_model_has_no_variants(model_info):
-        return "default"
-    return requested_effort
 
 
 class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):

--- a/modules/agents/opencode/message_processor.py
+++ b/modules/agents/opencode/message_processor.py
@@ -62,14 +62,21 @@ def is_empty_terminal_opencode_message(message: Mapping[str, Any]) -> bool:
     parts = message.get("parts")
     if not isinstance(parts, list):
         return True
-    non_status_parts = []
     for part in parts:
         if not isinstance(part, Mapping):
             continue
         part_type = part.get("type")
-        if part_type not in {"step-start", "step-finish"}:
-            non_status_parts.append(part)
-    return not non_status_parts
+        if part_type in {"step-start", "step-finish"}:
+            continue
+        text = part.get("text")
+        if part_type == "text":
+            if not isinstance(text, str) or not text.strip():
+                continue
+            return False
+        if isinstance(text, str) and not text.strip():
+            continue
+        return False
+    return True
 
 
 class OpenCodeMessageProcessorMixin:

--- a/modules/agents/opencode/message_processor.py
+++ b/modules/agents/opencode/message_processor.py
@@ -42,7 +42,7 @@ def extract_opencode_response_text(
 
 
 def is_empty_terminal_opencode_message(message: Mapping[str, Any]) -> bool:
-    """Return True when OpenCode completed without text, error, or token usage."""
+    """Return True when OpenCode completed without usable text or error."""
 
     info = message.get("info")
     if not isinstance(info, Mapping):
@@ -58,18 +58,6 @@ def is_empty_terminal_opencode_message(message: Mapping[str, Any]) -> bool:
         return False
     if extract_opencode_response_text(message, allow_non_text_fallback=True):
         return False
-
-    tokens = info.get("tokens")
-    if isinstance(tokens, Mapping):
-        token_values = [
-            tokens.get("input"),
-            tokens.get("output"),
-            tokens.get("reasoning"),
-            tokens.get("cache", {}).get("read") if isinstance(tokens.get("cache"), Mapping) else None,
-            tokens.get("cache", {}).get("write") if isinstance(tokens.get("cache"), Mapping) else None,
-        ]
-        if any(isinstance(value, (int, float)) and value > 0 for value in token_values):
-            return False
 
     parts = message.get("parts")
     if not isinstance(parts, list):

--- a/modules/agents/opencode/message_processor.py
+++ b/modules/agents/opencode/message_processor.py
@@ -41,6 +41,49 @@ def extract_opencode_response_text(
     return ""
 
 
+def is_empty_terminal_opencode_message(message: Mapping[str, Any]) -> bool:
+    """Return True when OpenCode completed without text, error, or token usage."""
+
+    info = message.get("info")
+    if not isinstance(info, Mapping):
+        return False
+    if info.get("role") != "assistant":
+        return False
+    time_info = info.get("time")
+    if not isinstance(time_info, Mapping) or not time_info.get("completed"):
+        return False
+    if info.get("error"):
+        return False
+    if info.get("finish") == "tool-calls":
+        return False
+    if extract_opencode_response_text(message, allow_non_text_fallback=True):
+        return False
+
+    tokens = info.get("tokens")
+    if isinstance(tokens, Mapping):
+        token_values = [
+            tokens.get("input"),
+            tokens.get("output"),
+            tokens.get("reasoning"),
+            tokens.get("cache", {}).get("read") if isinstance(tokens.get("cache"), Mapping) else None,
+            tokens.get("cache", {}).get("write") if isinstance(tokens.get("cache"), Mapping) else None,
+        ]
+        if any(isinstance(value, (int, float)) and value > 0 for value in token_values):
+            return False
+
+    parts = message.get("parts")
+    if not isinstance(parts, list):
+        return True
+    non_status_parts = []
+    for part in parts:
+        if not isinstance(part, Mapping):
+            continue
+        part_type = part.get("type")
+        if part_type not in {"step-start", "step-finish"}:
+            non_status_parts.append(part)
+    return not non_status_parts
+
+
 class OpenCodeMessageProcessorMixin:
     """Pure-ish helpers that depend only on instance config."""
 

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -11,6 +11,7 @@ from config.v2_config import DEFAULT_OPENCODE_ERROR_RETRY_LIMIT
 from modules.agents.base import AgentRequest
 from vibe.i18n import t as i18n_t
 
+from .message_processor import is_empty_terminal_opencode_message
 from .server import OpenCodeServerManager
 
 logger = logging.getLogger(__name__)
@@ -20,14 +21,14 @@ class OpenCodePollLoop:
     def __init__(self, agent):
         self._agent = agent
 
-    def _t(self, key: str) -> str:
+    def _t(self, key: str, **kwargs) -> str:
         controller = getattr(self._agent, "controller", None)
         translate = getattr(controller, "_t", None)
         if callable(translate):
-            return str(translate(key))
+            return str(translate(key, **kwargs))
         config = getattr(controller, "config", None)
         lang = getattr(config, "language", "en")
-        return str(i18n_t(key, lang))
+        return str(i18n_t(key, lang, **kwargs))
 
     def _build_restored_handle(self, poll_info):
         snapshot = poll_info.processing_indicator or {
@@ -44,6 +45,22 @@ class OpenCodePollLoop:
 
     def _build_restored_context(self, poll_info):
         return self._build_restored_handle(poll_info).context
+
+    def _empty_terminal_message_text(
+        self,
+        *,
+        model_dict: Optional[Dict[str, str]],
+        reasoning_effort: Optional[str],
+    ) -> str:
+        provider_id = (model_dict or {}).get("providerID") or self._t("common.default")
+        model_id = (model_dict or {}).get("modelID") or self._t("common.default")
+        variant = reasoning_effort or self._t("common.default")
+        return self._t(
+            "error.opencodeEmptyResponse",
+            provider=provider_id,
+            model=model_id,
+            variant=variant,
+        )
 
     def _build_restored_ack_request(self, poll_info) -> AgentRequest:
         handle = self._build_restored_handle(poll_info)
@@ -321,6 +338,25 @@ class OpenCodePollLoop:
                                 last_message_id=last_id,
                                 emitted_message_ids=emitted_assistant_messages,
                             )
+                        if not final_text and not msg_error and is_empty_terminal_opencode_message(last_message):
+                            message = self._empty_terminal_message_text(
+                                model_dict=model_dict,
+                                reasoning_effort=reasoning_effort,
+                            )
+                            logger.warning(
+                                "OpenCode session %s completed without text/error (provider=%s model=%s variant=%s)",
+                                session_id,
+                                (model_dict or {}).get("providerID"),
+                                (model_dict or {}).get("modelID"),
+                                reasoning_effort,
+                            )
+                            await self._agent.controller.emit_agent_message(
+                                request.context,
+                                "result",
+                                message,
+                                is_error=True,
+                            )
+                            return None, False
                         break
 
             await asyncio.sleep(poll_interval_seconds)
@@ -499,6 +535,24 @@ class OpenCodePollLoop:
                                         last_message_id=last_info.get("id"),
                                         emitted_message_ids=emitted_assistant_messages,
                                     )
+                                if not final_text and not msg_error and is_empty_terminal_opencode_message(last_message):
+                                    message = self._empty_terminal_message_text(
+                                        model_dict=None,
+                                        reasoning_effort=None,
+                                    )
+                                    logger.warning(
+                                        "Restored OpenCode session %s completed without text/error",
+                                        session_id,
+                                    )
+                                    await self._agent.controller.emit_agent_message(
+                                        context,
+                                        "result",
+                                        message,
+                                        is_error=True,
+                                    )
+                                    self._agent.sessions.remove_active_poll(session_id)
+                                    await self.remove_restored_ack(poll_info)
+                                    return
                                 break
 
                 await asyncio.sleep(poll_interval_seconds)

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -86,6 +86,61 @@ def find_opencode_model_info(
     return None
 
 
+def _opencode_model_supports_variant(model_info: dict | None, variant: str | None) -> bool:
+    if not isinstance(model_info, dict) or not isinstance(variant, str) or not variant.strip():
+        return False
+    variants = model_info.get("variants")
+    if isinstance(variants, dict) and variant in variants:
+        return True
+    capabilities = model_info.get("capabilities")
+    if variants is None and "variants" not in model_info and isinstance(capabilities, dict):
+        return capabilities.get("reasoning") is True
+    return False
+
+
+def _opencode_model_has_no_variants(model_info: dict | None) -> bool:
+    if not isinstance(model_info, dict):
+        return False
+    capabilities = model_info.get("capabilities")
+    if isinstance(capabilities, dict):
+        if capabilities.get("reasoning") is True:
+            return False
+        if capabilities.get("reasoning") is False:
+            return True
+    variants = model_info.get("variants")
+    if variants is None and "variants" not in model_info:
+        return True
+    return isinstance(variants, dict) and not variants
+
+
+def resolve_opencode_reasoning_effort(
+    model_dict: dict[str, str] | None,
+    requested_effort: str | None,
+    model_catalog: dict | None,
+) -> str | None:
+    """Return the variant OpenCode should receive for this model."""
+
+    if not model_dict:
+        return requested_effort
+    provider_id = model_dict.get("providerID")
+    model_id = model_dict.get("modelID")
+    if not provider_id or not model_id:
+        return requested_effort
+    if not isinstance(model_catalog, dict):
+        return requested_effort
+
+    model_info = find_opencode_model_info(model_catalog, provider_id, model_id)
+    if requested_effort:
+        if _opencode_model_supports_variant(model_info, requested_effort):
+            return requested_effort
+        if isinstance(model_info, dict):
+            return "default"
+        return requested_effort
+    if _opencode_model_has_no_variants(model_info):
+        return "default"
+    return requested_effort
+
+
 def _find_model_variants(opencode_models: dict, target_model: Optional[str]) -> Dict[str, Any]:
     target_provider, target_model_id = _parse_model_key(target_model)
     if not target_provider or not target_model_id or not isinstance(opencode_models, dict):

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -17,8 +17,9 @@ from core.message_dispatcher import ConsolidatedMessageDispatcher
 from core.processing_indicator import ProcessingIndicatorService
 from modules.agents.base import AgentRequest
 from modules.agents.service import AgentService
-from modules.agents.opencode.agent import OpenCodeAgent, resolve_opencode_reasoning_effort
+from modules.agents.opencode.agent import OpenCodeAgent
 from modules.agents.opencode.poll_loop import OpenCodePollLoop
+from modules.agents.opencode.utils import resolve_opencode_reasoning_effort
 
 
 @dataclass
@@ -1343,6 +1344,94 @@ def test_opencode_poll_emits_error_result_on_retry_exhaustion():
     assert should_emit is False
     assert ("result", True) in emitted
     assert not any(mtype == "notify" for mtype, _ in emitted)
+
+
+def test_opencode_poll_emits_error_result_on_empty_terminal_message():
+    emitted = []
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(self, context, backend, message):
+            return False
+
+    class _Formatter:
+        def format_toolcall(self, *args, **kwargs):
+            return "tool"
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def _t(self, key, **kwargs):
+            if key == "common.default":
+                return "(Default)"
+            if key == "error.opencodeEmptyResponse":
+                return "empty:{provider}/{model}/{variant}".format(**kwargs)
+            return f"translated:{key}"
+
+        async def emit_agent_message(self, context, message_type, text, parse_mode=None, *, is_error=False, level="normal"):
+            emitted.append((message_type, text, is_error))
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+        im_client = type("IM", (), {"formatter": _Formatter()})()
+
+        def _get_formatter(self, context):
+            return _Formatter()
+
+        def _to_relative_path(self, path, working_path):
+            return path
+
+        def _extract_response_text(self, message):
+            return ""
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            return [
+                {
+                    "info": {
+                        "id": "msg-empty",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "finish": "unknown",
+                        "tokens": {
+                            "input": 0,
+                            "output": 0,
+                            "reasoning": 0,
+                            "cache": {"read": 0, "write": 0},
+                        },
+                    },
+                    "parts": [
+                        {"type": "step-start", "id": "step-start"},
+                        {"type": "step-finish", "id": "step-finish"},
+                    ],
+                }
+            ]
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    loop = OpenCodePollLoop(_Agent())
+    final_text, should_emit = asyncio.run(
+        loop.run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict={"providerID": "glm", "modelID": "glm-5.2"},
+            reasoning_effort="default",
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert final_text is None
+    assert should_emit is False
+    assert emitted == [("result", "empty:glm/glm-5.2/default", True)]
 
 
 def test_processing_indicator_handle_is_source_of_truth_for_backend_cleanup():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1394,10 +1394,10 @@ def test_opencode_poll_emits_error_result_on_empty_terminal_message():
                         "time": {"completed": 1},
                         "finish": "unknown",
                         "tokens": {
-                            "input": 0,
-                            "output": 0,
-                            "reasoning": 0,
-                            "cache": {"read": 0, "write": 0},
+                            "input": 8,
+                            "output": 4,
+                            "reasoning": 2,
+                            "cache": {"read": 1, "write": 0},
                         },
                     },
                     "parts": [

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -360,6 +360,105 @@ def test_opencode_options_does_not_readd_unconfigured_user_model_provider(
     assert [p["id"] for p in providers] == ["openai"]
 
 
+def test_opencode_options_filters_catalog_provider_with_only_stale_user_model(
+    monkeypatch, tmp_path
+):
+    import config.v2_compat as v2_compat
+    import modules.agents.opencode as opencode_module
+
+    class _FakeManager:
+        async def ensure_running(self):
+            return "http://127.0.0.1:4096"
+
+        async def get_available_agents(self, directory):
+            return []
+
+        async def get_available_models(self, directory):
+            return {
+                "providers": [
+                    {"id": "openai", "models": {"gpt-5": {}}},
+                    {"id": "zai", "models": {"glm-5.2": {}}},
+                ],
+                "default": {
+                    "openai": "gpt-5",
+                    "zai": "glm-5.2",
+                },
+            }
+
+        async def get_providers(self):
+            return {
+                "all": [
+                    {"id": "openai", "name": "OpenAI"},
+                    {"id": "zai", "name": "Z.AI"},
+                ],
+                "connected": ["openai", "zai"],
+            }
+
+        async def get_default_config(self, directory):
+            return {}
+
+        async def close_http_session(self, *, loop=None):
+            pass
+
+    class _FakeServerManager:
+        @staticmethod
+        async def get_instance(**kwargs):
+            return _FakeManager()
+
+    auth_path = tmp_path / ".local" / "share" / "opencode" / "auth.json"
+    auth_path.parent.mkdir(parents=True)
+    auth_path.write_text(json.dumps({"openai": {"type": "api", "key": "sk-test"}}))
+    config_path = tmp_path / ".config" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "provider": {
+                    "zai": {
+                        "options": {"baseURL": "https://relay.example"},
+                        "models": {
+                            "glm-5.2": {
+                                "id": "glm-5.2",
+                                "name": "glm-5.2",
+                                "vibe_remote": {"user_model": True},
+                            }
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {})
+    monkeypatch.setattr(api.V2Config, "load", staticmethod(lambda: object()))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        v2_compat,
+        "to_app_config",
+        lambda config: SimpleNamespace(
+            opencode=SimpleNamespace(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=10,
+            )
+        ),
+    )
+    monkeypatch.setattr(opencode_module, "OpenCodeServerManager", _FakeServerManager)
+    monkeypatch.setattr(
+        opencode_module,
+        "build_reasoning_effort_options",
+        lambda models, model_key: [{"value": "__default__"}],
+    )
+
+    result = asyncio.run(api.opencode_options_async("/tmp/workspace"))
+
+    assert result["ok"] is True
+    providers = result["data"]["models"]["providers"]
+    assert [p["id"] for p in providers] == ["openai"]
+    assert result["data"]["models"]["default"] == {"openai": "gpt-5"}
+
+
 def test_opencode_options_preserves_models_when_provider_catalog_fails(
     monkeypatch, tmp_path
 ):

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -763,10 +763,10 @@ def test_opencode_provider_test_fails_on_empty_terminal_message(
                 "time": {"completed": 123},
                 "finish": "unknown",
                 "tokens": {
-                    "input": 0,
-                    "output": 0,
-                    "reasoning": 0,
-                    "cache": {"read": 0, "write": 0},
+                    "input": 8,
+                    "output": 4,
+                    "reasoning": 2,
+                    "cache": {"read": 1, "write": 0},
                 },
             },
             "parts": [

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -26,7 +26,10 @@ from core.agent_auth_service import (
     ClaudeOAuthBatch,
     WebAuthFlow,
 )
-from modules.agents.opencode.message_processor import extract_opencode_response_text
+from modules.agents.opencode.message_processor import (
+    extract_opencode_response_text,
+    is_empty_terminal_opencode_message,
+)
 from vibe.claude_config import (
     MANAGED_ENV_VALUES,
     clear_claude_oauth_credentials_files,
@@ -104,6 +107,26 @@ def test_opencode_message_text_extractor_ignores_non_text_by_default() -> None:
         extract_opencode_response_text(message, allow_non_text_fallback=True)
         == "internal chain-of-thought-ish content"
     )
+
+
+def test_empty_terminal_opencode_message_treats_blank_text_as_empty() -> None:
+    message = {
+        "info": {
+            "id": "msg_blank",
+            "role": "assistant",
+            "time": {"completed": 123},
+            "finish": "unknown",
+            "tokens": {
+                "input": 8,
+                "output": 4,
+                "reasoning": 2,
+                "cache": {"read": 1, "write": 0},
+            },
+        },
+        "parts": [{"type": "text", "text": " \n\t "}],
+    }
+
+    assert is_empty_terminal_opencode_message(message) is True
 
 
 def test_unsupported_backend_raises(service: AgentAuthService) -> None:

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -575,6 +575,8 @@ class _FakeOpencodeServer:
         self.messages: list[dict] = []
         self.prompt_calls: list[dict] = []
         self.abort_calls: list[tuple[str, str]] = []
+        self.active_calls: list[str] = []
+        self.inactive_calls: list[str] = []
         self.message_sent = False
 
     async def get_provider_auth(self):
@@ -592,6 +594,12 @@ class _FakeOpencodeServer:
     async def prompt_async(self, **kwargs):
         self.prompt_calls.append(kwargs)
         self.message_sent = True
+
+    async def mark_run_active(self, session_id):
+        self.active_calls.append(session_id)
+
+    async def mark_run_inactive(self, session_id):
+        self.inactive_calls.append(session_id)
 
     async def abort_session(self, session_id, directory):
         self.abort_calls.append((session_id, directory))
@@ -759,7 +767,9 @@ def test_opencode_provider_test_returns_excerpt_from_non_text_part(
         "providerID": "anthropic",
         "modelID": "claude-opus-4.8",
     }
+    assert fake.active_calls == ["sess_probe"]
     assert fake.abort_calls == [("sess_probe", os.path.expanduser("~"))]
+    assert fake.inactive_calls == ["sess_probe"]
 
 
 def test_opencode_provider_test_fails_on_empty_terminal_message(
@@ -807,7 +817,9 @@ def test_opencode_provider_test_fails_on_empty_terminal_message(
     assert result["model"] == "glm-5.2"
     assert "glm-5.2" in result["detail"]
     assert fake.prompt_calls[-1]["reasoning_effort"] == "default"
+    assert fake.active_calls == ["sess_probe"]
     assert fake.abort_calls == [("sess_probe", os.path.expanduser("~"))]
+    assert fake.inactive_calls == ["sess_probe"]
 
 
 def test_remove_web_auth_rejects_unsupported_backend(service: AgentAuthService) -> None:

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -550,7 +550,7 @@ class _FakeOpencodeServer:
         self.catalog: dict = {}
         self.created_session: dict = {"info": {"id": "sess_probe"}}
         self.messages: list[dict] = []
-        self.sent_messages: list[tuple[str, str, str, dict | None]] = []
+        self.prompt_calls: list[dict] = []
         self.abort_calls: list[tuple[str, str]] = []
         self.message_sent = False
 
@@ -566,8 +566,8 @@ class _FakeOpencodeServer:
     async def list_messages(self, _session_id, _directory):
         return self.messages if self.message_sent else []
 
-    async def send_message(self, session_id, directory, content, *, model=None):
-        self.sent_messages.append((session_id, directory, content, model))
+    async def prompt_async(self, **kwargs):
+        self.prompt_calls.append(kwargs)
         self.message_sent = True
 
     async def abort_session(self, session_id, directory):
@@ -732,10 +732,58 @@ def test_opencode_provider_test_returns_excerpt_from_non_text_part(
     assert result["ok"] is True
     assert result["model"] == "claude-opus-4.8"
     assert result["excerpt"] == "Hello from a non-text OpenCode part"
-    assert fake.sent_messages[-1][3] == {
+    assert fake.prompt_calls[-1]["model"] == {
         "providerID": "anthropic",
         "modelID": "claude-opus-4.8",
     }
+    assert fake.abort_calls == [("sess_probe", os.path.expanduser("~"))]
+
+
+def test_opencode_provider_test_fails_on_empty_terminal_message(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeOpencodeServer()
+    fake.catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "glm-5.2": {
+                        "capabilities": {"reasoning": False},
+                    }
+                },
+            }
+        ]
+    }
+    fake.messages = [
+        {
+            "info": {
+                "id": "msg_assistant",
+                "role": "assistant",
+                "time": {"completed": 123},
+                "finish": "unknown",
+                "tokens": {
+                    "input": 0,
+                    "output": 0,
+                    "reasoning": 0,
+                    "cache": {"read": 0, "write": 0},
+                },
+            },
+            "parts": [
+                {"type": "step-start", "id": "step_start"},
+                {"type": "step-finish", "id": "step_finish"},
+            ],
+        }
+    ]
+    monkeypatch.setattr(service, "_opencode_server", AsyncMock(return_value=fake))
+
+    result = _run(service.test_opencode_provider("glm", model="glm-5.2"))
+
+    assert result["ok"] is False
+    assert result["error"] == "empty_response"
+    assert result["model"] == "glm-5.2"
+    assert "glm-5.2" in result["detail"]
+    assert fake.prompt_calls[-1]["reasoning_effort"] == "default"
     assert fake.abort_calls == [("sess_probe", os.path.expanduser("~"))]
 
 

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -86,7 +86,7 @@ const SERVER_START_MAX_RETRIES = 5;
 const SERVER_START_RETRY_DELAY_MS = 3000;
 
 const FILTER_MODES: ReadonlyArray<FilterMode> = ['all', 'configured', 'oauth', 'local'];
-const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
+const REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'];
 
 const defaultReasoningEfforts = () => [...REASONING_EFFORTS];
 

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -86,12 +86,19 @@ const SERVER_START_MAX_RETRIES = 5;
 const SERVER_START_RETRY_DELAY_MS = 3000;
 
 const FILTER_MODES: ReadonlyArray<FilterMode> = ['all', 'configured', 'oauth', 'local'];
+const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+const defaultReasoningEfforts = () => [...REASONING_EFFORTS];
+
+const notifyOpenCodeModelOptionsChanged = () => {
+  window.dispatchEvent(new CustomEvent('avibe:opencode-model-options-changed'));
+};
 
 const emptyEdit = (): ProviderEditState => ({
   apiKey: '',
   baseUrl: '',
   modelId: '',
-  reasoningEfforts: [],
+  reasoningEfforts: defaultReasoningEfforts(),
   modelSaving: false,
   removingModelId: null,
   saving: false,
@@ -101,7 +108,6 @@ const emptyEdit = (): ProviderEditState => ({
   editingKey: false,
 });
 
-const REASONING_EFFORTS = ['low', 'medium', 'high', 'xhigh', 'max'];
 const CUSTOM_PROVIDER_ADAPTERS: CustomProviderAdapter[] = [
   'openai-compatible',
   'anthropic-compatible',
@@ -415,6 +421,7 @@ export const OpencodeProviderConfig: React.FC<{
       setCustomProviderDraft(emptyCustomProviderDraft());
       setShowCustomProviderForm(false);
       showToast(t('settings.backends.opencodeCustomProviderSaved'), 'success');
+      notifyOpenCodeModelOptionsChanged();
       if (!applyMutationCatalogRefresh(result)) {
         await loadProviders();
       }
@@ -449,6 +456,7 @@ export const OpencodeProviderConfig: React.FC<{
       }
       updateEdit(provider.id, { deletingProvider: false, error: null });
       showToast(t('settings.backends.opencodeCustomProviderRemoved'), 'success');
+      notifyOpenCodeModelOptionsChanged();
       if (expandedId === provider.id) setExpandedId(null);
       await loadProviders();
     } catch (e: any) {
@@ -505,6 +513,7 @@ export const OpencodeProviderConfig: React.FC<{
         error: null,
       });
       showToast(t('settings.backends.opencodeProviderSaved'), 'success');
+      notifyOpenCodeModelOptionsChanged();
       if (!applyMutationCatalogRefresh(result)) {
         await loadProviders();
       }
@@ -538,6 +547,7 @@ export const OpencodeProviderConfig: React.FC<{
       }
       updateEdit(provider.id, { removing: false, error: null });
       showToast(t('settings.backends.opencodeProviderRemoved'), 'success');
+      notifyOpenCodeModelOptionsChanged();
       await loadProviders();
     } catch (e: any) {
       updateEdit(provider.id, {
@@ -587,11 +597,12 @@ export const OpencodeProviderConfig: React.FC<{
       }
       updateEdit(provider.id, {
         modelId: '',
-        reasoningEfforts: [],
+        reasoningEfforts: defaultReasoningEfforts(),
         modelSaving: false,
         error: null,
       });
       showToast(t('settings.backends.opencodeProviderModelSaved'), 'success');
+      notifyOpenCodeModelOptionsChanged();
       await loadProviders();
     } catch (e: any) {
       updateEdit(provider.id, {
@@ -614,6 +625,7 @@ export const OpencodeProviderConfig: React.FC<{
       }
       updateEdit(provider.id, { removingModelId: null, error: null });
       showToast(t('settings.backends.opencodeProviderModelRemoved'), 'success');
+      notifyOpenCodeModelOptionsChanged();
       await loadProviders();
     } catch (e: any) {
       updateEdit(provider.id, {

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -1356,6 +1356,7 @@ export const OpencodeProviderConfig: React.FC<{
                                     subtitle={t('settings.backends.opencodeProviderOauthPanelSubtitle')}
                                     hideRemove
                                     onSuccess={() => {
+                                      notifyOpenCodeModelOptionsChanged();
                                       // Refresh the providers list so
                                       // the just-authorised provider
                                       // flips to "configured" and the

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -147,6 +147,27 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
     [agents, allowedBackendSet],
   );
 
+  useEffect(() => {
+    const clearOpenCodeModels = () => {
+      setModelsByBackend((prev) => {
+        if (!prev.opencode) return prev;
+        const next = { ...prev };
+        delete next.opencode;
+        return next;
+      });
+      setModelLabelsByBackend((prev) => {
+        if (!prev.opencode) return prev;
+        const next = { ...prev };
+        delete next.opencode;
+        return next;
+      });
+    };
+    window.addEventListener('avibe:opencode-model-options-changed', clearOpenCodeModels);
+    return () => {
+      window.removeEventListener('avibe:opencode-model-options-changed', clearOpenCodeModels);
+    };
+  }, []);
+
   const grouped = useMemo(() => {
     const groups: Record<string, VibeAgentBrief[]> = {};
     for (const agent of visibleAgents) {

--- a/ui/src/lib/backendModels.ts
+++ b/ui/src/lib/backendModels.ts
@@ -44,7 +44,7 @@ export async function fetchBackendModels(
   }
   if (backend === 'opencode') {
     const res = await api.getOpencodeProviders();
-    const models = (res.providers ?? []).flatMap((p) =>
+    const models = (res.providers ?? []).filter((p) => p.configured).flatMap((p) =>
       (p.models ?? []).map((m) => `${p.id}/${m}`),
     );
     return { models };

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5276,10 +5276,34 @@ def _merge_opencode_user_models(
 ) -> dict:
     """Overlay user-configured ``provider.<id>.models`` onto model metadata."""
 
-    if not isinstance(models, dict) or not user_model_index:
+    if not isinstance(models, dict):
         return models
     providers_raw = models.get("providers")
     if not isinstance(providers_raw, list):
+        return models
+    if allowed_provider_ids is not None:
+        filtered_providers = []
+        for provider in providers_raw:
+            if not isinstance(provider, dict):
+                continue
+            pid = _opencode_provider_id(provider)
+            if isinstance(pid, str) and pid in allowed_provider_ids:
+                filtered_providers.append(provider)
+        raw_defaults = models.get("default")
+        filtered_defaults = {}
+        if isinstance(raw_defaults, dict):
+            filtered_defaults = {
+                pid: model_id
+                for pid, model_id in raw_defaults.items()
+                if pid in allowed_provider_ids
+            }
+        models = {
+            **models,
+            "providers": filtered_providers,
+            "default": filtered_defaults,
+        }
+        providers_raw = models.get("providers", [])
+    if not user_model_index:
         return models
 
     providers = []

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -58,7 +58,8 @@
     "fileAttachmentUploadFailedWithLink": "⚠️ I could not deliver {filename} as a WeChat file. You can download it from Avibe after signing in if prompted:\n{url}",
     "fileAttachmentUploadFailedNoLink": "⚠️ I could not deliver {filename} as a WeChat file. Please ask me to resend it or use another channel.",
     "opencodeQuestionToolDisabled": "OpenCode asked an interactive question, but Avibe disables the OpenCode question tool. Please send a new follow-up message with your answer or direction.",
-    "opencodeQuestionToolDisabledRestored": "Restored OpenCode session asked an interactive question, but Avibe disables the OpenCode question tool. Please send a new follow-up message with your answer or direction."
+    "opencodeQuestionToolDisabledRestored": "Restored OpenCode session asked an interactive question, but Avibe disables the OpenCode question tool. Please send a new follow-up message with your answer or direction.",
+    "opencodeEmptyResponse": "OpenCode finished, but the provider returned no text or error. Provider: {provider}; model: {model}; reasoning: {variant}. Check that this provider/model combination supports the selected adapter, Base URL, API key, and reasoning setting."
   },
   "success": {
     "settingsUpdated": "Settings updated successfully!",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -58,7 +58,8 @@
     "fileAttachmentUploadFailedWithLink": "⚠️ {filename} 没能作为微信文件直接发送。你可以通过 Avibe 下载；如提示登录，请先登录：\n{url}",
     "fileAttachmentUploadFailedNoLink": "⚠️ {filename} 没能作为微信文件直接发送。请让我重新发送，或换一个渠道接收这个文件。",
     "opencodeQuestionToolDisabled": "OpenCode 发起了交互式提问，但 Avibe 已禁用 OpenCode 的 question 工具。请直接发送一条新消息，告诉我你的答案或下一步方向。",
-    "opencodeQuestionToolDisabledRestored": "恢复中的 OpenCode 会话发起了交互式提问，但 Avibe 已禁用 OpenCode 的 question 工具。请直接发送一条新消息，告诉我你的答案或下一步方向。"
+    "opencodeQuestionToolDisabledRestored": "恢复中的 OpenCode 会话发起了交互式提问，但 Avibe 已禁用 OpenCode 的 question 工具。请直接发送一条新消息，告诉我你的答案或下一步方向。",
+    "opencodeEmptyResponse": "OpenCode 已结束，但服务商没有返回文本或错误。Provider：{provider}；模型：{model}；推理强度：{variant}。请检查这个 provider/model 组合是否支持当前适配器、Base URL、API Key 和推理强度设置。"
   },
   "success": {
     "settingsUpdated": "设置更新成功！",


### PR DESCRIPTION
## Summary
- make OpenCode provider connectivity tests use the same `prompt_async` path as real sessions
- surface completed-but-empty OpenCode runs as a precise error instead of `(No response from OpenCode)`
- keep OpenCode selectable model lists limited to configured providers and invalidate stale UI caches after provider/key/model changes
- default manually-added OpenCode model reasoning efforts to all supported levels

## Validation
- `python3 -m ruff check core/agent_auth_service.py modules/agents/opencode/agent.py modules/agents/opencode/message_processor.py modules/agents/opencode/poll_loop.py modules/agents/opencode/utils.py vibe/api.py tests/test_ui_api.py tests/test_web_oauth_flow.py tests/test_multi_platform_runtime.py`
- `python3 -m pytest tests/test_ui_api.py tests/test_web_oauth_flow.py tests/test_multi_platform_runtime.py tests/test_save_opencode_provider_auth.py tests/test_opencode_provider_base_url.py`
- `npm run build` in `ui/`

## Evidence layers
- Unit: OpenCode options filtering, auth probe empty response, poll-loop empty response
- Contract: provider catalog/options filtering and provider model/auth persistence tests
- Scenario: regression symptom path covered by prompt_async probe parity and configured-provider-only model lists
- Manual residual checks: read regression `/api/opencode/options` and provider catalog state without mutating it
