### PR TITLE
fix(tests): isolate Codex/Claude config homes so the suite can't wipe real auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,30 +82,32 @@ Hard rule:
 
 - **Never restart the local `vibe` service for routine verification.**
 - The local `vibe` process may be the coding agent runtime itself; restarting it can interrupt the session.
-- **Tests and probes must never mutate the current local environment or live user state.**
-  Do not run commands, setup flows, migrations, installers, config writes, or
-  agent detection/install tests against `~/.avibe`, legacy `~/.vibe_remote`, the user's shell
-  environment, or the running local service unless the user explicitly asks for
-  that exact local operation. Use an isolated `VIBE_REMOTE_HOME`, a temporary
-  fixture directory, the Incus regression environment, or the existing regression
-  environment instead.
-- Treat third-party agent and CLI homes as live user state too. Codex
-  `~/.codex`, Claude Code `~/.claude`, OpenCode `~/.config/opencode`,
-  `~/.opencode`, `~/.local/share/opencode`, XDG data/config dirs, keychains,
-  token stores, and similar backend-owned files are not test scratch space.
-  Tests that call real auth/config writers must redirect every resolver the
-  writer uses (`VIBE_REMOTE_HOME`, `CODEX_HOME`, `CLAUDE_CONFIG_DIR`,
-  `Path.home()`, XDG env vars, or an explicit `home=` argument) before the
-  write path runs.
-- Mocking the external login process is not enough. If the success path invokes
-  production cleanup/persistence code, assume it can still rewrite real
-  credentials unless the test proves the resolved destination is isolated.
-  Add a regression guard for any new backend credential store showing both the
-  resolved path and an actual write land under the isolated home.
+- **Tests and probes must be hermetic by default.** A test may exercise
+  production code paths, but its filesystem, process environment, service
+  endpoints, credential stores, caches, and external accounts must be isolated
+  from the developer's real machine unless the user explicitly asks for that
+  exact local operation. Treat every default resolver (`$HOME`, XDG dirs,
+  keychains, CLI config homes, token stores, running services, browser/user
+  profiles, and cloud accounts) as production data until the test redirects or
+  mocks it.
+- Isolation must cover the whole call path, not just the obvious dependency.
+  Mocking a network login, subprocess, or platform client is not enough if the
+  success/failure path still calls real cleanup, persistence, migration, install,
+  or detection helpers. Before adding or changing tests, trace every write-capable
+  helper they can reach and make the destination explicit: `tmp_path`,
+  `VIBE_REMOTE_HOME`, backend-specific homes such as `CODEX_HOME` /
+  `CLAUDE_CONFIG_DIR`, patched `Path.home()`, XDG env vars, fake servers, or
+  explicit `home=` / config arguments.
+- Add negative safety coverage for new write-capable surfaces. A regression test
+  should prove both that the resolver points at the isolated location and that a
+  representative real write lands there, not in live user state. This applies to
+  Avibe state, third-party agent homes (Codex, Claude Code, OpenCode), package
+  manager/global CLI config, browser profiles, OS keychains, and any future
+  backend-owned credential/cache store.
 - Tests marked `uses_real_paths` are for read-only path-resolution coverage
   only. They must not call save/apply/delete/migration/install helpers, backend
-  auth setup flows, CLI logout/login commands, or any helper that can mutate
-  files under the real home.
+  auth setup flows, CLI login/logout commands, or anything else that can mutate
+  files, services, credentials, or accounts reachable from the real environment.
 - Unless the user explicitly asks otherwise, use the Incus regression environment for user-facing verification.
 
 ### Regression Testing (Incus)
@@ -346,10 +348,10 @@ Testing guidance:
 - for reusable capability-first testing guidance, use `standards/scenario-testing/AGENTS.md` as the entrypoint; project-specific scenario metadata lives under `tests/scenarios/`
 - when a scenario catalog exists, make the scenario ID visible in the automated test and in the PR description
 - for multi-step auth/setup flows, update `tests/scenarios/auth_setup/catalog.yaml` and add or update a closed-loop scenario harness case under `tests/scenarios/auth_setup/test_auth_setup_scenarios.py`; keep provider-specific parsing and heuristics in focused unit tests
-- for auth/setup tests, include negative safety coverage for live-state writes:
-  verify that backend credential homes resolve to isolated paths and that the
-  no-explicit-home write path cannot touch the developer's real Codex, Claude
-  Code, OpenCode, XDG, or keychain-backed state
+- for tests that exercise write-capable production paths, include isolation
+  coverage: verify the relevant home/config/cache/account resolver points at
+  test-owned state, and verify a representative write cannot touch real local
+  or external user state
 - for UI changes, run `npm run build` in `ui/`
 - for cross-platform or user-facing verification, use the Incus regression workflow
 - until CI fully covers a flow, do a manual sanity check for the affected workflow when practical

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,32 +82,12 @@ Hard rule:
 
 - **Never restart the local `vibe` service for routine verification.**
 - The local `vibe` process may be the coding agent runtime itself; restarting it can interrupt the session.
-- **Tests and probes must be hermetic by default.** A test may exercise
-  production code paths, but its filesystem, process environment, service
-  endpoints, credential stores, caches, and external accounts must be isolated
-  from the developer's real machine unless the user explicitly asks for that
-  exact local operation. Treat every default resolver (`$HOME`, XDG dirs,
-  keychains, CLI config homes, token stores, running services, browser/user
-  profiles, and cloud accounts) as production data until the test redirects or
-  mocks it.
-- Isolation must cover the whole call path, not just the obvious dependency.
-  Mocking a network login, subprocess, or platform client is not enough if the
-  success/failure path still calls real cleanup, persistence, migration, install,
-  or detection helpers. Before adding or changing tests, trace every write-capable
-  helper they can reach and make the destination explicit: `tmp_path`,
-  `VIBE_REMOTE_HOME`, backend-specific homes such as `CODEX_HOME` /
-  `CLAUDE_CONFIG_DIR`, patched `Path.home()`, XDG env vars, fake servers, or
-  explicit `home=` / config arguments.
-- Add negative safety coverage for new write-capable surfaces. A regression test
-  should prove both that the resolver points at the isolated location and that a
-  representative real write lands there, not in live user state. This applies to
-  Avibe state, third-party agent homes (Codex, Claude Code, OpenCode), package
-  manager/global CLI config, browser profiles, OS keychains, and any future
-  backend-owned credential/cache store.
-- Tests marked `uses_real_paths` are for read-only path-resolution coverage
-  only. They must not call save/apply/delete/migration/install helpers, backend
-  auth setup flows, CLI login/logout commands, or anything else that can mutate
-  files, services, credentials, or accounts reachable from the real environment.
+- **Tests and probes must be hermetic by default.** Treat `$HOME`, XDG dirs,
+  keychains, CLI config/token stores, running services, browser profiles, and
+  cloud accounts as production data unless the user explicitly asks otherwise.
+- Any test that reaches write-capable production paths must redirect the whole
+  call path to test-owned state and prove a representative write cannot touch
+  real local or external user state; `uses_real_paths` tests must remain read-only.
 - Unless the user explicitly asks otherwise, use the Incus regression environment for user-facing verification.
 
 ### Regression Testing (Incus)
@@ -348,10 +328,6 @@ Testing guidance:
 - for reusable capability-first testing guidance, use `standards/scenario-testing/AGENTS.md` as the entrypoint; project-specific scenario metadata lives under `tests/scenarios/`
 - when a scenario catalog exists, make the scenario ID visible in the automated test and in the PR description
 - for multi-step auth/setup flows, update `tests/scenarios/auth_setup/catalog.yaml` and add or update a closed-loop scenario harness case under `tests/scenarios/auth_setup/test_auth_setup_scenarios.py`; keep provider-specific parsing and heuristics in focused unit tests
-- for tests that exercise write-capable production paths, include isolation
-  coverage: verify the relevant home/config/cache/account resolver points at
-  test-owned state, and verify a representative write cannot touch real local
-  or external user state
 - for UI changes, run `npm run build` in `ui/`
 - for cross-platform or user-facing verification, use the Incus regression workflow
 - until CI fully covers a flow, do a manual sanity check for the affected workflow when practical

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,23 @@ Hard rule:
   that exact local operation. Use an isolated `VIBE_REMOTE_HOME`, a temporary
   fixture directory, the Incus regression environment, or the existing regression
   environment instead.
+- Treat third-party agent and CLI homes as live user state too. Codex
+  `~/.codex`, Claude Code `~/.claude`, OpenCode `~/.config/opencode`,
+  `~/.opencode`, `~/.local/share/opencode`, XDG data/config dirs, keychains,
+  token stores, and similar backend-owned files are not test scratch space.
+  Tests that call real auth/config writers must redirect every resolver the
+  writer uses (`VIBE_REMOTE_HOME`, `CODEX_HOME`, `CLAUDE_CONFIG_DIR`,
+  `Path.home()`, XDG env vars, or an explicit `home=` argument) before the
+  write path runs.
+- Mocking the external login process is not enough. If the success path invokes
+  production cleanup/persistence code, assume it can still rewrite real
+  credentials unless the test proves the resolved destination is isolated.
+  Add a regression guard for any new backend credential store showing both the
+  resolved path and an actual write land under the isolated home.
+- Tests marked `uses_real_paths` are for read-only path-resolution coverage
+  only. They must not call save/apply/delete/migration/install helpers, backend
+  auth setup flows, CLI logout/login commands, or any helper that can mutate
+  files under the real home.
 - Unless the user explicitly asks otherwise, use the Incus regression environment for user-facing verification.
 
 ### Regression Testing (Incus)
@@ -329,6 +346,10 @@ Testing guidance:
 - for reusable capability-first testing guidance, use `standards/scenario-testing/AGENTS.md` as the entrypoint; project-specific scenario metadata lives under `tests/scenarios/`
 - when a scenario catalog exists, make the scenario ID visible in the automated test and in the PR description
 - for multi-step auth/setup flows, update `tests/scenarios/auth_setup/catalog.yaml` and add or update a closed-loop scenario harness case under `tests/scenarios/auth_setup/test_auth_setup_scenarios.py`; keep provider-specific parsing and heuristics in focused unit tests
+- for auth/setup tests, include negative safety coverage for live-state writes:
+  verify that backend credential homes resolve to isolated paths and that the
+  no-explicit-home write path cannot touch the developer's real Codex, Claude
+  Code, OpenCode, XDG, or keychain-backed state
 - for UI changes, run `npm run build` in `ui/`
 - for cross-platform or user-facing verification, use the Incus regression workflow
 - until CI fully covers a flow, do a manual sanity check for the affected workflow when practical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ extend-ignore = ["E501"]
 asyncio_mode = "auto"
 markers = [
     "integration: platform integration tests requiring Docker + platform tokens",
-    "uses_real_paths: opt out of the autouse VIBE_REMOTE_HOME isolation so the test can exercise the real config.paths resolver (must remain read-only)",
+    "uses_real_paths: opt out of the autouse home/config isolation so the test can exercise real path resolvers (must remain read-only)",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,15 @@ written — only its env-var-set branch is exercised under isolation, and
 the function itself is never replaced, so the suite still catches
 regressions in path-resolution logic.
 
+The same hazard applies to the agent backends' on-disk credential files:
+Codex resolves its home from ``CODEX_HOME`` (falling back to ``~/.codex``)
+and Claude Code from ``CLAUDE_CONFIG_DIR`` (falling back to ``~/.claude``).
+Tests that drive ``apply_codex_auth`` / ``apply_claude_auth`` — directly or
+through the auth-setup scenario harness — would otherwise rewrite the
+developer's real ``~/.codex/auth.json`` (dropping ``OPENAI_API_KEY``) and
+``~/.claude/settings.json`` (dropping ``ANTHROPIC_*`` env). We pin both to
+per-test tmp dirs for the same reason.
+
 Path-resolution tests (e.g. ``tests/test_v2_paths.py::test_paths_are_under_home``)
 intentionally cover the env-var-unset branch where ``get_vibe_remote_dir``
 falls back to the default home. Those opt out with
@@ -39,6 +48,12 @@ def _isolate_vibe_remote_home(request, tmp_path, monkeypatch):
         return
     monkeypatch.delenv("AVIBE_HOME", raising=False)
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    # Keep Codex / Claude Code credential writes off the developer's real
+    # home. Tests that manage these env vars themselves (e.g. the
+    # ``get_codex_home`` env-precedence tests) override these via their own
+    # monkeypatch calls, which run after this fixture.
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ The post-install bookkeeping in ``vibe.api._run_install_command`` then
 called ``load_config()`` / ``cfg.save()`` against the real config.json and
 persisted the fixture path, surfacing in the UI after the next restart.
 
-Isolation mechanism: we set ``HOME``, XDG config/data/cache homes, and
+Isolation mechanism: we set ``HOME``, XDG config/data/cache/state homes, and
 ``VIBE_REMOTE_HOME`` to a per-test tmp directory, and patch
 ``pathlib.Path.home`` to match. This means ``config.paths.get_vibe_remote_dir``
 runs as written — only its env-var-set branch is exercised under isolation, and
@@ -61,6 +61,7 @@ def _isolate_vibe_remote_home(request, tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(isolated_home / ".config"))
     monkeypatch.setenv("XDG_DATA_HOME", str(isolated_home / ".local" / "share"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(isolated_home / ".cache"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(isolated_home / ".local" / "state"))
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(isolated_home / ".vibe_remote"))
     # Keep Codex / Claude Code credential writes off the developer's real
     # home. Tests that manage these env vars themselves (e.g. the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,9 @@
 
 Per AGENTS.md ("Tests and probes must never mutate the current local
 environment or live user state"), every test runs against an isolated
-data directory by default, so config writes, state files, and runtime
-markers can never leak into the developer's real ``~/.avibe/`` or
-``~/.vibe_remote/``
-directory.
+data directory by default, so config writes, state files, runtime
+markers, and backend credential files can never leak into the
+developer's real home.
 
 Historically a handful of install / upgrade tests mocked
 ``resolve_cli_path`` to return fixture paths like
@@ -14,11 +13,13 @@ The post-install bookkeeping in ``vibe.api._run_install_command`` then
 called ``load_config()`` / ``cfg.save()`` against the real config.json and
 persisted the fixture path, surfacing in the UI after the next restart.
 
-Isolation mechanism: we set ``VIBE_REMOTE_HOME`` to a per-test tmp
-directory. This means ``config.paths.get_vibe_remote_dir`` runs as
-written — only its env-var-set branch is exercised under isolation, and
-the function itself is never replaced, so the suite still catches
-regressions in path-resolution logic.
+Isolation mechanism: we set ``VIBE_REMOTE_HOME`` and patch
+``pathlib.Path.home`` to a per-test tmp directory. This means
+``config.paths.get_vibe_remote_dir`` runs as written — only its
+env-var-set branch is exercised under isolation, and the function
+itself is never replaced, so the suite still catches regressions in
+path-resolution logic while tools that fall back to ``Path.home()`` do
+not see the developer's real home.
 
 The same hazard applies to the agent backends' on-disk credential files:
 Codex resolves its home from ``CODEX_HOME`` (falling back to ``~/.codex``)
@@ -26,8 +27,11 @@ and Claude Code from ``CLAUDE_CONFIG_DIR`` (falling back to ``~/.claude``).
 Tests that drive ``apply_codex_auth`` / ``apply_claude_auth`` — directly or
 through the auth-setup scenario harness — would otherwise rewrite the
 developer's real ``~/.codex/auth.json`` (dropping ``OPENAI_API_KEY``) and
-``~/.claude/settings.json`` (dropping ``ANTHROPIC_*`` env). We pin both to
-per-test tmp dirs for the same reason.
+``~/.claude/settings.json`` (dropping ``ANTHROPIC_*`` env). OpenCode has
+no dedicated config-home env var in our helper layer and resolves
+``~/.local/share/opencode/auth.json`` from ``Path.home()``, so the
+patched home is its isolation boundary. We pin all three to per-test tmp
+dirs for the same reason.
 
 Path-resolution tests (e.g. ``tests/test_v2_paths.py::test_paths_are_under_home``)
 intentionally cover the env-var-unset branch where ``get_vibe_remote_dir``
@@ -39,7 +43,11 @@ write to ``~/.vibe_remote/``).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+
+REAL_USER_HOME = Path.home()
 
 
 @pytest.fixture(autouse=True)
@@ -47,13 +55,15 @@ def _isolate_vibe_remote_home(request, tmp_path, monkeypatch):
     if request.node.get_closest_marker("uses_real_paths"):
         return
     monkeypatch.delenv("AVIBE_HOME", raising=False)
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    isolated_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: isolated_home)
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(isolated_home / ".vibe_remote"))
     # Keep Codex / Claude Code credential writes off the developer's real
     # home. Tests that manage these env vars themselves (e.g. the
     # ``get_codex_home`` env-precedence tests) override these via their own
     # monkeypatch calls, which run after this fixture.
-    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    monkeypatch.setenv("CODEX_HOME", str(isolated_home / ".codex"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(isolated_home / ".claude"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,13 @@ The post-install bookkeeping in ``vibe.api._run_install_command`` then
 called ``load_config()`` / ``cfg.save()`` against the real config.json and
 persisted the fixture path, surfacing in the UI after the next restart.
 
-Isolation mechanism: we set ``VIBE_REMOTE_HOME`` and patch
-``pathlib.Path.home`` to a per-test tmp directory. This means
-``config.paths.get_vibe_remote_dir`` runs as written — only its
-env-var-set branch is exercised under isolation, and the function
-itself is never replaced, so the suite still catches regressions in
-path-resolution logic while tools that fall back to ``Path.home()`` do
-not see the developer's real home.
+Isolation mechanism: we set ``HOME``, XDG config/data/cache homes, and
+``VIBE_REMOTE_HOME`` to a per-test tmp directory, and patch
+``pathlib.Path.home`` to match. This means ``config.paths.get_vibe_remote_dir``
+runs as written — only its env-var-set branch is exercised under isolation, and
+the function itself is never replaced, so the suite still catches regressions in
+path-resolution logic while Python helpers, subprocesses, and ``expanduser("~")``
+do not see the developer's real home.
 
 The same hazard applies to the agent backends' on-disk credential files:
 Codex resolves its home from ``CODEX_HOME`` (falling back to ``~/.codex``)
@@ -57,6 +57,10 @@ def _isolate_vibe_remote_home(request, tmp_path, monkeypatch):
     monkeypatch.delenv("AVIBE_HOME", raising=False)
     isolated_home = tmp_path / "home"
     monkeypatch.setattr(Path, "home", lambda: isolated_home)
+    monkeypatch.setenv("HOME", str(isolated_home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(isolated_home / ".config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(isolated_home / ".local" / "share"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(isolated_home / ".cache"))
     monkeypatch.setenv("VIBE_REMOTE_HOME", str(isolated_home / ".vibe_remote"))
     # Keep Codex / Claude Code credential writes off the developer's real
     # home. Tests that manage these env vars themselves (e.g. the

--- a/tests/test_conftest_auth_home_isolation.py
+++ b/tests/test_conftest_auth_home_isolation.py
@@ -1,12 +1,15 @@
-"""Regression guard: the autouse isolation fixture must redirect the Codex
-and Claude Code config homes to per-test tmp dirs.
+"""Regression guard: the autouse isolation fixture must redirect backend
+credential homes to per-test tmp dirs.
 
 Without this, auth-setup tests that drive ``apply_codex_auth`` /
 ``apply_claude_auth`` (notably the scenarios under
 ``tests/scenarios/auth_setup/``) rewrite the developer's real
 ``~/.codex/auth.json`` and ``~/.claude/settings.json``, silently dropping
-``OPENAI_API_KEY`` and the ``ANTHROPIC_*`` env block. This violates the
-AGENTS.md rule that tests must never mutate live user state.
+``OPENAI_API_KEY`` and the ``ANTHROPIC_*`` env block. OpenCode resolves
+``~/.local/share/opencode/auth.json`` from ``Path.home()`` in our helper
+layer, so it needs the same default isolation even though the current
+auth-setup scenarios mock its installer. This violates the AGENTS.md rule
+that tests must never mutate live user state.
 """
 
 from __future__ import annotations
@@ -14,15 +17,17 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from vibe import claude_config, codex_config
+from tests.conftest import REAL_USER_HOME
+from vibe import claude_config, codex_config, opencode_config
 
 
-def test_codex_and_claude_homes_are_isolated_from_real_home() -> None:
-    real_home = Path.home()
+def test_backend_credential_homes_are_isolated_from_real_home() -> None:
     codex_home = codex_config.get_codex_home()
     claude_home = claude_config.get_claude_home()
+    opencode_auth = opencode_config.get_opencode_auth_path()
 
-    # The autouse fixture must have pinned both env vars to a tmp dir.
+    # The autouse fixture must have pinned explicit backend homes where the
+    # underlying tool supports them.
     assert os.environ.get("CODEX_HOME")
     assert os.environ.get("CLAUDE_CONFIG_DIR")
 
@@ -30,8 +35,18 @@ def test_codex_and_claude_homes_are_isolated_from_real_home() -> None:
     # / ~/.claude.
     assert codex_home == Path(os.environ["CODEX_HOME"]).expanduser()
     assert claude_home == Path(os.environ["CLAUDE_CONFIG_DIR"]).expanduser()
-    assert codex_home != real_home / ".codex"
-    assert claude_home != real_home / ".claude"
+    assert codex_home != REAL_USER_HOME / ".codex"
+    assert claude_home != REAL_USER_HOME / ".claude"
+
+    # OpenCode has no env-var home override in our helpers, so the autouse
+    # Path.home patch is its default isolation boundary.
+    assert Path.home() != REAL_USER_HOME
+    assert opencode_auth == (
+        Path.home() / ".local" / "share" / "opencode" / "auth.json"
+    )
+    assert opencode_auth != (
+        REAL_USER_HOME / ".local" / "share" / "opencode" / "auth.json"
+    )
 
 
 def test_apply_auth_writes_land_under_isolated_home() -> None:
@@ -43,9 +58,20 @@ def test_apply_auth_writes_land_under_isolated_home() -> None:
     )
     isolated_auth = codex_config.get_codex_home() / "auth.json"
     assert isolated_auth.exists()
-    assert isolated_auth != Path.home() / ".codex" / "auth.json"
+    assert isolated_auth != REAL_USER_HOME / ".codex" / "auth.json"
 
     claude_config.apply_claude_auth(auth_mode="oauth", api_key=None, base_url=None)
     isolated_settings = claude_config.get_claude_settings_path()
     assert isolated_settings.exists()
-    assert isolated_settings != Path.home() / ".claude" / "settings.json"
+    assert isolated_settings != REAL_USER_HOME / ".claude" / "settings.json"
+
+    opencode_auth = opencode_config.get_opencode_auth_path()
+    opencode_auth.parent.mkdir(parents=True, exist_ok=True)
+    opencode_auth.write_text(
+        '{"opencode":{"type":"api","key":"sk-isolation-test"}}\n',
+        encoding="utf-8",
+    )
+    assert opencode_auth.exists()
+    assert opencode_auth != (
+        REAL_USER_HOME / ".local" / "share" / "opencode" / "auth.json"
+    )

--- a/tests/test_conftest_auth_home_isolation.py
+++ b/tests/test_conftest_auth_home_isolation.py
@@ -1,0 +1,51 @@
+"""Regression guard: the autouse isolation fixture must redirect the Codex
+and Claude Code config homes to per-test tmp dirs.
+
+Without this, auth-setup tests that drive ``apply_codex_auth`` /
+``apply_claude_auth`` (notably the scenarios under
+``tests/scenarios/auth_setup/``) rewrite the developer's real
+``~/.codex/auth.json`` and ``~/.claude/settings.json``, silently dropping
+``OPENAI_API_KEY`` and the ``ANTHROPIC_*`` env block. This violates the
+AGENTS.md rule that tests must never mutate live user state.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from vibe import claude_config, codex_config
+
+
+def test_codex_and_claude_homes_are_isolated_from_real_home() -> None:
+    real_home = Path.home()
+    codex_home = codex_config.get_codex_home()
+    claude_home = claude_config.get_claude_home()
+
+    # The autouse fixture must have pinned both env vars to a tmp dir.
+    assert os.environ.get("CODEX_HOME")
+    assert os.environ.get("CLAUDE_CONFIG_DIR")
+
+    # And the resolved homes must honour them rather than the real ~/.codex
+    # / ~/.claude.
+    assert codex_home == Path(os.environ["CODEX_HOME"]).expanduser()
+    assert claude_home == Path(os.environ["CLAUDE_CONFIG_DIR"]).expanduser()
+    assert codex_home != real_home / ".codex"
+    assert claude_home != real_home / ".claude"
+
+
+def test_apply_auth_writes_land_under_isolated_home() -> None:
+    """End-to-end: the no-``home`` arg write path used by the live service
+    (and exercised by the auth-setup scenarios) must land under the
+    isolated home, never the real one."""
+    codex_config.apply_codex_auth(
+        auth_mode="api_key", api_key="sk-isolation-test", base_url=None
+    )
+    isolated_auth = codex_config.get_codex_home() / "auth.json"
+    assert isolated_auth.exists()
+    assert isolated_auth != Path.home() / ".codex" / "auth.json"
+
+    claude_config.apply_claude_auth(auth_mode="oauth", api_key=None, base_url=None)
+    isolated_settings = claude_config.get_claude_settings_path()
+    assert isolated_settings.exists()
+    assert isolated_settings != Path.home() / ".claude" / "settings.json"

--- a/tests/test_conftest_auth_home_isolation.py
+++ b/tests/test_conftest_auth_home_isolation.py
@@ -15,6 +15,9 @@ that tests must never mutate live user state.
 from __future__ import annotations
 
 import os
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 from tests.conftest import REAL_USER_HOME
@@ -25,11 +28,15 @@ def test_backend_credential_homes_are_isolated_from_real_home() -> None:
     codex_home = codex_config.get_codex_home()
     claude_home = claude_config.get_claude_home()
     opencode_auth = opencode_config.get_opencode_auth_path()
+    isolated_home = Path(os.environ["HOME"])
 
     # The autouse fixture must have pinned explicit backend homes where the
     # underlying tool supports them.
     assert os.environ.get("CODEX_HOME")
     assert os.environ.get("CLAUDE_CONFIG_DIR")
+    assert os.environ.get("XDG_CONFIG_HOME") == str(isolated_home / ".config")
+    assert os.environ.get("XDG_DATA_HOME") == str(isolated_home / ".local" / "share")
+    assert os.environ.get("XDG_CACHE_HOME") == str(isolated_home / ".cache")
 
     # And the resolved homes must honour them rather than the real ~/.codex
     # / ~/.claude.
@@ -41,12 +48,38 @@ def test_backend_credential_homes_are_isolated_from_real_home() -> None:
     # OpenCode has no env-var home override in our helpers, so the autouse
     # Path.home patch is its default isolation boundary.
     assert Path.home() != REAL_USER_HOME
+    assert Path.home() == isolated_home
+    assert os.path.expanduser("~") == str(isolated_home)
     assert opencode_auth == (
         Path.home() / ".local" / "share" / "opencode" / "auth.json"
     )
     assert opencode_auth != (
         REAL_USER_HOME / ".local" / "share" / "opencode" / "auth.json"
     )
+
+
+def test_subprocess_home_and_xdg_paths_are_isolated() -> None:
+    code = (
+        "import json, os, pathlib; "
+        "print(json.dumps({"
+        "'home_env': os.environ.get('HOME'), "
+        "'path_home': str(pathlib.Path.home()), "
+        "'expanduser': os.path.expanduser('~'), "
+        "'xdg_config': os.environ.get('XDG_CONFIG_HOME'), "
+        "'xdg_data': os.environ.get('XDG_DATA_HOME'), "
+        "'xdg_cache': os.environ.get('XDG_CACHE_HOME')"
+        "}))"
+    )
+    payload = subprocess.check_output([sys.executable, "-c", code], text=True)
+    data = json.loads(payload)
+    isolated_home = Path(os.environ["HOME"])
+
+    assert data["home_env"] == str(isolated_home)
+    assert data["path_home"] == str(isolated_home)
+    assert data["expanduser"] == str(isolated_home)
+    assert data["xdg_config"] == str(isolated_home / ".config")
+    assert data["xdg_data"] == str(isolated_home / ".local" / "share")
+    assert data["xdg_cache"] == str(isolated_home / ".cache")
 
 
 def test_apply_auth_writes_land_under_isolated_home() -> None:

--- a/tests/test_conftest_auth_home_isolation.py
+++ b/tests/test_conftest_auth_home_isolation.py
@@ -37,6 +37,7 @@ def test_backend_credential_homes_are_isolated_from_real_home() -> None:
     assert os.environ.get("XDG_CONFIG_HOME") == str(isolated_home / ".config")
     assert os.environ.get("XDG_DATA_HOME") == str(isolated_home / ".local" / "share")
     assert os.environ.get("XDG_CACHE_HOME") == str(isolated_home / ".cache")
+    assert os.environ.get("XDG_STATE_HOME") == str(isolated_home / ".local" / "state")
 
     # And the resolved homes must honour them rather than the real ~/.codex
     # / ~/.claude.
@@ -67,7 +68,8 @@ def test_subprocess_home_and_xdg_paths_are_isolated() -> None:
         "'expanduser': os.path.expanduser('~'), "
         "'xdg_config': os.environ.get('XDG_CONFIG_HOME'), "
         "'xdg_data': os.environ.get('XDG_DATA_HOME'), "
-        "'xdg_cache': os.environ.get('XDG_CACHE_HOME')"
+        "'xdg_cache': os.environ.get('XDG_CACHE_HOME'), "
+        "'xdg_state': os.environ.get('XDG_STATE_HOME')"
         "}))"
     )
     payload = subprocess.check_output([sys.executable, "-c", code], text=True)
@@ -80,6 +82,7 @@ def test_subprocess_home_and_xdg_paths_are_isolated() -> None:
     assert data["xdg_config"] == str(isolated_home / ".config")
     assert data["xdg_data"] == str(isolated_home / ".local" / "share")
     assert data["xdg_cache"] == str(isolated_home / ".cache")
+    assert data["xdg_state"] == str(isolated_home / ".local" / "state")
 
 
 def test_apply_auth_writes_land_under_isolated_home() -> None:


### PR DESCRIPTION
## What

Stops tests from rewriting real developer/user state, and records the broader rule as concise hermetic-testing guidance.

## Root cause

The autouse fixture isolated only `VIBE_REMOTE_HOME`. Auth/setup tests could still reach production cleanup paths that resolved backend-owned state from `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `HOME`, or XDG defaults. Mocking the visible login/subprocess boundary was not enough because later success-path persistence still used real resolvers.

## Fix

- Pin `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `HOME`, and XDG config/data/cache/state homes to per-test tmp dirs.
- Patch `Path.home()` to the same isolated home.
- Add guards proving Codex, Claude Code, OpenCode, `expanduser("~")`, and subprocesses all resolve to isolated state and representative writes cannot touch real home.
- Keep `uses_real_paths` read-only and document the general hermetic-test rule in `AGENTS.md` in two short bullets.

## Affected scenario IDs

- **AUTH-SETUP-901**
- **AUTH-SETUP-207**
- **AUTH-SETUP-105**
- **AUTH-SETUP-002**
- **AUTH-SETUP-205**

OpenCode was not currently clobbered because its scenario installer is mocked, but its resolver is now covered so a future real-write test cannot silently reintroduce the same class of bug.

## Evidence layers

- **Unit**: `tests/test_conftest_auth_home_isolation.py`, `tests/test_v2_paths.py`, `tests/test_opencode_provider_keys_reader.py`
- **Scenario/OpenCode**: `tests/scenarios/auth_setup/test_auth_setup_scenarios.py`, `tests/test_save_opencode_provider_auth.py`
- **Codex/Claude disk writers**: `tests/test_codex_config.py`, `tests/test_claude_subprocess_env.py`, `tests/test_settings_disk_fallback.py`
- **UI/API adjacent home assumptions**: `tests/test_ui_api.py`
- **Lint/build**: `ruff check tests/conftest.py tests/test_conftest_auth_home_isolation.py`; `npm ci && npm run build` in `ui/`
