### PR TITLE
Fix running fork boundary reservation

### DIFF
--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -196,6 +196,7 @@ def reserve_forked_session(
             metadata = _load_metadata(row["metadata_json"])
             metadata.pop("fork_opencode_message_id", None)
             metadata.pop("fork_opencode_fork_empty_history", None)
+            metadata.pop("fork_opencode_boundary_from_active_run", None)
             metadata.update(
                 {
                     "created_via": "session_fork",

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -19,6 +19,7 @@ from vibe.i18n import t
 TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
 TERMINAL_AGENT_OUTPUT_TYPES = {"result", "error"}
 SOURCE_PROGRESS_AGENT_OUTPUT_TYPES = {"assistant", *TERMINAL_AGENT_OUTPUT_TYPES}
+ACTIVE_SOURCE_RUN_STATUSES = ("pending", "queued", "processing", "running")
 
 
 class SessionForkError(ValueError):
@@ -80,6 +81,17 @@ class ForkSourceState:
         return self.anchor_author == "agent" and self.anchor_type in TERMINAL_AGENT_OUTPUT_TYPES
 
 
+@dataclass(frozen=True)
+class SourceMessageAnchor:
+    message_id: Optional[str] = None
+    author: Optional[str] = None
+    message_type: Optional[str] = None
+
+    @property
+    def is_running_user_turn(self) -> bool:
+        return self.author == "user" and self.message_type == "user"
+
+
 def reserve_forked_session(
     *,
     source_session_id: str,
@@ -131,10 +143,18 @@ def reserve_forked_session(
                 raise SessionForkError(
                     f"agent session has no native session id to fork: {source_session_id}"
                 )
-            effective_trim_latest_running_turn = bool(
-                trim_latest_running_turn and source_backend in TRIM_LATEST_RUNNING_TURN_BACKENDS
+            source_anchor = _latest_source_message_anchor(conn, str(row["id"]))
+            inferred_running_turn = source_anchor.is_running_user_turn or (
+                source_backend == "opencode"
+                and _source_has_active_agent_run(conn, str(row["id"]))
             )
-            effective_native_turn_started = bool(native_turn_started and effective_trim_latest_running_turn)
+            effective_trim_latest_running_turn = bool(
+                source_backend in TRIM_LATEST_RUNNING_TURN_BACKENDS
+                and (trim_latest_running_turn or inferred_running_turn)
+            )
+            effective_native_turn_started = bool(
+                effective_trim_latest_running_turn and (native_turn_started or inferred_running_turn)
+            )
             opencode_fork_message_id: Optional[str] = None
             opencode_fork_empty_history = False
             if effective_trim_latest_running_turn and source_backend == "opencode":
@@ -142,7 +162,7 @@ def reserve_forked_session(
                 if fork_point is not None:
                     opencode_fork_message_id, opencode_fork_empty_history = fork_point
                     effective_native_turn_started = True
-            source_message_id = _latest_source_message_id(conn, str(row["id"]))
+            source_message_id = source_anchor.message_id
             override_agent = agent_store.require_enabled(agent_name) if agent_name else None
             if override_agent is not None and override_agent.backend != source_backend:
                 raise SessionForkError(
@@ -432,14 +452,14 @@ def _forked_session_title(source_title: str, lang: str = "en") -> str:
     return t("fork.title", lang, title=source_title) if source_title else t("fork.titleUntitled", lang)
 
 
-def _latest_source_message_id(conn: Any, source_session_id: str) -> Optional[str]:
+def _latest_source_message_anchor(conn: Any, source_session_id: str) -> SourceMessageAnchor:
     from sqlalchemy import func, or_, select
 
     from storage.messages_service import TRANSCRIPT_TYPES
     from storage.models import messages
 
     row = conn.execute(
-        select(messages.c.id)
+        select(messages.c.id, messages.c.author, messages.c.type)
         .where(
             messages.c.session_id == source_session_id,
             or_(
@@ -449,8 +469,33 @@ def _latest_source_message_id(conn: Any, source_session_id: str) -> Optional[str
         )
         .order_by(messages.c.created_at.desc(), messages.c.id.desc())
         .limit(1)
-    ).scalar_one_or_none()
-    return str(row) if row else None
+    ).mappings().first()
+    if row is None:
+        return SourceMessageAnchor()
+    return SourceMessageAnchor(
+        message_id=str(row["id"]) if row["id"] else None,
+        author=str(row["author"] or "").strip() or None,
+        message_type=str(row["type"] or "").strip() or None,
+    )
+
+
+def _source_has_active_agent_run(conn: Any, source_session_id: str) -> bool:
+    from sqlalchemy import select
+
+    from storage.models import agent_runs
+
+    return (
+        conn.execute(
+            select(agent_runs.c.id)
+            .where(
+                agent_runs.c.session_id == source_session_id,
+                agent_runs.c.status.in_(ACTIVE_SOURCE_RUN_STATUSES),
+            )
+            .order_by(agent_runs.c.created_at.desc(), agent_runs.c.id.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        is not None
+    )
 
 
 def _opencode_running_fork_point(source_native_session_id: str) -> Optional[tuple[Optional[str], bool]]:

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -36,6 +36,7 @@ class SessionForkSpec:
     native_turn_started: bool = False
     opencode_fork_message_id: Optional[str] = None
     opencode_fork_empty_history: bool = False
+    opencode_boundary_from_active_run: bool = False
 
     def to_metadata(self) -> dict[str, Any]:
         metadata = {
@@ -53,6 +54,8 @@ class SessionForkSpec:
             metadata["opencode_fork_message_id"] = self.opencode_fork_message_id
         if self.opencode_fork_empty_history:
             metadata["opencode_fork_empty_history"] = True
+        if self.opencode_boundary_from_active_run:
+            metadata["opencode_boundary_from_active_run"] = True
         return metadata
 
 
@@ -75,6 +78,7 @@ class ForkSourceState:
     latest_after_anchor_type: Optional[str] = None
     has_messages_after_anchor: bool = False
     has_terminal_agent_output_after_anchor: bool = False
+    has_user_turn_after_anchor: bool = False
 
     @property
     def anchor_is_terminal_agent_output(self) -> bool:
@@ -144,23 +148,28 @@ def reserve_forked_session(
                     f"agent session has no native session id to fork: {source_session_id}"
                 )
             source_anchor = _latest_source_message_anchor(conn, str(row["id"]))
+            source_has_active_run = _source_has_active_agent_run(conn, str(row["id"]))
             inferred_running_turn = source_anchor.is_running_user_turn or (
                 source_backend == "opencode"
-                and _source_has_active_agent_run(conn, str(row["id"]))
+                and source_has_active_run
             )
             effective_trim_latest_running_turn = bool(
                 source_backend in TRIM_LATEST_RUNNING_TURN_BACKENDS
                 and (trim_latest_running_turn or inferred_running_turn)
             )
             effective_native_turn_started = bool(
-                effective_trim_latest_running_turn and (native_turn_started or inferred_running_turn)
+                effective_trim_latest_running_turn and native_turn_started
             )
             opencode_fork_message_id: Optional[str] = None
             opencode_fork_empty_history = False
+            opencode_boundary_from_active_run = False
             if effective_trim_latest_running_turn and source_backend == "opencode":
                 fork_point = _opencode_running_fork_point(source_native)
                 if fork_point is not None:
                     opencode_fork_message_id, opencode_fork_empty_history = fork_point
+                    opencode_boundary_from_active_run = bool(
+                        source_has_active_run and not source_anchor.is_running_user_turn
+                    )
                     effective_native_turn_started = True
             source_message_id = source_anchor.message_id
             override_agent = agent_store.require_enabled(agent_name) if agent_name else None
@@ -204,6 +213,8 @@ def reserve_forked_session(
                 metadata["fork_opencode_message_id"] = opencode_fork_message_id
             if opencode_fork_empty_history:
                 metadata["fork_opencode_fork_empty_history"] = True
+            if opencode_boundary_from_active_run:
+                metadata["fork_opencode_boundary_from_active_run"] = True
             session_id = create_agent_session_row(
                 conn,
                 scope_id=row["scope_id"],
@@ -234,6 +245,7 @@ def reserve_forked_session(
             native_turn_started=effective_native_turn_started,
             opencode_fork_message_id=opencode_fork_message_id,
             opencode_fork_empty_history=opencode_fork_empty_history,
+            opencode_boundary_from_active_run=opencode_boundary_from_active_run,
         )
         return SessionForkResult(
             session_id=session_id,
@@ -276,6 +288,8 @@ def fork_metadata_from_request(metadata: dict[str, Any] | None) -> dict[str, Any
         result["opencode_fork_message_id"] = opencode_message
     if bool(fork.get("opencode_fork_empty_history")):
         result["opencode_fork_empty_history"] = True
+    if bool(fork.get("opencode_boundary_from_active_run")):
+        result["opencode_boundary_from_active_run"] = True
     source_message = _clean_optional(fork.get("source_message_id"))
     if source_message:
         result["source_message_id"] = source_message
@@ -306,6 +320,8 @@ def fork_metadata_from_session_metadata(metadata: dict[str, Any] | None) -> dict
         result["opencode_fork_message_id"] = opencode_message
     if bool(metadata.get("fork_opencode_fork_empty_history")):
         result["opencode_fork_empty_history"] = True
+    if bool(metadata.get("fork_opencode_boundary_from_active_run")):
+        result["opencode_boundary_from_active_run"] = True
     source_message = _clean_optional(metadata.get("fork_source_message_id"))
     if source_message:
         result["source_message_id"] = source_message
@@ -399,6 +415,19 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
                 latest_after_anchor_author == "agent"
                 and latest_after_anchor_type in TERMINAL_AGENT_OUTPUT_TYPES
             )
+            has_user_turn_after_anchor = (
+                conn.execute(
+                    select(messages.c.id)
+                    .where(
+                        messages.c.session_id == source_session_id,
+                        messages.c.author == "user",
+                        messages.c.type == "user",
+                        after_anchor,
+                    )
+                    .limit(1)
+                ).first()
+                is not None
+            )
             return ForkSourceState(
                 anchor_author=str(anchor["author"] or "").strip() or None,
                 anchor_type=str(anchor["type"] or "").strip() or None,
@@ -406,6 +435,7 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
                 latest_after_anchor_type=latest_after_anchor_type or None,
                 has_messages_after_anchor=latest_after_anchor is not None,
                 has_terminal_agent_output_after_anchor=has_terminal_agent_output_after_anchor,
+                has_user_turn_after_anchor=has_user_turn_after_anchor,
             )
     except Exception as exc:
         import logging

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -793,6 +793,8 @@ class CodexAgent(BaseAgent):
             getattr(source_state, "anchor_author", None) == "user"
             and getattr(source_state, "anchor_type", None) == "user"
         )
+        if getattr(source_state, "has_user_turn_after_anchor", False):
+            return False
         if anchor_is_running_user and bool(fork.get("native_turn_started")):
             return True
         if source_state.has_messages_after_anchor:

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -795,8 +795,12 @@ class CodexAgent(BaseAgent):
         )
         if getattr(source_state, "has_user_turn_after_anchor", False):
             return False
-        if anchor_is_running_user and bool(fork.get("native_turn_started")):
-            return True
+        if anchor_is_running_user:
+            if source_state.has_messages_after_anchor:
+                return True
+            if bool(fork.get("native_turn_started")):
+                return True
+            return await self._fork_source_turn_now_started(fork)
         if source_state.has_messages_after_anchor:
             return not source_state.has_terminal_agent_output_after_anchor
         if bool(fork.get("native_turn_started")):

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -789,10 +789,11 @@ class CodexAgent(BaseAgent):
         source_state = fork_source_state(fork)
         if source_state.anchor_is_terminal_agent_output:
             return False
-        if (
+        anchor_is_running_user = (
             getattr(source_state, "anchor_author", None) == "user"
             and getattr(source_state, "anchor_type", None) == "user"
-        ):
+        )
+        if anchor_is_running_user and bool(fork.get("native_turn_started")):
             return True
         if source_state.has_messages_after_anchor:
             return not source_state.has_terminal_agent_output_after_anchor

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -789,6 +789,11 @@ class CodexAgent(BaseAgent):
         source_state = fork_source_state(fork)
         if source_state.anchor_is_terminal_agent_output:
             return False
+        if (
+            getattr(source_state, "anchor_author", None) == "user"
+            and getattr(source_state, "anchor_type", None) == "user"
+        ):
+            return True
         if source_state.has_messages_after_anchor:
             return not source_state.has_terminal_agent_output_after_anchor
         if bool(fork.get("native_turn_started")):

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -114,6 +114,8 @@ class OpenCodeSessionManager:
             return False, None
         message_id = str(fork.get("opencode_fork_message_id") or "").strip()
         if message_id:
+            if bool(fork.get("opencode_boundary_from_active_run")):
+                return True, message_id
             source_state = fork_source_state(fork)
             anchor_is_running_user = (
                 getattr(source_state, "anchor_author", None) == "user"

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -115,13 +115,23 @@ class OpenCodeSessionManager:
         message_id = str(fork.get("opencode_fork_message_id") or "").strip()
         if message_id:
             source_state = fork_source_state(fork)
-            if source_state.anchor_is_terminal_agent_output or source_state.has_terminal_agent_output_after_anchor:
+            anchor_is_running_user = (
+                getattr(source_state, "anchor_author", None) == "user"
+                and getattr(source_state, "anchor_type", None) == "user"
+            )
+            if source_state.anchor_is_terminal_agent_output:
                 logger.info(
                     "OpenCode running fork for %s kept full history because the source completed before first use",
                     source_session_id,
                 )
                 return True, None
-            if getattr(source_state, "has_messages_after_anchor", False):
+            if source_state.has_terminal_agent_output_after_anchor and not anchor_is_running_user:
+                logger.info(
+                    "OpenCode running fork for %s kept full history because the source completed before first use",
+                    source_session_id,
+                )
+                return True, None
+            if getattr(source_state, "has_messages_after_anchor", False) and not anchor_is_running_user:
                 point = self._current_running_fork_point(source_session_id)
                 if point.available:
                     return True, point.message_id

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2008,6 +2008,72 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         rollback_params = transport.send_request.await_args_list[1].args[1]
         self.assertEqual(rollback_params, {"threadId": "thread-fork", "numTurns": 1})
 
+    async def test_start_or_resume_thread_does_not_roll_back_when_new_user_after_anchor(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-user-a",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": True,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with patch.object(
+            _MODULE,
+            "fork_source_state",
+            return_value=SimpleNamespace(
+                anchor_author="user",
+                anchor_type="user",
+                anchor_is_terminal_agent_output=False,
+                latest_after_anchor_author="user",
+                latest_after_anchor_type="user",
+                has_messages_after_anchor=True,
+                has_terminal_agent_output_after_anchor=False,
+                has_user_turn_after_anchor=True,
+            ),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/inject_items",
+        ])
+
     async def test_start_or_resume_thread_does_not_roll_back_user_anchor_before_native_start(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2008,6 +2008,73 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         rollback_params = transport.send_request.await_args_list[1].args[1]
         self.assertEqual(rollback_params, {"threadId": "thread-fork", "numTurns": 1})
 
+    async def test_start_or_resume_thread_rolls_back_user_anchor_completed_before_native_start_flag(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-user",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": False,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with patch.object(
+            _MODULE,
+            "fork_source_state",
+            return_value=SimpleNamespace(
+                anchor_author="user",
+                anchor_type="user",
+                anchor_is_terminal_agent_output=False,
+                latest_after_anchor_author="agent",
+                latest_after_anchor_type="result",
+                has_messages_after_anchor=True,
+                has_terminal_agent_output_after_anchor=True,
+                has_user_turn_after_anchor=False,
+            ),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/rollback",
+            "thread/inject_items",
+        ])
+
     async def test_start_or_resume_thread_does_not_roll_back_when_new_user_after_anchor(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2008,6 +2008,78 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         rollback_params = transport.send_request.await_args_list[1].args[1]
         self.assertEqual(rollback_params, {"threadId": "thread-fork", "numTurns": 1})
 
+    async def test_start_or_resume_thread_does_not_roll_back_user_anchor_before_native_start(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-user",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": False,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with (
+            patch.object(
+                _MODULE,
+                "fork_source_state",
+                return_value=SimpleNamespace(
+                    anchor_author="user",
+                    anchor_type="user",
+                    anchor_is_terminal_agent_output=False,
+                    latest_after_anchor_author=None,
+                    latest_after_anchor_type=None,
+                    has_messages_after_anchor=False,
+                    has_terminal_agent_output_after_anchor=False,
+                ),
+            ),
+            patch(
+                "vibe.internal_client.turn_state",
+                new=AsyncMock(return_value={"body": {"in_flight": False, "native_turn_started": False}}),
+            ) as turn_state,
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        turn_state.assert_awaited_once_with("ses-source")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/inject_items",
+        ])
+
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the
         # reserved MAIN native.

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1940,6 +1940,74 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             "thread/inject_items",
         ])
 
+    async def test_start_or_resume_thread_rolls_back_reserved_user_anchor_after_source_completed(self):
+        agent = object.__new__(CodexAgent)
+        agent.controller = SimpleNamespace(config=SimpleNamespace(platform="avibe", reply_enhancements=False))
+        agent.codex_config = SimpleNamespace(default_model=None)
+        agent.sessions = SimpleNamespace(
+            get_agent_session_id=Mock(return_value=None),
+            ensure_agent_session_id=Mock(return_value="ses-target"),
+            bind_agent_session=Mock(return_value="ses-target"),
+        )
+        agent._session_mgr = SimpleNamespace(set_thread_id=Mock())
+        agent._fork_correction_pending_base_sessions = set()
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            context=SimpleNamespace(
+                platform="avibe",
+                platform_specific={
+                    "agent_session_target": {
+                        "id": "ses-target",
+                        "agent_backend": "codex",
+                        "native_session_id": "",
+                        "native_session_fork": {
+                            "source_session_id": "ses-source",
+                            "source_native_session_id": "thread-source",
+                            "source_backend": "codex",
+                            "source_message_id": "msg-user",
+                            "trim_latest_running_turn": True,
+                            "native_turn_started": True,
+                        },
+                    }
+                },
+                user_id="scheduled",
+                channel_id="ses-target",
+                thread_id=None,
+            ),
+            base_session_id="ses-target",
+            session_key="avibe::project::proj_1",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            vibe_agent_model=None,
+            vibe_agent_reasoning_effort=None,
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-fork"}}))
+
+        with patch.object(
+            _MODULE,
+            "fork_source_state",
+            return_value=SimpleNamespace(
+                anchor_author="user",
+                anchor_type="user",
+                anchor_is_terminal_agent_output=False,
+                latest_after_anchor_author="agent",
+                latest_after_anchor_type="result",
+                has_messages_after_anchor=True,
+                has_terminal_agent_output_after_anchor=True,
+            ),
+        ):
+            thread_id = await agent._start_or_resume_thread(transport, request)
+
+        self.assertEqual(thread_id, "thread-fork")
+        self.assertEqual([call.args[0] for call in transport.send_request.await_args_list], [
+            "thread/fork",
+            "thread/rollback",
+            "thread/inject_items",
+        ])
+        rollback_params = transport.send_request.await_args_list[1].args[1]
+        self.assertEqual(rollback_params, {"threadId": "thread-fork", "numTurns": 1})
+
     async def test_resume_thread_skips_reserved_native_for_explicit_subagent(self):
         # Explicit per-turn subagent: it has its own thread; must NOT resume the
         # reserved MAIN native.

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -558,6 +558,8 @@ def test_opencode_saved_boundary_is_ignored_when_source_completed_after_anchor()
         "modules.agents.opencode.session.fork_source_state",
         return_value=SimpleNamespace(
             anchor_is_terminal_agent_output=False,
+            anchor_author="assistant",
+            anchor_type="assistant",
             has_terminal_agent_output_after_anchor=True,
         ),
     ):
@@ -566,6 +568,56 @@ def test_opencode_saved_boundary_is_ignored_when_source_completed_after_anchor()
     assert session_id == "oc-fork"
     server.list_messages.assert_not_awaited()
     server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id=None)
+    server.create_session.assert_not_awaited()
+
+
+def test_opencode_saved_user_boundary_survives_source_completion_before_fork_starts() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "source_message_id": "msg-user",
+                "trim_latest_running_turn": True,
+                "native_turn_started": True,
+                "opencode_fork_message_id": "oc-msg-user",
+            },
+        },
+    }
+
+    with patch(
+        "modules.agents.opencode.session.fork_source_state",
+        return_value=SimpleNamespace(
+            anchor_is_terminal_agent_output=False,
+            anchor_author="user",
+            anchor_type="user",
+            has_messages_after_anchor=True,
+            has_terminal_agent_output_after_anchor=True,
+        ),
+    ):
+        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-user")
     server.create_session.assert_not_awaited()
 
 

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -522,6 +522,54 @@ def test_opencode_saved_boundary_is_ignored_when_source_completed_before_anchor(
     server.create_session.assert_not_awaited()
 
 
+def test_opencode_active_run_boundary_survives_terminal_avibe_anchor() -> None:
+    sessions = SimpleNamespace(
+        get_agent_session_id=Mock(return_value=None),
+        ensure_agent_session_id=Mock(return_value="ses-fork"),
+        bind_agent_session=Mock(return_value="ses-fork"),
+        bind_agent_session_by_id=Mock(return_value="ses-fork"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        fork_session=AsyncMock(return_value={"id": "oc-fork"}),
+        create_session=AsyncMock(),
+        list_messages=AsyncMock(),
+    )
+    request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "ses-fork",
+        "agent_session_target": {
+            "id": "ses-fork",
+            "agent_backend": "opencode",
+            "native_session_id": "",
+            "native_session_fork": {
+                "source_session_id": "ses-source",
+                "source_native_session_id": "oc-source",
+                "source_backend": "opencode",
+                "source_message_id": "msg-result",
+                "trim_latest_running_turn": True,
+                "native_turn_started": True,
+                "opencode_fork_message_id": "oc-msg-user",
+                "opencode_boundary_from_active_run": True,
+            },
+        },
+    }
+
+    with patch(
+        "modules.agents.opencode.session.fork_source_state",
+        return_value=SimpleNamespace(
+            anchor_is_terminal_agent_output=True,
+            has_terminal_agent_output_after_anchor=False,
+        ),
+    ):
+        session_id = asyncio.run(manager.get_or_create_session_id(request, server))
+
+    assert session_id == "oc-fork"
+    server.list_messages.assert_not_awaited()
+    server.fork_session.assert_awaited_once_with("oc-source", directory="/repo", message_id="oc-msg-user")
+    server.create_session.assert_not_awaited()
+
+
 def test_opencode_saved_boundary_is_ignored_when_source_completed_after_anchor() -> None:
     sessions = SimpleNamespace(
         get_agent_session_id=Mock(return_value=None),

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -200,7 +200,7 @@ def test_reserve_forked_session_infers_running_user_anchor_without_live_hint(tmp
 
     assert result.fork.source_message_id == running_user["id"]
     assert result.fork.trim_latest_running_turn is True
-    assert result.fork.native_turn_started is True
+    assert result.fork.native_turn_started is False
     engine = create_sqlite_engine(db_path)
     try:
         with engine.connect() as conn:
@@ -213,7 +213,7 @@ def test_reserve_forked_session_infers_running_user_anchor_without_live_hint(tmp
     metadata = json.loads(forked["metadata_json"])
     assert metadata["fork_source_message_id"] == running_user["id"]
     assert metadata["fork_trim_latest_running_turn"] is True
-    assert metadata["fork_native_turn_started"] is True
+    assert metadata["fork_native_turn_started"] is False
 
 
 def test_reserve_forked_session_does_not_infer_trim_for_claude(tmp_path: Path) -> None:
@@ -358,6 +358,7 @@ def test_reserve_forked_opencode_running_fork_records_frozen_native_message(
     assert metadata["fork_opencode_message_id"] == "oc-msg-3"
     assert metadata["fork_trim_latest_running_turn"] is True
     assert metadata["fork_native_turn_started"] is True
+    assert "fork_opencode_boundary_from_active_run" not in metadata
 
 
 def test_reserve_forked_opencode_active_run_freezes_native_boundary_without_live_hint(
@@ -445,6 +446,7 @@ def test_reserve_forked_opencode_active_run_freezes_native_boundary_without_live
     assert metadata["fork_trim_latest_running_turn"] is True
     assert metadata["fork_native_turn_started"] is True
     assert metadata["fork_opencode_message_id"] == "oc-msg-3"
+    assert metadata["fork_opencode_boundary_from_active_run"] is True
 
 
 def test_reserve_forked_opencode_running_first_turn_records_user_boundary(
@@ -1002,6 +1004,7 @@ def test_fork_source_state_uses_latest_progress_after_anchor(
         assert state.latest_after_anchor_type == "user"
         assert state.has_messages_after_anchor is True
         assert state.has_terminal_agent_output_after_anchor is False
+        assert state.has_user_turn_after_anchor is True
     finally:
         engine.dispose()
 

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -496,6 +496,54 @@ def test_reserve_forked_opencode_running_first_turn_records_user_boundary(
     assert "fork_opencode_fork_empty_history" not in metadata
 
 
+def test_reserve_forked_session_clears_stale_opencode_active_run_boundary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
+    _seed_opencode_messages(xdg_home, "oc-source", ["user"])
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(
+                    agent_backend="opencode",
+                    agent_variant="opencode",
+                    native_session_id="oc-source",
+                    metadata_json=json.dumps(
+                        {
+                            "created_via": "session_fork",
+                            "fork_opencode_message_id": "stale-oc-msg",
+                            "fork_opencode_fork_empty_history": True,
+                            "fork_opencode_boundary_from_active_run": True,
+                        }
+                    ),
+                )
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(source_session_id=source_id, db_path=db_path)
+
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            forked = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    metadata = json.loads(forked["metadata_json"])
+    assert "fork_opencode_message_id" not in metadata
+    assert "fork_opencode_fork_empty_history" not in metadata
+    assert "fork_opencode_boundary_from_active_run" not in metadata
+
+
 def test_reserve_forked_opencode_missing_boundary_preserves_trim_intent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -23,7 +23,7 @@ from modules.im import MessageContext
 from storage.agent_session_rows import create_agent_session_row
 from storage.db import create_sqlite_engine
 from storage import messages_service
-from storage.models import agent_sessions, scope_settings
+from storage.models import agent_runs, agent_sessions, scope_settings
 from storage.sessions_service import SQLiteSessionsService
 from storage.settings_service import upsert_scope
 
@@ -175,6 +175,84 @@ def test_reserve_forked_codex_running_fork_marks_trim(tmp_path: Path) -> None:
     assert metadata["fork_native_turn_started"] is True
 
 
+def test_reserve_forked_session_infers_running_user_anchor_without_live_hint(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(
+                select(agent_sessions.c.scope_id).where(agent_sessions.c.id == source_id)
+            ).mappings().one()
+            running_user = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="long running request",
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(source_session_id=source_id, db_path=db_path)
+
+    assert result.fork.source_message_id == running_user["id"]
+    assert result.fork.trim_latest_running_turn is True
+    assert result.fork.native_turn_started is True
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            forked = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    metadata = json.loads(forked["metadata_json"])
+    assert metadata["fork_source_message_id"] == running_user["id"]
+    assert metadata["fork_trim_latest_running_turn"] is True
+    assert metadata["fork_native_turn_started"] is True
+
+
+def test_reserve_forked_session_does_not_infer_trim_for_claude(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(
+                select(agent_sessions.c.scope_id).where(agent_sessions.c.id == source_id)
+            ).mappings().one()
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(
+                    agent_backend="claude",
+                    agent_variant="claude",
+                    native_session_id="claude-source",
+                )
+            )
+            messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="active claude request",
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(source_session_id=source_id, db_path=db_path)
+
+    assert result.fork.source_backend == "claude"
+    assert result.fork.trim_latest_running_turn is False
+    assert result.fork.native_turn_started is False
+
+
 def _seed_opencode_messages(
     xdg_home: Path,
     native_session_id: str,
@@ -280,6 +358,93 @@ def test_reserve_forked_opencode_running_fork_records_frozen_native_message(
     assert metadata["fork_opencode_message_id"] == "oc-msg-3"
     assert metadata["fork_trim_latest_running_turn"] is True
     assert metadata["fork_native_turn_started"] is True
+
+
+def test_reserve_forked_opencode_active_run_freezes_native_boundary_without_live_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    xdg_home = tmp_path / "xdg"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
+    _seed_opencode_messages(xdg_home, "oc-source", ["user", "assistant", "user"])
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(
+                    agent_backend="opencode",
+                    agent_variant="opencode",
+                    native_session_id="oc-source",
+                )
+            )
+            conn.execute(
+                agent_runs.insert().values(
+                    id="run-active-source",
+                    definition_id=None,
+                    run_type="agent",
+                    status="running",
+                    source_kind="cli",
+                    source_actor=None,
+                    parent_run_id=None,
+                    agent_name="worker",
+                    agent_id="agent-worker",
+                    agent_backend="opencode",
+                    model=None,
+                    reasoning_effort=None,
+                    session_policy="resume",
+                    session_id=source_id,
+                    legacy_session_key=None,
+                    post_to=None,
+                    deliver_key=None,
+                    prompt="active source prompt",
+                    message="active source prompt",
+                    message_payload_json="{}",
+                    result_text=None,
+                    result_payload_json=None,
+                    message_ids_json=None,
+                    callback_session_id=None,
+                    callback_status=None,
+                    callback_error=None,
+                    callback_run_id=None,
+                    callback_completed_at=None,
+                    cancel_requested=0,
+                    cancel_requested_at=None,
+                    pid=None,
+                    exit_code=None,
+                    error=None,
+                    stdout=None,
+                    stderr=None,
+                    created_at="2026-06-16T00:00:01Z",
+                    started_at="2026-06-16T00:00:02Z",
+                    completed_at=None,
+                    updated_at="2026-06-16T00:00:02Z",
+                    metadata_json="{}",
+                )
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(source_session_id=source_id, db_path=db_path)
+
+    assert result.fork.trim_latest_running_turn is True
+    assert result.fork.native_turn_started is True
+    assert result.fork.opencode_fork_message_id == "oc-msg-3"
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            forked = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == result.session_id)
+            ).mappings().one()
+    finally:
+        engine.dispose()
+
+    metadata = json.loads(forked["metadata_json"])
+    assert metadata["fork_trim_latest_running_turn"] is True
+    assert metadata["fork_native_turn_started"] is True
+    assert metadata["fork_opencode_message_id"] == "oc-msg-3"
 
 
 def test_reserve_forked_opencode_running_first_turn_records_user_boundary(


### PR DESCRIPTION
## Summary
- Freeze running fork boundaries during shared session fork reservation when CLI/Harness runs are active.
- Preserve saved Codex/OpenCode trim intent even if the source run completes before the fork run actually starts.
- Add focused unit coverage and a regression CLI E2E for running-session fork behavior.

## Validation
- `uv run pytest tests/test_session_fork.py tests/test_opencode_session_manager.py tests/test_codex_agent.py tests/test_cli_agent_run_schema.py -q`
- `uv run ruff check core/services/session_fork.py tests/test_session_fork.py modules/agents/opencode/session.py modules/agents/codex/agent.py tests/test_opencode_session_manager.py tests/test_codex_agent.py`
- Worktree Incus CLI E2E: source OpenCode run stayed active at fork reservation; fork run started after source completion; fork native history excluded the source running user marker.
