### PR TITLE
feat(ui): refine /admin/groups routing panel & deprecate the system message type

### DIFF
--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -13,7 +13,10 @@ from config import paths
 logger = logging.getLogger(__name__)
 
 DEFAULT_SHOW_MESSAGE_TYPES: List[str] = ["assistant"]
-ALLOWED_MESSAGE_TYPES = {"system", "assistant", "toolcall"}
+# "system" is deprecated: system/init messages are never pushed to users, so it
+# is no longer a user-facing toggle. Normalizing against this set drops any
+# legacy "system" value still stored in show_message_types.
+ALLOWED_MESSAGE_TYPES = {"assistant", "toolcall"}
 SCHEMA_VERSION = 5
 SCOPED_KEY_SEP = "::"
 

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -23,7 +23,6 @@ class SettingsHandler(BaseHandler):
 
     def _message_type_display_names(self) -> dict:
         return {
-            "system": self._t("messageType.system"),
             "assistant": self._t("messageType.assistant"),
             "toolcall": self._t("messageType.toolcall"),
         }
@@ -341,7 +340,6 @@ class SettingsHandler(BaseHandler):
                 title=self._t("info.messageTypesTitle"),
                 emoji="📋",
                 items=[
-                    (self._t("messageType.system"), self._t("messageType.systemDesc")),
                     (self._t("messageType.toolcall"), self._t("messageType.toolcallDesc")),
                     (self._t("messageType.assistant"), self._t("messageType.assistantDesc")),
                     (self._t("messageType.result"), self._t("messageType.resultDesc")),

--- a/modules/im/telegram.py
+++ b/modules/im/telegram.py
@@ -2067,7 +2067,6 @@ class TelegramBot(BaseIMClient):
 
     def _settings_message_type_label(self, msg_type: str) -> str:
         display_names = {
-            "system": self._t("messageType.system"),
             "assistant": self._t("messageType.assistant"),
             "toolcall": self._t("messageType.toolcall"),
         }

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -375,14 +375,17 @@ class SettingsManager:
         self.update_user_settings(user_id, settings)
 
     def get_available_message_types(self) -> List[str]:
-        """Get list of available message types that can be hidden"""
-        return ["system", "assistant", "toolcall"]
+        """Get list of available message types that can be hidden.
+
+        ``system`` is intentionally excluded: system/init messages are never
+        pushed to users, so there is nothing for the toggle to control.
+        """
+        return ["assistant", "toolcall"]
 
     def get_message_type_display_names(self) -> Dict[str, str]:
         """Get display names for message types"""
         return {
-            "system": "System",
-            "assistant": "Assistant",
+            "assistant": "Muttering",
             "toolcall": "Toolcall",
         }
 

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -394,8 +394,13 @@ class SettingsManager:
         return self.MESSAGE_TYPE_ALIASES.get(message_type, message_type)
 
     def _normalize_show_message_types(self, show_message_types: Optional[List[str]]) -> List[str]:
-        """Normalize and migrate show message types to current canonical schema."""
-        allowed = {"system", "assistant", "toolcall"}
+        """Normalize and migrate show message types to current canonical schema.
+
+        "system" is deprecated and dropped here: system/init messages are never
+        pushed to users, so a legacy stored "system" value is filtered out on
+        load/save instead of leaking into settings UIs.
+        """
+        allowed = {"assistant", "toolcall"}
         if show_message_types is None:
             return DEFAULT_SHOW_MESSAGE_TYPES.copy()
         normalized: List[str] = []

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -19,6 +19,7 @@ from config.v2_settings import (
     _make_scoped_key,
     _split_scoped_key,
     normalize_routing_settings,
+    normalize_show_message_types,
 )
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
 from storage.models import auth_codes, scope_settings, scopes
@@ -78,7 +79,7 @@ class SQLiteSettingsService:
                     require_mention=_nullable_bool_int(item.require_mention),
                     settings_json=_json_dumps(
                         {
-                            "show_message_types": item.show_message_types,
+                            "show_message_types": normalize_show_message_types(item.show_message_types),
                             "routing": routing,
                             "require_bind": item.require_bind,
                         }
@@ -156,7 +157,7 @@ class SQLiteSettingsService:
                             "bound_at": item.bound_at or "",
                             "dm_chat_id": item.dm_chat_id or "",
                             "pending_bind_menu_hint": bool(item.pending_bind_menu_hint),
-                            "show_message_types": item.show_message_types,
+                            "show_message_types": normalize_show_message_types(item.show_message_types),
                             "routing": routing,
                         }
                     ),
@@ -233,7 +234,7 @@ class SQLiteSettingsService:
             key = _make_scoped_key(str(row["platform"]), str(row["native_id"]))
             result[key] = ChannelSettings(
                 enabled=bool(row["enabled"]),
-                show_message_types=_json_list(payload.get("show_message_types")),
+                show_message_types=normalize_show_message_types(_json_list(payload.get("show_message_types"))),
                 custom_cwd=row["workdir"],
                 routing=_routing_from_row(row, payload),
                 require_mention=_nullable_bool(row["require_mention"]),
@@ -272,7 +273,7 @@ class SQLiteSettingsService:
                 is_admin=str(row["role"] or "").lower() in {"admin", "owner"},
                 bound_at=str(payload.get("bound_at") or ""),
                 enabled=bool(row["enabled"]),
-                show_message_types=_json_list(payload.get("show_message_types")),
+                show_message_types=normalize_show_message_types(_json_list(payload.get("show_message_types"))),
                 custom_cwd=row["workdir"],
                 routing=_routing_from_row(row, payload),
                 dm_chat_id=str(payload.get("dm_chat_id") or ""),

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -608,3 +608,63 @@ def test_settings_store_custom_path_uses_sibling_config_primary_platform(tmp_pat
     finally:
         sessions.close()
         store.close()
+
+
+def test_sqlite_filters_deprecated_system_message_type(tmp_path: Path) -> None:
+    """The deprecated "system" message type must not survive the SQLite settings
+    round-trip, and a legacy raw row that still contains it is filtered on load.
+
+    Regression for the Codex review on PR #638: the SQLite store load/save path
+    bypassed message-type normalization, so stored "system" leaked through
+    store-level APIs (e.g. /api/users) until the row was edited.
+    """
+    db_path = tmp_path / "vibe.sqlite"
+    run_migrations(db_path)
+    service = SQLiteSettingsService(db_path)
+    try:
+        # save-normalize: "system" is stripped before it is persisted.
+        service.save_state(
+            SettingsState(
+                channels={
+                    "slack::C1": ChannelSettings(
+                        enabled=True, show_message_types=["system", "assistant"]
+                    )
+                },
+                users={
+                    "slack::U1": UserSettings(
+                        display_name="Alex", enabled=True, show_message_types=["system", "toolcall"]
+                    )
+                },
+            )
+        )
+        saved = service.load_state()
+        assert saved.channels["slack::C1"].show_message_types == ["assistant"]
+        assert saved.users["slack::U1"].show_message_types == ["toolcall"]
+
+        # Simulate legacy rows written before the deprecation by injecting raw
+        # "system" back into settings_json, bypassing save-normalize.
+        engine = create_sqlite_engine(db_path)
+        with engine.begin() as conn:
+            for row in conn.execute(
+                select(scope_settings.c.scope_id, scope_settings.c.settings_json)
+            ).all():
+                payload = json.loads(row.settings_json)
+                if "show_message_types" in payload:
+                    payload["show_message_types"] = ["system", *payload["show_message_types"]]
+                    conn.execute(
+                        scope_settings.update()
+                        .where(scope_settings.c.scope_id == row.scope_id)
+                        .values(settings_json=json.dumps(payload))
+                    )
+        engine.dispose()
+    finally:
+        service.close()
+
+    # load-normalize: a fresh reader drops the legacy "system" value.
+    reader = SQLiteSettingsService(db_path)
+    try:
+        legacy = reader.load_state()
+    finally:
+        reader.close()
+    assert legacy.channels["slack::C1"].show_message_types == ["assistant"]
+    assert legacy.users["slack::U1"].show_message_types == ["toolcall"]

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -235,12 +235,14 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
     return ['low', 'medium', 'high', 'xhigh'].map((value) => ({ value, label: getReasoningLabel(value, value) }));
   })();
 
-  // Top row: working dir + Vibe Agent (+ optional require_mention / require_bind) — dynamic grid columns
-  const topGridCols = showRequireMention ? 'md:grid-cols-4' : 'md:grid-cols-2';
+  // Access row: working dir (+ optional require_mention / require_bind for
+  // channels). The Agent selector lives in the routing row below so it shares a
+  // line with Model + Reasoning effort.
+  const accessGridCols = showRequireMention ? 'md:grid-cols-3' : 'md:grid-cols-1';
 
   return (
     <div className={clsx('space-y-4', containerClass)}>
-      <div className={clsx('grid grid-cols-1 gap-3', topGridCols)}>
+      <div className={clsx('grid grid-cols-1 gap-3', accessGridCols)}>
         {/* Working directory */}
         <div className="space-y-1">
           <label className="text-xs font-medium uppercase text-muted">{t('channelList.workingDirectory')}</label>
@@ -261,58 +263,6 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
               <FolderOpen size={14} />
             </button>
           </div>
-        </div>
-
-        {/* Vibe Agent */}
-        <div className="space-y-1">
-          <label className="text-xs font-medium uppercase text-muted">{t('channelList.agent')}</label>
-          <div className="relative">
-            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2">
-              <Bot size={14} className="text-muted" />
-            </span>
-            <CompactSelect
-              value={value.routing.agent_name || ''}
-              onChange={(e) => {
-                const nextName = e.target.value || null;
-                onChange({
-                  routing: {
-                    ...value.routing,
-                    agent_name: nextName,
-                    model: null,
-                    reasoning_effort: null,
-                    opencode_model: null,
-                    opencode_reasoning_effort: null,
-                    claude_model: null,
-                    claude_reasoning_effort: null,
-                    codex_model: null,
-                    codex_reasoning_effort: null,
-                  },
-                });
-              }}
-              className="w-full pl-9 pr-3"
-            >
-              <option value="">
-                {defaultVibeAgent ? `${t('common.default')} · ${defaultVibeAgent.name}` : t('common.default')}
-              </option>
-              {vibeAgents.map((agent) => (
-                <option key={agent.name} value={agent.name}>
-                  {agent.name}
-                  {agent.backend ? ` · ${agent.backend}` : ''}
-                  {agent.model ? ` / ${agent.model}` : ''}
-                </option>
-              ))}
-            </CompactSelect>
-          </div>
-          {inheritedVibeAgent && (
-            <div className="flex items-center gap-1.5 text-[11px] text-muted">
-              <BackendIcon backend={inheritedVibeAgent.backend} variant="glyph" size={12} />
-              <span className="truncate">
-                {inheritedVibeAgent.backend}
-                {inheritedVibeAgent.model ? ` / ${inheritedVibeAgent.model}` : ''}
-                {inheritedVibeAgent.reasoning_effort ? ` / ${inheritedVibeAgent.reasoning_effort}` : ''}
-              </span>
-            </div>
-          )}
         </div>
 
         {/* Require @mention (channels only) */}
@@ -355,7 +305,11 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                       aria-checked={active}
                       onClick={() => setMention(seg.id)}
                       className={clsx(
-                        'flex-1 rounded-[4px] px-2.5 text-[12px] transition-colors',
+                        // The "inherit" label carries the inherited state in
+                        // parentheses, so it needs more room than on/off to
+                        // avoid wrapping.
+                        'whitespace-nowrap rounded-[4px] px-2 text-[12px] transition-colors',
+                        seg.id === 'inherit' ? 'flex-[1.6]' : 'flex-1',
                         active
                           ? 'border border-mint/30 bg-mint-soft font-bold text-mint'
                           : 'font-medium text-muted hover:text-foreground'
@@ -417,8 +371,59 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
         })()}
       </div>
 
-      {/* Scope-level overrides */}
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      {/* Routing: Agent + Model + Reasoning effort share one row */}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        {/* Vibe Agent */}
+        <div className="space-y-1">
+          <label className="text-xs font-medium uppercase text-muted">{t('channelList.agent')}</label>
+          <div className="relative">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2">
+              <Bot size={14} className="text-muted" />
+            </span>
+            <CompactSelect
+              value={value.routing.agent_name || ''}
+              onChange={(e) => {
+                const nextName = e.target.value || null;
+                onChange({
+                  routing: {
+                    ...value.routing,
+                    agent_name: nextName,
+                    model: null,
+                    reasoning_effort: null,
+                    opencode_model: null,
+                    opencode_reasoning_effort: null,
+                    claude_model: null,
+                    claude_reasoning_effort: null,
+                    codex_model: null,
+                    codex_reasoning_effort: null,
+                  },
+                });
+              }}
+              className="w-full pl-9 pr-3"
+            >
+              <option value="">
+                {defaultVibeAgent ? `${t('common.default')} · ${defaultVibeAgent.name}` : t('common.default')}
+              </option>
+              {vibeAgents.map((agent) => (
+                <option key={agent.name} value={agent.name}>
+                  {agent.name}
+                  {agent.backend ? ` · ${agent.backend}` : ''}
+                  {agent.model ? ` / ${agent.model}` : ''}
+                </option>
+              ))}
+            </CompactSelect>
+          </div>
+          {inheritedVibeAgent && (
+            <div className="flex items-center gap-1.5 text-[11px] text-muted">
+              <BackendIcon backend={inheritedVibeAgent.backend} variant="glyph" size={12} />
+              <span className="truncate">
+                {inheritedVibeAgent.backend}
+                {inheritedVibeAgent.model ? ` / ${inheritedVibeAgent.model}` : ''}
+                {inheritedVibeAgent.reasoning_effort ? ` / ${inheritedVibeAgent.reasoning_effort}` : ''}
+              </span>
+            </div>
+          )}
+        </div>
         <div className="space-y-1">
           <label className="text-xs font-medium uppercase text-muted">{t('channelList.model')}</label>
           {modelOverrideControl}
@@ -452,9 +457,9 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
           </span>
         </div>
         <div className="flex flex-wrap gap-2 text-sm">
-          {['system', 'assistant', 'toolcall'].map((msgType) => {
+          {['assistant', 'toolcall'].map((msgType) => {
             const checked = (value.show_message_types || []).includes(msgType);
-            const label = msgType === 'toolcall' ? 'Toolcall' : msgType.charAt(0).toUpperCase() + msgType.slice(1);
+            const label = t(`channelList.messageType.${msgType}`);
             return (
               <button
                 key={msgType}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1157,7 +1157,11 @@
     "useGlobalDefault": "Use global default",
     "backend": "Backend",
     "showMessageTypes": "Show Message Types",
-    "showMessageTypesHint": "Control which message types are displayed in Slack:\n\n• System: Agent startup/status messages\n• Assistant: Agent responses and explanations\n• Toolcall: Tool execution details (one-line summary)\n\nNote: The agent's final result is always shown regardless of these settings.",
+    "showMessageTypesHint": "Control which message types are shown in the conversation:\n\n• Muttering: Agent responses and explanations\n• Toolcall: Tool execution details (one-line summary)\n\nNote: The agent's final result is always shown regardless of these settings.",
+    "messageType": {
+      "assistant": "Muttering",
+      "toolcall": "Toolcall"
+    },
     "opencodeSettings": "OpenCode Settings",
     "claudeSettings": "Claude Settings",
     "codexSettings": "Codex Settings",
@@ -1177,7 +1181,7 @@
     "requireMention": "Require @Mention",
     "requireMentionOn": "Require @mention",
     "requireMentionOff": "Don't require @mention",
-    "requireBind": "Bound users only",
+    "requireBind": "Allowed Users",
     "requireBindOn": "Bound only",
     "requireBindOff": "Anyone",
     "mentionStatusOn": "Require @",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1157,7 +1157,11 @@
     "useGlobalDefault": "使用全局默认值",
     "backend": "后端",
     "showMessageTypes": "显示的消息类型",
-    "showMessageTypesHint": "控制在 Slack 中显示哪些消息类型：\n\n• System：Agent 启动/状态消息\n• Assistant：Agent 的回复和解释\n• Toolcall：工具执行详情（单行摘要）\n\n注意：Agent 的最终结果消息会始终显示，不受此设置影响。",
+    "showMessageTypesHint": "控制在对话中显示哪些消息类型：\n\n• 喃喃自语：Agent 的回复和解释\n• 工具调用：工具执行详情（单行摘要）\n\n注意：Agent 的最终结果消息会始终显示，不受此设置影响。",
+    "messageType": {
+      "assistant": "喃喃自语",
+      "toolcall": "工具调用"
+    },
     "opencodeSettings": "OpenCode 设置",
     "claudeSettings": "Claude 设置",
     "codexSettings": "Codex 设置",
@@ -1177,7 +1181,7 @@
     "requireMention": "需要 @提及",
     "requireMentionOn": "需要@",
     "requireMentionOff": "不用@",
-    "requireBind": "仅限已绑定用户",
+    "requireBind": "允许对话的用户",
     "requireBindOn": "仅绑定用户",
     "requireBindOff": "所有人",
     "mentionStatusOn": "需要 @",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -348,7 +348,7 @@
   },
   "messageType": {
     "system": "System",
-    "assistant": "Assistant",
+    "assistant": "Muttering",
     "toolcall": "Toolcall",
     "result": "Result",
     "systemDesc": "System initialization and status messages",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -348,7 +348,7 @@
   },
   "messageType": {
     "system": "系统",
-    "assistant": "助手",
+    "assistant": "喃喃自语",
     "toolcall": "工具调用",
     "result": "结果",
     "systemDesc": "系统初始化和状态消息",


### PR DESCRIPTION
## Capability

Refines the shared **RoutingConfigPanel** (used by `/admin/groups` and `/users`) per live feedback, and finishes deprecating the **`system` message type** across every user-facing surface (Web + IM).

## Changes

UI (`ui/src/components/shared/RoutingConfigPanel.tsx`):
- **Agent + Model + Reasoning effort now share one routing row** (`md:grid-cols-3`). The access row above keeps Working directory (+ require @mention / allowed-users on channels).
- **"Inherit (…)" segment no longer wraps**: more flex weight on the inherit segment + `whitespace-nowrap` + tighter padding.
- **Message-type chips** drop `system` (now `['assistant','toolcall']`) and route their labels through i18n instead of a hardcoded ternary.

Copy / i18n:
- `requireBind` label → **"Allowed Users" / "允许对话的用户"** (was "Bound users only / 仅限已绑定用户").
- New `channelList.messageType.{assistant,toolcall}` and renamed concept: **assistant → "Muttering" / "喃喃自语"**, **toolcall → "Toolcall" / "工具调用"**. `showMessageTypesHint` updated (System bullet dropped, labels renamed).
- Backend `vibe/i18n` `messageType.assistant` → Muttering / 喃喃自语.

Remove the `system` toggle everywhere it surfaced:
- `get_available_message_types()` → `["assistant","toolcall"]`; IM `/settings` keyboard, Slack/Discord/Telegram modals, and the "about message types" list all follow.
- **Root cause (from review):** `system` removed from `ALLOWED_MESSAGE_TYPES` and the settings_manager normalize allow-set, so any legacy stored `system` value is filtered at the data layer on load/save instead of leaking into IM settings summaries. The dispatcher canonicalization guard intentionally keeps `system` (a hypothetical system emit stays classified + hidden, not reclassified as assistant).

Why safe: no backend path emits a user-facing `system` message (only `assistant` / `toolcall` / `result` / `notify`), so the toggle controlled nothing — the Web UI was the outlier vs. the IM side, which already excluded it.

## Evidence

- **Unit**: `pytest tests/test_telegram_bot.py` (49) + `tests/test_settings_handler.py tests/test_core_services_settings.py tests/test_sqlite_settings_store.py` (44) green.
- **Contract**: ran `normalize_show_message_types(['assistant','system','toolcall']) -> ['assistant','toolcall']`, `['system'] -> []`, `None -> ['assistant']`.
- **Build/lint**: `cd ui && npm run build` (tsc+vite) green; `ruff check` on all changed Python clean.
- **Scenario**: no scenario-catalog entry covers this settings-UI surface; none added.
- **Residual manual check**: visual eyeball of the 3-up routing row and the inherit-segment wrap on the real `/admin/groups` page (pending local Incus regression).