### PR TITLE
feat(chat): queued message text selectable + recall to input

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -107,7 +107,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -274,7 +273,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -327,6 +325,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -334,6 +357,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -840,7 +864,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.45.0.tgz",
       "integrity": "sha512-LAaceAtcQpVMDvldhkrQC1MSawpj7aAm1CfGg6RbyQgTDDp2fKnP1gDhjQIef3lH8W2fYeXRe66EdzaFkoGHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@lexical/devtools-core": "0.45.0",
@@ -928,7 +951,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.45.0.tgz",
       "integrity": "sha512-Fo5MMErqoPlUyTw1qVMZ9kE33ZjJF957KU683tsCrrlaVisVxpboL7BbAnxWTwCcIpAsfc6AUndJJ70M9NDMGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0",
         "@lexical/selection": "0.45.0",
@@ -2419,7 +2441,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2430,7 +2451,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2492,7 +2512,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2769,7 +2788,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2952,7 +2970,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3305,7 +3322,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3836,7 +3852,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -3992,6 +4007,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -4103,7 +4119,6 @@
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.45.0.tgz",
       "integrity": "sha512-z2M9C2ILPW7SopQE1aKbOFdZJbe3HvsrgWnJKveMDrSEvVjU9Hce4UpKVsAdkwY7TgY9RDuCV3+sfrGu0WkL+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0"
       }
@@ -4126,6 +4141,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -5545,7 +5561,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5573,7 +5588,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -5634,7 +5648,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5644,7 +5657,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6234,7 +6246,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6488,7 +6499,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6901,7 +6911,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -107,6 +107,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -273,6 +274,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -325,31 +327,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -357,7 +334,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -864,6 +840,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.45.0.tgz",
       "integrity": "sha512-LAaceAtcQpVMDvldhkrQC1MSawpj7aAm1CfGg6RbyQgTDDp2fKnP1gDhjQIef3lH8W2fYeXRe66EdzaFkoGHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@lexical/devtools-core": "0.45.0",
@@ -951,6 +928,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.45.0.tgz",
       "integrity": "sha512-Fo5MMErqoPlUyTw1qVMZ9kE33ZjJF957KU683tsCrrlaVisVxpboL7BbAnxWTwCcIpAsfc6AUndJJ70M9NDMGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0",
         "@lexical/selection": "0.45.0",
@@ -2441,6 +2419,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2451,6 +2430,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2512,6 +2492,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2788,6 +2769,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2970,6 +2952,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3322,6 +3305,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3852,6 +3836,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -4007,7 +3992,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -4119,6 +4103,7 @@
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.45.0.tgz",
       "integrity": "sha512-z2M9C2ILPW7SopQE1aKbOFdZJbe3HvsrgWnJKveMDrSEvVjU9Hce4UpKVsAdkwY7TgY9RDuCV3+sfrGu0WkL+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0"
       }
@@ -4141,7 +4126,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -5561,6 +5545,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5588,6 +5573,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -5648,6 +5634,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5657,6 +5644,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6246,6 +6234,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6499,6 +6488,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6911,6 +6901,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, Bell, Bot, ChevronDown, Clock, GitFork, Info, Loader2, MessageSquare, Pencil, Presentation, UploadCloud, X } from 'lucide-react';
+import { ArrowLeft, Bell, Bot, ChevronDown, Clock, GitFork, Info, Loader2, MessageSquare, Pencil, Presentation, Undo2, UploadCloud, X } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -954,6 +954,17 @@ export const ChatPage: React.FC = () => {
     [api, sessionId, refreshQueue],
   );
 
+  // Pull a queued message back into the composer (to edit / resend) and drop it
+  // from the queue — it's no longer queued, it's back in the input. Append so a
+  // draft already in the box isn't clobbered.
+  const recallQueued = useCallback(
+    (item: WorkbenchMessage) => {
+      if (item.text) composerRef.current?.appendText(item.text);
+      void removeQueued(item.id);
+    },
+    [removeQueued],
+  );
+
   const sendQueueNow = useCallback(async () => {
     // "立即发送": interrupt the running turn + flush the queue now. The queue
     // flushes as one merged turn, so this runs the whole queue.
@@ -1336,7 +1347,7 @@ export const ChatPage: React.FC = () => {
           onQuoteSelection={quoteSelectionToComposer}
           onAskInNewSession={askInNewSession}
         />
-        <QueueStrip queue={queue} onRemove={removeQueued} onSendNow={sendQueueNow} />
+        <QueueStrip queue={queue} onRemove={removeQueued} onRecall={recallQueued} onSendNow={sendQueueNow} />
         {/* key by session so the composer remounts per session — its draft-seeding
             + local value reset, instead of carrying across sessions (Codex P2). */}
         <Compose
@@ -1364,28 +1375,58 @@ export const ChatPage: React.FC = () => {
 // One queued message. Its text is a single truncated line by default; clicking
 // it expands to the full wrapped text (and clicking again collapses it) so a
 // long queued prompt can be read without sending it.
-const QueueRow: React.FC<{ item: WorkbenchMessage; onRemove: (id: string) => void }> = ({ item, onRemove }) => {
+const QueueRow: React.FC<{
+  item: WorkbenchMessage;
+  onRemove: (id: string) => void;
+  onRecall: (item: WorkbenchMessage) => void;
+}> = ({ item, onRemove, onRecall }) => {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
+  // A plain selectable element (not a <button>) so desktop users can drag-select
+  // the text; a click still toggles expand/collapse — unless the click ended a
+  // text selection, in which case we leave the selection alone.
+  const toggle = () => {
+    if (window.getSelection()?.toString()) return;
+    setExpanded((v) => !v);
+  };
   return (
     <div className="flex items-start gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setExpanded((v) => !v);
+          }
+        }}
         aria-expanded={expanded}
         className={clsx(
-          'min-w-0 flex-1 text-left text-[12px] text-foreground',
+          'min-w-0 flex-1 cursor-pointer select-text text-left text-[12px] text-foreground',
           expanded ? 'whitespace-pre-wrap break-words' : 'truncate',
         )}
       >
         {item.text}
-      </button>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={() => onRecall(item)}
+        aria-label={t('chat.queue.recall')}
+        title={t('chat.queue.recall')}
+        className="size-6 shrink-0 text-muted hover:text-foreground"
+      >
+        <Undo2 className="size-3.5" />
+      </Button>
       <Button
         type="button"
         variant="ghost"
         size="icon"
         onClick={() => onRemove(item.id)}
         aria-label={t('chat.queue.remove')}
+        title={t('chat.queue.remove')}
         className="size-6 shrink-0 text-muted hover:text-destructive"
       >
         <X className="size-3.5" />
@@ -1397,8 +1438,9 @@ const QueueRow: React.FC<{ item: WorkbenchMessage; onRemove: (id: string) => voi
 const QueueStrip: React.FC<{
   queue: WorkbenchMessage[];
   onRemove: (id: string) => void;
+  onRecall: (item: WorkbenchMessage) => void;
   onSendNow: () => void;
-}> = ({ queue, onRemove, onSendNow }) => {
+}> = ({ queue, onRemove, onRecall, onSendNow }) => {
   const { t } = useTranslation();
   if (queue.length === 0) return null;
   return (
@@ -1415,7 +1457,7 @@ const QueueStrip: React.FC<{
         </div>
         <div className="flex max-h-32 flex-col gap-1 overflow-y-auto">
           {queue.map((item) => (
-            <QueueRow key={item.id} item={item} onRemove={onRemove} />
+            <QueueRow key={item.id} item={item} onRemove={onRemove} onRecall={onRecall} />
           ))}
         </div>
       </div>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -961,13 +961,24 @@ export const ChatPage: React.FC = () => {
   // duplicate turn. Append (not replace) so an existing draft isn't clobbered.
   const recallQueued = useCallback(
     async (item: WorkbenchMessage) => {
-      if (!sessionId) return;
+      const sid = sessionId;
+      if (!sid) return;
       try {
-        await api.removeQueuedMessage(sessionId, item.id);
+        const { removed } = await api.removeQueuedMessage(sid, item.id);
+        // Bail if the user switched sessions during the request — otherwise we'd
+        // stage the old row's text into a different session's composer.
+        if (sessionIdRef.current !== sid) return;
+        // ``removed: false`` means the row was already gone (double-click, or a
+        // concurrent flush/other tab). Don't stage the text — that would requeue
+        // a duplicate — just resync the queue.
+        if (!removed) {
+          void refreshQueue();
+          return;
+        }
         setQueue((prev) => prev.filter((m) => m.id !== item.id));
         if (item.text) composerRef.current?.appendText(item.text);
       } catch {
-        void refreshQueue(); // delete failed → leave it queued, don't stage the text
+        if (sessionIdRef.current === sid) void refreshQueue();
       }
     },
     [api, sessionId, refreshQueue],
@@ -1397,11 +1408,13 @@ const QueueRow: React.FC<{
     if (window.getSelection()?.toString()) return;
     setExpanded((v) => !v);
   };
-  // A queued send can carry uploaded files (content.attachments). Recall only
-  // pulls text, so offer it only for text-only rows — recalling an attachment
-  // row would silently drop the files. Such rows can still be deleted or sent.
+  // Offer recall only for the user's own text-only queued prompts:
+  //  - harness/scheduled rows (source !== 'user') carry provenance flush_queue
+  //    needs (suppress-delivery, native-id dedupe) that a plain recall would drop;
+  //  - recall can't carry uploaded files (content.attachments), so an attachment
+  //    row would silently lose them. Both can still be deleted or left to send.
   const att = (item.content as Record<string, unknown> | undefined)?.attachments;
-  const canRecall = !(Array.isArray(att) && att.length > 0);
+  const canRecall = item.source === 'user' && !(Array.isArray(att) && att.length > 0);
   return (
     <div className="flex items-start gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
       <div

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -955,14 +955,22 @@ export const ChatPage: React.FC = () => {
   );
 
   // Pull a queued message back into the composer (to edit / resend) and drop it
-  // from the queue — it's no longer queued, it's back in the input. Append so a
-  // draft already in the box isn't clobbered.
+  // from the queue. Delete server-side FIRST and only append the text once the
+  // row is actually gone — otherwise a failed delete would leave the message
+  // both queued (still scheduled to send) and editable in the composer, i.e. a
+  // duplicate turn. Append (not replace) so an existing draft isn't clobbered.
   const recallQueued = useCallback(
-    (item: WorkbenchMessage) => {
-      if (item.text) composerRef.current?.appendText(item.text);
-      void removeQueued(item.id);
+    async (item: WorkbenchMessage) => {
+      if (!sessionId) return;
+      try {
+        await api.removeQueuedMessage(sessionId, item.id);
+        setQueue((prev) => prev.filter((m) => m.id !== item.id));
+        if (item.text) composerRef.current?.appendText(item.text);
+      } catch {
+        void refreshQueue(); // delete failed → leave it queued, don't stage the text
+      }
     },
-    [removeQueued],
+    [api, sessionId, refreshQueue],
   );
 
   const sendQueueNow = useCallback(async () => {
@@ -1389,6 +1397,11 @@ const QueueRow: React.FC<{
     if (window.getSelection()?.toString()) return;
     setExpanded((v) => !v);
   };
+  // A queued send can carry uploaded files (content.attachments). Recall only
+  // pulls text, so offer it only for text-only rows — recalling an attachment
+  // row would silently drop the files. Such rows can still be deleted or sent.
+  const att = (item.content as Record<string, unknown> | undefined)?.attachments;
+  const canRecall = !(Array.isArray(att) && att.length > 0);
   return (
     <div className="flex items-start gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
       <div
@@ -1409,17 +1422,19 @@ const QueueRow: React.FC<{
       >
         {item.text}
       </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        onClick={() => onRecall(item)}
-        aria-label={t('chat.queue.recall')}
-        title={t('chat.queue.recall')}
-        className="size-6 shrink-0 text-muted hover:text-foreground"
-      >
-        <Undo2 className="size-3.5" />
-      </Button>
+      {canRecall && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={() => onRecall(item)}
+          aria-label={t('chat.queue.recall')}
+          title={t('chat.queue.recall')}
+          className="size-6 shrink-0 text-muted hover:text-foreground"
+        >
+          <Undo2 className="size-3.5" />
+        </Button>
+      )}
       <Button
         type="button"
         variant="ghost"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1885,6 +1885,7 @@
     "queue": {
       "title": "Queued · {{count}}",
       "sendNow": "Send now",
+      "recall": "Recall to input",
       "remove": "Remove from queue"
     }
   }

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1884,6 +1884,7 @@
     "queue": {
       "title": "排队中 · {{count}}",
       "sendNow": "立即发送",
+      "recall": "撤回到输入框",
       "remove": "移出队列"
     }
   }


### PR DESCRIPTION
## Capability
Two interaction tweaks to the **send-while-busy queue** rows shown above the composer (`QueueStrip` / `QueueRow` in `ChatPage.tsx`).

### 1. Desktop text selection
The queued text was wrapped in a `<button>`, so a desktop click only toggled expand/collapse and the text **couldn't be selected**. It's now a selectable element (`role="button"` + `select-text`): a click still toggles, **unless the click ended a text selection** (guarded via `window.getSelection()`), so drag-to-select works. Keyboard Enter/Space still toggles (a11y preserved).

### 2. Recall to input
A **recall** action (`Undo2` icon) sits left of the delete (✕) button. Clicking it **appends the queued message back into the composer** (to edit/resend) and removes it from the queue. Wired through `QueueStrip` → `recallQueued` in `ChatPage`, reusing `ComposerHandle.appendText` (non-destructive — appends with a separating space if a draft is present).

i18n: `chat.queue.recall` (en + zh).

## Out of scope (separate, under investigation)
A reported mobile-PWA **Typeless voice-input truncation** bug is being diagnosed separately (needs on-device observation); not part of this PR. Serialization was ruled out (`serializeEditorState` already joins all paragraphs).

## Evidence
- **Contract**: `cd ui && npm run build` green (tsc + vite, no TS errors); en/zh JSON valid.
- **Residual manual**: desktop — drag-select queued text (no toggle), click toggles, recall pulls text into the composer + drops the row; mobile — tap toggles, recall works. Screenshot in the design preview.