### PR TITLE
fix(paths): remove legacy VIBE_REMOTE_HOME env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION} \
     pip install --no-cache-dir -e .
 
 # Runtime config
-ENV VIBE_REMOTE_HOME=/data/vibe_remote
+ENV AVIBE_HOME=/data/avibe
 ENV PYTHONUNBUFFERED=1
 
 EXPOSE 5123

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,5 @@
 from .paths import (
     AVIBE_HOME_ENV,
-    LEGACY_VIBE_REMOTE_HOME_ENV,
     get_vibe_remote_dir,
     get_config_dir,
     get_state_dir,
@@ -25,7 +24,6 @@ __all__ = [
     "SettingsStore",
     "SessionsStore",
     "AVIBE_HOME_ENV",
-    "LEGACY_VIBE_REMOTE_HOME_ENV",
     "get_vibe_remote_dir",
     "get_config_dir",
     "get_state_dir",

--- a/config/paths.py
+++ b/config/paths.py
@@ -4,9 +4,8 @@ from pathlib import Path
 
 
 AVIBE_HOME_ENV = "AVIBE_HOME"
-LEGACY_VIBE_REMOTE_HOME_ENV = "VIBE_REMOTE_HOME"
 AVIBE_HOME_DIRNAME = ".avibe"
-LEGACY_VIBE_REMOTE_HOME_DIRNAME = ".vibe_remote"
+LEGACY_HOME_DIRNAME = ".vibe_remote"
 HOME_MIGRATION_NOTICE_PATH = "state/home_migration_notice"
 
 
@@ -19,7 +18,7 @@ def _default_avibe_dir(home: Path | None = None) -> Path:
 
 
 def _legacy_vibe_remote_dir(home: Path | None = None) -> Path:
-    return (home or Path.home()) / LEGACY_VIBE_REMOTE_HOME_DIRNAME
+    return (home or Path.home()) / LEGACY_HOME_DIRNAME
 
 
 def _is_symlink_to(path: Path, target: Path) -> bool:
@@ -59,10 +58,6 @@ def get_vibe_remote_dir() -> Path:
     if custom:
         return _expand_path(custom)
 
-    legacy_custom = os.environ.get(LEGACY_VIBE_REMOTE_HOME_ENV)
-    if legacy_custom:
-        return _expand_path(legacy_custom)
-
     avibe_dir = _default_avibe_dir()
     legacy_dir = _legacy_vibe_remote_dir()
     if avibe_dir.exists() or avibe_dir.is_symlink():
@@ -75,10 +70,10 @@ def get_vibe_remote_dir() -> Path:
 def migrate_default_home() -> Path:
     """Adopt the default avibe home while preserving legacy path compatibility.
 
-    Explicit home env vars are honored as-is and never migrated. The migration
+    Explicit ``AVIBE_HOME`` is honored as-is and never migrated. The migration
     only applies to default homes under ``Path.home()``.
     """
-    if os.environ.get(AVIBE_HOME_ENV) or os.environ.get(LEGACY_VIBE_REMOTE_HOME_ENV):
+    if os.environ.get(AVIBE_HOME_ENV):
         return get_vibe_remote_dir()
 
     avibe_dir = _default_avibe_dir()

--- a/docker-compose.e2e-integration.yml
+++ b/docker-compose.e2e-integration.yml
@@ -18,12 +18,12 @@ services:
     env_file:
       - .env.e2e
     environment:
-      - VIBE_REMOTE_HOME=/data/vibe_remote
+      - AVIBE_HOME=/data/avibe
       - VIBE_DEPLOYMENT_ENV=integration
       - VIBE_UI_PORT=5123
       - E2E_TEST_MODE=true
     volumes:
-      - vibe-e2e-data:/data/vibe_remote
+      - vibe-e2e-data:/data/avibe
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5123/health', timeout=3)"]
       interval: 3s

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "${VIBE_E2E_PORT:-15123}:5123"
     environment:
-      - VIBE_REMOTE_HOME=/data/vibe_remote
+      - AVIBE_HOME=/data/avibe
       - VIBE_DEPLOYMENT_ENV=e2e
       - VIBE_UI_PORT=5123
     healthcheck:

--- a/docs/plans/e2e-integration-test.md
+++ b/docs/plans/e2e-integration-test.md
@@ -163,7 +163,7 @@ services:
     ports:
       - "${VIBE_E2E_PORT:-15123}:5123"
     environment:
-      - VIBE_REMOTE_HOME=/data/vibe_remote
+      - AVIBE_HOME=/data/avibe
       - VIBE_UI_PORT=5123
       # Platform tokens (Bot A - SUT)
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-}
@@ -175,7 +175,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
     volumes:
-      - vibe-e2e-data:/data/vibe_remote
+      - vibe-e2e-data:/data/avibe
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5123/health', timeout=3)"]
       interval: 3s

--- a/docs/plans/rebrand-avibe.md
+++ b/docs/plans/rebrand-avibe.md
@@ -43,7 +43,7 @@ From `pyproject.toml`, `AGENTS.md`, live CLI, and a repo-wide grep:
 - PyPI dist name: **`vibe-remote`** (`[project].name`).
 - Command: **`vibe`** → `vibe.cli:main` (`[project.scripts]`).
 - Wheel packages: **`vibe`, `config`, `core`, `modules`, `storage`** — import surface is multi-package, NOT a single `vibe_remote`.
-- Runtime home: `~/.vibe_remote/` (`state/`, `logs/`), env `VIBE_REMOTE_HOME`, log file `vibe_remote.log`; pytest autouse `VIBE_REMOTE_HOME` isolation + marker `uses_real_paths`.
+- Runtime home: `~/.avibe/` (`state/`, `logs/`), env `AVIBE_HOME`, log file `vibe_remote.log`; pytest autouse `AVIBE_HOME` isolation + marker `uses_real_paths`. Old `~/.vibe_remote/` remains a directory migration path.
 - i18n: backend `vibe/i18n/`; frontend `ui/src/i18n/{en,zh}.json`. No hardcoded user-facing strings (AGENTS.md §6).
 - Other repos: `avibe-bot-backend` (keep), `avibe-docs` (keep; domain on-brand, body copy not).
 
@@ -80,8 +80,8 @@ table above, (c) brand/display strings, (d) the runtime-home-dir migration.
 Adopt Alex's model: on upgrade, `rename(~/.vibe_remote → ~/.avibe)`, then create
 symlink `~/.vibe_remote → ~/.avibe`. Hardening so it never strands anyone:
 - **The in-code resolver is the real guarantee, not the symlink.** Resolution
-  order in `config/paths`: `AVIBE_HOME` → `VIBE_REMOTE_HOME` (deprecated, warn)
-  → `~/.avibe` if exists → `~/.vibe_remote` if exists (adopt) → default `~/.avibe`.
+  order in `config/paths`: `AVIBE_HOME` → `~/.avibe` if exists →
+  `~/.vibe_remote` if exists (adopt) → default `~/.avibe`.
   The symlink is a convenience for stale absolute references, not the mechanism.
 - **Atomic + idempotent + run-before-live.** Do the migration at CLI startup
   BEFORE the service binds or caches any path (the live `vibe` process may be the
@@ -176,8 +176,8 @@ record:
 - CLI command and user shell command examples using `vibe`.
 - Python import packages and code identifiers: `vibe`, `config`, `core`,
   `modules`, `storage`.
-- Deprecated compatibility inputs that must remain accepted, especially
-  `VIBE_REMOTE_HOME` and old `~/.vibe_remote` path handling.
+- Deprecated compatibility inputs that must remain accepted, especially old
+  `~/.vibe_remote` path handling.
 - Tests and fixtures that intentionally simulate old users, old package names,
   old paths, or old GitHub URLs.
 - Migration IDs, historical release notes, and compatibility prose where the old
@@ -318,10 +318,9 @@ runtime compatibility surfaces.
 
 - CLI command `vibe` and Python package imports `vibe`, `config`, `core`,
   `modules`, `storage` stay unchanged.
-- `VIBE_REMOTE_HOME` stays accepted as a deprecated compatibility env var.
-  Implementation should introduce `AVIBE_HOME` before it in resolver priority.
+- `AVIBE_HOME` is the only runtime-home env var.
 - Old `~/.vibe_remote` remains a migration/adoption path. Tests should include
-  an old-user-only home and both-env-var cases.
+  an old-user-only home and a removed-legacy-env case.
 - The old PyPI project name `vibe-remote` remains in the one-time
   `vibe-remote==3.0.0` shim and migration tests.
 - Existing release marker `<!-- vibe-remote:update-notification=none -->`
@@ -410,8 +409,8 @@ Do first:
 - P1 distribution/update/install surface: `pyproject.toml`, release workflows,
   `vibe/upgrade.py`, `core/update_checker.py`, `install.sh`, `install.ps1`,
   `npm/avibe/*`, and focused tests.
-- P2 home-dir migration: `config/paths.py`, `AVIBE_HOME`, deprecated
-  `VIBE_REMOTE_HOME`, `~/.avibe` default, old `~/.vibe_remote` adoption,
+- P2 home-dir migration: `config/paths.py`, `AVIBE_HOME`, `~/.avibe` default,
+  old `~/.vibe_remote` adoption,
   back-symlink, conflict rules, and old-user simulation tests.
 - P3 main-repo product copy: README/README_ZH, VISION/VISION_ZH, backend i18n,
   frontend i18n, UI metadata, Slack manifest, Sentry/user-agent labels where
@@ -476,7 +475,7 @@ Updated surfaces:
   non-protocol user agents now use `avibe`.
 
 Intentionally retained:
-- `VIBE_REMOTE_HOME`, `~/.vibe_remote`, `vibe_remote.log`, cookies, OpenCode
+- `~/.vibe_remote`, `vibe_remote.log`, cookies, OpenCode
   metadata keys, release-marker compatibility, legacy `vibe-remote` package
   uninstall/shim references, and test fixtures that simulate old installs.
 - Product Hunt URLs/badge identifiers until the external listing is replaced or
@@ -525,7 +524,7 @@ Still intentionally retained:
   to an `avibe.bot` redirect before the 3.0.0 release.
 - `skills/use-avibe` is the current skill slug/path; stale skill references
   should not remain in new prompt injection.
-- `VIBE_REMOTE_HOME`, `~/.vibe_remote`, `vibe_remote.log`, cookie names,
+- `~/.vibe_remote`, `vibe_remote.log`, cookie names,
   OpenCode metadata keys, legacy release markers, and `vibe-remote` shim /
   uninstall references remain compatibility surfaces.
 - Product Hunt badge URLs and historical docs/plans remain old-name references

--- a/docs/plans/restart-orphan-bug.md
+++ b/docs/plans/restart-orphan-bug.md
@@ -288,7 +288,7 @@ delayed restart path is fire-and-forget with no audit trail.
 
 After this fix, the following invariants must hold:
 
-1. At most one `service_main.py` process per `VIBE_REMOTE_HOME` data dir
+1. At most one `service_main.py` process per `AVIBE_HOME` data dir
    at any time. A second invocation either reuses the existing one or
    fails loudly.
 2. Every `vibe restart` (CLI direct, CLI delayed, Web UI, `do_upgrade`
@@ -305,7 +305,7 @@ After this fix, the following invariants must hold:
 
 The first-principles boundary is:
 
-> Same `VIBE_REMOTE_HOME` means same service identity. Exactly one process may
+> Same `AVIBE_HOME` means same service identity. Exactly one process may
 > own that service identity at a time.
 
 Pidfiles are now treated as auxiliary status, not the source of running
@@ -347,7 +347,7 @@ Scanning can be useful for diagnostics, but it is the wrong primary
 boundary. A process list answers "what looks like a service process right
 now?" The product invariant is different: "who owns this data directory?"
 The lock answers the invariant directly and avoids false positives across
-different worktrees, installs, and `VIBE_REMOTE_HOME` values.
+different worktrees, installs, and `AVIBE_HOME` values.
 
 ## 6. Implementation plan
 
@@ -417,7 +417,7 @@ After this branch lands:
    keep the spawn_background path as a fallback when no service-manager
    integration is registered.
 2. **What counts as "the same install"?** Resolved here: same
-   `VIBE_REMOTE_HOME` means same service identity, regardless of Python
+   `AVIBE_HOME` means same service identity, regardless of Python
    install path.
 4. **Stop-grace window.** Some IM backends (Lark websocket reconnect
    loops, OpenCode server) may need more than 5s to flush. Should

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -504,7 +504,7 @@ def cloud_init_user_data() -> str:
         Group={SERVICE_USER}
         WorkingDirectory={SOURCE_DIR}
         Environment=HOME={SERVICE_HOME}
-        Environment=VIBE_REMOTE_HOME=
+        Environment=AVIBE_HOME=
         Environment=VIBE_DEPLOYMENT_ENV=regression
         Environment=VIBE_INTERNAL_DISPATCH_SOCKET=/tmp/vibe_remote/dispatch.sock
         Environment=PYTHONUNBUFFERED=1

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -153,7 +153,7 @@ python3 "$API_HELPER" GET '/settings?platform=slack'
 
 ## Runtime Layout
 
-Avibe stores runtime data under `~/.avibe/` by default (or `AVIBE_HOME` if set). For backward compatibility, `VIBE_REMOTE_HOME` is still honored when set, and existing default `~/.vibe_remote/` homes may be migrated to `~/.avibe/` with `~/.vibe_remote` kept as a back-symlink. The only paths an agent normally needs:
+Avibe stores runtime data under `~/.avibe/` by default, or under `AVIBE_HOME` when that env var is set. Existing default `~/.vibe_remote/` homes may be migrated to `~/.avibe/` with `~/.vibe_remote` kept as a back-symlink. The only paths an agent normally needs:
 
 - `~/.avibe/config/config.json` — global config; mutate through `POST /config`, not by editing the file
 - `~/.avibe/logs/vibe_remote.log` — main application log; read via `POST /logs`

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -153,7 +153,7 @@ python3 "$API_HELPER" GET '/settings?platform=slack'
 
 ## Runtime Layout
 
-Avibe stores runtime data under `~/.avibe/` by default (or `AVIBE_HOME` if set). For backward compatibility, `VIBE_REMOTE_HOME` is still honored when set, and existing default `~/.vibe_remote/` homes may be migrated to `~/.avibe/` with `~/.vibe_remote` kept as a back-symlink. The only paths an agent normally needs:
+Avibe stores runtime data under `~/.avibe/` by default, or under `AVIBE_HOME` when that env var is set. Existing default `~/.vibe_remote/` homes may be migrated to `~/.avibe/` with `~/.vibe_remote` kept as a back-symlink. The only paths an agent normally needs:
 
 - `~/.avibe/config/config.json` — global config; mutate through `POST /config`, not by editing the file
 - `~/.avibe/logs/vibe_remote.log` — main application log; read via `POST /logs`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ called ``load_config()`` / ``cfg.save()`` against the real config.json and
 persisted the fixture path, surfacing in the UI after the next restart.
 
 Isolation mechanism: we set ``HOME``, XDG config/data/cache/state homes, and
-``VIBE_REMOTE_HOME`` to a per-test tmp directory, and patch
+``AVIBE_HOME`` to a per-test tmp directory, and patch
 ``pathlib.Path.home`` to match. This means ``config.paths.get_vibe_remote_dir``
 runs as written — only its env-var-set branch is exercised under isolation, and
 the function itself is never replaced, so the suite still catches regressions in
@@ -38,7 +38,7 @@ intentionally cover the env-var-unset branch where ``get_vibe_remote_dir``
 falls back to the default home. Those opt out with
 ``@pytest.mark.uses_real_paths``, run against the real environment, and
 must remain read-only (they may not call ``cfg.save()`` or otherwise
-write to ``~/.vibe_remote/``).
+write to ``~/.avibe/`` or legacy ``~/.vibe_remote/``).
 """
 
 from __future__ import annotations
@@ -62,7 +62,7 @@ def _isolate_vibe_remote_home(request, tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_DATA_HOME", str(isolated_home / ".local" / "share"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(isolated_home / ".cache"))
     monkeypatch.setenv("XDG_STATE_HOME", str(isolated_home / ".local" / "state"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(isolated_home / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(isolated_home / ".avibe"))
     # Keep Codex / Claude Code credential writes off the developer's real
     # home. Tests that manage these env vars themselves (e.g. the
     # ``get_codex_home`` env-precedence tests) override these via their own
@@ -76,7 +76,7 @@ def _reset_oauth_runtime_state():
     """Reset module-level in-memory OAuth caches between tests.
 
     The handshake store, diagnostic-log throttles, and the unauthenticated /auth
-    rate limiter live in process memory (not under the isolated VIBE_REMOTE_HOME),
+    rate limiter live in process memory (not under the isolated Avibe home),
     so without this they would leak across tests sharing a pytest process — e.g. the
     rate limiter accumulating across files and spuriously 429-ing an unrelated test.
     """

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -58,7 +58,7 @@ class TestCLIPackageInstalled:
         assert result.stdout.strip()  # Should print a version string
 
     def test_config_paths_uses_env(self, vibe_container):
-        """VIBE_REMOTE_HOME env var should control the base directory."""
+        """AVIBE_HOME env var should control the base directory."""
         result = _docker_exec("python -c 'from config.paths import get_vibe_remote_dir; print(get_vibe_remote_dir())'")
         assert result.returncode == 0
-        assert "/data/vibe_remote" in result.stdout
+        assert "/data/avibe" in result.stdout

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -39,15 +39,15 @@ class _IsolatedClaudeConfigDirMixin:
 
 @contextmanager
 def _temporary_vibe_home(tmp_path: Path):
-    previous_home = os.environ.get("VIBE_REMOTE_HOME")
-    os.environ["VIBE_REMOTE_HOME"] = str(tmp_path)
+    previous_home = os.environ.get("AVIBE_HOME")
+    os.environ["AVIBE_HOME"] = str(tmp_path)
     try:
         yield
     finally:
         if previous_home is None:
-            os.environ.pop("VIBE_REMOTE_HOME", None)
+            os.environ.pop("AVIBE_HOME", None)
         else:
-            os.environ["VIBE_REMOTE_HOME"] = previous_home
+            os.environ["AVIBE_HOME"] = previous_home
 
 
 class _StubIMClient:

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -86,7 +86,7 @@ def _full_config_payload() -> dict:
 
 
 def test_save_config_merges_partial_payload(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     original = api.save_config(_full_config_payload())
     assert original.show_duration is True
@@ -112,7 +112,7 @@ def test_save_config_seeds_default_for_partial_payload_on_fresh_install(monkeypa
     ``V2Config.from_payload`` and raised (missing ``mode``/``runtime``), so the
     advertised first-run "Configure provider" flow failed until a config existed.
     """
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     import pytest
 
@@ -136,7 +136,7 @@ def test_save_config_seeds_default_for_partial_payload_on_fresh_install(monkeypa
 
 
 def test_save_config_defaults_show_duration_to_false_for_new_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload.pop("show_duration")
@@ -147,7 +147,7 @@ def test_save_config_defaults_show_duration_to_false_for_new_config(monkeypatch,
 
 
 def test_save_config_defaults_include_time_info_to_true_for_new_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload.pop("include_time_info")
@@ -158,7 +158,7 @@ def test_save_config_defaults_include_time_info_to_true_for_new_config(monkeypat
 
 
 def test_save_config_accepts_typing_ack_mode(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     updated = api.save_config({**_full_config_payload(), "ack_mode": "typing"})
 
@@ -166,7 +166,7 @@ def test_save_config_accepts_typing_ack_mode(monkeypatch, tmp_path):
 
 
 def test_save_config_merges_audio_asr_settings(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     created = api.save_config(_full_config_payload())
     assert created.audio_asr.enabled is True
@@ -186,7 +186,7 @@ def test_save_config_merges_audio_asr_settings(monkeypatch, tmp_path):
 
 
 def test_save_config_marks_explicit_audio_asr_disable_patch(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     api.save_config(_full_config_payload())
 
@@ -207,7 +207,7 @@ def test_config_load_defaults_missing_audio_asr_to_enabled():
 
 
 def test_save_config_preserves_show_pages_prompt_toggle(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     created = api.save_config(_full_config_payload())
     assert created.show_pages_prompt is True
@@ -239,7 +239,7 @@ def test_config_load_preserves_pre_upgrade_audio_asr_false_as_opt_out():
 
 
 def test_save_config_preserves_explicit_audio_asr_opt_out(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload["audio_asr"] = {
@@ -255,7 +255,7 @@ def test_save_config_preserves_explicit_audio_asr_opt_out(monkeypatch, tmp_path)
 
 
 def test_config_to_payload_redacts_remote_access_secrets_and_save_preserves_them(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     payload = _full_config_payload()
     payload["remote_access"] = {
         "provider": "vibe_cloud",
@@ -290,7 +290,7 @@ def test_config_to_payload_redacts_remote_access_secrets_and_save_preserves_them
 
 
 def test_config_to_payload_redacts_platform_and_gateway_secrets_and_save_preserves_them(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     payload = _full_config_payload()
     payload["slack"] = {
         **payload["slack"],
@@ -371,7 +371,7 @@ def test_config_to_payload_redacts_platform_and_gateway_secrets_and_save_preserv
 
 
 def test_save_config_accepts_slack_disable_link_unfurl(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload["slack"]["disable_link_unfurl"] = True
@@ -382,7 +382,7 @@ def test_save_config_accepts_slack_disable_link_unfurl(monkeypatch, tmp_path):
 
 
 def test_save_config_preserves_platforms_metadata(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload["slack"]["bot_token"] = "xoxb-valid-token"
@@ -407,7 +407,7 @@ def test_save_config_preserves_platforms_metadata(monkeypatch, tmp_path):
 
 
 def test_save_config_migrates_legacy_single_platform(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     updated = api.save_config(_full_config_payload())
     payload = api.config_to_payload(updated)
@@ -418,7 +418,7 @@ def test_save_config_migrates_legacy_single_platform(monkeypatch, tmp_path):
 
 
 def test_save_config_rejects_enabled_platform_without_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     import pytest
 
@@ -435,7 +435,7 @@ def test_save_config_rejects_enabled_platform_without_config(monkeypatch, tmp_pa
 
 
 def test_save_config_rejects_enabled_platform_without_runtime_credentials(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     import pytest
 
@@ -461,7 +461,7 @@ def test_save_config_rejects_enabled_platform_without_runtime_credentials(monkey
 
 
 def test_save_config_allows_slack_bot_token_only_runtime_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = {
         **_full_config_payload(),
@@ -480,7 +480,7 @@ def test_save_config_allows_slack_bot_token_only_runtime_config(monkeypatch, tmp
 def test_save_config_rejects_setup_completion_with_enabled_platform_without_runtime_credentials(
     monkeypatch, tmp_path
 ):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     import pytest
 
@@ -504,7 +504,7 @@ def test_save_config_rejects_setup_completion_with_enabled_platform_without_runt
 def test_save_config_allows_unrelated_save_for_legacy_enabled_platform_without_runtime_credentials(
     monkeypatch, tmp_path
 ):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload["platform"] = "slack"
@@ -520,7 +520,7 @@ def test_save_config_allows_unrelated_save_for_legacy_enabled_platform_without_r
 
 
 def test_save_config_allows_redacted_lark_round_trip_for_legacy_missing_secret(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload["platform"] = "lark"
@@ -560,7 +560,7 @@ def test_save_config_allows_redacted_lark_round_trip_for_legacy_missing_secret(m
 
 
 def test_save_config_preserves_disabled_platform_credentials(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     payload = _full_config_payload()
     payload["platform"] = "avibe"
@@ -597,7 +597,7 @@ def test_save_config_preserves_disabled_platform_credentials(monkeypatch, tmp_pa
 
 
 def test_init_sessions_is_noop_when_sessions_file_exists(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     store = api.SessionsStore()
     store.state.session_mappings = {

--- a/tests/test_cli_agent_run_schema.py
+++ b/tests/test_cli_agent_run_schema.py
@@ -102,7 +102,7 @@ def test_agent_run_async_accepts_callback_session_id(tmp_path: Path, capsys) -> 
     from storage.settings_service import upsert_scope
 
     state_home = tmp_path / "home"
-    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+    with patch.dict("os.environ", {"AVIBE_HOME": str(state_home)}):
         ensure_sqlite_state()
         db_path = state_home / "state" / "vibe.sqlite"
         engine = create_sqlite_engine(db_path)
@@ -256,7 +256,7 @@ def test_agent_run_fork_session_reserves_new_session_and_persists_metadata(tmp_p
     from storage.models import agent_sessions
 
     state_home = tmp_path / "home"
-    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+    with patch.dict("os.environ", {"AVIBE_HOME": str(state_home)}):
         ensure_sqlite_state()
         db_path = state_home / "state" / "vibe.sqlite"
         source_session_id = _seed_bound_session(db_path, tmp_path)
@@ -319,7 +319,7 @@ def test_agent_run_fork_rejects_cross_backend_agent(tmp_path: Path, capsys) -> N
     from storage.importer import ensure_sqlite_state
 
     state_home = tmp_path / "home"
-    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+    with patch.dict("os.environ", {"AVIBE_HOME": str(state_home)}):
         ensure_sqlite_state()
         db_path = state_home / "state" / "vibe.sqlite"
         source_session_id = _seed_bound_session(db_path, tmp_path)
@@ -355,7 +355,7 @@ def test_agent_run_private_session_workdir_follows_invocation_cwd(tmp_path: Path
     state_home = tmp_path / "home"
     invoke_dir = tmp_path / "repo"
     invoke_dir.mkdir()
-    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+    with patch.dict("os.environ", {"AVIBE_HOME": str(state_home)}):
         ensure_sqlite_state()
         db_path = state_home / "state" / "vibe.sqlite"
         agent_store = cli.VibeAgentStore(db_path)
@@ -386,7 +386,7 @@ def test_agent_run_explicit_cwd_wins(tmp_path: Path, capsys, monkeypatch) -> Non
     invoke_dir.mkdir()
     picked_dir = tmp_path / "elsewhere"
     picked_dir.mkdir()
-    with patch.dict("os.environ", {"VIBE_REMOTE_HOME": str(state_home)}):
+    with patch.dict("os.environ", {"AVIBE_HOME": str(state_home)}):
         ensure_sqlite_state()
         db_path = state_home / "state" / "vibe.sqlite"
         agent_store = cli.VibeAgentStore(db_path)

--- a/tests/test_cli_pagination.py
+++ b/tests/test_cli_pagination.py
@@ -8,7 +8,7 @@ from vibe import cli
 
 
 def test_runs_list_cli_defaults_to_first_page(monkeypatch, tmp_path, capsys) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -42,7 +42,7 @@ def test_runs_list_cli_defaults_to_first_page(monkeypatch, tmp_path, capsys) -> 
 
 
 def test_runs_list_cli_filters_status_and_query(monkeypatch, tmp_path, capsys) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -84,7 +84,7 @@ def test_runs_list_cli_filters_status_and_query(monkeypatch, tmp_path, capsys) -
 
 
 def test_runs_list_cli_normalizes_offset_time_filters(monkeypatch, tmp_path, capsys) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -117,7 +117,7 @@ def test_runs_list_cli_normalizes_offset_time_filters(monkeypatch, tmp_path, cap
 
 
 def test_runs_list_cli_next_command_uses_absolute_time_filters(monkeypatch, tmp_path, capsys) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -144,7 +144,7 @@ def test_runs_list_cli_next_command_uses_absolute_time_filters(monkeypatch, tmp_
 
 
 def test_data_query_cli_runs_read_only_sql(monkeypatch, tmp_path, capsys) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -170,7 +170,7 @@ def test_data_query_cli_runs_read_only_sql(monkeypatch, tmp_path, capsys) -> Non
 
 
 def test_data_query_cli_omits_next_command_for_stdin_sql(monkeypatch, tmp_path, capsys) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -198,7 +198,7 @@ def test_data_query_cli_omits_next_command_for_stdin_sql(monkeypatch, tmp_path, 
 
 
 def test_data_query_cli_rejects_writes(monkeypatch, tmp_path, capsys) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     store = SQLiteBackgroundTaskStore()
     store.close()

--- a/tests/test_controller_agent_status.py
+++ b/tests/test_controller_agent_status.py
@@ -91,7 +91,7 @@ def test_run_marks_running_at_acceptance_before_dispatch(monkeypatch, tmp_path):
     accept-time write closes the startup window where a cross-backend PATCH
     could land while the row still read idle."""
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from storage.importer import ensure_sqlite_state
 
     ensure_sqlite_state()

--- a/tests/test_controller_config_reload.py
+++ b/tests/test_controller_config_reload.py
@@ -24,7 +24,7 @@ def _config_payload(discord_payload: dict | None = None, telegram_payload: dict 
 
 
 def test_refresh_config_updates_platform_message_settings(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     stale_discord_config = DiscordConfig(bot_token="discord-token", require_mention=True)
     controller = Controller.__new__(Controller)
@@ -55,7 +55,7 @@ def test_refresh_config_updates_platform_message_settings(tmp_path, monkeypatch)
 
 
 def test_refresh_config_updates_telegram_option_only_settings(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     stale_telegram_config = TelegramConfig(
         bot_token="123456:test-token",
@@ -93,7 +93,7 @@ def test_refresh_config_updates_telegram_option_only_settings(tmp_path, monkeypa
 
 
 def test_refresh_config_updates_remote_access_for_audio_asr(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     controller = Controller.__new__(Controller)
     controller.config = V2Config.from_payload(_config_payload({"bot_token": "discord-token"}))

--- a/tests/test_core_services_sessions.py
+++ b/tests/test_core_services_sessions.py
@@ -25,7 +25,7 @@ from storage.settings_service import upsert_scope
 
 @pytest.fixture()
 def isolated_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     yield tmp_path
 

--- a/tests/test_core_services_settings.py
+++ b/tests/test_core_services_settings.py
@@ -21,7 +21,7 @@ from core.services import settings as settings_service
 
 @pytest.fixture()
 def isolated_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     yield tmp_path
     SettingsStore.reset_instance()

--- a/tests/test_discord_guild_settings.py
+++ b/tests/test_discord_guild_settings.py
@@ -32,7 +32,7 @@ def _config_payload() -> dict:
 
 
 def test_settings_store_persists_discord_guild_scope(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     store = SettingsStore.get_instance()
@@ -55,7 +55,7 @@ def test_settings_store_persists_discord_guild_scope(tmp_path, monkeypatch) -> N
 
 
 def test_discord_settings_manager_prefers_explicit_guild_scope(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     manager = SettingsManager(platform="discord")
@@ -67,7 +67,7 @@ def test_discord_settings_manager_prefers_explicit_guild_scope(tmp_path, monkeyp
 
 
 def test_save_config_moves_legacy_discord_allowlist_to_settings(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     saved = api.save_config(
@@ -92,7 +92,7 @@ def test_save_config_moves_legacy_discord_allowlist_to_settings(tmp_path, monkey
 
 
 def test_save_config_moves_legacy_discord_denylist_to_settings(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     saved = api.save_config(
@@ -119,7 +119,7 @@ def test_save_config_moves_legacy_discord_denylist_to_settings(tmp_path, monkeyp
 
 
 def test_partial_save_config_migrates_existing_legacy_discord_denylist(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     paths.ensure_data_dirs()
@@ -150,7 +150,7 @@ def test_partial_save_config_migrates_existing_legacy_discord_denylist(tmp_path,
 
 
 def test_partial_legacy_guild_config_update_preserves_omitted_denylist(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     paths.ensure_data_dirs()
@@ -185,7 +185,7 @@ def test_partial_legacy_guild_config_update_preserves_omitted_denylist(tmp_path,
 
 
 def test_direct_config_save_preserves_unmigrated_discord_guild_rules(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     config = V2Config.from_payload(
@@ -215,7 +215,7 @@ def test_direct_config_save_preserves_unmigrated_discord_guild_rules(tmp_path, m
 
 
 def test_save_settings_preserves_discord_denylist_policy_when_default_omitted(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     store = SettingsStore.get_instance()
@@ -244,7 +244,7 @@ def test_save_settings_preserves_discord_denylist_policy_when_default_omitted(tm
 
 
 def test_wizard_style_guild_save_preserves_migrated_discord_denylist(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     store = SettingsStore.get_instance()
@@ -265,7 +265,7 @@ def test_wizard_style_guild_save_preserves_migrated_discord_denylist(tmp_path, m
 
 
 def test_save_config_validates_before_migrating_discord_guild_settings(tmp_path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     payload = {

--- a/tests/test_docker_entrypoint_supervisor.py
+++ b/tests/test_docker_entrypoint_supervisor.py
@@ -35,7 +35,7 @@ class DockerEntrypointSupervisorTests(unittest.TestCase):
                     if len(args) >= 2 and args[0] == "-c":
                         code = args[1]
                         if "get_runtime_dir" in code:
-                            print(Path(os.environ["VIBE_REMOTE_HOME"]) / "runtime")
+                            print(Path(os.environ["AVIBE_HOME"]) / "runtime")
                             sys.exit(0)
                         if "run_ui_server" in code:
                             time.sleep(30)
@@ -50,7 +50,7 @@ class DockerEntrypointSupervisorTests(unittest.TestCase):
 
             env = os.environ.copy()
             env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
-            env["VIBE_REMOTE_HOME"] = str(tmp_path / "home")
+            env["AVIBE_HOME"] = str(tmp_path / "home")
 
             result = subprocess.run(
                 ["bash", str(ENTRYPOINT), "full"],
@@ -126,7 +126,8 @@ class DockerEntrypointSupervisorTests(unittest.TestCase):
                         break
                     time.sleep(0.1)
                 self.assertTrue(runtime_pid_path.exists())
-                self.assertFalse((Path(env["VIBE_REMOTE_HOME"]) / "runtime" / "vibe.pid").exists())
+                legacy_pid_path = Path(env["VIBE_REMOTE_HOME"]) / "runtime" / "vibe.pid"
+                self.assertFalse(legacy_pid_path.exists())
             finally:
                 os.killpg(proc.pid, signal.SIGTERM)
                 try:
@@ -151,7 +152,7 @@ class DockerEntrypointSupervisorTests(unittest.TestCase):
                     from pathlib import Path
 
                     args = sys.argv[1:]
-                    runtime_dir = Path(os.environ["VIBE_REMOTE_HOME"]) / "runtime"
+                    runtime_dir = Path(os.environ["AVIBE_HOME"]) / "runtime"
                     runtime_dir.mkdir(parents=True, exist_ok=True)
                     real_python = os.environ["REAL_PYTHON"]
 
@@ -189,7 +190,7 @@ class DockerEntrypointSupervisorTests(unittest.TestCase):
 
             env = os.environ.copy()
             env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
-            env["VIBE_REMOTE_HOME"] = str(tmp_path / "home")
+            env["AVIBE_HOME"] = str(tmp_path / "home")
             env["REAL_PYTHON"] = sys.executable
 
             proc = subprocess.Popen(
@@ -231,7 +232,7 @@ class DockerEntrypointSupervisorTests(unittest.TestCase):
                     from pathlib import Path
 
                     args = sys.argv[1:]
-                    runtime_dir = Path(os.environ["VIBE_REMOTE_HOME"]) / "runtime"
+                    runtime_dir = Path(os.environ["AVIBE_HOME"]) / "runtime"
                     runtime_dir.mkdir(parents=True, exist_ok=True)
                     status_path = runtime_dir / "status.json"
 
@@ -283,7 +284,7 @@ class DockerEntrypointSupervisorTests(unittest.TestCase):
 
             env = os.environ.copy()
             env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
-            env["VIBE_REMOTE_HOME"] = str(tmp_path / "home")
+            env["AVIBE_HOME"] = str(tmp_path / "home")
 
             proc = subprocess.Popen(
                 ["bash", str(ENTRYPOINT), "full"],

--- a/tests/test_incus_regression_supervisor.py
+++ b/tests/test_incus_regression_supervisor.py
@@ -27,7 +27,7 @@ def _write_restart_status(status: dict) -> None:
 
 
 def test_restart_in_progress_true_while_job_pid_alive(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _write_restart_status({"ok": None, "state": "running", "supervisor_pid": 4242, "supervisor_started_at": 1000.0})
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 4242)
@@ -40,7 +40,7 @@ def test_restart_in_progress_false_when_pid_reused(monkeypatch, tmp_path):
     # Pid is alive but its start time no longer matches what the job recorded —
     # the pid was reused (e.g. after a reboot) by an unrelated process, so the
     # restart is not actually in progress and recovery must proceed.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _write_restart_status({"ok": None, "state": "running", "supervisor_pid": 4242, "supervisor_started_at": 1000.0})
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 4242)
@@ -53,7 +53,7 @@ def test_restart_in_progress_false_when_job_pid_dead(monkeypatch, tmp_path):
     # The P2: a killed restart job or a reboot leaves ok=None + state=running with
     # a now-dead pid. The supervisor must treat it as stale, not in progress, so
     # it can exit nonzero and let systemd recover instead of looping "restarting".
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _write_restart_status({"ok": None, "state": "running", "supervisor_pid": 4242})
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: False)
@@ -63,7 +63,7 @@ def test_restart_in_progress_false_when_job_pid_dead(monkeypatch, tmp_path):
 
 def test_restart_in_progress_false_without_recorded_pid(monkeypatch, tmp_path):
     # An older "running" status with no job pid can't be confirmed alive → stale.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _write_restart_status({"ok": None, "state": "running"})
 
@@ -74,7 +74,7 @@ def test_restart_in_progress_false_for_scheduled_restart(monkeypatch, tmp_path):
     # A delayed restart is only sleeping ("scheduled") and hasn't stopped the
     # service yet, so a crash during the delay must still be recovered — even
     # though the job process is alive.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _write_restart_status({"ok": None, "state": "scheduled", "supervisor_pid": 4242})
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)
@@ -83,7 +83,7 @@ def test_restart_in_progress_false_for_scheduled_restart(monkeypatch, tmp_path):
 
 
 def test_restart_in_progress_false_when_completed(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _write_restart_status({"ok": True, "state": "succeeded", "supervisor_pid": 4242})
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)
@@ -97,7 +97,7 @@ def test_main_recovers_when_restart_leaves_unready_service(monkeypatch, tmp_path
     # not adopt the unready pid and loop forever — it must exit nonzero so systemd
     # recovers the service. Old ready pid 100 is dead; the file now points at the
     # hung pid 200 (alive, not recorded); the UI (333) is alive; no restart active.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("200", encoding="utf-8")
     paths.get_runtime_ui_pid_path().write_text("333", encoding="utf-8")
@@ -126,7 +126,7 @@ def test_main_backs_off_during_active_restart(monkeypatch, tmp_path):
     # write "restarting" and keep waiting, never exit for systemd. Guards the
     # TOCTOU where the restart begins after the loop-top: the recovery branch
     # re-reads _restart_in_progress() before exiting.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_ui_pid_path().write_text("333", encoding="utf-8")
 

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -117,7 +117,7 @@ def _build_controller_double(handler=None):
 
 
 def test_default_socket_path_lives_under_state_dir(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.delenv("VIBE_INTERNAL_DISPATCH_SOCKET", raising=False)
     path = internal_server.default_socket_path()
     assert path.name == "dispatch.sock"
@@ -316,7 +316,7 @@ def test_dispatch_forwards_session_routing_into_platform_specific(monkeypatch, t
     from storage.importer import ensure_sqlite_state
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -395,7 +395,7 @@ def test_dispatch_async_starts_turn_and_returns_202(monkeypatch, tmp_path):
 
     # dispatch_async reads the queue (to preserve order after a Stop), so it needs
     # an initialized state DB even on the empty-queue happy path.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     started = asyncio.Event()
@@ -452,7 +452,7 @@ def test_dispatch_async_no_terminal_result_keeps_session_in_flight(monkeypatch, 
     """
     from storage.importer import ensure_sqlite_state
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     started = asyncio.Event()
@@ -508,7 +508,7 @@ def test_dispatch_async_enqueues_during_busy_turn(monkeypatch, tmp_path):
     from storage.importer import ensure_sqlite_state
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -584,7 +584,7 @@ def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):
     from storage.importer import ensure_sqlite_state
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -664,7 +664,7 @@ def test_cancel_does_not_flush_queue(monkeypatch, tmp_path):
     from storage.importer import ensure_sqlite_state
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -1010,7 +1010,7 @@ def test_scheduled_gate_idle_runs_turn_with_lifecycle(monkeypatch, tmp_path):
 
     # submit_scheduled reads the queue (idle → empty-queue happy path), so it
     # needs an initialized state DB.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     captured: dict = {}
@@ -1074,7 +1074,7 @@ def test_scheduled_gate_busy_enqueues_and_leaves_chat_turn_untouched(monkeypatch
     from storage.importer import ensure_sqlite_state
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -1137,7 +1137,7 @@ def test_scheduled_gate_cancel_stops_scheduled_run(monkeypatch, tmp_path):
     from storage.importer import ensure_sqlite_state
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -1244,7 +1244,7 @@ def _manager_capturing_runs():
 def test_flush_runs_scheduled_row_as_scheduled_with_provenance(tmp_path, monkeypatch):
     """A queued scheduled run flushes as its OWN SOURCE_SCHEDULED turn with its
     delivery provenance restored — not merged into a plain user turn (#84)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     override = {"channel_id": "slack-321", "platform": "slack"}
     session_id = _seed_avibe_session_with_queue(
         [(
@@ -1284,7 +1284,7 @@ def test_flush_segments_user_then_scheduled_in_order(tmp_path, monkeypatch):
     into one user turn; the scheduled row then runs separately with its provenance.
     The completion-reflush handles the next segment, so one flush runs only the first
     segment and leaves the rest (#84)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     session_id = _seed_avibe_session_with_queue(
         [
             ("u1", None),
@@ -1313,7 +1313,7 @@ def test_flush_segments_user_then_scheduled_in_order(tmp_path, monkeypatch):
 
 
 def test_flush_mixed_owner_user_rows_preserves_owner_list(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     from core.services import sessions as sessions_service
     from storage import messages_service

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -336,7 +336,7 @@ def test_reconcile_startup_dependencies_can_be_disabled(monkeypatch):
 
 
 def test_startup_show_page_prewarm_targets_recent_non_offline(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from config import paths
     from core.show_pages import ShowPageStore
 

--- a/tests/test_message_mirror.py
+++ b/tests/test_message_mirror.py
@@ -35,7 +35,7 @@ from storage.settings_service import upsert_scope
 
 @pytest.fixture()
 def isolated_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     yield tmp_path
 

--- a/tests/test_message_search.py
+++ b/tests/test_message_search.py
@@ -2,7 +2,7 @@
 window mode on ``list_session_messages`` — Phase 1 of the message-search feature.
 
 Mirrors the fixture pattern in ``tests/test_messages_service.py``: an isolated
-``VIBE_REMOTE_HOME`` (so the live ``~/.avibe`` is never touched), a SQLite engine
+``AVIBE_HOME`` (so the live ``~/.avibe`` is never touched), a SQLite engine
 from ``create_sqlite_engine``, and direct inserts that control ``created_at`` /
 ``type`` / ``platform`` / ``content_text``.
 """
@@ -25,7 +25,7 @@ from storage.settings_service import upsert_scope
 
 @pytest.fixture()
 def isolated_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     yield tmp_path
 

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -22,7 +22,7 @@ from storage.settings_service import upsert_scope
 
 @pytest.fixture()
 def isolated_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     yield tmp_path
 

--- a/tests/test_projects_service.py
+++ b/tests/test_projects_service.py
@@ -19,7 +19,7 @@ from storage.models import scope_settings, scopes
 
 @pytest.fixture
 def engine():
-    # conftest's autouse fixture points VIBE_REMOTE_HOME at a per-test tmp dir,
+    # conftest's autouse fixture points AVIBE_HOME at a per-test tmp dir,
     # so this initialises and connects to an isolated SQLite state file.
     ensure_sqlite_state()
     return create_sqlite_engine()

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -86,7 +86,7 @@ def test_make_session_cookie_requires_session_secret() -> None:
 
 
 def test_pair_redeems_key_and_starts_connector(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.enabled = False
     config.remote_access.vibe_cloud.session_secret = ""
@@ -126,7 +126,7 @@ def test_pair_redeems_key_and_starts_connector(monkeypatch, tmp_path) -> None:
 
 
 def test_pair_origin_service_follows_effective_ui_port(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_UI_PORT", "15130")
     config = _config()
     config.ui.setup_host = "0.0.0.0"
@@ -137,7 +137,7 @@ def test_pair_origin_service_follows_effective_ui_port(monkeypatch, tmp_path) ->
 
 
 def test_pair_origin_service_ignores_configured_ui_host(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.ui.setup_host = "192.168.2.3"
     config.ui.setup_port = 15130
@@ -149,7 +149,7 @@ def test_pair_origin_service_ignores_configured_ui_host(monkeypatch, tmp_path) -
 def test_pair_origin_service_uses_ipv4_loopback_when_localhost_resolves_dual_stack(
     monkeypatch, tmp_path
 ) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(runtime, "resolve_localhost_family", lambda: "inet")
     config = _config()
     config.ui.setup_host = "localhost"
@@ -165,7 +165,7 @@ def test_pair_origin_service_uses_ipv4_loopback_when_localhost_resolves_dual_sta
 def test_pair_origin_service_uses_ipv6_loopback_when_localhost_resolves_v6_only(
     monkeypatch, tmp_path
 ) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(runtime, "resolve_localhost_family", lambda: "inet6")
     config = _config()
     config.ui.setup_host = "localhost"
@@ -179,7 +179,7 @@ def test_pair_origin_service_uses_ipv6_loopback_when_localhost_resolves_v6_only(
 
 
 def test_pair_origin_service_preserves_ipv6_loopback(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.ui.setup_host = "::1"
     config.ui.setup_port = 15130
@@ -189,7 +189,7 @@ def test_pair_origin_service_preserves_ipv6_loopback(monkeypatch, tmp_path) -> N
 
 
 def test_pair_origin_service_preserves_bracketed_ipv6_loopback(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.ui.setup_host = "[::1]"
     config.ui.setup_port = 15130
@@ -199,7 +199,7 @@ def test_pair_origin_service_preserves_bracketed_ipv6_loopback(monkeypatch, tmp_
 
 
 def test_pair_origin_service_uses_ipv6_loopback_for_ipv6_wildcard(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.ui.setup_host = "::"
     config.ui.setup_port = 15130
@@ -209,7 +209,7 @@ def test_pair_origin_service_uses_ipv6_loopback_for_ipv6_wildcard(monkeypatch, t
 
 
 def test_runtime_status_payload_reports_local_origin_and_tunnel_state(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.ui.setup_host = "100.97.103.112"
     config.save()
@@ -236,7 +236,7 @@ def test_runtime_status_payload_reports_local_origin_and_tunnel_state(monkeypatc
 
 
 def test_observed_cloudflared_origin_service_reads_only_log_tail(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     remote_access._cloudflared_stderr_path().parent.mkdir(parents=True, exist_ok=True)
     remote_access._cloudflared_stderr_path().write_bytes(
         b'originService=http://old.local:5123\n'
@@ -249,7 +249,7 @@ def test_observed_cloudflared_origin_service_reads_only_log_tail(monkeypatch, tm
 
 
 def test_observed_cloudflared_origin_service_uses_latest_mixed_log_format(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     remote_access._cloudflared_stderr_path().parent.mkdir(parents=True, exist_ok=True)
     remote_access._cloudflared_stderr_path().write_text(
         'ERR originService=http://100.97.103.112:5123\n'
@@ -261,7 +261,7 @@ def test_observed_cloudflared_origin_service_uses_latest_mixed_log_format(monkey
 
 
 def test_report_runtime_status_posts_to_backend(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     cloud = config.remote_access.vibe_cloud
     cloud.backend_url = "https://backend.test"
@@ -300,7 +300,7 @@ def test_report_runtime_status_posts_to_backend(monkeypatch, tmp_path) -> None:
 
 
 def test_report_runtime_status_posts_when_remote_access_is_disabled(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     cloud = config.remote_access.vibe_cloud
     cloud.enabled = False
@@ -363,7 +363,7 @@ def test_pair_persists_with_locked_incremental_config_save(monkeypatch) -> None:
 
 
 def test_pair_reports_success_when_connector_start_fails(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.enabled = False
     config.save()
@@ -399,7 +399,7 @@ def test_pair_reports_success_when_connector_start_fails(monkeypatch, tmp_path) 
 
 
 def test_pair_rejects_origin_update_failure_before_saving_config(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.enabled = False
     config.save()
@@ -462,7 +462,7 @@ def test_pair_preserves_backend_error_response(monkeypatch) -> None:
 
 
 def test_pair_queues_lifecycle_status_for_drain(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     reports = []
 
@@ -499,7 +499,7 @@ def test_pair_queues_lifecycle_status_for_drain(monkeypatch, tmp_path) -> None:
 
 
 def test_lifecycle_status_report_does_not_block_stop(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     started = threading.Event()
     release = threading.Event()
 
@@ -524,7 +524,7 @@ def test_lifecycle_status_report_does_not_block_stop(monkeypatch, tmp_path) -> N
 
 
 def test_lifecycle_status_thread_start_failure_is_best_effort(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     with remote_access._STATUS_REPORT_LOCK:
         remote_access._STATUS_REPORT_THREADS.clear()
@@ -584,7 +584,7 @@ def test_status_heartbeat_can_retry_after_thread_start_failure(monkeypatch) -> N
 
 
 def test_stop_ui_continues_when_remote_access_stop_fails(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     stop_calls = []
     timings = {}
 
@@ -599,7 +599,7 @@ def test_stop_ui_continues_when_remote_access_stop_fails(monkeypatch, tmp_path) 
 
 
 def test_stop_ui_can_skip_remote_access_stop(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     stop_calls = []
     timings = {}
 
@@ -661,7 +661,7 @@ def test_cloudflared_pid_detection_rejects_non_cloudflared_paths(monkeypatch) ->
 
 
 def test_stop_preserves_pid_file_when_process_stop_fails(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     pid = 123
     remote_access._pid_path().parent.mkdir(parents=True, exist_ok=True)
     remote_access._pid_path().write_text(str(pid), encoding="utf-8")
@@ -681,7 +681,7 @@ def test_stop_preserves_pid_file_when_process_stop_fails(monkeypatch, tmp_path) 
 
 
 def test_stop_preserves_pid_file_when_stop_reports_success_but_process_survives(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     pid = 123
     remote_access._pid_path().parent.mkdir(parents=True, exist_ok=True)
     remote_access._pid_path().write_text(str(pid), encoding="utf-8")
@@ -707,7 +707,7 @@ def test_stop_preserves_pid_file_when_stop_reports_success_but_process_survives(
 
 
 def test_status_preserves_pid_file_when_process_command_is_unknown(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     pid = 123
     remote_access._pid_path().parent.mkdir(parents=True, exist_ok=True)
     remote_access._pid_path().write_text(str(pid), encoding="utf-8")
@@ -726,7 +726,7 @@ def test_status_preserves_pid_file_when_process_command_is_unknown(monkeypatch, 
 
 
 def test_start_refuses_duplicate_connector_when_process_command_is_unknown(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     pid = 123
     config = _config()
     config.remote_access.vibe_cloud.tunnel_token = "tunnel-token"
@@ -752,7 +752,7 @@ def test_start_refuses_duplicate_connector_when_process_command_is_unknown(monke
 
 
 def test_start_returns_failure_when_remote_access_is_disabled(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.enabled = False
     config.save()
@@ -766,7 +766,7 @@ def test_start_returns_failure_when_remote_access_is_disabled(monkeypatch, tmp_p
 
 
 def test_start_revalidates_config_after_connector_lock(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.enabled = False
     load_lock_states = []
@@ -786,7 +786,7 @@ def test_start_revalidates_config_after_connector_lock(monkeypatch, tmp_path) ->
 
 
 def test_start_returns_structured_error_when_initial_config_load_fails(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     def fail_load():
         raise ValueError("corrupt config")
@@ -802,7 +802,7 @@ def test_start_returns_structured_error_when_initial_config_load_fails(monkeypat
 
 
 def test_start_uses_current_persisted_config_over_stale_argument(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     stale_config = _config()
     stale_config.remote_access.vibe_cloud.tunnel_token = "stale-token"
     persisted_config = _config()
@@ -824,7 +824,7 @@ def test_start_uses_current_persisted_config_over_stale_argument(monkeypatch, tm
 
 
 def test_stop_loads_config_before_connector_lock(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     load_lock_states = []
 
@@ -841,7 +841,7 @@ def test_stop_loads_config_before_connector_lock(monkeypatch, tmp_path) -> None:
 
 
 def test_reconcile_stops_when_remote_access_is_disabled(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.enabled = False
 
@@ -853,7 +853,7 @@ def test_reconcile_stops_when_remote_access_is_disabled(monkeypatch, tmp_path) -
 
 
 def test_start_restarts_when_runtime_signature_changes(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.tunnel_token = "new-token"
     config.save()
@@ -903,7 +903,7 @@ def test_start_restarts_when_runtime_signature_changes(monkeypatch, tmp_path) ->
 
 
 def test_start_clears_previous_cloudflared_logs_before_spawn(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.tunnel_token = "tunnel-token"
     config.save()

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -30,7 +30,7 @@ def _fake_stop_runtime(calls, *, ui_stopped=True, ui_pid=None, service_stopped=T
 
 
 def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("12345", encoding="utf-8")
     calls = {}
@@ -65,7 +65,7 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
 
 
 def test_schedule_restart_can_prepare_show_runtime_after_restart(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     calls = {}
 
@@ -93,7 +93,7 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
     # The "scheduled" status is seeded before spawning; if the spawn fails, no
     # child will overwrite it, so schedule_restart must mark it failed (otherwise
     # `vibe status` shows a permanently pending restart that never ran).
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
@@ -116,7 +116,7 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
 
 
 def test_restart_job_stops_and_starts_service(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -151,7 +151,7 @@ def test_restart_job_stops_and_starts_service(monkeypatch, tmp_path):
 
 
 def test_restart_job_prepares_show_runtime_after_service_start(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -189,7 +189,7 @@ def test_restart_job_prepares_show_runtime_after_service_start(monkeypatch, tmp_
 
 
 def test_restart_job_schedules_pending_followup_after_success(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -239,7 +239,7 @@ def test_restart_job_schedules_pending_followup_after_success(monkeypatch, tmp_p
 
 
 def test_restart_job_aborts_when_stop_fails(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -264,7 +264,7 @@ def test_restart_job_aborts_when_stop_fails(monkeypatch, tmp_path):
 
 
 def test_restart_job_continues_when_old_pid_already_exited(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -287,7 +287,7 @@ def test_restart_job_continues_when_old_pid_already_exited(monkeypatch, tmp_path
 
 
 def test_restart_job_adopts_slow_starting_service_pid(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -322,7 +322,7 @@ def test_restart_job_adopts_slow_starting_service_pid(monkeypatch, tmp_path):
 
 
 def test_restart_job_marks_start_runtime_failed(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
 
@@ -345,7 +345,7 @@ def test_restart_job_marks_start_runtime_failed(monkeypatch, tmp_path):
 
 
 def test_restart_job_waits_for_service_lock_release_before_start(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -372,7 +372,7 @@ def test_restart_job_waits_for_service_lock_release_before_start(monkeypatch, tm
 
 
 def test_restart_job_fails_when_service_lock_does_not_release(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []
@@ -396,7 +396,7 @@ def test_restart_job_fails_when_service_lock_does_not_release(monkeypatch, tmp_p
 
 
 def test_start_runtime_processes_starts_service_and_ui(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     calls = []
     config = SimpleNamespace(
         ui=SimpleNamespace(setup_port=5123),
@@ -446,7 +446,7 @@ def test_start_runtime_processes_starts_service_and_ui(monkeypatch, tmp_path):
 
 
 def test_stop_runtime_for_restart_stops_ui_and_service(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     calls = []
     ui_entered = threading.Event()
@@ -487,7 +487,7 @@ def test_stop_runtime_for_restart_stops_ui_and_service(monkeypatch, tmp_path):
 def test_schedule_restart_service_scope_adds_flag(monkeypatch, tmp_path):
     """A service-only restart passes ``--scope service`` to the supervisor job;
     the default ``all`` scope adds no flag (back-compat for CLI/upgrade)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     commands: list[list[str]] = []
@@ -512,7 +512,7 @@ def test_schedule_restart_service_scope_adds_flag(monkeypatch, tmp_path):
 def test_restart_job_service_scope_keeps_ui(monkeypatch, tmp_path):
     """scope='service' restarts only the service: the UI is neither stopped nor
     started, so its recorded pid is preserved across the restart."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
     calls = []

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -218,7 +218,7 @@ def test_build_session_key_for_context_uses_platform_specific_platform() -> None
 
 
 def test_scheduled_task_store_uses_sqlite_when_path_is_default(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     store = ScheduledTaskStore()
     task = store.add_task(
         name="Hourly summary",
@@ -241,7 +241,7 @@ def test_scheduled_task_store_uses_sqlite_when_path_is_default(tmp_path: Path, m
 
 
 def test_sqlite_update_task_persists_changes(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     store = ScheduledTaskStore()
     task = store.add_task(
         name="Hourly summary",
@@ -278,7 +278,7 @@ def test_sqlite_update_task_persists_changes(tmp_path: Path, monkeypatch) -> Non
 
 
 def test_task_execution_store_uses_sqlite_runs_when_root_is_default(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     store = TaskExecutionStore()
     request = store.enqueue_hook_send(
         session_key="slack::channel::C123",
@@ -1362,7 +1362,7 @@ def test_drain_requests_executes_hook_send(tmp_path: Path) -> None:
 
 
 def test_agent_run_stays_running_until_terminal_result(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     request_store = TaskExecutionStore()
     request = request_store.enqueue_agent_run(
         session_key="slack::channel::C123",
@@ -1455,7 +1455,7 @@ def test_agent_run_stays_running_until_terminal_result(tmp_path: Path, monkeypat
 
 
 def test_agent_run_preserves_failed_terminal_status(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     request_store = TaskExecutionStore()
     request = request_store.enqueue_agent_run(
         session_key="slack::channel::C123",
@@ -1532,7 +1532,7 @@ def test_agent_run_preserves_failed_terminal_status(tmp_path: Path, monkeypatch)
 
 
 def test_agent_run_callback_enqueues_only_result_to_caller_session(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     caller_session_id = _make_avibe_session(monkeypatch, tmp_path)
     request_store = TaskExecutionStore()
     request = request_store.enqueue_agent_run(
@@ -1582,7 +1582,7 @@ def test_agent_run_callback_enqueues_only_result_to_caller_session(tmp_path: Pat
 
 
 def test_agent_run_callback_builds_failure_message_without_result_text(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     caller_session_id = _make_avibe_session(monkeypatch, tmp_path)
     request_store = TaskExecutionStore()
     request = request_store.enqueue_agent_run(
@@ -1612,7 +1612,7 @@ def test_agent_run_callback_builds_failure_message_without_result_text(tmp_path:
 
 
 def test_agent_run_synchronous_dispatch_error_marks_failed(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     request_store = TaskExecutionStore()
     request = request_store.enqueue_agent_run(
         session_key="slack::channel::C123",
@@ -2414,7 +2414,7 @@ def _make_avibe_session(monkeypatch, tmp_path) -> str:
     from storage.models import scope_settings
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     with engine.begin() as conn:

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -56,7 +56,7 @@ def test_detect_sentry_environment_defaults_to_local(monkeypatch):
     monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
     monkeypatch.delenv("VIBE_DEPLOYMENT_ENV", raising=False)
     monkeypatch.delenv("E2E_TEST_MODE", raising=False)
-    monkeypatch.setenv("VIBE_REMOTE_HOME", "/tmp/vibe-remote-home")
+    monkeypatch.setenv("AVIBE_HOME", "/tmp/vibe-remote-home")
     monkeypatch.setattr(sentry_integration, "Path", lambda _: type("P", (), {"exists": staticmethod(lambda: False)})())
 
     assert sentry_integration.detect_sentry_environment() == "local"
@@ -75,13 +75,13 @@ def test_detect_sentry_environment_marks_integration_mode(monkeypatch):
     monkeypatch.delenv("SENTRY_ENVIRONMENT", raising=False)
     monkeypatch.delenv("VIBE_DEPLOYMENT_ENV", raising=False)
     monkeypatch.setenv("E2E_TEST_MODE", "true")
-    monkeypatch.setenv("VIBE_REMOTE_HOME", "/tmp/vibe-remote-home")
+    monkeypatch.setenv("AVIBE_HOME", "/tmp/vibe-remote-home")
 
     assert sentry_integration.detect_sentry_environment() == "integration"
 
 
 def test_build_sentry_contexts_contains_debug_metadata(monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", "/tmp/vibe-remote-home")
+    monkeypatch.setenv("AVIBE_HOME", "/tmp/vibe-remote-home")
 
     contexts = sentry_integration.build_sentry_contexts(_config(), component="service", environment="regression")
 

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -130,7 +130,7 @@ def test_archived_session_not_reused_for_anchor(monkeypatch, tmp_path: Path) -> 
     Runs on the MIGRATED schema (``ensure_sqlite_state`` → alembic), because that
     unique index only exists post-migration; ``metadata.create_all`` omits it, so
     a create_all-only test would miss the archived-row collision entirely."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     db_path = paths.get_sqlite_state_path()
     service = SQLiteSessionsService(db_path)
@@ -230,7 +230,7 @@ def test_archive_clears_queued_and_pending_messages(tmp_path: Path) -> None:
 
 def test_archived_show_page_cannot_be_republished(monkeypatch, tmp_path: Path) -> None:
     """Archive takes the Show Page offline and locks it there — no re-sharing."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     db_path = paths.get_sqlite_state_path()
     service = SQLiteSessionsService(db_path)
@@ -258,7 +258,7 @@ def test_archived_show_page_cannot_be_republished(monkeypatch, tmp_path: Path) -
 def test_republish_archived_session_creates_no_show_page(monkeypatch, tmp_path: Path) -> None:
     """Republishing an archived session that never had a page must NOT first
     materialize a default page (the guard runs before ``ensure``)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     db_path = paths.get_sqlite_state_path()
     service = SQLiteSessionsService(db_path)
@@ -304,7 +304,7 @@ def test_bind_by_id_does_not_resurrect_archived(tmp_path: Path) -> None:
 
 def test_archived_session_excluded_from_inbox(monkeypatch, tmp_path: Path) -> None:
     """An archived session (and its unread) drops out of the inbox feed + badges."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     db_path = paths.get_sqlite_state_path()
     service = SQLiteSessionsService(db_path)
@@ -360,7 +360,7 @@ def test_is_session_archived_flag(tmp_path: Path) -> None:
 
 def test_show_event_rejected_for_archived_session(monkeypatch, tmp_path: Path) -> None:
     """An already-open Show Page can't write events into an archived session."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     db_path = paths.get_sqlite_state_path()
     service = SQLiteSessionsService(db_path)

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -11,7 +11,7 @@ from vibe import cli
 
 
 def _setup(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     ensure_sqlite_state(primary_platform="avibe")
     return create_sqlite_engine(paths.get_sqlite_state_path())
@@ -94,7 +94,7 @@ def test_list_pagination_fixed_ten_no_limit_flag(monkeypatch, tmp_path, capsys):
 def test_list_on_fresh_home_returns_empty(monkeypatch, tmp_path, capsys):
     # No ensure_sqlite_state(): _open_session_engine must bootstrap the DB itself,
     # so a fresh Avibe home returns a clean empty list, not "no such table" (Codex P2).
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     code, payload = _run(cli.cmd_session_list, ["session", "list"], capsys)
     assert code == 0

--- a/tests/test_session_titles.py
+++ b/tests/test_session_titles.py
@@ -16,7 +16,7 @@ from storage.settings_service import upsert_scope
 
 
 def test_backfill_agent_session_title_uses_first_user_message_for_claude(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     published: list[tuple[str, dict]] = []
     monkeypatch.setattr(inbox_events.bus, "publish", lambda event_type, data: published.append((event_type, data)))

--- a/tests/test_settings_disk_fallback.py
+++ b/tests/test_settings_disk_fallback.py
@@ -136,7 +136,7 @@ def test_get_claude_auth_prefers_cli_oauth_status(
     """
     _write_claude_settings(tmp_path, {})
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
 
     class _FakeAgent:
@@ -189,7 +189,7 @@ def test_get_claude_auth_resolves_default_claude_cli_before_status_probe(
 ) -> None:
     _write_claude_settings(tmp_path, {})
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
 
     resolved_cli = tmp_path / ".claude" / "local" / "claude"
@@ -236,7 +236,7 @@ def test_get_claude_auth_ignores_cli_api_key_status_for_oauth(
 ) -> None:
     _write_claude_settings(tmp_path, {})
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
 
     class _FakeAgent:
@@ -289,7 +289,7 @@ def test_get_claude_auth_suppresses_stale_disk_oauth_for_concrete_non_oauth_stat
         encoding="utf-8",
     )
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_dir))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
 
     class _FakeAgent:
@@ -328,7 +328,7 @@ def test_get_claude_auth_treats_setup_token_status_as_oauth(
 ) -> None:
     _write_claude_settings(tmp_path, {})
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
 
     class _FakeAgent:
@@ -381,7 +381,7 @@ def test_claude_settings_json_auth_token_surfaces_in_get_claude_auth(
     # find our fake settings.json and the V2Config load returns defaults
     # (i.e. ``api_key=None``).
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
     monkeypatch.setattr("vibe.api._read_claude_cli_oauth_signed_in", lambda _path, **_kwargs: None)
 
@@ -430,7 +430,7 @@ def test_claude_api_key_mode_wins_over_stale_oauth_credentials(
         encoding="utf-8",
     )
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_dir))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
     monkeypatch.setattr("vibe.api._read_claude_cli_oauth_signed_in", lambda _path, **_kwargs: None)
 
@@ -500,7 +500,7 @@ def test_save_claude_auth_writes_settings_json_and_clears_v2_secret(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
     monkeypatch.setattr("vibe.api._read_claude_cli_oauth_signed_in", lambda _path, **_kwargs: None)
     cleanup_calls: list[bool] = []
@@ -554,7 +554,7 @@ def test_save_claude_auth_reports_partial_when_oauth_cleanup_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
     monkeypatch.setattr("vibe.api._read_claude_cli_oauth_signed_in", lambda _path, **_kwargs: None)
     monkeypatch.setattr(
@@ -600,7 +600,7 @@ def test_save_claude_auth_restores_pending_oauth_backup_before_writing_new_key(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
     monkeypatch.setattr("vibe.api._read_claude_cli_oauth_signed_in", lambda _path, **_kwargs: None)
 
@@ -652,7 +652,7 @@ def test_save_claude_auth_keeps_settings_token_over_legacy_v2_key(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
     _write_claude_settings(
         tmp_path,
@@ -724,7 +724,7 @@ def test_save_claude_auth_fails_without_overwriting_malformed_settings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
     claude_dir = tmp_path / ".claude"
     claude_dir.mkdir()

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -65,7 +65,7 @@ def test_runtime_prepare_cli_preserves_offline_environment(monkeypatch):
 def test_runtime_manager_from_args_preserves_offline_environment(monkeypatch, tmp_path):
     parser = cli.build_parser()
     args = parser.parse_args(["runtime", "status"])
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_SHOW_RUNTIME_OFFLINE", "1")
 
     manager = cli._show_runtime_manager_from_args(args)
@@ -107,7 +107,7 @@ def _save_config() -> V2Config:
 
 
 def test_store_defaults_to_private_and_rotates_public_share(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -139,7 +139,7 @@ def test_store_defaults_to_private_and_rotates_public_share(monkeypatch, tmp_pat
 
 
 def test_rotate_share_requires_public(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     store = ShowPageStore()
@@ -156,7 +156,7 @@ def test_rotate_share_requires_public(monkeypatch, tmp_path):
 
 
 def test_store_lists_pages_by_updated_time_and_visibility(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -178,7 +178,7 @@ def test_store_lists_pages_by_updated_time_and_visibility(monkeypatch, tmp_path)
 
 
 def test_store_lists_show_pages_with_page_and_query(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -201,7 +201,7 @@ def test_store_lists_show_pages_with_page_and_query(monkeypatch, tmp_path):
 
 
 def test_store_escapes_show_page_session_id_prefix_filter(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -221,7 +221,7 @@ def test_store_escapes_show_page_session_id_prefix_filter(monkeypatch, tmp_path)
 
 
 def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     page_dir = ensure_show_page_dir("ses123")
 
     index_path = page_dir / "index.html"
@@ -251,7 +251,7 @@ def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
 
 
 def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     captured = {}
@@ -299,7 +299,7 @@ def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
 
 
 def test_show_path_cli_keeps_page_when_prewarm_fails(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -318,7 +318,7 @@ def test_show_path_cli_keeps_page_when_prewarm_fails(monkeypatch, tmp_path, caps
 
 
 def test_show_path_cli_prewarm_uses_verified_loopback_for_non_loopback_host(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     config = _save_config()
     config.ui.setup_host = "192.168.2.3"
@@ -362,7 +362,7 @@ def test_show_path_cli_prewarm_uses_verified_loopback_for_non_loopback_host(monk
 def test_show_path_cli_prewarm_falls_back_to_configured_ui_host_after_loopback_mismatch(
     monkeypatch, tmp_path, capsys
 ):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     config = _save_config()
     config.ui.setup_host = "192.168.2.3"
@@ -406,7 +406,7 @@ def test_show_path_cli_prewarm_falls_back_to_configured_ui_host_after_loopback_m
 
 
 def test_show_list_cli_json_reports_existing_pages(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -431,7 +431,7 @@ def test_show_list_cli_json_reports_existing_pages(monkeypatch, tmp_path, capsys
 
 
 def test_show_list_cli_json_reports_pagination(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -454,7 +454,7 @@ def test_show_list_cli_json_reports_pagination(monkeypatch, tmp_path, capsys):
 
 
 def test_show_list_cli_next_command_uses_absolute_time_filters(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -477,7 +477,7 @@ def test_show_list_cli_next_command_uses_absolute_time_filters(monkeypatch, tmp_
 
 
 def test_show_list_cli_filters_visibility(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
 
@@ -499,7 +499,7 @@ def test_show_list_cli_filters_visibility(monkeypatch, tmp_path, capsys):
 
 
 def test_show_page_payload_requires_enabled_avibe_cloud(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     config = _save_config()
     config.remote_access.vibe_cloud.enabled = False
@@ -521,7 +521,7 @@ def test_show_page_payload_requires_enabled_avibe_cloud(monkeypatch, tmp_path):
 
 
 def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     prewarmed = []
@@ -570,7 +570,7 @@ def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
 
 
 def test_show_update_rotate_share_fails_while_private(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     parser = cli.build_parser()
@@ -587,7 +587,7 @@ def test_show_mark_cli_records_event_and_message(monkeypatch, tmp_path, capsys):
     from storage import messages_service
     from sqlalchemy import select
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     from storage.importer import ensure_sqlite_state
@@ -641,7 +641,7 @@ def test_show_mark_cli_records_event_and_message(monkeypatch, tmp_path, capsys):
 
 
 def test_show_mark_cli_posts_to_live_ui_when_running(monkeypatch, tmp_path, capsys):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
@@ -719,7 +719,7 @@ def test_show_event_cli_records_generic_event(monkeypatch, tmp_path, capsys):
     from storage.models import agent_sessions, messages, show_session_events
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     ensure_sqlite_state()
@@ -777,7 +777,7 @@ def test_show_event_cli_records_generic_event(monkeypatch, tmp_path, capsys):
 
 
 def test_show_event_cli_dispatch_flag_updates_annotation_payload(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
@@ -837,7 +837,7 @@ def test_show_event_cli_dispatch_flag_updates_annotation_payload(monkeypatch, tm
 
 
 def test_show_event_cli_dispatch_preserves_top_level_payload(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
@@ -891,7 +891,7 @@ def test_show_event_cli_dispatch_fallback_records_and_dispatches(monkeypatch, tm
     from storage.models import agent_sessions, show_session_events
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     ensure_sqlite_state()
@@ -957,7 +957,7 @@ def test_show_event_cli_fallback_rejects_mismatched_session_id(monkeypatch, tmp_
     from storage.models import agent_sessions, show_session_events
     from storage.settings_service import upsert_scope
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     ensure_sqlite_state()
@@ -1015,7 +1015,7 @@ def test_show_event_cli_fallback_rejects_mismatched_session_id(monkeypatch, tmp_
 
 
 def test_show_mark_cli_posts_to_configured_ui_host_when_running(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     config = _save_config()
     config.remote_access.vibe_cloud.enabled = False

--- a/tests/test_show_pages_admin_api.py
+++ b/tests/test_show_pages_admin_api.py
@@ -51,7 +51,7 @@ def _set_visibility(session_id: str, visibility: str) -> None:
 
 
 def test_list_show_pages_orders_newest_first_and_joins_title(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _seed_session("ses_titled", title="Q2 funnel dashboard")
     _seed_session("ses_plain")
@@ -77,7 +77,7 @@ def test_list_show_pages_orders_newest_first_and_joins_title(monkeypatch, tmp_pa
 
 
 def test_set_show_page_visibility_public_then_offline(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _seed_session("ses_x")
     _set_visibility("ses_x", "private")
@@ -94,7 +94,7 @@ def test_set_show_page_visibility_public_then_offline(monkeypatch, tmp_path):
 
 
 def test_set_show_page_visibility_rejects_invalid(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _seed_session("ses_x")
 
@@ -104,7 +104,7 @@ def test_set_show_page_visibility_rejects_invalid(monkeypatch, tmp_path):
 
 
 def test_rotate_share_requires_public_and_revokes_previous(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _seed_session("ses_x")
     _set_visibility("ses_x", "private")
@@ -122,7 +122,7 @@ def test_rotate_share_requires_public_and_revokes_previous(monkeypatch, tmp_path
 
 
 def test_show_pages_list_route_returns_payload(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _seed_session("ses_route", title="Release notes preview")
     _set_visibility("ses_route", "public")

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -15,7 +15,7 @@ from storage.settings_service import upsert_scope
 
 @pytest.fixture()
 def isolated_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     yield tmp_path
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -1219,7 +1219,7 @@ def test_sessions_store_runtime_updates_do_not_flush_stale_snapshots(tmp_path: P
 
 
 def test_sessions_store_bootstrap_uses_config_primary_platform(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_config_path().write_text(
         json.dumps({"platform": "lark", "platforms": {"enabled": ["lark"], "primary": "lark"}}),

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -533,7 +533,7 @@ def test_settings_load_ignores_row_model_without_agent_name(tmp_path: Path) -> N
 
 
 def test_settings_store_bootstrap_uses_config_primary_platform(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_config_path().write_text(
         json.dumps({"platform": "discord", "platforms": {"enabled": ["discord"], "primary": "discord"}}),

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2517,7 +2517,7 @@ def test_telegram_list_chats_returns_discovered_groups(tmp_path, monkeypatch):
 
 
 def test_vibe_agent_api_crud_and_settings_catalog(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
 
     created = api.create_vibe_agent(
         {
@@ -2543,7 +2543,7 @@ def test_vibe_agent_api_crud_and_settings_catalog(tmp_path, monkeypatch):
 
 
 def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
 
     listed = api.get_vibe_agents()
     names = {agent["name"] for agent in listed["agents"]}
@@ -2553,7 +2553,7 @@ def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_pa
 
 
 def test_builtin_default_agent_enabled_state_follows_backend_config(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()
     try:
         store.ensure_builtin_default_agents(["opencode", "claude"])
@@ -2607,7 +2607,7 @@ def test_enabled_agent_backends_respect_explicit_disabled_backend():
 
 
 def test_user_can_disable_builtin_default_agent_without_catalog_reenabling_it(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()
     try:
         store.ensure_builtin_default_agents(["opencode"])
@@ -2620,7 +2620,7 @@ def test_user_can_disable_builtin_default_agent_without_catalog_reenabling_it(tm
 
 
 def test_disabled_agent_cannot_be_set_as_default(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()
     try:
         store.create(name="reviewer", backend="codex", enabled=False)
@@ -2631,7 +2631,7 @@ def test_disabled_agent_cannot_be_set_as_default(tmp_path, monkeypatch):
 
 
 def test_vibe_agent_api_rejects_non_boolean_enabled(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
 
     with pytest.raises(ValueError, match="Agent enabled must be a JSON boolean"):
         api.create_vibe_agent({"name": "reviewer", "backend": "codex", "enabled": "false"})
@@ -2644,7 +2644,7 @@ def test_vibe_agent_api_rejects_non_boolean_enabled(tmp_path, monkeypatch):
 
 
 def test_builtin_default_agent_uses_first_enabled_backend_when_no_default_exists(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()
     try:
         store.ensure_builtin_default_agents(["opencode", "claude", "codex"])
@@ -2654,7 +2654,7 @@ def test_builtin_default_agent_uses_first_enabled_backend_when_no_default_exists
 
 
 def test_api_builtin_default_agents_ignore_legacy_config_default_backend(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     config = V2Config(
         mode="self_host",
         version="v2",
@@ -2674,7 +2674,7 @@ def test_api_builtin_default_agents_ignore_legacy_config_default_backend(tmp_pat
 
 
 def test_builtin_default_agent_does_not_reuse_conflicting_user_agent(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()
     try:
         store.create(name="opencode", backend="codex")
@@ -2685,7 +2685,7 @@ def test_builtin_default_agent_does_not_reuse_conflicting_user_agent(tmp_path, m
 
 
 def test_builtin_default_agent_does_not_lock_existing_user_agent(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     store = VibeAgentStore()
     try:
         created = store.create(name="opencode", backend="opencode")
@@ -2700,7 +2700,7 @@ def test_builtin_default_agent_does_not_lock_existing_user_agent(tmp_path, monke
 
 
 def test_vibe_agent_import_reports_unreadable_file_as_client_error(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     missing_file = tmp_path / "missing-agent.md"
 
     with pytest.raises(ValueError, match="Unable to read or parse agent import file"):
@@ -2708,7 +2708,7 @@ def test_vibe_agent_import_reports_unreadable_file_as_client_error(tmp_path, mon
 
 
 def test_vibe_agent_import_rejects_non_markdown_direct_file(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     secret_file = tmp_path / "config.json"
     secret_file.write_text('{"token":"secret"}', encoding="utf-8")
 
@@ -2717,7 +2717,7 @@ def test_vibe_agent_import_rejects_non_markdown_direct_file(tmp_path, monkeypatc
 
 
 def test_vibe_agent_import_rejects_markdown_without_agent_frontmatter(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     notes_file = tmp_path / "private-notes.md"
     notes_file.write_text("# Private notes\n\nnon-agent content\n", encoding="utf-8")
 
@@ -2726,7 +2726,7 @@ def test_vibe_agent_import_rejects_markdown_without_agent_frontmatter(tmp_path, 
 
 
 def test_vibe_agent_import_allows_uppercase_markdown_extension(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     agent_file = tmp_path / "Reviewer.MD"
     agent_file.write_text("---\nname: reviewer\n---\nReview carefully.\n", encoding="utf-8")
 
@@ -2737,7 +2737,7 @@ def test_vibe_agent_import_allows_uppercase_markdown_extension(tmp_path, monkeyp
 
 
 def test_vibe_agent_import_skips_invalid_global_agent_file(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     valid_file = tmp_path / "valid.md"
     invalid_file = tmp_path / "invalid.md"
     valid_file.write_text("---\nname: reviewer\n---\nReview carefully.\n", encoding="utf-8")
@@ -2758,7 +2758,7 @@ def test_vibe_agent_import_skips_invalid_global_agent_file(tmp_path, monkeypatch
 
 
 def test_vibe_agent_api_rejects_backend_update(tmp_path, monkeypatch):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     api.create_vibe_agent({"name": "worker", "backend": "codex"})
 
     with pytest.raises(ValueError, match="backend is immutable"):

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -98,7 +98,7 @@ def _cloudflare_headers() -> dict[str, str]:
 
 
 def test_remote_host_redirects_to_vibe_cloud_login(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -122,7 +122,7 @@ def test_login_redirect_sets_persistent_handshake_cookie(monkeypatch, tmp_path):
     # cross-origin authorize excursion, so the callback can't read the handshake
     # back and deterministically fails with invalid_oauth_state. The handshake
     # cookie must be persistent. Regression guard for the PWA login dead-end.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
 
     with app.test_request_context("/dashboard", base_url="https://alex.avibe.bot"):
@@ -137,7 +137,7 @@ def test_login_redirect_sets_stable_device_binding_cookie(monkeypatch, tmp_path)
     # The store-fallback recovery is bound to this persistent per-browser device
     # cookie, which (unlike the per-flow handshake state) survives the iOS authorize
     # excursion. The login redirect must seed it, long-lived.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
 
     with app.test_request_context("/dashboard", base_url="https://alex.avibe.bot"):
@@ -154,7 +154,7 @@ def test_login_redirect_sets_stable_device_binding_cookie(monkeypatch, tmp_path)
 
 
 def test_remote_setup_route_requires_vibe_cloud_login(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -173,7 +173,7 @@ def test_remote_setup_route_requires_vibe_cloud_login(monkeypatch, tmp_path):
 
 
 def test_remote_config_get_without_session_returns_login_required(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -192,7 +192,7 @@ def test_api_config_blocked_host_returns_machine_readable_error(monkeypatch, tmp
     503 with a machine-readable ``error`` code (not a redirect, not an opaque
     body). The guard reads this to show an explicit "access blocked" screen
     instead of bouncing the visitor to the setup wizard."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -207,7 +207,7 @@ def test_api_config_blocked_host_returns_machine_readable_error(monkeypatch, tmp
 
 
 def test_remote_host_strips_retry_marker_from_oauth_next(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -226,7 +226,7 @@ def test_remote_host_strips_retry_marker_from_oauth_next(monkeypatch, tmp_path):
 
 
 def test_remote_host_with_explicit_port_still_requires_login(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get("/dashboard", base_url="https://alex.avibe.bot:443", follow_redirects=False)
@@ -236,7 +236,7 @@ def test_remote_host_with_explicit_port_still_requires_login(monkeypatch, tmp_pa
 
 
 def test_remote_host_with_trailing_dot_still_requires_login(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get("/dashboard", base_url="https://alex.avibe.bot.", follow_redirects=False)
@@ -246,7 +246,7 @@ def test_remote_host_with_trailing_dot_still_requires_login(monkeypatch, tmp_pat
 
 
 def test_remote_health_does_not_require_remote_access_cookie(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -261,7 +261,7 @@ def test_remote_health_does_not_require_remote_access_cookie(monkeypatch, tmp_pa
 
 
 def test_localhost_does_not_require_remote_access_cookie(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get("/health", base_url="http://127.0.0.1:5123")
@@ -272,7 +272,7 @@ def test_localhost_does_not_require_remote_access_cookie(monkeypatch, tmp_path):
 def test_live_request_cannot_spoof_test_remote_addr_header(monkeypatch, tmp_path):
     """The compatibility test-client shim accepts an environ_base REMOTE_ADDR,
     but the transport header it uses must not be honored on live ASGI traffic."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     async def _exercise():
@@ -291,7 +291,7 @@ def test_live_request_cannot_spoof_test_remote_addr_header(monkeypatch, tmp_path
 
 
 def test_docker_loopback_host_requires_explicit_trust(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.delenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", raising=False)
     _save_config(tmp_path)
 
@@ -306,7 +306,7 @@ def test_docker_loopback_host_requires_explicit_trust(monkeypatch, tmp_path):
 
 
 def test_docker_loopback_health_probe_is_allowed_when_explicitly_trusted(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", "172.17.0.1")
@@ -322,7 +322,7 @@ def test_docker_loopback_health_probe_is_allowed_when_explicitly_trusted(monkeyp
 
 
 def test_docker_loopback_status_probe_is_allowed_when_explicitly_trusted(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", "172.17.0.1")
@@ -338,7 +338,7 @@ def test_docker_loopback_status_probe_is_allowed_when_explicitly_trusted(monkeyp
 
 
 def test_docker_loopback_probe_accepts_ipv4_mapped_peer(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", "172.17.0.1")
@@ -354,7 +354,7 @@ def test_docker_loopback_probe_accepts_ipv4_mapped_peer(monkeypatch, tmp_path):
 
 
 def test_docker_loopback_trust_does_not_bypass_ui_auth(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", "172.17.0.1")
@@ -371,7 +371,7 @@ def test_docker_loopback_trust_does_not_bypass_ui_auth(monkeypatch, tmp_path):
 
 
 def test_docker_loopback_trust_requires_loopback_port_binding(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "0.0.0.0")
     _save_config(tmp_path)
@@ -387,7 +387,7 @@ def test_docker_loopback_trust_requires_loopback_port_binding(monkeypatch, tmp_p
 
 
 def test_docker_loopback_ui_requires_loopback_port_binding(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "0.0.0.0")
     _save_config(tmp_path)
@@ -403,7 +403,7 @@ def test_docker_loopback_ui_requires_loopback_port_binding(monkeypatch, tmp_path
 
 
 def test_docker_loopback_trust_still_rejects_non_local_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     _save_config(tmp_path)
@@ -419,7 +419,7 @@ def test_docker_loopback_trust_still_rejects_non_local_host(monkeypatch, tmp_pat
 
 
 def test_docker_loopback_trust_rejects_untrusted_peer(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     _save_config(tmp_path)
@@ -435,7 +435,7 @@ def test_docker_loopback_trust_rejects_untrusted_peer(monkeypatch, tmp_path):
 
 
 def test_docker_loopback_trust_requires_configured_peer_ip(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", "172.17.0.1")
@@ -451,7 +451,7 @@ def test_docker_loopback_trust_requires_configured_peer_ip(monkeypatch, tmp_path
 
 
 def test_docker_loopback_trust_accepts_runtime_default_gateway(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.delenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", raising=False)
@@ -476,7 +476,7 @@ def test_docker_loopback_trust_accepts_runtime_default_gateway(monkeypatch, tmp_
 
 
 def test_docker_loopback_trust_rejects_same_network_container_peer(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", "172.17.0.1")
@@ -493,7 +493,7 @@ def test_docker_loopback_trust_rejects_same_network_container_peer(monkeypatch, 
 
 
 def test_docker_loopback_trust_rejects_non_gateway_peer_on_dynamic_bridge(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.delenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", raising=False)
@@ -518,7 +518,7 @@ def test_docker_loopback_trust_rejects_non_gateway_peer_on_dynamic_bridge(monkey
 
 
 def test_docker_loopback_trust_accepts_ipv4_mapped_configured_peer(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv("VIBE_REMOTE_ALLOW_DOCKER_LOOPBACK_PEERS", "1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_BIND_HOST", "127.0.0.1")
     monkeypatch.setenv("VIBE_REMOTE_DOCKER_LOOPBACK_PEER_IPS", "172.17.0.1")
@@ -534,7 +534,7 @@ def test_docker_loopback_trust_accepts_ipv4_mapped_configured_peer(monkeypatch, 
 
 
 def test_unmatched_non_local_host_fails_closed_when_remote_access_enabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -549,7 +549,7 @@ def test_unmatched_non_local_host_fails_closed_when_remote_access_enabled(monkey
 
 
 def test_loopback_proxy_with_public_host_mismatch_fails_closed(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -563,7 +563,7 @@ def test_loopback_proxy_with_public_host_mismatch_fails_closed(monkeypatch, tmp_
 
 
 def test_loopback_proxy_with_partial_forwarded_metadata_fails_closed(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -579,7 +579,7 @@ def test_loopback_proxy_with_partial_forwarded_metadata_fails_closed(monkeypatch
 
 
 def test_loopback_origin_proxy_with_loopback_host_is_allowed(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -597,7 +597,7 @@ def test_loopback_origin_proxy_with_loopback_host_is_allowed(monkeypatch, tmp_pa
 
 
 def test_remote_host_allows_valid_remote_session(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     client.set_cookie(remote_access.SESSION_COOKIE_NAME, remote_access.make_session_cookie(config, "alex@example.com", "user-1"), domain="alex.avibe.bot")
@@ -625,7 +625,7 @@ def _forged_session_cookie(config: V2Config, exp: int, *, email: str = "alex@exa
 
 
 def test_remote_host_does_not_renew_fresh_cookie(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     client.set_cookie(
@@ -643,7 +643,7 @@ def test_remote_host_does_not_renew_fresh_cookie(monkeypatch, tmp_path):
 def test_remote_host_renews_cookie_past_half_ttl(monkeypatch, tmp_path):
     import time as _time
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     near_exp = int(_time.time()) + (remote_access.SESSION_TTL_SECONDS // 2) - 60
     cookie = _forged_session_cookie(config, near_exp)
@@ -674,7 +674,7 @@ def test_remote_host_does_not_renew_cookie_on_rejected_post(monkeypatch, tmp_pat
     keep a stolen session alive indefinitely."""
     import time as _time
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     near_exp = int(_time.time()) + (remote_access.SESSION_TTL_SECONDS // 2) - 60
     cookie = _forged_session_cookie(config, near_exp)
@@ -766,7 +766,7 @@ def test_spoofed_loopback_host_is_not_local_when_peer_is_remote(monkeypatch):
 
 
 def test_cloudflare_forwarded_request_with_loopback_host_fails_closed(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -781,7 +781,7 @@ def test_cloudflare_forwarded_request_with_loopback_host_fails_closed(monkeypatc
 
 
 def test_remote_host_fails_closed_when_disabled_but_hostname_still_matches(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.enabled = False
     config.save()
@@ -798,7 +798,7 @@ def test_remote_host_fails_closed_when_disabled_but_hostname_still_matches(monke
 
 
 def test_unmatched_non_local_host_fails_closed_when_remote_access_disabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.enabled = False
     config.save()
@@ -815,7 +815,7 @@ def test_unmatched_non_local_host_fails_closed_when_remote_access_disabled(monke
 
 
 def test_remote_host_fails_closed_when_public_url_is_invalid(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.public_url = "alex.avibe.bot"
     config.save()
@@ -832,7 +832,7 @@ def test_remote_host_fails_closed_when_public_url_is_invalid(monkeypatch, tmp_pa
 
 
 def test_remote_host_fails_closed_when_public_url_is_http(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.public_url = "http://alex.avibe.bot"
     config.save()
@@ -849,7 +849,7 @@ def test_remote_host_fails_closed_when_public_url_is_http(monkeypatch, tmp_path)
 
 
 def test_remote_host_fails_closed_when_public_url_contains_userinfo(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.public_url = "https://user:pass@alex.avibe.bot"
     config.save()
@@ -866,7 +866,7 @@ def test_remote_host_fails_closed_when_public_url_contains_userinfo(monkeypatch,
 
 
 def test_remote_host_fails_closed_when_public_url_is_empty(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.public_url = ""
     config.save()
@@ -883,7 +883,7 @@ def test_remote_host_fails_closed_when_public_url_is_empty(monkeypatch, tmp_path
 
 
 def test_remote_host_fails_closed_when_session_secret_is_empty(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.session_secret = ""
     config.save()
@@ -895,7 +895,7 @@ def test_remote_host_fails_closed_when_session_secret_is_empty(monkeypatch, tmp_
 
 
 def test_config_post_rotates_session_secret_when_remote_access_is_disabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     old_secret = config.remote_access.vibe_cloud.session_secret
     client = app.test_client()
@@ -917,7 +917,7 @@ def test_config_post_rotates_session_secret_when_remote_access_is_disabled(monke
 
 
 def test_config_post_skips_reconcile_when_remote_access_is_unchanged(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     reconcile_calls = []
@@ -936,7 +936,7 @@ def test_config_post_skips_reconcile_when_remote_access_is_unchanged(monkeypatch
 
 
 def test_config_post_returns_saved_config_when_remote_reconcile_fails(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     old_secret = config.remote_access.vibe_cloud.session_secret
     client = app.test_client()
@@ -960,7 +960,7 @@ def test_config_post_returns_saved_config_when_remote_reconcile_fails(monkeypatc
 
 
 def test_config_post_reconciles_after_releasing_config_lock(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     client = app.test_client()
     lock_states = []
@@ -983,7 +983,7 @@ def test_config_post_reconciles_after_releasing_config_lock(monkeypatch, tmp_pat
 
 
 def test_config_post_reconciles_from_fresh_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     client = app.test_client()
     reconcile_args = []
@@ -1006,7 +1006,7 @@ def test_config_post_reconciles_from_fresh_config(monkeypatch, tmp_path):
 
 
 def test_remote_callback_rejects_nonce_mismatch(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
 
@@ -1039,7 +1039,7 @@ def test_remote_callback_rejects_nonce_mismatch(monkeypatch, tmp_path):
 
 
 def test_remote_callback_rejects_when_remote_access_is_disabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     oauth_cookie = ui_server._make_oauth_cookie(
@@ -1071,7 +1071,7 @@ def test_remote_callback_rejects_when_remote_access_is_disabled(monkeypatch, tmp
 
 
 def test_remote_callback_restarts_oauth_when_state_cookie_was_lost(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     state = ui_server._make_oauth_state(
@@ -1094,7 +1094,7 @@ def test_remote_callback_restarts_oauth_when_state_cookie_was_lost(monkeypatch, 
 
 
 def test_remote_callback_does_not_restart_oauth_twice(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     state = ui_server._make_oauth_state(
@@ -1115,7 +1115,7 @@ def test_remote_callback_does_not_restart_oauth_twice(monkeypatch, tmp_path):
 
 
 def test_remote_callback_renders_relogin_page_for_legacy_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     client = app.test_client()
 
@@ -1136,7 +1136,7 @@ def test_remote_callback_recovers_via_store_when_cookie_state_desyncs(monkeypatc
     # runs in a separate in-app-browser context. The callback must still complete by
     # recovering the PKCE secrets from the server-side store, keyed by the signed URL
     # state. Regression guard for the deterministic PWA invalid_oauth_state dead-end.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     secret = config.remote_access.vibe_cloud.session_secret
     client = app.test_client()
@@ -1192,7 +1192,7 @@ def test_remote_callback_recovers_via_store_when_cookie_state_desyncs(monkeypatc
 
 
 def test_oauth_handshake_store_is_single_use_and_expires(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     remote_access.store_oauth_handshake("rid-abc", nonce="n", code_verifier="v", next_target="/x")
@@ -1217,7 +1217,7 @@ def test_oauth_handshake_store_caps_entries(monkeypatch, tmp_path):
     # The store is written on every unauthenticated redirect; a hard cap prevents
     # unbounded inode growth under a burst. At capacity, new writes are shed and
     # existing in-flight entries are preserved.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     monkeypatch.setattr(remote_access, "OAUTH_HANDSHAKE_MAX_ENTRIES", 3)
 
@@ -1234,7 +1234,7 @@ def test_oauth_handshake_cap_holds_under_concurrency(monkeypatch, tmp_path):
     # lock, many threads could pass the count check before any writes.
     import threading
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     monkeypatch.setattr(remote_access, "OAUTH_HANDSHAKE_MAX_ENTRIES", 5)
 
@@ -1259,7 +1259,7 @@ def test_oauth_handshake_cap_holds_under_concurrency(monkeypatch, tmp_path):
 def test_unauthenticated_auth_requests_are_rate_limited(monkeypatch, tmp_path):
     # Root-level bound: a flood of unauthenticated login-start requests from one
     # client is 429'd, instead of each one doing handshake/cookie/log work.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     monkeypatch.setattr(ui_server, "_AUTH_RATELIMIT_MAX_PER_WINDOW", 3)
     client = app.test_client()
@@ -1281,7 +1281,7 @@ def test_auth_rate_limit_ignores_untrusted_forwarded_ip(monkeypatch, tmp_path):
     # A direct (non-loopback) peer can't dodge the limit by rotating CF-Connecting-IP:
     # the forwarded IP is trusted only from the loopback tunnel peer, so such a peer
     # is keyed by its real address and the rotating header is ignored.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     monkeypatch.setattr(ui_server, "_AUTH_RATELIMIT_MAX_PER_WINDOW", 3)
     client = app.test_client()
@@ -1303,7 +1303,7 @@ def test_auth_rate_limit_ignores_untrusted_forwarded_ip(monkeypatch, tmp_path):
 def test_auth_rate_limit_table_is_bounded(monkeypatch, tmp_path):
     # The limiter's own table is hard-capped (LRU eviction), so a burst of distinct
     # clients can't drive unbounded in-process memory growth.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     monkeypatch.setattr(ui_server, "_AUTH_RATELIMIT_MAX_TRACKED_CLIENTS", 3)
     client = app.test_client()
@@ -1341,7 +1341,7 @@ def test_oauth_diag_log_is_rate_limited(monkeypatch):
 def test_oauth_error_page_localizes_from_accept_language(monkeypatch, tmp_path):
     # The re-login page copy must come from vibe/i18n and honor the browser's
     # Accept-Language (the only server-readable locale signal pre-auth).
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     client = app.test_client()
 
@@ -1364,7 +1364,7 @@ def test_remote_callback_refuses_store_fallback_without_device_binding(monkeypat
     # isn't the one that started the flow. The store record is bound to the attacker's
     # device id; the victim's browser presents its own (different) device cookie plus a
     # stale handshake cookie, so the store-fallback must refuse — no token exchange.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     secret = config.remote_access.vibe_cloud.session_secret
     client = app.test_client()
@@ -1413,7 +1413,7 @@ def test_oauth_handshake_pop_is_atomic_single_use_under_concurrency(monkeypatch,
     import threading
     from unittest import mock
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     remote_access.store_oauth_handshake("race-rid000", nonce="n", code_verifier="v", next_target="/")
 
@@ -1444,7 +1444,7 @@ def test_oauth_handshake_pop_is_atomic_single_use_under_concurrency(monkeypatch,
 
 
 def test_remote_callback_accepts_html_escaped_state_separator(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     oauth_cookie = ui_server._make_oauth_cookie(
@@ -1480,7 +1480,7 @@ def test_remote_callback_accepts_html_escaped_state_separator(monkeypatch, tmp_p
 
 
 def test_remote_callback_sanitizes_protocol_relative_next(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
     oauth_cookie = ui_server._make_oauth_cookie(
@@ -1521,7 +1521,7 @@ def _save_config_with_setup_host(tmp_path, host: str) -> V2Config:
 
 
 def test_setup_host_lan_request_is_treated_as_local(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
     _mock_interface(monkeypatch, "192.168.2.3", 24)
 
@@ -1535,7 +1535,7 @@ def test_setup_host_lan_request_is_treated_as_local(monkeypatch, tmp_path):
 
 
 def test_setup_host_request_from_self_is_treated_as_local(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
     _mock_interface(monkeypatch, "192.168.2.3", 24)
 
@@ -1549,7 +1549,7 @@ def test_setup_host_request_from_self_is_treated_as_local(monkeypatch, tmp_path)
 
 
 def test_setup_host_with_public_peer_is_not_local(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
 
     response = app.test_client().get(
@@ -1567,7 +1567,7 @@ def test_setup_host_lan_peer_with_tailscale_setup_is_not_local(monkeypatch, tmp_
     """Wildcard-bind regression guard: a LAN peer cannot inherit setup-host
     trust by spoofing the Host header to a Tailscale setup_host that lives
     in a different private block."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "100.97.103.112")
 
     response = app.test_client().get(
@@ -1584,7 +1584,7 @@ def test_setup_host_lan_peer_with_tailscale_setup_is_not_local(monkeypatch, tmp_
 def test_setup_host_tailscale_peer_with_lan_setup_is_not_local(monkeypatch, tmp_path):
     """Inverse of the LAN-vs-Tailscale check: a Tailscale peer cannot inherit
     setup-host trust by spoofing the Host header to a LAN setup_host."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
 
     response = app.test_client().get(
@@ -1601,7 +1601,7 @@ def test_setup_host_tailscale_peer_with_lan_setup_is_not_local(monkeypatch, tmp_
 def test_setup_host_tailscale_peer_with_tailscale_setup_is_local(monkeypatch, tmp_path):
     """Same-block trust still works: a Tailscale peer can inherit setup-host
     trust when setup_host is also in 100.64/10."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "100.97.103.112")
 
     response = app.test_client().get(
@@ -1619,7 +1619,7 @@ def test_setup_host_rfc1918_peer_outside_interface_subnet_is_not_local(monkeypat
     /24 mask. Pre-wildcard, the kernel only let in peers on the same
     interface subnet — _local_interface_network restores that scoping
     using the actual netmask."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "10.1.2.3")
     _mock_interface(monkeypatch, "10.1.2.3", 24)
 
@@ -1636,7 +1636,7 @@ def test_setup_host_rfc1918_peer_outside_interface_subnet_is_not_local(monkeypat
 
 def test_setup_host_rfc1918_peer_in_same_interface_subnet_is_local(monkeypatch, tmp_path):
     """Same-subnet RFC1918 peer still inherits trust (typical home/office LAN)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "10.1.2.3")
     _mock_interface(monkeypatch, "10.1.2.3", 24)
 
@@ -1652,7 +1652,7 @@ def test_setup_host_rfc1918_peer_in_same_interface_subnet_is_local(monkeypatch, 
 def test_setup_host_192168_peer_outside_interface_subnet_is_not_local(monkeypatch, tmp_path):
     """A peer on 192.168.2/24 cannot spoof Host=192.168.1.5 when the
     interface mask is /24."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.1.5")
     _mock_interface(monkeypatch, "192.168.1.5", 24)
 
@@ -1671,7 +1671,7 @@ def test_setup_host_with_16_prefix_includes_peer_in_same_16(monkeypatch, tmp_pat
     """When the interface mask is /16, a peer on a different /24 within
     the same /16 still inherits trust — fixed-/24 estimates were too
     narrow for /16 LANs."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.1.5")
     _mock_interface(monkeypatch, "192.168.1.5", 16)
 
@@ -1687,7 +1687,7 @@ def test_setup_host_with_16_prefix_includes_peer_in_same_16(monkeypatch, tmp_pat
 def test_setup_host_with_20_prefix_includes_peer_in_same_20(monkeypatch, tmp_path):
     """/20 corporate networks (4096 addresses) are honored without
     artificially narrowing to /24."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "10.1.16.5")
     _mock_interface(monkeypatch, "10.1.16.5", 20)
 
@@ -1703,7 +1703,7 @@ def test_setup_host_with_20_prefix_includes_peer_in_same_20(monkeypatch, tmp_pat
 def test_setup_host_with_20_prefix_excludes_peer_outside_20(monkeypatch, tmp_path):
     """/20 still excludes peers outside the /20 (peer in next /20 is not
     on the same routed subnet)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "10.1.16.5")
     _mock_interface(monkeypatch, "10.1.16.5", 20)
 
@@ -1722,7 +1722,7 @@ def test_setup_host_unknown_to_local_interfaces_is_not_local(monkeypatch, tmp_pa
     """If setup_host is not configured on any local interface, deny trust
     rather than guess a subnet — this preserves the kernel's pre-wildcard
     "no matching interface, no traffic" semantics."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.99.99")
     _mock_no_interfaces(monkeypatch)
 
@@ -1740,7 +1740,7 @@ def test_setup_host_unknown_to_local_interfaces_is_not_local(monkeypatch, tmp_pa
 def test_setup_host_ipv6_with_56_prefix_includes_peer_in_same_56(monkeypatch, tmp_path):
     """A non-/64 IPv6 LAN (e.g. /56 prefix delegated to the home network)
     is honored without artificially narrowing to /64."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "fd00:0:0:1::5")
     _mock_interface(monkeypatch, "fd00:0:0:1::5", 56)
 
@@ -1755,7 +1755,7 @@ def test_setup_host_ipv6_with_56_prefix_includes_peer_in_same_56(monkeypatch, tm
 
 def test_setup_host_ipv6_with_64_prefix_excludes_peer_outside_64(monkeypatch, tmp_path):
     """Default IPv6 LAN /64 still scopes peers correctly."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "fd00::5")
     _mock_interface(monkeypatch, "fd00::5", 64)
 
@@ -1784,7 +1784,7 @@ def test_setup_host_tunnel_off_allows_routed_peer_outside_interface_subnet(monke
     setup_host across a /16 corporate or campus net must have been routed
     legitimately, so the application layer should not add a second-pass
     subnet gate (regression noted in Codex review of #252)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_tunnel_off_with_setup_host(tmp_path, "10.1.2.3")
     _mock_interface(monkeypatch, "10.1.2.3", 24)
 
@@ -1800,7 +1800,7 @@ def test_setup_host_tunnel_off_allows_routed_peer_outside_interface_subnet(monke
 def test_setup_host_tunnel_off_still_rejects_public_peer(monkeypatch, tmp_path):
     """Tunnel-off relaxation of the subnet gate must not relax the
     private-peer requirement: a public peer is still untrusted."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_tunnel_off_with_setup_host(tmp_path, "10.1.2.3")
 
     response = app.test_client().get(
@@ -1819,7 +1819,7 @@ def test_setup_host_tunnel_on_still_enforces_subnet_gate(monkeypatch, tmp_path):
     wildcard bind requires the application-layer subnet gate, so the same
     cross-subnet peer that is allowed when the tunnel is off must be
     rejected when the tunnel is on."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "10.1.2.3")
     _mock_interface(monkeypatch, "10.1.2.3", 24)
 
@@ -1835,7 +1835,7 @@ def test_setup_host_tunnel_on_still_enforces_subnet_gate(monkeypatch, tmp_path):
 
 
 def test_setup_host_mismatched_host_header_is_not_local(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
 
     response = app.test_client().get(
@@ -1850,7 +1850,7 @@ def test_setup_host_mismatched_host_header_is_not_local(monkeypatch, tmp_path):
 
 
 def test_setup_host_wildcard_allows_actual_lan_interface_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(ui_server, "_is_containerized_runtime", lambda: False)
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "192.168.2.3", 24)
@@ -1865,7 +1865,7 @@ def test_setup_host_wildcard_allows_actual_lan_interface_host(monkeypatch, tmp_p
 
 
 def test_setup_host_wildcard_allows_bare_metal_eth_lan_interface(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(ui_server, "_is_containerized_runtime", lambda: False)
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "192.168.2.3", 24, name="eth0")
@@ -1880,7 +1880,7 @@ def test_setup_host_wildcard_allows_bare_metal_eth_lan_interface(monkeypatch, tm
 
 
 def test_setup_host_wildcard_does_not_trust_container_eth_interface(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(ui_server, "_is_containerized_runtime", lambda: True)
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "192.168.2.3", 24, name="eth0")
@@ -1897,7 +1897,7 @@ def test_setup_host_wildcard_does_not_trust_container_eth_interface(monkeypatch,
 
 
 def test_setup_host_wildcard_does_not_trust_unconfigured_lan_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_no_interfaces(monkeypatch)
 
@@ -1913,7 +1913,7 @@ def test_setup_host_wildcard_does_not_trust_unconfigured_lan_host(monkeypatch, t
 
 
 def test_setup_host_wildcard_does_not_trust_docker_bridge_interface(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "172.17.0.1", 16, name="docker0")
 
@@ -1929,7 +1929,7 @@ def test_setup_host_wildcard_does_not_trust_docker_bridge_interface(monkeypatch,
 
 
 def test_setup_host_wildcard_does_not_trust_cni_bridge_interface(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "192.168.2.3", 24, name="cni0")
 
@@ -1945,7 +1945,7 @@ def test_setup_host_wildcard_does_not_trust_cni_bridge_interface(monkeypatch, tm
 
 
 def test_setup_host_wildcard_does_not_trust_flannel_interface(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "10.244.0.1", 24, name="flannel.1")
 
@@ -1961,7 +1961,7 @@ def test_setup_host_wildcard_does_not_trust_flannel_interface(monkeypatch, tmp_p
 
 
 def test_setup_host_wildcard_does_not_trust_bridge_interface_in_cgnat_range(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "100.97.103.112", 32, name="docker0")
 
@@ -1977,7 +1977,7 @@ def test_setup_host_wildcard_does_not_trust_bridge_interface_in_cgnat_range(monk
 
 
 def test_setup_host_wildcard_rejects_peer_outside_interface_subnet(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "192.168.1.5", 24)
 
@@ -1993,7 +1993,7 @@ def test_setup_host_wildcard_rejects_peer_outside_interface_subnet(monkeypatch, 
 
 
 def test_setup_host_wildcard_rejects_public_peer(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "192.168.2.3", 24)
 
@@ -2009,7 +2009,7 @@ def test_setup_host_wildcard_rejects_public_peer(monkeypatch, tmp_path):
 
 
 def test_setup_host_wildcard_with_reverse_proxy_header_is_not_local(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "192.168.2.3", 24)
 
@@ -2026,7 +2026,7 @@ def test_setup_host_wildcard_with_reverse_proxy_header_is_not_local(monkeypatch,
 
 
 def test_setup_host_wildcard_with_reverse_proxy_header_skips_interface_probe(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     monkeypatch.setattr(
         ui_server,
@@ -2047,7 +2047,7 @@ def test_setup_host_wildcard_with_reverse_proxy_header_skips_interface_probe(mon
 
 
 def test_setup_host_wildcard_allows_actual_tailscale_interface_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "100.97.103.112", 32, name="tailscale0")
     _mock_tailscale_whois(monkeypatch, "100.97.103.5")
@@ -2062,7 +2062,7 @@ def test_setup_host_wildcard_allows_actual_tailscale_interface_host(monkeypatch,
 
 
 def test_setup_host_wildcard_rejects_tailscale_peer_without_whois(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "100.97.103.112", 32, name="tailscale0")
     monkeypatch.setattr(ui_server, "_TAILSCALE_PEER_CACHE", {})
@@ -2080,7 +2080,7 @@ def test_setup_host_wildcard_rejects_tailscale_peer_without_whois(monkeypatch, t
 
 
 def test_setup_host_wildcard_rejects_tailscale_subnet_router_peer(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "100.97.103.112", 32, name="tailscale0")
     _mock_tailscale_whois(monkeypatch, "100.97.103.5", allowed_ips=["100.97.103.5/32", "192.168.50.0/24"])
@@ -2097,7 +2097,7 @@ def test_setup_host_wildcard_rejects_tailscale_subnet_router_peer(monkeypatch, t
 
 
 def test_setup_host_wildcard_does_not_trust_unconfigured_tailscale_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_no_interfaces(monkeypatch)
 
@@ -2113,7 +2113,7 @@ def test_setup_host_wildcard_does_not_trust_unconfigured_tailscale_host(monkeypa
 
 
 def test_setup_host_ipv6_wildcard_allows_actual_private_interface_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(ui_server, "_is_containerized_runtime", lambda: False)
     _save_config_with_setup_host(tmp_path, "::")
     _mock_interface(monkeypatch, "fd00::5", 64)
@@ -2128,7 +2128,7 @@ def test_setup_host_ipv6_wildcard_allows_actual_private_interface_host(monkeypat
 
 
 def test_setup_host_ipv6_wildcard_allows_tailscale_ula_interface_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "::")
     _mock_interface(monkeypatch, "fd7a:115c:a1e0::5", 128, name="tailscale0")
     _mock_tailscale_whois(monkeypatch, "fd7a:115c:a1e0::20")
@@ -2143,7 +2143,7 @@ def test_setup_host_ipv6_wildcard_allows_tailscale_ula_interface_host(monkeypatc
 
 
 def test_setup_host_ipv6_wildcard_does_not_trust_bridge_in_tailscale_ula_range(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "::")
     _mock_interface(monkeypatch, "fd7a:115c:a1e0::5", 64, name="docker0")
 
@@ -2159,7 +2159,7 @@ def test_setup_host_ipv6_wildcard_does_not_trust_bridge_in_tailscale_ula_range(m
 
 
 def test_setup_host_wildcard_does_not_trust_generic_utun_tunnel(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     _mock_interface(monkeypatch, "100.97.103.112", 32, name="utun4")
     monkeypatch.setattr(ui_server, "_tailscale_local_addresses", lambda: frozenset())
@@ -2176,7 +2176,7 @@ def test_setup_host_wildcard_does_not_trust_generic_utun_tunnel(monkeypatch, tmp
 
 
 def test_setup_host_wildcard_trusts_utun_when_tailscale_reports_local_ip(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "0.0.0.0")
     address = ipaddress.ip_address("100.97.103.112")
     _mock_interface(monkeypatch, str(address), 32, name="utun4")
@@ -2193,7 +2193,7 @@ def test_setup_host_wildcard_trusts_utun_when_tailscale_reports_local_ip(monkeyp
 
 
 def test_setup_host_ipv6_wildcard_does_not_trust_generic_utun_tunnel(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "::")
     _mock_interface(monkeypatch, "fd7a:115c:a1e0::5", 128, name="utun4")
     monkeypatch.setattr(ui_server, "_tailscale_local_addresses", lambda: frozenset())
@@ -2210,7 +2210,7 @@ def test_setup_host_ipv6_wildcard_does_not_trust_generic_utun_tunnel(monkeypatch
 
 
 def test_setup_host_ipv6_wildcard_trusts_utun_when_tailscale_reports_local_ip(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "::")
     address = ipaddress.ip_address("fd7a:115c:a1e0::5")
     _mock_interface(monkeypatch, str(address), 128, name="utun4")
@@ -2227,7 +2227,7 @@ def test_setup_host_ipv6_wildcard_trusts_utun_when_tailscale_reports_local_ip(mo
 
 
 def test_setup_host_with_cloudflare_metadata_is_not_local(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
 
     response = app.test_client().get(
@@ -2249,7 +2249,7 @@ def test_setup_host_with_reverse_proxy_header_is_not_local(monkeypatch, tmp_path
     looks "local" — but X-Forwarded-For (or any other forwarded header) tells
     us the actual client is unknown, so the request must not be trusted.
     """
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config_with_setup_host(tmp_path, "192.168.2.3")
 
     response = app.test_client().get(
@@ -2271,7 +2271,7 @@ def test_settings_get_serves_json_even_for_browser_accept(monkeypatch, tmp_path)
     user-facing /settings URL is handled by the static catch-all instead, so
     the API path itself never collides with a UI route anymore.
     """
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(
@@ -2289,7 +2289,7 @@ def test_settings_get_returns_json_for_fetch_callers(monkeypatch, tmp_path):
     """fetch() from the SPA hits /settings without an explicit text/html in
     Accept; the handler must keep returning JSON so getSettings() works.
     """
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().get(

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -74,7 +74,7 @@ def test_normalize_response_supports_body_headers_tuple():
 def test_harness_routes_page_filter_and_return_counts(monkeypatch, tmp_path):
     from storage.background import SQLiteBackgroundTaskStore
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -150,7 +150,7 @@ def test_harness_routes_page_filter_and_return_counts(monkeypatch, tmp_path):
 def test_harness_bootstrap_returns_counts_and_selected_page(monkeypatch, tmp_path):
     from storage.background import SQLiteBackgroundTaskStore
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     store = SQLiteBackgroundTaskStore()
     try:
@@ -199,7 +199,7 @@ def test_workbench_projects_bootstrap_returns_requested_session_pages(monkeypatc
     from storage.projects_service import create_project
     from storage.workbench_sessions_service import create_session
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     project_a_dir = tmp_path / "project-a"
@@ -233,7 +233,7 @@ def test_config_get_on_fresh_install_returns_default_needing_setup(monkeypatch, 
     # needs_setup=True instead of propagating FileNotFoundError as a 500 —
     # and must not create the file (the read stays a read; save_config owns
     # the first write).
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from config import paths
 
     assert not paths.get_config_path().exists()
@@ -250,7 +250,7 @@ def test_config_get_on_fresh_install_returns_default_needing_setup(monkeypatch, 
 
 
 def test_config_routes_redact_platform_and_gateway_secrets(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     payload = _full_config_payload()
     payload["slack"] = {
         **payload["slack"],
@@ -314,7 +314,7 @@ def test_config_routes_redact_platform_and_gateway_secrets(monkeypatch, tmp_path
 
 
 def test_config_post_hot_reconciles_platform_enablement(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
     from vibe import internal_client
 
@@ -348,7 +348,7 @@ def test_config_post_hot_reconciles_platform_enablement(monkeypatch, tmp_path):
 
 
 def test_config_post_hot_reconciles_platform_runtime_credential_change(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
     from vibe import internal_client
 
@@ -402,7 +402,7 @@ def test_platform_runtime_fields_changed_detects_primary_only_change():
 
 
 def test_config_post_non_platform_change_does_not_reconcile_platforms(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
     from vibe import internal_client
 
@@ -423,7 +423,7 @@ def test_config_post_non_platform_change_does_not_reconcile_platforms(monkeypatc
 
 
 def test_config_post_schedules_service_restart_when_hot_reconcile_unavailable(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
     from vibe import internal_client
 
@@ -457,7 +457,7 @@ def test_config_post_schedules_service_restart_when_hot_reconcile_unavailable(mo
 
 
 def test_config_post_schedules_service_restart_when_hot_reconcile_fails(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
     from vibe import internal_client
 
@@ -495,7 +495,7 @@ def test_config_post_schedules_service_restart_when_hot_reconcile_fails(monkeypa
 
 
 def test_config_restart_fallback_marks_pending_restart_when_restart_in_flight(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import restart_supervisor
     from vibe import runtime
 
@@ -526,7 +526,7 @@ def test_config_restart_fallback_marks_pending_restart_when_restart_in_flight(mo
 
 
 def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import restart_supervisor
     from vibe import runtime
 
@@ -682,7 +682,7 @@ def test_wechat_qr_poll_passes_verify_code(monkeypatch):
 
 
 def test_persist_wechat_qr_credentials_saves_before_restart(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
 
     payload = _full_config_payload()
@@ -715,7 +715,7 @@ def test_persist_wechat_qr_credentials_saves_before_restart(monkeypatch, tmp_pat
 
 
 def test_persist_wechat_qr_credentials_seeds_fresh_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from config import paths
     from vibe import api
 
@@ -852,7 +852,7 @@ def test_wechat_qr_poll_blocks_restart_when_credential_persist_fails(monkeypatch
 
 
 def test_web_push_subscription_routes_roundtrip(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     client = app.test_client()
@@ -904,7 +904,7 @@ def test_web_push_status_sync_disables_previous_endpoint_for_same_device(monkeyp
     from storage import web_push_service
     from storage.db import create_sqlite_engine
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     client = app.test_client()
@@ -962,7 +962,7 @@ def test_web_push_status_sync_disables_client_known_previous_endpoint(monkeypatc
     from storage import web_push_service
     from storage.db import create_sqlite_engine
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     client = app.test_client()
@@ -1025,7 +1025,7 @@ def test_web_push_status_sync_does_not_reenable_disabled_endpoint(monkeypatch, t
     from storage import web_push_service
     from storage.db import create_sqlite_engine
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     client = app.test_client()
@@ -1070,7 +1070,7 @@ def test_web_push_unsubscribe_is_scoped_to_current_user(monkeypatch, tmp_path):
     from storage import web_push_service
     from storage.db import create_sqlite_engine
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     monkeypatch.setattr(ui_server, "_web_push_user_key", lambda: "remote:user-a")
 
@@ -1103,7 +1103,7 @@ def test_web_push_unsubscribe_is_scoped_to_current_user(monkeypatch, tmp_path):
 
 
 def test_web_push_test_route_sends_to_enabled_subscriptions(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     sends = []
@@ -1148,7 +1148,7 @@ def test_web_push_test_route_sends_to_enabled_subscriptions(monkeypatch, tmp_pat
 
 
 def test_web_push_test_route_targets_current_endpoint_only(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
 
     sends = []
@@ -1192,7 +1192,7 @@ def test_sessions_create_preserves_metadata_without_web_push_owner(monkeypatch, 
     from storage.db import create_sqlite_engine
     from storage.projects_service import create_project
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     project_dir = tmp_path / "project"

--- a/tests/test_ui_server_install.py
+++ b/tests/test_ui_server_install.py
@@ -22,7 +22,7 @@ def _save_setup_host_config(host: str) -> None:
 
 
 def test_install_agent_allows_same_origin_request(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_setup_host_config("192.168.2.3")
     monkeypatch.setattr(
         api,
@@ -43,7 +43,7 @@ def test_install_agent_allows_same_origin_request(monkeypatch, tmp_path):
 
 
 def test_install_agent_rejects_cross_origin_request(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_setup_host_config("192.168.2.3")
     monkeypatch.setattr(api, "start_agent_install_job", lambda name: {"ok": True, "name": name})
 
@@ -61,7 +61,7 @@ def test_install_agent_rejects_cross_origin_request(monkeypatch, tmp_path):
 
 
 def test_install_agent_rejects_missing_csrf_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(api, "start_agent_install_job", lambda name: {"ok": True, "name": name})
 
     client = app.test_client()
@@ -76,7 +76,7 @@ def test_install_agent_rejects_missing_csrf_token(monkeypatch, tmp_path):
 
 
 def test_install_agent_rejects_missing_origin(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(api, "start_agent_install_job", lambda name: {"ok": True, "name": name})
 
     client = app.test_client()
@@ -90,7 +90,7 @@ def test_install_agent_rejects_missing_origin(monkeypatch, tmp_path):
 
 
 def test_install_agent_status_allows_poll(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_setup_host_config("192.168.2.3")
     monkeypatch.setattr(
         api,
@@ -144,7 +144,7 @@ def test_install_job_fails_when_runtime_refresh_fails(monkeypatch):
 
 
 def test_vibe_agent_routes_return_structured_client_errors(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     client = app.test_client()
 
     missing = client.get("/api/agents/missing")

--- a/tests/test_ui_server_logs.py
+++ b/tests/test_ui_server_logs.py
@@ -15,7 +15,7 @@ def _set_mtime(path, timestamp: str) -> None:
 
 
 def test_logs_endpoint_returns_multiple_sources(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     (paths.get_logs_dir() / "vibe_remote.log").write_text(
@@ -50,7 +50,7 @@ def test_logs_endpoint_returns_multiple_sources(monkeypatch, tmp_path):
 
 
 def test_logs_endpoint_returns_aggregated_all_view(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     service_log = paths.get_logs_dir() / "vibe_remote.log"
@@ -87,7 +87,7 @@ def test_logs_endpoint_returns_aggregated_all_view(monkeypatch, tmp_path):
 
 
 def test_logs_endpoint_caps_aggregated_all_view_to_requested_lines(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     (paths.get_logs_dir() / "vibe_remote.log").write_text(
@@ -136,7 +136,7 @@ def test_logs_endpoint_caps_aggregated_all_view_to_requested_lines(monkeypatch, 
 
 
 def test_logs_endpoint_keeps_traceback_exception_summary_with_error_entry(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     (paths.get_logs_dir() / "vibe_remote.log").write_text(
@@ -159,7 +159,7 @@ def test_logs_endpoint_keeps_traceback_exception_summary_with_error_entry(monkey
 
 
 def test_logs_endpoint_preserves_recent_unstructured_logs_in_all_view(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     service_log = paths.get_logs_dir() / "vibe_remote.log"
@@ -191,7 +191,7 @@ def test_logs_endpoint_preserves_recent_unstructured_logs_in_all_view(monkeypatc
 
 
 def test_logs_endpoint_falls_back_to_service_for_unknown_source(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
 
     (paths.get_logs_dir() / "vibe_remote.log").write_text(
@@ -210,7 +210,7 @@ def test_logs_endpoint_falls_back_to_service_for_unknown_source(monkeypatch, tmp
 
 
 def test_status_endpoint_degrades_when_pid_probe_raises(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("12345", encoding="utf-8")
     runtime.write_status("running", detail="pid=12345", service_pid=12345)
@@ -231,7 +231,7 @@ def test_status_endpoint_degrades_when_pid_probe_raises(monkeypatch, tmp_path):
 
 
 def test_control_start_reuses_running_service_without_stop(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     runtime.write_status("running", detail="already running", service_pid=12345, ui_pid=67890)
     calls = []
@@ -250,7 +250,7 @@ def test_control_start_reuses_running_service_without_stop(monkeypatch, tmp_path
 
 
 def test_control_stop_uses_locked_service_stop(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     runtime.write_status("running", detail="running", service_pid=12345, ui_pid=67890)
     paths.get_runtime_pid_path().write_text("12345", encoding="utf-8")
@@ -269,7 +269,7 @@ def test_control_stop_uses_locked_service_stop(monkeypatch, tmp_path):
 
 
 def test_control_restart_schedules_restart_job(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     runtime.write_status("running", detail="running", service_pid=12345, ui_pid=67890)
     paths.get_runtime_pid_path().write_text("12345", encoding="utf-8")
@@ -304,7 +304,7 @@ def test_control_restart_schedules_restart_job(monkeypatch, tmp_path):
 def test_control_restart_rejects_overlapping_restart(monkeypatch, tmp_path):
     """A restart already in flight (live supervisor) blocks a second one so two
     jobs can't race on the same pid files + lock."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe.ui_server import app
     import vibe.restart_supervisor as restart_supervisor
 
@@ -333,7 +333,7 @@ def test_control_restart_rejects_overlapping_restart(monkeypatch, tmp_path):
 def test_control_restart_ignores_dead_supervisor(monkeypatch, tmp_path):
     """A 'running' status whose supervisor pid is dead is stale and must NOT
     block a new restart."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe.ui_server import app
     import vibe.restart_supervisor as restart_supervisor
 
@@ -361,7 +361,7 @@ def test_control_restart_ignores_stale_pidless_seed(monkeypatch, tmp_path):
     """A pid-less 'scheduled' seed older than the grace window (the supervisor
     died before recording its pid) is stale and must NOT block restarts forever;
     a FRESH pid-less seed still blocks (the child is just starting)."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     import time as _time
 
     from vibe.ui_server import app

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -9,7 +9,7 @@ from tests.ui_server_test_helpers import csrf_headers
 
 
 def test_csrf_token_endpoint_returns_cookie_and_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     client = app.test_client()
     response = client.get("/api/csrf-token", base_url="http://127.0.0.1:15131")
 
@@ -26,7 +26,7 @@ def test_csrf_token_endpoint_returns_cookie_and_token(monkeypatch, tmp_path):
 
 
 def test_config_post_rejects_cross_origin(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     client = app.test_client()
     headers = csrf_headers(client, "http://127.0.0.1:15131")
     headers["Origin"] = "http://evil.example"
@@ -43,7 +43,7 @@ def test_config_post_rejects_cross_origin(monkeypatch, tmp_path):
 
 
 def test_config_post_rejects_missing_csrf_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     client = app.test_client()
     response = client.post(
         "/api/config",
@@ -57,7 +57,7 @@ def test_config_post_rejects_missing_csrf_token(monkeypatch, tmp_path):
 
 
 def test_config_post_rejects_malformed_json(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     client = app.test_client()
     headers = csrf_headers(client, "http://127.0.0.1:15131")
 
@@ -72,7 +72,7 @@ def test_config_post_rejects_malformed_json(monkeypatch, tmp_path):
 
 
 def test_config_post_rejects_host_mismatch_before_parsing_malformed_json(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     V2Config(
         mode="self_host",
         version="v2",
@@ -95,7 +95,7 @@ def test_config_post_rejects_host_mismatch_before_parsing_malformed_json(monkeyp
 
 
 def test_config_post_accepts_vendor_json_content_type(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     V2Config(
         mode="self_host",
         version="v2",
@@ -118,7 +118,7 @@ def test_config_post_accepts_vendor_json_content_type(monkeypatch, tmp_path):
 
 
 def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     V2Config(
         mode="self_host",
         version="v2",
@@ -152,7 +152,7 @@ def test_config_post_allows_forwarded_origin(monkeypatch, tmp_path):
 
 
 def test_config_post_returns_400_for_enabled_platform_missing_credentials(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     V2Config(
         mode="self_host",
         version="v2",

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -26,7 +26,7 @@ from tests.ui_server_test_helpers import csrf_headers
 
 @pytest.fixture()
 def isolated_state(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     yield tmp_path
 

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -163,7 +163,7 @@ def _write_runtime_manifest(tmp_path: Path, archive_path: Path, *, sha256: str |
 
 
 def test_private_show_page_requires_remote_login(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
 
@@ -179,7 +179,7 @@ def test_private_show_page_requires_remote_login(monkeypatch, tmp_path):
 
 
 def test_private_show_page_serves_locally(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
 
@@ -190,7 +190,7 @@ def test_private_show_page_serves_locally(monkeypatch, tmp_path):
 
 
 def test_private_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(body=b"<h1>Runtime Page</h1>")
@@ -225,7 +225,7 @@ def test_private_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
 
 
 def test_private_show_page_materializes_workspace_before_runtime_proxy(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page_record("ses123", "private")
     page_dir = paths.get_show_pages_dir() / "ses123"
@@ -244,7 +244,7 @@ def test_private_show_page_materializes_workspace_before_runtime_proxy(monkeypat
 
 
 def test_private_show_page_injects_runtime_event_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: f"token-{session_id}")
@@ -280,7 +280,7 @@ def test_private_show_page_injects_runtime_event_config(monkeypatch, tmp_path):
 
 
 def test_private_show_page_does_not_inject_runtime_event_config_into_attachment_html(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: f"token-{session_id}")
@@ -305,7 +305,7 @@ def test_private_show_page_does_not_inject_runtime_event_config_into_attachment_
 
 
 def test_private_show_page_does_not_inject_runtime_event_config_into_ranged_html(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: f"token-{session_id}")
@@ -337,7 +337,7 @@ def test_private_show_page_does_not_inject_runtime_event_config_into_ranged_html
 
 
 def test_private_show_page_runtime_config_overrides_existing_client_defaults(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: f"token-{session_id}")
@@ -357,7 +357,7 @@ def test_private_show_page_runtime_config_overrides_existing_client_defaults(mon
 
 
 def test_public_show_runtime_source_rewrites_private_runtime_paths(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(
@@ -393,7 +393,7 @@ def test_public_show_runtime_source_rewrites_private_runtime_paths(monkeypatch, 
 
 
 def test_public_show_runtime_html_rewrites_private_runtime_client_paths(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(
@@ -446,7 +446,7 @@ def test_show_runtime_public_client_shims_are_cacheable():
 
 
 def test_public_show_runtime_direct_client_paths_return_shims(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(body=b"real vite client")
@@ -471,7 +471,7 @@ def test_public_show_runtime_direct_client_paths_return_shims(monkeypatch, tmp_p
 
 
 def test_public_show_page_does_not_inject_write_runtime_config(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: f"token-{session_id}")
@@ -491,7 +491,7 @@ def test_public_show_page_does_not_inject_write_runtime_config(monkeypatch, tmp_
 
 
 def test_private_show_page_falls_back_to_static_when_runtime_unavailable(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     set_show_runtime_manager_for_tests(_FakeShowRuntimeManager(fail=True))
@@ -508,7 +508,7 @@ def test_private_show_page_falls_back_to_static_when_runtime_unavailable(monkeyp
 
 
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     set_show_runtime_manager_for_tests(_FakeShowRuntimeManager(fail=True))
@@ -525,7 +525,7 @@ def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
 
 
 def test_private_show_page_api_does_not_fall_back_to_static(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     (paths.get_show_pages_dir() / "ses123" / "api" / "health.ts").write_text("export const secret = true\n", encoding="utf-8")
@@ -541,7 +541,7 @@ def test_private_show_page_api_does_not_fall_back_to_static(monkeypatch, tmp_pat
 
 
 def test_private_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(body=b'{"ok":true}', extra_headers={"content-type": "application/json"})
@@ -570,7 +570,7 @@ def test_private_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):
 
 
 def test_private_show_page_records_show_event(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -612,7 +612,7 @@ def test_private_show_page_records_show_event(monkeypatch, tmp_path):
 
 
 def test_private_show_page_rejects_mismatched_event_session_id(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -639,7 +639,7 @@ def test_private_show_page_rejects_mismatched_event_session_id(monkeypatch, tmp_
 
 
 def test_private_show_page_dispatches_human_show_event(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -687,7 +687,7 @@ def test_private_show_page_dispatches_human_show_event(monkeypatch, tmp_path):
 
 
 def test_private_show_page_dispatches_screenshot_annotation_batch(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -751,7 +751,7 @@ def test_private_show_page_dispatches_screenshot_annotation_batch(monkeypatch, t
 
 
 def test_private_show_page_rejects_show_event_without_write_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -779,7 +779,7 @@ def test_private_show_page_rejects_show_event_without_write_token(monkeypatch, t
 
 
 def test_private_show_page_rejects_other_session_write_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -804,7 +804,7 @@ def test_private_show_page_rejects_other_session_write_token(monkeypatch, tmp_pa
 
 
 def test_private_show_page_sets_show_event_write_cookie(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -822,7 +822,7 @@ def test_private_show_page_sets_show_event_write_cookie(monkeypatch, tmp_path):
 
 
 def test_public_show_page_clears_show_event_write_cookie(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     share_id = _create_show_page("ses123", "public")
@@ -839,7 +839,7 @@ def test_show_events_stream_replays_all_persisted_pages_before_live(monkeypatch,
     from core.show_session_events import ShowSessionEventStore
     from vibe.ui_server import _show_events_stream
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -887,7 +887,7 @@ def test_show_events_stream_forwards_live_dispatch_events(monkeypatch, tmp_path)
     from vibe.sse_broker import broker
     from vibe.ui_server import _show_events_stream
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
@@ -923,7 +923,7 @@ def test_public_show_events_stream_redacts_nested_dispatch_ids(monkeypatch, tmp_
     from vibe.sse_broker import broker
     from vibe.ui_server import _show_events_stream
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "public")
@@ -968,7 +968,7 @@ def test_public_show_events_stream_redacts_nested_dispatch_ids(monkeypatch, tmp_
 def test_public_show_page_events_redact_internal_ids(monkeypatch, tmp_path):
     from core.show_session_events import ShowSessionEventStore
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     share_id = _create_show_page("ses123", "public")
@@ -1004,7 +1004,7 @@ def test_public_show_events_stream_redacts_internal_ids(monkeypatch, tmp_path):
     from core.show_session_events import ShowSessionEventStore
     from vibe.ui_server import _show_events_stream
 
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     _create_show_page("ses123", "public")
@@ -1046,7 +1046,7 @@ def test_public_show_events_stream_redacts_internal_ids(monkeypatch, tmp_path):
 
 
 def test_cli_show_event_ingress_records_and_publishes(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     published = []
@@ -1077,7 +1077,7 @@ def test_cli_show_event_ingress_records_and_publishes(monkeypatch, tmp_path):
 
 
 def test_cli_show_event_ingress_requires_cli_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
 
@@ -1098,7 +1098,7 @@ def test_cli_show_event_ingress_requires_cli_token(monkeypatch, tmp_path):
 
 
 def test_cli_show_prewarm_ingress_uses_ui_runtime_manager(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     calls = []
 
@@ -1125,7 +1125,7 @@ def test_cli_show_prewarm_ingress_uses_ui_runtime_manager(monkeypatch, tmp_path)
 
 
 def test_cli_show_prewarm_ingress_requires_cli_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
 
     response = app.test_client().post(
@@ -1142,7 +1142,7 @@ def test_cli_show_prewarm_ingress_requires_cli_token(monkeypatch, tmp_path):
 
 
 def test_cli_show_event_ingress_allows_configured_host_with_cli_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.enabled = False
     config.ui.setup_host = "10.1.2.3"
@@ -1168,7 +1168,7 @@ def test_cli_show_event_ingress_allows_configured_host_with_cli_token(monkeypatc
 
 
 def test_cli_show_event_ingress_rejects_configured_host_without_cli_token(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.remote_access.vibe_cloud.enabled = False
     config.ui.setup_host = "10.1.2.3"
@@ -1193,7 +1193,7 @@ def test_cli_show_event_ingress_rejects_configured_host_without_cli_token(monkey
 
 
 def test_public_show_page_events_are_read_only(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
     share_id = _create_show_page("ses123", "public")
@@ -1216,7 +1216,7 @@ def test_public_show_page_events_are_read_only(monkeypatch, tmp_path):
 
 
 def test_private_show_page_api_mutation_rejects_missing_origin(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(body=b'{"ok":true}', extra_headers={"content-type": "application/json"})
@@ -1237,7 +1237,7 @@ def test_private_show_page_api_mutation_rejects_missing_origin(monkeypatch, tmp_
 
 
 def test_private_show_page_api_mutation_rejects_cross_origin(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(body=b'{"ok":true}', extra_headers={"content-type": "application/json"})
@@ -1261,7 +1261,7 @@ def test_private_show_page_api_mutation_rejects_cross_origin(monkeypatch, tmp_pa
 
 
 def test_private_show_page_preserves_runtime_redirect_location(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(
@@ -1285,7 +1285,7 @@ def test_private_show_page_preserves_runtime_redirect_location(monkeypatch, tmp_
 
 
 def test_private_show_page_rewrites_absolute_runtime_redirect_location(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(
@@ -2162,7 +2162,7 @@ def test_startup_dependency_reconcile_prewarms_runtime_after_prepare(monkeypatch
 
 def test_show_runtime_proxy_logs_entry_timing(monkeypatch, tmp_path, caplog):
     caplog.set_level("INFO")
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager(body=b"<html><body><div id=\"root\">ready</div></body></html>")
@@ -2177,7 +2177,7 @@ def test_show_runtime_proxy_logs_entry_timing(monkeypatch, tmp_path, caplog):
 
 
 def test_private_show_page_hmr_websocket_requires_private_page(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "offline")
 
@@ -2193,7 +2193,7 @@ def test_private_show_page_hmr_websocket_requires_private_page(monkeypatch, tmp_
 
 
 def test_private_show_page_hmr_websocket_requires_remote_session(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
 
@@ -2209,7 +2209,7 @@ def test_private_show_page_hmr_websocket_requires_remote_session(monkeypatch, tm
 
 
 def test_private_show_page_hmr_websocket_accepts_remote_session(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     _create_show_page("ses123", "private")
     manager = _FakeShowRuntimeManager()
@@ -2234,7 +2234,7 @@ def test_private_show_page_hmr_websocket_accepts_remote_session(monkeypatch, tmp
 
 
 def test_private_show_page_hmr_websocket_accepts_setup_host_local_peer(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     config.ui.setup_host = "192.168.2.3"
     config.save()
@@ -2261,7 +2261,7 @@ def test_private_show_page_hmr_websocket_accepts_setup_host_local_peer(monkeypat
 
 
 def test_public_show_page_hmr_websocket_uses_share_path(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager()
@@ -2282,7 +2282,7 @@ def test_public_show_page_hmr_websocket_uses_share_path(monkeypatch, tmp_path):
 
 
 def test_public_show_page_hmr_websocket_requires_public_page(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "private")
 
@@ -2298,7 +2298,7 @@ def test_public_show_page_hmr_websocket_requires_public_page(monkeypatch, tmp_pa
 
 
 def test_private_show_page_redirects_without_trailing_slash(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
 
@@ -2313,7 +2313,7 @@ def test_private_show_page_redirects_without_trailing_slash(monkeypatch, tmp_pat
 
 
 def test_public_show_page_skips_remote_login_but_requires_public_host(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     set_show_runtime_manager_for_tests(_FakeShowRuntimeManager(fail=True))
@@ -2346,7 +2346,7 @@ def test_public_show_page_skips_remote_login_but_requires_public_host(monkeypatc
 
 
 def test_public_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(body=b"<h1>Public Runtime Page</h1>")
@@ -2368,7 +2368,7 @@ def test_public_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
 
 
 def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page_record("ses123", "public")
     page_dir = paths.get_show_pages_dir() / "ses123"
@@ -2392,7 +2392,7 @@ def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatc
 
 
 def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(
@@ -2416,7 +2416,7 @@ def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_pa
 
 
 def test_public_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(body=b'{"ok":true}', extra_headers={"content-type": "application/json"})
@@ -2446,7 +2446,7 @@ def test_public_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):
 
 
 def test_public_show_page_api_mutation_rejects_cross_origin(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(body=b'{"ok":true}', extra_headers={"content-type": "application/json"})
@@ -2471,7 +2471,7 @@ def test_public_show_page_api_mutation_rejects_cross_origin(monkeypatch, tmp_pat
 
 
 def test_public_show_page_api_does_not_fall_back_to_static(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     (paths.get_show_pages_dir() / "ses123" / "api" / "health.ts").write_text("export const secret = true\n", encoding="utf-8")
@@ -2491,7 +2491,7 @@ def test_public_show_page_api_does_not_fall_back_to_static(monkeypatch, tmp_path
 
 
 def test_public_show_page_redirects_without_trailing_slash(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
 
@@ -2506,7 +2506,7 @@ def test_public_show_page_redirects_without_trailing_slash(monkeypatch, tmp_path
 
 
 def test_public_and_private_paths_are_canonical_by_visibility(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
 
@@ -2524,7 +2524,7 @@ def test_public_and_private_paths_are_canonical_by_visibility(monkeypatch, tmp_p
 
 
 def test_rotated_public_share_url_stops_working(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     old_share_id = _create_show_page("ses123", "public")
 
@@ -2542,7 +2542,7 @@ def test_rotated_public_share_url_stops_working(monkeypatch, tmp_path):
 
 
 def test_offline_show_page_returns_explanatory_page(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
 
@@ -2560,7 +2560,7 @@ def test_offline_show_page_returns_explanatory_page(monkeypatch, tmp_path):
 
 
 def test_show_page_rejects_path_traversal(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     (tmp_path / "secret.txt").write_text("secret", encoding="utf-8")
@@ -2572,7 +2572,7 @@ def test_show_page_rejects_path_traversal(monkeypatch, tmp_path):
 
 
 def test_show_page_serves_assets_with_strict_headers(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
 
@@ -2585,7 +2585,7 @@ def test_show_page_serves_assets_with_strict_headers(monkeypatch, tmp_path):
 
 
 def test_show_runtime_vendor_asset_proxy_is_immutable(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     manager = _FakeShowRuntimeManager(
         body=b"export const React = {};",
@@ -2622,7 +2622,7 @@ def test_show_runtime_vendor_asset_proxy_forwards_query_and_is_public(monkeypatc
     # No remote login configured here: the vendor namespace is referenced by the
     # anonymous public `/p/<share>/` surface via the runtime's import map, so it must be
     # reachable without authentication just like the public surface itself.
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     manager = _FakeShowRuntimeManager(
         body=b".vendor{}",
@@ -2646,7 +2646,7 @@ def test_show_runtime_vendor_asset_proxy_forwards_query_and_is_public(monkeypatc
 
 
 def test_show_runtime_vendor_asset_proxy_does_not_mark_errors_immutable(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     manager = _FakeShowRuntimeManager(
         body=b'{"error":"Not found"}',
@@ -2667,7 +2667,7 @@ def test_show_runtime_vendor_asset_proxy_does_not_mark_errors_immutable(monkeypa
 
 
 def test_retired_show_runtime_deps_route_is_gone(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     manager = _FakeShowRuntimeManager(body=b"export default {}")
     set_show_runtime_manager_for_tests(manager)
@@ -2688,7 +2688,7 @@ def test_retired_show_runtime_deps_route_is_gone(monkeypatch, tmp_path):
 
 
 def test_private_show_page_passes_runtime_importmap_through(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
     monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: f"token-{session_id}")
@@ -2723,7 +2723,7 @@ def test_private_show_page_passes_runtime_importmap_through(monkeypatch, tmp_pat
 
 
 def test_public_show_page_passes_runtime_importmap_through_unmodified(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     import_map = '{"imports":{"react":"/_show-runtime/vendor/abc123/react.js","@avibe/show-ui/":"/_show-runtime/vendor/abc123/@avibe_show-ui/"}}'

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -52,7 +52,7 @@ class _FakeIMClient:
 
 
 def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
@@ -67,7 +67,7 @@ def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
 
 
 def test_update_notification_admin_dms_include_buttons_except_wechat(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
@@ -141,7 +141,7 @@ def test_fetch_update_notification_policy_reads_github_release_body():
 
 
 def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("discord", {"123456789012345678": UserSettings(display_name="Discord", is_admin=True)})
@@ -161,7 +161,7 @@ def test_update_notification_returns_false_when_all_admin_dms_fail(monkeypatch, 
 
 
 def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("discord", {"123456789012345678": UserSettings(display_name="Discord", is_admin=True)})
@@ -198,7 +198,7 @@ def test_failed_update_notification_does_not_defer_idle_auto_update(monkeypatch,
 
 
 def test_silent_release_metadata_skips_notifications_but_keeps_auto_update(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform("slack", {"U1": UserSettings(display_name="Slack", is_admin=True)})
@@ -243,7 +243,7 @@ def test_silent_release_metadata_skips_notifications_but_keeps_auto_update(monke
 
 
 def test_update_check_reconciles_askill_even_when_product_auto_update_disabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     checker = UpdateChecker(
         _StubController(SettingsStore.get_instance()),
@@ -274,7 +274,7 @@ def test_update_check_reconciles_askill_even_when_product_auto_update_disabled(m
 
 
 def test_update_check_reconciles_askill_even_when_product_checks_disabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig(check_interval_minutes=0))
     reconciled = []
@@ -290,7 +290,7 @@ def test_update_check_reconciles_askill_even_when_product_checks_disabled(monkey
 
 
 def test_suppressed_post_update_notification_does_not_write_marker(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
 
@@ -307,7 +307,7 @@ def test_suppressed_post_update_notification_does_not_write_marker(monkeypatch, 
 
 
 def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
 
@@ -321,7 +321,7 @@ def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp
 
 
 def test_post_update_notification_uses_unicode_emoji_for_non_slack(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     controller = _StubController(store)
@@ -339,7 +339,7 @@ def test_post_update_notification_uses_unicode_emoji_for_non_slack(monkeypatch, 
 
 
 def test_stop_returns_cancellable_task(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     async def run_test():
@@ -355,7 +355,7 @@ def test_stop_returns_cancellable_task(monkeypatch, tmp_path):
 
 
 def test_start_keeps_running_for_managed_dependencies_when_product_checks_disabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
 
     async def run_test():

--- a/tests/test_user_platform_scope.py
+++ b/tests/test_user_platform_scope.py
@@ -13,7 +13,7 @@ from vibe import api
 
 
 def test_get_users_respects_platform_scope(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform(
@@ -34,7 +34,7 @@ def test_get_users_respects_platform_scope(monkeypatch, tmp_path):
 
 
 def test_toggle_admin_is_scoped_per_platform(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform(
@@ -55,7 +55,7 @@ def test_toggle_admin_is_scoped_per_platform(monkeypatch, tmp_path):
 
 
 def test_controller_codex_overrides_resolve_dm_user_scope(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
     store = SettingsStore.get_instance()
     store.set_users_for_platform(

--- a/tests/test_v2_paths.py
+++ b/tests/test_v2_paths.py
@@ -32,36 +32,33 @@ def test_ensure_data_dirs(tmp_path, monkeypatch):
     assert "free of secrets unless the user explicitly asks." in text
 
 
-def test_avibe_home_env_wins_over_legacy_env(tmp_path, monkeypatch):
+def test_avibe_home_env_sets_custom_home(tmp_path, monkeypatch):
     avibe_home = tmp_path / "custom-avibe"
-    legacy_home = tmp_path / "custom-legacy"
     monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(legacy_home))
 
     assert paths.get_vibe_remote_dir() == avibe_home.resolve()
 
     paths.ensure_data_dirs()
 
     assert (avibe_home / "state").exists()
-    assert not legacy_home.exists()
 
 
-def test_legacy_env_is_honored_without_migration(tmp_path, monkeypatch):
-    legacy_home = tmp_path / "explicit-legacy"
+def test_legacy_env_is_ignored(tmp_path, monkeypatch):
+    custom_legacy_home = tmp_path / "explicit-legacy"
     monkeypatch.delenv("AVIBE_HOME", raising=False)
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(legacy_home))
+    monkeypatch.setenv("VIBE_REMOTE_HOME", str(custom_legacy_home))
+    monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
 
-    assert paths.get_vibe_remote_dir() == legacy_home.resolve()
+    assert paths.get_vibe_remote_dir() == tmp_path / ".avibe"
 
     paths.ensure_data_dirs()
 
-    assert (legacy_home / "state").exists()
-    assert not (tmp_path / ".avibe").exists()
+    assert not custom_legacy_home.exists()
+    assert (tmp_path / ".avibe" / "state").exists()
 
 
 def test_default_prefers_existing_avibe_home(tmp_path, monkeypatch):
     monkeypatch.delenv("AVIBE_HOME", raising=False)
-    monkeypatch.delenv("VIBE_REMOTE_HOME", raising=False)
     monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
     avibe_home = tmp_path / ".avibe"
     avibe_home.mkdir()
@@ -77,7 +74,6 @@ def test_default_prefers_existing_avibe_home(tmp_path, monkeypatch):
 
 def test_default_adopts_old_user_home_without_data_loss(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv("AVIBE_HOME", raising=False)
-    monkeypatch.delenv("VIBE_REMOTE_HOME", raising=False)
     monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
     old_home = tmp_path / ".vibe_remote"
     old_state = old_home / "state"
@@ -106,7 +102,6 @@ def test_default_adopts_old_user_home_without_data_loss(tmp_path, monkeypatch, c
 
 def test_existing_avibe_and_legacy_real_dirs_do_not_clobber(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv("AVIBE_HOME", raising=False)
-    monkeypatch.delenv("VIBE_REMOTE_HOME", raising=False)
     monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
     avibe_home = tmp_path / ".avibe"
     legacy_home = tmp_path / ".vibe_remote"
@@ -130,7 +125,6 @@ def test_existing_avibe_and_legacy_real_dirs_do_not_clobber(tmp_path, monkeypatc
 
 def test_symlink_creation_failure_still_uses_avibe_home(tmp_path, monkeypatch):
     monkeypatch.delenv("AVIBE_HOME", raising=False)
-    monkeypatch.delenv("VIBE_REMOTE_HOME", raising=False)
     monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
     avibe_home = tmp_path / ".avibe"
     avibe_home.mkdir()
@@ -148,7 +142,6 @@ def test_symlink_creation_failure_still_uses_avibe_home(tmp_path, monkeypatch):
 
 def test_default_new_user_uses_avibe_home(tmp_path, monkeypatch):
     monkeypatch.delenv("AVIBE_HOME", raising=False)
-    monkeypatch.delenv("VIBE_REMOTE_HOME", raising=False)
     monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
 
     assert paths.get_vibe_remote_dir() == tmp_path / ".avibe"

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -165,7 +165,7 @@ def test_managed_watch_shell_detaches_waiter_stdin(tmp_path: Path, monkeypatch) 
 
 
 def test_managed_watch_store_uses_sqlite_when_path_is_default(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     store = ManagedWatchStore()
     watch = store.add_watch(
         name="Watch CI",
@@ -240,7 +240,7 @@ def test_sqlite_remove_watch_soft_deletes_watch_but_keeps_runtime(tmp_path: Path
 
 
 def test_watch_runtime_store_uses_sqlite_when_path_is_default(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     store = WatchRuntimeStateStore()
 
     store.write(

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -92,7 +92,7 @@ def test_maybe_notify_inbox_message_skips_non_notifiable(monkeypatch):
 
 
 def test_send_to_enabled_subscriptions_waits_then_sends_to_owner_devices(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -174,7 +174,7 @@ def test_send_to_enabled_subscriptions_waits_then_sends_to_owner_devices(monkeyp
 def test_send_to_enabled_subscriptions_sets_global_badge_count(monkeypatch, tmp_path):
     """badge_count in the sent payload is the GLOBAL unread total, not the
     triggering session's per-session count — the app-icon badge is one number."""
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -256,7 +256,7 @@ def test_send_to_enabled_subscriptions_sets_global_badge_count(monkeypatch, tmp_
 
 
 def test_send_to_enabled_subscriptions_uses_legacy_session_owner(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -319,7 +319,7 @@ def test_send_to_enabled_subscriptions_uses_legacy_session_owner(monkeypatch, tm
 
 
 def test_send_to_enabled_subscriptions_prefers_message_owner_over_legacy_session(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -388,7 +388,7 @@ def test_send_to_enabled_subscriptions_prefers_message_owner_over_legacy_session
 
 
 def test_send_to_enabled_subscriptions_sends_to_merged_prompt_owners(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -459,7 +459,7 @@ def test_send_to_enabled_subscriptions_sends_to_merged_prompt_owners(monkeypatch
 
 
 def test_send_to_enabled_subscriptions_ignores_untrusted_author_id(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -527,7 +527,7 @@ def test_send_to_enabled_subscriptions_ignores_untrusted_author_id(monkeypatch, 
 
 
 def test_send_to_enabled_subscriptions_ignores_queued_owner(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -599,7 +599,7 @@ def test_send_to_enabled_subscriptions_ignores_queued_owner(monkeypatch, tmp_pat
 
 
 def test_send_to_enabled_subscriptions_skips_messages_marked_read_during_delay(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -656,7 +656,7 @@ def test_send_to_enabled_subscriptions_skips_messages_marked_read_during_delay(m
 
 
 def test_send_to_enabled_subscriptions_skips_unowned_remote_single_owner(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -712,7 +712,7 @@ def test_send_to_enabled_subscriptions_skips_unowned_remote_single_owner(monkeyp
 
 
 def test_send_to_enabled_subscriptions_falls_back_to_local_owner(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -769,7 +769,7 @@ def test_send_to_enabled_subscriptions_falls_back_to_local_owner(monkeypatch, tm
 
 
 def test_send_to_enabled_subscriptions_skips_local_fallback_when_remote_access_enabled(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -826,7 +826,7 @@ def test_send_to_enabled_subscriptions_skips_local_fallback_when_remote_access_e
 
 
 def test_send_to_enabled_subscriptions_sends_terminal_error_with_owner(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -894,7 +894,7 @@ def test_send_to_enabled_subscriptions_sends_terminal_error_with_owner(monkeypat
 
 
 def test_send_to_enabled_subscriptions_skips_ambiguous_legacy_owner(monkeypatch, tmp_path):
-    monkeypatch.setenv("VIBE_REMOTE_HOME", str(tmp_path))
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"

--- a/tests/test_wechat_bot.py
+++ b/tests/test_wechat_bot.py
@@ -580,7 +580,7 @@ class WeChatBotTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_process_inbound_message_persists_context_token(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.dict("os.environ", {"VIBE_REMOTE_HOME": tmpdir}):
+            with patch.dict("os.environ", {"AVIBE_HOME": tmpdir}):
                 bot = self._make_bot()
                 bot.check_authorization = lambda **kwargs: AuthResult(allowed=True, is_dm=True)
                 bot.dispatch_text_command = AsyncMock(return_value=False)
@@ -605,7 +605,7 @@ class WeChatBotTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_dm_reuses_persisted_context_token(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.dict("os.environ", {"VIBE_REMOTE_HOME": tmpdir}):
+            with patch.dict("os.environ", {"AVIBE_HOME": tmpdir}):
                 bot = self._make_bot()
                 bot._remember_context_token("user-1", "ctx-persisted")
 
@@ -800,7 +800,7 @@ class WeChatBotTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_send_message_marks_session_expired_on_explicit_error(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch.dict("os.environ", {"VIBE_REMOTE_HOME": tmpdir}):
+            with patch.dict("os.environ", {"AVIBE_HOME": tmpdir}):
                 bot = self._make_bot()
                 context = MessageContext(
                     user_id="user-1",

--- a/tests/test_workbench_session_defaults.py
+++ b/tests/test_workbench_session_defaults.py
@@ -19,7 +19,7 @@ from storage.settings_service import upsert_scope
 
 @pytest.fixture
 def engine():
-    # conftest's autouse fixture isolates VIBE_REMOTE_HOME per test.
+    # conftest's autouse fixture isolates AVIBE_HOME per test.
     ensure_sqlite_state()
     return create_sqlite_engine()
 

--- a/vibe/sentry_integration.py
+++ b/vibe/sentry_integration.py
@@ -147,7 +147,7 @@ def detect_sentry_environment() -> str:
     if deployment:
         return deployment.strip()
 
-    vibe_home = os.environ.get("AVIBE_HOME") or os.environ.get("VIBE_REMOTE_HOME", "")
+    vibe_home = os.environ.get("AVIBE_HOME", "")
     if "incus-regression" in vibe_home or "three-regression" in vibe_home:
         return "regression"
 


### PR DESCRIPTION
## Summary

- remove `VIBE_REMOTE_HOME` from the runtime home resolver; `AVIBE_HOME` is now the only env-var override
- keep `~/.vibe_remote` as a legacy on-disk migration/adoption path, including the back-symlink behavior
- update Docker/e2e config, test isolation, skills, and migration notes to use `AVIBE_HOME`
- add regression coverage that a set `VIBE_REMOTE_HOME` no longer redirects runtime state

## Evidence

- unit: `uv run pytest tests/test_v2_paths.py tests/test_conftest_auth_home_isolation.py tests/test_docker_entrypoint_supervisor.py tests/test_sentry_integration.py tests/test_ui_server_logs.py tests/test_settings_disk_fallback.py tests/test_ui_api.py -q`
- lint: `uvx ruff check` on changed Python files
- contract: `npm run build` in `ui/` so editable Python packaging can include `ui/dist`
- residual manual checks: repo grep confirms `VIBE_REMOTE_HOME` remains only in tests that assert it is ignored, plus unrelated `/data/vibe_remote` migration fixtures

## Risk

This intentionally breaks the old env-var override. Existing default `~/.vibe_remote` directories are still migrated/adopted, so user data compatibility remains covered.
