### PR TITLE
feat(vaults): support all avault installer targets

### DIFF
--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -33,7 +33,7 @@ class _FakeHTTPResponse:
 
 
 def _fake_avault_archive(
-    content: bytes = b"#!/bin/sh\necho avault 0.1.1\n",
+    content: bytes = b"#!/bin/sh\necho avault 0.1.2\n",
     *,
     member_name: str = "avault",
 ) -> bytes:

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -32,10 +32,14 @@ class _FakeHTTPResponse:
         return self._body
 
 
-def _fake_avault_archive(content: bytes = b"#!/bin/sh\necho avault 0.1.0\n") -> bytes:
+def _fake_avault_archive(
+    content: bytes = b"#!/bin/sh\necho avault 0.1.1\n",
+    *,
+    member_name: str = "avault",
+) -> bytes:
     raw = io.BytesIO()
     with tarfile.open(fileobj=raw, mode="w:gz") as archive:
-        info = tarfile.TarInfo("avault")
+        info = tarfile.TarInfo(member_name)
         info.size = len(content)
         info.mode = 0o755
         archive.addfile(info, io.BytesIO(content))
@@ -43,7 +47,8 @@ def _fake_avault_archive(content: bytes = b"#!/bin/sh\necho avault 0.1.0\n") -> 
 
 
 def _installable_avault_release(monkeypatch, *, target: str = "macos-arm64", sha256: str | None = None):
-    archive = _fake_avault_archive()
+    member_name = api._avault_binary_name_for_target(target)
+    archive = _fake_avault_archive(member_name=member_name)
     digest = sha256 or hashlib.sha256(archive).hexdigest()
     manifest = {
         "schema_version": 1,
@@ -68,18 +73,18 @@ def _installable_avault_release(monkeypatch, *, target: str = "macos-arm64", sha
         raise AssertionError(f"unexpected url: {url}")
 
     monkeypatch.setattr(api.urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(api.shutil, "which", lambda _binary: None)
     def fake_candidate_cli_paths(binary: str):
         expanded = api.Path(api.os.path.expanduser(binary))
         has_path_separator = api.os.sep in binary or (api.os.altsep is not None and api.os.altsep in binary)
         if expanded.is_absolute() or has_path_separator:
             return [expanded]
         if binary == "avault":
-            return [api.Path.home() / ".local" / "bin" / "avault"]
+            return [api._avault_managed_bin_path(target)]
         return []
 
+    monkeypatch.setattr(api.shutil, "which", lambda _binary: None)
     monkeypatch.setattr(api, "_candidate_cli_paths", fake_candidate_cli_paths)
-    return calls
+    return calls, member_name
 
 
 def test_install_askill_uses_official_curl_installer(monkeypatch):
@@ -208,8 +213,8 @@ def test_install_avault_unsupported_platform_is_clear_failure(monkeypatch):
 def test_install_avault_force_keeps_existing_binary_on_unsupported_platform(monkeypatch):
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "/opt/avault/bin/avault")
     monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/opt/avault/bin/avault" if b == "/opt/avault/bin/avault" else None)
-    monkeypatch.setattr("platform.system", lambda: "Linux")
-    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    monkeypatch.setattr("platform.system", lambda: "FreeBSD")
+    monkeypatch.setattr("platform.machine", lambda: "riscv64")
     monkeypatch.setattr(api.urllib.request, "urlopen", lambda *a, **k: pytest.fail("should not download"))
 
     out = api.install_avault(force=True)
@@ -218,50 +223,66 @@ def test_install_avault_force_keeps_existing_binary_on_unsupported_platform(monk
     assert out["path"] == "/opt/avault/bin/avault"
 
 
-def test_avault_target_detects_macos_arm64(monkeypatch):
-    monkeypatch.setattr("platform.system", lambda: "Darwin")
-    monkeypatch.setattr("platform.machine", lambda: "arm64")
+@pytest.mark.parametrize(
+    ("system", "machine", "target"),
+    [
+        ("Darwin", "arm64", "macos-arm64"),
+        ("Darwin", "x86_64", "macos-x64"),
+        ("Linux", "x86_64", "linux-x64"),
+        ("Linux", "amd64", "linux-x64"),
+        ("Linux", "aarch64", "linux-arm64"),
+        ("Linux", "arm64", "linux-arm64"),
+        ("Windows", "AMD64", "windows-x64"),
+        ("Windows", "x86_64", "windows-x64"),
+        ("Windows", "ARM64", "windows-arm64"),
+    ],
+)
+def test_avault_target_detects_supported_platforms(monkeypatch, system, machine, target):
+    monkeypatch.setattr("platform.system", lambda: system)
+    monkeypatch.setattr("platform.machine", lambda: machine)
 
-    assert api._avault_target() == ("macos-arm64", "Darwin-arm64")
+    assert api._avault_target() == (target, f"{system}-{machine}")
 
 
-def test_avault_target_detects_linux_x64(monkeypatch):
-    monkeypatch.setattr("platform.system", lambda: "Linux")
-    monkeypatch.setattr("platform.machine", lambda: "amd64")
+def test_windows_candidate_paths_include_managed_exe(monkeypatch):
+    candidates = api._windows_executable_candidates([api.Path.home() / ".local" / "bin" / "avault"])
 
-    assert api._avault_target() == ("linux-x64", "Linux-amd64")
+    assert api.Path.home() / ".local" / "bin" / "avault.exe" in candidates
 
 
-def test_install_avault_downloads_manifest_verifies_and_installs(monkeypatch):
+@pytest.mark.parametrize(
+    ("system", "machine", "target"),
+    [
+        ("Darwin", "arm64", "macos-arm64"),
+        ("Darwin", "x86_64", "macos-x64"),
+        ("Linux", "x86_64", "linux-x64"),
+        ("Linux", "aarch64", "linux-arm64"),
+        ("Windows", "AMD64", "windows-x64"),
+        ("Windows", "ARM64", "windows-arm64"),
+    ],
+)
+def test_install_avault_downloads_manifest_verifies_and_installs(monkeypatch, system, machine, target):
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
-    monkeypatch.setattr("platform.system", lambda: "Darwin")
-    monkeypatch.setattr("platform.machine", lambda: "arm64")
-    calls = _installable_avault_release(monkeypatch, target="macos-arm64")
+    monkeypatch.setattr("platform.system", lambda: system)
+    monkeypatch.setattr("platform.machine", lambda: machine)
+    calls, member_name = _installable_avault_release(monkeypatch, target=target)
 
     out = api.install_avault()
 
-    installed = api.Path.home() / ".local" / "bin" / "avault"
+    installed = api.Path.home() / ".local" / "bin" / member_name
     assert out["ok"] is True
     assert out["path"] == str(installed)
     assert installed.exists()
-    assert installed.stat().st_mode & 0o777 == 0o755
-    assert api.resolve_cli_path("avault") == str(installed)
+    if not target.startswith("windows-"):
+        assert installed.stat().st_mode & 0o777 == 0o755
+    if target.startswith("windows-"):
+        assert api.V2Config.load().agents.avault.cli_path == str(installed)
+    else:
+        assert api.resolve_cli_path("avault") == str(installed)
     assert calls == [
         f"https://github.com/avibe-bot/avault/releases/download/v{api.AVAULT_VERSION}/manifest.json",
-        f"https://github.com/avibe-bot/avault/releases/download/v{api.AVAULT_VERSION}/avault-{api.AVAULT_VERSION}-macos-arm64.tar.gz",
+        f"https://github.com/avibe-bot/avault/releases/download/v{api.AVAULT_VERSION}/avault-{api.AVAULT_VERSION}-{target}.tar.gz",
     ]
-
-
-def test_install_avault_downloads_linux_x64_asset(monkeypatch):
-    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
-    monkeypatch.setattr("platform.system", lambda: "Linux")
-    monkeypatch.setattr("platform.machine", lambda: "x86_64")
-    calls = _installable_avault_release(monkeypatch, target="linux-x64")
-
-    out = api.install_avault()
-
-    assert out["ok"] is True
-    assert calls[-1].endswith(f"/avault-{api.AVAULT_VERSION}-linux-x64.tar.gz")
 
 
 def test_install_avault_checksum_mismatch_installs_nothing(monkeypatch):
@@ -301,7 +322,7 @@ def test_install_avault_force_redownloads_when_present(monkeypatch):
     installed.parent.mkdir(parents=True, exist_ok=True)
     installed.write_text("old\n", encoding="utf-8")
     installed.chmod(0o755)
-    calls = _installable_avault_release(monkeypatch, target="macos-arm64")
+    calls, _member_name = _installable_avault_release(monkeypatch, target="macos-arm64")
 
     out = api.install_avault(force=True)
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3309,7 +3309,7 @@ def _run_install_command(
 
 _ASKILL_INSTALL_LOCK = threading.Lock()
 _AVAULT_INSTALL_LOCK = threading.Lock()
-AVAULT_VERSION = "0.1.1"
+AVAULT_VERSION = "0.1.2"
 _AVAULT_RELEASE_BASE_URL = f"https://github.com/avibe-bot/avault/releases/download/v{AVAULT_VERSION}/"
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -269,6 +269,20 @@ def _npm_binary_candidates_for_prefix(prefix_path: Path, binary: str) -> list[Pa
     return derived_candidates
 
 
+def _windows_executable_candidates(candidates: list[Path]) -> list[Path]:
+    result: list[Path] = []
+    for candidate in candidates:
+        result.append(candidate)
+        if candidate.suffix.lower() not in {".cmd", ".exe"}:
+            result.extend(
+                [
+                    candidate.with_name(f"{candidate.name}.exe"),
+                    candidate.with_name(f"{candidate.name}.cmd"),
+                ]
+            )
+    return result
+
+
 def _candidate_cli_paths(binary: str) -> list[Path]:
     if not binary:
         return []
@@ -296,6 +310,8 @@ def _candidate_cli_paths(binary: str) -> list[Path]:
         Path("/opt/homebrew/bin") / binary,
         Path("/usr/local/bin") / binary,
     ]
+    if os.name == "nt":
+        common_candidates = _windows_executable_candidates(common_candidates)
     for candidate in common_candidates + _nvm_binary_candidates(binary) + _npm_global_binary_candidates(binary):
         if candidate not in candidates:
             candidates.append(candidate)
@@ -3293,7 +3309,7 @@ def _run_install_command(
 
 _ASKILL_INSTALL_LOCK = threading.Lock()
 _AVAULT_INSTALL_LOCK = threading.Lock()
-AVAULT_VERSION = "0.1.0"
+AVAULT_VERSION = "0.1.1"
 _AVAULT_RELEASE_BASE_URL = f"https://github.com/avibe-bot/avault/releases/download/v{AVAULT_VERSION}/"
 
 
@@ -3412,13 +3428,28 @@ def _avault_target() -> tuple[str | None, str]:
 
     if normalized_system == "darwin" and normalized_machine == "arm64":
         return "macos-arm64", platform_label
+    if normalized_system == "darwin" and normalized_machine in {"x86_64", "amd64"}:
+        return "macos-x64", platform_label
     if normalized_system == "linux" and normalized_machine in {"x86_64", "amd64"}:
         return "linux-x64", platform_label
+    if normalized_system == "linux" and normalized_machine in {"aarch64", "arm64"}:
+        return "linux-arm64", platform_label
+    if normalized_system == "windows" and normalized_machine in {"amd64", "x86_64"}:
+        return "windows-x64", platform_label
+    if normalized_system == "windows" and normalized_machine == "arm64":
+        return "windows-arm64", platform_label
     return None, platform_label
 
 
-def _avault_managed_bin_path() -> Path:
-    return Path.home() / ".local" / "bin" / "avault"
+def _avault_binary_name_for_target(target: str) -> str:
+    return "avault.exe" if target.startswith("windows-") else "avault"
+
+
+def _avault_managed_bin_path(target: str | None = None) -> Path:
+    target = target or (_avault_target()[0] or "")
+    # Windows uses the same Avibe-managed bin directory, with the .exe name
+    # that _candidate_cli_paths("avault") checks on Windows.
+    return Path.home() / ".local" / "bin" / _avault_binary_name_for_target(target)
 
 
 def _persist_avault_cli_path(path: str) -> None:
@@ -3455,17 +3486,17 @@ def _download_avault_release_file(url: str) -> bytes:
         return response.read()
 
 
-def _extract_avault_binary(archive_bytes: bytes, output_path: Path) -> None:
+def _extract_avault_binary(archive_bytes: bytes, output_path: Path, member_name: str = "avault") -> None:
     import io
     import tarfile
 
     output_real = output_path.parent.resolve()
     with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as archive:
-        member = next((item for item in archive.getmembers() if item.name == "avault"), None)
+        member = next((item for item in archive.getmembers() if item.name == member_name), None)
         if member is None or not member.isfile():
             raise ValueError("archive does not contain the avault executable")
         target = (output_path.parent / member.name).resolve()
-        if target.parent != output_real or target.name != "avault":
+        if target.parent != output_real or target.name != member_name:
             raise ValueError("archive contains an unsafe avault path")
         source = archive.extractfile(member)
         if source is None:
@@ -3541,15 +3572,18 @@ def install_avault(force: bool = False) -> dict:
                 "path": None,
             }
 
-        install_path = _avault_managed_bin_path()
+        member_name = _avault_binary_name_for_target(target)
+        install_path = _avault_managed_bin_path(target)
         install_path.parent.mkdir(parents=True, exist_ok=True)
         with tempfile.TemporaryDirectory(prefix="avault-install-", dir=install_path.parent) as tmp_dir:
-            tmp_path = Path(tmp_dir) / "avault"
-            _extract_avault_binary(archive_bytes, tmp_path)
-            tmp_path.chmod(0o755)
+            tmp_path = Path(tmp_dir) / member_name
+            _extract_avault_binary(archive_bytes, tmp_path, member_name)
+            if not target.startswith("windows-"):
+                tmp_path.chmod(0o755)
             os.replace(tmp_path, install_path)
-        install_path.chmod(0o755)
-        _clear_macos_quarantine(install_path)
+        if not target.startswith("windows-"):
+            install_path.chmod(0o755)
+            _clear_macos_quarantine(install_path)
         _persist_avault_cli_path(str(install_path))
 
         return {


### PR DESCRIPTION
## Summary
- bump the pinned avault installer version to 0.1.1
- expand target detection to macOS arm64/x64, Linux x64/arm64, and Windows x64/arm64 using the exact manifest names
- install Windows builds as avault.exe in Avibe's managed bin directory and teach CLI resolution to check Windows executable suffixes
- select the platform-specific archive member while keeping checksum verification, safe extraction, idempotency, force writeback, and unsupported-host fallback behavior

## Target map
- Darwin arm64 -> macos-arm64
- Darwin x86_64 -> macos-x64
- Linux x86_64/amd64 -> linux-x64
- Linux aarch64/arm64 -> linux-arm64
- Windows AMD64/x86_64 -> windows-x64
- Windows ARM64 -> windows-arm64

## Evidence
- unit: `python3 -m pytest tests/test_local_deps.py -q`
- lint: `ruff check vibe/api.py tests/test_local_deps.py`

## Notes
- Manual end-to-end install depends on the avibe-bot/avault v0.1.1 GitHub release and manifest being live; mocked tests pass without real network access.
