### PR TITLE
fix: percent-encode non-ASCII paths in x-opencode-directory header

### DIFF
--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -13,6 +13,7 @@ import re
 import socket
 import subprocess
 import time
+from urllib.parse import quote as _url_quote
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -38,6 +39,17 @@ DEFAULT_OPENCODE_PORT = 4096
 DEFAULT_OPENCODE_HOST = "127.0.0.1"
 SERVER_START_TIMEOUT = 15
 OPENCODE_LOG_TAIL_BYTES = 2_000_000
+
+
+def _percent_encode_path(path: str) -> str:
+    """Percent-encode *path* so it is safe for an HTTP header value.
+
+    RFC 7230 only allows visible US-ASCII characters (plus whitespace)
+    in header field values.  Non-ASCII bytes (e.g. CJK characters in
+    project paths) must be percent-encoded, otherwise they will be
+    misinterpreted by the receiving end.
+    """
+    return _url_quote(path, safe="/")
 
 
 class OpenCodeServerManager:
@@ -1079,7 +1091,7 @@ class OpenCodeServerManager:
             async with session.post(
                 f"{self.base_url}/session",
                 json=body,
-                headers={"x-opencode-directory": directory},
+                headers={"x-opencode-directory": _percent_encode_path(directory)},
             ) as resp:
                 if resp.status != 200:
                     text = await resp.text()
@@ -1092,7 +1104,7 @@ class OpenCodeServerManager:
             async with session.post(
                 f"{self.base_url}/session/{source_session_id}/fork",
                 json={},
-                headers={"x-opencode-directory": directory},
+                headers={"x-opencode-directory": _percent_encode_path(directory)},
             ) as resp:
                 if resp.status != 200:
                     text = await resp.text()
@@ -1125,7 +1137,7 @@ class OpenCodeServerManager:
             async with session.post(
                 f"{self.base_url}/session/{session_id}/message",
                 json=body,
-                headers={"x-opencode-directory": directory},
+                headers={"x-opencode-directory": _percent_encode_path(directory)},
             ) as resp:
                 if resp.status != 200:
                     error_text = await resp.text()
@@ -1167,7 +1179,7 @@ class OpenCodeServerManager:
             async with session.post(
                 f"{self.base_url}/session/{session_id}/prompt_async",
                 json=body,
-                headers={"x-opencode-directory": directory},
+                headers={"x-opencode-directory": _percent_encode_path(directory)},
             ) as resp:
                 # OpenCode returns 204 when accepted.
                 if resp.status not in (200, 204):
@@ -1180,7 +1192,7 @@ class OpenCodeServerManager:
             session = await self._get_http_session()
             async with session.get(
                 f"{self.base_url}/session/{session_id}/message",
-                headers={"x-opencode-directory": directory},
+                headers={"x-opencode-directory": _percent_encode_path(directory)},
             ) as resp:
                 if resp.status != 200:
                     error_text = await resp.text()
@@ -1192,7 +1204,7 @@ class OpenCodeServerManager:
             session = await self._get_http_session()
             async with session.get(
                 f"{self.base_url}/session/{session_id}/message/{message_id}",
-                headers={"x-opencode-directory": directory},
+                headers={"x-opencode-directory": _percent_encode_path(directory)},
             ) as resp:
                 if resp.status != 200:
                     error_text = await resp.text()
@@ -1206,7 +1218,7 @@ class OpenCodeServerManager:
             try:
                 async with session.post(
                     f"{self.base_url}/session/{session_id}/abort",
-                    headers={"x-opencode-directory": directory},
+                    headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     return resp.status == 200
             except Exception as e:
@@ -1228,7 +1240,7 @@ class OpenCodeServerManager:
             try:
                 async with session.get(
                     f"{self.base_url}/session/{session_id}",
-                    headers={"x-opencode-directory": directory},
+                    headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
                         return await resp.json()
@@ -1263,7 +1275,7 @@ class OpenCodeServerManager:
             try:
                 async with session.get(
                     f"{self.base_url}/agent",
-                    headers={"x-opencode-directory": directory},
+                    headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
                         agents = await resp.json()
@@ -1286,7 +1298,7 @@ class OpenCodeServerManager:
             try:
                 async with session.get(
                     f"{self.base_url}/config/providers",
-                    headers={"x-opencode-directory": directory},
+                    headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
                         return await resp.json()
@@ -1307,7 +1319,7 @@ class OpenCodeServerManager:
             try:
                 async with session.get(
                     f"{self.base_url}/config",
-                    headers={"x-opencode-directory": directory},
+                    headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
                         return await resp.json()

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -117,6 +117,41 @@ class _FakeSession:
 
 
 class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
+    def test_percent_encode_path_preserves_round_trip_sensitive_paths(self):
+        self.assertEqual(
+            SERVER_MODULE._percent_encode_path("/tmp/小说"),
+            "/tmp/%E5%B0%8F%E8%AF%B4",
+        )
+        self.assertEqual(
+            SERVER_MODULE._percent_encode_path("/tmp/a b"),
+            "/tmp/a%20b",
+        )
+        self.assertEqual(
+            SERVER_MODULE._percent_encode_path("/tmp/a%20b"),
+            "/tmp/a%2520b",
+        )
+
+    async def test_prompt_async_percent_encodes_directory_header(self):
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        fake_session = _FakeSession()
+
+        async def _fake_get_http_session():
+            return fake_session
+
+        manager._get_http_session = _fake_get_http_session  # type: ignore[method-assign]
+
+        await manager.prompt_async(
+            session_id="ses-1",
+            directory="/tmp/小说/a%20b",
+            text="hello",
+        )
+
+        self.assertEqual(len(fake_session.posts), 1)
+        self.assertEqual(
+            fake_session.posts[0]["headers"],
+            {"x-opencode-directory": "/tmp/%E5%B0%8F%E8%AF%B4/a%2520b"},
+        )
+
     async def test_prompt_async_includes_tools_when_provided(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()


### PR DESCRIPTION
HTTP headers per RFC 7230 only allow ASCII. Project paths with CJK characters were placed raw in x-opencode-directory header, causing OpenCode to receive corrupted paths and fail.

Percent-encode directory path before placing in the header.

Tests:
- Added OpenCode server unit coverage for non-ASCII, space, and literal percent directory header encoding.
- `pytest tests/test_opencode_server.py`
- `ruff check modules/agents/opencode/server.py tests/test_opencode_server.py`

Fixes #620
