### PR TITLE
fix(install): pair and start from avibe.bot

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,8 @@ NODE_MINIMUM_REQUIREMENT="20.19+ or 22.12+"
 VIBE_BIN_PATH=""
 VIBE_TOOL_BIN_DIR=""
 ORIGINAL_PATH="$PATH"
+REMOTE_ACCESS_PAIRING_KEY=""
+REMOTE_ACCESS_PAIRED=""
 
 print_banner() {
     echo -e "${BLUE}"
@@ -575,7 +577,7 @@ prepare_show_runtime() {
 }
 
 pair_remote_access() {
-    local pairing_key="${AVIBE_PAIRING_KEY:-}"
+    local pairing_key="${REMOTE_ACCESS_PAIRING_KEY:-}"
     local backend_url="${AVIBE_PAIRING_BACKEND_URL:-https://avibe.bot}"
     local vibe_cmd="${VIBE_BIN_PATH:-}"
 
@@ -589,6 +591,7 @@ pair_remote_access() {
 
     info "Pairing this Avibe with avibe.bot..."
     "$vibe_cmd" remote pair "$pairing_key" --backend-url "$backend_url"
+    REMOTE_ACCESS_PAIRED="1"
     success "Remote access paired"
 
     info "Starting Avibe service..."
@@ -605,10 +608,17 @@ print_next_steps() {
     echo -e "${GREEN}Installation complete!${NC}"
     echo ""
     echo -e "${BLUE}Next steps:${NC}"
-    if [ -n "${AVIBE_PAIRING_KEY:-}" ]; then
-        echo "  1. Open your avibe.bot URL"
-        echo "  2. Sign in with the same avibe.bot account to continue"
-        echo "  3. Optional: run 'vibe status' to check the local service"
+    if [ "${REMOTE_ACCESS_PAIRED:-}" = "1" ]; then
+        if is_vibe_immediately_available; then
+            echo "  1. Open your avibe.bot URL"
+            echo "  2. Sign in with the same avibe.bot account to continue"
+            echo "  3. Optional: run 'vibe status' to check the local service"
+        else
+            echo "  1. Run 'export PATH=\"${vibe_dir}:\$PATH\"' in your shell"
+            echo "  2. Open your avibe.bot URL"
+            echo "  3. Sign in with the same avibe.bot account to continue"
+            echo "  4. Optional: run 'vibe status' to check the local service"
+        fi
         echo ""
         echo -e "${BLUE}Quick commands:${NC}"
         echo "  vibe          - Start Avibe (service + web UI)"
@@ -622,9 +632,11 @@ print_next_steps() {
         echo "  uv tool uninstall vibe-remote    # legacy uv install"
         echo "  pip uninstall avibe-os vibe-remote"
         echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
-        echo ""
-        echo -e "${BLUE}If 'vibe' is not found in a new shell:${NC}"
-        echo "  ${VIBE_BIN_PATH:-$HOME/.local/bin/vibe}"
+        if ! is_vibe_immediately_available; then
+            echo ""
+            echo -e "${BLUE}If 'vibe' is not found in a new shell:${NC}"
+            echo "  ${VIBE_BIN_PATH:-$HOME/.local/bin/vibe}"
+        fi
         echo ""
         echo -e "${BLUE}Documentation:${NC}"
         echo "  https://github.com/${REPO}#readme"
@@ -669,6 +681,8 @@ print_next_steps() {
 # Main installation flow
 main() {
     print_banner
+    REMOTE_ACCESS_PAIRING_KEY="${AVIBE_PAIRING_KEY:-}"
+    unset AVIBE_PAIRING_KEY
     
     local os
     os=$(detect_os)

--- a/install.sh
+++ b/install.sh
@@ -574,6 +574,28 @@ prepare_show_runtime() {
     fi
 }
 
+pair_remote_access() {
+    local pairing_key="${AVIBE_PAIRING_KEY:-}"
+    local backend_url="${AVIBE_PAIRING_BACKEND_URL:-https://avibe.bot}"
+    local vibe_cmd="${VIBE_BIN_PATH:-}"
+
+    if [ -z "$pairing_key" ]; then
+        return 0
+    fi
+
+    if [ -z "$vibe_cmd" ] || [ ! -x "$vibe_cmd" ]; then
+        error "Cannot pair remote access because the vibe command is not available."
+    fi
+
+    info "Pairing this Avibe with avibe.bot..."
+    "$vibe_cmd" remote pair "$pairing_key" --backend-url "$backend_url"
+    success "Remote access paired"
+
+    info "Starting Avibe service..."
+    "$vibe_cmd" start
+    success "Avibe service started"
+}
+
 # Print next steps
 print_next_steps() {
     local vibe_dir
@@ -583,6 +605,33 @@ print_next_steps() {
     echo -e "${GREEN}Installation complete!${NC}"
     echo ""
     echo -e "${BLUE}Next steps:${NC}"
+    if [ -n "${AVIBE_PAIRING_KEY:-}" ]; then
+        echo "  1. Open your avibe.bot URL"
+        echo "  2. Sign in with the same avibe.bot account to continue"
+        echo "  3. Optional: run 'vibe status' to check the local service"
+        echo ""
+        echo -e "${BLUE}Quick commands:${NC}"
+        echo "  vibe          - Start Avibe (service + web UI)"
+        echo "  vibe status   - Check service status"
+        echo "  vibe remote   - Manage remote Web UI access"
+        echo "  vibe stop     - Stop all services"
+        echo "  vibe doctor   - Run diagnostics"
+        echo ""
+        echo -e "${BLUE}Uninstall:${NC}"
+        echo "  uv tool uninstall avibe-os       # current uv install"
+        echo "  uv tool uninstall vibe-remote    # legacy uv install"
+        echo "  pip uninstall avibe-os vibe-remote"
+        echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
+        echo ""
+        echo -e "${BLUE}If 'vibe' is not found in a new shell:${NC}"
+        echo "  ${VIBE_BIN_PATH:-$HOME/.local/bin/vibe}"
+        echo ""
+        echo -e "${BLUE}Documentation:${NC}"
+        echo "  https://github.com/${REPO}#readme"
+        echo ""
+        return
+    fi
+
     if is_vibe_immediately_available; then
         echo "  1. Run 'vibe' to open the setup wizard"
         echo "  2. Choose your chat platform and agent backend"
@@ -648,6 +697,11 @@ main() {
     # Pre-download the current platform Show Runtime when possible. This is
     # intentionally warning-only so Node/network issues never break avibe.
     prepare_show_runtime
+
+    # Optional avibe.bot one-step install + pair flow. This runs through the
+    # verified absolute vibe path, not PATH, so it works even when the installer
+    # put the command into a fallback tool bin directory.
+    pair_remote_access
     
     # Done
     print_next_steps

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -36,6 +36,11 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
 
         printf '%s' "${{UV_TOOL_BIN_DIR:-}}" > "{uv_log}"
 
+        if [ -n "${{AVIBE_PAIRING_KEY:-}}" ]; then
+            printf 'uv leaked key\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+            exit 8
+        fi
+
         if [ "$1" != "tool" ] || [ "$2" != "install" ]; then
             exit 1
         fi
@@ -50,15 +55,31 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         elif [ "${{1:-}}" = "version" ]; then
             echo "avibe-os 9.9.9"
         elif [ "${{1:-}}" = "runtime" ] && [ "${{2:-}}" = "prepare" ]; then
+            if [ -n "${{AVIBE_PAIRING_KEY:-}}" ]; then
+                printf 'runtime prepare leaked key\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+                exit 8
+            fi
             if [ "${{VIBE_TEST_RUNTIME_PREPARE_FAIL:-}}" = "1" ]; then
                 echo "node missing" >&2
                 exit 9
             fi
             echo "Show Runtime ready."
         elif [ "${{1:-}}" = "remote" ] && [ "${{2:-}}" = "pair" ]; then
+            if [ -n "${{AVIBE_PAIRING_KEY:-}}" ]; then
+                printf 'remote pair leaked key\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+                exit 8
+            fi
             printf 'remote pair %s %s %s\\n' "${{3:-}}" "${{4:-}}" "${{5:-}}" >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+            if [ "${{VIBE_TEST_REMOTE_PAIR_FAIL:-}}" = "1" ]; then
+                echo "Remote access is paired, but the tunnel did not start." >&2
+                exit 7
+            fi
             echo "Remote access is ready"
         elif [ "${{1:-}}" = "start" ]; then
+            if [ -n "${{AVIBE_PAIRING_KEY:-}}" ]; then
+                printf 'start leaked key\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+                exit 8
+            fi
             printf 'start\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
             echo "Web UI:"
         else
@@ -185,17 +206,18 @@ def test_install_script_keeps_vibe_available_on_current_path(tmp_path):
 def test_install_script_pairs_and_starts_with_verified_vibe_path(tmp_path):
     home_dir = tmp_path / "home"
     home_dir.mkdir()
-    path_dir = tmp_path / "path-bin"
-    path_dir.mkdir()
+    uv_bin = tmp_path / "uv-bin"
+    uv_bin.mkdir()
     tool_bin = tmp_path / "tool-bin"
     call_log = tmp_path / "vibe-calls.log"
     uv_log = tmp_path / "uv-tool-bin-dir.txt"
 
-    _write_fake_uv(path_dir / "uv", uv_log)
+    _write_fake_uv(uv_bin / "uv", uv_log)
+    uv_bin.chmod(0o555)
 
     env = os.environ.copy()
     env["HOME"] = str(home_dir)
-    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["PATH"] = os.pathsep.join([str(uv_bin), "/usr/bin", "/bin"])
     env["UV_TOOL_BIN_DIR"] = str(tool_bin)
     env["VIBE_TEST_CALL_LOG"] = str(call_log)
     env["AVIBE_PAIRING_KEY"] = "vrp_test"
@@ -205,9 +227,38 @@ def test_install_script_pairs_and_starts_with_verified_vibe_path(tmp_path):
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
     assert "Pairing this Avibe with avibe.bot" in install_result.stdout
     assert "Avibe service started" in install_result.stdout
+    assert "Open your avibe.bot URL" in install_result.stdout
+    assert 'export PATH="' in install_result.stdout
     assert call_log.read_text(encoding="utf-8").splitlines() == [
         "remote pair vrp_test --backend-url https://avibe.bot",
         "start",
+    ]
+
+
+def test_install_script_stops_when_remote_pair_cannot_start_tunnel(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    call_log = tmp_path / "vibe-calls.log"
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["VIBE_TEST_CALL_LOG"] = str(call_log)
+    env["AVIBE_PAIRING_KEY"] = "vrp_test"
+    env["VIBE_TEST_REMOTE_PAIR_FAIL"] = "1"
+
+    install_result = _install(env)
+
+    assert install_result.returncode == 7, install_result.stdout + install_result.stderr
+    assert "Pairing this Avibe with avibe.bot" in install_result.stdout
+    assert "Remote access paired" not in install_result.stdout
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        "remote pair vrp_test --backend-url https://avibe.bot",
     ]
 
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -55,6 +55,12 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
                 exit 9
             fi
             echo "Show Runtime ready."
+        elif [ "${{1:-}}" = "remote" ] && [ "${{2:-}}" = "pair" ]; then
+            printf 'remote pair %s %s %s\\n' "${{3:-}}" "${{4:-}}" "${{5:-}}" >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+            echo "Remote access is ready"
+        elif [ "${{1:-}}" = "start" ]; then
+            printf 'start\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+            echo "Web UI:"
         else
             echo "started"
         fi
@@ -174,6 +180,35 @@ def test_install_script_keeps_vibe_available_on_current_path(tmp_path):
     assert version_result.returncode == 0, version_result.stdout + version_result.stderr
     assert "avibe-os 9.9.9" in version_result.stdout
     assert uv_log.read_text(encoding="utf-8")
+
+
+def test_install_script_pairs_and_starts_with_verified_vibe_path(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    tool_bin = tmp_path / "tool-bin"
+    call_log = tmp_path / "vibe-calls.log"
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["UV_TOOL_BIN_DIR"] = str(tool_bin)
+    env["VIBE_TEST_CALL_LOG"] = str(call_log)
+    env["AVIBE_PAIRING_KEY"] = "vrp_test"
+
+    install_result = _install(env)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert "Pairing this Avibe with avibe.bot" in install_result.stdout
+    assert "Avibe service started" in install_result.stdout
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        "remote pair vrp_test --backend-url https://avibe.bot",
+        "start",
+    ]
 
 
 def test_install_script_installs_node_when_missing(tmp_path):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -699,6 +699,66 @@ def test_cmd_remote_pair_prompts_and_reports_success(monkeypatch, capsys):
     assert "vibe remote status" in output
 
 
+def test_cmd_remote_pair_fails_when_tunnel_does_not_start(monkeypatch, capsys):
+    monkeypatch.setattr(cli.getpass, "getpass", lambda prompt: "vrp_prompt")
+
+    def fake_pair(pairing_key: str, backend_url: str, device_name: str):
+        return {
+            "ok": True,
+            "public_url": "https://alex.avibe.bot",
+            "running": False,
+            "start": {"ok": False, "error": "cloudflared_spawn_failed", "detail": "spawn failed"},
+        }
+
+    monkeypatch.setattr(remote_access, "pair", fake_pair)
+
+    result = cli.cmd_remote_pair(
+        SimpleNamespace(
+            pairing_key=None,
+            backend_url="https://backend.test",
+            device_name="Mac Studio",
+            json=False,
+        )
+    )
+
+    assert result == 1
+    output = capsys.readouterr()
+    assert "Step 3: Pairing saved" in output.out
+    assert "Remote access is paired, but the tunnel did not start." in output.err
+    assert "vibe remote start" in output.err
+
+
+def test_cmd_remote_pair_json_marks_start_failure_as_not_ok(monkeypatch, capsys):
+    monkeypatch.setattr(cli.getpass, "getpass", lambda prompt: "vrp_prompt")
+
+    def fake_pair(pairing_key: str, backend_url: str, device_name: str):
+        return {
+            "ok": True,
+            "pairing": {"ok": True},
+            "public_url": "https://alex.avibe.bot",
+            "running": False,
+            "start": {"ok": False, "error": "cloudflared_spawn_failed"},
+        }
+
+    monkeypatch.setattr(remote_access, "pair", fake_pair)
+
+    result = cli.cmd_remote_pair(
+        SimpleNamespace(
+            pairing_key=None,
+            backend_url="https://backend.test",
+            device_name="Mac Studio",
+            json=True,
+        )
+    )
+
+    assert result == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["pairing"] == {"ok": True}
+    assert payload["start"]["ok"] is False
+    assert payload["error"] == "cloudflared_spawn_failed"
+
+
 def test_cmd_remote_setup_explains_before_prompting_for_key(monkeypatch, capsys):
     events = []
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -5354,17 +5354,22 @@ def _run_remote_pair(args, *, guided: bool) -> int:
         getattr(args, "backend_url", "https://avibe.bot"),
         getattr(args, "device_name", "avibe"),
     )
+    start_result = result.get("start") if isinstance(result.get("start"), dict) else {}
+    command_ok = bool(result.get("ok") and start_result.get("ok"))
     if getattr(args, "json", False):
-        _print_json(result)
-        return 0 if result.get("ok") else 1
+        payload = {**result, "ok": command_ok}
+        if result.get("ok") and not command_ok:
+            payload.setdefault("pairing", {"ok": True})
+            payload.setdefault("error", str(start_result.get("error") or "remote_start_failed"))
+        _print_json(payload)
+        return 0 if command_ok else 1
 
     if not result.get("ok"):
         _print_remote_pair_failure(result)
         return 1
 
-    start_result = result.get("start") if isinstance(result.get("start"), dict) else {}
     _print_remote_pair_success(result, start_result)
-    return 0
+    return 0 if command_ok else 1
 
 
 def cmd_remote_pair(args):


### PR DESCRIPTION
## Summary
- add an `AVIBE_PAIRING_KEY` install-script path for avibe.bot one-step install + pair
- run pairing through the verified absolute `vibe` binary path instead of relying on parent-shell PATH
- start Avibe after pairing so the remote UI is actually reachable

## Validation
- `bash -n install.sh`
- `python3 -m pytest tests/test_install_script.py tests/test_remote_access_vibe_cloud.py tests/test_vibe_cli.py -q`
- `ruff check tests/test_install_script.py tests/test_remote_access_vibe_cloud.py tests/test_vibe_cli.py`
- `git diff --check`
