### PR TITLE
fix(claude): backstop idle eviction for stuck-active sessions (#622)

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -34,7 +34,18 @@ DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 600
 # eviction from the receiver's flag-release logic, so a stuck-active session can
 # no longer pin its ~220MB ``claude`` subprocess until the next service restart.
 # A genuine in-flight turn keeps touching ``last_activity`` (assistant/tool
-# messages), so it stays well under this cap. Set to 0 to disable the backstop.
+# messages), so it normally stays well under this cap. Set to 0 to disable the
+# backstop.
+#
+# Trade-off: ``last_activity`` is only refreshed when an SDK message arrives.
+# Because a stuck (blocked-receiver) session and a session running a single
+# silent tool call are indistinguishable from ``last_activity`` alone, a real
+# turn whose ONE tool invocation runs silently for longer than
+# ``idle_timeout * multiplier`` (default 30min) would be force-evicted mid-turn.
+# The default 3x is chosen because Claude Code's Bash tool caps at 10min, so a
+# single 30min-silent turn is not expected in practice; raise the multiplier if
+# your deployment runs longer silent tools (e.g. long builds via custom/MCP
+# tools that emit no intermediate messages).
 DEFAULT_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER = 3
 DEFAULT_OPENCODE_ERROR_RETRY_LIMIT = 1
 DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX = 14

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -26,6 +26,16 @@ logger = logging.getLogger(__name__)
 CONFIG_LOCK = threading.RLock()
 
 DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 600
+# Absolute-age backstop for idle eviction. A Claude session that is still
+# flagged ``active`` (its per-turn receiver never released the flag, e.g. a
+# long-lived receiver blocked on ``receive_messages`` with no stream EOF) is
+# force-evicted once its ``last_activity`` is older than
+# ``idle_timeout * STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER``. This decouples
+# eviction from the receiver's flag-release logic, so a stuck-active session can
+# no longer pin its ~220MB ``claude`` subprocess until the next service restart.
+# A genuine in-flight turn keeps touching ``last_activity`` (assistant/tool
+# messages), so it stays well under this cap. Set to 0 to disable the backstop.
+DEFAULT_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER = 3
 DEFAULT_OPENCODE_ERROR_RETRY_LIMIT = 1
 DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX = 14
 MIN_CHAT_MESSAGE_FONT_SIZE_PX = 12

--- a/core/controller.py
+++ b/core/controller.py
@@ -1249,6 +1249,13 @@ class Controller:
                         await self.session_handler.evict_idle_sessions(claude_timeout)
                     except Exception as e:
                         logger.error("Claude idle cleanup failed: %s", e, exc_info=True)
+                    try:
+                        # Defense-in-depth: reconcile live claude subprocesses
+                        # against tracked sessions and reap orphans (no-owner /
+                        # cross-restart) the idle-eviction path cannot see.
+                        await self.session_handler.reap_orphaned_claude_sessions()
+                    except Exception as e:
+                        logger.error("Claude orphan reaper failed: %s", e, exc_info=True)
 
                 if codex_timeout > 0:
                     codex_agent = self.agent_service.agents.get("codex")

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -20,6 +20,7 @@ from modules.agents.native_sessions.base import build_resume_preview
 from modules.agents.claude_process_reaper import (
     get_claude_client_pid,
     reap_duplicate_claude_resume_processes,
+    reap_orphaned_claude_processes,
 )
 from config.v2_config import DEFAULT_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER
 from core.avibe_cloud import avibe_cloud_url_available
@@ -1309,6 +1310,36 @@ class SessionHandler(BaseHandler):
             evicted += 1
 
         return evicted
+
+    async def reap_orphaned_claude_sessions(self) -> int:
+        """Reap leaked ``claude`` subprocesses not owned by any tracked session.
+
+        Defense-in-depth backstop for the idle-eviction path: even if a session
+        slips out of tracking (or a previous service instance left a child
+        reparented to init), the resident ``claude`` subprocess is reconciled
+        against the set of currently-tracked sessions and terminated when it has
+        no owner. See ``reap_orphaned_claude_processes`` for the safety guards.
+        """
+        owned_pids: set[int] = set()
+        tracked_resume_ids: dict[str, int] = {}
+        for client in list(self.claude_sessions.values()):
+            pid = get_claude_client_pid(client)
+            if not pid:
+                continue
+            owned_pids.add(pid)
+            native_session_id = getattr(client, "_vibe_native_session_id", None)
+            if native_session_id:
+                tracked_resume_ids[str(native_session_id)] = pid
+        try:
+            return await reap_orphaned_claude_processes(
+                owned_pids=owned_pids,
+                tracked_resume_ids=tracked_resume_ids,
+                cli_path=self._get_claude_cli_path_override(),
+                logger=logger,
+            )
+        except Exception:
+            logger.debug("Claude orphan reaper failed", exc_info=True)
+            return 0
 
     async def handle_session_error(self, composite_key: str, context: MessageContext, error: Exception):
         """Handle session-related errors"""

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1330,16 +1330,15 @@ class SessionHandler(BaseHandler):
             native_session_id = getattr(client, "_vibe_native_session_id", None)
             if native_session_id:
                 tracked_resume_ids[str(native_session_id)] = pid
-        try:
-            return await reap_orphaned_claude_processes(
-                owned_pids=owned_pids,
-                tracked_resume_ids=tracked_resume_ids,
-                cli_path=self._get_claude_cli_path_override(),
-                logger=logger,
-            )
-        except Exception:
-            logger.debug("Claude orphan reaper failed", exc_info=True)
-            return 0
+        # Let unexpected errors surface to the caller (``periodic_cleanup``
+        # logs them at error level); ``reap_orphaned_claude_processes`` already
+        # absorbs the expected ``ps``-read failure internally.
+        return await reap_orphaned_claude_processes(
+            owned_pids=owned_pids,
+            tracked_resume_ids=tracked_resume_ids,
+            cli_path=self._get_claude_cli_path_override(),
+            logger=logger,
+        )
 
     async def handle_session_error(self, composite_key: str, context: MessageContext, error: Exception):
         """Handle session-related errors"""

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -21,6 +21,7 @@ from modules.agents.claude_process_reaper import (
     get_claude_client_pid,
     reap_duplicate_claude_resume_processes,
 )
+from config.v2_config import DEFAULT_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER
 from core.avibe_cloud import avibe_cloud_url_available
 from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
@@ -1234,10 +1235,31 @@ class SessionHandler(BaseHandler):
         if exc is not None:
             logger.warning("Claude receiver ended with error during cleanup: %s", exc)
 
-    async def evict_idle_sessions(self, idle_timeout: float) -> int:
-        """Disconnect Claude sessions that have been idle beyond the timeout."""
+    async def evict_idle_sessions(
+        self,
+        idle_timeout: float,
+        stuck_active_multiplier: float = DEFAULT_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER,
+    ) -> int:
+        """Disconnect Claude sessions that have been idle beyond the timeout.
+
+        A session is normally exempt from eviction while it is flagged
+        ``active`` (a turn is in flight). That veto is **not** absolute: if the
+        receiver coroutine never releases the flag (e.g. it stays alive but
+        blocked on ``receive_messages`` with no stream EOF), the session would
+        otherwise be pinned forever and its ``claude`` subprocess would survive
+        until the next service restart. As an independent backstop, a session
+        that is ``active`` but whose ``last_activity`` is older than
+        ``idle_timeout * stuck_active_multiplier`` is force-evicted regardless of
+        why the flag was not cleared. A genuine in-flight turn keeps touching
+        ``last_activity`` via assistant/tool messages, so it stays well under
+        this cap. Pass ``stuck_active_multiplier <= 0`` to disable the backstop.
+        """
         if idle_timeout <= 0:
             return 0
+
+        stuck_threshold = (
+            idle_timeout * stuck_active_multiplier if stuck_active_multiplier > 0 else None
+        )
 
         now = time.monotonic()
         expired: list[tuple[str, float]] = []
@@ -1247,10 +1269,14 @@ class SessionHandler(BaseHandler):
                 self.session_last_activity.pop(composite_key, None)
                 self.active_sessions.discard(composite_key)
                 continue
+            idle_for = now - last_activity
             if composite_key in self.active_sessions:
+                # Stuck-active backstop: only evict once well past the cap.
+                if stuck_threshold is not None and idle_for >= stuck_threshold:
+                    expired.append((composite_key, idle_for))
                 continue
-            if now - last_activity >= idle_timeout:
-                expired.append((composite_key, now - last_activity))
+            if idle_for >= idle_timeout:
+                expired.append((composite_key, idle_for))
 
         evicted = 0
         for composite_key, idle_for in expired:
@@ -1259,13 +1285,26 @@ class SessionHandler(BaseHandler):
                 self.session_last_activity.pop(composite_key, None)
                 self.active_sessions.discard(composite_key)
                 continue
-            if composite_key in self.active_sessions:
-                continue
             if current_last_activity is None:
                 continue
-            if time.monotonic() - current_last_activity < idle_timeout:
-                continue
-            logger.info("Evicting idle Claude session %s after %.1fs idle", composite_key, idle_for)
+            # Re-derive the decision from current state: a session may have been
+            # touched or (de)activated between the two passes.
+            recheck_idle = time.monotonic() - current_last_activity
+            if composite_key in self.active_sessions:
+                if stuck_threshold is None or recheck_idle < stuck_threshold:
+                    continue
+                logger.warning(
+                    "Force-evicting stuck-active Claude session %s after %.1fs idle "
+                    "(>= %sx idle_timeout=%ss); receiver never released the active flag",
+                    composite_key,
+                    idle_for,
+                    stuck_active_multiplier,
+                    idle_timeout,
+                )
+            else:
+                if recheck_idle < idle_timeout:
+                    continue
+                logger.info("Evicting idle Claude session %s after %.1fs idle", composite_key, idle_for)
             await self.cleanup_session(composite_key)
             evicted += 1
 

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1325,14 +1325,22 @@ class SessionHandler(BaseHandler):
         """
         owned_pids: set[int] = set()
         tracked_resume_ids: dict[str, int] = {}
+        owner_set_complete = True
         for client in list(self.claude_sessions.values()):
             pid = get_claude_client_pid(client)
             if not pid:
+                # A tracked client whose pid we cannot resolve means the owner
+                # set is incomplete: its live process would look ownerless to
+                # the in-tree sweep. Disable that sweep this round.
+                owner_set_complete = False
                 continue
             owned_pids.add(pid)
             native_session_id = getattr(client, "_vibe_native_session_id", None)
             if native_session_id:
                 tracked_resume_ids[str(native_session_id)] = pid
+        # A session create in flight has spawned a subprocess (connect()) that is
+        # not yet in claude_sessions; the in-tree sweep must not touch it.
+        creates_in_flight = bool(self.claude_session_creates)
         # Let unexpected errors surface to the caller (``periodic_cleanup``
         # logs them at error level); ``reap_orphaned_claude_processes`` already
         # absorbs the expected ``ps``-read failure internally.
@@ -1341,6 +1349,7 @@ class SessionHandler(BaseHandler):
             tracked_resume_ids=tracked_resume_ids,
             cli_path=self._get_claude_cli_path_override(),
             logger=logger,
+            reap_in_tree=owner_set_complete and not creates_in_flight,
         )
 
     async def handle_session_error(self, composite_key: str, context: MessageContext, error: Exception):

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1252,8 +1252,11 @@ class SessionHandler(BaseHandler):
         that is ``active`` but whose ``last_activity`` is older than
         ``idle_timeout * stuck_active_multiplier`` is force-evicted regardless of
         why the flag was not cleared. A genuine in-flight turn keeps touching
-        ``last_activity`` via assistant/tool messages, so it stays well under
-        this cap. Pass ``stuck_active_multiplier <= 0`` to disable the backstop.
+        ``last_activity`` via assistant/tool messages, so it normally stays well
+        under this cap. Pass ``stuck_active_multiplier <= 0`` to disable the
+        backstop. Caveat: a real turn whose single tool call runs silently for
+        longer than the cap is indistinguishable from a stuck session and would
+        be force-evicted — see ``DEFAULT_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER``.
         """
         if idle_timeout <= 0:
             return 0

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1301,14 +1301,14 @@ class SessionHandler(BaseHandler):
                     "Force-evicting stuck-active Claude session %s after %.1fs idle "
                     "(>= %sx idle_timeout=%ss); receiver never released the active flag",
                     composite_key,
-                    idle_for,
+                    recheck_idle,
                     stuck_active_multiplier,
                     idle_timeout,
                 )
             else:
                 if recheck_idle < idle_timeout:
                     continue
-                logger.info("Evicting idle Claude session %s after %.1fs idle", composite_key, idle_for)
+                logger.info("Evicting idle Claude session %s after %.1fs idle", composite_key, recheck_idle)
             await self.cleanup_session(composite_key)
             evicted += 1
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -654,31 +654,48 @@ class ClaudeAgent(BaseAgent):
                         # stale straggler. No-op for fresh sessions / absent tokens.
                         self._adopt_pending_turn_token(context, pending_request)
 
-                        await self.emit_result_message(
-                            context,
-                            result_text,
-                            subtype=getattr(message, "subtype", "") or "",
-                            duration_ms=getattr(message, "duration_ms", 0),
-                            parse_mode="markdown",
-                            request=pending_request,
-                        )
-                        native_session_id = self._native_session_ids.get(composite_key) or self._reserved_native_session_id(
-                            context,
-                            self.name,
-                        ) or self._reserved_native_session_id(
-                            getattr(pending_request, "context", None),
-                            self.name,
-                        )
-                        if pending_request is not None and native_session_id:
-                            self._maybe_backfill_session_title(pending_request, native_session_id)
+                        # A terminal result settles the turn. The pending request
+                        # was already popped above, so the idle transition must run
+                        # even if emitting the result or backfilling the title
+                        # raises — otherwise the inner ``except … continue`` below
+                        # would swallow the error, skip the mark-idle, and leave the
+                        # session pinned ``active`` (exempt from idle eviction until
+                        # the next service restart). Run it in a ``finally``.
+                        try:
+                            await self.emit_result_message(
+                                context,
+                                result_text,
+                                subtype=getattr(message, "subtype", "") or "",
+                                duration_ms=getattr(message, "duration_ms", 0),
+                                parse_mode="markdown",
+                                request=pending_request,
+                            )
+                            native_session_id = self._native_session_ids.get(composite_key) or self._reserved_native_session_id(
+                                context,
+                                self.name,
+                            ) or self._reserved_native_session_id(
+                                getattr(pending_request, "context", None),
+                                self.name,
+                            )
+                            if pending_request is not None and native_session_id:
+                                self._maybe_backfill_session_title(pending_request, native_session_id)
 
-                        self._discard_pending_reaction(composite_key)
-
-                        self._last_assistant_text.pop(composite_key, None)
-                        is_idle = self._mark_session_idle_if_no_pending_requests(composite_key)
-                        session = await self.session_manager.get_or_create_session(context.user_id, context.channel_id)
-                        if session and is_idle:
-                            session.session_active[composite_key] = False
+                            self._discard_pending_reaction(composite_key)
+                            self._last_assistant_text.pop(composite_key, None)
+                        finally:
+                            is_idle = self._mark_session_idle_if_no_pending_requests(composite_key)
+                            try:
+                                session = await self.session_manager.get_or_create_session(
+                                    context.user_id, context.channel_id
+                                )
+                                if session and is_idle:
+                                    session.session_active[composite_key] = False
+                            except Exception:
+                                logger.debug(
+                                    "claude: failed to update session_active after result for %s",
+                                    composite_key,
+                                    exc_info=True,
+                                )
                         continue
 
                     # Ignore UserMessage/tool results; toolcalls are emitted from ToolUseBlock.

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -679,10 +679,13 @@ class ClaudeAgent(BaseAgent):
                             )
                             if pending_request is not None and native_session_id:
                                 self._maybe_backfill_session_title(pending_request, native_session_id)
-
+                        finally:
+                            # Settle the turn regardless of an emit/backfill
+                            # failure: clear the loading reaction and the stale
+                            # assistant-text fallback, then release the active
+                            # flag so the session can be idle-evicted.
                             self._discard_pending_reaction(composite_key)
                             self._last_assistant_text.pop(composite_key, None)
-                        finally:
                             is_idle = self._mark_session_idle_if_no_pending_requests(composite_key)
                             try:
                                 session = await self.session_manager.get_or_create_session(

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -246,7 +246,9 @@ def _process_ages(pids: set[int]) -> dict[int, float]:
 
     Returns a ``{pid: age_seconds}`` map. Pids whose age cannot be determined
     are simply absent (callers treat unknown age conservatively: do not reap).
-    Portable across Linux/macOS ``ps`` (``etimes`` = elapsed seconds).
+    ``etimes`` (elapsed seconds) is available on Linux procps-ng and macOS; on
+    busybox ``ps`` (Alpine) it is unsupported, so this returns ``{}`` and the
+    caller reaps nothing — the safe conservative fallback.
     """
     if not pids:
         return {}
@@ -366,7 +368,9 @@ async def reap_orphaned_claude_processes(
         return 0
 
     logger.warning(
-        "Reaping %d orphaned Claude process(es) (no owning session): %s",
+        "Reaping %d orphaned Claude process(es) with no owning session "
+        "(%d pids incl. descendants): %s",
+        len(aged_candidates),
         len(target_pids),
         sorted(target_pids),
     )

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -64,6 +64,24 @@ def _command_has_resume(command: str, native_session_id: str) -> bool:
     return False
 
 
+def _command_has_stream_json_input(command: str) -> bool:
+    """True if the command runs the Claude CLI in bidirectional streaming mode.
+
+    The Claude Agent SDK always launches the session CLI with
+    ``--input-format stream-json`` (see the SDK's subprocess transport). A
+    user's interactive ``claude`` or a one-shot ``claude -p`` — and ``claude``
+    spawned by another backend or a watch command — does not, so this scopes
+    the in-tree orphan sweep to SDK-spawned session subprocesses only.
+    """
+    parts = command.split()
+    for index, part in enumerate(parts):
+        if part == "--input-format" and index + 1 < len(parts) and parts[index + 1] == "stream-json":
+            return True
+        if part == "--input-format=stream-json":
+            return True
+    return False
+
+
 def _command_is_claude(command: str, cli_path: str | None = None) -> bool:
     parts = command.split()
     if not parts:
@@ -288,14 +306,15 @@ async def reap_orphaned_claude_processes(
 
     Two orphan classes are reaped:
 
-    (a) **In-process orphan** — a ``claude`` process inside the current
-        service's process tree that is no longer referenced by any tracked
-        session (``owned_pids``). This happens when session tracking is lost
-        but the subprocess survives. Only attempted when ``reap_in_tree`` is
-        True: the caller must pass False whenever the owner set may be
-        incomplete (a tracked client's pid could not be resolved, or a session
-        create is in flight), otherwise a live tracked/connecting process could
-        be misclassified as an orphan and killed.
+    (a) **In-process orphan** — a Claude SDK *session* subprocess (launched
+        with ``--input-format stream-json``) inside the current service's
+        process tree that is no longer referenced by any tracked session
+        (``owned_pids``). Scoping to the SDK streaming signature avoids reaping
+        a ``claude`` launched by another backend or a watch command. Only
+        attempted when ``reap_in_tree`` is True: the caller must pass False
+        whenever the owner set may be incomplete (a tracked client's pid could
+        not be resolved, or a session create is in flight), otherwise a live
+        tracked/connecting process could be misclassified as an orphan.
 
     (b) **Cross-restart orphan** — a ``claude`` process reparented to init
         (``ppid == 1``) after a previous service crashed/restarted, carrying a
@@ -344,12 +363,19 @@ async def reap_orphaned_claude_processes(
 
     candidates: set[int] = set()
 
-    # (a) in-tree claude processes we no longer own. Skipped when the owner set
-    # may be incomplete (unresolved tracked pid / session create in flight),
-    # since we could not then tell a live tracked process from an orphan.
+    # (a) in-tree claude processes we no longer own. Scoped to SDK session
+    # subprocesses (``--input-format stream-json``) so a `claude` launched by
+    # another backend or a watch command is never reaped. Skipped entirely when
+    # the owner set may be incomplete (unresolved tracked pid / session create
+    # in flight), since we could not then tell a live tracked process from an
+    # orphan.
     if reap_in_tree:
         for row in claude_rows:
-            if row.pid in service_tree and row.pid not in owned_all:
+            if (
+                row.pid in service_tree
+                and row.pid not in owned_all
+                and _command_has_stream_json_input(row.command)
+            ):
                 candidates.add(row.pid)
 
     # (b) init-reparented (ppid == 1) cross-restart orphan carrying a tracked

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -204,6 +204,22 @@ async def reap_duplicate_claude_resume_processes(
         native_session_id,
         keep_pid,
     )
+    return await _reap_pid_set(target_pids, terminate_timeout=terminate_timeout, logger=logger)
+
+
+async def _reap_pid_set(
+    target_pids: set[int],
+    *,
+    terminate_timeout: float,
+    logger: logging.Logger,
+) -> int:
+    """SIGTERM a set of pids, wait briefly, then SIGKILL the survivors.
+
+    Returns the number of pids that were targeted.
+    """
+    if not target_pids:
+        return 0
+
     for pid in sorted(target_pids):
         _signal_pid(pid, signal.SIGTERM, logger)
 
@@ -223,3 +239,135 @@ async def reap_duplicate_claude_resume_processes(
         _signal_pid(pid, KILL_SIGNAL, logger)
 
     return len(target_pids)
+
+
+def _process_ages(pids: set[int]) -> dict[int, float]:
+    """Best-effort elapsed-seconds-since-start for the given pids via ``ps``.
+
+    Returns a ``{pid: age_seconds}`` map. Pids whose age cannot be determined
+    are simply absent (callers treat unknown age conservatively: do not reap).
+    Portable across Linux/macOS ``ps`` (``etimes`` = elapsed seconds).
+    """
+    if not pids:
+        return {}
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "pid=,etimes=", "-p", ",".join(str(p) for p in sorted(pids))],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1.5,
+        )
+    except Exception:
+        return {}
+    ages: dict[int, float] = {}
+    for line in (result.stdout or "").splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        try:
+            ages[int(parts[0])] = float(parts[1])
+        except ValueError:
+            continue
+    return ages
+
+
+async def reap_orphaned_claude_processes(
+    *,
+    owned_pids: set[int],
+    tracked_resume_ids: dict[str, int],
+    cli_path: str | None = None,
+    logger: logging.Logger,
+    min_age_seconds: float = 60.0,
+    terminate_timeout: float = 2.0,
+) -> int:
+    """Reap leaked Claude CLI processes (defense-in-depth orphan reaper).
+
+    Two orphan classes are reaped:
+
+    (a) **In-process orphan** — a ``claude`` process inside the current
+        service's process tree that is no longer referenced by any tracked
+        session (``owned_pids``). This happens when session tracking is lost
+        but the subprocess survives.
+
+    (b) **Cross-restart orphan** — a ``claude`` process *outside* the current
+        service tree (e.g. reparented to init after a previous service crashed
+        or restarted) that carries a ``--resume <native_id>`` for a session we
+        currently own under a *different* pid. Matching the unique native
+        session id makes this safe against unrelated ``claude`` processes.
+
+    Safety guards:
+    - ``owned_pids`` and their descendants are never reaped.
+    - The current service pid is never reaped.
+    - A ``min_age_seconds`` grace window protects a freshly spawned process
+      that has not yet been registered into the tracked set (TOCTOU). A
+      candidate whose age cannot be determined is **not** reaped.
+    """
+    if os.name == "nt":
+        return 0
+
+    try:
+        all_rows = _parse_ps_rows(_run_ps())
+    except Exception:
+        logger.debug("Failed to read process table for Claude orphan cleanup", exc_info=True)
+        return 0
+
+    service_pid = os.getpid()
+    service_tree = {service_pid} | _descendant_pids(all_rows, service_pid)
+
+    owned_all: set[int] = {pid for pid in owned_pids if isinstance(pid, int) and pid > 0}
+    for pid in list(owned_all):
+        owned_all.update(_descendant_pids(all_rows, pid))
+
+    claude_rows = [
+        row
+        for row in all_rows
+        if row.pid != service_pid and _command_is_claude(row.command, cli_path=cli_path)
+    ]
+
+    candidates: set[int] = set()
+
+    # (a) in-tree claude processes we no longer own.
+    for row in claude_rows:
+        if row.pid in service_tree and row.pid not in owned_all:
+            candidates.add(row.pid)
+
+    # (b) out-of-tree claude carrying a tracked --resume id under a foreign pid.
+    for native_id, owner_pid in tracked_resume_ids.items():
+        if not native_id:
+            continue
+        for row in claude_rows:
+            if row.pid in service_tree:
+                continue  # in-tree handled by (a) / the duplicate reaper
+            if row.pid == owner_pid:
+                continue
+            if _command_has_resume(row.command, native_id):
+                candidates.add(row.pid)
+
+    candidates -= owned_all
+    candidates.discard(service_pid)
+    if not candidates:
+        return 0
+
+    # TOCTOU grace window: never reap a process younger than the cutoff, and
+    # never reap one whose age we cannot establish.
+    ages = _process_ages(candidates)
+    aged_candidates = {pid for pid in candidates if ages.get(pid, 0.0) >= min_age_seconds}
+    if not aged_candidates:
+        return 0
+
+    # Reap each orphan together with its descendants (e.g. node helpers).
+    target_pids: set[int] = set(aged_candidates)
+    for pid in aged_candidates:
+        target_pids.update(_descendant_pids(all_rows, pid))
+    target_pids -= owned_all
+    target_pids.discard(service_pid)
+    if not target_pids:
+        return 0
+
+    logger.warning(
+        "Reaping %d orphaned Claude process(es) (no owning session): %s",
+        len(target_pids),
+        sorted(target_pids),
+    )
+    return await _reap_pid_set(target_pids, terminate_timeout=terminate_timeout, logger=logger)

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -54,14 +54,19 @@ def _parse_ps_rows(output: str) -> list[ClaudeProcessRow]:
     return rows
 
 
-def _command_has_resume(command: str, native_session_id: str) -> bool:
+def _command_has_flag_value(command: str, flag: str, value: str) -> bool:
+    """True if ``command`` passes ``flag value`` or ``flag=value`` (token-exact)."""
     parts = command.split()
     for index, part in enumerate(parts):
-        if part == "--resume" and index + 1 < len(parts) and parts[index + 1] == native_session_id:
+        if part == flag and index + 1 < len(parts) and parts[index + 1] == value:
             return True
-        if part.startswith("--resume=") and part.removeprefix("--resume=") == native_session_id:
+        if part == f"{flag}={value}":
             return True
     return False
+
+
+def _command_has_resume(command: str, native_session_id: str) -> bool:
+    return _command_has_flag_value(command, "--resume", native_session_id)
 
 
 def _command_has_stream_json_input(command: str) -> bool:
@@ -73,13 +78,7 @@ def _command_has_stream_json_input(command: str) -> bool:
     spawned by another backend or a watch command — does not, so this scopes
     the in-tree orphan sweep to SDK-spawned session subprocesses only.
     """
-    parts = command.split()
-    for index, part in enumerate(parts):
-        if part == "--input-format" and index + 1 < len(parts) and parts[index + 1] == "stream-json":
-            return True
-        if part == "--input-format=stream-json":
-            return True
-    return False
+    return _command_has_flag_value(command, "--input-format", "stream-json")
 
 
 def _command_is_claude(command: str, cli_path: str | None = None) -> bool:
@@ -116,10 +115,20 @@ def find_claude_resume_processes(native_session_id: str, *, cli_path: str | None
     ]
 
 
-def _descendant_pids(rows: list[ClaudeProcessRow], root_pid: int) -> set[int]:
+def _build_children_map(rows: list[ClaudeProcessRow]) -> dict[int, list[int]]:
     children: dict[int, list[int]] = {}
     for row in rows:
         children.setdefault(row.ppid, []).append(row.pid)
+    return children
+
+
+def _descendant_pids(
+    rows: list[ClaudeProcessRow],
+    root_pid: int,
+    children: dict[int, list[int]] | None = None,
+) -> set[int]:
+    if children is None:
+        children = _build_children_map(rows)
 
     descendants: set[int] = set()
     stack = list(children.get(root_pid, []))
@@ -348,12 +357,16 @@ async def reap_orphaned_claude_processes(
         logger.debug("Failed to read process table for Claude orphan cleanup", exc_info=True)
         return 0
 
+    # Build the parent->children index once and reuse it for every descendant
+    # walk below (service tree, owned descendants, orphan descendants).
+    children = _build_children_map(all_rows)
+
     service_pid = os.getpid()
-    service_tree = {service_pid} | _descendant_pids(all_rows, service_pid)
+    service_tree = {service_pid} | _descendant_pids(all_rows, service_pid, children)
 
     owned_all: set[int] = {pid for pid in owned_pids if isinstance(pid, int) and pid > 0}
     for pid in list(owned_all):
-        owned_all.update(_descendant_pids(all_rows, pid))
+        owned_all.update(_descendant_pids(all_rows, pid, children))
 
     claude_rows = [
         row
@@ -410,7 +423,7 @@ async def reap_orphaned_claude_processes(
     # Reap each orphan together with its descendants (e.g. node helpers).
     target_pids: set[int] = set(aged_candidates)
     for pid in aged_candidates:
-        target_pids.update(_descendant_pids(all_rows, pid))
+        target_pids.update(_descendant_pids(all_rows, pid, children))
     target_pids -= owned_all
     target_pids.discard(service_pid)
     if not target_pids:

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -304,12 +304,18 @@ async def reap_orphaned_claude_processes(
     - A ``min_age_seconds`` grace window protects a freshly spawned process
       that has not yet been registered into the tracked set (TOCTOU). A
       candidate whose age cannot be determined is **not** reaped.
+
+    Returns the number of pids that were signalled, which includes descendant
+    helper processes — not the number of orphan roots. The blocking ``ps``
+    reads are offloaded to a thread so this never stalls the event loop (this
+    runs on every periodic cleanup sweep).
     """
     if os.name == "nt":
         return 0
 
+    loop = asyncio.get_running_loop()
     try:
-        all_rows = _parse_ps_rows(_run_ps())
+        all_rows = _parse_ps_rows(await loop.run_in_executor(None, _run_ps))
     except Exception:
         logger.debug("Failed to read process table for Claude orphan cleanup", exc_info=True)
         return 0
@@ -352,8 +358,8 @@ async def reap_orphaned_claude_processes(
         return 0
 
     # TOCTOU grace window: never reap a process younger than the cutoff, and
-    # never reap one whose age we cannot establish.
-    ages = _process_ages(candidates)
+    # never reap one whose age we cannot establish. Offload the ``ps`` read.
+    ages = await loop.run_in_executor(None, _process_ages, candidates)
     aged_candidates = {pid for pid in candidates if ages.get(pid, 0.0) >= min_age_seconds}
     if not aged_candidates:
         return 0

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -282,6 +282,7 @@ async def reap_orphaned_claude_processes(
     logger: logging.Logger,
     min_age_seconds: float = 60.0,
     terminate_timeout: float = 2.0,
+    reap_in_tree: bool = True,
 ) -> int:
     """Reap leaked Claude CLI processes (defense-in-depth orphan reaper).
 
@@ -290,13 +291,21 @@ async def reap_orphaned_claude_processes(
     (a) **In-process orphan** — a ``claude`` process inside the current
         service's process tree that is no longer referenced by any tracked
         session (``owned_pids``). This happens when session tracking is lost
-        but the subprocess survives.
+        but the subprocess survives. Only attempted when ``reap_in_tree`` is
+        True: the caller must pass False whenever the owner set may be
+        incomplete (a tracked client's pid could not be resolved, or a session
+        create is in flight), otherwise a live tracked/connecting process could
+        be misclassified as an orphan and killed.
 
-    (b) **Cross-restart orphan** — a ``claude`` process *outside* the current
-        service tree (e.g. reparented to init after a previous service crashed
-        or restarted) that carries a ``--resume <native_id>`` for a session we
-        currently own under a *different* pid. Matching the unique native
-        session id makes this safe against unrelated ``claude`` processes.
+    (b) **Cross-restart orphan** — a ``claude`` process reparented to init
+        (``ppid == 1``) after a previous service crashed/restarted, carrying a
+        ``--resume <native_id>`` for a session we currently own under a
+        *different* pid. Requiring ``ppid == 1`` (plus the unique native id)
+        keeps this from touching a user's manually-launched ``claude --resume``
+        of the same conversation (parented to their shell) or another live
+        Avibe instance's process (parented to that instance). The trade-off is
+        that an orphan reparented to a non-init subreaper (e.g. a systemd
+        service manager) is not reaped here.
 
     Safety guards:
     - ``owned_pids`` and their descendants are never reaped.
@@ -335,18 +344,26 @@ async def reap_orphaned_claude_processes(
 
     candidates: set[int] = set()
 
-    # (a) in-tree claude processes we no longer own.
-    for row in claude_rows:
-        if row.pid in service_tree and row.pid not in owned_all:
-            candidates.add(row.pid)
+    # (a) in-tree claude processes we no longer own. Skipped when the owner set
+    # may be incomplete (unresolved tracked pid / session create in flight),
+    # since we could not then tell a live tracked process from an orphan.
+    if reap_in_tree:
+        for row in claude_rows:
+            if row.pid in service_tree and row.pid not in owned_all:
+                candidates.add(row.pid)
 
-    # (b) out-of-tree claude carrying a tracked --resume id under a foreign pid.
+    # (b) init-reparented (ppid == 1) cross-restart orphan carrying a tracked
+    # --resume id under a foreign pid. The ppid==1 requirement excludes a
+    # user's manual `claude --resume` (parented to a shell) and another live
+    # Avibe instance's process (parented to that instance).
     for native_id, owner_pid in tracked_resume_ids.items():
         if not native_id:
             continue
         for row in claude_rows:
             if row.pid in service_tree:
                 continue  # in-tree handled by (a) / the duplicate reaper
+            if row.ppid != 1:
+                continue  # only reap true init-reparented orphans
             if row.pid == owner_pid:
                 continue
             if _command_has_resume(row.command, native_id):

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -104,6 +104,22 @@ class _StubClaudeAgentOptions:
         self.continue_conversation = False
 
 
+def _disconnect_counting_client(captured: dict[str, Any]):
+    """Stub ClaudeSDKClient that records how many times it was disconnected."""
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    return _StubClaudeSDKClient
+
+
 def test_to_app_config_preserves_claude_cli_path() -> None:
     v2 = V2Config(
         mode="self_host",
@@ -1047,18 +1063,8 @@ def test_evict_idle_sessions_force_evicts_stuck_active_session(monkeypatch, tmp_
     """
     captured: dict[str, Any] = {}
 
-    class _StubClaudeSDKClient:
-        def __init__(self, options):
-            captured["disconnects"] = 0
-
-        async def connect(self) -> None:
-            return None
-
-        async def disconnect(self) -> None:
-            captured["disconnects"] += 1
-
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
-    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _disconnect_counting_client(captured))
     monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
 
     controller = _Controller(tmp_path)
@@ -1085,18 +1091,8 @@ def test_evict_idle_sessions_keeps_stuck_active_below_cap(monkeypatch, tmp_path:
     """An active session below the absolute cap is still protected."""
     captured: dict[str, Any] = {}
 
-    class _StubClaudeSDKClient:
-        def __init__(self, options):
-            captured["disconnects"] = 0
-
-        async def connect(self) -> None:
-            return None
-
-        async def disconnect(self) -> None:
-            captured["disconnects"] += 1
-
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
-    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _disconnect_counting_client(captured))
     monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
 
     controller = _Controller(tmp_path)
@@ -1122,18 +1118,8 @@ def test_evict_idle_sessions_stuck_active_backstop_can_be_disabled(monkeypatch, 
     """``stuck_active_multiplier <= 0`` restores the absolute active veto."""
     captured: dict[str, Any] = {}
 
-    class _StubClaudeSDKClient:
-        def __init__(self, options):
-            captured["disconnects"] = 0
-
-        async def connect(self) -> None:
-            return None
-
-        async def disconnect(self) -> None:
-            captured["disconnects"] += 1
-
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
-    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _disconnect_counting_client(captured))
     monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
 
     controller = _Controller(tmp_path)
@@ -1161,18 +1147,8 @@ def test_evict_idle_sessions_spares_session_refreshed_between_passes(monkeypatch
     """
     captured: dict[str, Any] = {}
 
-    class _StubClaudeSDKClient:
-        def __init__(self, options):
-            captured["disconnects"] = 0
-
-        async def connect(self) -> None:
-            return None
-
-        async def disconnect(self) -> None:
-            captured["disconnects"] += 1
-
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
-    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _disconnect_counting_client(captured))
     monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
 
     controller = _Controller(tmp_path)
@@ -1207,18 +1183,8 @@ def test_evict_idle_sessions_evicts_stuck_active_deactivated_between_passes(monk
     """
     captured: dict[str, Any] = {}
 
-    class _StubClaudeSDKClient:
-        def __init__(self, options):
-            captured["disconnects"] = 0
-
-        async def connect(self) -> None:
-            return None
-
-        async def disconnect(self) -> None:
-            captured["disconnects"] += 1
-
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
-    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _disconnect_counting_client(captured))
     monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
 
     controller = _Controller(tmp_path)

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -1153,6 +1153,52 @@ def test_evict_idle_sessions_stuck_active_backstop_can_be_disabled(monkeypatch, 
     assert composite_key in controller.claude_sessions
 
 
+def test_evict_idle_sessions_spares_session_refreshed_between_passes(monkeypatch, tmp_path: Path) -> None:
+    """The recheck pass re-reads ``last_activity`` from current state.
+
+    A session that looked idle in the collect pass but was touched (a new
+    message arrived) before the recheck pass must NOT be evicted.
+    """
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    composite_key = f"slack_C123:{tmp_path}"
+
+    class _RefreshingActivity(dict):
+        # Collect pass iterates .items() and sees the stale 0.0 (idle 1000s);
+        # the recheck pass calls .get() and sees a freshly-touched 900.0
+        # (idle 100s < idle_timeout), so the session must be spared.
+        def get(self, key, default=None):
+            return 900.0
+
+    handler.session_last_activity = _RefreshingActivity({composite_key: 0.0})
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 0
+    assert captured["disconnects"] == 0
+    assert composite_key in controller.claude_sessions
+
+
 def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path: Path) -> None:
     events = []
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -1254,6 +1254,68 @@ def test_evict_idle_sessions_evicts_stuck_active_deactivated_between_passes(monk
     assert composite_key not in controller.claude_sessions
 
 
+def test_reap_orphaned_sessions_disables_in_tree_sweep_when_pid_unresolved(monkeypatch, tmp_path: Path) -> None:
+    """If a tracked client's pid cannot be resolved, the in-tree sweep is
+    disabled so the live process is not misclassified as an orphan."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_reap(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(session_handler_module, "reap_orphaned_claude_processes", _fake_reap)
+    monkeypatch.setattr(session_handler_module, "get_claude_client_pid", lambda client: None)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    composite_key = f"slack_C123:{tmp_path}"
+    controller.claude_sessions[composite_key] = object()  # tracked but pid unresolved
+
+    asyncio.run(handler.reap_orphaned_claude_sessions())
+
+    assert captured["reap_in_tree"] is False
+
+
+def test_reap_orphaned_sessions_disables_in_tree_sweep_when_create_in_flight(monkeypatch, tmp_path: Path) -> None:
+    """A session create in flight (subprocess spawned, not yet tracked) disables
+    the in-tree sweep."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_reap(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(session_handler_module, "reap_orphaned_claude_processes", _fake_reap)
+    monkeypatch.setattr(session_handler_module, "get_claude_client_pid", lambda client: 4321)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    handler.claude_session_creates["slack_C123:/in/flight"] = object()
+
+    asyncio.run(handler.reap_orphaned_claude_sessions())
+
+    assert captured["reap_in_tree"] is False
+
+
+def test_reap_orphaned_sessions_enables_in_tree_sweep_when_owner_set_complete(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _fake_reap(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(session_handler_module, "reap_orphaned_claude_processes", _fake_reap)
+    monkeypatch.setattr(session_handler_module, "get_claude_client_pid", lambda client: 4321)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    controller.claude_sessions[f"slack_C123:{tmp_path}"] = object()
+
+    asyncio.run(handler.reap_orphaned_claude_sessions())
+
+    assert captured["reap_in_tree"] is True
+
+
 def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path: Path) -> None:
     events = []
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -1199,6 +1199,61 @@ def test_evict_idle_sessions_spares_session_refreshed_between_passes(monkeypatch
     assert composite_key in controller.claude_sessions
 
 
+def test_evict_idle_sessions_evicts_stuck_active_deactivated_between_passes(monkeypatch, tmp_path: Path) -> None:
+    """Stuck-active in the collect pass, deactivated before recheck.
+
+    It must still be evicted — via the normal idle path — since by the recheck
+    pass it is no longer active and is well past ``idle_timeout``.
+    """
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    composite_key = f"slack_C123:{tmp_path}"
+    # Idle 2000s (>= 1800 stuck cap and >= 600 idle_timeout).
+    handler.session_last_activity[composite_key] = -1000.0
+
+    class _DeactivatingActiveSet(set):
+        def __init__(self, target_key: str):
+            super().__init__()
+            self.target_key = target_key
+            self.add(target_key)
+            self._checks = 0
+
+        def __contains__(self, item):
+            if item == self.target_key:
+                self._checks += 1
+                # active in the collect pass, deactivated by the recheck pass
+                return self._checks < 2
+            return super().__contains__(item)
+
+    handler.active_sessions = _DeactivatingActiveSet(composite_key)
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 1
+    assert captured["disconnects"] == 1
+    assert composite_key not in controller.claude_sessions
+
+
 def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path: Path) -> None:
     events = []
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -1034,6 +1034,125 @@ def test_session_handler_keeps_active_claude_session(monkeypatch, tmp_path: Path
     assert composite_key in controller.claude_sessions
 
 
+def test_evict_idle_sessions_force_evicts_stuck_active_session(monkeypatch, tmp_path: Path) -> None:
+    """The active flag is not an absolute veto.
+
+    Regression for the no-EOF / blocked-receiver leak: a receiver coroutine that
+    stays alive but blocked never releases the per-turn ``active`` flag, so the
+    session is pinned in ``active_sessions`` forever and its ``last_activity`` is
+    frozen. Once that frozen activity is older than the absolute cap
+    (``idle_timeout * multiplier``), the backstop must force-evict it. This is
+    distinct from the stream-exhausted path covered elsewhere, which relies on
+    the receiver actually terminating to release the flag.
+    """
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    composite_key = f"slack_C123:{tmp_path}"
+    # Stuck-active: active flag set, but activity frozen 2000s ago. With the
+    # default 3x multiplier the cap is 1800s, so 2000s > cap -> force-evict.
+    handler.session_last_activity[composite_key] = -1000.0
+    handler.active_sessions.add(composite_key)
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 1
+    assert captured["disconnects"] == 1
+    assert composite_key not in controller.claude_sessions
+    assert composite_key not in handler.active_sessions
+
+
+def test_evict_idle_sessions_keeps_stuck_active_below_cap(monkeypatch, tmp_path: Path) -> None:
+    """An active session below the absolute cap is still protected."""
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    composite_key = f"slack_C123:{tmp_path}"
+    # Idle for 1700s: past idle_timeout (600) but below the 1800s absolute cap.
+    handler.session_last_activity[composite_key] = -700.0
+    handler.active_sessions.add(composite_key)
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600))
+
+    assert evicted == 0
+    assert captured["disconnects"] == 0
+    assert composite_key in controller.claude_sessions
+    assert composite_key in handler.active_sessions
+
+
+def test_evict_idle_sessions_stuck_active_backstop_can_be_disabled(monkeypatch, tmp_path: Path) -> None:
+    """``stuck_active_multiplier <= 0`` restores the absolute active veto."""
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["disconnects"] = 0
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: 1000.0)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    _run_session(handler, context)
+
+    composite_key = f"slack_C123:{tmp_path}"
+    handler.session_last_activity[composite_key] = -100000.0
+    handler.active_sessions.add(composite_key)
+
+    evicted = asyncio.run(handler.evict_idle_sessions(600, stuck_active_multiplier=0))
+
+    assert evicted == 0
+    assert captured["disconnects"] == 0
+    assert composite_key in controller.claude_sessions
+
+
 def test_cleanup_session_swallows_cancelled_receiver_task(monkeypatch, tmp_path: Path) -> None:
     events = []
 

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -169,3 +169,166 @@ def test_reap_duplicate_claude_resume_processes_ignores_unrelated_unique_match(m
 
     assert reaped == 0
     assert signals == []
+
+
+def _patch_orphan_env(monkeypatch, table: str, ages: dict[int, float], alive: set[int]):
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid not in alive:
+                raise ProcessLookupError
+            return
+        alive.discard(pid)
+
+    monkeypatch.setattr(claude_process_reaper, "_run_ps", lambda: table)
+    monkeypatch.setattr(claude_process_reaper, "_process_ages", lambda pids: ages)
+    signals: list[tuple[int, int]] = []
+    real_kill = fake_kill
+
+    def recording_kill(pid, sig):
+        if sig != 0:
+            signals.append((pid, sig))
+        return real_kill(pid, sig)
+
+    monkeypatch.setattr(claude_process_reaper.os, "kill", recording_kill)
+    return signals
+
+
+def test_reap_orphaned_reaps_in_tree_no_owner_and_descendants(monkeypatch):
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"100 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
+            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+            "102 101 node helper.js",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {101: 999.0, 102: 999.0}, {100, 101, 102})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids={100},
+            tracked_resume_ids={"sess-1": 100},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 2
+    killed = {pid for pid, _ in signals}
+    assert 101 in killed and 102 in killed
+    assert 100 not in killed
+    assert service_pid not in killed
+
+
+def test_reap_orphaned_keeps_owned_in_tree_process(monkeypatch):
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"100 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {100: 999.0}, {100})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids={100},
+            tracked_resume_ids={"sess-1": 100},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []
+
+
+def test_reap_orphaned_reaps_cross_restart_init_parented_match(monkeypatch):
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"100 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
+            "300 1 /usr/local/bin/claude --resume sess-1 --model opus",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {300: 999.0}, {100, 300})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids={100},
+            tracked_resume_ids={"sess-1": 100},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 1
+    killed = {pid for pid, _ in signals}
+    assert killed == {300}
+
+
+def test_reap_orphaned_respects_min_age_grace_window(monkeypatch):
+    """A freshly spawned, not-yet-tracked process must not be reaped (TOCTOU)."""
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {101: 5.0}, {101})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids=set(),
+            tracked_resume_ids={},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []
+
+
+def test_reap_orphaned_skips_when_age_unknown(monkeypatch):
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {}, {101})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids=set(),
+            tracked_resume_ids={},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []
+
+
+def test_reap_orphaned_ignores_unrelated_out_of_tree_claude(monkeypatch):
+    """Out-of-tree claude not matching any tracked --resume id is left alone."""
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            "300 1 /usr/local/bin/claude --resume someone-elses-session",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {300: 999.0}, {300})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids=set(),
+            tracked_resume_ids={"sess-1": 100},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -199,7 +199,7 @@ def test_reap_orphaned_reaps_in_tree_no_owner_and_descendants(monkeypatch):
         [
             f"{service_pid} 1 python service_main.py",
             f"100 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
-            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+            f"101 {service_pid} /usr/local/bin/claude --output-format stream-json --verbose --resume sess-2 --input-format stream-json",
             "102 101 node helper.js",
         ]
     )
@@ -272,7 +272,7 @@ def test_reap_orphaned_respects_min_age_grace_window(monkeypatch):
     table = "\n".join(
         [
             f"{service_pid} 1 python service_main.py",
-            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+            f"101 {service_pid} /usr/local/bin/claude --output-format stream-json --verbose --resume sess-2 --input-format stream-json",
         ]
     )
     signals = _patch_orphan_env(monkeypatch, table, {101: 5.0}, {101})
@@ -294,7 +294,7 @@ def test_reap_orphaned_skips_when_age_unknown(monkeypatch):
     table = "\n".join(
         [
             f"{service_pid} 1 python service_main.py",
-            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+            f"101 {service_pid} /usr/local/bin/claude --output-format stream-json --verbose --resume sess-2 --input-format stream-json",
         ]
     )
     signals = _patch_orphan_env(monkeypatch, table, {}, {101})
@@ -334,13 +334,38 @@ def test_reap_orphaned_ignores_unrelated_out_of_tree_claude(monkeypatch):
     assert signals == []
 
 
+def test_reap_orphaned_ignores_in_tree_non_sdk_claude(monkeypatch):
+    """An in-tree `claude` that is NOT an SDK session subprocess (no
+    --input-format stream-json) — e.g. launched by another backend or a watch
+    command — must not be reaped even though it is unowned and old."""
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"401 {service_pid} /usr/local/bin/claude -p run-a-build",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {401: 999.0}, {401})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids=set(),
+            tracked_resume_ids={},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []
+
+
 def test_reap_orphaned_skips_in_tree_sweep_when_disabled(monkeypatch):
     """reap_in_tree=False (incomplete owner set) must not touch in-tree pids."""
     service_pid = os.getpid()
     table = "\n".join(
         [
             f"{service_pid} 1 python service_main.py",
-            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+            f"101 {service_pid} /usr/local/bin/claude --output-format stream-json --verbose --resume sess-2 --input-format stream-json",
         ]
     )
     signals = _patch_orphan_env(monkeypatch, table, {101: 999.0}, {101})

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -332,3 +332,52 @@ def test_reap_orphaned_ignores_unrelated_out_of_tree_claude(monkeypatch):
 
     assert reaped == 0
     assert signals == []
+
+
+def test_reap_orphaned_skips_in_tree_sweep_when_disabled(monkeypatch):
+    """reap_in_tree=False (incomplete owner set) must not touch in-tree pids."""
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"101 {service_pid} /usr/local/bin/claude --resume sess-2 --model opus",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {101: 999.0}, {101})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids=set(),
+            tracked_resume_ids={},
+            logger=logging.getLogger("test.claude_orphan"),
+            reap_in_tree=False,
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []
+
+
+def test_reap_orphaned_ignores_out_of_tree_resume_match_not_init_parented(monkeypatch):
+    """A user's manual `claude --resume <id>` (parented to a shell, not init)
+    must not be reaped even though the resume id matches a tracked session."""
+    service_pid = os.getpid()
+    table = "\n".join(
+        [
+            f"{service_pid} 1 python service_main.py",
+            f"100 {service_pid} /usr/local/bin/claude --resume sess-1 --model opus",
+            "300 999 /usr/local/bin/claude --resume sess-1 --model opus",
+        ]
+    )
+    signals = _patch_orphan_env(monkeypatch, table, {300: 999.0}, {100, 300})
+
+    reaped = asyncio.run(
+        claude_process_reaper.reap_orphaned_claude_processes(
+            owned_pids={100},
+            tracked_resume_ids={"sess-1": 100},
+            logger=logging.getLogger("test.claude_orphan"),
+        )
+    )
+
+    assert reaped == 0
+    assert signals == []

--- a/tests/test_claude_receiver_result_settle.py
+++ b/tests/test_claude_receiver_result_settle.py
@@ -1,0 +1,118 @@
+"""Regression: a terminal ResultMessage must settle the turn (release the
+per-turn ``active`` flag) even if emitting the result raises.
+
+Before the hardening, the result branch in ``ClaudeAgent._receive_messages``
+popped the pending request and then called ``emit_result_message`` /
+``_maybe_backfill_session_title`` BEFORE marking the session idle. If either
+raised, the inner ``except Exception: … continue`` swallowed it and skipped the
+mark-idle, so the long-lived receiver looped back and blocked with ``active``
+still set — pinning the session in ``active_sessions`` (exempt from idle
+eviction) until the next service restart. The mark-idle now runs in a
+``finally`` so the turn always settles.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agents.claude_agent import ClaudeAgent
+
+
+class _ResultMessage:
+    subtype = "success"
+    result = "done"
+    duration_ms = 1
+
+
+def _one_result_client():
+    class _Client:
+        def receive_messages(self):
+            async def _iterate():
+                yield _ResultMessage()
+
+            return _iterate()
+
+    return _Client()
+
+
+def _build_agent(mark_idle_calls):
+    controller = SimpleNamespace(
+        config=SimpleNamespace(platform="slack"),
+        im_client=SimpleNamespace(formatter=None),
+        settings_manager=SimpleNamespace(sessions=None),
+        session_manager=SimpleNamespace(
+            get_or_create_session=AsyncMock(return_value=SimpleNamespace(session_active={})),
+        ),
+        receiver_tasks={},
+        claude_sessions={},
+        claude_client=SimpleNamespace(_is_skip_message=lambda message: False),
+        session_handler=SimpleNamespace(
+            mark_session_idle=lambda key: mark_idle_calls.append(key),
+            touch_session_activity=lambda key: None,
+        ),
+    )
+    controller._get_session_key = lambda context: "session-key"
+
+    agent = ClaudeAgent(controller)
+    # Stub the external bits the result branch touches so the test isolates the
+    # settle-on-failure contract.
+    agent._detect_message_type = lambda message: "result"
+    agent._maybe_capture_session_id = lambda *a, **k: None
+    agent._consume_suppressed_synthetic_result = lambda *a, **k: False
+    agent._handle_auth_failure_result = AsyncMock(return_value=False)
+    agent._reserved_native_session_id = lambda *a, **k: None
+    agent._adopt_pending_turn_token = lambda *a, **k: None
+    agent._discard_pending_reaction = lambda key: None
+    agent._get_formatter = lambda context: None
+    agent._handle_receiver_eof = AsyncMock()
+    return agent
+
+
+class ResultSettlesTurnOnEmitFailureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_emit_failure_still_marks_session_idle(self):
+        mark_idle_calls: list[str] = []
+        agent = _build_agent(mark_idle_calls)
+        context = SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={})
+        composite_key = "session-1:/tmp/work"
+
+        # A turn is in flight: one pending request for this session.
+        agent._pending_requests[composite_key] = [SimpleNamespace(context=context)]
+        # Emitting the terminal result fails.
+        agent.emit_result_message = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await agent._receive_messages(
+            _one_result_client(), "session-1", "/tmp/work", context, composite_key=composite_key
+        )
+
+        # Despite the emit failure, the turn settled: the active flag was released
+        # and the pending request was popped.
+        agent.emit_result_message.assert_awaited_once()
+        self.assertEqual(mark_idle_calls, [composite_key])
+        self.assertFalse(agent._has_pending_requests(composite_key))
+
+    async def test_emit_success_marks_session_idle(self):
+        mark_idle_calls: list[str] = []
+        agent = _build_agent(mark_idle_calls)
+        context = SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={})
+        composite_key = "session-2:/tmp/work"
+
+        agent._pending_requests[composite_key] = [SimpleNamespace(context=context)]
+        agent.emit_result_message = AsyncMock(return_value=None)
+
+        await agent._receive_messages(
+            _one_result_client(), "session-2", "/tmp/work", context, composite_key=composite_key
+        )
+
+        agent.emit_result_message.assert_awaited_once()
+        self.assertEqual(mark_idle_calls, [composite_key])
+        self.assertFalse(agent._has_pending_requests(composite_key))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #622.

Idle Claude sessions are **not** reaped by the 10-minute idle-eviction mechanism when their long-lived receiver coroutine stays **alive but blocked** with the per-turn `active` flag still set. Such sessions are pinned in `active_sessions` forever, which permanently exempts them from `evict_idle_sessions`, so the resident `claude` CLI subprocess (~220-230 MB RSS each) survives until the **next full service restart**.

### Why the existing fixes don't cover it

- `40184d36` ("settle EOF turns through terminal cleanup") closes the **stream-EOF** sub-path: it settles a turn when `claude`'s stdout is exhausted without a `ResultMessage`.
- The receiver, however, is **long-lived and reused across turns** (PR #581, turn serialization). In stream-json input mode `claude` produces no stdout between turns, so `async for message in client.receive_messages()` **blocks waiting for the next query - it does not EOF**. There is no turn-level watchdog. So when the terminal `ResultMessage` never arrives (or an exception while emitting it is swallowed by the inner `except ... continue`), the receiver loops back and blocks with `active` still set. The EOF settle and the `finally` guard only run when the coroutine actually terminates, which never happens while it is blocked.

`evict_idle_sessions` treated membership in `active_sessions` as an **absolute veto** with no independent backstop, so these stuck-active sessions could never be reclaimed without restarting the service.

### Observed incident

A running build had 3 `claude` subprocesses idle for ~3 days (state `Sl`, ~220 MB RSS each, ~9 min CPU over 3 days). The idle-eviction loop was working the whole time for *other* sessions but never these - they only died on service restart, then reparented to init as untracked orphans.

## Fix

Three independent, layered changes. (1) is the minimal high-value fix; (2) and (3) are defense-in-depth.

### (1) Absolute-age eviction (`session_handler.evict_idle_sessions`)

Stop treating `active_sessions` as an absolute veto. A session that is `active` but whose `last_activity` is older than `idle_timeout * STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER` (default **3** -> `3 x 600s = 30min`) is force-evicted regardless of *why* the flag was not cleared. This is reliable because `touch_session_activity` updates per processed message: a blocked receiver's `last_activity` is frozen, so "active + very stale last_activity" cleanly identifies a stuck session. A genuine in-flight turn keeps touching activity via assistant/tool messages and stays well under the cap. The recheck pass re-derives the decision from current state. Setting the multiplier to `0` restores the old absolute veto.

### (2) Claude orphan/PID reaper (`claude_process_reaper.reap_orphaned_claude_processes`)

Mirror OpenCode's orphan cleanup. Run a reconciliation each cleanup sweep (from `Controller.periodic_cleanup`) that reaps two orphan classes: **(a) in-process orphan** - a `claude` in our own process tree no longer referenced by any tracked session; **(b) cross-restart orphan** - an out-of-tree `claude` (e.g. `ppid=1`) carrying a `--resume <native_id>` for a session we now own under a *different* pid, matched by the unique session UUID so unrelated `claude` processes are never touched.

Safety guards: tracked (owned) pids and their descendants are never reaped; the service pid is never reaped; a `min_age_seconds` grace window (default 60s) protects a freshly spawned, not-yet-registered process from a TOCTOU kill, and a candidate whose age cannot be determined is **not** reaped. Shared SIGTERM->SIGKILL escalation extracted into `_reap_pid_set` (no behavior change to the existing duplicate reaper). *Known limitation:* a session never resumed after a restart leaves no native id in memory, so its init-reparented orphan is not reaped by lifetime alone (documented; too risky).

### (3) Settle the turn in a `finally` (`claude_agent._receive_messages`)

In the terminal-result branch, if `emit_result_message` / `_maybe_backfill_session_title` raised, the inner `except ... continue` swallowed it and skipped the mark-idle. Wrap the throwable emit/backfill in a `try` and run the idle transition in its `finally`, so a terminal result always settles the turn regardless of emit failures.

## Tests

- `test_claude_cli_path.py`: stuck-active force-evict, below-cap kept, backstop-disabled. Existing eviction tests stay green.
- `test_claude_process_reaper.py`: in-tree no-owner reap (+descendants), owned-kept, cross-restart init-parented match, min-age grace window, unknown-age skip, unrelated out-of-tree non-match. Existing duplicate-reaper tests stay green.
- `test_claude_receiver_result_settle.py`: turn settles on both emit failure and success.
- Full unit suite green except 13 pre-existing, change-unrelated failures (`test_ui_show_pages` needs a Node runtime/network; `test_platform_registry` passes in isolation - order-dependent global-state pollution).

## Base note

Branched from `avibe-bot/avibe:master`. The complementary finally-guard fix (`3d366d1d`, `fix/active-session-leak`) is **not** on this base and is tracked separately; these backstops are orthogonal to it.

## Checklist

- [x] (1) Absolute-age eviction + config knob + regression tests
- [x] (2) Claude orphan/PID reaper + safety guards + tests
- [x] (3) Settle-the-turn `finally` hardening + tests
- [x] Full suite green (modulo pre-existing, unrelated failures)

Generated with [Claude Code](https://claude.com/claude-code)
