### PR TITLE
fix(deps): skip cli path persistence for local tools

### DIFF
--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -103,6 +103,29 @@ def test_install_askill_uses_official_curl_installer(monkeypatch):
     assert "curl -fsSL https://askill.sh | sh" in captured["cmd"][2]
 
 
+def test_askill_install_command_does_not_persist_agent_cli_path(monkeypatch):
+    config_loads = []
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def communicate(self, timeout=None):
+            return "installed", ""
+
+    monkeypatch.setattr(api.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/usr/local/bin/askill" if b == "askill" else None)
+    monkeypatch.setattr(api, "load_config", lambda: config_loads.append(True) or pytest.fail("askill should not load V2Config"))
+
+    out = api._run_install_command("askill", ["bash", "-c", "true"], lambda value: value, mode="install")
+
+    assert out["ok"] is True
+    assert out["path"] == "/usr/local/bin/askill"
+    assert config_loads == []
+
+
 def test_install_askill_unsupported_without_curl(monkeypatch):
     # No curl/bash (e.g. Windows): no broken npm fallback — a clear manual
     # message pointing at askill.sh, and _run_install_command is never invoked.

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3253,31 +3253,34 @@ def _run_install_command(
             # pre-upgrade value.
             _invalidate_version_cache(name)
 
-            # Persist the freshly-discovered install path to V2Config so the
-            # next ``get_backend_runtime`` reads it directly instead of
-            # relying on the resolver's stale-path fallback. Self-update
-            # commands normally keep the binary at the same path so this is
-            # a no-op for upgrades, but fresh installs after a missing
-            # bootstrap (or an installer that moves the file) need it.
-            if installed_path:
+            # Persist real Agent backend CLI paths to V2Config so the next
+            # ``get_backend_runtime`` reads them directly instead of relying
+            # on the resolver's stale-path fallback. Local dependencies such
+            # as askill reuse this runner but do not have ``agents.<name>``
+            # config entries, so they must not touch V2Config bookkeeping.
+            if installed_path and is_agent_backend(name):
                 try:
                     with CONFIG_LOCK:
                         try:
                             cfg = load_config()
                         except FileNotFoundError:
-                            cfg = V2Config()
-                        target = getattr(getattr(cfg, "agents", None), name, None)
-                        if target is not None:
-                            previous = getattr(target, "cli_path", "") or ""
-                            if previous != installed_path:
-                                target.cli_path = installed_path
-                                cfg.save()
-                                logger.info(
-                                    "install_agent: updated V2Config cli_path for %s: %s -> %s",
-                                    name,
-                                    previous or "<unset>",
-                                    installed_path,
-                                )
+                            logger.debug(
+                                "install_agent: config is not initialized; skipping cli_path persistence for %s",
+                                name,
+                            )
+                        else:
+                            target = getattr(getattr(cfg, "agents", None), name, None)
+                            if target is not None:
+                                previous = getattr(target, "cli_path", "") or ""
+                                if previous != installed_path:
+                                    target.cli_path = installed_path
+                                    cfg.save()
+                                    logger.info(
+                                        "install_agent: updated V2Config cli_path for %s: %s -> %s",
+                                        name,
+                                        previous or "<unset>",
+                                        installed_path,
+                                    )
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "install_agent: failed to persist cli_path for %s: %s",
@@ -3321,10 +3324,9 @@ def install_askill() -> dict:
     """Install (or refresh) the askill CLI — a required local dependency for Skills.
 
     Uses the official one-line installer (same shape as the OpenCode bootstrap
-    in ``install_agent``), with an npm fallback. Runs through
-    ``_run_install_command``, which already skips the ``agents.<name>.cli_path``
-    write when there is no ``agents.askill`` attribute, so it is safe for a
-    standalone (non-agent) tool.
+    in ``install_agent``). Runs through ``_run_install_command``, whose
+    V2Config cli_path bookkeeping is limited to real Agent backends, so it is
+    safe for a standalone local dependency.
     """
     import platform
 


### PR DESCRIPTION
## Summary
- restrict install-path persistence in the shared installer helper to real Agent backends
- skip V2Config bookkeeping for local dependencies such as askill
- cover the askill install success path so it cannot touch V2Config again

## Testing
- `python3 -m pytest tests/test_local_deps.py tests/test_ui_api.py::test_install_agent_returns_resolved_path -q`
- `ruff check vibe/api.py tests/test_local_deps.py`

## Risk
- Low. Backend CLI path persistence is still active for registered Agent backends; local dependencies now skip only the backend-specific config write.
