### PR TITLE
feat(show-page): make Show Pages installable to iOS Home Screen

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -449,21 +449,21 @@ def _default_index_html(session_id: str) -> str:
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Show Page {escaped}</title>
     <!-- PWA: let a user "Add to Home Screen" this Show Page as a standalone app.
-         iOS reads these apple-* tags plus the page's own URL; the icons are
-         served auth-free at the Avibe origin root (see _PWA_PUBLIC_ASSETS in
-         ui_server). We intentionally do NOT link /manifest.webmanifest here: it
-         is the workbench manifest whose start_url is "/", which would hijack the
-         installed icon back to the workbench instead of opening this page. We
-         also omit apple-mobile-web-app-title so a page that sets document.title
-         keeps its own Home Screen name. The apple-touch-icon carries a stable id
-         so a page can give the installed app its own icon by repointing this one
-         link's href — iOS picks the FIRST apple-touch-icon, so replace it rather
-         than appending another. -->
+         We declare it standalone-capable but DELIBERATELY ship no apple-touch-icon
+         or apple-mobile-web-app-title here. A page customizes its installed icon
+         and name by editing this file (a custom <title> / apple-mobile-web-app-title
+         and a relative apple-touch-icon.png), and a static default would compete
+         with that: iOS picks the FIRST apple-touch-icon in source order, so a
+         default link could shadow the page's own icon when a page appends rather
+         than replaces. With none declared, a customized page's icon is the only
+         one (it wins), and an un-customized page falls back to the Avibe origin's
+         /apple-touch-icon.png (served auth-free; see _PWA_PUBLIC_ASSETS in
+         ui_server) via iOS's root-directory icon lookup. We also do NOT link
+         /manifest.webmanifest: the workbench manifest's start_url "/" would hijack
+         the installed icon back to the workbench. -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <link rel="apple-touch-icon" id="app-touch-icon" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" href="/logo.png">
   </head>
   <body>
     <div id="root"></div>

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -455,11 +455,14 @@ def _default_index_html(session_id: str) -> str:
          is the workbench manifest whose start_url is "/", which would hijack the
          installed icon back to the workbench instead of opening this page. We
          also omit apple-mobile-web-app-title so a page that sets document.title
-         keeps its own Home Screen name. -->
+         keeps its own Home Screen name. The apple-touch-icon carries a stable id
+         so a page can give the installed app its own icon by repointing this one
+         link's href — iOS picks the FIRST apple-touch-icon, so replace it rather
+         than appending another. -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="apple-touch-icon" id="app-touch-icon" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" href="/logo.png">
   </head>
   <body>

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -448,6 +448,19 @@ def _default_index_html(session_id: str) -> str:
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Show Page {escaped}</title>
+    <!-- PWA: let a user "Add to Home Screen" this Show Page as a standalone app.
+         iOS reads these apple-* tags plus the page's own URL; the icons are
+         served auth-free at the Avibe origin root (see _PWA_PUBLIC_ASSETS in
+         ui_server). We intentionally do NOT link /manifest.webmanifest here: it
+         is the workbench manifest whose start_url is "/", which would hijack the
+         installed icon back to the workbench instead of opening this page. We
+         also omit apple-mobile-web-app-title so a page that sets document.title
+         keeps its own Home Screen name. -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/logo.png">
   </head>
   <body>
     <div id="root"></div>

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -233,6 +233,12 @@ def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
     assert "Ready to visualize" not in index_html
     assert "Loading Show Page" not in index_html
     assert "fallback-shell" not in index_html
+    # PWA "Add to Home Screen" support: standalone-capable + a real app icon.
+    assert 'name="apple-mobile-web-app-capable" content="yes"' in index_html
+    assert 'rel="apple-touch-icon" href="/apple-touch-icon.png"' in index_html
+    # Must NOT link the workbench manifest — its start_url "/" would hijack the
+    # installed Home Screen icon back to the workbench instead of this page.
+    assert 'rel="manifest"' not in index_html
     main_tsx = (page_dir / "src" / "main.tsx").read_text(encoding="utf-8")
     assert "globalThis.__AVIBE_SHOW__" in main_tsx
     assert "declare global" in main_tsx

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -235,7 +235,10 @@ def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
     assert "fallback-shell" not in index_html
     # PWA "Add to Home Screen" support: standalone-capable + a real app icon.
     assert 'name="apple-mobile-web-app-capable" content="yes"' in index_html
-    assert 'rel="apple-touch-icon" href="/apple-touch-icon.png"' in index_html
+    assert 'rel="apple-touch-icon"' in index_html
+    assert 'href="/apple-touch-icon.png"' in index_html
+    # Stable id so a Show Page can override the icon by repointing this one link.
+    assert 'id="app-touch-icon"' in index_html
     # Must NOT link the workbench manifest — its start_url "/" would hijack the
     # installed Home Screen icon back to the workbench instead of this page.
     assert 'rel="manifest"' not in index_html

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -233,12 +233,14 @@ def test_show_page_dir_creates_default_index(monkeypatch, tmp_path):
     assert "Ready to visualize" not in index_html
     assert "Loading Show Page" not in index_html
     assert "fallback-shell" not in index_html
-    # PWA "Add to Home Screen" support: standalone-capable + a real app icon.
+    # PWA "Add to Home Screen": declared standalone-capable.
     assert 'name="apple-mobile-web-app-capable" content="yes"' in index_html
-    assert 'rel="apple-touch-icon"' in index_html
-    assert 'href="/apple-touch-icon.png"' in index_html
-    # Stable id so a Show Page can override the icon by repointing this one link.
-    assert 'id="app-touch-icon"' in index_html
+    # Ship NO icon or app-title here, so a page's own apple-touch-icon /
+    # apple-mobile-web-app-title is never shadowed (iOS picks the FIRST
+    # apple-touch-icon in source order). The default icon comes from the Avibe
+    # origin root via iOS's root-directory fallback, not a competing link.
+    assert 'rel="apple-touch-icon"' not in index_html
+    assert 'name="apple-mobile-web-app-title"' not in index_html
     # Must NOT link the workbench manifest — its start_url "/" would hijack the
     # installed Home Screen icon back to the workbench instead of this page.
     assert 'rel="manifest"' not in index_html

--- a/ui/src/components/InstallHint.tsx
+++ b/ui/src/components/InstallHint.tsx
@@ -4,27 +4,18 @@ import { Plus, Share, Sparkles, X } from 'lucide-react';
 
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { Button } from './ui/button';
-import { isIosDevice, isStandalonePwa } from '@/lib/platform';
+import { isRealMobileSafari, isStandalonePwa } from '@/lib/platform';
 
 const STORAGE_KEY = 'vibe-remote-a2hs';
 
-// iOS in-app webviews (IM/social apps) and alt browsers can't "Add to Home
-// Screen" and don't expose Safari's share flow, so the nudge would give
-// impossible steps to exactly the IM-launched users this app targets. Only real
-// Safari qualifies — it carries both a "Version/<n>" and a "Safari" token, which
-// WKWebview-based in-app browsers and CriOS/FxiOS/etc. lack.
-const NON_SAFARI_UA = /CriOS|FxiOS|EdgiOS|OPiOS|mercury/i;
-const IN_APP_UA =
-  /MicroMessenger|FBAN|FBAV|FB_IAB|Instagram|Line\/|Twitter|WhatsApp|Snapchat|DingTalk|QQ\/|QQTheme|Slack|Discord|Feishu|Lark|; wv\)/i;
-
+// Only real iOS Safari can "Add to Home Screen": IM in-app webviews and alt
+// browsers (CriOS/FxiOS/etc.) don't expose Safari's share flow, so the nudge
+// would give impossible steps to exactly the IM-launched users this app targets.
+// isRealMobileSafari() (shared in lib/platform) encodes that filter.
 function shouldShowHint(): boolean {
   if (typeof window === 'undefined' || !window.matchMedia) return false;
   if (!window.matchMedia('(max-width: 767px)').matches) return false;
-  if (!isIosDevice()) return false;
-  const ua = navigator.userAgent || '';
-  const isRealSafari =
-    /Safari/.test(ua) && /Version\//.test(ua) && !NON_SAFARI_UA.test(ua) && !IN_APP_UA.test(ua);
-  if (!isRealSafari) return false;
+  if (!isRealMobileSafari()) return false;
   return !isStandalonePwa();
 }
 

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Copy, Loader2, Share2 } from 'lucide-react';
+import { Check, Copy, Loader2, Plus, Share2 } from 'lucide-react';
 
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -8,6 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Select } from '../ui/select';
 import { useApi } from '../../context/ApiContext';
 import { copyTextToClipboard } from '../../lib/utils';
+import { isIosDevice } from '../../lib/platform';
 import { copyHref, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 
 type ShowPagePayload = ShowPageLinkInfo & {
@@ -58,6 +59,11 @@ export const ShowPageShareControl: React.FC<{
   // select/copy yields the same link as the Copy button.
   const link = payload ? copyHref(payload) ?? '' : '';
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
+  // iOS can't be triggered to "Add to Home Screen" programmatically and the Web
+  // Share sheet doesn't offer it — only Safari's own page-share menu does. So on
+  // iOS we show steps to open the link in Safari and add it there. The Show Page
+  // index.html is PWA-capable, so the result launches as a standalone app.
+  const isIos = isIosDevice();
 
   // Re-fetch on every open so a visibility/share change made elsewhere (e.g. the
   // admin Show Pages page) is reflected; keep the last payload visible while
@@ -198,6 +204,18 @@ export const ShowPageShareControl: React.FC<{
             {payload && isPublic && !payload.url_available && (
               <div className="rounded-md border border-border px-2.5 py-2 text-xs text-muted">
                 {t('chat.showPage.publicUnavailable')}
+              </div>
+            )}
+
+            {isIos && link && (
+              <div className="rounded-md border border-border bg-foreground/[0.02] px-2.5 py-2">
+                <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                  <Plus className="size-3.5 shrink-0 text-cyan" />
+                  {t('chat.showPage.addToHomeTitle')}
+                </div>
+                <p className="mt-1 text-xs leading-relaxed text-muted">
+                  {t('chat.showPage.addToHomeBody')}
+                </p>
               </div>
             )}
           </>

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -8,7 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Select } from '../ui/select';
 import { useApi } from '../../context/ApiContext';
 import { copyTextToClipboard } from '../../lib/utils';
-import { isIosDevice } from '../../lib/platform';
+import { isIosDevice, isStandalonePwa } from '../../lib/platform';
 import { copyHref, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 
 type ShowPagePayload = ShowPageLinkInfo & {
@@ -60,10 +60,13 @@ export const ShowPageShareControl: React.FC<{
   const link = payload ? copyHref(payload) ?? '' : '';
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
   // iOS can't be triggered to "Add to Home Screen" programmatically and the Web
-  // Share sheet doesn't offer it — only Safari's own page-share menu does. So on
-  // iOS we show steps to open the link in Safari and add it there. The Show Page
-  // index.html is PWA-capable, so the result launches as a standalone app.
+  // Share sheet doesn't offer it — only Safari's own page-share menu does (the
+  // page index.html is PWA-capable, so the result launches standalone). The steps
+  // differ by context: in Safari, tap Share → Add to Home Screen; in the installed
+  // PWA the page can't hand off to Safari (a same-origin link stays in the in-app
+  // browser), so the user must copy the link and open it in Safari themselves.
   const isIos = isIosDevice();
+  const iosStandalone = isStandalonePwa();
 
   // Re-fetch on every open so a visibility/share change made elsewhere (e.g. the
   // admin Show Pages page) is reflected; keep the last payload visible while
@@ -214,7 +217,9 @@ export const ShowPageShareControl: React.FC<{
                   {t('chat.showPage.addToHomeTitle')}
                 </div>
                 <p className="mt-1 text-xs leading-relaxed text-muted">
-                  {t('chat.showPage.addToHomeBody')}
+                  {iosStandalone
+                    ? t('chat.showPage.addToHomeBodyPwa')
+                    : t('chat.showPage.addToHomeBodySafari')}
                 </p>
               </div>
             )}

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -216,11 +216,27 @@ export const ShowPageShareControl: React.FC<{
                   <Plus className="size-3.5 shrink-0 text-cyan" />
                   {t('chat.showPage.addToHomeTitle')}
                 </div>
-                <p className="mt-1 text-xs leading-relaxed text-muted">
-                  {iosStandalone
-                    ? t('chat.showPage.addToHomeBodyPwa')
-                    : t('chat.showPage.addToHomeBodySafari')}
-                </p>
+                {iosStandalone ? (
+                  // Installed PWA: a same-origin link can't hand off to Safari
+                  // (it stays trapped in scope), so the user must copy the link
+                  // and open it in Safari — the Copy button above does that.
+                  <p className="mt-1 text-xs leading-relaxed text-muted">
+                    {t('chat.showPage.addToHomeBodyPwa')}
+                  </p>
+                ) : (
+                  // Safari: the popover sits in the workbench while the Show Page
+                  // is framed, so Safari's own Share targets the workbench URL.
+                  // Open the Show Page top-level first (new tab) — then the user's
+                  // Share → Add to Home Screen captures the Show Page, not us.
+                  <a
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-1 block text-xs leading-relaxed text-foreground underline underline-offset-2"
+                  >
+                    {t('chat.showPage.addToHomeBodySafari')}
+                  </a>
+                )}
               </div>
             )}
           </>

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -8,7 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Select } from '../ui/select';
 import { useApi } from '../../context/ApiContext';
 import { copyTextToClipboard } from '../../lib/utils';
-import { isIosDevice, isStandalonePwa } from '../../lib/platform';
+import { isIosDevice, isRealMobileSafari, isStandalonePwa } from '../../lib/platform';
 import { copyHref, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 
 type ShowPagePayload = ShowPageLinkInfo & {
@@ -59,14 +59,14 @@ export const ShowPageShareControl: React.FC<{
   // select/copy yields the same link as the Copy button.
   const link = payload ? copyHref(payload) ?? '' : '';
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function';
-  // iOS can't be triggered to "Add to Home Screen" programmatically and the Web
-  // Share sheet doesn't offer it — only Safari's own page-share menu does (the
-  // page index.html is PWA-capable, so the result launches standalone). The steps
-  // differ by context: in Safari, tap Share → Add to Home Screen; in the installed
-  // PWA the page can't hand off to Safari (a same-origin link stays in the in-app
-  // browser), so the user must copy the link and open it in Safari themselves.
-  const isIos = isIosDevice();
-  const iosStandalone = isStandalonePwa();
+  // "Add to Home Screen" only works where Safari's page-share flow is reachable:
+  // real iOS Safari (tapping opens the Show Page top-level, then the user shares
+  // that), or an installed iOS standalone PWA (a same-origin link stays trapped in
+  // scope, so the user copies the link and opens it in Safari). iOS Chrome/Firefox
+  // and IM in-app browsers report iOS too but can't reach that flow, so we don't
+  // show steps they can't complete — matching the InstallHint nudge's gating.
+  const iosStandalone = isIosDevice() && isStandalonePwa();
+  const showAddToHome = !!link && (iosStandalone || isRealMobileSafari());
 
   // Re-fetch on every open so a visibility/share change made elsewhere (e.g. the
   // admin Show Pages page) is reflected; keep the last payload visible while
@@ -210,7 +210,7 @@ export const ShowPageShareControl: React.FC<{
               </div>
             )}
 
-            {isIos && link && (
+            {showAddToHome && (
               <div className="rounded-md border border-border bg-foreground/[0.02] px-2.5 py-2">
                 <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
                   <Plus className="size-3.5 shrink-0 text-cyan" />

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1805,7 +1805,7 @@
       "publicUnavailable": "Connect Avibe Cloud to get a public link others can open.",
       "loadError": "Couldn't load this Show Page.",
       "addToHomeTitle": "Add to Home Screen",
-      "addToHomeBodySafari": "Open this page in Safari, then Share → “Add to Home Screen”.",
+      "addToHomeBodySafari": "Tap here to open in a new tab, then Share → “Add to Home Screen”.",
       "addToHomeBodyPwa": "Copy the link above and open it in Safari, then tap Share → “Add to Home Screen”."
     },
     "titlePlaceholder": "Session title",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1803,7 +1803,9 @@
       "privateDesc": "Only you can view",
       "offlineNote": "This Show Page is offline and can't be shared right now.",
       "publicUnavailable": "Connect Avibe Cloud to get a public link others can open.",
-      "loadError": "Couldn't load this Show Page."
+      "loadError": "Couldn't load this Show Page.",
+      "addToHomeTitle": "Add to Home Screen",
+      "addToHomeBody": "Open this link in Safari, then tap Share → “Add to Home Screen” to use it as an app."
     },
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1805,7 +1805,7 @@
       "publicUnavailable": "Connect Avibe Cloud to get a public link others can open.",
       "loadError": "Couldn't load this Show Page.",
       "addToHomeTitle": "Add to Home Screen",
-      "addToHomeBodySafari": "Tap the Share button in the bottom bar, then “Add to Home Screen” to use it as an app.",
+      "addToHomeBodySafari": "Open this page in Safari, then Share → “Add to Home Screen”.",
       "addToHomeBodyPwa": "Copy the link above and open it in Safari, then tap Share → “Add to Home Screen”."
     },
     "titlePlaceholder": "Session title",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1805,7 +1805,8 @@
       "publicUnavailable": "Connect Avibe Cloud to get a public link others can open.",
       "loadError": "Couldn't load this Show Page.",
       "addToHomeTitle": "Add to Home Screen",
-      "addToHomeBody": "Open this link in Safari, then tap Share → “Add to Home Screen” to use it as an app."
+      "addToHomeBodySafari": "Tap the Share button in the bottom bar, then “Add to Home Screen” to use it as an app.",
+      "addToHomeBodyPwa": "Copy the link above and open it in Safari, then tap Share → “Add to Home Screen”."
     },
     "titlePlaceholder": "Session title",
     "pickAgent": "Pick an agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1804,7 +1804,8 @@
       "publicUnavailable": "连接 Avibe Cloud 后才能获得别人可打开的公开链接。",
       "loadError": "无法加载这个 Show Page。",
       "addToHomeTitle": "添加到主屏幕",
-      "addToHomeBody": "在 Safari 中打开此链接，点击分享按钮 →「添加到主屏幕」，即可当作 App 使用。"
+      "addToHomeBodySafari": "点底部的分享按钮，选「添加到主屏幕」，即可当作 App 使用。",
+      "addToHomeBodyPwa": "复制上方链接，在 Safari 中打开，再点分享 →「添加到主屏幕」。"
     },
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1804,7 +1804,7 @@
       "publicUnavailable": "连接 Avibe Cloud 后才能获得别人可打开的公开链接。",
       "loadError": "无法加载这个 Show Page。",
       "addToHomeTitle": "添加到主屏幕",
-      "addToHomeBodySafari": "点底部的分享按钮，选「添加到主屏幕」，即可当作 App 使用。",
+      "addToHomeBodySafari": "点此在 Safari 打开本页，再点分享 →「添加到主屏幕」。",
       "addToHomeBodyPwa": "复制上方链接，在 Safari 中打开，再点分享 →「添加到主屏幕」。"
     },
     "titlePlaceholder": "会话标题",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1804,7 +1804,7 @@
       "publicUnavailable": "连接 Avibe Cloud 后才能获得别人可打开的公开链接。",
       "loadError": "无法加载这个 Show Page。",
       "addToHomeTitle": "添加到主屏幕",
-      "addToHomeBodySafari": "点此在 Safari 打开本页，再点分享 →「添加到主屏幕」。",
+      "addToHomeBodySafari": "点此处在新页面中打开，再点「分享」 →「添加到主屏幕」。",
       "addToHomeBodyPwa": "复制上方链接，在 Safari 中打开，再点分享 →「添加到主屏幕」。"
     },
     "titlePlaceholder": "会话标题",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1802,7 +1802,9 @@
       "privateDesc": "只有你能查看",
       "offlineNote": "这个 Show Page 已离线，暂时无法分享。",
       "publicUnavailable": "连接 Avibe Cloud 后才能获得别人可打开的公开链接。",
-      "loadError": "无法加载这个 Show Page。"
+      "loadError": "无法加载这个 Show Page。",
+      "addToHomeTitle": "添加到主屏幕",
+      "addToHomeBody": "在 Safari 中打开此链接，点击分享按钮 →「添加到主屏幕」，即可当作 App 使用。"
     },
     "titlePlaceholder": "会话标题",
     "pickAgent": "选择 Agent",

--- a/ui/src/lib/platform.ts
+++ b/ui/src/lib/platform.ts
@@ -27,3 +27,23 @@ export function isStandalonePwa(): boolean {
     (!!window.matchMedia && window.matchMedia('(display-mode: standalone)').matches)
   );
 }
+
+// iOS in-app webviews (IM/social apps) and alternative browsers (Chrome/Firefox
+// on iOS) can't reach Safari's "Add to Home Screen" page-share flow, so callers
+// that nudge toward it must exclude them. Real Safari carries both a "Version/<n>"
+// and a "Safari" token, which WKWebView-based in-app browsers and CriOS/FxiOS/etc.
+// lack. Shared so the InstallHint nudge and the Show Page share hint agree.
+const NON_SAFARI_IOS_UA = /CriOS|FxiOS|EdgiOS|OPiOS|mercury/i;
+const IN_APP_BROWSER_UA =
+  /MicroMessenger|FBAN|FBAV|FB_IAB|Instagram|Line\/|Twitter|WhatsApp|Snapchat|DingTalk|QQ\/|QQTheme|Slack|Discord|Feishu|Lark|; wv\)/i;
+
+export function isRealMobileSafari(): boolean {
+  if (!isIosDevice()) return false;
+  const ua = navigator.userAgent || '';
+  return (
+    /Safari/.test(ua) &&
+    /Version\//.test(ua) &&
+    !NON_SAFARI_IOS_UA.test(ua) &&
+    !IN_APP_BROWSER_UA.test(ua)
+  );
+}


### PR DESCRIPTION
## Capability
Let users add a **Show Page to the iOS Home Screen as a standalone app**, and guide them to the only flow iOS allows (no programmatic trigger exists).

## What changed
**1. Show Page `index.html` is now PWA-capable** (`core/show_pages.py`)
- Adds `apple-mobile-web-app-capable` / `mobile-web-app-capable` / status-bar style + `apple-touch-icon` + `icon`, referencing the icons the Avibe origin **already serves auth-free** (`_PWA_PUBLIC_ASSETS` in `ui_server.py`) — same-origin, so they resolve from `/show/` and `/p/`.
- **Intentionally does NOT link `/manifest.webmanifest`**: that is the workbench manifest whose `start_url` is `/`, which would hijack the installed icon back to the workbench instead of opening the page.
- **Omits `apple-mobile-web-app-title`** so a page that sets `document.title` keeps its own Home Screen name (a static title would override it).

**2. Share popover shows an iOS-only "Add to Home Screen" hint** (`ShowPageShareControl.tsx`)
- iOS exposes **no API** to trigger "Add to Home Screen", and the Web Share sheet (`navigator.share`) doesn't offer it — only Safari's own page-share menu does. So on iOS we show the steps: open the link in Safari → Share → Add to Home Screen.
- Reuses `isIosDevice()` and the `InstallHint` visual language (cyan accent, subtle bordered block). New i18n keys `chat.showPage.addToHomeTitle` / `addToHomeBody` (en + zh).

## Scope note
Only affects Show Pages **created after** this change — the scaffold skips files that already exist, matching prior scaffold-change behavior (#584). Existing pages keep their old `index.html`.

## Evidence
- **Unit**: extended `tests/test_show_pages.py::test_show_page_dir_creates_default_index` to pin the PWA tags + a guard that the workbench manifest is NOT linked (`rel="manifest"`). 30 passed.
- **Contract**: `cd ui && npm run build` green (tsc + vite, no TS errors); `ruff check` clean; en/zh JSON valid.
- **Residual manual**: real-device — on a FRESH session, open a public Show Page in iOS Safari → Share → "Add to Home Screen"; launched icon opens the page standalone (no workbench chrome) with the real app icon. Verify the popover hint renders on iOS only.