### PR TITLE
fix(workbench): trim active fork turns

### DIFF
--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -123,10 +123,7 @@ def reserve_forked_session(
             opencode_fork_empty_history = False
             if effective_trim_latest_running_turn and source_backend == "opencode":
                 fork_point = _opencode_running_fork_point(source_native)
-                if fork_point is None:
-                    effective_trim_latest_running_turn = False
-                    effective_native_turn_started = False
-                else:
+                if fork_point is not None:
                     opencode_fork_message_id, opencode_fork_empty_history = fork_point
                     effective_native_turn_started = True
             source_message_id = _latest_source_message_id(conn, str(row["id"]))

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 from config import paths
 from vibe.i18n import t
 
-TRIM_LATEST_RUNNING_TURN_BACKENDS = {"opencode"}
+TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
 
 
 class SessionForkError(ValueError):
@@ -121,13 +121,14 @@ def reserve_forked_session(
             effective_native_turn_started = bool(native_turn_started and effective_trim_latest_running_turn)
             opencode_fork_message_id: Optional[str] = None
             opencode_fork_empty_history = False
-            if effective_native_turn_started and source_backend == "opencode":
+            if effective_trim_latest_running_turn and source_backend == "opencode":
                 fork_point = _opencode_running_fork_point(source_native)
                 if fork_point is None:
                     effective_trim_latest_running_turn = False
                     effective_native_turn_started = False
                 else:
                     opencode_fork_message_id, opencode_fork_empty_history = fork_point
+                    effective_native_turn_started = True
             source_message_id = _latest_source_message_id(conn, str(row["id"]))
             override_agent = agent_store.require_enabled(agent_name) if agent_name else None
             if override_agent is not None and override_agent.backend != source_backend:

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -310,6 +310,68 @@ def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
     return str(fork.get("source_native_session_id") or "").strip() or None
 
 
+def fork_source_has_agent_output_after_anchor(fork: dict[str, Any] | None) -> bool:
+    """Whether the source has produced terminal agent output after the fork anchor."""
+
+    if not isinstance(fork, dict):
+        return False
+    source_session_id = _clean_optional(fork.get("source_session_id"))
+    source_message_id = _clean_optional(fork.get("source_message_id"))
+    if not source_session_id or not source_message_id:
+        return False
+
+    from sqlalchemy import and_, exists, select
+
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
+    from storage.models import messages
+
+    ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(paths.get_state_dir()))
+    engine = create_sqlite_engine(paths.get_sqlite_state_path())
+    try:
+        with engine.connect() as conn:
+            anchor = conn.execute(
+                select(messages.c.created_at, messages.c.id)
+                .where(messages.c.session_id == source_session_id, messages.c.id == source_message_id)
+                .limit(1)
+            ).first()
+            if anchor is None:
+                return False
+            anchor_created_at, anchor_id = anchor
+            return bool(
+                conn.execute(
+                    select(
+                        exists().where(
+                            and_(
+                                messages.c.session_id == source_session_id,
+                                messages.c.author == "agent",
+                                messages.c.type.in_(["result", "notify", "error"]),
+                                (
+                                    (messages.c.created_at > anchor_created_at)
+                                    | (
+                                        (messages.c.created_at == anchor_created_at)
+                                        & (messages.c.id > anchor_id)
+                                    )
+                                ),
+                            )
+                        )
+                    )
+                ).scalar()
+            )
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Failed to inspect fork source output for %s after %s: %s",
+            source_session_id,
+            source_message_id,
+            exc,
+        )
+        return False
+    finally:
+        engine.dispose()
+
+
 def _load_metadata(value: Any) -> dict[str, Any]:
     try:
         loaded = json.loads(value or "{}")

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -17,7 +17,8 @@ from config import paths
 from vibe.i18n import t
 
 TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
-TERMINAL_AGENT_OUTPUT_TYPES = {"result", "notify", "error"}
+TERMINAL_AGENT_OUTPUT_TYPES = {"result", "error"}
+SOURCE_PROGRESS_AGENT_OUTPUT_TYPES = {"assistant", *TERMINAL_AGENT_OUTPUT_TYPES}
 
 
 class SessionForkError(ValueError):
@@ -358,7 +359,16 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
             )
             has_messages_after_anchor = bool(
                 conn.execute(
-                    select(exists().where(and_(messages.c.session_id == source_session_id, after_anchor)))
+                    select(
+                        exists().where(
+                            and_(
+                                messages.c.session_id == source_session_id,
+                                messages.c.author == "agent",
+                                messages.c.type.in_(list(SOURCE_PROGRESS_AGENT_OUTPUT_TYPES)),
+                                after_anchor,
+                            )
+                        )
+                    )
                 ).scalar()
             )
             has_terminal_agent_output_after_anchor = bool(

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -70,6 +70,8 @@ class SessionForkResult:
 class ForkSourceState:
     anchor_author: Optional[str] = None
     anchor_type: Optional[str] = None
+    latest_after_anchor_author: Optional[str] = None
+    latest_after_anchor_type: Optional[str] = None
     has_messages_after_anchor: bool = False
     has_terminal_agent_output_after_anchor: bool = False
 
@@ -334,7 +336,7 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
     if not source_session_id or not source_message_id:
         return ForkSourceState()
 
-    from sqlalchemy import and_, exists, select
+    from sqlalchemy import select
 
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
@@ -357,38 +359,32 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
                 (messages.c.created_at > anchor_created_at)
                 | ((messages.c.created_at == anchor_created_at) & (messages.c.id > anchor_id))
             )
-            has_messages_after_anchor = bool(
-                conn.execute(
-                    select(
-                        exists().where(
-                            and_(
-                                messages.c.session_id == source_session_id,
-                                messages.c.author == "agent",
-                                messages.c.type.in_(list(SOURCE_PROGRESS_AGENT_OUTPUT_TYPES)),
-                                after_anchor,
-                            )
-                        )
-                    )
-                ).scalar()
+            latest_after_anchor = conn.execute(
+                select(messages.c.author, messages.c.type)
+                .where(
+                    messages.c.session_id == source_session_id,
+                    messages.c.type.in_(["user", *list(SOURCE_PROGRESS_AGENT_OUTPUT_TYPES)]),
+                    after_anchor,
+                )
+                .order_by(messages.c.created_at.desc(), messages.c.id.desc())
+                .limit(1)
+            ).mappings().first()
+            latest_after_anchor_author = (
+                str(latest_after_anchor["author"] or "").strip() if latest_after_anchor else ""
             )
-            has_terminal_agent_output_after_anchor = bool(
-                conn.execute(
-                    select(
-                        exists().where(
-                            and_(
-                                messages.c.session_id == source_session_id,
-                                messages.c.author == "agent",
-                                messages.c.type.in_(list(TERMINAL_AGENT_OUTPUT_TYPES)),
-                                after_anchor,
-                            )
-                        )
-                    )
-                ).scalar()
+            latest_after_anchor_type = (
+                str(latest_after_anchor["type"] or "").strip() if latest_after_anchor else ""
+            )
+            has_terminal_agent_output_after_anchor = (
+                latest_after_anchor_author == "agent"
+                and latest_after_anchor_type in TERMINAL_AGENT_OUTPUT_TYPES
             )
             return ForkSourceState(
                 anchor_author=str(anchor["author"] or "").strip() or None,
                 anchor_type=str(anchor["type"] or "").strip() or None,
-                has_messages_after_anchor=has_messages_after_anchor,
+                latest_after_anchor_author=latest_after_anchor_author or None,
+                latest_after_anchor_type=latest_after_anchor_type or None,
+                has_messages_after_anchor=latest_after_anchor is not None,
                 has_terminal_agent_output_after_anchor=has_terminal_agent_output_after_anchor,
             )
     except Exception as exc:

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -27,6 +27,8 @@ class SessionForkSpec:
     source_native_session_id: str
     source_backend: str
     source_message_id: Optional[str] = None
+    trim_latest_running_turn: bool = False
+    opencode_fork_message_id: Optional[str] = None
 
     def to_metadata(self) -> dict[str, Any]:
         metadata = {
@@ -36,6 +38,10 @@ class SessionForkSpec:
         }
         if self.source_message_id:
             metadata["source_message_id"] = self.source_message_id
+        if self.trim_latest_running_turn:
+            metadata["trim_latest_running_turn"] = True
+        if self.opencode_fork_message_id:
+            metadata["opencode_fork_message_id"] = self.opencode_fork_message_id
         return metadata
 
 
@@ -56,6 +62,7 @@ def reserve_forked_session(
     agent_name: Optional[str] = None,
     model: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    trim_latest_running_turn: bool = False,
     db_path: Optional[Path] = None,
     title_lang: str = "en",
 ) -> SessionForkResult:
@@ -100,6 +107,12 @@ def reserve_forked_session(
                     f"agent session has no native session id to fork: {source_session_id}"
                 )
             source_message_id = _latest_source_message_id(conn, str(row["id"]))
+            opencode_fork_message_id = None
+            if trim_latest_running_turn and source_backend == "opencode":
+                opencode_fork_message_id = _opencode_fork_message_before_latest_user(
+                    conn,
+                    str(row["id"]),
+                )
 
             override_agent = agent_store.require_enabled(agent_name) if agent_name else None
             if override_agent is not None and override_agent.backend != source_backend:
@@ -131,9 +144,12 @@ def reserve_forked_session(
                     "fork_source_message_id": source_message_id,
                     "fork_source_native_session_id": source_native,
                     "fork_source_backend": source_backend,
+                    "fork_trim_latest_running_turn": bool(trim_latest_running_turn),
                     "fork_created_at": now,
                 }
             )
+            if opencode_fork_message_id:
+                metadata["fork_opencode_message_id"] = opencode_fork_message_id
             session_id = create_agent_session_row(
                 conn,
                 scope_id=row["scope_id"],
@@ -160,6 +176,8 @@ def reserve_forked_session(
             source_native_session_id=source_native,
             source_backend=source_backend,
             source_message_id=source_message_id,
+            trim_latest_running_turn=bool(trim_latest_running_turn),
+            opencode_fork_message_id=opencode_fork_message_id,
         )
         return SessionForkResult(
             session_id=session_id,
@@ -188,11 +206,20 @@ def fork_metadata_from_request(metadata: dict[str, Any] | None) -> dict[str, Any
     source_session = _clean_optional(fork.get("source_session_id"))
     if not (source_backend and source_native and source_session):
         return None
-    return {
+    result = {
         "source_session_id": source_session,
         "source_native_session_id": source_native,
         "source_backend": source_backend,
     }
+    if bool(fork.get("trim_latest_running_turn")):
+        result["trim_latest_running_turn"] = True
+    source_message = _clean_optional(fork.get("source_message_id"))
+    if source_message:
+        result["source_message_id"] = source_message
+    opencode_message = _clean_optional(fork.get("opencode_fork_message_id"))
+    if opencode_message:
+        result["opencode_fork_message_id"] = opencode_message
+    return result
 
 
 def fork_metadata_from_session_metadata(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -205,15 +232,24 @@ def fork_metadata_from_session_metadata(metadata: dict[str, Any] | None) -> dict
     source_session = _clean_optional(metadata.get("fork_source_session_id"))
     if not (source_backend and source_native and source_session):
         return None
-    return {
+    result = {
         "source_session_id": source_session,
         "source_native_session_id": source_native,
         "source_backend": source_backend,
     }
+    if bool(metadata.get("fork_trim_latest_running_turn")):
+        result["trim_latest_running_turn"] = True
+    source_message = _clean_optional(metadata.get("fork_source_message_id"))
+    if source_message:
+        result["source_message_id"] = source_message
+    opencode_message = _clean_optional(metadata.get("fork_opencode_message_id"))
+    if opencode_message:
+        result["opencode_fork_message_id"] = opencode_message
+    return result
 
 
-def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
-    """Native source id if this turn should fork instead of start fresh."""
+def pending_native_fork(context: Any, backend: str) -> Optional[dict[str, Any]]:
+    """Native fork spec if this turn should fork instead of start fresh."""
 
     payload = getattr(context, "platform_specific", None) or {}
     target = payload.get("agent_session_target")
@@ -232,7 +268,18 @@ def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
     if str(fork.get("source_backend") or "").strip() != backend:
         return None
     source_native = str(fork.get("source_native_session_id") or "").strip()
-    return source_native or None
+    if not source_native:
+        return None
+    return {**fork, "source_native_session_id": source_native}
+
+
+def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
+    """Native source id if this turn should fork instead of start fresh."""
+
+    fork = pending_native_fork(context, backend)
+    if not fork:
+        return None
+    return str(fork.get("source_native_session_id") or "").strip() or None
 
 
 def _load_metadata(value: Any) -> dict[str, Any]:
@@ -273,6 +320,47 @@ def _latest_source_message_id(conn: Any, source_session_id: str) -> Optional[str
         .limit(1)
     ).scalar_one_or_none()
     return str(row) if row else None
+
+
+def _opencode_fork_message_before_latest_user(conn: Any, source_session_id: str) -> Optional[str]:
+    """Native OpenCode message id immediately before the latest user turn.
+
+    OpenCode forks at a native message point. For a running source turn, the
+    latest user message is the prompt currently being answered, so the safe fork
+    point is the visible native message before it. If Avibe has no native id for
+    that previous point, the adapter will fall back to a full native fork.
+    """
+
+    from sqlalchemy import func, or_, select
+
+    from storage.messages_service import TRANSCRIPT_TYPES
+    from storage.models import messages
+
+    rows = (
+        conn.execute(
+            select(messages.c.author, messages.c.native_message_id)
+            .where(
+                messages.c.session_id == source_session_id,
+                or_(
+                    messages.c.type.in_(list(TRANSCRIPT_TYPES)),
+                    func.json_extract(messages.c.metadata_json, "$.source") == "show_page",
+                ),
+            )
+            .order_by(messages.c.created_at.desc(), messages.c.id.desc())
+            .limit(20)
+        )
+        .mappings()
+        .all()
+    )
+    for index, row in enumerate(rows):
+        if str(row["author"] or "").strip() != "user":
+            continue
+        for previous in rows[index + 1 :]:
+            native = _clean_optional(previous["native_message_id"])
+            if native:
+                return native
+        return None
+    return None
 
 
 def _fork_session_anchor(value: Any, *, source_session_id: str, now: str) -> Optional[str]:

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -16,6 +16,8 @@ from typing import Any, Optional
 from config import paths
 from vibe.i18n import t
 
+TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
+
 
 class SessionForkError(ValueError):
     """Raised when a Session cannot be forked."""
@@ -107,6 +109,10 @@ def reserve_forked_session(
                 raise SessionForkError(
                     f"agent session has no native session id to fork: {source_session_id}"
                 )
+            effective_trim_latest_running_turn = bool(
+                trim_latest_running_turn and source_backend in TRIM_LATEST_RUNNING_TURN_BACKENDS
+            )
+            effective_native_turn_started = bool(native_turn_started and effective_trim_latest_running_turn)
             source_message_id = _latest_source_message_id(conn, str(row["id"]))
             override_agent = agent_store.require_enabled(agent_name) if agent_name else None
             if override_agent is not None and override_agent.backend != source_backend:
@@ -139,8 +145,8 @@ def reserve_forked_session(
                     "fork_source_message_id": source_message_id,
                     "fork_source_native_session_id": source_native,
                     "fork_source_backend": source_backend,
-                    "fork_trim_latest_running_turn": bool(trim_latest_running_turn),
-                    "fork_native_turn_started": bool(native_turn_started),
+                    "fork_trim_latest_running_turn": effective_trim_latest_running_turn,
+                    "fork_native_turn_started": effective_native_turn_started,
                     "fork_created_at": now,
                 }
             )
@@ -170,8 +176,8 @@ def reserve_forked_session(
             source_native_session_id=source_native,
             source_backend=source_backend,
             source_message_id=source_message_id,
-            trim_latest_running_turn=bool(trim_latest_running_turn),
-            native_turn_started=bool(native_turn_started),
+            trim_latest_running_turn=effective_trim_latest_running_turn,
+            native_turn_started=effective_native_turn_started,
         )
         return SessionForkResult(
             session_id=session_id,

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -17,6 +17,7 @@ from config import paths
 from vibe.i18n import t
 
 TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
+TERMINAL_AGENT_OUTPUT_TYPES = {"result", "notify", "error"}
 
 
 class SessionForkError(ValueError):
@@ -62,6 +63,18 @@ class SessionForkResult:
     model: Optional[str]
     reasoning_effort: Optional[str]
     fork: SessionForkSpec
+
+
+@dataclass(frozen=True)
+class ForkSourceState:
+    anchor_author: Optional[str] = None
+    anchor_type: Optional[str] = None
+    has_messages_after_anchor: bool = False
+    has_terminal_agent_output_after_anchor: bool = False
+
+    @property
+    def anchor_is_terminal_agent_output(self) -> bool:
+        return self.anchor_author == "agent" and self.anchor_type in TERMINAL_AGENT_OUTPUT_TYPES
 
 
 def reserve_forked_session(
@@ -310,15 +323,15 @@ def pending_native_fork_source(context: Any, backend: str) -> Optional[str]:
     return str(fork.get("source_native_session_id") or "").strip() or None
 
 
-def fork_source_has_agent_output_after_anchor(fork: dict[str, Any] | None) -> bool:
-    """Whether the source has produced terminal agent output after the fork anchor."""
+def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
+    """Return source transcript state relative to the fork reservation anchor."""
 
     if not isinstance(fork, dict):
-        return False
+        return ForkSourceState()
     source_session_id = _clean_optional(fork.get("source_session_id"))
     source_message_id = _clean_optional(fork.get("source_message_id"))
     if not source_session_id or not source_message_id:
-        return False
+        return ForkSourceState()
 
     from sqlalchemy import and_, exists, select
 
@@ -331,45 +344,67 @@ def fork_source_has_agent_output_after_anchor(fork: dict[str, Any] | None) -> bo
     try:
         with engine.connect() as conn:
             anchor = conn.execute(
-                select(messages.c.created_at, messages.c.id)
+                select(messages.c.created_at, messages.c.id, messages.c.author, messages.c.type)
                 .where(messages.c.session_id == source_session_id, messages.c.id == source_message_id)
                 .limit(1)
-            ).first()
+            ).mappings().first()
             if anchor is None:
-                return False
-            anchor_created_at, anchor_id = anchor
-            return bool(
+                return ForkSourceState()
+            anchor_created_at = anchor["created_at"]
+            anchor_id = anchor["id"]
+            after_anchor = (
+                (messages.c.created_at > anchor_created_at)
+                | ((messages.c.created_at == anchor_created_at) & (messages.c.id > anchor_id))
+            )
+            has_messages_after_anchor = bool(
+                conn.execute(
+                    select(exists().where(and_(messages.c.session_id == source_session_id, after_anchor)))
+                ).scalar()
+            )
+            has_terminal_agent_output_after_anchor = bool(
                 conn.execute(
                     select(
                         exists().where(
                             and_(
                                 messages.c.session_id == source_session_id,
                                 messages.c.author == "agent",
-                                messages.c.type.in_(["result", "notify", "error"]),
-                                (
-                                    (messages.c.created_at > anchor_created_at)
-                                    | (
-                                        (messages.c.created_at == anchor_created_at)
-                                        & (messages.c.id > anchor_id)
-                                    )
-                                ),
+                                messages.c.type.in_(list(TERMINAL_AGENT_OUTPUT_TYPES)),
+                                after_anchor,
                             )
                         )
                     )
                 ).scalar()
             )
+            return ForkSourceState(
+                anchor_author=str(anchor["author"] or "").strip() or None,
+                anchor_type=str(anchor["type"] or "").strip() or None,
+                has_messages_after_anchor=has_messages_after_anchor,
+                has_terminal_agent_output_after_anchor=has_terminal_agent_output_after_anchor,
+            )
     except Exception as exc:
         import logging
 
         logging.getLogger(__name__).warning(
-            "Failed to inspect fork source output for %s after %s: %s",
+            "Failed to inspect fork source state for %s after %s: %s",
             source_session_id,
             source_message_id,
             exc,
         )
-        return False
+        return ForkSourceState()
     finally:
         engine.dispose()
+
+
+def fork_source_has_agent_output_after_anchor(fork: dict[str, Any] | None) -> bool:
+    """Whether the source produced terminal agent output after the fork anchor."""
+
+    return fork_source_state(fork).has_terminal_agent_output_after_anchor
+
+
+def fork_anchor_is_terminal_agent_output(fork: dict[str, Any] | None) -> bool:
+    """Whether the reservation anchor already points at a completed agent row."""
+
+    return fork_source_state(fork).anchor_is_terminal_agent_output
 
 
 def _load_metadata(value: Any) -> dict[str, Any]:

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 from config import paths
 from vibe.i18n import t
 
-TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
+TRIM_LATEST_RUNNING_TURN_BACKENDS = {"opencode"}
 
 
 class SessionForkError(ValueError):
@@ -31,6 +31,8 @@ class SessionForkSpec:
     source_message_id: Optional[str] = None
     trim_latest_running_turn: bool = False
     native_turn_started: bool = False
+    opencode_fork_message_id: Optional[str] = None
+    opencode_fork_empty_history: bool = False
 
     def to_metadata(self) -> dict[str, Any]:
         metadata = {
@@ -44,6 +46,10 @@ class SessionForkSpec:
             metadata["trim_latest_running_turn"] = True
         if self.native_turn_started:
             metadata["native_turn_started"] = True
+        if self.opencode_fork_message_id:
+            metadata["opencode_fork_message_id"] = self.opencode_fork_message_id
+        if self.opencode_fork_empty_history:
+            metadata["opencode_fork_empty_history"] = True
         return metadata
 
 
@@ -113,6 +119,15 @@ def reserve_forked_session(
                 trim_latest_running_turn and source_backend in TRIM_LATEST_RUNNING_TURN_BACKENDS
             )
             effective_native_turn_started = bool(native_turn_started and effective_trim_latest_running_turn)
+            opencode_fork_message_id: Optional[str] = None
+            opencode_fork_empty_history = False
+            if effective_native_turn_started and source_backend == "opencode":
+                fork_point = _opencode_running_fork_point(source_native)
+                if fork_point is None:
+                    effective_trim_latest_running_turn = False
+                    effective_native_turn_started = False
+                else:
+                    opencode_fork_message_id, opencode_fork_empty_history = fork_point
             source_message_id = _latest_source_message_id(conn, str(row["id"]))
             override_agent = agent_store.require_enabled(agent_name) if agent_name else None
             if override_agent is not None and override_agent.backend != source_backend:
@@ -137,6 +152,7 @@ def reserve_forked_session(
 
             metadata = _load_metadata(row["metadata_json"])
             metadata.pop("fork_opencode_message_id", None)
+            metadata.pop("fork_opencode_fork_empty_history", None)
             metadata.update(
                 {
                     "created_via": "session_fork",
@@ -150,6 +166,10 @@ def reserve_forked_session(
                     "fork_created_at": now,
                 }
             )
+            if opencode_fork_message_id:
+                metadata["fork_opencode_message_id"] = opencode_fork_message_id
+            if opencode_fork_empty_history:
+                metadata["fork_opencode_fork_empty_history"] = True
             session_id = create_agent_session_row(
                 conn,
                 scope_id=row["scope_id"],
@@ -178,6 +198,8 @@ def reserve_forked_session(
             source_message_id=source_message_id,
             trim_latest_running_turn=effective_trim_latest_running_turn,
             native_turn_started=effective_native_turn_started,
+            opencode_fork_message_id=opencode_fork_message_id,
+            opencode_fork_empty_history=opencode_fork_empty_history,
         )
         return SessionForkResult(
             session_id=session_id,
@@ -215,6 +237,11 @@ def fork_metadata_from_request(metadata: dict[str, Any] | None) -> dict[str, Any
         result["trim_latest_running_turn"] = True
     if bool(fork.get("native_turn_started")):
         result["native_turn_started"] = True
+    opencode_message = _clean_optional(fork.get("opencode_fork_message_id"))
+    if opencode_message:
+        result["opencode_fork_message_id"] = opencode_message
+    if bool(fork.get("opencode_fork_empty_history")):
+        result["opencode_fork_empty_history"] = True
     source_message = _clean_optional(fork.get("source_message_id"))
     if source_message:
         result["source_message_id"] = source_message
@@ -240,6 +267,11 @@ def fork_metadata_from_session_metadata(metadata: dict[str, Any] | None) -> dict
         result["trim_latest_running_turn"] = True
     if bool(metadata.get("fork_native_turn_started")):
         result["native_turn_started"] = True
+    opencode_message = _clean_optional(metadata.get("fork_opencode_message_id"))
+    if opencode_message:
+        result["opencode_fork_message_id"] = opencode_message
+    if bool(metadata.get("fork_opencode_fork_empty_history")):
+        result["opencode_fork_empty_history"] = True
     source_message = _clean_optional(metadata.get("fork_source_message_id"))
     if source_message:
         result["source_message_id"] = source_message
@@ -318,6 +350,15 @@ def _latest_source_message_id(conn: Any, source_session_id: str) -> Optional[str
         .limit(1)
     ).scalar_one_or_none()
     return str(row) if row else None
+
+
+def _opencode_running_fork_point(source_native_session_id: str) -> Optional[tuple[Optional[str], bool]]:
+    from modules.agents.native_sessions.opencode import OpenCodeNativeSessionProvider
+
+    point = OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(source_native_session_id)
+    if not point.available:
+        return None
+    return point.message_id, point.empty_history
 
 
 def _fork_session_anchor(value: Any, *, source_session_id: str, now: str) -> Optional[str]:

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -28,7 +28,7 @@ class SessionForkSpec:
     source_backend: str
     source_message_id: Optional[str] = None
     trim_latest_running_turn: bool = False
-    opencode_fork_message_id: Optional[str] = None
+    native_turn_started: bool = False
 
     def to_metadata(self) -> dict[str, Any]:
         metadata = {
@@ -40,8 +40,8 @@ class SessionForkSpec:
             metadata["source_message_id"] = self.source_message_id
         if self.trim_latest_running_turn:
             metadata["trim_latest_running_turn"] = True
-        if self.opencode_fork_message_id:
-            metadata["opencode_fork_message_id"] = self.opencode_fork_message_id
+        if self.native_turn_started:
+            metadata["native_turn_started"] = True
         return metadata
 
 
@@ -63,6 +63,7 @@ def reserve_forked_session(
     model: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     trim_latest_running_turn: bool = False,
+    native_turn_started: bool = False,
     db_path: Optional[Path] = None,
     title_lang: str = "en",
 ) -> SessionForkResult:
@@ -107,13 +108,6 @@ def reserve_forked_session(
                     f"agent session has no native session id to fork: {source_session_id}"
                 )
             source_message_id = _latest_source_message_id(conn, str(row["id"]))
-            opencode_fork_message_id = None
-            if trim_latest_running_turn and source_backend == "opencode":
-                opencode_fork_message_id = _opencode_fork_message_before_latest_user(
-                    conn,
-                    str(row["id"]),
-                )
-
             override_agent = agent_store.require_enabled(agent_name) if agent_name else None
             if override_agent is not None and override_agent.backend != source_backend:
                 raise SessionForkError(
@@ -136,6 +130,7 @@ def reserve_forked_session(
             target_title = _forked_session_title(source_title, title_lang)
 
             metadata = _load_metadata(row["metadata_json"])
+            metadata.pop("fork_opencode_message_id", None)
             metadata.update(
                 {
                     "created_via": "session_fork",
@@ -145,11 +140,10 @@ def reserve_forked_session(
                     "fork_source_native_session_id": source_native,
                     "fork_source_backend": source_backend,
                     "fork_trim_latest_running_turn": bool(trim_latest_running_turn),
+                    "fork_native_turn_started": bool(native_turn_started),
                     "fork_created_at": now,
                 }
             )
-            if opencode_fork_message_id:
-                metadata["fork_opencode_message_id"] = opencode_fork_message_id
             session_id = create_agent_session_row(
                 conn,
                 scope_id=row["scope_id"],
@@ -177,7 +171,7 @@ def reserve_forked_session(
             source_backend=source_backend,
             source_message_id=source_message_id,
             trim_latest_running_turn=bool(trim_latest_running_turn),
-            opencode_fork_message_id=opencode_fork_message_id,
+            native_turn_started=bool(native_turn_started),
         )
         return SessionForkResult(
             session_id=session_id,
@@ -213,12 +207,11 @@ def fork_metadata_from_request(metadata: dict[str, Any] | None) -> dict[str, Any
     }
     if bool(fork.get("trim_latest_running_turn")):
         result["trim_latest_running_turn"] = True
+    if bool(fork.get("native_turn_started")):
+        result["native_turn_started"] = True
     source_message = _clean_optional(fork.get("source_message_id"))
     if source_message:
         result["source_message_id"] = source_message
-    opencode_message = _clean_optional(fork.get("opencode_fork_message_id"))
-    if opencode_message:
-        result["opencode_fork_message_id"] = opencode_message
     return result
 
 
@@ -239,12 +232,11 @@ def fork_metadata_from_session_metadata(metadata: dict[str, Any] | None) -> dict
     }
     if bool(metadata.get("fork_trim_latest_running_turn")):
         result["trim_latest_running_turn"] = True
+    if bool(metadata.get("fork_native_turn_started")):
+        result["native_turn_started"] = True
     source_message = _clean_optional(metadata.get("fork_source_message_id"))
     if source_message:
         result["source_message_id"] = source_message
-    opencode_message = _clean_optional(metadata.get("fork_opencode_message_id"))
-    if opencode_message:
-        result["opencode_fork_message_id"] = opencode_message
     return result
 
 
@@ -320,47 +312,6 @@ def _latest_source_message_id(conn: Any, source_session_id: str) -> Optional[str
         .limit(1)
     ).scalar_one_or_none()
     return str(row) if row else None
-
-
-def _opencode_fork_message_before_latest_user(conn: Any, source_session_id: str) -> Optional[str]:
-    """Native OpenCode message id immediately before the latest user turn.
-
-    OpenCode forks at a native message point. For a running source turn, the
-    latest user message is the prompt currently being answered, so the safe fork
-    point is the visible native message before it. If Avibe has no native id for
-    that previous point, the adapter will fall back to a full native fork.
-    """
-
-    from sqlalchemy import func, or_, select
-
-    from storage.messages_service import TRANSCRIPT_TYPES
-    from storage.models import messages
-
-    rows = (
-        conn.execute(
-            select(messages.c.author, messages.c.native_message_id)
-            .where(
-                messages.c.session_id == source_session_id,
-                or_(
-                    messages.c.type.in_(list(TRANSCRIPT_TYPES)),
-                    func.json_extract(messages.c.metadata_json, "$.source") == "show_page",
-                ),
-            )
-            .order_by(messages.c.created_at.desc(), messages.c.id.desc())
-            .limit(20)
-        )
-        .mappings()
-        .all()
-    )
-    for index, row in enumerate(rows):
-        if str(row["author"] or "").strip() != "user":
-            continue
-        for previous in rows[index + 1 :]:
-            native = _clean_optional(previous["native_message_id"])
-            if native:
-                return native
-        return None
-    return None
 
 
 def _fork_session_anchor(value: Any, *, source_session_id: str, now: str) -> Optional[str]:

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -489,7 +489,26 @@ class SessionTurnManager:
         Chat page asks this to restore its working / Stop state (Codex P2)."""
         entry = self.in_flight.get(session_id)
         active = entry is not None and not entry.task.done()
-        return {"ok": True, "session_id": session_id, "in_flight": active}
+        native_turn_started = False
+        backend = ""
+        if active and entry is not None:
+            payload = getattr(entry.context, "platform_specific", None) or {}
+            target = payload.get("agent_session_target")
+            if isinstance(target, dict):
+                backend = str(target.get("agent_backend") or "").strip()
+            service = getattr(self.controller, "agent_service", None) if self.controller is not None else None
+            started = getattr(service, "runtime_turn_started", None)
+            if callable(started):
+                native_turn_started = started(entry.context) is True
+        result = {
+            "ok": True,
+            "session_id": session_id,
+            "in_flight": active,
+            "native_turn_started": native_turn_started,
+        }
+        if backend:
+            result["backend"] = backend
+        return result
 
     async def release_for_backend_refresh(
         self,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -769,7 +769,7 @@ class CodexAgent(BaseAgent):
             if not thread_id:
                 raise RuntimeError("Codex thread/fork returned no thread id")
 
-            should_trim = self._should_rollback_forked_running_turn(fork)
+            should_trim = await self._should_rollback_forked_running_turn(fork)
             if should_trim:
                 await self._rollback_forked_running_turn(transport, thread_id)
             await self._inject_forked_session_correction(transport, request, thread_id)
@@ -781,7 +781,7 @@ class CodexAgent(BaseAgent):
         logger.info("Forked Codex thread %s from %s for session %s", thread_id, source_thread_id, request.base_session_id)
         return thread_id
 
-    def _should_rollback_forked_running_turn(self, fork: dict[str, Any]) -> bool:
+    async def _should_rollback_forked_running_turn(self, fork: dict[str, Any]) -> bool:
         """Rollback only when Codex's latest-turn rollback still targets the reserved turn."""
 
         if not bool(fork.get("trim_latest_running_turn")):
@@ -791,7 +791,22 @@ class CodexAgent(BaseAgent):
             return False
         if source_state.has_messages_after_anchor:
             return not source_state.has_terminal_agent_output_after_anchor
-        return bool(fork.get("native_turn_started"))
+        if bool(fork.get("native_turn_started")):
+            return True
+        return await self._fork_source_turn_now_started(fork)
+
+    async def _fork_source_turn_now_started(self, fork: dict[str, Any]) -> bool:
+        source_session_id = str(fork.get("source_session_id") or "").strip()
+        if not source_session_id:
+            return False
+        from vibe import internal_client
+
+        try:
+            turn_result = await internal_client.turn_state(source_session_id)
+        except (internal_client.InternalServerTimeout, internal_client.InternalServerUnavailable):
+            return False
+        body = turn_result.get("body") or {}
+        return bool(body.get("in_flight") and body.get("native_turn_started"))
 
     async def _rollback_forked_running_turn(
         self,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -14,7 +14,7 @@ from config.v2_config import (
     DEFAULT_CODEX_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER,
 )
 from core.avibe_cloud import avibe_cloud_url_available
-from core.services.session_fork import fork_source_has_agent_output_after_anchor, pending_native_fork
+from core.services.session_fork import fork_source_state, pending_native_fork
 from core.system_prompt_injection import (
     build_forked_session_correction_prompt,
     build_system_prompt_injection,
@@ -769,9 +769,7 @@ class CodexAgent(BaseAgent):
             if not thread_id:
                 raise RuntimeError("Codex thread/fork returned no thread id")
 
-            should_trim = bool(fork.get("trim_latest_running_turn")) and (
-                bool(fork.get("native_turn_started")) or fork_source_has_agent_output_after_anchor(fork)
-            )
+            should_trim = self._should_rollback_forked_running_turn(fork)
             if should_trim:
                 await self._rollback_forked_running_turn(transport, thread_id)
             await self._inject_forked_session_correction(transport, request, thread_id)
@@ -782,6 +780,18 @@ class CodexAgent(BaseAgent):
         self._remember_thread_developer_instructions(request.base_session_id, thread_id, developer_instructions)
         logger.info("Forked Codex thread %s from %s for session %s", thread_id, source_thread_id, request.base_session_id)
         return thread_id
+
+    def _should_rollback_forked_running_turn(self, fork: dict[str, Any]) -> bool:
+        """Rollback only when Codex's latest-turn rollback still targets the reserved turn."""
+
+        if not bool(fork.get("trim_latest_running_turn")):
+            return False
+        source_state = fork_source_state(fork)
+        if source_state.anchor_is_terminal_agent_output:
+            return False
+        if source_state.has_messages_after_anchor:
+            return not source_state.has_terminal_agent_output_after_anchor
+        return bool(fork.get("native_turn_started"))
 
     async def _rollback_forked_running_turn(
         self,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -769,7 +769,7 @@ class CodexAgent(BaseAgent):
             if not thread_id:
                 raise RuntimeError("Codex thread/fork returned no thread id")
 
-            if bool(fork.get("trim_latest_running_turn")):
+            if bool(fork.get("trim_latest_running_turn")) and bool(fork.get("native_turn_started")):
                 await self._rollback_forked_running_turn(transport, thread_id)
             await self._inject_forked_session_correction(transport, request, thread_id)
         finally:

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -769,7 +769,7 @@ class CodexAgent(BaseAgent):
             if not thread_id:
                 raise RuntimeError("Codex thread/fork returned no thread id")
 
-            if bool(fork.get("trim_latest_running_turn")) and bool(fork.get("native_turn_started")):
+            if bool(fork.get("trim_latest_running_turn")):
                 await self._rollback_forked_running_turn(transport, thread_id)
             await self._inject_forked_session_correction(transport, request, thread_id)
         finally:

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -14,7 +14,7 @@ from config.v2_config import (
     DEFAULT_CODEX_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER,
 )
 from core.avibe_cloud import avibe_cloud_url_available
-from core.services.session_fork import pending_native_fork_source
+from core.services.session_fork import pending_native_fork
 from core.system_prompt_injection import (
     build_forked_session_correction_prompt,
     build_system_prompt_injection,
@@ -740,11 +740,12 @@ class CodexAgent(BaseAgent):
         self,
         transport: CodexTransport,
         request: AgentRequest,
-        source_thread_id: str,
+        fork: dict[str, Any],
     ) -> str:
         """Fork an existing Codex thread and bind the new thread id."""
         self.ensure_agent_session_id(request)
         _, effective_model, _, _ = self._resolve_codex_agent_settings(request)
+        source_thread_id = str(fork.get("source_native_session_id") or "").strip()
         params: Dict[str, Any] = {
             "threadId": source_thread_id,
             "cwd": request.working_path,
@@ -768,6 +769,8 @@ class CodexAgent(BaseAgent):
             if not thread_id:
                 raise RuntimeError("Codex thread/fork returned no thread id")
 
+            if bool(fork.get("trim_latest_running_turn")):
+                await self._rollback_forked_running_turn(transport, thread_id)
             await self._inject_forked_session_correction(transport, request, thread_id)
         finally:
             self._clear_fork_correction_pending(request.base_session_id)
@@ -776,6 +779,21 @@ class CodexAgent(BaseAgent):
         self._remember_thread_developer_instructions(request.base_session_id, thread_id, developer_instructions)
         logger.info("Forked Codex thread %s from %s for session %s", thread_id, source_thread_id, request.base_session_id)
         return thread_id
+
+    async def _rollback_forked_running_turn(
+        self,
+        transport: CodexTransport,
+        thread_id: str,
+    ) -> None:
+        """Remove the source's still-running latest turn from a forked thread."""
+
+        await transport.send_request(
+            "thread/rollback",
+            {
+                "threadId": thread_id,
+                "numTurns": 1,
+            },
+        )
 
     def _resolve_codex_agent_settings(
         self,
@@ -896,9 +914,9 @@ class CodexAgent(BaseAgent):
             logger.info("Resumed Codex thread %s for session %s", thread_id, request.base_session_id)
             return thread_id
 
-        fork_source = pending_native_fork_source(request.context, self.name)
-        if fork_source:
-            return await self._fork_thread(transport, request, fork_source)
+        fork = pending_native_fork(request.context, self.name)
+        if fork:
+            return await self._fork_thread(transport, request, fork)
 
         # No associated thread yet (genuinely first turn) — start fresh.
         return await self._start_thread(transport, request)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -760,6 +760,7 @@ class CodexAgent(BaseAgent):
 
         self._mark_fork_correction_pending(request.base_session_id)
         try:
+            should_trim = await self._should_rollback_forked_running_turn(fork)
             resp = await transport.send_request("thread/fork", params)
             thread_id = resp.get("id", "")
             if not thread_id:
@@ -769,7 +770,6 @@ class CodexAgent(BaseAgent):
             if not thread_id:
                 raise RuntimeError("Codex thread/fork returned no thread id")
 
-            should_trim = await self._should_rollback_forked_running_turn(fork)
             if should_trim:
                 await self._rollback_forked_running_turn(transport, thread_id)
             await self._inject_forked_session_correction(transport, request, thread_id)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -14,7 +14,7 @@ from config.v2_config import (
     DEFAULT_CODEX_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER,
 )
 from core.avibe_cloud import avibe_cloud_url_available
-from core.services.session_fork import pending_native_fork
+from core.services.session_fork import fork_source_has_agent_output_after_anchor, pending_native_fork
 from core.system_prompt_injection import (
     build_forked_session_correction_prompt,
     build_system_prompt_injection,
@@ -769,7 +769,10 @@ class CodexAgent(BaseAgent):
             if not thread_id:
                 raise RuntimeError("Codex thread/fork returned no thread id")
 
-            if bool(fork.get("trim_latest_running_turn")):
+            should_trim = bool(fork.get("trim_latest_running_turn")) and (
+                bool(fork.get("native_turn_started")) or fork_source_has_agent_output_after_anchor(fork)
+            )
+            if should_trim:
                 await self._rollback_forked_running_turn(transport, thread_id)
             await self._inject_forked_session_correction(transport, request, thread_id)
         finally:

--- a/modules/agents/native_sessions/opencode.py
+++ b/modules/agents/native_sessions/opencode.py
@@ -122,23 +122,30 @@ class OpenCodeNativeSessionProvider(NativeSessionProvider):
                     (native_session_id,),
                 )
                 messages = [
-                    (str(message_id or "").strip(), parse_json_blob(message_blob).get("role"))
+                    (str(message_id or "").strip(), parse_json_blob(message_blob))
                     for message_id, message_blob, _first_seen in cursor.fetchall()
                 ]
         except Exception as exc:
             logger.warning("Failed to read OpenCode fork point for %s: %s", native_session_id, exc)
             return OpenCodeForkPoint(available=False)
 
-        for index in range(len(messages) - 1, -1, -1):
-            message_id, role = messages[index]
-            if role != "user":
-                continue
-            if index == 0:
-                return OpenCodeForkPoint(available=True, empty_history=True)
-            previous_id = messages[index - 1][0]
-            if previous_id:
-                return OpenCodeForkPoint(available=True, message_id=previous_id)
+        if not messages:
             return OpenCodeForkPoint(available=False)
+        last_message_id, last_message = messages[-1]
+        last_role = last_message.get("role")
+        if last_role == "user":
+            if last_message_id:
+                return OpenCodeForkPoint(available=True, message_id=last_message_id)
+            return OpenCodeForkPoint(available=False)
+        if last_role == "assistant":
+            time_info = last_message.get("time") or {}
+            if time_info.get("completed"):
+                return OpenCodeForkPoint(available=False)
+            for message_id, message in reversed(messages[:-1]):
+                if message.get("role") == "user":
+                    if message_id:
+                        return OpenCodeForkPoint(available=True, message_id=message_id)
+                    return OpenCodeForkPoint(available=False)
         return OpenCodeForkPoint(available=False)
 
     @classmethod

--- a/modules/agents/native_sessions/opencode.py
+++ b/modules/agents/native_sessions/opencode.py
@@ -144,7 +144,12 @@ class OpenCodeNativeSessionProvider(NativeSessionProvider):
             return OpenCodeForkPoint(available=False)
         if last_role == "assistant":
             time_info = last_message.get("time") or {}
-            if time_info.get("completed") and not include_completed_assistant_tail:
+            finish_reason = last_message.get("finish")
+            if (
+                time_info.get("completed")
+                and finish_reason != "tool-calls"
+                and not include_completed_assistant_tail
+            ):
                 return OpenCodeForkPoint(available=False)
             for message_id, message in reversed(messages[:-1]):
                 if message.get("role") == "user":

--- a/modules/agents/native_sessions/opencode.py
+++ b/modules/agents/native_sessions/opencode.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 import logging
 import os
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 
 from .base import NativeSessionProvider, build_tail_preview, dt_from_ts, normalize_title_text, parse_json_blob
 from .types import BackendSessionTitle, NativeResumeSession
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OpenCodeForkPoint:
+    available: bool
+    message_id: str | None = None
+    empty_history: bool = False
 
 
 class OpenCodeNativeSessionProvider(NativeSessionProvider):
@@ -94,6 +102,44 @@ class OpenCodeNativeSessionProvider(NativeSessionProvider):
         fallback = str(item.locator.get("title") or item.native_session_id)
         item.last_agent_tail = build_tail_preview(preview or fallback)
         return item
+
+    def running_fork_point_before_latest_user(self, native_session_id: str) -> OpenCodeForkPoint:
+        """Return the immutable fork point that excludes the latest user turn."""
+
+        if not self.db_path.exists():
+            return OpenCodeForkPoint(available=False)
+        try:
+            with self._connect() as conn:
+                cursor = conn.execute(
+                    """
+                    SELECT m.id, m.data, MIN(p.time_created) AS first_seen
+                    FROM part p
+                    JOIN message m ON m.id = p.message_id
+                    WHERE p.session_id = ?
+                    GROUP BY m.id, m.data
+                    ORDER BY first_seen ASC, m.id ASC
+                    """,
+                    (native_session_id,),
+                )
+                messages = [
+                    (str(message_id or "").strip(), parse_json_blob(message_blob).get("role"))
+                    for message_id, message_blob, _first_seen in cursor.fetchall()
+                ]
+        except Exception as exc:
+            logger.warning("Failed to read OpenCode fork point for %s: %s", native_session_id, exc)
+            return OpenCodeForkPoint(available=False)
+
+        for index in range(len(messages) - 1, -1, -1):
+            message_id, role = messages[index]
+            if role != "user":
+                continue
+            if index == 0:
+                return OpenCodeForkPoint(available=True, empty_history=True)
+            previous_id = messages[index - 1][0]
+            if previous_id:
+                return OpenCodeForkPoint(available=True, message_id=previous_id)
+            return OpenCodeForkPoint(available=False)
+        return OpenCodeForkPoint(available=False)
 
     @classmethod
     def is_ignored_title(cls, title: str) -> bool:

--- a/modules/agents/native_sessions/opencode.py
+++ b/modules/agents/native_sessions/opencode.py
@@ -103,7 +103,12 @@ class OpenCodeNativeSessionProvider(NativeSessionProvider):
         item.last_agent_tail = build_tail_preview(preview or fallback)
         return item
 
-    def running_fork_point_before_latest_user(self, native_session_id: str) -> OpenCodeForkPoint:
+    def running_fork_point_before_latest_user(
+        self,
+        native_session_id: str,
+        *,
+        include_completed_assistant_tail: bool = False,
+    ) -> OpenCodeForkPoint:
         """Return the immutable fork point that excludes the latest user turn."""
 
         if not self.db_path.exists():
@@ -139,7 +144,7 @@ class OpenCodeNativeSessionProvider(NativeSessionProvider):
             return OpenCodeForkPoint(available=False)
         if last_role == "assistant":
             time_info = last_message.get("time") or {}
-            if time_info.get("completed"):
+            if time_info.get("completed") and not include_completed_assistant_tail:
                 return OpenCodeForkPoint(available=False)
             for message_id, message in reversed(messages[:-1]):
                 if message.get("role") == "user":

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -1098,12 +1098,20 @@ class OpenCodeServerManager:
                     raise RuntimeError(f"Failed to create session: {resp.status} {text}")
                 return await resp.json()
 
-    async def fork_session(self, source_session_id: str, directory: str) -> Dict[str, Any]:
+    async def fork_session(
+        self,
+        source_session_id: str,
+        directory: str,
+        message_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         async with self._request_scope():
             session = await self._get_http_session()
+            body: Dict[str, Any] = {}
+            if message_id:
+                body["messageID"] = message_id
             async with session.post(
                 f"{self.base_url}/session/{source_session_id}/fork",
-                json={},
+                json=body,
                 headers={"x-opencode-directory": _percent_encode_path(directory)},
             ) as resp:
                 if resp.status != 200:

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -100,18 +100,17 @@ class OpenCodeSessionManager:
                 return target_id
         return None
 
-    async def _resolve_running_fork_message_id(
+    async def _resolve_running_fork_point(
         self,
         server: OpenCodeServerManager,
         source_session_id: str,
         directory: str,
         fork: dict,
-    ) -> Optional[str]:
-        explicit = str(fork.get("opencode_fork_message_id") or "").strip()
-        if explicit:
-            return explicit
+    ) -> tuple[bool, Optional[str]]:
         if not bool(fork.get("trim_latest_running_turn")):
-            return None
+            return True, None
+        if not bool(fork.get("native_turn_started")):
+            return True, None
         try:
             messages = await server.list_messages(source_session_id, directory)
         except Exception as err:
@@ -120,7 +119,7 @@ class OpenCodeSessionManager:
                 source_session_id,
                 err,
             )
-            return None
+            return True, None
         for index in range(len(messages) - 1, -1, -1):
             info = messages[index].get("info", {})
             if info.get("role") != "user":
@@ -128,9 +127,9 @@ class OpenCodeSessionManager:
             for previous in range(index - 1, -1, -1):
                 message_id = str(messages[previous].get("info", {}).get("id") or "").strip()
                 if message_id:
-                    return message_id
-            return None
-        return None
+                    return True, message_id
+            return False, None
+        return False, None
 
     def ensure_agent_session_id(self, request: AgentRequest, session_anchor: str) -> Optional[str]:
         reserved_target_id = self._reserved_agent_session_id(request)
@@ -295,17 +294,22 @@ class OpenCodeSessionManager:
             try:
                 if fork:
                     fork_source = str(fork.get("source_native_session_id") or "").strip()
-                    message_id = await self._resolve_running_fork_message_id(
+                    should_fork, message_id = await self._resolve_running_fork_point(
                         server,
                         fork_source,
                         request.working_path,
                         fork,
                     )
-                    session_data = await server.fork_session(
-                        fork_source,
-                        directory=request.working_path,
-                        message_id=message_id,
-                    )
+                    if should_fork:
+                        session_data = await server.fork_session(
+                            fork_source,
+                            directory=request.working_path,
+                            message_id=message_id,
+                        )
+                    else:
+                        session_data = await server.create_session(
+                            directory=request.working_path,
+                        )
                 else:
                     session_data = await server.create_session(
                         directory=request.working_path,

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -14,6 +14,7 @@ from typing import Dict, Optional, Tuple
 
 from core.services.session_fork import pending_native_fork
 from modules.agents.base import AgentRequest, BaseAgent
+from modules.agents.native_sessions.opencode import OpenCodeNativeSessionProvider
 
 from .server import OpenCodeServerManager
 
@@ -109,18 +110,22 @@ class OpenCodeSessionManager:
     ) -> tuple[bool, Optional[str]]:
         if not bool(fork.get("trim_latest_running_turn")):
             return True, None
-        if not bool(fork.get("native_turn_started")):
-            return True, None
         if bool(fork.get("opencode_fork_empty_history")):
             return False, None
         message_id = str(fork.get("opencode_fork_message_id") or "").strip()
         if message_id:
             return True, message_id
+        point = OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(source_session_id)
+        if point.available:
+            if point.empty_history:
+                return False, None
+            if point.message_id:
+                return True, point.message_id
         logger.warning(
-            "OpenCode running fork for %s has no persisted fork point; falling back to a full fork",
+            "OpenCode running fork for %s has no persisted fork point; creating an empty fork target",
             source_session_id,
         )
-        return True, None
+        return False, None
 
     def ensure_agent_session_id(self, request: AgentRequest, session_anchor: str) -> Optional[str]:
         reserved_target_id = self._reserved_agent_session_id(request)

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -12,7 +12,7 @@ import os
 import time
 from typing import Dict, Optional, Tuple
 
-from core.services.session_fork import pending_native_fork
+from core.services.session_fork import fork_source_has_agent_output_after_anchor, pending_native_fork
 from modules.agents.base import AgentRequest, BaseAgent
 from modules.agents.native_sessions.opencode import OpenCodeNativeSessionProvider
 
@@ -115,17 +115,20 @@ class OpenCodeSessionManager:
         message_id = str(fork.get("opencode_fork_message_id") or "").strip()
         if message_id:
             return True, message_id
-        point = OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(source_session_id)
+        point = OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(
+            source_session_id,
+            include_completed_assistant_tail=fork_source_has_agent_output_after_anchor(fork),
+        )
         if point.available:
             if point.empty_history:
                 return False, None
             if point.message_id:
                 return True, point.message_id
         logger.warning(
-            "OpenCode running fork for %s has no persisted fork point; creating an empty fork target",
+            "OpenCode running fork for %s has no persisted fork point; preserving source history",
             source_session_id,
         )
-        return False, None
+        return True, None
 
     def ensure_agent_session_id(self, request: AgentRequest, session_anchor: str) -> Optional[str]:
         reserved_target_id = self._reserved_agent_session_id(request)

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -111,25 +111,16 @@ class OpenCodeSessionManager:
             return True, None
         if not bool(fork.get("native_turn_started")):
             return True, None
-        try:
-            messages = await server.list_messages(source_session_id, directory)
-        except Exception as err:
-            logger.warning(
-                "Failed to inspect OpenCode source session %s for running fork point: %s",
-                source_session_id,
-                err,
-            )
-            return True, None
-        for index in range(len(messages) - 1, -1, -1):
-            info = messages[index].get("info", {})
-            if info.get("role") != "user":
-                continue
-            for previous in range(index - 1, -1, -1):
-                message_id = str(messages[previous].get("info", {}).get("id") or "").strip()
-                if message_id:
-                    return True, message_id
+        if bool(fork.get("opencode_fork_empty_history")):
             return False, None
-        return False, None
+        message_id = str(fork.get("opencode_fork_message_id") or "").strip()
+        if message_id:
+            return True, message_id
+        logger.warning(
+            "OpenCode running fork for %s has no persisted fork point; falling back to a full fork",
+            source_session_id,
+        )
+        return True, None
 
     def ensure_agent_session_id(self, request: AgentRequest, session_anchor: str) -> Optional[str]:
         reserved_target_id = self._reserved_agent_session_id(request)

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -13,6 +13,7 @@ import time
 from typing import Dict, Optional, Tuple
 
 from core.services.session_fork import fork_source_state, pending_native_fork
+from modules.agents.native_sessions.opencode import OpenCodeNativeSessionProvider
 from modules.agents.base import AgentRequest, BaseAgent
 
 from .server import OpenCodeServerManager
@@ -121,6 +122,12 @@ class OpenCodeSessionManager:
                 )
                 return True, None
             return True, message_id
+        point = OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(
+            source_session_id,
+            include_completed_assistant_tail=False,
+        )
+        if point.available:
+            return True, point.message_id
         logger.warning(
             "OpenCode running fork for %s has no persisted fork point; preserving source history",
             source_session_id,

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -12,7 +12,7 @@ import os
 import time
 from typing import Dict, Optional, Tuple
 
-from core.services.session_fork import fork_anchor_is_terminal_agent_output, pending_native_fork
+from core.services.session_fork import fork_source_state, pending_native_fork
 from modules.agents.base import AgentRequest, BaseAgent
 
 from .server import OpenCodeServerManager
@@ -113,9 +113,10 @@ class OpenCodeSessionManager:
             return False, None
         message_id = str(fork.get("opencode_fork_message_id") or "").strip()
         if message_id:
-            if fork_anchor_is_terminal_agent_output(fork):
+            source_state = fork_source_state(fork)
+            if source_state.anchor_is_terminal_agent_output or source_state.has_terminal_agent_output_after_anchor:
                 logger.info(
-                    "OpenCode running fork for %s kept full history because the source completed before reservation",
+                    "OpenCode running fork for %s kept full history because the source completed before first use",
                     source_session_id,
                 )
                 return True, None

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -12,9 +12,8 @@ import os
 import time
 from typing import Dict, Optional, Tuple
 
-from core.services.session_fork import fork_source_has_agent_output_after_anchor, pending_native_fork
+from core.services.session_fork import fork_anchor_is_terminal_agent_output, pending_native_fork
 from modules.agents.base import AgentRequest, BaseAgent
-from modules.agents.native_sessions.opencode import OpenCodeNativeSessionProvider
 
 from .server import OpenCodeServerManager
 
@@ -114,16 +113,13 @@ class OpenCodeSessionManager:
             return False, None
         message_id = str(fork.get("opencode_fork_message_id") or "").strip()
         if message_id:
+            if fork_anchor_is_terminal_agent_output(fork):
+                logger.info(
+                    "OpenCode running fork for %s kept full history because the source completed before reservation",
+                    source_session_id,
+                )
+                return True, None
             return True, message_id
-        point = OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(
-            source_session_id,
-            include_completed_assistant_tail=fork_source_has_agent_output_after_anchor(fork),
-        )
-        if point.available:
-            if point.empty_history:
-                return False, None
-            if point.message_id:
-                return True, point.message_id
         logger.warning(
             "OpenCode running fork for %s has no persisted fork point; preserving source history",
             source_session_id,

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -12,7 +12,7 @@ import os
 import time
 from typing import Dict, Optional, Tuple
 
-from core.services.session_fork import pending_native_fork_source
+from core.services.session_fork import pending_native_fork
 from modules.agents.base import AgentRequest, BaseAgent
 
 from .server import OpenCodeServerManager
@@ -98,6 +98,38 @@ class OpenCodeSessionManager:
             target_id = str(session_target.get("id") or "").strip()
             if target_id:
                 return target_id
+        return None
+
+    async def _resolve_running_fork_message_id(
+        self,
+        server: OpenCodeServerManager,
+        source_session_id: str,
+        directory: str,
+        fork: dict,
+    ) -> Optional[str]:
+        explicit = str(fork.get("opencode_fork_message_id") or "").strip()
+        if explicit:
+            return explicit
+        if not bool(fork.get("trim_latest_running_turn")):
+            return None
+        try:
+            messages = await server.list_messages(source_session_id, directory)
+        except Exception as err:
+            logger.warning(
+                "Failed to inspect OpenCode source session %s for running fork point: %s",
+                source_session_id,
+                err,
+            )
+            return None
+        for index in range(len(messages) - 1, -1, -1):
+            info = messages[index].get("info", {})
+            if info.get("role") != "user":
+                continue
+            for previous in range(index - 1, -1, -1):
+                message_id = str(messages[previous].get("info", {}).get("id") or "").strip()
+                if message_id:
+                    return message_id
+            return None
         return None
 
     def ensure_agent_session_id(self, request: AgentRequest, session_anchor: str) -> Optional[str]:
@@ -259,12 +291,20 @@ class OpenCodeSessionManager:
         )
 
         if not session_id:
-            fork_source = pending_native_fork_source(request.context, self._agent_name)
+            fork = pending_native_fork(request.context, self._agent_name)
             try:
-                if fork_source:
+                if fork:
+                    fork_source = str(fork.get("source_native_session_id") or "").strip()
+                    message_id = await self._resolve_running_fork_message_id(
+                        server,
+                        fork_source,
+                        request.working_path,
+                        fork,
+                    )
                     session_data = await server.fork_session(
                         fork_source,
                         directory=request.working_path,
+                        message_id=message_id,
                     )
                 else:
                     session_data = await server.create_session(
@@ -273,11 +313,11 @@ class OpenCodeSessionManager:
                 session_id = session_data.get("id")
                 if session_id:
                     self.bind_agent_session_id(request, anchor, session_id)
-                    if fork_source:
+                    if fork:
                         logger.info(
                             "Forked OpenCode session %s from %s for %s",
                             session_id,
-                            fork_source,
+                            str(fork.get("source_native_session_id") or "").strip(),
                             request.base_session_id,
                         )
                     else:

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -121,11 +121,12 @@ class OpenCodeSessionManager:
                     source_session_id,
                 )
                 return True, None
+            if getattr(source_state, "has_messages_after_anchor", False):
+                point = self._current_running_fork_point(source_session_id)
+                if point.available:
+                    return True, point.message_id
             return True, message_id
-        point = OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(
-            source_session_id,
-            include_completed_assistant_tail=False,
-        )
+        point = self._current_running_fork_point(source_session_id)
         if point.available:
             return True, point.message_id
         logger.warning(
@@ -133,6 +134,12 @@ class OpenCodeSessionManager:
             source_session_id,
         )
         return True, None
+
+    def _current_running_fork_point(self, source_session_id: str):
+        return OpenCodeNativeSessionProvider().running_fork_point_before_latest_user(
+            source_session_id,
+            include_completed_assistant_tail=False,
+        )
 
     def ensure_agent_session_id(self, request: AgentRequest, session_anchor: str) -> Optional[str]:
         reserved_target_id = self._reserved_agent_session_id(request)

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -139,6 +139,15 @@ class AgentService:
             return
         gate.runtime_started = True
 
+    def runtime_turn_started(self, context: Any) -> bool:
+        payload = getattr(context, "platform_specific", None) or {}
+        runtime_key = str(payload.get(AGENT_RUNTIME_TURN_KEY) or "").strip()
+        runtime_token = str(payload.get(AGENT_RUNTIME_TURN_TOKEN) or "").strip()
+        if not runtime_key or not runtime_token:
+            return False
+        gate = self._turn_gates.get(runtime_key)
+        return bool(gate is not None and gate.token == runtime_token and gate.runtime_started)
+
     def release_runtime_turn(self, context: Any) -> None:
         payload = getattr(context, "platform_specific", None) or {}
         runtime_key = str(payload.get(AGENT_RUNTIME_TURN_KEY) or "").strip()

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1624,7 +1624,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             "thread-fork",
         )
 
-    async def test_start_or_resume_thread_skips_running_fork_rollback_before_native_start(self):
+    async def test_start_or_resume_thread_preserves_running_fork_rollback_before_native_start(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
         agent.codex_config = SimpleNamespace(default_model=None)
@@ -1672,8 +1672,11 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(thread_id, "thread-fork")
         self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
             "thread/fork",
+            "thread/rollback",
             "thread/inject_items",
         ])
+        rollback_params = transport.send_request.await_args_list[1].args[1]
+        self.assertEqual(rollback_params, {"threadId": "thread-fork", "numTurns": 1})
 
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1624,7 +1624,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             "thread-fork",
         )
 
-    async def test_start_or_resume_thread_preserves_running_fork_rollback_before_native_start(self):
+    async def test_start_or_resume_thread_skips_running_fork_rollback_before_native_start(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
         agent.codex_config = SimpleNamespace(default_model=None)
@@ -1668,6 +1668,59 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
 
         thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/inject_items",
+        ])
+
+    async def test_start_or_resume_thread_rolls_back_pre_start_fork_after_source_output(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-user",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": False,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with patch.object(_MODULE, "fork_source_has_agent_output_after_anchor", return_value=True):
+            thread_id = await agent._start_or_resume_thread(transport, request)
 
         self.assertEqual(thread_id, "thread-fork")
         self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1721,11 +1721,23 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             vibe_agent_model=None,
             vibe_agent_reasoning_effort=None,
         )
-        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+        turn_state_checked = False
+
+        async def turn_state(_source_session_id):
+            nonlocal turn_state_checked
+            turn_state_checked = True
+            return {"body": {"in_flight": True, "native_turn_started": True}}
+
+        async def send_request(method, params):
+            if method == "thread/fork":
+                self.assertTrue(turn_state_checked)
+            return {"thread": {"id": "thread-fork"}}
+
+        transport = SimpleNamespace(send_request=AsyncMock(side_effect=send_request))
 
         with patch(
             "vibe.internal_client.turn_state",
-            new=AsyncMock(return_value={"body": {"in_flight": True, "native_turn_started": True}}),
+            new=AsyncMock(side_effect=turn_state),
         ):
             thread_id = await agent._start_or_resume_thread(transport, request)
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1719,7 +1719,15 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         )
         transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
 
-        with patch.object(_MODULE, "fork_source_has_agent_output_after_anchor", return_value=True):
+        with patch.object(
+            _MODULE,
+            "fork_source_state",
+            return_value=SimpleNamespace(
+                anchor_is_terminal_agent_output=False,
+                has_messages_after_anchor=True,
+                has_terminal_agent_output_after_anchor=False,
+            ),
+        ):
             thread_id = await agent._start_or_resume_thread(transport, request)
 
         self.assertEqual(thread_id, "thread-fork")
@@ -1730,6 +1738,128 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         ])
         rollback_params = transport.send_request.await_args_list[1].args[1]
         self.assertEqual(rollback_params, {"threadId": "thread-fork", "numTurns": 1})
+
+    async def test_start_or_resume_thread_skips_running_fork_rollback_when_anchor_completed(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-result",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": True,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with patch.object(
+            _MODULE,
+            "fork_source_state",
+            return_value=SimpleNamespace(
+                anchor_is_terminal_agent_output=True,
+                has_messages_after_anchor=False,
+                has_terminal_agent_output_after_anchor=False,
+            ),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/inject_items",
+        ])
+
+    async def test_start_or_resume_thread_skips_running_fork_rollback_after_source_completed(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-user",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": False,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with patch.object(
+            _MODULE,
+            "fork_source_state",
+            return_value=SimpleNamespace(
+                anchor_is_terminal_agent_output=False,
+                has_messages_after_anchor=True,
+                has_terminal_agent_output_after_anchor=True,
+            ),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/inject_items",
+        ])
 
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1667,11 +1667,72 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         )
         transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
 
-        thread_id = await agent._start_or_resume_thread(transport, request)
+        with patch(
+            "vibe.internal_client.turn_state",
+            new=AsyncMock(return_value={"body": {"in_flight": False, "native_turn_started": False}}),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
 
         self.assertEqual(thread_id, "thread-fork")
         self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
             "thread/fork",
+            "thread/inject_items",
+        ])
+
+    async def test_start_or_resume_thread_rolls_back_pre_start_fork_after_source_started(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-user",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": False,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with patch(
+            "vibe.internal_client.turn_state",
+            new=AsyncMock(return_value={"body": {"in_flight": True, "native_turn_started": True}}),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/rollback",
             "thread/inject_items",
         ])
 
@@ -1724,6 +1785,8 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             "fork_source_state",
             return_value=SimpleNamespace(
                 anchor_is_terminal_agent_output=False,
+                latest_after_anchor_author="agent",
+                latest_after_anchor_type="assistant",
                 has_messages_after_anchor=True,
                 has_terminal_agent_output_after_anchor=False,
             ),
@@ -1788,6 +1851,8 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             "fork_source_state",
             return_value=SimpleNamespace(
                 anchor_is_terminal_agent_output=True,
+                latest_after_anchor_author=None,
+                latest_after_anchor_type=None,
                 has_messages_after_anchor=False,
                 has_terminal_agent_output_after_anchor=False,
             ),
@@ -1849,6 +1914,8 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             "fork_source_state",
             return_value=SimpleNamespace(
                 anchor_is_terminal_agent_output=False,
+                latest_after_anchor_author="agent",
+                latest_after_anchor_type="result",
                 has_messages_after_anchor=True,
                 has_terminal_agent_output_after_anchor=True,
             ),

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1564,6 +1564,65 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         agent.sessions.bind_agent_session.assert_not_called()
         self.assertFalse(agent.is_fork_correction_pending("ses-target"))
 
+    async def test_start_or_resume_thread_rolls_back_running_fork_before_correction(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "trim_latest_running_turn": True,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/rollback",
+            "thread/inject_items",
+        ])
+        rollback_params = transport.send_request.await_args_list[1].args[1]
+        self.assertEqual(rollback_params, {"threadId": "thread-fork", "numTurns": 1})
+        agent.sessions.bind_agent_session.assert_called_once_with(
+            "avibe::project::proj_1",
+            "codex",
+            "ses-target",
+            "thread-fork",
+        )
+
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the
         # reserved MAIN native.

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1589,6 +1589,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
                             "source_native_session_id": "thread-source",
                             "source_backend": "codex",
                             "trim_latest_running_turn": True,
+                            "native_turn_started": True,
                         },
                     }
                 },
@@ -1622,6 +1623,57 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             "ses-target",
             "thread-fork",
         )
+
+    async def test_start_or_resume_thread_skips_running_fork_rollback_before_native_start(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": False,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/inject_items",
+        ])
 
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -712,7 +712,9 @@ def test_cancel_does_not_flush_queue(monkeypatch, tmp_path):
 def test_turn_state_reflects_in_flight():
     """``/internal/turn-state`` reports whether a turn is running, so a freshly
     loaded / reconnected Chat page can restore its Stop state."""
-    app = internal_server.create_app(_build_controller_double())
+    controller = _build_controller_double()
+    controller.agent_service.runtime_turn_started.return_value = True
+    app = internal_server.create_app(controller)
     transport = httpx.ASGITransport(app=app)
 
     async def _go():
@@ -722,7 +724,12 @@ def test_turn_state_reflects_in_flight():
             task = asyncio.create_task(asyncio.sleep(60))
             app.state.in_flight_dispatches["ses_ts"] = session_turns.Turn(
                 task=task,
-                context=MessageContext(user_id="U", channel_id="C", platform="avibe"),
+                context=MessageContext(
+                    user_id="U",
+                    channel_id="C",
+                    platform="avibe",
+                    platform_specific={"agent_session_target": {"agent_backend": "opencode"}},
+                ),
             )
             busy = (await client.get("/internal/turn-state/ses_ts")).json()
             task.cancel()
@@ -731,6 +738,8 @@ def test_turn_state_reflects_in_flight():
     idle, busy = asyncio.run(_go())
     assert idle["in_flight"] is False
     assert busy["in_flight"] is True
+    assert busy["native_turn_started"] is True
+    assert busy["backend"] == "opencode"
 
 
 def test_cancel_returns_404_when_session_not_in_flight():

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -192,6 +192,31 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         body = fake_session.posts[0]["json"]
         self.assertNotIn("variant", body)
 
+    async def test_fork_session_sends_message_id_when_provided(self):
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        fake_session = _FakeSession()
+
+        def _post(url, json=None, headers=None):
+            fake_session.posts.append({"url": url, "json": json, "headers": headers})
+            return _FakeResponse(status=200, json_data={"id": "oc-fork"})
+
+        fake_session.post = _post
+
+        async def _fake_get_http_session():
+            return fake_session
+
+        manager._get_http_session = _fake_get_http_session  # type: ignore[method-assign]
+
+        result = await manager.fork_session("oc-source", directory="/tmp/work", message_id="oc-msg-prev")
+
+        self.assertEqual(result, {"id": "oc-fork"})
+        self.assertEqual(len(fake_session.posts), 1)
+        self.assertEqual(fake_session.posts[0]["json"], {"messageID": "oc-msg-prev"})
+        self.assertEqual(
+            fake_session.posts[0]["headers"],
+            {"x-opencode-directory": "/tmp/work"},
+        )
+
     async def test_load_opencode_user_config_supports_jsonc(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_home = Path(tmp_dir)

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -188,7 +188,7 @@ def test_opencode_startup_window_fork_does_not_infer_message_point() -> None:
     server.create_session.assert_not_awaited()
 
 
-def test_opencode_running_fork_infers_native_message_point_from_source_messages() -> None:
+def test_opencode_running_fork_uses_persisted_native_message_point() -> None:
     sessions = SimpleNamespace(
         get_agent_session_id=Mock(return_value=None),
         ensure_agent_session_id=Mock(return_value="ses-fork"),
@@ -199,13 +199,7 @@ def test_opencode_running_fork_infers_native_message_point_from_source_messages(
     server = SimpleNamespace(
         fork_session=AsyncMock(return_value={"id": "oc-fork"}),
         create_session=AsyncMock(),
-        list_messages=AsyncMock(
-            return_value=[
-                {"info": {"id": "oc-msg-1", "role": "user"}},
-                {"info": {"id": "oc-msg-2", "role": "assistant"}},
-                {"info": {"id": "oc-msg-3", "role": "user"}},
-            ]
-        ),
+        list_messages=AsyncMock(),
     )
     request = _request()
     request.context.platform_specific = {
@@ -220,6 +214,7 @@ def test_opencode_running_fork_infers_native_message_point_from_source_messages(
                 "source_backend": "opencode",
                 "trim_latest_running_turn": True,
                 "native_turn_started": True,
+                "opencode_fork_message_id": "oc-msg-2",
             },
         },
     }
@@ -227,7 +222,7 @@ def test_opencode_running_fork_infers_native_message_point_from_source_messages(
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-fork"
-    server.list_messages.assert_awaited_once_with("oc-source", "/repo")
+    server.list_messages.assert_not_awaited()
     server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-2")
     server.create_session.assert_not_awaited()
 
@@ -243,7 +238,7 @@ def test_opencode_running_first_turn_fork_creates_empty_session() -> None:
     server = SimpleNamespace(
         fork_session=AsyncMock(),
         create_session=AsyncMock(return_value={"id": "oc-empty"}),
-        list_messages=AsyncMock(return_value=[{"info": {"id": "oc-msg-1", "role": "user"}}]),
+        list_messages=AsyncMock(),
     )
     request = _request()
     request.context.platform_specific = {
@@ -258,6 +253,7 @@ def test_opencode_running_first_turn_fork_creates_empty_session() -> None:
                 "source_backend": "opencode",
                 "trim_latest_running_turn": True,
                 "native_turn_started": True,
+                "opencode_fork_empty_history": True,
             },
         },
     }
@@ -265,7 +261,7 @@ def test_opencode_running_first_turn_fork_creates_empty_session() -> None:
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-empty"
-    server.list_messages.assert_awaited_once_with("oc-source", "/repo")
+    server.list_messages.assert_not_awaited()
     server.create_session.assert_awaited_once_with(directory="/repo")
     server.fork_session.assert_not_awaited()
 

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -68,6 +68,34 @@ def _seed_opencode_completed_messages(tmp_path, native_session_id: str, roles: l
             )
 
 
+def _seed_opencode_tool_call_messages(tmp_path, native_session_id: str) -> None:
+    db_path = tmp_path / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, data TEXT)")
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT, message_id TEXT, time_created INTEGER, data TEXT)"
+        )
+        messages = [
+            {"role": "user"},
+            {
+                "role": "assistant",
+                "time": {"completed": 2},
+                "finish": "tool-calls",
+            },
+        ]
+        for index, data in enumerate(messages, start=1):
+            message_id = f"oc-msg-{index}"
+            conn.execute(
+                "INSERT INTO message (id, data) VALUES (?, ?)",
+                (message_id, json.dumps(data)),
+            )
+            conn.execute(
+                "INSERT INTO part (id, session_id, message_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+                (f"part-{index}", native_session_id, message_id, index, json.dumps({"type": "text"})),
+            )
+
+
 def test_opencode_reused_session_attaches_agent_session_id() -> None:
     sessions = SimpleNamespace(
         get_agent_session_id=Mock(return_value="oc-session-1"),
@@ -346,6 +374,100 @@ def test_opencode_running_fork_without_persisted_point_rechecks_native_boundary(
     }
 
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-3")
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_tool_call_turn_without_persisted_point_rechecks_native_boundary(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _seed_opencode_tool_call_messages(tmp_path, "oc-source")
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "trim_latest_running_turn": True,
+                "native_turn_started": False,
+            },
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-1")
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_stale_saved_boundary_rechecks_current_native_boundary(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _seed_opencode_messages(tmp_path, "oc-source", ["user", "assistant", "user"])
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "source_message_id": "msg-user",
+                "trim_latest_running_turn": True,
+                "native_turn_started": True,
+                "opencode_fork_message_id": "oc-msg-1",
+            },
+        },
+    }
+
+    with patch(
+        "modules.agents.opencode.session.fork_source_state",
+        return_value=SimpleNamespace(
+            anchor_is_terminal_agent_output=False,
+            has_messages_after_anchor=True,
+            has_terminal_agent_output_after_anchor=False,
+        ),
+    ):
+        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import sqlite3
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -38,6 +38,29 @@ def _seed_opencode_messages(tmp_path, native_session_id: str, roles: list[str]) 
             conn.execute(
                 "INSERT INTO message (id, data) VALUES (?, ?)",
                 (message_id, json.dumps({"role": role})),
+            )
+            conn.execute(
+                "INSERT INTO part (id, session_id, message_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+                (f"part-{index}", native_session_id, message_id, index, json.dumps({"type": "text"})),
+            )
+
+
+def _seed_opencode_completed_messages(tmp_path, native_session_id: str, roles: list[str]) -> None:
+    db_path = tmp_path / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, data TEXT)")
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT, message_id TEXT, time_created INTEGER, data TEXT)"
+        )
+        for index, role in enumerate(roles, start=1):
+            message_id = f"oc-msg-{index}"
+            data = {"role": role}
+            if role == "assistant":
+                data["time"] = {"completed": index}
+            conn.execute(
+                "INSERT INTO message (id, data) VALUES (?, ?)",
+                (message_id, json.dumps(data)),
             )
             conn.execute(
                 "INSERT INTO part (id, session_id, message_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
@@ -181,8 +204,8 @@ def test_opencode_startup_window_fork_does_not_infer_message_point() -> None:
     )
     manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
     server = SimpleNamespace(
-        fork_session=AsyncMock(),
-        create_session=AsyncMock(return_value={"id": "oc-empty"}),
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
         list_messages=AsyncMock(),
     )
     request = _request()
@@ -204,10 +227,10 @@ def test_opencode_startup_window_fork_does_not_infer_message_point() -> None:
 
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
-    assert session_id == "oc-empty"
-    server.fork_session.assert_not_awaited()
+    assert session_id == "oc-fork"
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
     server.list_messages.assert_not_awaited()
-    server.create_session.assert_awaited_once_with(directory="/repo")
+    server.create_session.assert_not_awaited()
 
 
 def test_opencode_running_fork_uses_persisted_native_message_point() -> None:
@@ -327,6 +350,50 @@ def test_opencode_running_fork_resolves_missing_persisted_point_from_native_db(
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
     server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-3")
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_completed_source_turn_uses_user_boundary_after_fork_anchor_output(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _seed_opencode_completed_messages(tmp_path, "oc-source", ["user", "assistant"])
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "source_message_id": "msg-user",
+                "trim_latest_running_turn": True,
+                "native_turn_started": False,
+            },
+        },
+    }
+
+    with patch("modules.agents.opencode.session.fork_source_has_agent_output_after_anchor", return_value=True):
+        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-1")
     server.create_session.assert_not_awaited()
 
 

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import sqlite3
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -21,6 +23,26 @@ def _request() -> AgentRequest:
         composite_session_id="base-1:/repo",
         session_key="slack::channel::C1",
     )
+
+
+def _seed_opencode_messages(tmp_path, native_session_id: str, roles: list[str]) -> None:
+    db_path = tmp_path / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, data TEXT)")
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT, message_id TEXT, time_created INTEGER, data TEXT)"
+        )
+        for index, role in enumerate(roles, start=1):
+            message_id = f"oc-msg-{index}"
+            conn.execute(
+                "INSERT INTO message (id, data) VALUES (?, ?)",
+                (message_id, json.dumps({"role": role})),
+            )
+            conn.execute(
+                "INSERT INTO part (id, session_id, message_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+                (f"part-{index}", native_session_id, message_id, index, json.dumps({"type": "text"})),
+            )
 
 
 def test_opencode_reused_session_attaches_agent_session_id() -> None:
@@ -159,8 +181,8 @@ def test_opencode_startup_window_fork_does_not_infer_message_point() -> None:
     )
     manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
     server = SimpleNamespace(
-        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
-        create_session=AsyncMock(),
+        fork_session=AsyncMock(),
+        create_session=AsyncMock(return_value={"id": "oc-empty"}),
         list_messages=AsyncMock(),
     )
     request = _request()
@@ -182,10 +204,10 @@ def test_opencode_startup_window_fork_does_not_infer_message_point() -> None:
 
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
-    assert session_id == "oc-fork"
-    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
+    assert session_id == "oc-empty"
+    server.fork_session.assert_not_awaited()
     server.list_messages.assert_not_awaited()
-    server.create_session.assert_not_awaited()
+    server.create_session.assert_awaited_once_with(directory="/repo")
 
 
 def test_opencode_running_fork_uses_persisted_native_message_point() -> None:
@@ -263,6 +285,48 @@ def test_opencode_running_first_turn_fork_uses_user_boundary() -> None:
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
     server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-1")
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_running_fork_resolves_missing_persisted_point_from_native_db(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    _seed_opencode_messages(tmp_path, "oc-source", ["user", "assistant", "user"])
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "trim_latest_running_turn": True,
+                "native_turn_started": False,
+            },
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-3")
     server.create_session.assert_not_awaited()
 
 

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -214,7 +214,7 @@ def test_opencode_running_fork_uses_persisted_native_message_point() -> None:
                 "source_backend": "opencode",
                 "trim_latest_running_turn": True,
                 "native_turn_started": True,
-                "opencode_fork_message_id": "oc-msg-2",
+                "opencode_fork_message_id": "oc-msg-3",
             },
         },
     }
@@ -223,11 +223,11 @@ def test_opencode_running_fork_uses_persisted_native_message_point() -> None:
 
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
-    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-2")
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-3")
     server.create_session.assert_not_awaited()
 
 
-def test_opencode_running_first_turn_fork_creates_empty_session() -> None:
+def test_opencode_running_first_turn_fork_uses_user_boundary() -> None:
     sessions = SimpleNamespace(
         get_agent_session_id=Mock(return_value=None),
         ensure_agent_session_id=Mock(return_value="ses-fork"),
@@ -236,8 +236,8 @@ def test_opencode_running_first_turn_fork_creates_empty_session() -> None:
     )
     manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
     server = SimpleNamespace(
-        fork_session=AsyncMock(),
-        create_session=AsyncMock(return_value={"id": "oc-empty"}),
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
         list_messages=AsyncMock(),
     )
     request = _request()
@@ -253,17 +253,17 @@ def test_opencode_running_first_turn_fork_creates_empty_session() -> None:
                 "source_backend": "opencode",
                 "trim_latest_running_turn": True,
                 "native_turn_started": True,
-                "opencode_fork_empty_history": True,
+                "opencode_fork_message_id": "oc-msg-1",
             },
         },
     }
 
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
-    assert session_id == "oc-empty"
+    assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
-    server.create_session.assert_awaited_once_with(directory="/repo")
-    server.fork_session.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-1")
+    server.create_session.assert_not_awaited()
 
 
 def test_opencode_reserved_agent_session_id_is_not_replaced() -> None:

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -311,7 +311,7 @@ def test_opencode_running_first_turn_fork_uses_user_boundary() -> None:
     server.create_session.assert_not_awaited()
 
 
-def test_opencode_running_fork_without_persisted_point_preserves_source_history(
+def test_opencode_running_fork_without_persisted_point_rechecks_native_boundary(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
@@ -349,7 +349,7 @@ def test_opencode_running_fork_without_persisted_point_preserves_source_history(
 
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
-    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-3")
     server.create_session.assert_not_awaited()
 
 

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -311,7 +311,7 @@ def test_opencode_running_first_turn_fork_uses_user_boundary() -> None:
     server.create_session.assert_not_awaited()
 
 
-def test_opencode_running_fork_resolves_missing_persisted_point_from_native_db(
+def test_opencode_running_fork_without_persisted_point_preserves_source_history(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
@@ -349,11 +349,93 @@ def test_opencode_running_fork_resolves_missing_persisted_point_from_native_db(
 
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
-    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-3")
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
     server.create_session.assert_not_awaited()
 
 
-def test_opencode_completed_source_turn_uses_user_boundary_after_fork_anchor_output(
+def test_opencode_saved_boundary_is_ignored_when_source_completed_before_anchor() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "source_message_id": "msg-result",
+                "trim_latest_running_turn": True,
+                "native_turn_started": True,
+                "opencode_fork_message_id": "oc-msg-user",
+            },
+        },
+    }
+
+    with patch("modules.agents.opencode.session.fork_anchor_is_terminal_agent_output", return_value=True):
+        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_saved_boundary_is_used_when_anchor_is_not_completed() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "source_message_id": "msg-user",
+                "trim_latest_running_turn": True,
+                "native_turn_started": True,
+                "opencode_fork_message_id": "oc-msg-user",
+            },
+        },
+    }
+
+    with patch("modules.agents.opencode.session.fork_anchor_is_terminal_agent_output", return_value=False):
+        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-user")
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_completed_source_turn_without_saved_boundary_preserves_source_history(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
@@ -388,12 +470,11 @@ def test_opencode_completed_source_turn_uses_user_boundary_after_fork_anchor_out
         },
     }
 
-    with patch("modules.agents.opencode.session.fork_source_has_agent_output_after_anchor", return_value=True):
-        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
-    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-1")
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
     server.create_session.assert_not_awaited()
 
 

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -112,7 +112,45 @@ def test_opencode_forks_pending_native_source() -> None:
     )
 
 
-def test_opencode_running_fork_passes_native_message_point() -> None:
+def test_opencode_idle_fork_ignores_stale_native_message_point() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "trim_latest_running_turn": False,
+                "opencode_fork_message_id": "oc-msg-prev",
+            },
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
+    server.list_messages.assert_not_awaited()
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_startup_window_fork_does_not_infer_message_point() -> None:
     sessions = SimpleNamespace(
         get_agent_session_id=Mock(return_value=None),
         ensure_agent_session_id=Mock(return_value="ses-fork"),
@@ -137,7 +175,7 @@ def test_opencode_running_fork_passes_native_message_point() -> None:
                 "source_native_session_id": "oc-source",
                 "source_backend": "opencode",
                 "trim_latest_running_turn": True,
-                "opencode_fork_message_id": "oc-msg-prev",
+                "native_turn_started": False,
             },
         },
     }
@@ -145,7 +183,7 @@ def test_opencode_running_fork_passes_native_message_point() -> None:
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-fork"
-    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-prev")
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
     server.list_messages.assert_not_awaited()
     server.create_session.assert_not_awaited()
 
@@ -181,6 +219,7 @@ def test_opencode_running_fork_infers_native_message_point_from_source_messages(
                 "source_native_session_id": "oc-source",
                 "source_backend": "opencode",
                 "trim_latest_running_turn": True,
+                "native_turn_started": True,
             },
         },
     }
@@ -191,6 +230,44 @@ def test_opencode_running_fork_infers_native_message_point_from_source_messages(
     server.list_messages.assert_awaited_once_with("oc-source", "/repo")
     server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-2")
     server.create_session.assert_not_awaited()
+
+
+def test_opencode_running_first_turn_fork_creates_empty_session() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(),
+        create_session=AsyncMock(return_value={"id": "oc-empty"}),
+        list_messages=AsyncMock(return_value=[{"info": {"id": "oc-msg-1", "role": "user"}}]),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "trim_latest_running_turn": True,
+                "native_turn_started": True,
+            },
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-empty"
+    server.list_messages.assert_awaited_once_with("oc-source", "/repo")
+    server.create_session.assert_awaited_once_with(directory="/repo")
+    server.fork_session.assert_not_awaited()
 
 
 def test_opencode_reserved_agent_session_id_is_not_replaced() -> None:

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -77,7 +77,11 @@ def test_opencode_forks_pending_native_source() -> None:
         bind_agent_session_by_id=Mock(return_value="ses-fork"),
     )
     manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
-    server = SimpleNamespace(fork_session=AsyncMock(return_value={"id": "oc-fork"}), create_session=AsyncMock())
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
     request = _request()
     request.context.platform_specific = {
         "agent_session_id": "ses-fork",
@@ -96,7 +100,7 @@ def test_opencode_forks_pending_native_source() -> None:
     session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-fork"
-    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo")
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
     server.create_session.assert_not_awaited()
     sessions.bind_agent_session_by_id.assert_called_once_with(
         "ses-fork",
@@ -106,6 +110,87 @@ def test_opencode_forks_pending_native_source() -> None:
         vibe_agent_name=None,
         vibe_agent_backend=None,
     )
+
+
+def test_opencode_running_fork_passes_native_message_point() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "trim_latest_running_turn": True,
+                "opencode_fork_message_id": "oc-msg-prev",
+            },
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-prev")
+    server.list_messages.assert_not_awaited()
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_running_fork_infers_native_message_point_from_source_messages() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(
+            return_value=[
+                {"info": {"id": "oc-msg-1", "role": "user"}},
+                {"info": {"id": "oc-msg-2", "role": "assistant"}},
+                {"info": {"id": "oc-msg-3", "role": "user"}},
+            ]
+        ),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "trim_latest_running_turn": True,
+            },
+        },
+    }
+
+    session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_awaited_once_with("oc-source", "/repo")
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-2")
+    server.create_session.assert_not_awaited()
 
 
 def test_opencode_reserved_agent_session_id_is_not_replaced() -> None:

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -385,7 +385,60 @@ def test_opencode_saved_boundary_is_ignored_when_source_completed_before_anchor(
         },
     }
 
-    with patch("modules.agents.opencode.session.fork_anchor_is_terminal_agent_output", return_value=True):
+    with patch(
+        "modules.agents.opencode.session.fork_source_state",
+        return_value=SimpleNamespace(
+            anchor_is_terminal_agent_output=True,
+            has_terminal_agent_output_after_anchor=False,
+        ),
+    ):
+        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_saved_boundary_is_ignored_when_source_completed_after_anchor() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "source_message_id": "msg-user",
+                "trim_latest_running_turn": True,
+                "native_turn_started": True,
+                "opencode_fork_message_id": "oc-msg-user",
+            },
+        },
+    }
+
+    with patch(
+        "modules.agents.opencode.session.fork_source_state",
+        return_value=SimpleNamespace(
+            anchor_is_terminal_agent_output=False,
+            has_terminal_agent_output_after_anchor=True,
+        ),
+    ):
         session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-fork"
@@ -426,7 +479,13 @@ def test_opencode_saved_boundary_is_used_when_anchor_is_not_completed() -> None:
         },
     }
 
-    with patch("modules.agents.opencode.session.fork_anchor_is_terminal_agent_output", return_value=False):
+    with patch(
+        "modules.agents.opencode.session.fork_source_state",
+        return_value=SimpleNamespace(
+            anchor_is_terminal_agent_output=False,
+            has_terminal_agent_output_after_anchor=False,
+        ),
+    ):
         session_id = asyncio.run(manager.get_or_create_session_id(request, server))
 
     assert session_id == "oc-fork"

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from core.services.session_fork import (
     SessionForkError,
     fork_metadata_from_session_metadata,
+    fork_source_has_agent_output_after_anchor,
     pending_native_fork,
     pending_native_fork_source,
     reserve_forked_session,
@@ -580,6 +581,51 @@ def test_pending_native_fork_source_uses_target_session_metadata() -> None:
     )
 
     assert pending_native_fork_source(ctx, "codex") == "thread-source"
+
+
+def test_fork_source_has_agent_output_after_anchor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            user = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="do the long task",
+            )
+
+        assert fork_source_has_agent_output_after_anchor(
+            {"source_session_id": source_id, "source_message_id": user["id"]}
+        ) is False
+
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="result",
+                text="done",
+            )
+
+        assert fork_source_has_agent_output_after_anchor(
+            {"source_session_id": source_id, "source_message_id": user["id"]}
+        ) is True
+    finally:
+        engine.dispose()
 
 
 def test_fork_metadata_from_session_metadata_uses_pending_row_fields() -> None:

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -699,6 +699,8 @@ def test_fork_source_state_tracks_nonterminal_messages_after_anchor(
         state = fork_source_state({"source_session_id": source_id, "source_message_id": user["id"]})
 
         assert state.anchor_is_terminal_agent_output is False
+        assert state.latest_after_anchor_author == "agent"
+        assert state.latest_after_anchor_type == "assistant"
         assert state.has_messages_after_anchor is True
         assert state.has_terminal_agent_output_after_anchor is False
     finally:
@@ -733,6 +735,8 @@ def test_fork_source_state_ignores_notify_as_terminal_output(
         state = fork_source_state(fork)
 
         assert state.anchor_is_terminal_agent_output is False
+        assert state.latest_after_anchor_author is None
+        assert state.latest_after_anchor_type is None
         assert state.has_messages_after_anchor is False
         assert state.has_terminal_agent_output_after_anchor is False
         assert fork_anchor_is_terminal_agent_output(fork) is False
@@ -777,7 +781,61 @@ def test_fork_source_state_ignores_operational_rows_after_anchor(
         state = fork_source_state({"source_session_id": source_id, "source_message_id": user["id"]})
 
         assert state.anchor_is_terminal_agent_output is False
+        assert state.latest_after_anchor_author is None
+        assert state.latest_after_anchor_type is None
         assert state.has_messages_after_anchor is False
+        assert state.has_terminal_agent_output_after_anchor is False
+    finally:
+        engine.dispose()
+
+
+def test_fork_source_state_uses_latest_progress_after_anchor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            anchor = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="first task",
+            )
+            messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="result",
+                text="first done",
+            )
+            messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="second task",
+            )
+
+        state = fork_source_state({"source_session_id": source_id, "source_message_id": anchor["id"]})
+
+        assert state.latest_after_anchor_author == "user"
+        assert state.latest_after_anchor_type == "user"
+        assert state.has_messages_after_anchor is True
         assert state.has_terminal_agent_output_after_anchor is False
     finally:
         engine.dispose()

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -705,6 +705,84 @@ def test_fork_source_state_tracks_nonterminal_messages_after_anchor(
         engine.dispose()
 
 
+def test_fork_source_state_ignores_notify_as_terminal_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            notify = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="notify",
+                text="still working",
+            )
+
+        fork = {"source_session_id": source_id, "source_message_id": notify["id"]}
+        state = fork_source_state(fork)
+
+        assert state.anchor_is_terminal_agent_output is False
+        assert state.has_messages_after_anchor is False
+        assert state.has_terminal_agent_output_after_anchor is False
+        assert fork_anchor_is_terminal_agent_output(fork) is False
+    finally:
+        engine.dispose()
+
+
+def test_fork_source_state_ignores_operational_rows_after_anchor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            user = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="do the long task",
+            )
+            for message_type in ("queued", "pending", "draft", "notify"):
+                messages_service.append(
+                    conn,
+                    scope_id=row["scope_id"],
+                    session_id=source_id,
+                    platform="avibe",
+                    author="agent",
+                    message_type=message_type,
+                    text=message_type,
+                )
+
+        state = fork_source_state({"source_session_id": source_id, "source_message_id": user["id"]})
+
+        assert state.anchor_is_terminal_agent_output is False
+        assert state.has_messages_after_anchor is False
+        assert state.has_terminal_agent_output_after_anchor is False
+    finally:
+        engine.dispose()
+
+
 def test_fork_metadata_from_session_metadata_uses_pending_row_fields() -> None:
     metadata = {
         "created_via": "session_fork",

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -326,13 +326,13 @@ def test_reserve_forked_opencode_running_first_turn_records_user_boundary(
     assert "fork_opencode_fork_empty_history" not in metadata
 
 
-def test_reserve_forked_opencode_idle_completed_tail_does_not_mark_trim(
+def test_reserve_forked_opencode_missing_boundary_preserves_trim_intent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     db_path = tmp_path / "vibe.sqlite"
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
-    _seed_opencode_messages(xdg_home, "oc-source", ["user", "assistant"])
+    _seed_opencode_messages(xdg_home, "oc-source", [])
     source_id = _seed_source_session(db_path, tmp_path)
     engine = create_sqlite_engine(db_path)
     try:
@@ -356,7 +356,7 @@ def test_reserve_forked_opencode_idle_completed_tail_does_not_mark_trim(
         db_path=db_path,
     )
 
-    assert result.fork.trim_latest_running_turn is False
+    assert result.fork.trim_latest_running_turn is True
     assert result.fork.native_turn_started is False
 
 

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -157,7 +157,7 @@ def test_reserve_forked_opencode_running_fork_records_previous_native_message(tm
                 .where(agent_sessions.c.id == source_id)
                 .values(agent_backend="opencode", agent_variant="opencode")
             )
-            previous = messages_service.append(
+            messages_service.append(
                 conn,
                 scope_id=row["scope_id"],
                 session_id=source_id,
@@ -183,12 +183,13 @@ def test_reserve_forked_opencode_running_fork_records_previous_native_message(tm
     result = reserve_forked_session(
         source_session_id=source_id,
         trim_latest_running_turn=True,
+        native_turn_started=True,
         db_path=db_path,
     )
 
     assert result.fork.source_message_id == latest_user["id"]
     assert result.fork.trim_latest_running_turn is True
-    assert result.fork.opencode_fork_message_id == "oc-msg-prev"
+    assert result.fork.native_turn_started is True
     engine = create_sqlite_engine(db_path)
     try:
         with engine.connect() as conn:
@@ -200,8 +201,9 @@ def test_reserve_forked_opencode_running_fork_records_previous_native_message(tm
 
     metadata = json.loads(forked["metadata_json"])
     assert metadata["fork_source_message_id"] == latest_user["id"]
-    assert metadata["fork_opencode_message_id"] == previous["native_message_id"]
+    assert "fork_opencode_message_id" not in metadata
     assert metadata["fork_trim_latest_running_turn"] is True
+    assert metadata["fork_native_turn_started"] is True
 
 
 def test_reserve_forked_session_uses_generic_title_for_untitled_source(tmp_path: Path) -> None:
@@ -386,7 +388,7 @@ def test_pending_native_fork_preserves_trim_metadata() -> None:
                     "source_backend": "opencode",
                     "source_message_id": "msg-avibe",
                     "trim_latest_running_turn": True,
-                    "opencode_fork_message_id": "oc-msg-prev",
+                    "native_turn_started": True,
                 },
             }
         },
@@ -398,7 +400,7 @@ def test_pending_native_fork_preserves_trim_metadata() -> None:
         "source_backend": "opencode",
         "source_message_id": "msg-avibe",
         "trim_latest_running_turn": True,
-        "opencode_fork_message_id": "oc-msg-prev",
+        "native_turn_started": True,
     }
 
 
@@ -448,7 +450,7 @@ def test_fork_metadata_from_session_metadata_preserves_trim_fields() -> None:
         "fork_source_backend": "opencode",
         "fork_source_message_id": "msg-avibe",
         "fork_trim_latest_running_turn": True,
-        "fork_opencode_message_id": "oc-msg-prev",
+        "fork_native_turn_started": True,
     }
 
     assert fork_metadata_from_session_metadata(metadata) == {
@@ -457,5 +459,5 @@ def test_fork_metadata_from_session_metadata_preserves_trim_fields() -> None:
         "source_backend": "opencode",
         "source_message_id": "msg-avibe",
         "trim_latest_running_turn": True,
-        "opencode_fork_message_id": "oc-msg-prev",
+        "native_turn_started": True,
     }

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -143,8 +144,61 @@ def test_reserve_forked_session_copies_row_and_applies_overrides(tmp_path: Path)
     assert metadata["fork_trim_latest_running_turn"] is False
 
 
-def test_reserve_forked_opencode_running_fork_records_previous_native_message(tmp_path: Path) -> None:
+def test_reserve_forked_codex_running_fork_does_not_mark_trim(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        trim_latest_running_turn=True,
+        native_turn_started=True,
+        db_path=db_path,
+    )
+
+    assert result.fork.source_backend == "codex"
+    assert result.fork.trim_latest_running_turn is False
+    assert result.fork.native_turn_started is False
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    metadata = json.loads(row["metadata_json"])
+    assert metadata["fork_trim_latest_running_turn"] is False
+    assert metadata["fork_native_turn_started"] is False
+
+
+def _seed_opencode_messages(xdg_home: Path, native_session_id: str, roles: list[str]) -> None:
+    db_path = xdg_home / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, data TEXT)")
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT, message_id TEXT, time_created INTEGER, data TEXT)"
+        )
+        for index, role in enumerate(roles, start=1):
+            message_id = f"oc-msg-{index}"
+            conn.execute(
+                "INSERT INTO message (id, data) VALUES (?, ?)",
+                (message_id, json.dumps({"role": role})),
+            )
+            conn.execute(
+                "INSERT INTO part (id, session_id, message_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+                (f"part-{index}", native_session_id, message_id, index, json.dumps({"type": "text"})),
+            )
+
+
+def test_reserve_forked_opencode_running_fork_records_frozen_native_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
+    _seed_opencode_messages(xdg_home, "oc-source", ["user", "assistant", "user"])
     source_id = _seed_source_session(db_path, tmp_path)
     engine = create_sqlite_engine(db_path)
     try:
@@ -155,7 +209,11 @@ def test_reserve_forked_opencode_running_fork_records_previous_native_message(tm
             conn.execute(
                 agent_sessions.update()
                 .where(agent_sessions.c.id == source_id)
-                .values(agent_backend="opencode", agent_variant="opencode")
+                .values(
+                    agent_backend="opencode",
+                    agent_variant="opencode",
+                    native_session_id="oc-source",
+                )
             )
             messages_service.append(
                 conn,
@@ -190,6 +248,7 @@ def test_reserve_forked_opencode_running_fork_records_previous_native_message(tm
     assert result.fork.source_message_id == latest_user["id"]
     assert result.fork.trim_latest_running_turn is True
     assert result.fork.native_turn_started is True
+    assert result.fork.opencode_fork_message_id == "oc-msg-2"
     engine = create_sqlite_engine(db_path)
     try:
         with engine.connect() as conn:
@@ -201,9 +260,55 @@ def test_reserve_forked_opencode_running_fork_records_previous_native_message(tm
 
     metadata = json.loads(forked["metadata_json"])
     assert metadata["fork_source_message_id"] == latest_user["id"]
-    assert "fork_opencode_message_id" not in metadata
+    assert metadata["fork_opencode_message_id"] == "oc-msg-2"
     assert metadata["fork_trim_latest_running_turn"] is True
     assert metadata["fork_native_turn_started"] is True
+
+
+def test_reserve_forked_opencode_running_first_turn_records_empty_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
+    _seed_opencode_messages(xdg_home, "oc-source", ["user"])
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(
+                    agent_backend="opencode",
+                    agent_variant="opencode",
+                    native_session_id="oc-source",
+                )
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        trim_latest_running_turn=True,
+        native_turn_started=True,
+        db_path=db_path,
+    )
+
+    assert result.fork.trim_latest_running_turn is True
+    assert result.fork.native_turn_started is True
+    assert result.fork.opencode_fork_empty_history is True
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            forked = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    metadata = json.loads(forked["metadata_json"])
+    assert metadata["fork_opencode_fork_empty_history"] is True
 
 
 def test_reserve_forked_session_uses_generic_title_for_untitled_source(tmp_path: Path) -> None:
@@ -389,6 +494,7 @@ def test_pending_native_fork_preserves_trim_metadata() -> None:
                     "source_message_id": "msg-avibe",
                     "trim_latest_running_turn": True,
                     "native_turn_started": True,
+                    "opencode_fork_message_id": "oc-msg-2",
                 },
             }
         },
@@ -401,6 +507,7 @@ def test_pending_native_fork_preserves_trim_metadata() -> None:
         "source_message_id": "msg-avibe",
         "trim_latest_running_turn": True,
         "native_turn_started": True,
+        "opencode_fork_message_id": "oc-msg-2",
     }
 
 
@@ -451,6 +558,7 @@ def test_fork_metadata_from_session_metadata_preserves_trim_fields() -> None:
         "fork_source_message_id": "msg-avibe",
         "fork_trim_latest_running_turn": True,
         "fork_native_turn_started": True,
+        "fork_opencode_message_id": "oc-msg-2",
     }
 
     assert fork_metadata_from_session_metadata(metadata) == {
@@ -460,4 +568,5 @@ def test_fork_metadata_from_session_metadata_preserves_trim_fields() -> None:
         "source_message_id": "msg-avibe",
         "trim_latest_running_turn": True,
         "native_turn_started": True,
+        "opencode_fork_message_id": "oc-msg-2",
     }

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from core.services.session_fork import (
     SessionForkError,
     fork_metadata_from_session_metadata,
+    pending_native_fork,
     pending_native_fork_source,
     reserve_forked_session,
 )
@@ -139,6 +140,68 @@ def test_reserve_forked_session_copies_row_and_applies_overrides(tmp_path: Path)
     assert row["title"] == "Fork Source"
     assert metadata["fork_source_message_id"] == visible_message["id"]
     assert metadata["fork_source_session_title"] == "Source"
+    assert metadata["fork_trim_latest_running_turn"] is False
+
+
+def test_reserve_forked_opencode_running_fork_records_previous_native_message(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(
+                select(agent_sessions.c.scope_id).where(agent_sessions.c.id == source_id)
+            ).mappings().one()
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(agent_backend="opencode", agent_variant="opencode")
+            )
+            previous = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="result",
+                text="completed answer",
+                native_message_id="oc-msg-prev",
+            )
+            latest_user = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="do the long task",
+                native_message_id="oc-msg-user",
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        trim_latest_running_turn=True,
+        db_path=db_path,
+    )
+
+    assert result.fork.source_message_id == latest_user["id"]
+    assert result.fork.trim_latest_running_turn is True
+    assert result.fork.opencode_fork_message_id == "oc-msg-prev"
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            forked = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    metadata = json.loads(forked["metadata_json"])
+    assert metadata["fork_source_message_id"] == latest_user["id"]
+    assert metadata["fork_opencode_message_id"] == previous["native_message_id"]
+    assert metadata["fork_trim_latest_running_turn"] is True
 
 
 def test_reserve_forked_session_uses_generic_title_for_untitled_source(tmp_path: Path) -> None:
@@ -308,6 +371,37 @@ def test_pending_native_fork_source_requires_empty_target_native() -> None:
     assert pending_native_fork_source(ctx, "codex") is None
 
 
+def test_pending_native_fork_preserves_trim_metadata() -> None:
+    ctx = MessageContext(
+        user_id="U1",
+        channel_id="C1",
+        platform_specific={
+            "agent_session_target": {
+                "id": "ses-target",
+                "agent_backend": "opencode",
+                "native_session_id": "",
+                "native_session_fork": {
+                    "source_session_id": "ses-source",
+                    "source_native_session_id": "oc-source",
+                    "source_backend": "opencode",
+                    "source_message_id": "msg-avibe",
+                    "trim_latest_running_turn": True,
+                    "opencode_fork_message_id": "oc-msg-prev",
+                },
+            }
+        },
+    )
+
+    assert pending_native_fork(ctx, "opencode") == {
+        "source_session_id": "ses-source",
+        "source_native_session_id": "oc-source",
+        "source_backend": "opencode",
+        "source_message_id": "msg-avibe",
+        "trim_latest_running_turn": True,
+        "opencode_fork_message_id": "oc-msg-prev",
+    }
+
+
 def test_pending_native_fork_source_uses_target_session_metadata() -> None:
     ctx = MessageContext(
         user_id="U1",
@@ -344,3 +438,24 @@ def test_fork_metadata_from_session_metadata_uses_pending_row_fields() -> None:
         "source_backend": "codex",
     }
     assert fork_metadata_from_session_metadata({"created_via": "session_fork"}) is None
+
+
+def test_fork_metadata_from_session_metadata_preserves_trim_fields() -> None:
+    metadata = {
+        "created_via": "session_fork",
+        "fork_source_session_id": "ses-source",
+        "fork_source_native_session_id": "oc-source",
+        "fork_source_backend": "opencode",
+        "fork_source_message_id": "msg-avibe",
+        "fork_trim_latest_running_turn": True,
+        "fork_opencode_message_id": "oc-msg-prev",
+    }
+
+    assert fork_metadata_from_session_metadata(metadata) == {
+        "source_session_id": "ses-source",
+        "source_native_session_id": "oc-source",
+        "source_backend": "opencode",
+        "source_message_id": "msg-avibe",
+        "trim_latest_running_turn": True,
+        "opencode_fork_message_id": "oc-msg-prev",
+    }

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -9,8 +9,10 @@ from sqlalchemy import select
 
 from core.services.session_fork import (
     SessionForkError,
+    fork_anchor_is_terminal_agent_output,
     fork_metadata_from_session_metadata,
     fork_source_has_agent_output_after_anchor,
+    fork_source_state,
     pending_native_fork,
     pending_native_fork_source,
     reserve_forked_session,
@@ -624,6 +626,81 @@ def test_fork_source_has_agent_output_after_anchor(tmp_path: Path, monkeypatch: 
         assert fork_source_has_agent_output_after_anchor(
             {"source_session_id": source_id, "source_message_id": user["id"]}
         ) is True
+    finally:
+        engine.dispose()
+
+
+def test_fork_source_state_identifies_completed_anchor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            result = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="result",
+                text="done",
+            )
+
+        fork = {"source_session_id": source_id, "source_message_id": result["id"]}
+        state = fork_source_state(fork)
+
+        assert state.anchor_is_terminal_agent_output is True
+        assert state.has_messages_after_anchor is False
+        assert state.has_terminal_agent_output_after_anchor is False
+        assert fork_anchor_is_terminal_agent_output(fork) is True
+    finally:
+        engine.dispose()
+
+
+def test_fork_source_state_tracks_nonterminal_messages_after_anchor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            user = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="do the long task",
+            )
+            messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="assistant",
+                text="thinking",
+            )
+
+        state = fork_source_state({"source_session_id": source_id, "source_message_id": user["id"]})
+
+        assert state.anchor_is_terminal_agent_output is False
+        assert state.has_messages_after_anchor is True
+        assert state.has_terminal_agent_output_after_anchor is False
     finally:
         engine.dispose()
 

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -144,7 +144,7 @@ def test_reserve_forked_session_copies_row_and_applies_overrides(tmp_path: Path)
     assert metadata["fork_trim_latest_running_turn"] is False
 
 
-def test_reserve_forked_codex_running_fork_does_not_mark_trim(tmp_path: Path) -> None:
+def test_reserve_forked_codex_running_fork_marks_trim(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     source_id = _seed_source_session(db_path, tmp_path)
 
@@ -156,8 +156,8 @@ def test_reserve_forked_codex_running_fork_does_not_mark_trim(tmp_path: Path) ->
     )
 
     assert result.fork.source_backend == "codex"
-    assert result.fork.trim_latest_running_turn is False
-    assert result.fork.native_turn_started is False
+    assert result.fork.trim_latest_running_turn is True
+    assert result.fork.native_turn_started is True
     engine = create_sqlite_engine(db_path)
     try:
         with engine.connect() as conn:
@@ -168,11 +168,17 @@ def test_reserve_forked_codex_running_fork_does_not_mark_trim(tmp_path: Path) ->
         engine.dispose()
 
     metadata = json.loads(row["metadata_json"])
-    assert metadata["fork_trim_latest_running_turn"] is False
-    assert metadata["fork_native_turn_started"] is False
+    assert metadata["fork_trim_latest_running_turn"] is True
+    assert metadata["fork_native_turn_started"] is True
 
 
-def _seed_opencode_messages(xdg_home: Path, native_session_id: str, roles: list[str]) -> None:
+def _seed_opencode_messages(
+    xdg_home: Path,
+    native_session_id: str,
+    roles: list[str],
+    *,
+    completed_assistant: bool = True,
+) -> None:
     db_path = xdg_home / "opencode" / "opencode.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(db_path) as conn:
@@ -184,7 +190,15 @@ def _seed_opencode_messages(xdg_home: Path, native_session_id: str, roles: list[
             message_id = f"oc-msg-{index}"
             conn.execute(
                 "INSERT INTO message (id, data) VALUES (?, ?)",
-                (message_id, json.dumps({"role": role})),
+                (
+                    message_id,
+                    json.dumps(
+                        {
+                            "role": role,
+                            "time": {"completed": index} if role == "assistant" and completed_assistant else {},
+                        }
+                    ),
+                ),
             )
             conn.execute(
                 "INSERT INTO part (id, session_id, message_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
@@ -248,7 +262,7 @@ def test_reserve_forked_opencode_running_fork_records_frozen_native_message(
     assert result.fork.source_message_id == latest_user["id"]
     assert result.fork.trim_latest_running_turn is True
     assert result.fork.native_turn_started is True
-    assert result.fork.opencode_fork_message_id == "oc-msg-2"
+    assert result.fork.opencode_fork_message_id == "oc-msg-3"
     engine = create_sqlite_engine(db_path)
     try:
         with engine.connect() as conn:
@@ -260,12 +274,12 @@ def test_reserve_forked_opencode_running_fork_records_frozen_native_message(
 
     metadata = json.loads(forked["metadata_json"])
     assert metadata["fork_source_message_id"] == latest_user["id"]
-    assert metadata["fork_opencode_message_id"] == "oc-msg-2"
+    assert metadata["fork_opencode_message_id"] == "oc-msg-3"
     assert metadata["fork_trim_latest_running_turn"] is True
     assert metadata["fork_native_turn_started"] is True
 
 
-def test_reserve_forked_opencode_running_first_turn_records_empty_history(
+def test_reserve_forked_opencode_running_first_turn_records_user_boundary(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     db_path = tmp_path / "vibe.sqlite"
@@ -297,7 +311,7 @@ def test_reserve_forked_opencode_running_first_turn_records_empty_history(
 
     assert result.fork.trim_latest_running_turn is True
     assert result.fork.native_turn_started is True
-    assert result.fork.opencode_fork_empty_history is True
+    assert result.fork.opencode_fork_message_id == "oc-msg-1"
     engine = create_sqlite_engine(db_path)
     try:
         with engine.connect() as conn:
@@ -308,7 +322,42 @@ def test_reserve_forked_opencode_running_first_turn_records_empty_history(
         engine.dispose()
 
     metadata = json.loads(forked["metadata_json"])
-    assert metadata["fork_opencode_fork_empty_history"] is True
+    assert metadata["fork_opencode_message_id"] == "oc-msg-1"
+    assert "fork_opencode_fork_empty_history" not in metadata
+
+
+def test_reserve_forked_opencode_idle_completed_tail_does_not_mark_trim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
+    _seed_opencode_messages(xdg_home, "oc-source", ["user", "assistant"])
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(
+                    agent_backend="opencode",
+                    agent_variant="opencode",
+                    native_session_id="oc-source",
+                )
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        trim_latest_running_turn=True,
+        native_turn_started=False,
+        db_path=db_path,
+    )
+
+    assert result.fork.trim_latest_running_turn is False
+    assert result.fork.native_turn_started is False
 
 
 def test_reserve_forked_session_uses_generic_title_for_untitled_source(tmp_path: Path) -> None:

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -303,7 +303,7 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path, mo
     payload = response.get_json()
     assert payload["metadata"]["fork_trim_latest_running_turn"] is True
     assert payload["metadata"]["fork_native_turn_started"] is True
-    assert payload["metadata"]["fork_opencode_message_id"] == "oc-msg-2"
+    assert payload["metadata"]["fork_opencode_message_id"] == "oc-msg-3"
     in_flight.assert_awaited_once_with(session_id)
 
 
@@ -344,13 +344,16 @@ def test_fork_session_does_not_mark_claude_running_source_for_trim(isolated_stat
     assert payload["metadata"]["fork_native_turn_started"] is False
 
 
-def test_fork_session_does_not_trim_before_native_turn_starts(isolated_state, tmp_path):
+def test_fork_session_trims_post_accept_open_code_before_native_turn_starts(isolated_state, tmp_path, monkeypatch):
     from sqlalchemy import update
 
     from storage.db import create_sqlite_engine
     from storage.models import agent_sessions
     from vibe.ui_server import app
 
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
+    _seed_opencode_messages(xdg_home, "native-source-1", ["user"])
     _, session_id = _make_session(tmp_path)
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -358,9 +361,9 @@ def test_fork_session_does_not_trim_before_native_turn_starts(isolated_state, tm
             update(agent_sessions)
             .where(agent_sessions.c.id == session_id)
             .values(
-                agent_backend="codex",
-                agent_variant="codex",
-                agent_name="codex",
+                agent_backend="opencode",
+                agent_variant="opencode",
+                agent_name="opencode",
                 native_session_id="native-source-1",
                 title="Source session",
             )
@@ -382,8 +385,9 @@ def test_fork_session_does_not_trim_before_native_turn_starts(isolated_state, tm
 
     assert response.status_code == 201
     payload = response.get_json()
-    assert payload["metadata"]["fork_trim_latest_running_turn"] is False
-    assert payload["metadata"]["fork_native_turn_started"] is False
+    assert payload["metadata"]["fork_trim_latest_running_turn"] is True
+    assert payload["metadata"]["fork_native_turn_started"] is True
+    assert payload["metadata"]["fork_opencode_message_id"] == "oc-msg-1"
 
 
 def test_fork_session_rejects_unbound_source_session(isolated_state, tmp_path):

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -242,7 +242,13 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
         conn.execute(
             update(agent_sessions)
             .where(agent_sessions.c.id == session_id)
-            .values(native_session_id="native-source-1", title="Source session")
+            .values(
+                agent_backend="codex",
+                agent_variant="codex",
+                agent_name="codex",
+                native_session_id="native-source-1",
+                title="Source session",
+            )
         )
         messages_service.append(
             conn,
@@ -275,6 +281,43 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
     in_flight.assert_awaited_once_with(session_id)
 
 
+def test_fork_session_does_not_mark_claude_running_source_for_trim(isolated_state, tmp_path):
+    from sqlalchemy import update
+
+    from storage.db import create_sqlite_engine
+    from storage.models import agent_sessions
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == session_id)
+            .values(native_session_id="claude-source-1", title="Source session")
+        )
+
+    in_flight = AsyncMock(
+        return_value={
+            "status_code": 200,
+            "body": {"ok": True, "in_flight": True, "native_turn_started": True},
+        }
+    )
+    with (
+        patch("vibe.sse_broker.broker.publish"),
+        patch("vibe.internal_client.turn_state", in_flight),
+    ):
+        client = app.test_client()
+        headers = csrf_headers(client)
+        response = client.post(f"/api/sessions/{session_id}/fork", json={}, headers=headers)
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["metadata"]["fork_source_backend"] == "claude"
+    assert payload["metadata"]["fork_trim_latest_running_turn"] is False
+    assert payload["metadata"]["fork_native_turn_started"] is False
+
+
 def test_fork_session_does_not_trim_before_native_turn_starts(isolated_state, tmp_path):
     from sqlalchemy import update
 
@@ -288,7 +331,13 @@ def test_fork_session_does_not_trim_before_native_turn_starts(isolated_state, tm
         conn.execute(
             update(agent_sessions)
             .where(agent_sessions.c.id == session_id)
-            .values(native_session_id="native-source-1", title="Source session")
+            .values(
+                agent_backend="codex",
+                agent_variant="codex",
+                agent_name="codex",
+                native_session_id="native-source-1",
+                title="Source session",
+            )
         )
 
     in_flight = AsyncMock(

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -10,6 +10,8 @@ controller process.
 
 from __future__ import annotations
 
+import json
+import sqlite3
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -73,6 +75,26 @@ def _make_session(tmp_path: Path) -> tuple[str, str]:
             agent_name="worker",
         )
     return scope_id, session["id"]
+
+
+def _seed_opencode_messages(xdg_home: Path, native_session_id: str, roles: list[str]) -> None:
+    db_path = xdg_home / "opencode" / "opencode.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, data TEXT)")
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, session_id TEXT, message_id TEXT, time_created INTEGER, data TEXT)"
+        )
+        for index, role in enumerate(roles, start=1):
+            message_id = f"oc-msg-{index}"
+            conn.execute(
+                "INSERT INTO message (id, data) VALUES (?, ?)",
+                (message_id, json.dumps({"role": role})),
+            )
+            conn.execute(
+                "INSERT INTO part (id, session_id, message_id, time_created, data) VALUES (?, ?, ?, ?, ?)",
+                (f"part-{index}", native_session_id, message_id, index, json.dumps({"type": "text"})),
+            )
 
 
 def test_route_fire_and_forgets_dispatch(isolated_state, tmp_path):
@@ -228,7 +250,7 @@ def test_fork_session_creates_new_workbench_session(isolated_state, tmp_path):
     )
 
 
-def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
+def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path, monkeypatch):
     from sqlalchemy import update
 
     from storage import messages_service
@@ -236,6 +258,9 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
     from storage.models import agent_sessions
     from vibe.ui_server import app
 
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
+    _seed_opencode_messages(xdg_home, "native-source-1", ["user", "assistant", "user"])
     scope_id, session_id = _make_session(tmp_path)
     engine = create_sqlite_engine()
     with engine.begin() as conn:
@@ -243,9 +268,9 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
             update(agent_sessions)
             .where(agent_sessions.c.id == session_id)
             .values(
-                agent_backend="codex",
-                agent_variant="codex",
-                agent_name="codex",
+                agent_backend="opencode",
+                agent_variant="opencode",
+                agent_name="opencode",
                 native_session_id="native-source-1",
                 title="Source session",
             )
@@ -278,6 +303,7 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
     payload = response.get_json()
     assert payload["metadata"]["fork_trim_latest_running_turn"] is True
     assert payload["metadata"]["fork_native_turn_started"] is True
+    assert payload["metadata"]["fork_opencode_message_id"] == "oc-msg-2"
     in_flight.assert_awaited_once_with(session_id)
 
 

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -228,6 +228,47 @@ def test_fork_session_creates_new_workbench_session(isolated_state, tmp_path):
     )
 
 
+def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
+    from sqlalchemy import update
+
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.models import agent_sessions
+    from vibe.ui_server import app
+
+    scope_id, session_id = _make_session(tmp_path)
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == session_id)
+            .values(native_session_id="native-source-1", title="Source session")
+        )
+        messages_service.append(
+            conn,
+            scope_id=scope_id,
+            session_id=session_id,
+            platform="avibe",
+            author="user",
+            message_type="user",
+            text="do work",
+        )
+
+    in_flight = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": True}})
+    with (
+        patch("vibe.sse_broker.broker.publish"),
+        patch("vibe.internal_client.turn_state", in_flight),
+    ):
+        client = app.test_client()
+        headers = csrf_headers(client)
+        response = client.post(f"/api/sessions/{session_id}/fork", json={}, headers=headers)
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["metadata"]["fork_trim_latest_running_turn"] is True
+    in_flight.assert_awaited_once_with(session_id)
+
+
 def test_fork_session_rejects_unbound_source_session(isolated_state, tmp_path):
     from vibe.ui_server import app
 

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -254,7 +254,12 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
             text="do work",
         )
 
-    in_flight = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": True}})
+    in_flight = AsyncMock(
+        return_value={
+            "status_code": 200,
+            "body": {"ok": True, "in_flight": True, "native_turn_started": True},
+        }
+    )
     with (
         patch("vibe.sse_broker.broker.publish"),
         patch("vibe.internal_client.turn_state", in_flight),
@@ -266,7 +271,44 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path):
     assert response.status_code == 201
     payload = response.get_json()
     assert payload["metadata"]["fork_trim_latest_running_turn"] is True
+    assert payload["metadata"]["fork_native_turn_started"] is True
     in_flight.assert_awaited_once_with(session_id)
+
+
+def test_fork_session_does_not_trim_before_native_turn_starts(isolated_state, tmp_path):
+    from sqlalchemy import update
+
+    from storage.db import create_sqlite_engine
+    from storage.models import agent_sessions
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == session_id)
+            .values(native_session_id="native-source-1", title="Source session")
+        )
+
+    in_flight = AsyncMock(
+        return_value={
+            "status_code": 200,
+            "body": {"ok": True, "in_flight": True, "native_turn_started": False},
+        }
+    )
+    with (
+        patch("vibe.sse_broker.broker.publish"),
+        patch("vibe.internal_client.turn_state", in_flight),
+    ):
+        client = app.test_client()
+        headers = csrf_headers(client)
+        response = client.post(f"/api/sessions/{session_id}/fork", json={}, headers=headers)
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["metadata"]["fork_trim_latest_running_turn"] is False
+    assert payload["metadata"]["fork_native_turn_started"] is False
 
 
 def test_fork_session_rejects_unbound_source_session(isolated_state, tmp_path):

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4291,11 +4291,10 @@ def _session_fork_error_response(err: Exception):
 async def _session_turn_state_for_fork(session_id: str) -> dict[str, bool]:
     """Authoritative best-effort live turn check for fork trimming.
 
-    ``agent_status`` can be stale after crashes/restarts. Trimming history is
-    destructive for the fork target, so only trim when the controller's live
-    in-flight registry says the backend runtime has accepted this turn. During
-    the startup window, a full native fork is already the correct pre-prompt
-    snapshot and rollback would delete completed history.
+    ``agent_status`` can be stale after crashes/restarts. Treat any live
+    in-flight turn as a trim candidate; backend-specific reservation code then
+    verifies whether a safe native boundary exists before it persists trim
+    metadata.
     """
 
     from vibe import internal_client
@@ -4310,7 +4309,7 @@ async def _session_turn_state_for_fork(session_id: str) -> dict[str, bool]:
     return {
         "in_flight": in_flight,
         "native_turn_started": native_turn_started,
-        "trim_latest_running_turn": in_flight and native_turn_started,
+        "trim_latest_running_turn": in_flight,
     }
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4288,8 +4288,26 @@ def _session_fork_error_response(err: Exception):
     return jsonify({"error": message, "code": "session_fork_failed"}), 400
 
 
+async def _session_in_flight_for_fork(session_id: str) -> bool:
+    """Authoritative best-effort live turn check for fork trimming.
+
+    ``agent_status`` can be stale after crashes/restarts. Trimming history is
+    destructive for the fork target, so only trim when the controller's live
+    in-flight registry explicitly says this source Session is still running.
+    """
+
+    from vibe import internal_client
+
+    try:
+        turn_result = await internal_client.turn_state(session_id)
+    except (internal_client.InternalServerUnavailable, internal_client.InternalServerTimeout):
+        return False
+    body = turn_result.get("body") or {}
+    return bool(body.get("in_flight"))
+
+
 @app.route("/api/sessions/<session_id>/fork", methods=["POST"])
-def sessions_fork(session_id: str):
+async def sessions_fork(session_id: str):
     from core.services import sessions as workbench_sessions_service
     from core.services import settings as settings_service
     from core.services.session_fork import SessionForkError, reserve_forked_session
@@ -4300,7 +4318,11 @@ def sessions_fork(session_id: str):
         # strings use) so the forked title matches the chosen UI, not the browser's
         # Accept-Language header which can differ from the user's selected language.
         title_lang = settings_service.load_config_or_default().language
-        result = reserve_forked_session(source_session_id=session_id, title_lang=title_lang)
+        result = reserve_forked_session(
+            source_session_id=session_id,
+            title_lang=title_lang,
+            trim_latest_running_turn=await _session_in_flight_for_fork(session_id),
+        )
         engine = _projects_engine()
         with engine.connect() as conn:
             session = workbench_sessions_service.get_session(conn, result.session_id)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4288,12 +4288,14 @@ def _session_fork_error_response(err: Exception):
     return jsonify({"error": message, "code": "session_fork_failed"}), 400
 
 
-async def _session_in_flight_for_fork(session_id: str) -> bool:
+async def _session_turn_state_for_fork(session_id: str) -> dict[str, bool]:
     """Authoritative best-effort live turn check for fork trimming.
 
     ``agent_status`` can be stale after crashes/restarts. Trimming history is
     destructive for the fork target, so only trim when the controller's live
-    in-flight registry explicitly says this source Session is still running.
+    in-flight registry says the backend runtime has accepted this turn. During
+    the startup window, a full native fork is already the correct pre-prompt
+    snapshot and rollback would delete completed history.
     """
 
     from vibe import internal_client
@@ -4301,31 +4303,52 @@ async def _session_in_flight_for_fork(session_id: str) -> bool:
     try:
         turn_result = await internal_client.turn_state(session_id)
     except (internal_client.InternalServerUnavailable, internal_client.InternalServerTimeout):
-        return False
+        return {"in_flight": False, "native_turn_started": False}
     body = turn_result.get("body") or {}
-    return bool(body.get("in_flight"))
+    in_flight = bool(body.get("in_flight"))
+    native_turn_started = bool(body.get("native_turn_started"))
+    return {
+        "in_flight": in_flight,
+        "native_turn_started": native_turn_started,
+        "trim_latest_running_turn": in_flight and native_turn_started,
+    }
+
+
+def _reserve_forked_session_for_ui(
+    session_id: str,
+    *,
+    trim_latest_running_turn: bool,
+    native_turn_started: bool,
+) -> dict:
+    from core.services import sessions as workbench_sessions_service
+    from core.services import settings as settings_service
+    from core.services.session_fork import reserve_forked_session
+
+    title_lang = settings_service.load_config_or_default().language
+    result = reserve_forked_session(
+        source_session_id=session_id,
+        title_lang=title_lang,
+        trim_latest_running_turn=trim_latest_running_turn,
+        native_turn_started=native_turn_started,
+    )
+    engine = _projects_engine()
+    with engine.connect() as conn:
+        return workbench_sessions_service.get_session(conn, result.session_id)
 
 
 @app.route("/api/sessions/<session_id>/fork", methods=["POST"])
 async def sessions_fork(session_id: str):
-    from core.services import sessions as workbench_sessions_service
-    from core.services import settings as settings_service
-    from core.services.session_fork import SessionForkError, reserve_forked_session
+    from core.services.session_fork import SessionForkError
     from vibe.sse_broker import broker
 
     try:
-        # Use the saved global UI language (the same source other backend-generated
-        # strings use) so the forked title matches the chosen UI, not the browser's
-        # Accept-Language header which can differ from the user's selected language.
-        title_lang = settings_service.load_config_or_default().language
-        result = reserve_forked_session(
-            source_session_id=session_id,
-            title_lang=title_lang,
-            trim_latest_running_turn=await _session_in_flight_for_fork(session_id),
+        fork_turn_state = await _session_turn_state_for_fork(session_id)
+        session = await asyncio.to_thread(
+            _reserve_forked_session_for_ui,
+            session_id,
+            trim_latest_running_turn=bool(fork_turn_state.get("trim_latest_running_turn")),
+            native_turn_started=bool(fork_turn_state.get("native_turn_started")),
         )
-        engine = _projects_engine()
-        with engine.connect() as conn:
-            session = workbench_sessions_service.get_session(conn, result.session_id)
     except SessionForkError as err:
         return _session_fork_error_response(err)
     except LookupError as err:


### PR DESCRIPTION
## What

- Trim the source session's active, still-running turn when a Workbench session is forked while the source turn is in flight.
- Apply backend-specific handling for Codex and OpenCode:
  - Codex forks first, rolls back one turn, then injects the fork session correction.
  - OpenCode passes a native fork message point when one is known or can be inferred from the source native messages.
- Keep idle/completed source sessions unchanged so completed assistant results are not accidentally removed from forked context.

## Testing

- `npm run build` in `ui/`
- `uv run pytest tests/test_ui_session_stream.py tests/test_session_fork.py tests/test_opencode_session_manager.py tests/test_codex_agent.py tests/test_scheduled_tasks.py::test_build_context_carries_pending_native_fork_metadata tests/test_scheduled_tasks.py::test_build_context_restores_pending_fork_from_session_metadata_when_run_metadata_missing tests/test_scheduled_tasks.py::test_busy_avibe_agent_run_requeue_preserves_session_fork_metadata tests/test_scheduled_tasks.py::test_workbench_queue_flush_recovery_preserves_session_fork_metadata tests/test_cli_agent_run_schema.py::test_agent_run_fork_session_reserves_new_session_and_persists_metadata tests/test_session_cli.py::test_forked_session_prompt_can_use_persisted_metadata`
- `uv run pytest tests/test_session_fork.py tests/test_opencode_session_manager.py tests/test_opencode_server.py tests/test_codex_agent.py::CodexAgentPayloadTests::test_start_or_resume_thread_forks_pending_native_source tests/test_codex_agent.py::CodexAgentPayloadTests::test_start_or_resume_thread_rolls_back_running_fork_before_correction tests/test_ui_session_stream.py::test_fork_session_creates_new_workbench_session tests/test_ui_session_stream.py::test_fork_session_marks_running_source_for_trim`
- `uv run ruff check core/services/session_fork.py modules/agents/codex/agent.py modules/agents/opencode/session.py modules/agents/opencode/server.py vibe/ui_server.py tests/test_session_fork.py tests/test_opencode_session_manager.py tests/test_opencode_server.py tests/test_codex_agent.py tests/test_ui_session_stream.py`

## Risks

- Claude fork behavior is intentionally unchanged because Claude Code does not expose a reliable message-point fork/rollback primitive.
- OpenCode falls back to a full fork if it cannot resolve a safe native message point before the running user turn.
