### PR TITLE
fix(remote-access): redact OAuth diagnostics

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -110,6 +110,13 @@ def test_exchange_oauth_code_wraps_token_endpoint_rejection(monkeypatch) -> None
     assert exc_info.value.detail == "invalid_code"
 
 
+def test_oauth_code_exchange_error_string_omits_rejection_detail() -> None:
+    error = remote_access.OAuthCodeExchangeError("token_endpoint_rejected", '{"code":"secret-code"}')
+
+    assert str(error) == "token_endpoint_rejected"
+    assert "secret-code" not in str(error)
+
+
 def test_exchange_oauth_code_reports_instance_mismatch(monkeypatch) -> None:
     config = _config()
 

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import logging
 import socket
 import asyncio
 from collections import namedtuple
@@ -1088,6 +1089,64 @@ def test_remote_callback_explains_clock_mismatch(monkeypatch, tmp_path):
     assert "oauth_time_mismatch" in response.text
     assert "Check this machine&#x27;s clock" in response.text
     assert "reason: expired_id_token" in response.text
+
+
+def test_remote_callback_redacts_quoted_oauth_details(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+
+    with app.test_request_context("/dashboard", base_url="https://alex.avibe.bot"):
+        redirect = ui_server._redirect_to_vibe_cloud_login(config)
+    oauth_cookie = redirect.headers["Set-Cookie"].split(";", 1)[0].split("=", 1)[1]
+    client.set_cookie(ui_server.REMOTE_OAUTH_COOKIE_NAME, oauth_cookie, domain="alex.avibe.bot")
+
+    def exchange(cfg, code, verifier):
+        raise remote_access.OAuthCodeExchangeError(
+            "token_endpoint_rejected",
+            '{"code":"secret-code","code_verifier":"secret-verifier","detail":"bad code"}',
+        )
+
+    monkeypatch.setattr(remote_access, "exchange_oauth_code", exchange)
+
+    state = ui_server._read_oauth_cookie(config.remote_access.vibe_cloud.session_secret, oauth_cookie)["state"]
+    response = client.get(f"/auth/callback?code=test-code&state={state}", base_url="https://alex.avibe.bot")
+
+    assert response.status_code == 400
+    assert "detail:" in response.text
+    assert "code=&lt;redacted&gt;" in response.text
+    assert "code_verifier=&lt;redacted&gt;" in response.text
+    assert "secret-code" not in response.text
+    assert "secret-verifier" not in response.text
+    assert "test-code" not in response.text
+
+
+def test_remote_callback_log_omits_raw_oauth_rejection_detail(monkeypatch, tmp_path, caplog):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+
+    with app.test_request_context("/dashboard", base_url="https://alex.avibe.bot"):
+        redirect = ui_server._redirect_to_vibe_cloud_login(config)
+    oauth_cookie = redirect.headers["Set-Cookie"].split(";", 1)[0].split("=", 1)[1]
+    client.set_cookie(ui_server.REMOTE_OAUTH_COOKIE_NAME, oauth_cookie, domain="alex.avibe.bot")
+
+    def exchange(cfg, code, verifier):
+        raise remote_access.OAuthCodeExchangeError("token_endpoint_rejected", '{"code":"secret-code"}')
+
+    monkeypatch.setattr(remote_access, "exchange_oauth_code", exchange)
+    with ui_server._oauth_diag_log_lock:
+        ui_server._oauth_diag_log_state.pop("exchange_failed", None)
+    caplog.set_level(logging.WARNING, logger="vibe.ui_server")
+
+    state = ui_server._read_oauth_cookie(config.remote_access.vibe_cloud.session_secret, oauth_cookie)["state"]
+    response = client.get(f"/auth/callback?code=test-code&state={state}", base_url="https://alex.avibe.bot")
+
+    assert response.status_code == 400
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "reason=token_endpoint_rejected" in messages
+    assert "secret-code" not in messages
+    assert "test-code" not in messages
 
 
 def test_remote_callback_rejects_when_remote_access_is_disabled(monkeypatch, tmp_path):

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -58,8 +58,7 @@ class BackendRequestError(Exception):
 
 class OAuthCodeExchangeError(Exception):
     def __init__(self, reason: str, detail: str | None = None):
-        message = reason if not detail else f"{reason}: {detail}"
-        super().__init__(message)
+        super().__init__(reason)
         self.reason = reason
         self.detail = detail or ""
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1351,8 +1351,8 @@ _OAUTH_EXCHANGE_ERROR_PAGE_BY_REASON = {
 
 _OAUTH_DIAGNOSTIC_DETAIL_MAX_CHARS = 240
 _OAUTH_DIAGNOSTIC_SECRET_PATTERN = re.compile(
-    r"(?i)\b(code|state|id_token|access_token|refresh_token|code_verifier|nonce)"
-    r"(\s*[=:]\s*|%3d)[^&\s,;}]+"
+    r"(?i)(?P<key_quote>['\"]?)\b(?P<key>code_verifier|id_token|access_token|refresh_token|code|state|nonce)\b(?P=key_quote)"
+    r"(?P<sep>\s*[=:]\s*|%3d)(?P<value_quote>['\"]?)[^&\s,;}]+(?P=value_quote)"
 )
 
 
@@ -1368,7 +1368,7 @@ def _sanitize_oauth_diagnostic_detail(value: str | None) -> str:
     if not value:
         return ""
     compact = " ".join(str(value).split())
-    redacted = _OAUTH_DIAGNOSTIC_SECRET_PATTERN.sub(lambda match: f"{match.group(1)}=<redacted>", compact)
+    redacted = _OAUTH_DIAGNOSTIC_SECRET_PATTERN.sub(lambda match: f"{match.group('key')}=<redacted>", compact)
     if len(redacted) <= _OAUTH_DIAGNOSTIC_DETAIL_MAX_CHARS:
         return redacted
     return redacted[: _OAUTH_DIAGNOSTIC_DETAIL_MAX_CHARS - 1].rstrip() + "..."
@@ -2982,7 +2982,8 @@ def remote_access_auth_callback():
         claims = result["claims"]
     except Exception as exc:
         # Unauthenticated-reachable (valid handshake + bad code), so rate-limited.
-        _log_oauth_diag("exchange_failed", "vibe cloud oauth code exchange failed: %s", exc)
+        reason = exc.reason if isinstance(exc, remote_access.OAuthCodeExchangeError) else exc.__class__.__name__
+        _log_oauth_diag("exchange_failed", "vibe cloud oauth code exchange failed: reason=%s", reason)
         error, diagnostics = _oauth_exchange_error_diagnostics(exc)
         return _oauth_callback_error_response(error, next_target=next_target, diagnostics=diagnostics)
     if claims.get("nonce") != handshake_nonce:


### PR DESCRIPTION
## What
- Stop `OAuthCodeExchangeError.__str__` from including token-endpoint rejection details, so callback warning logs only include the safe reason.
- Expand OAuth diagnostic redaction to cover quoted JSON / Python-dict forms like `{"code":"..."}` and `{'code': '...'}` before rendering copyable support details.

## Evidence
- Unit: `python3 -m pytest tests/test_ui_remote_access_auth.py tests/test_remote_access_vibe_cloud.py -q`
- Lint: `ruff check vibe/remote_access.py vibe/ui_server.py tests/test_ui_remote_access_auth.py tests/test_remote_access_vibe_cloud.py`
- Diff hygiene: `git diff --check`

## Context
Follow-up for post-merge Codex review comments on PR #657.
