### PR TITLE
test(update): make 3.0.4 update-checker tests hermetic (fix master unit-tests)

### DIFF
--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -381,6 +381,11 @@ def test_auto_update_skips_unattended_source_checkout_install(monkeypatch, tmp_p
         "_fetch_pypi_version_sync",
         lambda: {"current": "3.0.4.dev10+g4d621ef0a", "latest": "3.0.4", "has_update": True, "error": None},
     )
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_update_notification_policy_sync",
+        lambda version: {"version": version, "policy": "default", "error": None},
+    )
     monkeypatch.setattr(checker, "_is_idle", lambda: True)
     monkeypatch.setattr(update_checker, "get_running_vibe_path", lambda: "/tmp/dev-vibe")
     monkeypatch.setattr("vibe.runtime.get_service_main_path", lambda: Path("/repo/main.py"))
@@ -416,6 +421,11 @@ def test_restartless_auto_update_blocks_same_version_retry_and_notifies(monkeypa
         update_checker,
         "_fetch_pypi_version_sync",
         lambda: {"current": "3.0.3", "latest": "3.0.4", "has_update": True, "error": None},
+    )
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_update_notification_policy_sync",
+        lambda version: {"version": version, "policy": "default", "error": None},
     )
     monkeypatch.setattr(checker, "_is_idle", lambda: True)
     monkeypatch.setattr("vibe.runtime.get_service_main_path", lambda: Path("/pkg/service_main.py"))
@@ -453,6 +463,11 @@ def test_install_failure_auto_update_remains_retryable(monkeypatch, tmp_path):
         update_checker,
         "_fetch_pypi_version_sync",
         lambda: {"current": "3.0.3", "latest": "3.0.4", "has_update": True, "error": None},
+    )
+    monkeypatch.setattr(
+        update_checker,
+        "_fetch_update_notification_policy_sync",
+        lambda version: {"version": version, "policy": "default", "error": None},
     )
     monkeypatch.setattr(checker, "_is_idle", lambda: True)
     monkeypatch.setattr("vibe.runtime.get_service_main_path", lambda: Path("/pkg/service_main.py"))


### PR DESCRIPTION
## Capability

Makes the update-checker auto-update tests **hermetic** so they no longer depend on the live GitHub release of a hardcoded version. Fixes the pre-existing `unit-tests (0/4)` failure on `master` (and every open PR).

## Root cause

The three `3.0.4` auto-update tests in `tests/test_update_checker_platforms.py` hardcode `"latest": "3.0.4"` but mock **only** `_fetch_pypi_version_sync`, not `_fetch_update_notification_policy_sync`. So `_do_check()` → `_should_send_release_notifications("3.0.4")` reaches out to the **live GitHub release API**.

When the tests were written, `v3.0.4` did not yet exist, so the fetch errored and `_should_send_release_notifications` defaulted to `True` → no `suppress_post_update_notification` kwarg. Once **`v3.0.4` shipped as a silent release** (`update-notification=none`), the unmocked fetch started returning policy `none` → `release_notifications` became `False` → the production code (correctly) added `suppress_post_update_notification=True` to the `_perform_update` call, breaking:

```
assert attempts == [("3.0.4", {})]
# actual: [("3.0.4", {"suppress_post_update_notification": True})]
```

This is why it failed **only in CI** (GitHub reachable) and passed locally (fetch errored → defaulted `True`). The `1.0.1` tests never had this problem because they already mock the policy fetch.

## Fix

Mock `_fetch_update_notification_policy_sync` to return `policy: "default"` in all three `3.0.4` tests (the two failing ones plus the dev-version test), matching the existing `1.0.1` pattern. The product code is **unchanged and correct** — a silent release *should* suppress the post-update notification; the bug was purely a non-hermetic test reaching live release data.

## Evidence layers

- **Unit**: reproduced both failures locally with network up (`2 failed in 16.37s` — the seconds confirm the live fetch); after the fix the full file is `23 passed` and the two target tests drop from ~5–6s of network to deterministic.
- **Lint**: `ruff check` clean on the changed file.
- **Contract / scenario**: n/a — no scenario catalog covers the update checker.
- **Residual**: a separate, pre-existing non-hermetic smell remains — `_do_check()` attempts an `askill` install (logged as a warning, ~4–5s per test, no assertion impact). Out of scope for this fix; flagged for a follow-up.
