### PR TITLE
feat(vaults): real manifest-pinned avault installer

### DIFF
--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -8,9 +8,68 @@ shape.
 
 from __future__ import annotations
 
+import hashlib
+import io
+import json
+import tarfile
+
 import pytest
 
 from vibe import api
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _fake_avault_archive(content: bytes = b"#!/bin/sh\necho avault 0.1.0\n") -> bytes:
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w:gz") as archive:
+        info = tarfile.TarInfo("avault")
+        info.size = len(content)
+        info.mode = 0o755
+        archive.addfile(info, io.BytesIO(content))
+    return raw.getvalue()
+
+
+def _installable_avault_release(monkeypatch, *, target: str = "macos-arm64", sha256: str | None = None):
+    archive = _fake_avault_archive()
+    digest = sha256 or hashlib.sha256(archive).hexdigest()
+    manifest = {
+        "schema_version": 1,
+        "versions": {
+            api.AVAULT_VERSION: {
+                target: {
+                    "asset": f"avault-{api.AVAULT_VERSION}-{target}.tar.gz",
+                    "sha256": digest,
+                }
+            }
+        },
+    }
+    calls: list[str] = []
+
+    def fake_urlopen(request, timeout=30):
+        url = request.full_url
+        calls.append(url)
+        if url.endswith("/manifest.json"):
+            return _FakeHTTPResponse(json.dumps(manifest).encode("utf-8"))
+        if url.endswith(f"/avault-{api.AVAULT_VERSION}-{target}.tar.gz"):
+            return _FakeHTTPResponse(archive)
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(api.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(api.shutil, "which", lambda _binary: None)
+    return calls
 
 
 def test_install_askill_uses_official_curl_installer(monkeypatch):
@@ -123,14 +182,109 @@ def test_install_avault_uses_existing_configured_binary(monkeypatch):
     assert out["path"] == "/opt/avault/bin/avault"
 
 
-def test_install_avault_missing_is_clear_stub_failure(monkeypatch):
+def test_install_avault_unsupported_platform_is_clear_failure(monkeypatch):
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
     monkeypatch.setattr(api, "resolve_cli_path", lambda _b: None)
+    monkeypatch.setattr("platform.system", lambda: "FreeBSD")
+    monkeypatch.setattr("platform.machine", lambda: "riscv64")
+    monkeypatch.setattr(api.urllib.request, "urlopen", lambda *a, **k: pytest.fail("should not download"))
 
     out = api.install_avault()
 
     assert out["ok"] is False
-    assert "agents.avault.cli_path" in out["message"]
+    assert "no avault build for FreeBSD-riscv64" in out["message"]
+
+
+def test_avault_target_detects_macos_arm64(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+
+    assert api._avault_target() == ("macos-arm64", "Darwin-arm64")
+
+
+def test_avault_target_detects_linux_x64(monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "amd64")
+
+    assert api._avault_target() == ("linux-x64", "Linux-amd64")
+
+
+def test_install_avault_downloads_manifest_verifies_and_installs(monkeypatch):
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    calls = _installable_avault_release(monkeypatch, target="macos-arm64")
+
+    out = api.install_avault()
+
+    installed = api.Path.home() / ".local" / "bin" / "avault"
+    assert out["ok"] is True
+    assert out["path"] == str(installed)
+    assert installed.exists()
+    assert installed.stat().st_mode & 0o777 == 0o755
+    assert api.resolve_cli_path("avault") == str(installed)
+    assert calls == [
+        f"https://github.com/avibe-bot/avault/releases/download/v{api.AVAULT_VERSION}/manifest.json",
+        f"https://github.com/avibe-bot/avault/releases/download/v{api.AVAULT_VERSION}/avault-{api.AVAULT_VERSION}-macos-arm64.tar.gz",
+    ]
+
+
+def test_install_avault_downloads_linux_x64_asset(monkeypatch):
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    calls = _installable_avault_release(monkeypatch, target="linux-x64")
+
+    out = api.install_avault()
+
+    assert out["ok"] is True
+    assert calls[-1].endswith(f"/avault-{api.AVAULT_VERSION}-linux-x64.tar.gz")
+
+
+def test_install_avault_checksum_mismatch_installs_nothing(monkeypatch):
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    _installable_avault_release(monkeypatch, target="macos-arm64", sha256="0" * 64)
+
+    out = api.install_avault()
+
+    installed = api.Path.home() / ".local" / "bin" / "avault"
+    assert out["ok"] is False
+    assert "checksum" in out["message"]
+    assert not installed.exists()
+
+
+def test_install_avault_is_idempotent_when_present(monkeypatch):
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api.shutil, "which", lambda _binary: None)
+    installed = api.Path.home() / ".local" / "bin" / "avault"
+    installed.parent.mkdir(parents=True, exist_ok=True)
+    installed.write_text("#!/bin/sh\n", encoding="utf-8")
+    installed.chmod(0o755)
+    monkeypatch.setattr(api.urllib.request, "urlopen", lambda *a, **k: pytest.fail("should not download"))
+
+    out = api.install_avault()
+
+    assert out["ok"] is True
+    assert out["path"] == str(installed)
+
+
+def test_install_avault_force_redownloads_when_present(monkeypatch):
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    installed = api.Path.home() / ".local" / "bin" / "avault"
+    installed.parent.mkdir(parents=True, exist_ok=True)
+    installed.write_text("old\n", encoding="utf-8")
+    installed.chmod(0o755)
+    calls = _installable_avault_release(monkeypatch, target="macos-arm64")
+
+    out = api.install_avault(force=True)
+
+    assert out["ok"] is True
+    assert len(calls) == 2
+    assert installed.read_text(encoding="utf-8").startswith("#!/bin/sh")
 
 
 def test_avault_resolves_path_fallback_when_configured_path_missing(monkeypatch):
@@ -152,7 +306,7 @@ def test_ensure_avault_idempotent_when_present(monkeypatch):
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
     monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/usr/local/bin/avault")
     flag = {"installed": False}
-    monkeypatch.setattr(api, "install_avault", lambda: flag.__setitem__("installed", True) or {"ok": True})
+    monkeypatch.setattr(api, "install_avault", lambda force=False: flag.__setitem__("installed", True) or {"ok": True})
 
     out = api.ensure_avault_installed()
 
@@ -164,14 +318,14 @@ def test_ensure_avault_force_rechecks_existing_binary(monkeypatch):
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
     monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/usr/local/bin/avault")
     flag = {"installed": False}
-    monkeypatch.setattr(api, "install_avault", lambda: flag.__setitem__("installed", True) or {"ok": True})
+    monkeypatch.setattr(api, "install_avault", lambda force=False: flag.__setitem__("installed", True) or {"ok": True})
 
     out = api.ensure_avault_installed(force=True)
 
     assert flag["installed"] is True
     assert out["ok"] is True
     assert out["installed"] is True
-    assert out["changed"] is False
+    assert out["changed"] is True
 
 
 def test_avault_status_missing(monkeypatch):

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -69,6 +69,16 @@ def _installable_avault_release(monkeypatch, *, target: str = "macos-arm64", sha
 
     monkeypatch.setattr(api.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr(api.shutil, "which", lambda _binary: None)
+    def fake_candidate_cli_paths(binary: str):
+        expanded = api.Path(api.os.path.expanduser(binary))
+        has_path_separator = api.os.sep in binary or (api.os.altsep is not None and api.os.altsep in binary)
+        if expanded.is_absolute() or has_path_separator:
+            return [expanded]
+        if binary == "avault":
+            return [api.Path.home() / ".local" / "bin" / "avault"]
+        return []
+
+    monkeypatch.setattr(api, "_candidate_cli_paths", fake_candidate_cli_paths)
     return calls
 
 
@@ -195,6 +205,19 @@ def test_install_avault_unsupported_platform_is_clear_failure(monkeypatch):
     assert "no avault build for FreeBSD-riscv64" in out["message"]
 
 
+def test_install_avault_force_keeps_existing_binary_on_unsupported_platform(monkeypatch):
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "/opt/avault/bin/avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/opt/avault/bin/avault" if b == "/opt/avault/bin/avault" else None)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr(api.urllib.request, "urlopen", lambda *a, **k: pytest.fail("should not download"))
+
+    out = api.install_avault(force=True)
+
+    assert out["ok"] is True
+    assert out["path"] == "/opt/avault/bin/avault"
+
+
 def test_avault_target_detects_macos_arm64(monkeypatch):
     monkeypatch.setattr("platform.system", lambda: "Darwin")
     monkeypatch.setattr("platform.machine", lambda: "arm64")
@@ -285,6 +308,27 @@ def test_install_avault_force_redownloads_when_present(monkeypatch):
     assert out["ok"] is True
     assert len(calls) == 2
     assert installed.read_text(encoding="utf-8").startswith("#!/bin/sh")
+
+
+def test_ensure_avault_force_uses_managed_binary_after_install(monkeypatch):
+    configured = api.Path.home() / "custom" / "avault"
+    configured.parent.mkdir(parents=True, exist_ok=True)
+    configured.write_text("#!/bin/sh\necho old\n", encoding="utf-8")
+    configured.chmod(0o755)
+    cfg = api.save_config({})
+    cfg.agents.avault.cli_path = str(configured)
+    cfg.save()
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    _installable_avault_release(monkeypatch, target="macos-arm64")
+
+    out = api.ensure_avault_installed(force=True)
+
+    installed = api.Path.home() / ".local" / "bin" / "avault"
+    assert out["ok"] is True
+    assert out["path"] == str(installed)
+    assert api.V2Config.load().agents.avault.cli_path == str(installed)
+    assert api._resolve_avault_cli_path() == str(installed)
 
 
 def test_avault_resolves_path_fallback_when_configured_path_missing(monkeypatch):

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3290,6 +3290,8 @@ def _run_install_command(
 
 _ASKILL_INSTALL_LOCK = threading.Lock()
 _AVAULT_INSTALL_LOCK = threading.Lock()
+AVAULT_VERSION = "0.1.0"
+_AVAULT_RELEASE_BASE_URL = f"https://github.com/avibe-bot/avault/releases/download/v{AVAULT_VERSION}/"
 
 
 def _truncate_install_output(output: str, limit: int = 8192) -> str:
@@ -3396,30 +3398,140 @@ def _resolve_avault_cli_path() -> str | None:
     return None
 
 
-def install_avault() -> dict:
+def _avault_target() -> tuple[str | None, str]:
+    import platform
+
+    system = platform.system()
+    machine = platform.machine()
+    normalized_system = system.lower()
+    normalized_machine = machine.lower()
+    platform_label = f"{system or 'unknown'}-{machine or 'unknown'}"
+
+    if normalized_system == "darwin" and normalized_machine == "arm64":
+        return "macos-arm64", platform_label
+    if normalized_system == "linux" and normalized_machine in {"x86_64", "amd64"}:
+        return "linux-x64", platform_label
+    return None, platform_label
+
+
+def _avault_managed_bin_path() -> Path:
+    return Path.home() / ".local" / "bin" / "avault"
+
+
+def _download_avault_release_file(url: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "User-Agent": "avibe/avault-installer",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310 - public GitHub release asset
+        return response.read()
+
+
+def _extract_avault_binary(archive_bytes: bytes, output_path: Path) -> None:
+    import io
+    import tarfile
+
+    output_real = output_path.parent.resolve()
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as archive:
+        member = next((item for item in archive.getmembers() if item.name == "avault"), None)
+        if member is None or not member.isfile():
+            raise ValueError("archive does not contain the avault executable")
+        target = (output_path.parent / member.name).resolve()
+        if target.parent != output_real or target.name != "avault":
+            raise ValueError("archive contains an unsafe avault path")
+        source = archive.extractfile(member)
+        if source is None:
+            raise ValueError("archive does not contain readable avault data")
+        with output_path.open("wb") as out:
+            shutil.copyfileobj(source, out)
+
+
+def _clear_macos_quarantine(path: Path) -> None:
+    if os.sys.platform != "darwin":
+        return
+    try:
+        os.removexattr(path, "com.apple.quarantine")
+    except (AttributeError, FileNotFoundError, OSError):
+        pass
+
+
+def install_avault(force: bool = False) -> dict:
     """Install (or refresh) avault, the required local custody-core dependency.
 
-    Stub-first integration: for now, accept a locally built binary already
-    reachable through ``agents.avault.cli_path`` or PATH. The real installer
-    should swap in here and use Avibe's manifest-pinned binary download path
-    with checksum verification once the avault release pipeline lands.
+    Downloads the Avibe-pinned public avault release manifest and tarball,
+    verifies the manifest sha256, safely extracts the single ``avault`` member,
+    and atomically installs it into Avibe's managed CLI location.
     """
     path = _resolve_avault_cli_path()
-    if path:
+    if path and not force:
         return {
             "ok": True,
             "message": backend_t("dependencies.avault.ready"),
             "output": None,
             "path": path,
         }
-    # TODO(vaults): download the Avibe-pinned avault release asset from the
-    # compatibility manifest, verify its checksum, install it into Avibe's
-    # managed bin dir, then return the resolved binary path.
-    return {
-        "ok": False,
-        "message": backend_t("dependencies.avault.missing"),
-        "output": None,
-    }
+
+    import hashlib
+    import tempfile
+
+    target, platform_label = _avault_target()
+    if target is None:
+        return {
+            "ok": False,
+            "message": backend_t("dependencies.avault.noBuild", platform=platform_label),
+            "output": None,
+            "path": None,
+        }
+
+    try:
+        manifest_url = urllib.parse.urljoin(_AVAULT_RELEASE_BASE_URL, "manifest.json")
+        manifest = json.loads(_download_avault_release_file(manifest_url).decode("utf-8"))
+        entry = manifest["versions"][AVAULT_VERSION][target]
+        asset = entry["asset"]
+        expected_sha256 = str(entry["sha256"]).strip().lower()
+        if not isinstance(asset, str) or not asset.endswith(".tar.gz") or "/" in asset:
+            raise ValueError("manifest contains an invalid avault asset name")
+        if not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+            raise ValueError("manifest contains an invalid avault sha256")
+
+        archive_url = urllib.parse.urljoin(_AVAULT_RELEASE_BASE_URL, asset)
+        archive_bytes = _download_avault_release_file(archive_url)
+        actual_sha256 = hashlib.sha256(archive_bytes).hexdigest()
+        if actual_sha256 != expected_sha256:
+            return {
+                "ok": False,
+                "message": backend_t("dependencies.avault.checksumMismatch"),
+                "output": f"expected {expected_sha256}, got {actual_sha256}",
+                "path": None,
+            }
+
+        install_path = _avault_managed_bin_path()
+        install_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(prefix="avault-install-", dir=install_path.parent) as tmp_dir:
+            tmp_path = Path(tmp_dir) / "avault"
+            _extract_avault_binary(archive_bytes, tmp_path)
+            tmp_path.chmod(0o755)
+            os.replace(tmp_path, install_path)
+        install_path.chmod(0o755)
+        _clear_macos_quarantine(install_path)
+
+        return {
+            "ok": True,
+            "message": backend_t("dependencies.avault.installed", version=AVAULT_VERSION),
+            "output": f"Installed avault {AVAULT_VERSION} for {target}",
+            "path": str(install_path),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("avault install failed: %s", exc, exc_info=True)
+        return {
+            "ok": False,
+            "message": backend_t("dependencies.avault.installFailed", error=str(exc)),
+            "output": None,
+            "path": None,
+        }
 
 
 def ensure_avault_installed(force: bool = False) -> dict:
@@ -3435,11 +3547,11 @@ def ensure_avault_installed(force: bool = False) -> dict:
         existing = _resolve_avault_cli_path()
         if existing and not force:
             return {"ok": True, "installed": True, "changed": False, "path": existing}
-        result = install_avault()
+        result = install_avault(force=force)
         resolved = _resolve_avault_cli_path()
         installed = bool(resolved)
         result["installed"] = installed
-        result["changed"] = False
+        result["changed"] = installed and bool(result.get("ok")) and (not existing or force)
         result["path"] = resolved
         if result.get("ok") and not installed:
             result["ok"] = False

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3418,6 +3418,28 @@ def _avault_managed_bin_path() -> Path:
     return Path.home() / ".local" / "bin" / "avault"
 
 
+def _persist_avault_cli_path(path: str) -> None:
+    try:
+        try:
+            load_config()
+        except FileNotFoundError:
+            save_config({})
+        with CONFIG_LOCK:
+            cfg = load_config()
+            previous = getattr(cfg.agents.avault, "cli_path", "") or ""
+            if previous != path:
+                cfg.agents.avault.cli_path = path
+                cfg.save()
+                logger.info(
+                    "install_avault: updated V2Config cli_path: %s -> %s",
+                    previous or "<unset>",
+                    path,
+                )
+    except Exception as exc:
+        logger.warning("install_avault: failed to persist cli_path: %s", exc)
+        raise
+
+
 def _download_avault_release_file(url: str) -> bytes:
     request = urllib.request.Request(
         url,
@@ -3479,6 +3501,14 @@ def install_avault(force: bool = False) -> dict:
 
     target, platform_label = _avault_target()
     if target is None:
+        if path:
+            return {
+                "ok": True,
+                "message": backend_t("dependencies.avault.ready"),
+                "output": None,
+                "path": path,
+                "changed": False,
+            }
         return {
             "ok": False,
             "message": backend_t("dependencies.avault.noBuild", platform=platform_label),
@@ -3517,12 +3547,14 @@ def install_avault(force: bool = False) -> dict:
             os.replace(tmp_path, install_path)
         install_path.chmod(0o755)
         _clear_macos_quarantine(install_path)
+        _persist_avault_cli_path(str(install_path))
 
         return {
             "ok": True,
             "message": backend_t("dependencies.avault.installed", version=AVAULT_VERSION),
             "output": f"Installed avault {AVAULT_VERSION} for {target}",
             "path": str(install_path),
+            "changed": True,
         }
     except Exception as exc:  # noqa: BLE001
         logger.warning("avault install failed: %s", exc, exc_info=True)
@@ -3551,7 +3583,8 @@ def ensure_avault_installed(force: bool = False) -> dict:
         resolved = _resolve_avault_cli_path()
         installed = bool(resolved)
         result["installed"] = installed
-        result["changed"] = installed and bool(result.get("ok")) and (not existing or force)
+        if "changed" not in result:
+            result["changed"] = installed and bool(result.get("ok")) and (not existing or force)
         result["path"] = resolved
         if result.get("ok") and not installed:
             result["ok"] = False

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -31,6 +31,10 @@
     "avault": {
       "ready": "avault ready.",
       "missing": "avault is not installed. Build avault locally and put it on PATH, or set agents.avault.cli_path.",
+      "installed": "avault {version} installed.",
+      "noBuild": "no avault build for {platform}",
+      "checksumMismatch": "avault download checksum verification failed.",
+      "installFailed": "avault install failed: {error}",
       "installedNotFound": "avault installed but was not found on PATH; restart the service or check PATH.",
       "alreadyRunning": "avault install or update is already running; try again shortly."
     }

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -31,6 +31,10 @@
     "avault": {
       "ready": "avault 已就绪。",
       "missing": "尚未安装 avault。请先在本地构建 avault 并放到 PATH 上，或设置 agents.avault.cli_path。",
+      "installed": "avault {version} 已安装。",
+      "noBuild": "没有适用于 {platform} 的 avault 构建。",
+      "checksumMismatch": "avault 下载校验失败。",
+      "installFailed": "avault 安装失败：{error}",
       "installedNotFound": "avault 已安装，但当前 PATH 找不到它；请重启服务或检查 PATH。",
       "alreadyRunning": "avault 安装或更新正在运行，请稍后重试。"
     }


### PR DESCRIPTION
## Summary
- replace the avault install stub with a manifest-pinned public GitHub release installer
- pin avault to 0.1.0, detect macOS arm64 and Linux x64 targets, verify tarball sha256 before installing
- safely extract only the avault executable into the managed CLI location and keep installer tests hermetic

## Evidence
- unit: `python3 -m pytest tests/test_local_deps.py -q`
- lint: `ruff check vibe/api.py tests/test_local_deps.py`
- contract: unsupported platforms return a clear failure; checksum mismatch aborts without writing a binary

## Notes
- Manual end-to-end install depends on the avibe-bot/avault v0.1.0 GitHub release and manifest being live.
