### PR TITLE
test(regression): harden full-suite leftovers

### DIFF
--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -78,6 +78,16 @@ def _write_fake_node(path: Path, version: str = "v22.16.0") -> None:
     )
 
 
+def _write_missing_node(path: Path) -> None:
+    _write_executable(
+        path,
+        """\
+        #!/usr/bin/env bash
+        exit 127
+        """,
+    )
+
+
 def _write_fake_file(path: Path, mapping: dict[Path, str]) -> None:
     cases = "\n".join(
         f'        "{target}") echo "${{prefix}}{description}" ;;' for target, description in mapping.items()
@@ -174,6 +184,7 @@ def test_install_script_installs_node_when_missing(tmp_path):
     uv_log = tmp_path / "uv-tool-bin-dir.txt"
 
     _write_fake_uv(path_dir / "uv", uv_log)
+    _write_missing_node(path_dir / "node")
     _write_fake_uname(path_dir / "uname", machine="arm64")
     _write_executable(
         path_dir / "brew",
@@ -263,6 +274,7 @@ def test_install_script_continues_when_node_install_fails(tmp_path):
     uv_log = tmp_path / "uv-tool-bin-dir.txt"
 
     _write_fake_uv(path_dir / "uv", uv_log)
+    _write_missing_node(path_dir / "node")
     _write_fake_uname(path_dir / "uname", machine="arm64")
     _write_executable(
         path_dir / "brew",

--- a/tests/test_sse_broker.py
+++ b/tests/test_sse_broker.py
@@ -11,6 +11,7 @@ take down whichever caller was publishing the event. The lock added to
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import sys
 import threading
@@ -69,10 +70,16 @@ def test_publish_survives_concurrent_subscribe_churn():
     runner = threading.Thread(target=_runner, daemon=True)
     runner.start()
 
-    async def _seed_initial_subscriber():
-        broker.subscribe()
+    async def _seed_loop():
+        return broker.subscribe()
 
-    asyncio.run_coroutine_threadsafe(_seed_initial_subscriber(), loop).result(timeout=5)
+    stable_sub_id, stable_queue = asyncio.run_coroutine_threadsafe(_seed_loop(), loop).result(timeout=5)
+
+    async def _drain_stable_subscriber() -> None:
+        while True:
+            await stable_queue.get()
+
+    drain = asyncio.run_coroutine_threadsafe(_drain_stable_subscriber(), loop)
 
     stop = threading.Event()
     errors: list[BaseException] = []
@@ -97,13 +104,24 @@ def test_publish_survives_concurrent_subscribe_churn():
             broker.unsubscribe(sub_id)
             await asyncio.sleep(0)
 
-    asyncio.run_coroutine_threadsafe(_churn(), loop).result(timeout=15)
+    async def _unsubscribe(sub_id: int) -> None:
+        broker.unsubscribe(sub_id)
 
-    stop.set()
-    publisher.join(timeout=5)
+    try:
+        asyncio.run_coroutine_threadsafe(_churn(), loop).result(timeout=15)
+    finally:
+        stop.set()
+        publisher.join(timeout=5)
 
-    loop.call_soon_threadsafe(loop.stop)
-    runner.join(timeout=5)
-    loop.close()
+        drain.cancel()
+        try:
+            drain.result(timeout=5)
+        except concurrent.futures.CancelledError:
+            pass
+
+        asyncio.run_coroutine_threadsafe(_unsubscribe(stable_sub_id), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        runner.join(timeout=5)
+        loop.close()
 
     assert not errors, f"publish() raised under concurrent churn: {errors!r}"


### PR DESCRIPTION
## Summary

- make install-script Node-missing tests hermetic when the regression host already has `/usr/bin/node`
- keep the SSE broker concurrency test on the non-empty subscriber path without flooding the event loop
- preserve cleanup for publisher/drain threads when the churn assertion times out

## Why

The post-merge full regression pass for the stuck-active Codex/Claude fixes exposed stable leftovers outside those PRs:

- the install tests intended to simulate a missing Node binary, but Incus has Node 20.20.2 on PATH, so `install.sh` correctly skipped installation
- the SSE broker test kept an unconsumed subscriber while a tight publisher loop ran, saturating queue callbacks and starving the churn coroutine instead of testing the lock invariant

## Evidence

- Unit: local focused failures now pass
- Unit: local related files pass
- Regression: Incus worktree related files pass
- Regression: Incus CI-style unit gate passes, 173 test files one process each
- Residual manual checks: worktree regression environment is healthy at `http://127.0.0.1:15200`

No scenario catalog entries apply; this is test hardening only.
