### PR TITLE
fix(update): stop auto-update loop on local/dev builds

### DIFF
--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -240,6 +240,85 @@ def test_has_newer_version_handles_prerelease_without_packaging():
     assert has_newer_version("2.2.9.dev2", "2.2.9.dev1") is True
 
 
+def test_has_newer_version_ignores_local_build_segment():
+    # Regression: a source/dev install reports a setuptools-scm local version
+    # such as "3.0.4rc4.dev0+gf6ca08af6.d20260624". The old parser could not
+    # parse it and fell back to comparing only pure-digit components, so it
+    # ranked the build below the latest stable on PyPI ("3.0.3"). That made the
+    # updater "upgrade" on every cycle, restart, and DM "updated to 3.0.3" once
+    # a minute forever. The local segment must be ignored and the dev/rc build
+    # must sort correctly.
+    local_build = "3.0.4rc4.dev0+gf6ca08af6.d20260624"
+    assert has_newer_version("3.0.3", local_build) is False
+    assert has_newer_version(local_build, "3.0.3") is True
+    assert has_newer_version("3.0.4rc4", local_build) is True
+    assert has_newer_version(local_build, "3.0.4rc4") is False
+    assert has_newer_version("3.0.4+meta", "3.0.4") is False
+    assert has_newer_version("3.0.4", "3.0.4+meta") is False
+    assert has_newer_version("2.2.9rc1.dev2", "2.2.9rc1.dev1") is True
+    # Two local builds of the same release are incomparable -> treated equal.
+    assert has_newer_version("3.0.4+build2", "3.0.4+build1") is False
+    assert has_newer_version("3.0.4+build1", "3.0.4+build2") is False
+
+
+def test_has_newer_version_orders_dev_before_prerelease():
+    # A dev release of a final sorts before that release's alphas/betas/rcs.
+    assert has_newer_version("2.2.9a1", "2.2.9.dev1") is True
+    assert has_newer_version("2.2.9.dev1", "2.2.9a1") is False
+
+
+def test_get_latest_version_info_no_update_for_local_dev_build(monkeypatch, tmp_path):
+    # Integration-level guard for the notification/restart loop: a local dev
+    # build whose release is ahead of everything on PyPI must report no update.
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        """
+        {
+          "info": {"version": "3.0.3"},
+          "releases": {
+            "3.0.2": [{}],
+            "3.0.3": [{}]
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VIBE_UPDATE_METADATA_URL", metadata_path.as_uri())
+
+    info = get_latest_version_info("3.0.4rc4.dev0+gf6ca08af6.d20260624")
+
+    assert info["has_update"] is False
+
+
+def test_get_latest_version_info_offers_rc_to_local_dev_build(monkeypatch, tmp_path):
+    # A dev build is treated as a pre-release, so a matching-release rc on PyPI
+    # is a legitimate upgrade and must be offered. Locks in the allow_prereleases
+    # policy so a future change can't silently regress it.
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(
+        """
+        {
+          "info": {"version": "3.0.4rc1"},
+          "releases": {
+            "3.0.3": [{}],
+            "3.0.4rc1": [{}]
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VIBE_UPDATE_METADATA_URL", metadata_path.as_uri())
+
+    info = get_latest_version_info("3.0.4.dev0+gf6ca08af6.d20260624")
+
+    assert info == {
+        "current": "3.0.4.dev0+gf6ca08af6.d20260624",
+        "latest": "3.0.4rc1",
+        "has_update": True,
+        "error": None,
+    }
+
+
 def test_get_running_vibe_path_prefers_cached_launcher(monkeypatch):
     monkeypatch.setenv("VIBE_CURRENT_EXECUTABLE", "/custom/bin/vibe")
     monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -21,12 +21,30 @@ CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
 SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
+# PEP 440-ish parser: release + optional pre-release (a/b/rc) + optional
+# post + optional dev, plus a local version segment (``+local``) that we
+# accept but ignore for ordering. Word forms (alpha/beta/preview) are listed
+# before their single-letter aliases so the alternation does not match a bare
+# leading letter (e.g. the "a" in "alpha").
 _VERSION_RE = re.compile(
     r"^\s*v?(?P<release>\d+(?:\.\d+)*)"
-    r"(?:(?:[.-])?(?P<stage>a|b|rc|dev)(?P<stage_num>\d+))?"
-    r"(?:(?:[.-])?post(?P<post_num>\d+))?\s*$"
+    r"(?:[._-]?(?P<pre>alpha|beta|preview|pre|rc|a|b|c)[._-]?(?P<pre_num>\d+)?)?"
+    r"(?:[._-]?(?P<post>post)[._-]?(?P<post_num>\d+)?)?"
+    r"(?:[._-]?(?P<dev>dev)[._-]?(?P<dev_num>\d+)?)?"
+    r"(?:\+(?P<local>[a-z0-9._-]+))?\s*$",
+    re.IGNORECASE,
 )
-_STAGE_ORDER = {"dev": 0, "a": 1, "b": 2, "rc": 3, "final": 4}
+# Relative ordering of pre-release stages: a/alpha < b/beta < c/rc/pre/preview.
+_PRE_ORDER = {
+    "a": 0,
+    "alpha": 0,
+    "b": 1,
+    "beta": 1,
+    "c": 2,
+    "rc": 2,
+    "pre": 2,
+    "preview": 2,
+}
 
 
 @dataclass(frozen=True)
@@ -263,24 +281,65 @@ def _normalize_release_parts(parts: tuple[int, ...]) -> tuple[int, ...]:
     return tuple(normalized)
 
 
-def _parse_version(value: str) -> tuple[tuple[int, ...], int, int, int, int] | None:
+def _parse_version_parts(
+    value: str,
+) -> tuple[tuple[int, ...], tuple[int, int] | None, int | None, int | None] | None:
+    """Split a version into (release, pre, post, dev).
+
+    ``pre`` is ``(stage_order, num)`` for a/b/rc releases, else ``None``.
+    ``post`` / ``dev`` are the numeric component, or ``None`` when absent.
+    The local segment (``+...``) is matched but intentionally discarded: per
+    PEP 440 it does not affect ordering.
+    """
     match = _VERSION_RE.match(value)
     if not match:
         return None
 
-    release = tuple(int(part) for part in match.group("release").split("."))
-    stage = match.group("stage") or "final"
-    stage_num = int(match.group("stage_num") or "0")
-    post_num = int(match.group("post_num") or "0")
-    has_post = 1 if match.group("post_num") else 0
-    return (_normalize_release_parts(release), _STAGE_ORDER[stage], stage_num, has_post, post_num)
+    release = _normalize_release_parts(
+        tuple(int(part) for part in match.group("release").split("."))
+    )
+    pre = None
+    if match.group("pre"):
+        pre = (_PRE_ORDER[match.group("pre").lower()], int(match.group("pre_num") or "0"))
+    post = int(match.group("post_num") or "0") if match.group("post") else None
+    dev = int(match.group("dev_num") or "0") if match.group("dev") else None
+    return (release, pre, post, dev)
+
+
+def _version_key(
+    parts: tuple[tuple[int, ...], tuple[int, int] | None, int | None, int | None],
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+    """Build a totally-ordered, all-int comparison key (PEP 440 ordering).
+
+    Bands are plain int tuples so they never compare a number against a tuple.
+    Within a release: ``X.devN`` < ``Xa/b/rcN`` < ``X`` (final) < ``X.postN``,
+    and a trailing ``.devN`` sorts before the same version without it.
+    """
+    release, pre, post, dev = parts
+    if pre is None and post is None and dev is not None:
+        pre_band: tuple[int, ...] = (0,)  # bare X.devN sorts before any pre/final of X
+    elif pre is None:
+        pre_band = (2,)  # final (or post-only) sorts after pre-releases
+    else:
+        pre_band = (1, pre[0], pre[1])
+    post_band = (0,) if post is None else (1, post)
+    dev_band = (1,) if dev is None else (0, dev)  # a dev release sorts before the non-dev
+    return (release, pre_band, post_band, dev_band)
+
+
+def _parse_version(
+    value: str,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...]] | None:
+    parts = _parse_version_parts(value)
+    return None if parts is None else _version_key(parts)
 
 
 def _is_prerelease_version(value: str) -> bool:
-    parsed = _parse_version(value)
-    if parsed is None:
+    parts = _parse_version_parts(value)
+    if parts is None:
         return False
-    return parsed[1] < _STAGE_ORDER["final"]
+    _release, pre, _post, dev = parts
+    return pre is not None or dev is not None
 
 
 def _is_yanked_release(files: object) -> bool:
@@ -327,10 +386,21 @@ def has_newer_version(candidate: str, current: str) -> bool:
     if latest_parsed is not None and current_parsed is not None:
         return latest_parsed > current_parsed
 
+    # Fallback for strings the parser cannot handle: compare the leading
+    # integer of each of the first three dotted components. Stop at the first
+    # component without a leading digit so we never silently drop a position
+    # (e.g. treating "3.0.4rc4" as [3, 0] and ranking it below "3.0.3").
+    def _loose_parts(text: str) -> list[int]:
+        parts: list[int] = []
+        for chunk in text.split(".")[:3]:
+            digits = re.match(r"\d+", chunk)
+            if not digits:
+                break
+            parts.append(int(digits.group()))
+        return parts
+
     try:
-        current_parts = [int(x) for x in current.split(".")[:3] if x.isdigit()]
-        latest_parts = [int(x) for x in candidate.split(".")[:3] if x.isdigit()]
-        return latest_parts > current_parts
+        return _loose_parts(candidate) > _loose_parts(current)
     except (ValueError, AttributeError):
         return candidate != current
 


### PR DESCRIPTION
## Problem

A source/dev install reports a setuptools-scm version such as `3.0.4rc4.dev0+gf6ca08af6.d20260624`. The updater's `_VERSION_RE` in `vibe/upgrade.py` could not parse it — it had no support for a secondary `.dev` after a pre-release stage, nor for the `+local` segment. So `_parse_version` returned `None` and `has_newer_version` fell into this fallback:

```python
current_parts = [int(x) for x in current.split(".")[:3] if x.isdigit()]
```

`"3.0.4rc4.dev0+...".split(".")[:3]` → `["3","0","4rc4"]`, and `"4rc4".isdigit()` is `False`, so the patch component was **silently dropped** → current parsed as `[3, 0]`. That ranks below PyPI's latest stable `3.0.3`, so the updater believed an upgrade was available **every cycle**: it ran `uv tool install --upgrade` (a no-op, since `3.0.4rc4` > `3.0.3`), restarted, and DM'd `✅ Avibe has been updated to 3.0.3` to admins — roughly once a minute, forever.

## Fix

Rework the parser in `vibe/upgrade.py` to be PEP 440-ish while staying dependency-free (no `packaging` import, consistent with the existing `..._without_packaging` test):

- Accept an optional `+local` segment (matched but ignored for ordering, per PEP 440) and a dev release trailing a pre-release (e.g. `rc4.dev0`).
- Build an **all-int comparison key** `(release, pre_band, post_band, dev_band)` so ordering is correct (`X.devN` < `Xa/b/rcN` < `X` < `X.postN`, and a trailing `.devN` sorts before the same version without it) and no band ever compares a number against a tuple.
- `_is_prerelease_version` now reports a pre **or** dev component as a pre-release.
- Harden the unparseable-string fallback to stop at the first non-numeric component instead of dropping it.

## Tests

`tests/test_upgrade_flow.py` gains regression coverage:
- `test_has_newer_version_ignores_local_build_segment` — the exact loop scenario + local-segment equality.
- `test_has_newer_version_orders_dev_before_prerelease`.
- `test_get_latest_version_info_no_update_for_local_dev_build` — integration: no spurious update.
- `test_get_latest_version_info_offers_rc_to_local_dev_build` — locks in that a matching-release rc on PyPI is still offered to a dev build.

All 38 tests in the file pass; `ruff check` clean. Existing version-comparison tests are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)