### PR TITLE
fix(opencode): surface provider failures as notifications

### DIFF
--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -23,6 +23,7 @@ class ActivePollInfo:
     seen_tool_calls: List[str] = field(default_factory=list)
     emitted_assistant_messages: List[str] = field(default_factory=list)
     started_at: float = 0.0
+    prompt_started_at: Optional[float] = None
     # Ack reaction info for cleanup on restore
     ack_reaction_message_id: Optional[str] = None
     ack_reaction_emoji: Optional[str] = None
@@ -46,6 +47,7 @@ class ActivePollInfo:
             "seen_tool_calls": self.seen_tool_calls,
             "emitted_assistant_messages": self.emitted_assistant_messages,
             "started_at": self.started_at,
+            "prompt_started_at": self.prompt_started_at,
             "ack_reaction_message_id": self.ack_reaction_message_id,
             "ack_reaction_emoji": self.ack_reaction_emoji,
             "typing_indicator_active": self.typing_indicator_active,
@@ -80,6 +82,7 @@ class ActivePollInfo:
             seen_tool_calls=data.get("seen_tool_calls", []),
             emitted_assistant_messages=data.get("emitted_assistant_messages", []),
             started_at=data.get("started_at", 0.0),
+            prompt_started_at=data.get("prompt_started_at"),
             ack_reaction_message_id=data.get("ack_reaction_message_id"),
             ack_reaction_emoji=data.get("ack_reaction_emoji"),
             typing_indicator_active=bool(data.get("typing_indicator_active", False)),

--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -9,6 +9,13 @@ from config import paths
 logger = logging.getLogger(__name__)
 
 
+def _optional_str_dict(value: Any) -> Optional[Dict[str, str]]:
+    if not isinstance(value, dict):
+        return None
+    out = {str(key): str(item) for key, item in value.items() if isinstance(key, str) and isinstance(item, str)}
+    return out or None
+
+
 @dataclass
 class ActivePollInfo:
     """Information about an active poll that needs to be restored on restart."""
@@ -24,6 +31,8 @@ class ActivePollInfo:
     emitted_assistant_messages: List[str] = field(default_factory=list)
     started_at: float = 0.0
     prompt_started_at: Optional[float] = None
+    model_dict: Optional[Dict[str, str]] = None
+    reasoning_effort: Optional[str] = None
     # Ack reaction info for cleanup on restore
     ack_reaction_message_id: Optional[str] = None
     ack_reaction_emoji: Optional[str] = None
@@ -48,6 +57,8 @@ class ActivePollInfo:
             "emitted_assistant_messages": self.emitted_assistant_messages,
             "started_at": self.started_at,
             "prompt_started_at": self.prompt_started_at,
+            "model_dict": self.model_dict,
+            "reasoning_effort": self.reasoning_effort,
             "ack_reaction_message_id": self.ack_reaction_message_id,
             "ack_reaction_emoji": self.ack_reaction_emoji,
             "typing_indicator_active": self.typing_indicator_active,
@@ -83,6 +94,8 @@ class ActivePollInfo:
             emitted_assistant_messages=data.get("emitted_assistant_messages", []),
             started_at=data.get("started_at", 0.0),
             prompt_started_at=data.get("prompt_started_at"),
+            model_dict=_optional_str_dict(data.get("model_dict")),
+            reasoning_effort=data.get("reasoning_effort") if isinstance(data.get("reasoning_effort"), str) else None,
             ack_reaction_message_id=data.get("ack_reaction_message_id"),
             ack_reaction_emoji=data.get("ack_reaction_emoji"),
             typing_indicator_active=bool(data.get("typing_indicator_active", False)),

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2344,6 +2344,7 @@ class AgentAuthService:
             )
 
             try:
+                prompt_started_at = time.time()
                 await server.prompt_async(
                     session_id=session_id,
                     directory=directory,
@@ -2411,9 +2412,14 @@ class AgentAuthService:
                         lang = self._lang()
                         detail = None
                         try:
-                            detail = await server.get_recent_session_error(session_id)
+                            detail = await server.get_recent_session_error(session_id, since=prompt_started_at)
                         except Exception:  # noqa: BLE001
                             detail = None
+                        if not detail:
+                            try:
+                                detail = await server.get_provider_api_diagnostic(provider_id, chosen_model)
+                            except Exception:  # noqa: BLE001
+                                detail = None
                         i18n_key = (
                             "error.opencodeProviderRuntimeError"
                             if detail

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2409,15 +2409,26 @@ class AgentAuthService:
                     )
                     if not final_text and is_empty_terminal_opencode_message(terminal):
                         lang = self._lang()
+                        detail = None
+                        try:
+                            detail = await server.get_recent_session_error(session_id)
+                        except Exception:  # noqa: BLE001
+                            detail = None
+                        i18n_key = (
+                            "error.opencodeProviderRuntimeError"
+                            if detail
+                            else "error.opencodeEmptyResponse"
+                        )
                         return {
                             "ok": False,
                             "error": "empty_response",
                             "detail": i18n_t(
-                                "error.opencodeEmptyResponse",
+                                i18n_key,
                                 lang,
                                 provider=provider_id,
                                 model=chosen_model,
                                 variant=reasoning_effort or i18n_t("common.default", lang),
+                                detail=detail or "",
                             ),
                             "duration_ms": int((time.monotonic() - started) * 1000),
                             "model": chosen_model,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -25,7 +25,7 @@ from modules.agents.opencode.message_processor import (
     extract_opencode_response_text,
     is_empty_terminal_opencode_message,
 )
-from modules.agents.opencode.utils import resolve_opencode_reasoning_effort
+from modules.agents.opencode.utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
 from modules.im import InlineButton, InlineKeyboard, MessageContext
 from vibe.i18n import t as i18n_t
 from vibe.opencode_config import remove_opencode_provider_api_key
@@ -2337,6 +2337,11 @@ class AgentAuthService:
             except Exception:  # noqa: BLE001
                 catalog = None
             model_dict = {"providerID": provider_id, "modelID": chosen_model}
+            if isinstance(catalog, dict):
+                resolved_model_id = resolve_opencode_model_id(catalog, provider_id, chosen_model)
+                if resolved_model_id:
+                    chosen_model = resolved_model_id
+                    model_dict["modelID"] = resolved_model_id
             reasoning_effort = resolve_opencode_reasoning_effort(
                 model_dict,
                 None,
@@ -2349,7 +2354,7 @@ class AgentAuthService:
                     session_id=session_id,
                     directory=directory,
                     text="Hi",
-                    model={"providerID": provider_id, "modelID": chosen_model},
+                    model=model_dict,
                     reasoning_effort=reasoning_effort,
                     tools={"question": False},
                 )

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -365,6 +365,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 user_id=request.context.user_id or "",
                 platform=request.context.platform or platform_payload.get("platform") or "",
                 prompt_started_at=prompt_started_at,
+                model_dict=model_dict,
+                reasoning_effort=reasoning_effort,
             )
 
             final_text, should_emit = await self._poll_loop.run_prompt_poll(

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -321,6 +321,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 system=system_prompt_injection,
                 tools={"question": False},
             )
+            get_started_at = getattr(server, "get_last_prompt_started_at", None)
+            prompt_started_at = get_started_at(session_id) if callable(get_started_at) else None
             await server.mark_run_active(session_id)
             run_registered = True
             self.mark_runtime_turn_started(request.context)
@@ -355,6 +357,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 processing_indicator=self.controller.processing_indicator.snapshot_request(request),
                 user_id=request.context.user_id or "",
                 platform=request.context.platform or platform_payload.get("platform") or "",
+                prompt_started_at=prompt_started_at,
             )
 
             final_text, should_emit = await self._poll_loop.run_prompt_poll(

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -22,7 +22,7 @@ from .message_processor import OpenCodeMessageProcessorMixin
 from .poll_loop import OpenCodePollLoop
 from .server import OpenCodeServerManager
 from .session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
-from .utils import resolve_opencode_reasoning_effort
+from .utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
 
 logger = logging.getLogger(__name__)
 
@@ -269,6 +269,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if model_dict:
                 try:
                     model_catalog = await server.get_available_models(request.working_path)
+                    resolved_model_id = resolve_opencode_model_id(
+                        model_catalog,
+                        model_dict.get("providerID"),
+                        model_dict.get("modelID"),
+                    )
+                    if resolved_model_id and resolved_model_id != model_dict.get("modelID"):
+                        model_dict = {**model_dict, "modelID": resolved_model_id}
                     reasoning_effort = resolve_opencode_reasoning_effort(
                         model_dict,
                         reasoning_effort,

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -611,8 +611,8 @@ class OpenCodePollLoop:
                                         context=context,
                                         server=server,
                                         session_id=session_id,
-                                        model_dict=None,
-                                        reasoning_effort=None,
+                                        model_dict=getattr(poll_info, "model_dict", None),
+                                        reasoning_effort=getattr(poll_info, "reasoning_effort", None),
                                         prompt_started_at=prompt_started_at,
                                     )
                                     self._agent.sessions.remove_active_poll(session_id)

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -75,9 +75,18 @@ class OpenCodePollLoop:
         self,
         server: OpenCodeServerManager,
         session_id: str,
+        model_dict: Optional[Dict[str, str]] = None,
+        *,
+        since: Optional[float] = None,
     ) -> Optional[str]:
         try:
-            return await server.get_recent_session_error(session_id)
+            detail = await server.get_recent_session_error(session_id, since=since)
+            if detail:
+                return detail
+            provider_id = (model_dict or {}).get("providerID")
+            model_id = (model_dict or {}).get("modelID")
+            if provider_id and model_id:
+                return await server.get_provider_api_diagnostic(provider_id, model_id)
         except Exception as err:
             logger.debug("Failed to inspect OpenCode logs for %s: %s", session_id, err)
         return None
@@ -90,8 +99,14 @@ class OpenCodePollLoop:
         session_id: str,
         model_dict: Optional[Dict[str, str]],
         reasoning_effort: Optional[str],
+        prompt_started_at: Optional[float] = None,
     ) -> None:
-        detail = await self._empty_terminal_message_detail(server, session_id)
+        detail = await self._empty_terminal_message_detail(
+            server,
+            session_id,
+            model_dict=model_dict,
+            since=prompt_started_at,
+        )
         message = self._empty_terminal_message_text(
             model_dict=model_dict,
             reasoning_effort=reasoning_effort,
@@ -105,7 +120,7 @@ class OpenCodePollLoop:
         await self._agent.controller.emit_agent_message(
             context,
             "result",
-            "",
+            message,
             is_error=True,
             level="silent",
         )
@@ -195,6 +210,8 @@ class OpenCodePollLoop:
         emitted_assistant_messages: set[str] = set()
         poll_interval_seconds = 2.0
         final_text: Optional[str] = None
+        get_started_at = getattr(server, "get_last_prompt_started_at", None)
+        prompt_started_at = get_started_at(session_id) if callable(get_started_at) else None
 
         error_retry_count = 0
         error_retry_limit = getattr(
@@ -400,6 +417,7 @@ class OpenCodePollLoop:
                                 session_id=session_id,
                                 model_dict=model_dict,
                                 reasoning_effort=reasoning_effort,
+                                prompt_started_at=prompt_started_at,
                             )
                             return None, False
                         break
@@ -426,6 +444,10 @@ class OpenCodePollLoop:
         emitted_assistant_messages = set(poll_info.emitted_assistant_messages)
         poll_interval_seconds = 2.0
         final_text: Optional[str] = None
+        get_started_at = getattr(server, "get_last_prompt_started_at", None)
+        prompt_started_at = getattr(poll_info, "prompt_started_at", None) or (
+            get_started_at(session_id) if callable(get_started_at) else None
+        )
 
         error_retry_count = 0
         error_retry_limit = getattr(
@@ -591,6 +613,7 @@ class OpenCodePollLoop:
                                         session_id=session_id,
                                         model_dict=None,
                                         reasoning_effort=None,
+                                        prompt_started_at=prompt_started_at,
                                     )
                                     self._agent.sessions.remove_active_poll(session_id)
                                     await self.remove_restored_ack(poll_info)

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -51,15 +51,63 @@ class OpenCodePollLoop:
         *,
         model_dict: Optional[Dict[str, str]],
         reasoning_effort: Optional[str],
+        detail: Optional[str] = None,
     ) -> str:
         provider_id = (model_dict or {}).get("providerID") or self._t("common.default")
         model_id = (model_dict or {}).get("modelID") or self._t("common.default")
         variant = reasoning_effort or self._t("common.default")
+        if detail:
+            return self._t(
+                "error.opencodeProviderRuntimeError",
+                provider=provider_id,
+                model=model_id,
+                variant=variant,
+                detail=detail,
+            )
         return self._t(
             "error.opencodeEmptyResponse",
             provider=provider_id,
             model=model_id,
             variant=variant,
+        )
+
+    async def _empty_terminal_message_detail(
+        self,
+        server: OpenCodeServerManager,
+        session_id: str,
+    ) -> Optional[str]:
+        try:
+            return await server.get_recent_session_error(session_id)
+        except Exception as err:
+            logger.debug("Failed to inspect OpenCode logs for %s: %s", session_id, err)
+        return None
+
+    async def _emit_empty_terminal_failure(
+        self,
+        *,
+        context,
+        server: OpenCodeServerManager,
+        session_id: str,
+        model_dict: Optional[Dict[str, str]],
+        reasoning_effort: Optional[str],
+    ) -> None:
+        detail = await self._empty_terminal_message_detail(server, session_id)
+        message = self._empty_terminal_message_text(
+            model_dict=model_dict,
+            reasoning_effort=reasoning_effort,
+            detail=detail,
+        )
+        await self._agent.controller.emit_agent_message(
+            context,
+            "notify",
+            message,
+        )
+        await self._agent.controller.emit_agent_message(
+            context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
         )
 
     def _build_restored_ack_request(self, poll_info) -> AgentRequest:
@@ -339,10 +387,6 @@ class OpenCodePollLoop:
                                 emitted_message_ids=emitted_assistant_messages,
                             )
                         if not final_text and not msg_error and is_empty_terminal_opencode_message(last_message):
-                            message = self._empty_terminal_message_text(
-                                model_dict=model_dict,
-                                reasoning_effort=reasoning_effort,
-                            )
                             logger.warning(
                                 "OpenCode session %s completed without text/error (provider=%s model=%s variant=%s)",
                                 session_id,
@@ -350,11 +394,12 @@ class OpenCodePollLoop:
                                 (model_dict or {}).get("modelID"),
                                 reasoning_effort,
                             )
-                            await self._agent.controller.emit_agent_message(
-                                request.context,
-                                "result",
-                                message,
-                                is_error=True,
+                            await self._emit_empty_terminal_failure(
+                                context=request.context,
+                                server=server,
+                                session_id=session_id,
+                                model_dict=model_dict,
+                                reasoning_effort=reasoning_effort,
                             )
                             return None, False
                         break
@@ -536,19 +581,16 @@ class OpenCodePollLoop:
                                         emitted_message_ids=emitted_assistant_messages,
                                     )
                                 if not final_text and not msg_error and is_empty_terminal_opencode_message(last_message):
-                                    message = self._empty_terminal_message_text(
-                                        model_dict=None,
-                                        reasoning_effort=None,
-                                    )
                                     logger.warning(
                                         "Restored OpenCode session %s completed without text/error",
                                         session_id,
                                     )
-                                    await self._agent.controller.emit_agent_message(
-                                        context,
-                                        "result",
-                                        message,
-                                        is_error=True,
+                                    await self._emit_empty_terminal_failure(
+                                        context=context,
+                                        server=server,
+                                        session_id=session_id,
+                                        model_dict=None,
+                                        reasoning_effort=None,
                                     )
                                     self._agent.sessions.remove_active_poll(session_id)
                                     await self.remove_restored_ack(poll_info)

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from datetime import datetime
 import json
 import logging
 import os
@@ -11,7 +12,9 @@ from pathlib import Path
 import socket
 import subprocess
 import time
+import urllib.error
 import urllib.parse
+import urllib.request
 import threading
 from asyncio.subprocess import Process
 from typing import Any, Dict, List, Optional
@@ -22,7 +25,11 @@ from config import paths
 from core.process_isolation import isolated_subprocess_kwargs, terminate_process_tree
 from modules.agents.opencode.config_reconciler import OpenCodeConfigReconciler
 from vibe import runtime
-from vibe.opencode_config import load_first_opencode_user_config, read_opencode_provider_auth_entries
+from vibe.opencode_config import (
+    get_opencode_custom_provider_adapter,
+    load_first_opencode_user_config,
+    read_opencode_provider_auth_entries,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +76,7 @@ class OpenCodeServerManager:
         self._auth_refresh_pending = False
         self._auth_refresh_pending_port: Optional[int] = None
         self._pending_runtime_config: Optional[tuple[str, int, int]] = None
+        self._last_prompt_started_at: dict[str, float] = {}
 
     def _get_lock(self) -> asyncio.Lock:
         """Get or create an asyncio.Lock bound to the current event loop."""
@@ -395,12 +403,29 @@ class OpenCodeServerManager:
     def _safe_url(raw: object) -> str:
         if not isinstance(raw, str) or not raw.strip():
             return ""
-        parsed = urllib.parse.urlsplit(raw.strip())
+        value = raw.strip()
+        parsed = urllib.parse.urlsplit(value)
         if not parsed.scheme or not parsed.netloc:
-            return raw.strip()[:160]
+            # Relative provider paths may still carry query credentials, e.g.
+            # /messages?api_key=...; keep only the path.
+            return urllib.parse.urlunsplit(("", "", parsed.path or value.split("?", 1)[0].split("#", 1)[0], "", ""))[
+                :160
+            ]
         host = parsed.hostname or parsed.netloc
         port = f":{parsed.port}" if parsed.port else ""
         return urllib.parse.urlunsplit((parsed.scheme, f"{host}{port}", parsed.path or "", "", ""))[:160]
+
+    @staticmethod
+    def _log_line_timestamp(line: str) -> Optional[float]:
+        marker = "ERROR "
+        index = line.find(marker)
+        if index < 0:
+            return None
+        raw = line[index + len(marker) : index + len(marker) + 19]
+        try:
+            return datetime.strptime(raw, "%Y-%m-%dT%H:%M:%S").timestamp()
+        except ValueError:
+            return None
 
     @classmethod
     def _summarize_log_error_payload(cls, payload: object) -> Optional[str]:
@@ -441,7 +466,7 @@ class OpenCodeServerManager:
         candidates.append(Path.home() / "Library" / "Application Support" / "opencode" / "log")
         return candidates
 
-    def _recent_session_error_sync(self, session_id: str) -> Optional[str]:
+    def _recent_session_error_sync(self, session_id: str, since: Optional[float] = None) -> Optional[str]:
         if not session_id:
             return None
         log_files: list[Path] = []
@@ -459,6 +484,10 @@ class OpenCodeServerManager:
             for line in reversed(text.splitlines()):
                 if "ERROR" not in line or f"session.id={session_id}" not in line or "error=" not in line:
                     continue
+                if since is not None:
+                    log_ts = self._log_line_timestamp(line)
+                    if log_ts is None or log_ts < since - 2:
+                        continue
                 start = line.find("error={")
                 if start < 0:
                     continue
@@ -474,8 +503,124 @@ class OpenCodeServerManager:
                     return summary
         return None
 
-    async def get_recent_session_error(self, session_id: str) -> Optional[str]:
-        return await asyncio.to_thread(self._recent_session_error_sync, session_id)
+    def get_last_prompt_started_at(self, session_id: str) -> Optional[float]:
+        return self._last_prompt_started_at.get(session_id)
+
+    async def get_recent_session_error(self, session_id: str, since: Optional[float] = None) -> Optional[str]:
+        if since is None:
+            since = self.get_last_prompt_started_at(session_id)
+        return await asyncio.to_thread(self._recent_session_error_sync, session_id, since)
+
+    @staticmethod
+    def _diagnostic_payload_message(payload: object) -> str:
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                message = error.get("message")
+                if isinstance(message, str) and message.strip():
+                    return message.strip()[:240]
+            message = payload.get("message")
+            if isinstance(message, str) and message.strip():
+                return message.strip()[:240]
+        return ""
+
+    @staticmethod
+    def _append_provider_endpoint(base_url: str, endpoint_path: str) -> str:
+        return f"{base_url.rstrip('/')}/{endpoint_path.lstrip('/')}"
+
+    @classmethod
+    def _suggest_api_base_url(cls, base_url: str) -> str:
+        parsed = urllib.parse.urlsplit(base_url.rstrip("/"))
+        if parsed.path.rstrip("/").endswith("/v1"):
+            return cls._safe_url(base_url)
+        path = (parsed.path.rstrip("/") + "/v1") if parsed.path else "/v1"
+        return cls._safe_url(urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", "")))
+
+    def _provider_api_diagnostic_sync(self, provider_id: str, model_id: str) -> Optional[str]:
+        probe = load_first_opencode_user_config(logger_instance=logger)
+        config = probe.config
+        if not isinstance(config, dict):
+            return None
+        provider_map = config.get("provider")
+        if not isinstance(provider_map, dict):
+            return None
+        provider_config = provider_map.get(provider_id)
+        if not isinstance(provider_config, dict):
+            return None
+        options = provider_config.get("options")
+        if not isinstance(options, dict):
+            return None
+        base_url = options.get("baseURL")
+        api_key = options.get("apiKey")
+        if not isinstance(base_url, str) or not base_url.strip() or not isinstance(api_key, str) or not api_key:
+            return None
+
+        base_url = base_url.rstrip("/")
+        adapter = get_opencode_custom_provider_adapter(provider_id, provider_config)
+        if adapter == "anthropic-compatible":
+            endpoint_path = "/messages"
+            headers = {
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            }
+            body = {
+                "model": model_id,
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "OK"}],
+            }
+        else:
+            endpoint_path = "/chat/completions"
+            headers = {
+                "authorization": f"Bearer {api_key}",
+                "content-type": "application/json",
+            }
+            body = {
+                "model": model_id,
+                "messages": [{"role": "user", "content": "OK"}],
+                "stream": False,
+            }
+
+        try:
+            request = urllib.request.Request(
+                self._append_provider_endpoint(base_url, endpoint_path),
+                data=json.dumps(body).encode("utf-8"),
+                method="POST",
+            )
+            for key, value in headers.items():
+                request.add_header(key, value)
+            try:
+                with urllib.request.urlopen(request, timeout=12) as response:
+                    content_type = response.headers.get("content-type", "")
+                    raw = response.read(2048).decode(errors="replace")
+                    if "text/html" in content_type.lower() or raw.lstrip().lower().startswith("<!doctype html"):
+                        return (
+                            f"Provider Base URL {self._safe_url(base_url)} returned an HTML page instead of an API "
+                            f"response; use the API base path, usually {self._suggest_api_base_url(base_url)}."
+                        )
+                    return None
+            except urllib.error.HTTPError as err:
+                content_type = err.headers.get("content-type", "")
+                raw = err.read(2048).decode(errors="replace")
+                if "text/html" in content_type.lower() or raw.lstrip().lower().startswith("<!doctype html"):
+                    return (
+                        f"Provider Base URL {self._safe_url(base_url)} returned an HTML page instead of an API "
+                        f"response; use the API base path, usually {self._suggest_api_base_url(base_url)}."
+                    )
+                try:
+                    payload = json.loads(raw)
+                except Exception:
+                    payload = {}
+                message = self._diagnostic_payload_message(payload)
+                if message:
+                    return f"Provider API returned HTTP {err.code}: {message}"
+                return f"Provider API returned HTTP {err.code}."
+        except Exception as err:
+            logger.debug("OpenCode provider API diagnostic failed for %s/%s: %s", provider_id, model_id, err)
+        return None
+
+    async def get_provider_api_diagnostic(self, provider_id: str, model_id: str) -> Optional[str]:
+        return await asyncio.to_thread(self._provider_api_diagnostic_sync, provider_id, model_id)
 
     @staticmethod
     def _pid_exists(pid: int) -> bool:
@@ -923,6 +1068,7 @@ class OpenCodeServerManager:
     ) -> None:
         """Start a prompt asynchronously without holding the HTTP request open."""
 
+        started_at = time.time()
         async with self._request_scope():
             session = await self._get_http_session()
 
@@ -950,6 +1096,7 @@ class OpenCodeServerManager:
                 if resp.status not in (200, 204):
                     error_text = await resp.text()
                     raise RuntimeError(f"Failed to start async prompt: {resp.status} {error_text}")
+            self._last_prompt_started_at[session_id] = started_at
 
     async def list_messages(self, session_id: str, directory: str) -> List[Dict[str, Any]]:
         async with self._request_scope():

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 import json
 import logging
 import os
+from pathlib import Path
 import socket
 import subprocess
 import time
@@ -142,6 +143,13 @@ class OpenCodeServerManager:
         if self._base_url:
             return self._base_url
         return f"http://{self.host}:{self.port}"
+
+    @staticmethod
+    def _normalize_variant(reasoning_effort: Optional[str]) -> Optional[str]:
+        normalized = (reasoning_effort or "").strip()
+        if not normalized or normalized in {"default", "__default__"}:
+            return None
+        return normalized
 
     async def _get_http_session(self) -> aiohttp.ClientSession:
         current_loop = asyncio.get_running_loop()
@@ -355,6 +363,119 @@ class OpenCodeServerManager:
                 self._pid_file.unlink()
         except Exception as e:
             logger.debug(f"Failed to clear OpenCode pid file: {e}")
+
+    @staticmethod
+    def _extract_json_object(text: str, start: int) -> Optional[str]:
+        if start < 0 or start >= len(text) or text[start] != "{":
+            return None
+        depth = 0
+        in_string = False
+        escaped = False
+        for index in range(start, len(text)):
+            char = text[index]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : index + 1]
+        return None
+
+    @staticmethod
+    def _safe_url(raw: object) -> str:
+        if not isinstance(raw, str) or not raw.strip():
+            return ""
+        parsed = urllib.parse.urlsplit(raw.strip())
+        if not parsed.scheme or not parsed.netloc:
+            return raw.strip()[:160]
+        host = parsed.hostname or parsed.netloc
+        port = f":{parsed.port}" if parsed.port else ""
+        return urllib.parse.urlunsplit((parsed.scheme, f"{host}{port}", parsed.path or "", "", ""))[:160]
+
+    @classmethod
+    def _summarize_log_error_payload(cls, payload: object) -> Optional[str]:
+        if not isinstance(payload, dict):
+            return None
+        error = payload.get("error")
+        if not isinstance(error, dict):
+            error = payload
+
+        name = str(error.get("name") or "OpenCode provider error").strip()
+        cause = error.get("cause") if isinstance(error.get("cause"), dict) else {}
+        code = str(cause.get("code") or error.get("code") or "").strip()
+        url = cls._safe_url(error.get("url") or cause.get("path"))
+
+        message = ""
+        data = error.get("data")
+        if isinstance(data, dict):
+            message = str(data.get("message") or "").strip()
+        if not message:
+            message = str(error.get("message") or "").strip()
+
+        details = name
+        if code:
+            details += f" ({code})"
+        if url:
+            details += f" while calling {url}"
+        if message and message not in details:
+            details += f": {message[:200]}"
+        return details[:500]
+
+    @staticmethod
+    def _opencode_log_dirs() -> list[Path]:
+        candidates: list[Path] = []
+        data_home = os.environ.get("XDG_DATA_HOME")
+        if data_home:
+            candidates.append(Path(data_home).expanduser() / "opencode" / "log")
+        candidates.append(Path.home() / ".local" / "share" / "opencode" / "log")
+        candidates.append(Path.home() / "Library" / "Application Support" / "opencode" / "log")
+        return candidates
+
+    def _recent_session_error_sync(self, session_id: str) -> Optional[str]:
+        if not session_id:
+            return None
+        log_files: list[Path] = []
+        for directory in self._opencode_log_dirs():
+            try:
+                if directory.is_dir():
+                    log_files.extend(path for path in directory.glob("*.log") if path.is_file())
+            except Exception:
+                continue
+        for path in sorted(log_files, key=lambda item: item.stat().st_mtime, reverse=True)[:3]:
+            try:
+                text = path.read_text(errors="replace")[-2_000_000:]
+            except Exception:
+                continue
+            for line in reversed(text.splitlines()):
+                if "ERROR" not in line or f"session.id={session_id}" not in line or "error=" not in line:
+                    continue
+                start = line.find("error={")
+                if start < 0:
+                    continue
+                blob = self._extract_json_object(line, start + len("error="))
+                if not blob:
+                    continue
+                try:
+                    payload = json.loads(blob)
+                except Exception:
+                    continue
+                summary = self._summarize_log_error_payload(payload)
+                if summary:
+                    return summary
+        return None
+
+    async def get_recent_session_error(self, session_id: str) -> Optional[str]:
+        return await asyncio.to_thread(self._recent_session_error_sync, session_id)
 
     @staticmethod
     def _pid_exists(pid: int) -> bool:
@@ -775,8 +896,9 @@ class OpenCodeServerManager:
                 body["agent"] = agent
             if model:
                 body["model"] = model
-            if reasoning_effort:
-                body["variant"] = reasoning_effort
+            variant = self._normalize_variant(reasoning_effort)
+            if variant:
+                body["variant"] = variant
 
             async with session.post(
                 f"{self.base_url}/session/{session_id}/message",
@@ -811,8 +933,9 @@ class OpenCodeServerManager:
                 body["agent"] = agent
             if model:
                 body["model"] = model
-            if reasoning_effort:
-                body["variant"] = reasoning_effort
+            variant = self._normalize_variant(reasoning_effort)
+            if variant:
+                body["variant"] = variant
             if system:
                 body["system"] = system
             if tools:

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -528,7 +528,7 @@ class OpenCodeServerManager:
                     continue
                 if since is not None:
                     log_ts = self._log_line_timestamp(line)
-                    if log_ts is None or log_ts < since - 2:
+                    if log_ts is None or log_ts < since:
                         continue
                 start = line.find("error={")
                 if start < 0:

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -528,7 +528,7 @@ class OpenCodeServerManager:
                     continue
                 if since is not None:
                     log_ts = self._log_line_timestamp(line)
-                    if log_ts is None or log_ts < since:
+                    if log_ts is None or log_ts < int(since):
                         continue
                 start = line.find("error={")
                 if start < 0:
@@ -591,6 +591,18 @@ class OpenCodeServerManager:
         path = (parsed.path.rstrip("/") + "/v1") if parsed.path else "/v1"
         return cls._safe_url(urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", "")))
 
+    @staticmethod
+    def _diagnostic_adapter(provider_id: str, provider_config: Dict[str, Any]) -> Optional[str]:
+        adapter = get_opencode_custom_provider_adapter(provider_id, provider_config)
+        if adapter in {"anthropic-compatible", "openai-compatible"}:
+            return adapter
+        npm = provider_config.get("npm")
+        if provider_id == "anthropic" or npm == "@ai-sdk/anthropic":
+            return "anthropic-compatible"
+        if provider_id == "openai" or npm == "@ai-sdk/openai-compatible":
+            return "openai-compatible"
+        return None
+
     def _provider_api_diagnostic_sync(self, provider_id: str, model_id: str) -> Optional[str]:
         probe = load_first_opencode_user_config(logger_instance=logger)
         config = probe.config
@@ -613,13 +625,8 @@ class OpenCodeServerManager:
             return None
 
         base_url = base_url.rstrip("/")
-        adapter = get_opencode_custom_provider_adapter(provider_id, provider_config)
-        is_anthropic_compatible = (
-            adapter == "anthropic-compatible"
-            or provider_id == "anthropic"
-            or provider_config.get("npm") == "@ai-sdk/anthropic"
-        )
-        if is_anthropic_compatible:
+        adapter = self._diagnostic_adapter(provider_id, provider_config)
+        if adapter == "anthropic-compatible":
             endpoint_path = "/messages"
             headers = {
                 "x-api-key": api_key,
@@ -631,7 +638,7 @@ class OpenCodeServerManager:
                 "max_tokens": 8,
                 "messages": [{"role": "user", "content": "OK"}],
             }
-        else:
+        elif adapter == "openai-compatible":
             endpoint_path = "/chat/completions"
             headers = {
                 "authorization": f"Bearer {api_key}",
@@ -642,6 +649,8 @@ class OpenCodeServerManager:
                 "messages": [{"role": "user", "content": "OK"}],
                 "stream": False,
             }
+        else:
+            return None
 
         try:
             request = urllib.request.Request(
@@ -677,6 +686,12 @@ class OpenCodeServerManager:
                 if message:
                     return f"Provider API returned HTTP {err.code}: {message}"
                 return f"Provider API returned HTTP {err.code}."
+            except urllib.error.URLError as err:
+                reason = self._redact_diagnostic_text(str(err.reason or err))
+                return f"Provider API request failed: {reason[:240]}"
+            except (TimeoutError, OSError) as err:
+                reason = self._redact_diagnostic_text(str(err))
+                return f"Provider API request failed: {reason[:240] or type(err).__name__}"
         except Exception as err:
             logger.debug("OpenCode provider API diagnostic failed for %s/%s: %s", provider_id, model_id, err)
         return None

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import socket
 import subprocess
 import time
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_OPENCODE_PORT = 4096
 DEFAULT_OPENCODE_HOST = "127.0.0.1"
 SERVER_START_TIMEOUT = 15
+OPENCODE_LOG_TAIL_BYTES = 2_000_000
 
 
 class OpenCodeServerManager:
@@ -416,6 +418,32 @@ class OpenCodeServerManager:
         return urllib.parse.urlunsplit((parsed.scheme, f"{host}{port}", parsed.path or "", "", ""))[:160]
 
     @staticmethod
+    def _redact_diagnostic_text(text: str) -> str:
+        if not text:
+            return ""
+        def _redact_url_query(match: re.Match[str]) -> str:
+            value = match.group(0)
+            parsed = urllib.parse.urlsplit(value)
+            if not parsed.scheme or not parsed.netloc:
+                return value
+            return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+        redacted = re.sub(r"https?://[^\s,)>\]}]+", _redact_url_query, text)
+        redacted = re.sub(
+            r"(?i)\b(authorization)(\s*[:=]\s*)Bearer\s+[A-Za-z0-9._~+/=-]+",
+            r"\1\2Bearer [redacted]",
+            redacted,
+        )
+        redacted = re.sub(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+", "Bearer [redacted]", redacted)
+        redacted = re.sub(r"\bsk-[A-Za-z0-9._-]+", "[redacted]", redacted)
+        return re.sub(
+            r"(?i)\b(api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|x-api-key)"
+            r"(\s*[:=]\s*)([^\s,;&]+)",
+            r"\1\2[redacted]",
+            redacted,
+        )
+
+    @staticmethod
     def _log_line_timestamp(line: str) -> Optional[float]:
         marker = "ERROR "
         index = line.find(marker)
@@ -446,6 +474,7 @@ class OpenCodeServerManager:
             message = str(data.get("message") or "").strip()
         if not message:
             message = str(error.get("message") or "").strip()
+        message = cls._redact_diagnostic_text(message)
 
         details = name
         if code:
@@ -466,6 +495,20 @@ class OpenCodeServerManager:
         candidates.append(Path.home() / "Library" / "Application Support" / "opencode" / "log")
         return candidates
 
+    @staticmethod
+    def _read_text_tail(path: Path, max_bytes: int = OPENCODE_LOG_TAIL_BYTES) -> str:
+        try:
+            with path.open("rb") as handle:
+                handle.seek(0, os.SEEK_END)
+                size = handle.tell()
+                offset = max(0, size - max_bytes)
+                handle.seek(offset)
+                if offset > 0:
+                    handle.readline()
+                return handle.read(max_bytes).decode(errors="replace")
+        except Exception:
+            return ""
+
     def _recent_session_error_sync(self, session_id: str, since: Optional[float] = None) -> Optional[str]:
         if not session_id:
             return None
@@ -477,9 +520,8 @@ class OpenCodeServerManager:
             except Exception:
                 continue
         for path in sorted(log_files, key=lambda item: item.stat().st_mtime, reverse=True)[:3]:
-            try:
-                text = path.read_text(errors="replace")[-2_000_000:]
-            except Exception:
+            text = self._read_text_tail(path)
+            if not text:
                 continue
             for line in reversed(text.splitlines()):
                 if "ERROR" not in line or f"session.id={session_id}" not in line or "error=" not in line:
@@ -518,11 +560,24 @@ class OpenCodeServerManager:
             if isinstance(error, dict):
                 message = error.get("message")
                 if isinstance(message, str) and message.strip():
-                    return message.strip()[:240]
+                    return OpenCodeServerManager._redact_diagnostic_text(message.strip())[:240]
             message = payload.get("message")
             if isinstance(message, str) and message.strip():
-                return message.strip()[:240]
+                return OpenCodeServerManager._redact_diagnostic_text(message.strip())[:240]
         return ""
+
+    @staticmethod
+    def _auth_json_api_key(provider_id: str) -> Optional[str]:
+        try:
+            auth_entries = read_opencode_provider_auth_entries(logger_instance=logger)
+        except Exception as exc:
+            logger.debug("Could not read OpenCode auth entries for provider diagnostic: %s", exc)
+            return None
+        auth_entry = auth_entries.get(provider_id)
+        if not isinstance(auth_entry, dict) or auth_entry.get("type") != "api":
+            return None
+        key = auth_entry.get("key")
+        return key if isinstance(key, str) and key else None
 
     @staticmethod
     def _append_provider_endpoint(base_url: str, endpoint_path: str) -> str:
@@ -552,12 +607,19 @@ class OpenCodeServerManager:
             return None
         base_url = options.get("baseURL")
         api_key = options.get("apiKey")
+        if not isinstance(api_key, str) or not api_key:
+            api_key = self._auth_json_api_key(provider_id)
         if not isinstance(base_url, str) or not base_url.strip() or not isinstance(api_key, str) or not api_key:
             return None
 
         base_url = base_url.rstrip("/")
         adapter = get_opencode_custom_provider_adapter(provider_id, provider_config)
-        if adapter == "anthropic-compatible":
+        is_anthropic_compatible = (
+            adapter == "anthropic-compatible"
+            or provider_id == "anthropic"
+            or provider_config.get("npm") == "@ai-sdk/anthropic"
+        )
+        if is_anthropic_compatible:
             endpoint_path = "/messages"
             headers = {
                 "x-api-key": api_key,

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -91,7 +91,12 @@ def resolve_opencode_model_id(
     provider_id: str | None,
     model_id: str | None,
 ) -> str | None:
-    """Return the catalog-canonical model id for a provider/model pair."""
+    """Return the catalog-canonical model id for a provider/model pair.
+
+    This does not lowercase user input. Exact catalog matches win; otherwise we
+    only adopt the catalog casing when there is exactly one case-insensitive
+    match. Ambiguous or unknown ids are preserved.
+    """
 
     if not provider_id or not model_id or not isinstance(opencode_models, dict):
         return model_id

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -120,25 +120,29 @@ def resolve_opencode_reasoning_effort(
 ) -> str | None:
     """Return the variant OpenCode should receive for this model."""
 
+    normalized_effort = (requested_effort or "").strip() or None
+    if normalized_effort in {"default", "__default__"}:
+        normalized_effort = None
+
     if not model_dict:
-        return requested_effort
+        return normalized_effort
     provider_id = model_dict.get("providerID")
     model_id = model_dict.get("modelID")
     if not provider_id or not model_id:
-        return requested_effort
+        return normalized_effort
     if not isinstance(model_catalog, dict):
-        return requested_effort
+        return normalized_effort
 
     model_info = find_opencode_model_info(model_catalog, provider_id, model_id)
-    if requested_effort:
-        if _opencode_model_supports_variant(model_info, requested_effort):
-            return requested_effort
+    if normalized_effort:
+        if _opencode_model_supports_variant(model_info, normalized_effort):
+            return normalized_effort
         if isinstance(model_info, dict):
-            return "default"
-        return requested_effort
+            return None
+        return normalized_effort
     if _opencode_model_has_no_variants(model_info):
-        return "default"
-    return requested_effort
+        return None
+    return normalized_effort
 
 
 def _find_model_variants(opencode_models: dict, target_model: Optional[str]) -> Dict[str, Any]:

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -86,6 +86,36 @@ def find_opencode_model_info(
     return None
 
 
+def resolve_opencode_model_id(
+    opencode_models: dict | None,
+    provider_id: str | None,
+    model_id: str | None,
+) -> str | None:
+    """Return the catalog-canonical model id for a provider/model pair."""
+
+    if not provider_id or not model_id or not isinstance(opencode_models, dict):
+        return model_id
+
+    for provider in opencode_models.get("providers", []) or []:
+        if get_opencode_provider_id(provider) != provider_id:
+            continue
+
+        models = provider.get("models", {}) if isinstance(provider, dict) else {}
+        if isinstance(models, dict):
+            if model_id in models:
+                return model_id
+            matches = [key for key in models if isinstance(key, str) and key.casefold() == model_id.casefold()]
+            return matches[0] if len(matches) == 1 else model_id
+        if isinstance(models, list):
+            ids = [_opencode_model_entry_id(entry) for entry in models]
+            if model_id in ids:
+                return model_id
+            matches = [entry_id for entry_id in ids if entry_id and entry_id.casefold() == model_id.casefold()]
+            return matches[0] if len(matches) == 1 else model_id
+        return model_id
+    return model_id
+
+
 def _opencode_model_supports_variant(model_info: dict | None, variant: str | None) -> bool:
     if not isinstance(model_info, dict) or not isinstance(variant, str) or not variant.strip():
         return False

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -438,6 +438,8 @@ class SessionsFacade:
         user_id: str = "",
         platform: str = "",
         prompt_started_at: Optional[float] = None,
+        model_dict: Optional[Dict[str, str]] = None,
+        reasoning_effort: Optional[str] = None,
     ) -> None:
         poll_info = ActivePollInfo(
             opencode_session_id=opencode_session_id,
@@ -458,6 +460,8 @@ class SessionsFacade:
             processing_indicator=processing_indicator or {},
             user_id=user_id,
             platform=platform,
+            model_dict=model_dict,
+            reasoning_effort=reasoning_effort,
         )
         self.sessions_store.add_active_poll(poll_info)
         logger.debug("Added active poll: session=%s, thread=%s", opencode_session_id, thread_id)

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -437,6 +437,7 @@ class SessionsFacade:
         processing_indicator: Optional[Dict[str, Any]] = None,
         user_id: str = "",
         platform: str = "",
+        prompt_started_at: Optional[float] = None,
     ) -> None:
         poll_info = ActivePollInfo(
             opencode_session_id=opencode_session_id,
@@ -449,6 +450,7 @@ class SessionsFacade:
             seen_tool_calls=[],
             emitted_assistant_messages=[],
             started_at=time.time(),
+            prompt_started_at=prompt_started_at,
             ack_reaction_message_id=ack_reaction_message_id,
             ack_reaction_emoji=ack_reaction_emoji,
             typing_indicator_active=typing_indicator_active,

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1411,8 +1411,14 @@ def test_opencode_poll_emits_notify_and_silent_error_result_on_empty_terminal_me
             return ""
 
     class _Server:
-        async def get_recent_session_error(self, session_id):
+        async def get_recent_session_error(self, session_id, since=None):
             return "AI_APICallError (ECONNRESET) while calling https://relay.example/messages"
+
+        async def get_provider_api_diagnostic(self, provider_id, model_id):
+            return None
+
+        def get_last_prompt_started_at(self, session_id):
+            return 42.0
 
         async def list_messages(self, session_id, directory):
             return [
@@ -1467,7 +1473,12 @@ def test_opencode_poll_emits_notify_and_silent_error_result_on_empty_terminal_me
             False,
             "normal",
         ),
-        ("result", "", True, "silent"),
+        (
+            "result",
+            "provider:glm/glm-5.2/(Default):AI_APICallError (ECONNRESET) while calling https://relay.example/messages",
+            True,
+            "silent",
+        ),
     ]
 
 

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -681,7 +681,7 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
     assert calls[0]["reasoning_effort"] == "high"
 
 
-def test_opencode_resets_saved_variant_for_non_reasoning_model():
+def test_opencode_clears_default_variant_for_non_reasoning_model():
     catalog = {
         "providers": [
             {
@@ -702,11 +702,11 @@ def test_opencode_resets_saved_variant_for_non_reasoning_model():
             None,
             catalog,
         )
-        == "default"
+        is None
     )
 
 
-def test_opencode_resets_saved_variant_for_model_without_variant_metadata():
+def test_opencode_clears_default_variant_for_model_without_variant_metadata():
     catalog = {
         "providers": [
             {
@@ -727,7 +727,7 @@ def test_opencode_resets_saved_variant_for_model_without_variant_metadata():
             None,
             catalog,
         )
-        == "default"
+        is None
     )
 
 
@@ -756,7 +756,7 @@ def test_opencode_keeps_unspecified_variant_when_catalog_says_reasoning_supporte
     )
 
 
-def test_opencode_resets_saved_variant_for_list_model_catalog():
+def test_opencode_clears_default_variant_for_list_model_catalog():
     catalog = {
         "providers": [
             {
@@ -777,7 +777,7 @@ def test_opencode_resets_saved_variant_for_list_model_catalog():
             None,
             catalog,
         )
-        == "default"
+        is None
     )
 
 
@@ -803,6 +803,30 @@ def test_opencode_keeps_supported_reasoning_variant():
             catalog,
         )
         == "high"
+    )
+
+
+def test_opencode_clears_unsupported_requested_variant():
+    catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "glm-5.2": {
+                        "variants": {"high": {"thinking": {"effort": "high"}}},
+                    }
+                },
+            }
+        ]
+    }
+
+    assert (
+        resolve_opencode_reasoning_effort(
+            {"providerID": "glm", "modelID": "glm-5.2"},
+            "default",
+            catalog,
+        )
+        is None
     )
 
 
@@ -857,7 +881,7 @@ def test_opencode_keeps_requested_variant_when_catalog_says_reasoning_supported(
     )
 
 
-def test_opencode_resets_unsupported_reasoning_variant():
+def test_opencode_clears_unsupported_reasoning_variant():
     catalog = {
         "providers": [
             {
@@ -878,7 +902,7 @@ def test_opencode_resets_unsupported_reasoning_variant():
             "max",
             catalog,
         )
-        == "default"
+        is None
     )
 
 
@@ -1346,7 +1370,7 @@ def test_opencode_poll_emits_error_result_on_retry_exhaustion():
     assert not any(mtype == "notify" for mtype, _ in emitted)
 
 
-def test_opencode_poll_emits_error_result_on_empty_terminal_message():
+def test_opencode_poll_emits_notify_and_silent_error_result_on_empty_terminal_message():
     emitted = []
 
     class _AuthSvc:
@@ -1365,10 +1389,12 @@ def test_opencode_poll_emits_error_result_on_empty_terminal_message():
                 return "(Default)"
             if key == "error.opencodeEmptyResponse":
                 return "empty:{provider}/{model}/{variant}".format(**kwargs)
+            if key == "error.opencodeProviderRuntimeError":
+                return "provider:{provider}/{model}/{variant}:{detail}".format(**kwargs)
             return f"translated:{key}"
 
         async def emit_agent_message(self, context, message_type, text, parse_mode=None, *, is_error=False, level="normal"):
-            emitted.append((message_type, text, is_error))
+            emitted.append((message_type, text, is_error, level))
 
     class _Agent:
         opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
@@ -1385,6 +1411,9 @@ def test_opencode_poll_emits_error_result_on_empty_terminal_message():
             return ""
 
     class _Server:
+        async def get_recent_session_error(self, session_id):
+            return "AI_APICallError (ECONNRESET) while calling https://relay.example/messages"
+
         async def list_messages(self, session_id, directory):
             return [
                 {
@@ -1424,14 +1453,22 @@ def test_opencode_poll_emits_error_result_on_empty_terminal_message():
             "oc-session",
             agent_to_use=None,
             model_dict={"providerID": "glm", "modelID": "glm-5.2"},
-            reasoning_effort="default",
+            reasoning_effort=None,
             baseline_message_ids=set(),
         )
     )
 
     assert final_text is None
     assert should_emit is False
-    assert emitted == [("result", "empty:glm/glm-5.2/default", True)]
+    assert emitted == [
+        (
+            "notify",
+            "provider:glm/glm-5.2/(Default):AI_APICallError (ECONNRESET) while calling https://relay.example/messages",
+            False,
+            "normal",
+        ),
+        ("result", "", True, "silent"),
+    ]
 
 
 def test_processing_indicator_handle_is_source_of_truth_for_backend_cleanup():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1398,6 +1398,11 @@ def test_opencode_poll_emits_notify_and_silent_error_result_on_empty_terminal_me
     class _Controller:
         agent_auth_service = _AuthSvc()
 
+        def __init__(self):
+            self.config = type("Config", (), {"platform": "slack", "ack_mode": "reaction", "language": "en"})()
+            self.im_client = type("IM", (), {"formatter": _Formatter()})()
+            self.processing_indicator = ProcessingIndicatorService(self)
+
         def _t(self, key, **kwargs):
             if key == "common.default":
                 return "(Default)"
@@ -1490,6 +1495,143 @@ def test_opencode_poll_emits_notify_and_silent_error_result_on_empty_terminal_me
         (
             "result",
             "provider:glm/glm-5.2/(Default):AI_APICallError (ECONNRESET) while calling https://relay.example/messages",
+            True,
+            "silent",
+        ),
+    ]
+
+
+def test_opencode_restored_poll_preserves_model_details_for_empty_terminal_probe():
+    emitted = []
+    removed = []
+    diagnostics = []
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(self, context, backend, message):
+            return False
+
+    class _Formatter:
+        def format_toolcall(self, *args, **kwargs):
+            return "tool"
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def __init__(self):
+            self.config = type("Config", (), {"platform": "slack", "ack_mode": "reaction", "language": "en"})()
+            self.im_client = type("IM", (), {"formatter": _Formatter()})()
+            self.processing_indicator = ProcessingIndicatorService(self)
+
+        def _t(self, key, **kwargs):
+            if key == "common.default":
+                return "(Default)"
+            if key == "error.opencodeEmptyResponse":
+                return "empty:{provider}/{model}/{variant}".format(**kwargs)
+            if key == "error.opencodeProviderRuntimeError":
+                return "provider:{provider}/{model}/{variant}:{detail}".format(**kwargs)
+            return f"translated:{key}"
+
+        async def emit_agent_message(self, context, message_type, text, parse_mode=None, *, is_error=False, level="normal"):
+            emitted.append((message_type, text, is_error, level))
+
+    class _Sessions:
+        def update_active_poll_state(self, *args, **kwargs):
+            return None
+
+        def remove_active_poll(self, session_id):
+            removed.append(session_id)
+
+    class _Server:
+        async def get_recent_session_error(self, session_id, since=None):
+            return None
+
+        async def get_provider_api_diagnostic(self, provider_id, model_id):
+            diagnostics.append((provider_id, model_id))
+            return "Provider API returned HTTP 503: No available accounts"
+
+        async def abort_session(self, session_id, directory):
+            return None
+
+        async def list_messages(self, session_id, directory):
+            return [
+                {
+                    "info": {
+                        "id": "msg-empty",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "finish": "unknown",
+                        "tokens": {
+                            "input": 8,
+                            "output": 4,
+                            "reasoning": 2,
+                            "cache": {"read": 1, "write": 0},
+                        },
+                    },
+                    "parts": [{"type": "step-finish", "id": "step-finish"}],
+                }
+            ]
+
+    server = _Server()
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+        sessions = _Sessions()
+        im_client = type("IM", (), {"formatter": _Formatter()})()
+
+        async def _get_server(self):
+            return server
+
+        def _get_formatter(self, context):
+            return _Formatter()
+
+        def _to_relative_path(self, path, working_path):
+            return path
+
+        def _extract_response_text(self, message):
+            return ""
+
+        async def emit_result_message(self, *args, **kwargs):
+            raise AssertionError("empty terminal path should emit failure directly")
+
+        async def _remove_ack_reaction(self, request):
+            return None
+
+    poll = ActivePollInfo(
+        opencode_session_id="oc-session",
+        base_session_id="base",
+        channel_id="c",
+        thread_id="t",
+        settings_key="c",
+        working_path="/tmp/work",
+        baseline_message_ids=[],
+        platform="slack",
+        model_dict={"providerID": "glm", "modelID": "glm-5.2"},
+        reasoning_effort="high",
+        prompt_started_at=42.0,
+    )
+
+    loop = OpenCodePollLoop(_Agent())
+    asyncio.run(loop.run_restored_poll_loop(poll))
+
+    assert diagnostics == [("glm", "glm-5.2")]
+    assert removed == ["oc-session"]
+    assert emitted == [
+        (
+            "notify",
+            "Resuming interrupted OpenCode session after restart...",
+            False,
+            "normal",
+        ),
+        (
+            "notify",
+            "provider:glm/glm-5.2/high:Provider API returned HTTP 503: No available accounts",
+            False,
+            "normal",
+        ),
+        (
+            "result",
+            "provider:glm/glm-5.2/high:Provider API returned HTTP 503: No available accounts",
             True,
             "silent",
         ),

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -565,6 +565,20 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
         async def list_messages(self, session_id, directory):
             return []
 
+        async def get_available_models(self, directory):
+            return {
+                "providers": [
+                    {
+                        "id": "openai",
+                        "models": {
+                            "gpt-5.4": {
+                                "variants": {"high": {}},
+                            }
+                        },
+                    }
+                ]
+            }
+
         async def prompt_async(self, **kwargs):
             calls.append(kwargs)
 
@@ -625,13 +639,13 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
                     "remote_access": None,
                     "language": "en",
                     "opencode": type(
-                        "OpenCodeConfig",
-                        (),
-                        {
-                            "default_model": "gpt-5.4",
-                            "default_provider": "openai",
-                            "default_reasoning_effort": "high",
-                        },
+                            "OpenCodeConfig",
+                            (),
+                            {
+                                "default_model": "GPT-5.4",
+                                "default_provider": "openai",
+                                "default_reasoning_effort": "high",
+                            },
                     )(),
                 },
             )()

--- a/tests/test_opencode_default_provider_routing.py
+++ b/tests/test_opencode_default_provider_routing.py
@@ -14,6 +14,7 @@ import dataclasses
 
 from config.v2_config import OpenCodeConfig
 from modules.agents.opencode.agent import resolve_opencode_model_dict
+from modules.agents.opencode.utils import resolve_opencode_model_id
 
 
 def test_opencode_config_default_provider_is_unset_by_default() -> None:
@@ -58,3 +59,49 @@ def test_prefixed_model_ignores_default_provider() -> None:
         "providerID": "openai",
         "modelID": "gpt-5",
     }
+
+
+def test_model_id_uses_catalog_casing_for_unique_match() -> None:
+    catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "glm-5.2": {"id": "glm-5.2"},
+                },
+            }
+        ]
+    }
+
+    assert resolve_opencode_model_id(catalog, "glm", "GLM-5.2") == "glm-5.2"
+
+
+def test_model_id_preserves_exact_catalog_match() -> None:
+    catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "GLM-5.2": {"id": "GLM-5.2"},
+                },
+            }
+        ]
+    }
+
+    assert resolve_opencode_model_id(catalog, "glm", "GLM-5.2") == "GLM-5.2"
+
+
+def test_model_id_does_not_guess_ambiguous_case_match() -> None:
+    catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "glm-5.2": {"id": "glm-5.2"},
+                    "GLM-5.2": {"id": "GLM-5.2"},
+                },
+            }
+        ]
+    }
+
+    assert resolve_opencode_model_id(catalog, "glm", "Glm-5.2") == "Glm-5.2"

--- a/tests/test_opencode_default_provider_routing.py
+++ b/tests/test_opencode_default_provider_routing.py
@@ -91,6 +91,21 @@ def test_model_id_preserves_exact_catalog_match() -> None:
     assert resolve_opencode_model_id(catalog, "glm", "GLM-5.2") == "GLM-5.2"
 
 
+def test_model_id_uses_uppercase_catalog_casing_for_unique_match() -> None:
+    catalog = {
+        "providers": [
+            {
+                "id": "vendor",
+                "models": {
+                    "GLM-5.2": {"id": "GLM-5.2"},
+                },
+            }
+        ]
+    }
+
+    assert resolve_opencode_model_id(catalog, "vendor", "glm-5.2") == "GLM-5.2"
+
+
 def test_model_id_does_not_guess_ambiguous_case_match() -> None:
     catalog = {
         "providers": [

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1,5 +1,7 @@
 import asyncio
 import importlib.util
+import io
+import json
 import sys
 import tempfile
 import types
@@ -36,15 +38,22 @@ OpenCodeServerManager = SERVER_MODULE.OpenCodeServerManager
 
 
 class _FakeResponse:
-    def __init__(self, *, status: int = 204, text: str = "", json_data=None):
+    def __init__(self, *, status: int = 204, text: str = "", json_data=None, headers=None):
         self.status = status
         self._text = text
         self._json_data = json_data
+        self.headers = headers or {}
 
     async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
         return False
 
     async def text(self):
@@ -55,6 +64,21 @@ class _FakeResponse:
 
     async def json(self):
         return self._json_data if self._json_data is not None else {}
+
+
+class _FakeUrlOpenResponse:
+    def __init__(self, *, text: str = "", headers=None):
+        self._text = text
+        self.headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, size=-1):
+        return self._text.encode() if size is None or size < 0 else self._text.encode()[:size]
 
 
 class _FakeSession:
@@ -1202,6 +1226,186 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn("secret system prompt", summary or "")
         self.assertNotIn("sk-secret", summary or "")
+
+    def test_recent_session_error_uses_current_prompt_window_and_strips_relative_query(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            stale_payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "cause": {
+                        "code": "ECONNRESET",
+                        "path": "/messages?api_key=stale-secret",
+                    },
+                }
+            }
+            current_payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "cause": {
+                        "code": "ECONNRESET",
+                        "path": "/messages?api_key=current-secret#frag",
+                    },
+                }
+            }
+            (log_dir / "2026-06-19T040950.log").write_text(
+                f"ERROR 2026-06-19T04:09:49 +1ms service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(stale_payload)} stream error\n"
+                f"ERROR 2026-06-19T04:10:03 +1ms service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(current_payload)} stream error\n",
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]):
+                summary = manager._recent_session_error_sync(
+                    "ses_test",
+                    since=SERVER_MODULE.datetime(2026, 6, 19, 4, 10, 0).timestamp(),
+                )
+
+        self.assertEqual(
+            summary,
+            "AI_APICallError (ECONNRESET) while calling /messages",
+        )
+        self.assertNotIn("api_key", summary or "")
+        self.assertNotIn("secret", summary or "")
+
+    def test_recent_session_error_ignores_old_log_entries_for_current_prompt(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "cause": {"code": "ECONNRESET", "path": "/messages?api_key=old-secret"},
+                }
+            }
+            (log_dir / "2026-06-19T040950.log").write_text(
+                f"ERROR 2026-06-19T04:09:49 +1ms service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(payload)} stream error\n",
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]):
+                summary = manager._recent_session_error_sync(
+                    "ses_test",
+                    since=SERVER_MODULE.datetime(2026, 6, 19, 4, 10, 0).timestamp(),
+                )
+
+        self.assertIsNone(summary)
+
+    async def test_prompt_async_records_prompt_start_time_for_log_correlation(self):
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        fake_session = _FakeSession()
+
+        async def _fake_get_http_session():
+            return fake_session
+
+        manager._get_http_session = _fake_get_http_session  # type: ignore[method-assign]
+
+        with patch.object(SERVER_MODULE.time, "time", return_value=1234.5):
+            await manager.prompt_async(
+                session_id="ses-1",
+                directory="/tmp/work",
+                text="hello",
+            )
+
+        self.assertEqual(manager.get_last_prompt_started_at("ses-1"), 1234.5)
+
+    def test_provider_api_diagnostic_detects_html_base_url(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "provider": {
+                            "glm": {
+                                "npm": "@ai-sdk/anthropic",
+                                "options": {
+                                    "baseURL": "https://relay.example",
+                                    "apiKey": "sk-secret",
+                                },
+                                "vibe_remote": {
+                                    "custom": True,
+                                    "adapter": "anthropic-compatible",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            class _UrlOpen:
+                def __call__(self, request, timeout=None):
+                    self.request = request
+                    return _FakeUrlOpenResponse(
+                        text="<!doctype html><html>Relay UI</html>",
+                        headers={"content-type": "text/html; charset=utf-8"},
+                    )
+
+            fake_urlopen = _UrlOpen()
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.urllib.request, "urlopen", fake_urlopen),
+            ):
+                detail = manager._provider_api_diagnostic_sync("glm", "glm-5.2")
+
+        self.assertIn("returned an HTML page", detail or "")
+        self.assertIn("https://relay.example/v1", detail or "")
+        self.assertNotIn("sk-secret", detail or "")
+        self.assertEqual(fake_urlopen.request.full_url, "https://relay.example/messages")
+
+    def test_provider_api_diagnostic_reports_json_api_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "provider": {
+                            "glm": {
+                                "npm": "@ai-sdk/anthropic",
+                                "options": {
+                                    "baseURL": "https://relay.example/v1",
+                                    "apiKey": "sk-secret",
+                                },
+                                "vibe_remote": {
+                                    "custom": True,
+                                    "adapter": "anthropic-compatible",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            def _raise_http_error(request, timeout=None):
+                response = io.BytesIO(
+                    b'{"error":{"message":"No available accounts: no available accounts","type":"api_error"}}'
+                )
+                raise SERVER_MODULE.urllib.error.HTTPError(
+                    request.full_url,
+                    503,
+                    "Service Unavailable",
+                    {"content-type": "application/json; charset=utf-8"},
+                    response,
+                )
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.urllib.request, "urlopen", _raise_http_error),
+            ):
+                detail = manager._provider_api_diagnostic_sync("glm", "glm-5.2")
+
+        self.assertEqual(
+            detail,
+            "Provider API returned HTTP 503: No available accounts: no available accounts",
+        )
+        self.assertNotIn("sk-secret", detail or "")
 
 
 async def _async_none():

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1227,6 +1227,56 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("secret system prompt", summary or "")
         self.assertNotIn("sk-secret", summary or "")
 
+    def test_recent_session_error_redacts_freeform_error_message(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            line_payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "data": {
+                        "message": (
+                            "invalid api_key=sk-secret-123 at "
+                            "https://relay.example/messages?api_key=sk-query-secret"
+                        )
+                    },
+                }
+            }
+            (log_dir / "2026-06-19T040950.log").write_text(
+                f"ERROR 2026-06-19T04:10:03 +1ms service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(line_payload)} stream error\n",
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]):
+                summary = manager._recent_session_error_sync("ses_test")
+
+        self.assertIn("api_key=[redacted]", summary or "")
+        self.assertIn("https://relay.example/messages", summary or "")
+        self.assertNotIn("sk-secret", summary or "")
+        self.assertNotIn("sk-query-secret", summary or "")
+
+    def test_recent_session_error_reads_only_log_tail(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            line_payload = {"error": {"name": "AI_APICallError", "cause": {"code": "ECONNRESET"}}}
+            log_path = log_dir / "2026-06-19T040950.log"
+            log_path.write_bytes(
+                b"x" * (SERVER_MODULE.OPENCODE_LOG_TAIL_BYTES + 1024)
+                + b"\n"
+                + f"ERROR 2026-06-19T04:10:03 +1ms service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(line_payload)} stream error\n".encode(
+                    "utf-8"
+                )
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with (
+                patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]),
+                patch.object(SERVER_MODULE.Path, "read_text", side_effect=AssertionError("must not read full log")),
+            ):
+                summary = manager._recent_session_error_sync("ses_test")
+
+        self.assertEqual(summary, "AI_APICallError (ECONNRESET)")
+
     def test_recent_session_error_uses_current_prompt_window_and_strips_relative_query(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             log_dir = Path(tmp_dir)
@@ -1406,6 +1456,103 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             "Provider API returned HTTP 503: No available accounts: no available accounts",
         )
         self.assertNotIn("sk-secret", detail or "")
+
+    def test_provider_api_diagnostic_redacts_json_api_error(self):
+        payload = {
+            "error": {
+                "message": (
+                    "bad Authorization: Bearer relay-token and "
+                    "https://relay.example/messages?api_key=sk-query-secret"
+                )
+            }
+        }
+
+        detail = OpenCodeServerManager._diagnostic_payload_message(payload)
+
+        self.assertIn("Bearer [redacted]", detail)
+        self.assertIn("https://relay.example/messages", detail)
+        self.assertNotIn("relay-token", detail)
+        self.assertNotIn("sk-query-secret", detail)
+
+    def test_provider_api_diagnostic_uses_auth_json_api_key(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            auth_path = tmp_home / ".local" / "share" / "opencode" / "auth.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            auth_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "provider": {
+                            "glm": {
+                                "npm": "@ai-sdk/anthropic",
+                                "options": {
+                                    "baseURL": "https://relay.example/v1",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            auth_path.write_text('{"glm":{"type":"api","key":"sk-auth-json"}}', encoding="utf-8")
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            class _UrlOpen:
+                def __call__(self, request, timeout=None):
+                    self.request = request
+                    return _FakeUrlOpenResponse(text='{"ok":true}', headers={"content-type": "application/json"})
+
+            fake_urlopen = _UrlOpen()
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.urllib.request, "urlopen", fake_urlopen),
+            ):
+                detail = manager._provider_api_diagnostic_sync("glm", "glm-5.2")
+
+        self.assertIsNone(detail)
+        self.assertEqual(fake_urlopen.request.headers.get("X-api-key"), "sk-auth-json")
+        self.assertEqual(fake_urlopen.request.full_url, "https://relay.example/v1/messages")
+
+    def test_provider_api_diagnostic_probes_builtin_anthropic_as_anthropic(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "provider": {
+                            "anthropic": {
+                                "options": {
+                                    "baseURL": "https://relay.example/v1",
+                                    "apiKey": "sk-secret",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            class _UrlOpen:
+                def __call__(self, request, timeout=None):
+                    self.request = request
+                    return _FakeUrlOpenResponse(text='{"ok":true}', headers={"content-type": "application/json"})
+
+            fake_urlopen = _UrlOpen()
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.urllib.request, "urlopen", fake_urlopen),
+            ):
+                detail = manager._provider_api_diagnostic_sync("anthropic", "claude-opus-4")
+
+        self.assertIsNone(detail)
+        self.assertEqual(fake_urlopen.request.full_url, "https://relay.example/v1/messages")
+        self.assertEqual(fake_urlopen.request.headers.get("X-api-key"), "sk-secret")
+        self.assertNotIn("Authorization", fake_urlopen.request.headers)
 
 
 async def _async_none():

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1341,6 +1341,29 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(summary)
 
+    def test_recent_session_error_ignores_pre_prompt_log_inside_short_window(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "cause": {"code": "ECONNRESET", "path": "/messages?api_key=old-secret"},
+                }
+            }
+            (log_dir / "2026-06-19T040950.log").write_text(
+                f"ERROR 2026-06-19T04:09:59 +1ms service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(payload)} stream error\n",
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]):
+                summary = manager._recent_session_error_sync(
+                    "ses_test",
+                    since=SERVER_MODULE.datetime(2026, 6, 19, 4, 10, 0).timestamp(),
+                )
+
+        self.assertIsNone(summary)
+
     async def test_prompt_async_records_prompt_start_time_for_log_correlation(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -113,6 +113,26 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         body = fake_session.posts[0]["json"]
         self.assertEqual(body["tools"], {"question": False})
 
+    async def test_prompt_async_omits_default_variant(self):
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        fake_session = _FakeSession()
+
+        async def _fake_get_http_session():
+            return fake_session
+
+        manager._get_http_session = _fake_get_http_session  # type: ignore[method-assign]
+
+        await manager.prompt_async(
+            session_id="ses-1",
+            directory="/tmp/work",
+            text="hello",
+            reasoning_effort="default",
+        )
+
+        self.assertEqual(len(fake_session.posts), 1)
+        body = fake_session.posts[0]["json"]
+        self.assertNotIn("variant", body)
+
     async def test_load_opencode_user_config_supports_jsonc(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_home = Path(tmp_dir)
@@ -1148,6 +1168,40 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 }
             ],
         )
+
+    def test_recent_session_error_summarizes_provider_failure_without_request_body(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            line_payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "cause": {
+                        "code": "ECONNRESET",
+                        "path": "https://user:secret@relay.example/messages?api_key=hidden",
+                    },
+                    "url": "https://relay.example/messages",
+                    "requestBodyValues": {
+                        "system": [{"text": "secret system prompt"}],
+                        "apiKey": "sk-secret",
+                    },
+                }
+            }
+            (log_dir / "2026-06-19T040950.log").write_text(
+                "INFO unrelated\n"
+                + f"ERROR service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(line_payload)} stream error\n",
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]):
+                summary = manager._recent_session_error_sync("ses_test")
+
+        self.assertEqual(
+            summary,
+            "AI_APICallError (ECONNRESET) while calling https://relay.example/messages",
+        )
+        self.assertNotIn("secret system prompt", summary or "")
+        self.assertNotIn("sk-secret", summary or "")
 
 
 async def _async_none():

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1364,6 +1364,30 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(summary)
 
+    def test_recent_session_error_keeps_same_second_current_prompt_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "cause": {"code": "ECONNRESET", "path": "/messages?api_key=current-secret"},
+                }
+            }
+            (log_dir / "2026-06-19T041003.log").write_text(
+                f"ERROR 2026-06-19T04:10:03 +1ms service=llm session.id=ses_test error={SERVER_MODULE.json.dumps(payload)} stream error\n",
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]):
+                summary = manager._recent_session_error_sync(
+                    "ses_test",
+                    since=SERVER_MODULE.datetime(2026, 6, 19, 4, 10, 3, 500000).timestamp(),
+                )
+
+        self.assertEqual(summary, "AI_APICallError (ECONNRESET) while calling /messages")
+        self.assertNotIn("current-secret", summary or "")
+
     async def test_prompt_async_records_prompt_start_time_for_log_correlation(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()
@@ -1480,6 +1504,48 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn("sk-secret", detail or "")
 
+    def test_provider_api_diagnostic_reports_transport_failure(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "provider": {
+                            "glm": {
+                                "npm": "@ai-sdk/anthropic",
+                                "options": {
+                                    "baseURL": "https://relay.example/v1?api_key=sk-query-secret",
+                                    "apiKey": "sk-secret",
+                                },
+                                "vibe_remote": {
+                                    "custom": True,
+                                    "adapter": "anthropic-compatible",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            def _raise_url_error(request, timeout=None):
+                raise SERVER_MODULE.urllib.error.URLError("timed out with api_key=sk-url-secret")
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.urllib.request, "urlopen", _raise_url_error),
+            ):
+                detail = manager._provider_api_diagnostic_sync("glm", "glm-5.2")
+
+        self.assertIn("Provider API request failed", detail or "")
+        self.assertIn("timed out", detail or "")
+        self.assertNotIn("sk-secret", detail or "")
+        self.assertNotIn("sk-url-secret", detail or "")
+        self.assertNotIn("sk-query-secret", detail or "")
+
     def test_provider_api_diagnostic_redacts_json_api_error(self):
         payload = {
             "error": {
@@ -1576,6 +1642,42 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fake_urlopen.request.full_url, "https://relay.example/v1/messages")
         self.assertEqual(fake_urlopen.request.headers.get("X-api-key"), "sk-secret")
         self.assertNotIn("Authorization", fake_urlopen.request.headers)
+
+    def test_provider_api_diagnostic_skips_unsupported_reserved_provider(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_home = Path(tmp_dir)
+            config_path = tmp_home / ".config" / "opencode" / "opencode.json"
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "provider": {
+                            "google": {
+                                "options": {
+                                    "baseURL": "https://generativelanguage.googleapis.com/v1beta",
+                                    "apiKey": "sk-secret",
+                                },
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+            calls = []
+
+            def _unexpected_urlopen(request, timeout=None):
+                calls.append(request.full_url)
+                raise AssertionError(f"unexpected diagnostic request to {request.full_url}")
+
+            with (
+                patch("vibe.opencode_config.Path.home", return_value=tmp_home),
+                patch.object(SERVER_MODULE.urllib.request, "urlopen", _unexpected_urlopen),
+            ):
+                detail = manager._provider_api_diagnostic_sync("google", "gemini-2.5-pro")
+
+        self.assertIsNone(detail)
+        self.assertEqual(calls, [])
 
 
 async def _async_none():

--- a/tests/test_v2_sessions.py
+++ b/tests/test_v2_sessions.py
@@ -163,6 +163,8 @@ def test_active_poll_persists_typing_cleanup_context(tmp_path, monkeypatch):
         user_id="wx-user",
         platform="wechat",
         prompt_started_at=1234.5,
+        model_dict={"providerID": "glm", "modelID": "glm-5.2"},
+        reasoning_effort="high",
     )
 
     reloaded = SessionsStore()
@@ -174,6 +176,8 @@ def test_active_poll_persists_typing_cleanup_context(tmp_path, monkeypatch):
     assert poll.context_token == "ctx-4"
     assert poll.processing_indicator["context_token"] == "ctx-4"
     assert poll.prompt_started_at == 1234.5
+    assert poll.model_dict == {"providerID": "glm", "modelID": "glm-5.2"}
+    assert poll.reasoning_effort == "high"
 
 
 # --- session_mappings migration tests ---

--- a/tests/test_v2_sessions.py
+++ b/tests/test_v2_sessions.py
@@ -162,6 +162,7 @@ def test_active_poll_persists_typing_cleanup_context(tmp_path, monkeypatch):
         },
         user_id="wx-user",
         platform="wechat",
+        prompt_started_at=1234.5,
     )
 
     reloaded = SessionsStore()
@@ -172,6 +173,7 @@ def test_active_poll_persists_typing_cleanup_context(tmp_path, monkeypatch):
     assert poll.typing_indicator_active is True
     assert poll.context_token == "ctx-4"
     assert poll.processing_indicator["context_token"] == "ctx-4"
+    assert poll.prompt_started_at == 1234.5
 
 
 # --- session_mappings migration tests ---

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -604,6 +604,9 @@ class _FakeOpencodeServer:
     async def abort_session(self, session_id, directory):
         self.abort_calls.append((session_id, directory))
 
+    async def get_recent_session_error(self, session_id):
+        return None
+
     async def start_provider_oauth(self, provider_id, *, method, prompt_answers):
         self.start_calls.append((provider_id, method, prompt_answers))
         return self.next_authorize
@@ -816,7 +819,7 @@ def test_opencode_provider_test_fails_on_empty_terminal_message(
     assert result["error"] == "empty_response"
     assert result["model"] == "glm-5.2"
     assert "glm-5.2" in result["detail"]
-    assert fake.prompt_calls[-1]["reasoning_effort"] == "default"
+    assert fake.prompt_calls[-1]["reasoning_effort"] is None
     assert fake.active_calls == ["sess_probe"]
     assert fake.abort_calls == [("sess_probe", os.path.expanduser("~"))]
     assert fake.inactive_calls == ["sess_probe"]

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -604,7 +604,10 @@ class _FakeOpencodeServer:
     async def abort_session(self, session_id, directory):
         self.abort_calls.append((session_id, directory))
 
-    async def get_recent_session_error(self, session_id):
+    async def get_recent_session_error(self, session_id, since=None):
+        return None
+
+    async def get_provider_api_diagnostic(self, provider_id, model_id):
         return None
 
     async def start_provider_oauth(self, provider_id, *, method, prompt_answers):

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -828,6 +828,40 @@ def test_opencode_provider_test_fails_on_empty_terminal_message(
     assert fake.inactive_calls == ["sess_probe"]
 
 
+def test_opencode_provider_test_uses_catalog_model_casing(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeOpencodeServer()
+    fake.catalog = {
+        "providers": [
+            {
+                "id": "glm",
+                "models": {
+                    "glm-5.2": {"id": "glm-5.2"},
+                },
+            }
+        ]
+    }
+    fake.messages = [
+        {
+            "info": {
+                "id": "msg_assistant",
+                "role": "assistant",
+                "time": {"completed": 123},
+                "finish": "stop",
+            },
+            "parts": [{"type": "text", "text": "OK"}],
+        }
+    ]
+    monkeypatch.setattr(service, "_opencode_server", AsyncMock(return_value=fake))
+
+    result = _run(service.test_opencode_provider("glm", model="GLM-5.2"))
+
+    assert result["ok"] is True
+    assert result["model"] == "glm-5.2"
+    assert fake.prompt_calls[-1]["model"] == {"providerID": "glm", "modelID": "glm-5.2"}
+
+
 def test_remove_web_auth_rejects_unsupported_backend(service: AgentAuthService) -> None:
     # OpenCode joined ``WEB_BACKENDS`` for OAuth, but ``remove_web_auth``
     # is claude / codex specific — opencode providers use the

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -59,7 +59,8 @@
     "fileAttachmentUploadFailedNoLink": "⚠️ I could not deliver {filename} as a WeChat file. Please ask me to resend it or use another channel.",
     "opencodeQuestionToolDisabled": "OpenCode asked an interactive question, but Avibe disables the OpenCode question tool. Please send a new follow-up message with your answer or direction.",
     "opencodeQuestionToolDisabledRestored": "Restored OpenCode session asked an interactive question, but Avibe disables the OpenCode question tool. Please send a new follow-up message with your answer or direction.",
-    "opencodeEmptyResponse": "OpenCode finished, but the provider returned no text or error. Provider: {provider}; model: {model}; reasoning: {variant}. Check that this provider/model combination supports the selected adapter, Base URL, API key, and reasoning setting."
+    "opencodeEmptyResponse": "OpenCode finished without a model reply. Provider: {provider}; model: {model}; reasoning: {variant}. OpenCode did not expose a provider error for this run.",
+    "opencodeProviderRuntimeError": "OpenCode provider request failed. Provider: {provider}; model: {model}; reasoning: {variant}. Detail: {detail}"
   },
   "success": {
     "settingsUpdated": "Settings updated successfully!",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -59,7 +59,8 @@
     "fileAttachmentUploadFailedNoLink": "⚠️ {filename} 没能作为微信文件直接发送。请让我重新发送，或换一个渠道接收这个文件。",
     "opencodeQuestionToolDisabled": "OpenCode 发起了交互式提问，但 Avibe 已禁用 OpenCode 的 question 工具。请直接发送一条新消息，告诉我你的答案或下一步方向。",
     "opencodeQuestionToolDisabledRestored": "恢复中的 OpenCode 会话发起了交互式提问，但 Avibe 已禁用 OpenCode 的 question 工具。请直接发送一条新消息，告诉我你的答案或下一步方向。",
-    "opencodeEmptyResponse": "OpenCode 已结束，但服务商没有返回文本或错误。Provider：{provider}；模型：{model}；推理强度：{variant}。请检查这个 provider/model 组合是否支持当前适配器、Base URL、API Key 和推理强度设置。"
+    "opencodeEmptyResponse": "OpenCode 已结束，但没有产出模型回复。Provider：{provider}；模型：{model}；推理强度：{variant}。这次运行里 OpenCode 没有暴露服务商错误。",
+    "opencodeProviderRuntimeError": "OpenCode 服务商请求失败。Provider：{provider}；模型：{model}；推理强度：{variant}。详情：{detail}"
   },
   "success": {
     "settingsUpdated": "设置更新成功！",


### PR DESCRIPTION
## What
- stop sending the UI "default" reasoning selection as a real OpenCode `variant`
- surface OpenCode empty terminal completions as `notify` messages, while using a silent error `result` only to settle the run state
- read the current OpenCode session's recent provider error log and show a short sanitized runtime detail when OpenCode leaves only a zero-token empty assistant message

## Why
Regression showed `glm/glm-5.2` produced an OpenCode assistant message with only `step-finish`, `finish=unknown`, and zero tokens. OpenCode's own log for that same session had the underlying provider failure: `AI_APICallError (ECONNRESET)` calling the Anthropic-compatible `/messages` endpoint. The previous UI text hid that cause and was incorrectly returned as an agent result message.

## Tests
- `python3 -m pytest tests/test_opencode_server.py tests/test_web_oauth_flow.py tests/test_multi_platform_runtime.py`
- `python3 -m ruff check core/agent_auth_service.py modules/agents/opencode/poll_loop.py modules/agents/opencode/server.py modules/agents/opencode/utils.py tests/test_multi_platform_runtime.py tests/test_opencode_server.py tests/test_web_oauth_flow.py`
