### PR TITLE
fix(update): narrow post-update failure notification

### DIFF
--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -711,30 +711,21 @@ class UpdateChecker:
         try:
             im_client = self._get_im_client_for_platform(resolved_platform)
             if channel_id and message_id and resolved_platform == "slack":
-                try:
-                    await im_client.web_client.chat_update(channel=channel_id, ts=message_id, text=failure_text)
-                    logger.info("Updated original message with post-update failure notification")
-                    return
-                except Exception as e:
-                    logger.error("Failed to update Slack post-update failure message: %s", e)
+                await im_client.web_client.chat_update(channel=channel_id, ts=message_id, text=failure_text)
+                logger.info("Updated original message with post-update failure notification")
+                return
             if channel_id and message_id:
-                try:
-                    context = MessageContext(user_id="system", channel_id=channel_id, platform=resolved_platform)
-                    await im_client.edit_message(context, message_id, text=failure_text)
-                    logger.info("Updated %s message with post-update failure notification", resolved_platform)
-                    return
-                except Exception as e:
-                    logger.error("Failed to edit %s post-update failure message: %s", resolved_platform, e)
+                context = MessageContext(user_id="system", channel_id=channel_id, platform=resolved_platform)
+                await im_client.edit_message(context, message_id, text=failure_text)
+                logger.info("Updated %s message with post-update failure notification", resolved_platform)
+                return
 
             admin_ids = self._get_admin_user_ids()
             if admin_ids:
                 for uid in admin_ids:
-                    try:
-                        admin_client, raw_user_id, _ = self._get_im_client_for_user(uid)
-                        await admin_client.send_dm(raw_user_id, failure_text)
-                        logger.info("Sent post-update failure notification to admin %s", uid)
-                    except Exception as e:
-                        logger.error("Failed to send post-update failure notification to admin %s: %s", uid, e)
+                    admin_client, raw_user_id, _ = self._get_im_client_for_user(uid)
+                    await admin_client.send_dm(raw_user_id, failure_text)
+                    logger.info("Sent post-update failure notification to admin %s", uid)
             elif resolved_platform == "slack":
                 owner_id = await self._get_workspace_owner_id()
                 if owner_id:
@@ -742,16 +733,6 @@ class UpdateChecker:
                     if dm_channel:
                         await im_client.web_client.chat_postMessage(channel=dm_channel, text=failure_text)
                         logger.info("Sent post-update failure notification to %s", owner_id)
-            elif resolved_platform == "discord":
-                channel_id = self._get_default_notification_channel_id()
-                if channel_id:
-                    context = MessageContext(user_id="system", channel_id=channel_id, platform="discord")
-                    await self.controller.get_im_client_for_context(context).send_message(
-                        context,
-                        failure_text,
-                        parse_mode="markdown",
-                    )
-                    logger.info("Sent Discord post-update failure notification to channel %s", channel_id)
         except Exception as e:
             logger.error("Failed to send post-update failure notification: %s", e)
 

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -11,7 +11,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from config.v2_settings import ChannelSettings, SettingsStore, UserSettings
+from config.v2_settings import SettingsStore, UserSettings
 from config.v2_config import UpdateConfig
 from core import update_checker
 from core.update_checker import UpdateChecker
@@ -35,16 +35,12 @@ class _StubController:
         self.im_client = object()
         self.im_clients = {}
 
-    def get_im_client_for_context(self, context):
-        return self.im_clients.get(context.platform) or self.im_client
-
 
 class _FakeIMClient:
     def __init__(self, message_id="msg-1"):
         self.message_id = message_id
         self.dm_calls = []
         self.edit_calls = []
-        self.message_calls = []
 
     async def send_dm(self, user_id: str, text: str, **kwargs):
         self.dm_calls.append((user_id, text, kwargs))
@@ -53,10 +49,6 @@ class _FakeIMClient:
     async def edit_message(self, context, message_id: str, text: str, **kwargs):
         self.edit_calls.append((context, message_id, text, kwargs))
         return True
-
-    async def send_message(self, context, text: str, **kwargs):
-        self.message_calls.append((context, text, kwargs))
-        return self.message_id
 
 
 def test_get_admin_user_ids_includes_all_platforms(monkeypatch, tmp_path):
@@ -447,100 +439,6 @@ def test_restartless_auto_update_blocks_same_version_retry_and_notifies(monkeypa
     assert "`3.0.3`" in text
     assert checker.state.blocked_auto_update_version == "3.0.4"
     assert checker.state.blocked_auto_update_reason == "restart_not_scheduled"
-
-
-def test_post_update_failure_notification_uses_discord_fallback_channel(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    SettingsStore.reset_instance()
-    store = SettingsStore.get_instance()
-    store.update_channel("123456789012345678", ChannelSettings(enabled=True), platform="discord")
-    controller = _StubController(store)
-    controller.config.platform = "discord"
-    discord_client = _FakeIMClient()
-    controller.im_clients = {"discord": discord_client}
-    controller.im_client = discord_client
-    checker = UpdateChecker(controller, UpdateConfig())
-
-    asyncio.run(
-        checker._send_post_update_failure_notification(
-            target_version="3.0.4",
-            running_version="3.0.3",
-            platform="discord",
-        )
-    )
-
-    assert discord_client.message_calls
-    context, text, kwargs = discord_client.message_calls[0]
-    assert context.platform == "discord"
-    assert context.channel_id == "123456789012345678"
-    assert "did not take effect" in text
-    assert kwargs["parse_mode"] == "markdown"
-
-
-def test_post_update_failure_notification_continues_after_admin_dm_failure(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    SettingsStore.reset_instance()
-    store = SettingsStore.get_instance()
-    store.set_users_for_platform("telegram", {"bad": UserSettings(display_name="Bad", is_admin=True)})
-    store.set_users_for_platform("discord", {"good": UserSettings(display_name="Good", is_admin=True)})
-    store.save()
-    controller = _StubController(store)
-
-    class _FailingDMClient(_FakeIMClient):
-        async def send_dm(self, user_id: str, text: str, **kwargs):
-            raise RuntimeError("dm failed")
-
-    bad_client = _FailingDMClient()
-    good_client = _FakeIMClient()
-    controller.im_clients = {"telegram": bad_client, "discord": good_client}
-    checker = UpdateChecker(controller, UpdateConfig())
-
-    asyncio.run(
-        checker._send_post_update_failure_notification(
-            target_version="3.0.4",
-            running_version="3.0.3",
-        )
-    )
-
-    assert bad_client.dm_calls == []
-    assert good_client.dm_calls
-    user_id, text, _ = good_client.dm_calls[0]
-    assert user_id == "good"
-    assert "did not take effect" in text
-
-
-def test_post_update_failure_notification_falls_back_after_edit_failure(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    SettingsStore.reset_instance()
-    store = SettingsStore.get_instance()
-    store.set_users_for_platform("telegram", {"admin": UserSettings(display_name="Admin", is_admin=True)})
-    store.save()
-    controller = _StubController(store)
-
-    class _FailingEditClient(_FakeIMClient):
-        async def edit_message(self, context, message_id: str, text: str, **kwargs):
-            self.edit_calls.append((context, message_id, text, kwargs))
-            raise RuntimeError("edit failed")
-
-    telegram_client = _FailingEditClient()
-    controller.im_clients = {"telegram": telegram_client}
-    checker = UpdateChecker(controller, UpdateConfig())
-
-    asyncio.run(
-        checker._send_post_update_failure_notification(
-            target_version="3.0.4",
-            running_version="3.0.3",
-            channel_id="123456",
-            message_id="42",
-            platform="telegram",
-        )
-    )
-
-    assert telegram_client.edit_calls
-    assert telegram_client.dm_calls
-    user_id, text, _ = telegram_client.dm_calls[0]
-    assert user_id == "admin"
-    assert "did not take effect" in text
 
 
 def test_install_failure_auto_update_remains_retryable(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Clean up the post-update failure notification expansion from #648 while keeping the root auto-update fixes intact.

This PR keeps:
- post-update runtime version verification before success notifications
- deterministic retry blocking for restart-not-scheduled and version-mismatch cases
- retryable behavior for transient install failures
- source/dev unattended auto-update guard

It removes the extra notification delivery expansion that was pulled in while addressing review feedback:
- Discord fallback-channel delivery for post-update failures
- per-admin best-effort fallback after a DM failure
- edit-failure fallback into a separate DM path

## Testing

- `pytest -q tests/test_update_checker_platforms.py tests/test_upgrade_flow.py`
- `ruff check core/update_checker.py tests/test_update_checker_platforms.py`
