### PR TITLE
fix(telegram): reset DM sessions across agent routes

### DIFF
--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -43,6 +43,7 @@ class ActivePollInfo:
     # User identity for restoring question UI context
     user_id: str = ""
     platform: str = ""
+    session_key: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -66,6 +67,7 @@ class ActivePollInfo:
             "processing_indicator": self.processing_indicator,
             "user_id": self.user_id,
             "platform": self.platform,
+            "session_key": self.session_key,
         }
 
     @classmethod
@@ -103,6 +105,7 @@ class ActivePollInfo:
             processing_indicator=processing_indicator,
             user_id=data.get("user_id", ""),
             platform=data.get("platform", ""),
+            session_key=data.get("session_key", ""),
         )
 
 

--- a/core/controller.py
+++ b/core/controller.py
@@ -24,6 +24,7 @@ from core.handlers import (
 )
 from core.agent_auth_service import AgentAuthService
 from core.audio_asr import AudioAsrService
+from core.message_context import build_context_session_key
 from core.message_dispatcher import ConsolidatedMessageDispatcher
 from core.processing_indicator import ProcessingIndicatorService
 from core.runtime_commands import RuntimeCommandWatcher
@@ -861,7 +862,8 @@ class Controller:
         tracking never collide.
         """
         platform = context.platform or (context.platform_specific or {}).get("platform") or self.primary_platform
-        return f"{platform}::{self._get_settings_key(context)}"
+        settings_key = self._get_settings_key(context)
+        return build_context_session_key(context, platform=platform, settings_key=settings_key)
 
     def get_im_client_for_context(self, context: Optional[MessageContext] = None) -> BaseIMClient:
         if context is None:

--- a/core/handlers/command_handlers.py
+++ b/core/handlers/command_handlers.py
@@ -106,6 +106,31 @@ class CommandHandlers(BaseHandler):
         platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
         return f"{platform}::{self._get_settings_key(context)}"
 
+    def _session_anchor_for_new(self, context: MessageContext) -> str:
+        session_handler = getattr(self.controller, "session_handler", None)
+        getter = getattr(session_handler, "get_base_session_id", None)
+        if callable(getter):
+            try:
+                return getter(context)
+            except Exception:
+                logger.debug("Failed to resolve session anchor for /new", exc_info=True)
+        platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
+        payload = context.platform_specific or {}
+        if payload.get("is_dm", False):
+            base_id = context.thread_id or context.channel_id or context.user_id
+        else:
+            base_id = context.thread_id or context.message_id or context.channel_id or context.user_id
+        return f"{platform}_{base_id}"
+
+    def _compat_session_keys_for_new(self, context: MessageContext, session_key: str) -> list[str]:
+        keys = [session_key]
+        platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
+        payload = context.platform_specific or {}
+        if platform == "telegram" and payload.get("is_dm", False) and context.channel_id:
+            keys.append(f"{platform}::channel::{context.channel_id}")
+            keys.append(f"{platform}::{context.channel_id}")
+        return list(dict.fromkeys(keys))
+
     def _store_resume_snapshot(
         self,
         context: MessageContext,
@@ -499,7 +524,16 @@ class CommandHandlers(BaseHandler):
                     logger.info("Started new Telegram topic session for user %s", context.user_id)
                     return
             session_key = self._get_session_key(context)
-            await self.controller.agent_service.clear_sessions(session_key)
+            session_anchor = self._session_anchor_for_new(context)
+            sessions = getattr(self.controller, "sessions", None)
+            clear_base = getattr(sessions, "clear_session_base", None)
+            for key in self._compat_session_keys_for_new(context, session_key):
+                await self.controller.agent_service.clear_sessions(key)
+                if callable(clear_base):
+                    try:
+                        clear_base(key, session_anchor)
+                    except Exception:
+                        logger.debug("Failed to clear session base for %s:%s", key, session_anchor, exc_info=True)
             full_response = f"🆕 {self._t('command.new.started')}"
 
             channel_context = self._get_channel_context(context)

--- a/core/handlers/command_handlers.py
+++ b/core/handlers/command_handlers.py
@@ -5,6 +5,7 @@ import os
 import time
 from typing import Any, Optional
 from config.platform_registry import get_platform_descriptor
+from core.message_context import requires_typed_user_session_key
 from modules.agents import get_agent_display_name
 from modules.agents.native_sessions.types import NativeResumeSession
 from modules.agents.base import AgentRequest
@@ -126,7 +127,7 @@ class CommandHandlers(BaseHandler):
         keys = [session_key]
         platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
         payload = context.platform_specific or {}
-        if platform == "telegram" and payload.get("is_dm", False) and context.channel_id:
+        if payload.get("is_dm", False) and requires_typed_user_session_key(context) and context.channel_id:
             keys.append(f"{platform}::channel::{context.channel_id}")
             keys.append(f"{platform}::{context.channel_id}")
         return list(dict.fromkeys(keys))

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -508,6 +508,67 @@ class SettingsHandler(BaseHandler):
             return False
         return bool(getattr(backend_config, "enabled", True))
 
+    def _context_can_start_fresh_session_without_reset(self, context: MessageContext) -> bool:
+        im_client = self._get_im_client(context)
+        is_dm = bool((context.platform_specific or {}).get("is_dm", False))
+        if is_dm:
+            return bool(getattr(im_client, "should_use_thread_for_dm_session", lambda: False)())
+        uses_threads = bool(getattr(im_client, "should_use_thread_for_reply", lambda: False)())
+        uses_message_sessions = bool(
+            getattr(im_client, "should_use_message_id_for_channel_session", lambda _context=None: True)(context)
+        )
+        return uses_threads and uses_message_sessions
+
+    def _session_anchor_for_context(self, context: MessageContext) -> str:
+        session_handler = getattr(self.controller, "session_handler", None)
+        getter = getattr(session_handler, "get_base_session_id", None)
+        if callable(getter):
+            try:
+                return getter(context)
+            except Exception:
+                logger.debug("Failed to resolve session anchor for routing update hint", exc_info=True)
+        platform = context.platform or (context.platform_specific or {}).get("platform") or self.config.platform
+        payload = context.platform_specific or {}
+        base_id = context.channel_id or context.user_id if payload.get("is_dm", False) else context.channel_id
+        return f"{platform}_{base_id or context.user_id}"
+
+    def _resolve_route_backend(self, agent_name: Optional[str]) -> Optional[str]:
+        if not agent_name:
+            return None
+        name = str(agent_name)
+        if name in {"opencode", "claude", "codex"}:
+            return name
+        store = getattr(self.controller, "vibe_agent_store", None)
+        if store is None:
+            return None
+        try:
+            agent = store.get(name)
+        except Exception:
+            return None
+        backend = getattr(agent, "backend", None) if agent else None
+        return str(backend) if backend else None
+
+    def _routing_update_needs_new_session_hint(self, context: MessageContext, selected_backend: str) -> bool:
+        if self._context_can_start_fresh_session_without_reset(context):
+            return False
+        finder = getattr(self.sessions, "find_session_for_anchor", None)
+        if not callable(finder):
+            return False
+        session_key = self._get_session_key(context)
+        session_anchor = self._session_anchor_for_context(context)
+        try:
+            row = finder(session_key, session_anchor)
+        except Exception:
+            logger.debug("Failed to inspect current session for routing update hint", exc_info=True)
+            return False
+        if not row:
+            return False
+        current_backend = str(row.get("agent_backend") or "").strip()
+        if not current_backend:
+            current_backend = self._resolve_route_backend(row.get("agent_name")) or ""
+        next_backend = self._resolve_route_backend(selected_backend) or str(selected_backend or "").strip()
+        return bool(current_backend and next_backend and current_backend != next_backend)
+
     async def _handle_routing_slack(self, context: MessageContext):
         """Handle routing for Slack using modal dialog"""
         im_client = self._get_im_client(context)
@@ -810,6 +871,7 @@ class SettingsHandler(BaseHandler):
             )
 
             settings_manager.set_channel_routing(settings_key, routing)
+            needs_new_session_hint = self._routing_update_needs_new_session_hint(context, backend)
 
             parts = [f"{self._t('routing.label.backend')}: **{backend}**"]
             if backend == "opencode":
@@ -835,6 +897,8 @@ class SettingsHandler(BaseHandler):
                     parts.append(f"{self._t('routing.label.model')}: **{codex_model}**")
                 if codex_reasoning_effort:
                     parts.append(f"{self._t('routing.label.reasoningEffort')}: **{codex_reasoning_effort}**")
+            if needs_new_session_hint:
+                parts.extend(["", self._t("success.routingUpdateNeedsNewSession")])
 
             if notify_user:
                 await im_client.send_message(

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -548,7 +548,42 @@ class SettingsHandler(BaseHandler):
         backend = getattr(agent, "backend", None) if agent else None
         return str(backend) if backend else None
 
-    def _routing_update_needs_new_session_hint(self, context: MessageContext, selected_backend: str) -> bool:
+    @staticmethod
+    def _routing_target_from_row(row: dict) -> tuple[str, str, str, str, str]:
+        backend = str(row.get("agent_backend") or "").strip()
+        agent_name = str(row.get("agent_name") or "").strip()
+        if not agent_name and backend in {"opencode", "claude", "codex"}:
+            agent_name = backend
+        variant = str(row.get("agent_variant") or "").strip()
+        if variant == backend and agent_name == backend:
+            variant = ""
+        return (
+            agent_name,
+            backend,
+            variant,
+            str(row.get("model") or "").strip(),
+            str(row.get("reasoning_effort") or "").strip(),
+        )
+
+    def _routing_target_from_settings(self, routing) -> tuple[str, str, str, str, str]:
+        agent_name = str(getattr(routing, "agent_name", None) or "").strip()
+        backend = str(self._resolve_route_backend(agent_name) or agent_name).strip()
+        variant = ""
+        if backend == "opencode":
+            variant = str(getattr(routing, "opencode_agent", None) or "").strip()
+        elif backend == "claude":
+            variant = str(getattr(routing, "claude_agent", None) or "").strip()
+        elif backend == "codex":
+            variant = str(getattr(routing, "codex_agent", None) or "").strip()
+        return (
+            agent_name,
+            backend,
+            variant,
+            str(getattr(routing, "model", None) or "").strip(),
+            str(getattr(routing, "reasoning_effort", None) or "").strip(),
+        )
+
+    def _routing_update_needs_new_session_hint(self, context: MessageContext, routing) -> bool:
         if self._context_can_start_fresh_session_without_reset(context):
             return False
         finder = getattr(self.sessions, "find_session_for_anchor", None)
@@ -563,11 +598,13 @@ class SettingsHandler(BaseHandler):
             return False
         if not row:
             return False
-        current_backend = str(row.get("agent_backend") or "").strip()
-        if not current_backend:
-            current_backend = self._resolve_route_backend(row.get("agent_name")) or ""
-        next_backend = self._resolve_route_backend(selected_backend) or str(selected_backend or "").strip()
-        return bool(current_backend and next_backend and current_backend != next_backend)
+        current_target = self._routing_target_from_row(row)
+        next_target = self._routing_target_from_settings(routing)
+        if not any(current_target):
+            return True
+        if current_target[1] and next_target[1] and current_target[1] != next_target[1]:
+            return True
+        return current_target != next_target
 
     async def _handle_routing_slack(self, context: MessageContext):
         """Handle routing for Slack using modal dialog"""
@@ -871,7 +908,7 @@ class SettingsHandler(BaseHandler):
             )
 
             settings_manager.set_channel_routing(settings_key, routing)
-            needs_new_session_hint = self._routing_update_needs_new_session_hint(context, backend)
+            needs_new_session_hint = self._routing_update_needs_new_session_hint(context, routing)
 
             parts = [f"{self._t('routing.label.backend')}: **{backend}**"]
             if backend == "opencode":

--- a/core/message_context.py
+++ b/core/message_context.py
@@ -19,3 +19,28 @@ def resolve_context_platform(
         payload = context.platform_specific or {}
         platform = context.platform or payload.get("platform") or platform
     return str(platform or default)
+
+
+def resolve_context_settings_key(context: MessageContext) -> str:
+    payload = context.platform_specific or {}
+    value = context.user_id if payload.get("is_dm", False) else context.channel_id
+    return str(value or "")
+
+
+def requires_typed_user_session_key(context: MessageContext) -> bool:
+    payload = context.platform_specific or {}
+    return bool(payload.get("is_dm", False) and context.user_id and context.channel_id == context.user_id)
+
+
+def build_context_session_key(
+    context: MessageContext,
+    *,
+    platform: Optional[str] = None,
+    settings_key: Optional[str] = None,
+    fallback_platform: Optional[str] = None,
+) -> str:
+    resolved_platform = platform or resolve_context_platform(context, fallback_platform=fallback_platform)
+    resolved_settings_key = settings_key if settings_key is not None else resolve_context_settings_key(context)
+    if requires_typed_user_session_key(context):
+        return f"{resolved_platform}::user::{resolved_settings_key}"
+    return f"{resolved_platform}::{resolved_settings_key}"

--- a/core/message_mirror.py
+++ b/core/message_mirror.py
@@ -34,9 +34,11 @@ from storage.db import create_sqlite_engine
 
 logger = logging.getLogger(__name__)
 
-# Non-avibe IM scopes are stored as 'channel' rows — one per DM/group/topic.
-# avibe projects are 'project' typed and pre-created via ``/api/projects``;
-# this module never touches those.
+# Non-avibe IM scopes are stored as channel rows. Platforms whose DM chat id is
+# literally the user id (Telegram/WeChat style) would otherwise collide with a
+# user scope for the same native id, so those DMs are stored as user rows.
+# avibe projects are 'project' typed and pre-created via ``/api/projects``; this
+# module never touches those.
 DEFAULT_SCOPE_TYPE = "channel"
 
 
@@ -46,14 +48,17 @@ def _now() -> str:
 
 def _resolve_scope_id(conn, context: MessageContext) -> Optional[str]:
     platform = (context.platform or "").strip()
-    native_id = (context.channel_id or "").strip()
+    is_dm = bool((context.platform_specific or {}).get("is_dm", False))
+    use_user_scope = is_dm and context.channel_id and context.user_id and context.channel_id == context.user_id
+    scope_type = "user" if use_user_scope else DEFAULT_SCOPE_TYPE
+    native_id = ((context.user_id if use_user_scope else context.channel_id) or "").strip()
     if not platform or not native_id:
         return None
     try:
         return settings_service.upsert_scope(
             conn,
             platform=platform,
-            scope_type=DEFAULT_SCOPE_TYPE,
+            scope_type=scope_type,
             native_id=native_id,
             now=_now(),
             supports_threads=bool(context.thread_id),

--- a/core/processing_indicator.py
+++ b/core/processing_indicator.py
@@ -43,6 +43,7 @@ class ProcessingIndicatorHandle:
             "channel_id": self.context.channel_id or "",
             "thread_id": self.context.thread_id or "",
             "message_id": self.context.message_id or "",
+            "is_dm": bool(payload.get("is_dm", False)),
             "context_token": str(payload.get("context_token") or ""),
             "ack_message_id": self.ack_message_id,
             "ack_message_channel_id": self.ack_message_channel_id,
@@ -58,6 +59,8 @@ class ProcessingIndicatorHandle:
         platform_specific: dict[str, Any] = {}
         if platform:
             platform_specific["platform"] = platform
+        if data.get("is_dm") is not None:
+            platform_specific["is_dm"] = bool(data.get("is_dm"))
         if context_token:
             platform_specific["context_token"] = context_token
         context = MessageContext(

--- a/core/services/agent_run_target.py
+++ b/core/services/agent_run_target.py
@@ -103,7 +103,7 @@ def resolve_agent_run_target(
 
     platform = _platform_for(context, controller)
     settings_key = _settings_key_for(context)
-    session_key = _session_key_for(context, platform, settings_key)
+    session_key = build_context_session_key(context, platform=platform, settings_key=settings_key)
     anchor = str(base_session_id or _fallback_anchor(context, platform))
     engine = _engine_for(controller)
 
@@ -252,7 +252,7 @@ def resolve_agent_run_target(
             model=agent_target.model,
             reasoning_effort=agent_target.reasoning_effort,
             workdir=resolved_new_workdir,
-            metadata={"created_via": "agent_run_target", "source": source},
+            metadata={"created_via": "agent_run_target", "source": source, "legacy_scope_key": session_key},
         )
         created = conn.execute(
             select(
@@ -349,10 +349,6 @@ def _platform_for(context: MessageContext, controller: Any) -> str:
 
 def _settings_key_for(context: MessageContext) -> str:
     return resolve_context_settings_key(context)
-
-
-def _session_key_for(context: MessageContext, platform: str, settings_key: str) -> str:
-    return build_context_session_key(context, platform=platform, settings_key=settings_key)
 
 
 def _fallback_anchor(context: MessageContext, platform: str) -> str:

--- a/core/services/agent_run_target.py
+++ b/core/services/agent_run_target.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 from sqlalchemy import Engine, select
 
+from core.message_context import build_context_session_key, resolve_context_settings_key
 from modules.im import MessageContext
 from storage.agent_session_rows import create_agent_session_row
 from storage.models import agent_sessions, scope_settings, scopes
@@ -102,7 +103,7 @@ def resolve_agent_run_target(
 
     platform = _platform_for(context, controller)
     settings_key = _settings_key_for(context)
-    session_key = f"{platform}::{settings_key}"
+    session_key = _session_key_for(context, platform, settings_key)
     anchor = str(base_session_id or _fallback_anchor(context, platform))
     engine = _engine_for(controller)
 
@@ -347,8 +348,11 @@ def _platform_for(context: MessageContext, controller: Any) -> str:
 
 
 def _settings_key_for(context: MessageContext) -> str:
-    payload = context.platform_specific or {}
-    return str(context.user_id if payload.get("is_dm", False) else context.channel_id)
+    return resolve_context_settings_key(context)
+
+
+def _session_key_for(context: MessageContext, platform: str, settings_key: str) -> str:
+    return build_context_session_key(context, platform=platform, settings_key=settings_key)
 
 
 def _fallback_anchor(context: MessageContext, platform: str) -> str:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -19,7 +19,7 @@ from modules.agents.base import AgentRequest, BaseAgent
 
 from .client_manager import OpenCodeClientManager
 from .message_processor import OpenCodeMessageProcessorMixin
-from .poll_loop import OpenCodePollLoop
+from .poll_loop import OpenCodePollLoop, restored_session_key_from_poll_info
 from .server import OpenCodeServerManager
 from .session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
 from .utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
@@ -36,6 +36,15 @@ def resolve_opencode_model_dict(model_str: str | None, default_provider: str | N
     if isinstance(default_provider, str) and default_provider.strip():
         return {"providerID": default_provider.strip(), "modelID": model_str}
     return None
+
+
+def _raw_settings_key_from_session_key(session_key: str) -> str:
+    parts = str(session_key or "").split("::")
+    if len(parts) >= 3 and parts[1] in {"user", "channel", "platform", "project"}:
+        return "::".join(parts[2:])
+    if len(parts) >= 2:
+        return "::".join(parts[1:])
+    return str(session_key or "")
 
 
 class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
@@ -344,9 +353,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             # ActivePollInfo stores raw settings_key + separate platform field;
             # request.session_key is the scoped session key (platform::raw_id),
             # so strip the prefix before persisting.
-            raw_settings_key = request.session_key
-            if "::" in raw_settings_key:
-                raw_settings_key = raw_settings_key.split("::", 1)[1]
+            raw_settings_key = _raw_settings_key_from_session_key(request.session_key)
             platform_payload = request.context.platform_specific or {}
 
             self.sessions.add_active_poll(
@@ -618,7 +625,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 poll_info.base_session_id,
                 poll_info.opencode_session_id,
                 poll_info.working_path,
-                f"{poll_info.platform}::{poll_info.settings_key}" if poll_info.platform else poll_info.settings_key,
+                restored_session_key_from_poll_info(poll_info),
             )
             restored_count += 1
 

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -350,9 +350,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 request.working_path,
             )
 
-            # ActivePollInfo stores raw settings_key + separate platform field;
-            # request.session_key is the scoped session key (platform::raw_id),
-            # so strip the prefix before persisting.
+            # Keep both the raw settings key for legacy lookup and the complete
+            # scoped key so restored polls remain attached to typed scopes.
             raw_settings_key = _raw_settings_key_from_session_key(request.session_key)
             platform_payload = request.context.platform_specific or {}
 
@@ -374,6 +373,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 prompt_started_at=prompt_started_at,
                 model_dict=model_dict,
                 reasoning_effort=reasoning_effort,
+                session_key=request.session_key,
             )
 
             final_text, should_emit = await self._poll_loop.run_prompt_poll(

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -41,6 +41,9 @@ def restored_context_from_poll_info(poll_info) -> MessageContext:
 
 
 def restored_session_key_from_poll_info(poll_info, *, context: Optional[MessageContext] = None) -> str:
+    session_key = str(getattr(poll_info, "session_key", "") or "").strip()
+    if session_key:
+        return session_key
     restored_context = context or restored_context_from_poll_info(poll_info)
     return build_context_session_key(
         restored_context,

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -22,17 +22,21 @@ logger = logging.getLogger(__name__)
 def restored_context_from_poll_info(poll_info) -> MessageContext:
     snapshot = poll_info.processing_indicator if isinstance(poll_info.processing_indicator, dict) else {}
     platform = str(snapshot.get("platform") or poll_info.platform or "")
+    user_id = str(snapshot.get("user_id") or poll_info.user_id or "")
+    channel_id = str(snapshot.get("channel_id") or poll_info.channel_id or "")
     context_token = str(snapshot.get("context_token") or getattr(poll_info, "context_token", "") or "")
     platform_specific: dict[str, Any] = {}
     if platform:
         platform_specific["platform"] = platform
     if snapshot.get("is_dm") is not None:
         platform_specific["is_dm"] = bool(snapshot.get("is_dm"))
+    elif platform in {"telegram", "wechat"} and user_id and user_id == channel_id:
+        platform_specific["is_dm"] = True
     if context_token:
         platform_specific["context_token"] = context_token
     return MessageContext(
-        user_id=str(snapshot.get("user_id") or poll_info.user_id or ""),
-        channel_id=str(snapshot.get("channel_id") or poll_info.channel_id or ""),
+        user_id=user_id,
+        channel_id=channel_id,
         platform=platform or None,
         thread_id=snapshot.get("thread_id") or poll_info.thread_id or None,
         message_id=snapshot.get("message_id") or None,

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -8,13 +8,45 @@ import time
 from typing import Any, Dict, Optional
 
 from config.v2_config import DEFAULT_OPENCODE_ERROR_RETRY_LIMIT
+from core.message_context import build_context_session_key
 from modules.agents.base import AgentRequest
+from modules.im import MessageContext
 from vibe.i18n import t as i18n_t
 
 from .message_processor import is_empty_terminal_opencode_message
 from .server import OpenCodeServerManager
 
 logger = logging.getLogger(__name__)
+
+
+def restored_context_from_poll_info(poll_info) -> MessageContext:
+    snapshot = poll_info.processing_indicator if isinstance(poll_info.processing_indicator, dict) else {}
+    platform = str(snapshot.get("platform") or poll_info.platform or "")
+    context_token = str(snapshot.get("context_token") or getattr(poll_info, "context_token", "") or "")
+    platform_specific: dict[str, Any] = {}
+    if platform:
+        platform_specific["platform"] = platform
+    if snapshot.get("is_dm") is not None:
+        platform_specific["is_dm"] = bool(snapshot.get("is_dm"))
+    if context_token:
+        platform_specific["context_token"] = context_token
+    return MessageContext(
+        user_id=str(snapshot.get("user_id") or poll_info.user_id or ""),
+        channel_id=str(snapshot.get("channel_id") or poll_info.channel_id or ""),
+        platform=platform or None,
+        thread_id=snapshot.get("thread_id") or poll_info.thread_id or None,
+        message_id=snapshot.get("message_id") or None,
+        platform_specific=platform_specific or None,
+    )
+
+
+def restored_session_key_from_poll_info(poll_info, *, context: Optional[MessageContext] = None) -> str:
+    restored_context = context or restored_context_from_poll_info(poll_info)
+    return build_context_session_key(
+        restored_context,
+        platform=poll_info.platform or restored_context.platform,
+        settings_key=poll_info.settings_key,
+    )
 
 
 class OpenCodePollLoop:
@@ -128,7 +160,7 @@ class OpenCodePollLoop:
     def _build_restored_ack_request(self, poll_info) -> AgentRequest:
         handle = self._build_restored_handle(poll_info)
         context = handle.context
-        session_key = f"{poll_info.platform}::{poll_info.settings_key}" if poll_info.platform else poll_info.settings_key
+        session_key = restored_session_key_from_poll_info(poll_info, context=context)
         return AgentRequest(
             context=context,
             message="",

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -153,10 +153,19 @@ class SessionsFacade:
         agent_name: str,
         thread_id: str,
     ) -> None:
+        self.remove_agent_session(user_id, agent_name, thread_id)
+
+    def remove_agent_session(
+        self,
+        user_id: Union[int, str],
+        agent_name: str,
+        thread_id: str,
+    ) -> bool:
         user_key = self._normalize_user_id(user_id)
         removed = self.sessions_store.remove_agent_session(user_key, agent_name, thread_id)
         if removed:
             logger.info("Cleared %s session mapping for user %s: %s", agent_name, user_id, thread_id)
+        return bool(removed)
 
     def clear_agent_sessions(self, user_id: Union[int, str], agent_name: str) -> None:
         user_key = self._normalize_user_id(user_id)

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -449,6 +449,7 @@ class SessionsFacade:
         prompt_started_at: Optional[float] = None,
         model_dict: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        session_key: str = "",
     ) -> None:
         poll_info = ActivePollInfo(
             opencode_session_id=opencode_session_id,
@@ -471,6 +472,7 @@ class SessionsFacade:
             platform=platform,
             model_dict=model_dict,
             reasoning_effort=reasoning_effort,
+            session_key=session_key,
         )
         self.sessions_store.add_active_poll(poll_info)
         logger.debug("Added active poll: session=%s, thread=%s", opencode_session_id, thread_id)

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -969,14 +969,22 @@ def _lookup_scope_id(conn: Connection, scope_key: str) -> str | None:
     NEVER upserts a scope — for read paths that must not create one."""
     raw = str(scope_key or "")
     parts = raw.split("::")
+    scope_type = None
     if len(parts) >= 3 and parts[1] in {"channel", "user", "platform", "project"}:
-        platform, native_id = parts[0], "::".join(parts[2:])
+        platform, scope_type, native_id = parts[0], parts[1], "::".join(parts[2:])
     else:
         platform, native_id = _split_scoped_key(scope_key)
         if platform is None:
             platform = "unknown"
     if not platform or not native_id:
         return None
+    if scope_type:
+        found = conn.execute(
+            select(scopes.c.id)
+            .where(scopes.c.platform == platform, scopes.c.scope_type == scope_type, scopes.c.native_id == native_id)
+            .limit(1)
+        ).scalar_one_or_none()
+        return str(found) if found is not None else None
     found = conn.execute(
         select(scopes.c.id).where(scopes.c.platform == platform, scopes.c.native_id == native_id).limit(1)
     ).scalar_one_or_none()

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -896,6 +896,7 @@ class SQLiteSessionsService:
                 agent_sessions.c.native_session_id,
                 agent_sessions.c.metadata_json,
                 scopes.c.platform,
+                scopes.c.scope_type,
                 scopes.c.native_id,
             ).join(scopes, scopes.c.id == agent_sessions.c.scope_id, isouter=True)
         ).mappings()
@@ -1046,8 +1047,11 @@ def _legacy_scope_key(row: dict[str, Any]) -> str:
     if isinstance(metadata, dict) and metadata.get("legacy_scope_key"):
         return str(metadata["legacy_scope_key"])
     platform = row.get("platform")
+    scope_type = row.get("scope_type")
     native_id = row.get("native_id")
     if platform and native_id:
+        if scope_type == "user" and platform in {"telegram", "wechat"}:
+            return f"{platform}::user::{native_id}"
         return f"{platform}::{native_id}"
     scope_id = row.get("scope_id")
     if isinstance(scope_id, str) and scope_id.count("::") >= 2:

--- a/tests/test_agent_run_target.py
+++ b/tests/test_agent_run_target.py
@@ -261,12 +261,13 @@ def test_telegram_dm_new_session_ignores_legacy_channel_scope_session(tmp_path):
     assert target.agent_session_id is not None
     with controller.sqlite_engine.connect() as conn:
         rows = conn.exec_driver_sql(
-            "select scope_id, agent_backend, session_anchor from agent_sessions order by scope_id"
+            "select scope_id, agent_backend, session_anchor, metadata_json from agent_sessions order by scope_id"
         ).all()
-    assert rows == [
+    assert [(row.scope_id, row.agent_backend, row.session_anchor) for row in rows] == [
         ("telegram::channel::58181121", "opencode", "telegram_58181121"),
         ("telegram::user::58181121", "claude", "telegram_58181121"),
     ]
+    assert json.loads(rows[1].metadata_json)["legacy_scope_key"] == "telegram::user::58181121"
 
 
 def test_new_im_session_ignores_legacy_scope_backend(tmp_path):

--- a/tests/test_agent_run_target.py
+++ b/tests/test_agent_run_target.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from core.services import sessions as sessions_service
 from core.services.agent_run_target import resolve_agent_run_target
 from modules.im import MessageContext
+from storage.agent_session_rows import create_agent_session_row
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
 from storage.models import scope_settings
@@ -188,6 +189,84 @@ def test_new_im_session_uses_resolved_vibe_agent(tmp_path):
     assert session["agent_variant"] == "codex"
     assert session["model"] == "gpt-5.5"
     assert session["reasoning_effort"] == "high"
+
+
+def test_telegram_dm_new_session_ignores_legacy_channel_scope_session(tmp_path):
+    workdir = tmp_path / "telegram-dm"
+    claude_agent = SimpleNamespace(
+        id="agent-claude",
+        name="claude",
+        backend="claude",
+        model="claude-opus-4-8",
+        reasoning_effort=None,
+    )
+    controller = _controller(tmp_path)
+    controller.primary_platform = "telegram"
+    controller.config.platform = "telegram"
+    controller.resolve_vibe_agent_for_context = (
+        lambda _context, override_agent_name=None, required=False: claude_agent
+    )
+    with controller.sqlite_engine.begin() as conn:
+        user_scope_id = upsert_scope(
+            conn,
+            platform="telegram",
+            scope_type="user",
+            native_id="58181121",
+            now="2026-06-19T07:30:00Z",
+        )
+        _seed_scope_settings(
+            conn,
+            user_scope_id,
+            workdir=str(workdir),
+            agent_name="claude",
+            routing={"agent_name": "claude", "claude_model": "claude-opus-4-8"},
+        )
+        legacy_channel_scope_id = upsert_scope(
+            conn,
+            platform="telegram",
+            scope_type="channel",
+            native_id="58181121",
+            now="2026-06-19T07:30:00Z",
+        )
+        create_agent_session_row(
+            conn,
+            scope_id=legacy_channel_scope_id,
+            agent_backend="opencode",
+            agent_variant="opencode",
+            agent_name="opencode",
+            session_anchor="telegram_58181121",
+            native_session_id="oc-native",
+            workdir=str(workdir),
+        )
+
+    ctx = MessageContext(
+        user_id="58181121",
+        channel_id="58181121",
+        message_id="100",
+        platform="telegram",
+        platform_specific={"platform": "telegram", "is_dm": True},
+    )
+
+    target = resolve_agent_run_target(
+        ctx,
+        controller=controller,
+        base_session_id="telegram_58181121",
+    )
+
+    assert target.scope_id == "telegram::user::58181121"
+    assert target.session_key == "telegram::user::58181121"
+    assert target.agent_backend == "claude"
+    assert target.agent_name == "claude"
+    assert target.model == "claude-opus-4-8"
+    assert target.agent_session_id is not None
+    with controller.sqlite_engine.connect() as conn:
+        rows = conn.exec_driver_sql(
+            "select scope_id, agent_backend, session_anchor from agent_sessions order by scope_id"
+        ).all()
+    assert rows == [
+        ("telegram::channel::58181121", "opencode", "telegram_58181121"),
+        ("telegram::user::58181121", "claude", "telegram_58181121"),
+    ]
 
 
 def test_new_im_session_ignores_legacy_scope_backend(tmp_path):

--- a/tests/test_command_handler_user_names.py
+++ b/tests/test_command_handler_user_names.py
@@ -3,6 +3,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from modules.im import MessageContext
 
@@ -12,37 +13,44 @@ sys.path.insert(0, str(ROOT))
 
 
 def _load_command_handlers_class():
-    agents_module = types.ModuleType("modules.agents")
-    agents_module.__path__ = [str(ROOT / "modules" / "agents")]
-    setattr(agents_module, "AgentRequest", type("AgentRequest", (), {}))
-    setattr(
-        agents_module, "get_agent_display_name", lambda agent_name, fallback=None: agent_name or fallback or "Unknown"
-    )
-    sys.modules["modules.agents"] = agents_module
-    agents_base_module = types.ModuleType("modules.agents.base")
-    setattr(agents_base_module, "AgentRequest", type("AgentRequest", (), {}))
-    sys.modules["modules.agents.base"] = agents_base_module
+    with patch.dict(sys.modules, {}, clear=False):
+        agents_module = types.ModuleType("modules.agents")
+        agents_module.__path__ = [str(ROOT / "modules" / "agents")]
+        setattr(agents_module, "AgentRequest", type("AgentRequest", (), {}))
+        setattr(
+            agents_module,
+            "get_agent_display_name",
+            lambda agent_name, fallback=None: agent_name or fallback or "Unknown",
+        )
+        sys.modules["modules.agents"] = agents_module
+        agents_base_module = types.ModuleType("modules.agents.base")
+        setattr(agents_base_module, "AgentRequest", type("AgentRequest", (), {}))
+        sys.modules["modules.agents.base"] = agents_base_module
 
-    core_pkg = types.ModuleType("core")
-    core_pkg.__path__ = [str(ROOT / "core")]
-    sys.modules["core"] = core_pkg
+        core_pkg = types.ModuleType("core")
+        core_pkg.__path__ = [str(ROOT / "core")]
+        sys.modules["core"] = core_pkg
 
-    handlers_pkg = types.ModuleType("core.handlers")
-    handlers_pkg.__path__ = [str(ROOT / "core" / "handlers")]
-    sys.modules["core.handlers"] = handlers_pkg
+        handlers_pkg = types.ModuleType("core.handlers")
+        handlers_pkg.__path__ = [str(ROOT / "core" / "handlers")]
+        sys.modules["core.handlers"] = handlers_pkg
 
-    for module_name, relative_path in (
-        ("core.handlers.base", ROOT / "core" / "handlers" / "base.py"),
-        ("core.handlers.command_handlers", ROOT / "core" / "handlers" / "command_handlers.py"),
-    ):
-        spec = importlib.util.spec_from_file_location(module_name, relative_path)
-        assert spec is not None
-        assert spec.loader is not None
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+        command_module = None
+        for module_name, relative_path in (
+            ("core.handlers.base", ROOT / "core" / "handlers" / "base.py"),
+            ("core.handlers.command_handlers", ROOT / "core" / "handlers" / "command_handlers.py"),
+        ):
+            spec = importlib.util.spec_from_file_location(module_name, relative_path)
+            assert spec is not None
+            assert spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+            if module_name == "core.handlers.command_handlers":
+                command_module = module
 
-    return sys.modules["core.handlers.command_handlers"].CommandHandlers
+        assert command_module is not None
+        return command_module.CommandHandlers
 
 
 CommandHandlers = _load_command_handlers_class()
@@ -96,6 +104,7 @@ class _StubController:
         self.im_client = _StubIMClient(user_info)
         self.settings_manager = _StubSettingsManager()
         self.sessions = self.settings_manager
+        self.session_handler = None
         self.session_manager = object()
         self.receiver_tasks = {}
         self.agent_service = type("AgentService", (), {"default_agent": "codex"})()
@@ -104,7 +113,11 @@ class _StubController:
         return context.user_id if context.channel_id.startswith("D") else context.channel_id
 
     def _get_session_key(self, context: MessageContext) -> str:
-        return f"{getattr(context, 'platform', None) or 'test'}::{self._get_settings_key(context)}"
+        platform = getattr(context, "platform", None) or "test"
+        is_dm = bool((context.platform_specific or {}).get("is_dm", False))
+        if is_dm and context.channel_id == context.user_id:
+            return f"{platform}::user::{self._get_settings_key(context)}"
+        return f"{platform}::{self._get_settings_key(context)}"
 
     def resolve_agent_for_context(self, context: MessageContext) -> str:
         return "codex"
@@ -197,6 +210,46 @@ class CommandHandlerUserNameTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             controller.im_client.sent_messages,
             [("wx-chat", "🆕 已开启新的会话。你下一条消息会从全新对话开始。")],
+        )
+
+    async def test_telegram_dm_new_command_clears_user_and_legacy_channel_scopes(self):
+        controller = _StubController({"display_name": "Alex"})
+        setattr(controller.config, "platform", "telegram")
+        clear_calls = []
+        clear_base_calls = []
+
+        async def _record_clear(session_key):
+            clear_calls.append(session_key)
+            return {}
+
+        controller.agent_service.clear_sessions = _record_clear  # type: ignore[attr-defined]
+        controller.sessions = type(
+            "Sessions",
+            (),
+            {"clear_session_base": lambda _self, key, anchor: clear_base_calls.append((key, anchor)) or 1},
+        )()
+        handler = CommandHandlers(controller)
+        context = MessageContext(
+            user_id="58181121",
+            channel_id="58181121",
+            message_id="77",
+            platform="telegram",
+            platform_specific={"platform": "telegram", "is_dm": True},
+        )
+
+        await handler.handle_new(context)
+
+        self.assertEqual(
+            clear_calls,
+            ["telegram::user::58181121", "telegram::channel::58181121", "telegram::58181121"],
+        )
+        self.assertEqual(
+            clear_base_calls,
+            [
+                ("telegram::user::58181121", "telegram_58181121"),
+                ("telegram::channel::58181121", "telegram_58181121"),
+                ("telegram::58181121", "telegram_58181121"),
+            ],
         )
 
     async def test_telegram_new_command_creates_topic_session_when_supported(self):

--- a/tests/test_command_handler_user_names.py
+++ b/tests/test_command_handler_user_names.py
@@ -252,6 +252,46 @@ class CommandHandlerUserNameTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_wechat_dm_new_command_clears_user_and_legacy_channel_scopes(self):
+        controller = _StubController({"display_name": "Alex"})
+        setattr(controller.config, "platform", "wechat")
+        clear_calls = []
+        clear_base_calls = []
+
+        async def _record_clear(session_key):
+            clear_calls.append(session_key)
+            return {}
+
+        controller.agent_service.clear_sessions = _record_clear  # type: ignore[attr-defined]
+        controller.sessions = type(
+            "Sessions",
+            (),
+            {"clear_session_base": lambda _self, key, anchor: clear_base_calls.append((key, anchor)) or 1},
+        )()
+        handler = CommandHandlers(controller)
+        context = MessageContext(
+            user_id="wxid_alice",
+            channel_id="wxid_alice",
+            message_id="77",
+            platform="wechat",
+            platform_specific={"platform": "wechat", "is_dm": True},
+        )
+
+        await handler.handle_new(context)
+
+        self.assertEqual(
+            clear_calls,
+            ["wechat::user::wxid_alice", "wechat::channel::wxid_alice", "wechat::wxid_alice"],
+        )
+        self.assertEqual(
+            clear_base_calls,
+            [
+                ("wechat::user::wxid_alice", "wechat_wxid_alice"),
+                ("wechat::channel::wxid_alice", "wechat_wxid_alice"),
+                ("wechat::wxid_alice", "wechat_wxid_alice"),
+            ],
+        )
+
     async def test_telegram_new_command_creates_topic_session_when_supported(self):
         controller = _StubController({"display_name": "Alex"})
         setattr(controller.config, "platform", "telegram")

--- a/tests/test_message_context_helpers.py
+++ b/tests/test_message_context_helpers.py
@@ -1,0 +1,26 @@
+from core.message_context import build_context_session_key, resolve_context_settings_key
+from modules.im import MessageContext
+
+
+def test_chat_id_equals_user_id_dm_gets_typed_user_session_key():
+    context = MessageContext(
+        user_id="58181121",
+        channel_id="58181121",
+        platform="telegram",
+        platform_specific={"platform": "telegram", "is_dm": True},
+    )
+
+    assert resolve_context_settings_key(context) == "58181121"
+    assert build_context_session_key(context) == "telegram::user::58181121"
+
+
+def test_distinct_dm_channel_keeps_legacy_session_key():
+    context = MessageContext(
+        user_id="U123",
+        channel_id="D456",
+        platform="slack",
+        platform_specific={"platform": "slack", "is_dm": True},
+    )
+
+    assert resolve_context_settings_key(context) == "U123"
+    assert build_context_session_key(context, settings_key="U123") == "slack::U123"

--- a/tests/test_message_mirror.py
+++ b/tests/test_message_mirror.py
@@ -71,6 +71,29 @@ def test_inbound_creates_scope_and_user_row(isolated_state):
         assert message_rows[0]["author_id"] == "U_alice"
 
 
+def test_telegram_dm_mirror_uses_user_scope_when_chat_id_equals_user_id(isolated_state):
+    ctx = MessageContext(
+        user_id="58181121",
+        channel_id="58181121",
+        platform="telegram",
+        message_id="101",
+        platform_specific={"is_dm": True, "platform": "telegram"},
+    )
+
+    mirror_inbound(ctx, "hello")
+    persist_agent_message(ctx, "result", "hi")
+
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        scope_row = conn.execute(
+            select(scopes).where(scopes.c.platform == "telegram", scopes.c.native_id == "58181121")
+        ).mappings().one()
+        rows = conn.execute(select(messages).where(messages.c.platform == "telegram")).mappings().all()
+
+    assert scope_row["scope_type"] == "user"
+    assert {row["scope_id"] for row in rows} == {"telegram::user::58181121"}
+
+
 def test_persist_agent_writes_typed_agent_row_on_same_scope(isolated_state):
     ctx = _slack_ctx()
     mirror_inbound(ctx, "ping")

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -179,6 +179,41 @@ def test_restored_telegram_dm_poll_keeps_typed_user_session_key():
     ]
 
 
+def test_restored_legacy_telegram_dm_poll_infers_typed_user_session_key():
+    poll = ActivePollInfo(
+        opencode_session_id="oc-telegram",
+        base_session_id="telegram_58181121",
+        channel_id="58181121",
+        thread_id="",
+        settings_key="58181121",
+        working_path="/tmp/work",
+        platform="telegram",
+        user_id="58181121",
+        processing_indicator={
+            "platform": "telegram",
+            "user_id": "58181121",
+            "channel_id": "58181121",
+            "thread_id": "",
+        },
+    )
+    agent, _, _, request_sessions = _build_agent({"oc-telegram": poll})
+
+    async def _run():
+        restored = await agent.restore_active_polls()
+        await asyncio.sleep(0)
+        for task in list(agent._active_requests.values()):
+            if not task.done():
+                await task
+        return restored
+
+    restored = asyncio.run(_run())
+
+    assert restored == 1
+    assert request_sessions == [
+        ("telegram_58181121", "oc-telegram", "/tmp/work", "telegram::user::58181121")
+    ]
+
+
 def test_restored_poll_prefers_persisted_typed_channel_session_key():
     poll = ActivePollInfo(
         opencode_session_id="oc-slack",

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -41,6 +41,7 @@ def _build_agent(active_polls: dict[str, ActivePollInfo]):
     ``set_agent_status`` writes."""
     status_writes: list[tuple[str, str]] = []
     removed: list[str] = []
+    request_sessions: list[tuple[str, str, str, str]] = []
 
     class _Server:
         async def list_messages(self, session_id, directory):
@@ -63,6 +64,7 @@ def _build_agent(active_polls: dict[str, ActivePollInfo]):
 
     class _SessionManager:
         def set_request_session(self, *args):
+            request_sessions.append(args)
             return None
 
         def pop_request_session(self, *args):
@@ -99,12 +101,12 @@ def _build_agent(active_polls: dict[str, ActivePollInfo]):
         return server
 
     agent._get_server = _get_server
-    return agent, status_writes, removed
+    return agent, status_writes, removed, request_sessions
 
 
 def test_restored_avibe_poll_marks_session_running():
     poll = _make_poll(platform="avibe", base_session_id="ses_wb", opencode_session_id="oc-1")
-    agent, status_writes, _ = _build_agent({"oc-1": poll})
+    agent, status_writes, _, _ = _build_agent({"oc-1": poll})
 
     async def _run():
         restored = await agent.restore_active_polls()
@@ -125,7 +127,7 @@ def test_restored_avibe_poll_marks_session_running():
 
 def test_restored_im_poll_does_not_touch_agent_status():
     poll = _make_poll(platform="slack", base_session_id="slack:thread", opencode_session_id="oc-2")
-    agent, status_writes, _ = _build_agent({"oc-2": poll})
+    agent, status_writes, _, _ = _build_agent({"oc-2": poll})
 
     async def _run():
         restored = await agent.restore_active_polls()
@@ -139,6 +141,42 @@ def test_restored_im_poll_does_not_touch_agent_status():
     assert restored == 1
     # IM polls carry no workbench session id → no dot, so no status write at all.
     assert status_writes == []
+
+
+def test_restored_telegram_dm_poll_keeps_typed_user_session_key():
+    poll = ActivePollInfo(
+        opencode_session_id="oc-telegram",
+        base_session_id="telegram_58181121",
+        channel_id="58181121",
+        thread_id="",
+        settings_key="58181121",
+        working_path="/tmp/work",
+        platform="telegram",
+        user_id="58181121",
+        processing_indicator={
+            "platform": "telegram",
+            "user_id": "58181121",
+            "channel_id": "58181121",
+            "thread_id": "",
+            "is_dm": True,
+        },
+    )
+    agent, _, _, request_sessions = _build_agent({"oc-telegram": poll})
+
+    async def _run():
+        restored = await agent.restore_active_polls()
+        await asyncio.sleep(0)
+        for task in list(agent._active_requests.values()):
+            if not task.done():
+                await task
+        return restored
+
+    restored = asyncio.run(_run())
+
+    assert restored == 1
+    assert request_sessions == [
+        ("telegram_58181121", "oc-telegram", "/tmp/work", "telegram::user::58181121")
+    ]
 
 
 def test_workbench_session_id_for_poll_resolution():

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -179,6 +179,35 @@ def test_restored_telegram_dm_poll_keeps_typed_user_session_key():
     ]
 
 
+def test_restored_poll_prefers_persisted_typed_channel_session_key():
+    poll = ActivePollInfo(
+        opencode_session_id="oc-slack",
+        base_session_id="slack_171717.123",
+        channel_id="C1",
+        thread_id="171717.123",
+        settings_key="C1",
+        working_path="/tmp/work",
+        platform="slack",
+        session_key="slack::channel::C1",
+    )
+    agent, _, _, request_sessions = _build_agent({"oc-slack": poll})
+
+    async def _run():
+        restored = await agent.restore_active_polls()
+        await asyncio.sleep(0)
+        for task in list(agent._active_requests.values()):
+            if not task.done():
+                await task
+        return restored
+
+    restored = asyncio.run(_run())
+
+    assert restored == 1
+    assert request_sessions == [
+        ("slack_171717.123", "oc-slack", "/tmp/work", "slack::channel::C1")
+    ]
+
+
 def test_workbench_session_id_for_poll_resolution():
     avibe = _make_poll(platform="avibe", base_session_id="ses_wb", opencode_session_id="oc-1")
     slack = _make_poll(platform="slack", base_session_id="slack:thread", opencode_session_id="oc-2")

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -264,3 +264,24 @@ def test_session_facade_ensure_fallback_does_not_clear_existing_native_session()
 
     assert facade.ensure_agent_session_id("slack::channel::C1", "codex", "base-1") is None
     assert facade.get_agent_session_id("slack::channel::C1", "base-1", "codex") == "thread-old"
+
+
+def test_sessions_facade_remove_agent_session_delegates_to_store() -> None:
+    class _Store:
+        def __init__(self):
+            self.removed = []
+
+        def remove_agent_session(self, user_id, agent_name, thread_id):
+            self.removed.append((user_id, agent_name, thread_id))
+            return True
+
+    store = _Store()
+    facade = SessionsFacade(store)
+
+    assert facade.remove_agent_session("telegram::user::58181121", "claude", "telegram_58181121") is True
+    facade.clear_agent_session_mapping("telegram::user::58181121", "claude", "telegram_58181121")
+
+    assert store.removed == [
+        ("telegram::user::58181121", "claude", "telegram_58181121"),
+        ("telegram::user::58181121", "claude", "telegram_58181121"),
+    ]

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -37,6 +37,58 @@ def _make_handler(settings_manager: _StubSettingsManager) -> tuple[SettingsHandl
     return SettingsHandler(controller), send_message
 
 
+class _FlatScopeSessions:
+    def __init__(self, row: dict | None):
+        self.row = row
+        self.calls: list[tuple[str, str]] = []
+
+    def find_session_for_anchor(self, session_key: str, session_anchor: str):
+        self.calls.append((session_key, session_anchor))
+        return self.row
+
+
+class _FlatScopeSettingsManager:
+    def __init__(self, routing: RoutingSettings | None = None):
+        self.routing = routing
+        self.saved_routing: RoutingSettings | None = None
+
+    def get_channel_routing(self, settings_key: str) -> RoutingSettings | None:
+        assert settings_key == "58181121"
+        return self.routing
+
+    def set_channel_routing(self, settings_key: str, routing: RoutingSettings) -> None:
+        assert settings_key == "58181121"
+        self.saved_routing = routing
+
+
+def _make_flat_scope_handler(
+    *,
+    platform: str = "telegram",
+    row: dict | None,
+    threaded: bool = False,
+) -> tuple[SettingsHandler, AsyncMock, _FlatScopeSessions]:
+    send_message = AsyncMock()
+    sessions = _FlatScopeSessions(row)
+    settings_manager = _FlatScopeSettingsManager(RoutingSettings(agent_name="opencode"))
+    im_client = SimpleNamespace(
+        send_message=send_message,
+        should_use_thread_for_reply=lambda: threaded,
+        should_use_thread_for_dm_session=lambda: threaded,
+        should_use_message_id_for_channel_session=lambda context=None: threaded,
+    )
+    controller = SimpleNamespace(
+        config=SimpleNamespace(platform=platform, language="zh"),
+        im_client=im_client,
+        settings_manager=settings_manager,
+        sessions=sessions,
+        session_handler=SimpleNamespace(get_base_session_id=lambda context: f"{platform}_58181121"),
+        _get_settings_key=lambda context: "58181121",
+        _get_session_key=lambda context: f"{platform}::user::58181121",
+        _get_lang=lambda: "zh",
+    )
+    return SettingsHandler(controller), send_message, sessions
+
+
 def test_handle_routing_update_preserves_existing_codex_agent_when_omitted() -> None:
     settings_manager = _StubSettingsManager(
         RoutingSettings(
@@ -137,6 +189,97 @@ def test_handle_routing_update_handles_first_codex_save_without_existing_routing
     assert settings_manager.saved_routing.codex_model is None
     assert settings_manager.saved_routing.codex_reasoning_effort is None
     send_message.assert_not_awaited()
+
+
+def test_handle_routing_update_warns_flat_scope_with_existing_backend_session() -> None:
+    handler, send_message, sessions = _make_flat_scope_handler(row={"agent_backend": "opencode"})
+
+    asyncio.run(
+        handler.handle_routing_update(
+            user_id="58181121",
+            channel_id="58181121",
+            backend="claude",
+            opencode_agent=None,
+            opencode_model=None,
+            claude_agent=None,
+            claude_model=None,
+            platform="telegram",
+            is_dm=True,
+        )
+    )
+
+    text = send_message.await_args.args[1]
+    assert "Agent设置已更新！" in text
+    assert "请使用 /start 命令创建新会话，或丢弃当前会话，以使设置变更生效。" in text
+    assert sessions.calls == [("telegram::user::58181121", "telegram_58181121")]
+
+
+def test_handle_routing_update_warns_wechat_flat_scope_with_existing_backend_session() -> None:
+    handler, send_message, sessions = _make_flat_scope_handler(platform="wechat", row={"agent_backend": "opencode"})
+
+    asyncio.run(
+        handler.handle_routing_update(
+            user_id="58181121",
+            channel_id="58181121",
+            backend="claude",
+            opencode_agent=None,
+            opencode_model=None,
+            claude_agent=None,
+            claude_model=None,
+            platform="wechat",
+            is_dm=True,
+        )
+    )
+
+    text = send_message.await_args.args[1]
+    assert "请使用 /start 命令创建新会话，或丢弃当前会话，以使设置变更生效。" in text
+    assert sessions.calls == [("wechat::user::58181121", "wechat_58181121")]
+
+
+def test_handle_routing_update_does_not_warn_when_flat_scope_has_no_session() -> None:
+    handler, send_message, sessions = _make_flat_scope_handler(row=None)
+
+    asyncio.run(
+        handler.handle_routing_update(
+            user_id="58181121",
+            channel_id="58181121",
+            backend="claude",
+            opencode_agent=None,
+            opencode_model=None,
+            claude_agent=None,
+            claude_model=None,
+            platform="telegram",
+            is_dm=True,
+        )
+    )
+
+    text = send_message.await_args.args[1]
+    assert "Agent设置已更新！" in text
+    assert "请使用 /start 命令创建新会话" not in text
+    assert sessions.calls == [("telegram::user::58181121", "telegram_58181121")]
+
+
+def test_handle_routing_update_does_not_warn_threaded_scope() -> None:
+    handler, send_message, sessions = _make_flat_scope_handler(platform="slack", row={"agent_backend": "opencode"}, threaded=True)
+
+    asyncio.run(
+        handler.handle_routing_update(
+            user_id="U123",
+            channel_id="D123",
+            backend="claude",
+            opencode_agent=None,
+            opencode_model=None,
+            claude_agent=None,
+            claude_model=None,
+            platform="slack",
+            is_dm=True,
+        )
+    )
+
+    text = send_message.await_args.args[1]
+    assert "Agent设置已更新！" in text
+    assert "请使用 /start 命令创建新会话" not in text
+    assert sessions.calls == []
 
 
 class _RoutingSettingsManager:

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -236,6 +236,66 @@ def test_handle_routing_update_warns_wechat_flat_scope_with_existing_backend_ses
     assert sessions.calls == [("wechat::user::58181121", "wechat_58181121")]
 
 
+def test_handle_routing_update_warns_flat_scope_same_backend_model_change() -> None:
+    handler, send_message, sessions = _make_flat_scope_handler(
+        row={
+            "agent_name": "claude",
+            "agent_backend": "claude",
+            "agent_variant": "claude",
+            "model": "claude-sonnet-4-5",
+            "reasoning_effort": "",
+        }
+    )
+
+    asyncio.run(
+        handler.handle_routing_update(
+            user_id="58181121",
+            channel_id="58181121",
+            backend="claude",
+            opencode_agent=None,
+            opencode_model=None,
+            claude_agent=None,
+            claude_model="claude-opus-4-1",
+            platform="telegram",
+            is_dm=True,
+        )
+    )
+
+    text = send_message.await_args.args[1]
+    assert "请使用 /new 命令创建新会话，以使设置变更生效。新会话创建后将覆盖当前会话。" in text
+    assert sessions.calls == [("telegram::user::58181121", "telegram_58181121")]
+
+
+def test_handle_routing_update_does_not_warn_flat_scope_same_session_target() -> None:
+    handler, send_message, sessions = _make_flat_scope_handler(
+        row={
+            "agent_name": "claude",
+            "agent_backend": "claude",
+            "agent_variant": "claude",
+            "model": "claude-sonnet-4-5",
+            "reasoning_effort": "",
+        }
+    )
+
+    asyncio.run(
+        handler.handle_routing_update(
+            user_id="58181121",
+            channel_id="58181121",
+            backend="claude",
+            opencode_agent=None,
+            opencode_model=None,
+            claude_agent=None,
+            claude_model="claude-sonnet-4-5",
+            platform="telegram",
+            is_dm=True,
+        )
+    )
+
+    text = send_message.await_args.args[1]
+    assert "请使用 /new 命令创建新会话" not in text
+    assert sessions.calls == [("telegram::user::58181121", "telegram_58181121")]
+
+
 def test_handle_routing_update_does_not_warn_when_flat_scope_has_no_session() -> None:
     handler, send_message, sessions = _make_flat_scope_handler(row=None)
 

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -210,7 +210,7 @@ def test_handle_routing_update_warns_flat_scope_with_existing_backend_session() 
 
     text = send_message.await_args.args[1]
     assert "Agent设置已更新！" in text
-    assert "请使用 /start 命令创建新会话，或丢弃当前会话，以使设置变更生效。" in text
+    assert "请使用 /new 命令创建新会话，以使设置变更生效。新会话创建后将覆盖当前会话。" in text
     assert sessions.calls == [("telegram::user::58181121", "telegram_58181121")]
 
 
@@ -232,7 +232,7 @@ def test_handle_routing_update_warns_wechat_flat_scope_with_existing_backend_ses
     )
 
     text = send_message.await_args.args[1]
-    assert "请使用 /start 命令创建新会话，或丢弃当前会话，以使设置变更生效。" in text
+    assert "请使用 /new 命令创建新会话，以使设置变更生效。新会话创建后将覆盖当前会话。" in text
     assert sessions.calls == [("wechat::user::58181121", "wechat_58181121")]
 
 
@@ -255,7 +255,7 @@ def test_handle_routing_update_does_not_warn_when_flat_scope_has_no_session() ->
 
     text = send_message.await_args.args[1]
     assert "Agent设置已更新！" in text
-    assert "请使用 /start 命令创建新会话" not in text
+    assert "请使用 /new 命令创建新会话" not in text
     assert sessions.calls == [("telegram::user::58181121", "telegram_58181121")]
 
 
@@ -278,7 +278,7 @@ def test_handle_routing_update_does_not_warn_threaded_scope() -> None:
 
     text = send_message.await_args.args[1]
     assert "Agent设置已更新！" in text
-    assert "请使用 /start 命令创建新会话" not in text
+    assert "请使用 /new 命令创建新会话" not in text
     assert sessions.calls == []
 
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -705,6 +705,51 @@ def test_sessions_store_clear_backend_prunes_cached_custom_variant_rows(tmp_path
         store.close()
 
 
+def test_clear_session_base_can_target_typed_user_and_channel_scopes(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    try:
+        with store._service.engine.begin() as conn:
+            user_scope_id = resolve_scope_from_legacy_key(
+                conn, "telegram::user::58181121", now="2026-06-19T07:30:00Z"
+            )
+            channel_scope_id = resolve_scope_from_legacy_key(
+                conn, "telegram::channel::58181121", now="2026-06-19T07:30:00Z"
+            )
+            assert user_scope_id is not None
+            assert channel_scope_id is not None
+            create_agent_session_row(
+                conn,
+                scope_id=user_scope_id,
+                agent_backend="claude",
+                agent_variant="claude",
+                session_anchor="telegram_58181121",
+                native_session_id="claude-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+            create_agent_session_row(
+                conn,
+                scope_id=channel_scope_id,
+                agent_backend="opencode",
+                agent_variant="opencode",
+                session_anchor="telegram_58181121",
+                native_session_id="oc-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+        store.load()
+
+        assert store.clear_session_base("telegram::user::58181121", "telegram_58181121") == 1
+        assert store.find_session_for_anchor("telegram::user::58181121", "telegram_58181121") is None
+        assert store.find_session_for_anchor("telegram::channel::58181121", "telegram_58181121") is not None
+
+        assert store.clear_session_base("telegram::channel::58181121", "telegram_58181121") == 1
+        assert store.find_session_for_anchor("telegram::channel::58181121", "telegram_58181121") is None
+    finally:
+        store.close()
+
+
 def test_sessions_store_remove_backend_session_prunes_cached_custom_variant_row(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     store = SessionsStore(sessions_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -750,6 +750,62 @@ def test_clear_session_base_can_target_typed_user_and_channel_scopes(tmp_path: P
         store.close()
 
 
+def test_typed_user_scope_session_mapping_survives_reload_without_legacy_metadata(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    try:
+        with store._service.engine.begin() as conn:
+            user_scope_id = resolve_scope_from_legacy_key(
+                conn, "telegram::user::58181121", now="2026-06-19T07:30:00Z"
+            )
+            assert user_scope_id is not None
+            create_agent_session_row(
+                conn,
+                scope_id=user_scope_id,
+                agent_backend="claude",
+                agent_variant="claude",
+                session_anchor="telegram_58181121",
+                native_session_id="claude-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+
+        store.load()
+
+        assert store.state.session_mappings["telegram::user::58181121"]["claude"]["telegram_58181121"] == (
+            "claude-native"
+        )
+        assert "telegram::58181121" not in store.state.session_mappings
+    finally:
+        store.close()
+
+
+def test_slack_user_scope_session_mapping_keeps_legacy_untyped_key_on_reload(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    try:
+        with store._service.engine.begin() as conn:
+            user_scope_id = resolve_scope_from_legacy_key(conn, "slack::user::U123", now="2026-06-19T07:30:00Z")
+            assert user_scope_id is not None
+            create_agent_session_row(
+                conn,
+                scope_id=user_scope_id,
+                agent_backend="claude",
+                agent_variant="claude",
+                session_anchor="slack_171717.123",
+                native_session_id="claude-native",
+                workdir="/tmp",
+                require_workdir=False,
+            )
+
+        store.load()
+
+        assert store.state.session_mappings["slack::U123"]["claude"]["slack_171717.123"] == "claude-native"
+        assert "slack::user::U123" not in store.state.session_mappings
+    finally:
+        store.close()
+
+
 def test_sessions_store_remove_backend_session_prunes_cached_custom_variant_row(tmp_path: Path) -> None:
     sessions_path = tmp_path / "sessions.json"
     store = SessionsStore(sessions_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -108,6 +108,34 @@ def test_sessions_store_reloads_external_sqlite_writes(tmp_path: Path) -> None:
         store.close()
 
 
+def test_sessions_facade_preserves_active_poll_session_key(tmp_path: Path) -> None:
+    sessions_path = tmp_path / "sessions.json"
+    store = SessionsStore(sessions_path)
+    facade = SessionsFacade(store)
+    try:
+        facade.add_active_poll(
+            opencode_session_id="oc-typed",
+            base_session_id="slack_171717.123",
+            channel_id="C1",
+            thread_id="171717.123",
+            settings_key="C1",
+            working_path="/repo",
+            baseline_message_ids=[],
+            platform="slack",
+            session_key="slack::channel::C1",
+        )
+
+        reloaded = SessionsStore(sessions_path)
+        try:
+            poll = reloaded.get_active_poll("oc-typed")
+            assert poll is not None
+            assert poll.session_key == "slack::channel::C1"
+        finally:
+            reloaded.close()
+    finally:
+        store.close()
+
+
 def test_sqlite_sessions_service_preserves_agent_session_ids_on_save(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -72,7 +72,7 @@
     "sessionResumedContinueDirect": "💬 *Send your next message directly* to continue with this session.",
     "sessionResumedThreadFreshTip": "_(Sending a new message in the main channel will start a fresh session.)_",
     "routingUpdated": "Agent routing updated!",
-    "routingUpdateNeedsNewSession": "Use /start to create a new session, or discard the current session, for this setting change to take effect."
+    "routingUpdateNeedsNewSession": "Use /new to create a new session for this setting change to take effect. The new session will replace the current session."
   },
   "settings": {
     "personalizationTitle": "Personalization Settings",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -71,7 +71,8 @@
     "sessionResumedContinueDiscordThread": "💬 *Reply in the subchannel to this message* to continue with this session.",
     "sessionResumedContinueDirect": "💬 *Send your next message directly* to continue with this session.",
     "sessionResumedThreadFreshTip": "_(Sending a new message in the main channel will start a fresh session.)_",
-    "routingUpdated": "Agent routing updated!"
+    "routingUpdated": "Agent routing updated!",
+    "routingUpdateNeedsNewSession": "Use /start to create a new session, or discard the current session, for this setting change to take effect."
   },
   "settings": {
     "personalizationTitle": "Personalization Settings",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -72,7 +72,7 @@
     "sessionResumedContinueDirect": "💬 *接下来直接发送消息* 即可继续该会话。",
     "sessionResumedThreadFreshTip": "_(在主会话中发送新消息将开始新的会话。)_",
     "routingUpdated": "Agent设置已更新！",
-    "routingUpdateNeedsNewSession": "请使用 /start 命令创建新会话，或丢弃当前会话，以使设置变更生效。"
+    "routingUpdateNeedsNewSession": "请使用 /new 命令创建新会话，以使设置变更生效。新会话创建后将覆盖当前会话。"
   },
   "settings": {
     "personalizationTitle": "个性化设置",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -71,7 +71,8 @@
     "sessionResumedContinueDiscordThread": "💬 *请在子区回复这条消息* 以继续该会话。",
     "sessionResumedContinueDirect": "💬 *接下来直接发送消息* 即可继续该会话。",
     "sessionResumedThreadFreshTip": "_(在主会话中发送新消息将开始新的会话。)_",
-    "routingUpdated": "Agent设置已更新！"
+    "routingUpdated": "Agent设置已更新！",
+    "routingUpdateNeedsNewSession": "请使用 /start 命令创建新会话，或丢弃当前会话，以使设置变更生效。"
   },
   "settings": {
     "personalizationTitle": "个性化设置",


### PR DESCRIPTION
## Summary

Fix Telegram private-chat session routing when a user switches Agents and starts a new session.

## Root Cause

Telegram private chats use the same native id for the chat and the user. The new routing model stores the configured Agent on the user scope, but older session rows and compatibility paths could still live under channel or untyped legacy keys. `/new` cleared backend runtime state, but did not reliably clear the persisted `agent_sessions` rows for the same Telegram private-chat anchor, so the next message could resume the stale OpenCode session instead of following the current Claude Agent route.

## Changes

- Build canonical typed user session keys for Telegram-style DMs where `channel_id == user_id`.
- Make `/new` clear the current typed user key plus legacy channel/untyped keys for Telegram private chats.
- Make persisted session lookups respect typed user/channel scope keys.
- Store Telegram private-chat mirrored messages on user scope to avoid channel/user native-id collisions.
- Preserve typed session keys across OpenCode active-poll save/restore.
- Isolate a command-handler test stub that was leaking fake `modules.agents.base` into later tests.

## Evidence

- Unit: `uv run pytest tests/test_message_context_helpers.py tests/test_agent_run_target.py tests/test_controller_vibe_agent_routing.py tests/test_command_handler_user_names.py tests/test_telegram_bot.py tests/test_sqlite_sessions_store.py tests/test_message_mirror.py tests/test_opencode_restore_polls.py`
- Lint: `uv run ruff check ...` for touched Python files and tests
- Regression: synced this branch into local Incus `master` target and replayed the current Telegram private-chat database state. The replay cleared typed user, legacy channel, and untyped sessions, then resolved the next message to `telegram::user::58181121 -> claude / claude-opus-4-8`.

## Residual Checks

- Full CI should still run on the PR.
