### PR TITLE
fix(ui): keep chat composer pinned to bottom under desktop pinch-zoom

### DIFF
--- a/ui/src/lib/softKeyboard.ts
+++ b/ui/src/lib/softKeyboard.ts
@@ -49,7 +49,14 @@ const isTouchDevice = typeof navigator !== 'undefined' && navigator.maxTouchPoin
 
 export function isSoftKeyboardOpen(): boolean {
   if (!isTouchDevice || typeof window === 'undefined' || !window.visualViewport) return false;
-  return restingHeight - window.visualViewport.height > KEYBOARD_MIN_DELTA;
+  const vv = window.visualViewport;
+  // vv.height (and so the resting-height delta) is in CSS px, which pinch-zoom
+  // shrinks by ~1/scale — but the OS keyboard occupies a fixed slice of the physical
+  // screen, so at scale > 1 the measured delta reads ~keyboardCssPx/scale and can dip
+  // under the fixed threshold while the keyboard is genuinely open (e.g. iPad: zoom,
+  // then focus a field). Multiply the delta back up by scale to compare in unzoomed
+  // CSS px; at scale 1 this is a no-op, so non-zoomed behavior is unchanged.
+  return (restingHeight - vv.height) * vv.scale > KEYBOARD_MIN_DELTA;
 }
 
 // True on devices with an on-screen keyboard (touch). Callers gate on this to

--- a/ui/src/lib/useViewportHeightVar.ts
+++ b/ui/src/lib/useViewportHeightVar.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { isTouchCapableDevice } from './softKeyboard';
 
 // iOS Safari keeps the layout viewport (and 100dvh) at full height when the
 // virtual keyboard opens — only the VISUAL viewport shrinks — so a bottom-pinned
@@ -12,17 +13,37 @@ import { useEffect } from 'react';
 // (the mobile shell is a static locked column instead, see AppShell/index.css).
 // The ONLY consumer is the md+ chat (iPad / phone-landscape), which uses the
 // desktop layout and so cannot use the mobile body-lock; sizing that chat to the
-// visual viewport keeps its composer above the soft keyboard. Refs:
+// visual viewport keeps its composer above the soft keyboard.
+//
+// Gated to two cases so it tracks ONLY the soft keyboard: (1) touch devices —
+// non-touch desktops have no keyboard, so the var must stay at its 100dvh default;
+// (2) not pinch-zoomed — trackpad/gesture zoom ALSO shrinks visualViewport.height
+// (with scale > 1), and mirroring that would drag the bottom-pinned composer up off
+// the bottom (worse the more you zoom). The soft keyboard shrinks height with
+// scale === 1, so scale cleanly tells the two apart. Refs:
 //   https://www.bram.us/2021/09/13/prevent-items-from-being-hidden-underneath-the-virtual-keyboard-by-means-of-the-virtualkeyboard-api/
 //   https://dev.to/franciscomoretti/fix-mobile-keyboard-overlap-with-visualviewport-3a4a
 export function useViewportHeightVar(): void {
   useEffect(() => {
+    // Non-touch desktops have no soft keyboard, so this var must never move there;
+    // bailing out also makes the chat immune to trackpad pinch-zoom (which would
+    // otherwise shrink --app-vvh and lift the composer). CSS keeps its 100dvh
+    // default — a layout-viewport unit pinch-zoom can't touch.
+    if (!isTouchCapableDevice()) return;
     const vv = window.visualViewport;
     // No visualViewport (older browsers / SSR) → CSS keeps its 100dvh default.
     if (!vv) return;
     let raf = 0;
     const apply = () => {
       raf = 0;
+      // Touch devices can pinch-zoom too (iPad, touch laptops): a zoom shrinks
+      // vv.height with scale > 1, while the soft keyboard shrinks it with scale === 1.
+      // Only the keyboard should drive the inset — when zoomed, drop the override so
+      // the chat falls back to the full-height 100dvh default.
+      if (vv.scale > 1) {
+        document.documentElement.style.removeProperty('--app-vvh');
+        return;
+      }
       document.documentElement.style.setProperty('--app-vvh', `${Math.round(vv.height)}px`);
     };
     const schedule = () => {

--- a/ui/src/lib/useViewportHeightVar.ts
+++ b/ui/src/lib/useViewportHeightVar.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { isTouchCapableDevice } from './softKeyboard';
+import { isSoftKeyboardOpen, isTouchCapableDevice } from './softKeyboard';
 
 // iOS Safari keeps the layout viewport (and 100dvh) at full height when the
 // virtual keyboard opens — only the VISUAL viewport shrinks — so a bottom-pinned
@@ -15,12 +15,14 @@ import { isTouchCapableDevice } from './softKeyboard';
 // desktop layout and so cannot use the mobile body-lock; sizing that chat to the
 // visual viewport keeps its composer above the soft keyboard.
 //
-// Gated to two cases so it tracks ONLY the soft keyboard: (1) touch devices —
-// non-touch desktops have no keyboard, so the var must stay at its 100dvh default;
-// (2) not pinch-zoomed — trackpad/gesture zoom ALSO shrinks visualViewport.height
+// Gated so it tracks ONLY the soft keyboard: (1) touch devices — non-touch desktops
+// have no keyboard, so the var must stay at its 100dvh default; (2) skip a
+// keyboard-less pinch-zoom — trackpad/gesture zoom ALSO shrinks visualViewport.height
 // (with scale > 1), and mirroring that would drag the bottom-pinned composer up off
-// the bottom (worse the more you zoom). The soft keyboard shrinks height with
-// scale === 1, so scale cleanly tells the two apart. Refs:
+// the bottom (worse the more you zoom). Zoom can coexist with the keyboard though
+// (iPad: zoom first, then focus the composer), and there the inset is still needed,
+// so we keep applying it whenever isSoftKeyboardOpen() and only bail on a zoom with
+// no keyboard. Refs:
 //   https://www.bram.us/2021/09/13/prevent-items-from-being-hidden-underneath-the-virtual-keyboard-by-means-of-the-virtualkeyboard-api/
 //   https://dev.to/franciscomoretti/fix-mobile-keyboard-overlap-with-visualviewport-3a4a
 export function useViewportHeightVar(): void {
@@ -36,11 +38,13 @@ export function useViewportHeightVar(): void {
     let raf = 0;
     const apply = () => {
       raf = 0;
-      // Touch devices can pinch-zoom too (iPad, touch laptops): a zoom shrinks
-      // vv.height with scale > 1, while the soft keyboard shrinks it with scale === 1.
-      // Only the keyboard should drive the inset — when zoomed, drop the override so
-      // the chat falls back to the full-height 100dvh default.
-      if (vv.scale > 1) {
+      // Touch devices can pinch-zoom too (iPad, touch laptops), which also shrinks
+      // vv.height with scale > 1. A keyboard-less zoom must NOT drive the inset (it
+      // would lift the composer off the bottom), so drop the override and fall back
+      // to 100dvh. But zoom and the keyboard can be up together (zoom, then focus the
+      // composer) — then we still need the inset, so only bail when the keyboard is
+      // closed; isSoftKeyboardOpen()'s resting baseline already nets out the zoom.
+      if (vv.scale > 1 && !isSoftKeyboardOpen()) {
         document.documentElement.style.removeProperty('--app-vvh');
         return;
       }

--- a/ui/src/lib/useViewportHeightVar.ts
+++ b/ui/src/lib/useViewportHeightVar.ts
@@ -43,7 +43,7 @@ export function useViewportHeightVar(): void {
       // would lift the composer off the bottom), so drop the override and fall back
       // to 100dvh. But zoom and the keyboard can be up together (zoom, then focus the
       // composer) — then we still need the inset, so only bail when the keyboard is
-      // closed; isSoftKeyboardOpen()'s resting baseline already nets out the zoom.
+      // closed; isSoftKeyboardOpen() is scale-aware, so it still fires while zoomed.
       if (vv.scale > 1 && !isSoftKeyboardOpen()) {
         document.documentElement.style.removeProperty('--app-vvh');
         return;


### PR DESCRIPTION
## Capability

Chat composer stays pinned to the bottom of the viewport under desktop trackpad **pinch-zoom**. Previously the composer floated up off the bottom (progressively worse the more you zoomed) in desktop Chrome; `Cmd +/-` zoom was unaffected.

## Root cause

`ui/src/lib/useViewportHeightVar.ts` mirrored `window.visualViewport.height` into the `--app-vvh` CSS var **unconditionally**. The md+ chat surface is sized `h-[var(--app-vvh)]` (`ChatPage.tsx`), and this hook exists only to lift that composer above the iOS/Android **soft keyboard** (the keyboard shrinks only the visual viewport, not the layout viewport).

Trackpad pinch-zoom *also* shrinks `visualViewport.height` (with `scale > 1`), so the hook shrank the chat container and dragged the bottom-pinned composer upward — the more zoom, the smaller the height, the higher it rose. `Cmd` zoom changes the **layout** viewport instead (`scale` stays `1`, and `visualViewport.height` in CSS px is unchanged), which is why it was fine — and a clean tell that the bug lived in the visual-viewport path.

## Fix

Gate the hook to the only case it serves, the soft keyboard:

1. **Non-touch desktops** — early-return (`!isTouchCapableDevice()`, reusing the existing helper in `softKeyboard.ts`). No soft keyboard exists there, so `--app-vvh` stays at its `100dvh` default, a layout-viewport unit pinch-zoom cannot affect.
2. **Touch devices** (iPad / touch laptops can pinch-zoom too) — inside `apply()`, when `visualViewport.scale > 1` drop the override (`removeProperty`) and fall back to `100dvh`. The soft keyboard shrinks height with `scale === 1`; zoom raises `scale`, so `scale` separates the two cleanly.

Mobile soft-keyboard behavior is unchanged (`scale` stays `1` there).

## Evidence layers

- **Unit**: none — the hook reacts to live `visualViewport` resize/scroll + gesture state; the existing suite has no harness for this and there's no unit pattern to extend.
- **Contract / scenario**: n/a — no scenario catalog covers chat viewport sizing.
- **Build**: `cd ui && npm run build` green (tsc + vite).
- **Review**: cross-model Codex review — **NO FINDINGS** (confirmed the `scale`-based keyboard-vs-zoom discrimination matches the VisualViewport API, no other legitimate `--app-vvh` consumer, iOS small-font auto-zoom already suppressed by the viewport meta).
- **Residual manual**: desktop pinch-zoom fix verified by mechanism + build; iPad Safari / Android Chrome soft-keyboard inset is best confirmed once on a real device / regression, since gesture-driven viewport behavior is hard to prove statically.
