### PR TITLE
fix(vaults): remove value preview metadata

### DIFF
--- a/docs/plans/avault-custody-core.md
+++ b/docs/plans/avault-custody-core.md
@@ -206,7 +206,7 @@ Through-line legend: 🔓 plaintext · 📦 blind box (sealed to `avault`) · �
 2. Browser **seals the value to `avault`'s pubkey** → 📦; `POST /api/vault/secrets` carries the blind box.
 3. Daemon relays 📦 to `avault` (it cannot open it).
 4. `avault`: open 📦 → read master key from store → fresh DEK → AES-256-GCM encrypt (random nonce, **AAD = `name + scheme + version`**) → wrap DEK under master key → zeroize plaintext + DEK → return 🔒 `{ciphertext, nonce, wrap_meta}`.
-5. Daemon writes the row to `vault_secrets` (ciphertext, wrap_meta, preview `…last4`, `protection=standard`, audit `created`). 🔒 only; no plaintext, no key persists in Python.
+5. Daemon writes the row to `vault_secrets` (ciphertext, wrap_meta, `protection=standard`, audit `created`). 🔒 only; no plaintext, no key, and no value-derived data is stored or surfaced in metadata.
 
 **Protected tier:** step 2 is the **browser encrypting under the VMK** (it unlocks the VMK with the passkey/password first, or uses an existing VMK session) and the POST body is already 🔒. Python never sees plaintext at all.
 

--- a/storage/alembic/versions/20260626_0024_remove_vault_secret_preview.py
+++ b/storage/alembic/versions/20260626_0024_remove_vault_secret_preview.py
@@ -1,0 +1,59 @@
+"""remove value-derived vault secret previews
+
+Revision ID: 20260626_0024
+Revises: 20260621_0023
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from alembic import op
+
+revision = "20260626_0024"
+down_revision = "20260621_0023"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    bind = op.get_bind()
+    row = bind.exec_driver_sql(
+        "select 1 from sqlite_master where type = 'table' and name = ?",
+        (name,),
+    ).first()
+    return row is not None
+
+
+def _strip_preview(raw: str | None) -> tuple[bool, str | None]:
+    if not raw:
+        return False, raw
+    try:
+        payload: Any = json.loads(raw)
+    except (TypeError, ValueError):
+        return False, raw
+    if not isinstance(payload, dict) or "preview" not in payload:
+        return False, raw
+    payload.pop("preview", None)
+    return True, json.dumps(payload) if payload else None
+
+
+def upgrade() -> None:
+    if not _table_exists("vault_secrets"):
+        return
+    bind = op.get_bind()
+    rows = list(bind.exec_driver_sql("select id, public_meta from vault_secrets").mappings())
+    for row in rows:
+        changed, public_meta = _strip_preview(row["public_meta"])
+        if changed:
+            bind.exec_driver_sql(
+                "update vault_secrets set public_meta = ? where id = ?",
+                (public_meta, row["id"]),
+            )
+
+
+def downgrade() -> None:
+    # Value-derived previews are intentionally not recoverable.
+    pass

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -27,7 +27,6 @@ from storage.models import vault_audit, vault_groups, vault_requests, vault_secr
 from storage.vault_crypto import Sealed
 
 DEFAULT_GROUP = "default"
-_PREVIEW_TAIL = 4
 
 
 class VaultServiceError(Exception):
@@ -62,19 +61,6 @@ def _id(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex[:12]}"
 
 
-def value_preview(value: str) -> str:
-    """Non-secret masked hint for list/detail views (last few chars, like #555).
-
-    Computed by the caller from the plaintext *before* sealing (avault returns only
-    ciphertext), then stored as non-secret metadata via :func:`create_secret`.
-    """
-    if not value:
-        return ""
-    if len(value) <= _PREVIEW_TAIL:
-        return "•" * len(value)
-    return "…" + value[-_PREVIEW_TAIL:]
-
-
 def _loads(raw: str | None) -> Any:
     if not raw:
         return None
@@ -84,9 +70,14 @@ def _loads(raw: str | None) -> Any:
         return None
 
 
+def _public_meta(raw: str | None) -> dict[str, Any]:
+    payload = _loads(raw)
+    return payload if isinstance(payload, dict) else {}
+
+
 def _meta_payload(row: dict[str, Any]) -> dict[str, Any]:
     """Masked, value-free metadata for a secret row."""
-    public_meta = _loads(row.get("public_meta")) or {}
+    public_meta = _public_meta(row.get("public_meta"))
     return {
         "name": row["name"],
         "group": row.get("group_name"),
@@ -96,7 +87,6 @@ def _meta_payload(row: dict[str, Any]) -> dict[str, Any]:
         "signer_kind": row.get("signer_kind"),
         "source": row.get("source"),
         "description": public_meta.get("description"),
-        "preview": public_meta.get("preview", ""),
         # Policy is non-secret (allowed hosts, auth scheme name) — safe to surface.
         "policy": _loads(row.get("policy")) or {},
         "last_used_at": row.get("last_used_at"),
@@ -184,7 +174,6 @@ def create_secret(
     *,
     name: str,
     sealed: Sealed,
-    preview: str = "",
     group: str = DEFAULT_GROUP,
     tags: list[str] | None = None,
     protection: str = "standard",
@@ -195,7 +184,7 @@ def create_secret(
     """Create a standard-tier secret from an avault-sealed envelope; return masked metadata.
 
     The value is sealed by the caller via the avault client (this layer never sees
-    plaintext or keys). ``preview`` is the caller-computed non-secret last-4 hint.
+    plaintext or keys). No value-derived metadata is stored or returned.
 
     ``policy`` is a non-secret JSON dict (e.g. ``allowed_hosts`` + ``auth`` scheme for
     the brokered ``fetch`` mode); it never contains the value.
@@ -209,7 +198,7 @@ def create_secret(
 
     _ensure_group(conn, group)
     now = _now()
-    public_meta = {"preview": preview}
+    public_meta = {}
     if description:
         public_meta["description"] = description
     try:
@@ -225,7 +214,7 @@ def create_secret(
                 ciphertext=sealed.ciphertext,
                 nonce=sealed.nonce,
                 wrap_meta=sealed.wrap_meta,
-                public_meta=json.dumps(public_meta),
+                public_meta=json.dumps(public_meta) if public_meta else None,
                 policy=json.dumps(policy) if policy else None,
                 use_count=0,
                 created_at=now,
@@ -269,14 +258,12 @@ def rotate_secret(
     conn: Connection,
     name: str,
     sealed: Sealed,
-    *,
-    preview: str = "",
 ) -> dict[str, Any]:
     row = _require_row(conn, name)
     if row.get("protection") != "standard":
         raise UnsupportedProtectionError("only the standard tier is available in P0")
-    public_meta = _loads(row.get("public_meta")) or {}
-    public_meta["preview"] = preview
+    public_meta = _public_meta(row.get("public_meta"))
+    public_meta.pop("preview", None)
     conn.execute(
         vault_secrets.update()
         .where(vault_secrets.c.name == name)
@@ -284,7 +271,7 @@ def rotate_secret(
             ciphertext=sealed.ciphertext,
             nonce=sealed.nonce,
             wrap_meta=sealed.wrap_meta,
-            public_meta=json.dumps(public_meta),
+            public_meta=json.dumps(public_meta) if public_meta else None,
             updated_at=_now(),
         )
     )
@@ -403,7 +390,6 @@ def fulfill_provision(
     request_id: str,
     sealed: Sealed,
     *,
-    preview: str = "",
     group: str = DEFAULT_GROUP,
     description: str | None = None,
 ) -> dict[str, Any]:
@@ -415,7 +401,6 @@ def fulfill_provision(
         conn,
         name=row["secret_name"],
         sealed=sealed,
-        preview=preview,
         group=group,
         description=description,
     )

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -16,7 +16,7 @@ from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
 
 
-HEAD_REVISION = "20260621_0023"
+HEAD_REVISION = "20260626_0024"
 
 
 def _index_sql(conn: sqlite3.Connection, name: str) -> str:
@@ -231,6 +231,52 @@ def test_run_migrations_rebuilds_inbox_indexes_for_harness_dedupe(tmp_path: Path
         assert version == (HEAD_REVISION,)
         assert "harness_dedupe" in _index_sql(conn, "ix_messages_inbox_activity")
         assert "harness_dedupe" in _index_sql(conn, "ix_messages_inbox_user_send")
+
+
+def test_run_migrations_strips_vault_secret_preview_metadata(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+
+    run_migrations(db_path, revision="20260621_0023")
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute("select version_num from alembic_version").fetchone()
+        assert version == ("20260621_0023",)
+        conn.executemany(
+            """
+            insert into vault_secrets (
+                id, name, group_name, tags, kind, protection, source,
+                ciphertext, nonce, wrap_meta, public_meta, policy,
+                use_count, created_at, updated_at
+            ) values (?, ?, 'default', null, 'static', 'standard', 'manual',
+                'ct', 'nonce', 'wrap', ?, null, 0, 'now', 'now')
+            """,
+            [
+                ("vlt_keep", "KEEP_DESC", json.dumps({"description": "kept", "preview": "…1234", "pubkey": "pk"})),
+                ("vlt_empty", "ONLY_PREVIEW", json.dumps({"preview": "…9999"})),
+                ("vlt_null", "NULL_META", None),
+                ("vlt_blank", "BLANK_META", ""),
+                ("vlt_bad", "BAD_META", "not-json"),
+                ("vlt_other", "OTHER_META", json.dumps({"description": "other"})),
+            ],
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute("select version_num from alembic_version").fetchone()
+        rows = dict(conn.execute("select name, public_meta from vault_secrets order by name").fetchall())
+
+    assert version == (HEAD_REVISION,)
+    assert json.loads(rows["KEEP_DESC"]) == {"description": "kept", "pubkey": "pk"}
+    assert rows["ONLY_PREVIEW"] is None
+    assert rows["NULL_META"] is None
+    assert rows["BLANK_META"] == ""
+    assert rows["BAD_META"] == "not-json"
+    assert json.loads(rows["OTHER_META"]) == {"description": "other"}
+    assert "preview" not in json.dumps(rows)
+    assert "1234" not in json.dumps(rows)
+    assert "9999" not in json.dumps(rows)
 
 
 def test_scope_agent_backfill_migrates_explicit_agent_routes(tmp_path: Path) -> None:

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import json
 
 import pytest
+from sqlalchemy import select
 
 from storage import vault_service
+from storage.models import vault_secrets
 from storage.vault_crypto import Sealed
 from vibe import api
 
@@ -27,15 +29,24 @@ def test_create_list_delete_roundtrip(monkeypatch):
     created = api.create_vault_secret({"name": "OPENAI_API_KEY", "value": "sk-ant-abcd1234", "description": "key"})
     assert created["ok"] is True
     assert created["secret"]["name"] == "OPENAI_API_KEY"
-    assert created["secret"]["preview"] == "…1234"
+    assert "preview" not in created["secret"]
     assert "sk-ant-abcd1234" not in json.dumps(created)
+    assert "1234" not in json.dumps(created)
     seal.assert_called_once_with("OPENAI_API_KEY", b"sk-ant-abcd1234")
     with api._vault_engine().connect() as conn:
         assert vault_service.get_envelope(conn, "OPENAI_API_KEY") == _sealed("api")
+        public_meta_raw = conn.execute(
+            select(vault_secrets.c.public_meta).where(vault_secrets.c.name == "OPENAI_API_KEY")
+        ).scalar_one()
+        public_meta = json.loads(public_meta_raw)
+        assert public_meta == {"description": "key"}
+        assert "preview" not in public_meta
+        assert "1234" not in json.dumps(vault_service.get_secret_meta(conn, "OPENAI_API_KEY"))
 
     listed = api.get_vault_secrets()
     assert [s["name"] for s in listed["secrets"]] == ["OPENAI_API_KEY"]
     assert "sk-ant-abcd1234" not in json.dumps(listed)
+    assert "1234" not in json.dumps(listed)
 
     removed = api.delete_vault_secret("OPENAI_API_KEY")
     assert removed == {"ok": True, "removed": True, "name": "OPENAI_API_KEY"}

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -73,7 +73,7 @@ def test_parse_env_specs(specs, expected):
     assert cli._parse_env_specs(specs) == expected
 
 
-def test_set_seals_with_avault_and_stores_preview(tmp_path, capfd, monkeypatch):
+def test_set_seals_with_avault_without_value_derived_metadata(tmp_path, capfd, monkeypatch):
     from unittest.mock import Mock
 
     from vibe import api
@@ -87,8 +87,9 @@ def test_set_seals_with_avault_and_stores_preview(tmp_path, capfd, monkeypatch):
     payload = json.loads(capfd.readouterr().out)
     secret = payload["secret"]
     assert secret["name"] == "OPENAI_API_KEY"
-    assert secret["preview"] == "…1234"
+    assert "preview" not in secret
     assert "sk-ant-abcd1234" not in json.dumps(payload)
+    assert "1234" not in json.dumps(payload)
     seal.assert_called_once_with("OPENAI_API_KEY", b"sk-ant-abcd1234")
     with cli._open_vault_engine().connect() as conn:
         assert vault_service.get_envelope(conn, "OPENAI_API_KEY") == _sealed("saved")

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -38,18 +38,10 @@ def _row(engine, name: str) -> dict:
         return dict(conn.execute(select(vault_secrets).where(vault_secrets.c.name == name)).mappings().one())
 
 
-def test_value_preview_masks_tail_hint():
-    assert vs.value_preview("") == ""
-    assert vs.value_preview("abc") == "•••"
-    assert vs.value_preview("abcd") == "••••"
-    assert vs.value_preview("abcde") == "…bcde"
-
-
-def test_create_stores_envelope_and_masked_meta(vault):
+def test_create_stores_envelope_and_value_free_meta(vault):
     meta = _create(
         vault,
         name="OPENAI_API_KEY",
-        preview="…1234",
         description="key",
         policy={"allowed_hosts": ["api.example.com"]},
     )
@@ -57,19 +49,38 @@ def test_create_stores_envelope_and_masked_meta(vault):
     assert meta["name"] == "OPENAI_API_KEY"
     assert meta["protection"] == "standard"
     assert meta["group"] == "default"
-    assert meta["preview"] == "…1234"
+    assert "preview" not in meta
     assert meta["policy"] == {"allowed_hosts": ["api.example.com"]}
     assert "plaintext" not in json.dumps(meta)
     row = _row(vault, "OPENAI_API_KEY")
     assert row["ciphertext"] == "ct-1"
     assert row["nonce"] == "n-1"
     assert row["wrap_meta"] == "wm-1"
+    assert json.loads(row["public_meta"]) == {"description": "key"}
+
+
+def test_create_persists_no_value_derived_public_meta(vault):
+    secret_value = "sk-ant-abcd1234"
+    value_tail = secret_value[-4:]
+    _create(vault, name="NO_PREVIEW_KEY")
+
+    row = _row(vault, "NO_PREVIEW_KEY")
+    assert row["public_meta"] is None
+
+    with vault.connect() as conn:
+        meta = vs.get_secret_meta(conn, "NO_PREVIEW_KEY")
+        listed = vs.list_secrets(conn)
+
+    assert "preview" not in meta
+    assert "preview" not in json.dumps(listed)
+    assert value_tail not in json.dumps(meta)
+    assert value_tail not in json.dumps(listed)
 
 
 def test_get_envelope_and_get_envelopes_return_stored_envelopes(vault):
-    _create(vault, name="A_KEY", preview="…1111")
+    _create(vault, name="A_KEY")
     with vault.begin() as conn:
-        vs.create_secret(conn, name="B_KEY", sealed=_sealed("2"), preview="…2222")
+        vs.create_secret(conn, name="B_KEY", sealed=_sealed("2"))
     with vault.connect() as conn:
         assert vs.get_envelope(conn, "A_KEY") == _sealed()
         assert vs.get_envelopes(conn, ["B_KEY", "A_KEY"]) == {
@@ -110,9 +121,9 @@ def test_record_proxy_use_bumps_usage_and_audits(vault):
 
 
 def test_list_secrets_masked_and_group_filtered(vault):
-    _create(vault, name="A_KEY", preview="…1111", group="default")
-    _create(vault, name="B_KEY", preview="…2222", group="crypto")
-    _create(vault, name="C_KEY", preview="…3333", group="crypto")
+    _create(vault, name="A_KEY", group="default")
+    _create(vault, name="B_KEY", group="crypto")
+    _create(vault, name="C_KEY", group="crypto")
     with vault.connect() as conn:
         all_names = [m["name"] for m in vs.list_secrets(conn)]
         crypto_names = [m["name"] for m in vs.list_secrets(conn, group="crypto")]
@@ -136,13 +147,22 @@ def test_protected_tier_not_available_in_p0(vault):
         _create(vault, name="SECRET", protection="protected")
 
 
-def test_rotate_changes_envelope_and_preview(vault):
-    _create(vault, name="ROT", preview="…9999")
+def test_rotate_changes_envelope_and_strips_legacy_preview(vault):
+    _create(vault, name="ROT", description="rotating")
     with vault.begin() as conn:
-        meta = vs.rotate_secret(conn, "ROT", _sealed("new"), preview="…0000")
-    assert meta["preview"] == "…0000"
+        conn.execute(
+            vault_secrets.update()
+            .where(vault_secrets.c.name == "ROT")
+            .values(public_meta=json.dumps({"description": "rotating", "preview": "…9999"}))
+        )
+    with vault.begin() as conn:
+        meta = vs.rotate_secret(conn, "ROT", _sealed("new"))
+    assert "preview" not in meta
+    assert meta["description"] == "rotating"
     with vault.connect() as conn:
         assert vs.get_envelope(conn, "ROT") == _sealed("new")
+    row = _row(vault, "ROT")
+    assert json.loads(row["public_meta"]) == {"description": "rotating"}
 
 
 def test_delete_removes_secret(vault):
@@ -154,7 +174,7 @@ def test_delete_removes_secret(vault):
 
 
 def test_audit_records_events_without_values(vault):
-    _create(vault, name="AUD", preview="…lue42")
+    _create(vault, name="AUD")
     with vault.begin() as conn:
         vs.record_deliveries(conn, ["AUD"], requester={"agent": "claude"}, mode="run")
         vs.delete_secret(conn, "AUD")
@@ -177,7 +197,7 @@ def test_create_auto_creates_missing_group(vault):
 def test_create_fulfills_pending_provision_request(vault):
     with vault.begin() as conn:
         req = vs.create_provision_request(conn, "ASKED_KEY", requester={"agent": "claude"})
-    _create(vault, name="ASKED_KEY", preview="…ided")
+    _create(vault, name="ASKED_KEY")
     with vault.connect() as conn:
         status = conn.execute(select(vault_requests.c.status).where(vault_requests.c.id == req["id"])).scalar_one()
     assert status == "fulfilled"
@@ -195,8 +215,8 @@ def test_provision_request_and_fulfill(vault):
         req = vs.create_provision_request(conn, "NEW_KEY", reason="sync needs it", requester={"agent": "claude"})
     assert req["status"] == "pending"
     with vault.begin() as conn:
-        meta = vs.fulfill_provision(conn, req["id"], _sealed("filled"), preview="…7777", description="filled")
-    assert meta["preview"] == "…7777"
+        meta = vs.fulfill_provision(conn, req["id"], _sealed("filled"), description="filled")
+    assert "preview" not in meta
     assert meta["description"] == "filled"
     with vault.connect() as conn:
         assert vs.get_envelope(conn, "NEW_KEY") == _sealed("filled")

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -195,9 +195,9 @@ export const VaultsPage: React.FC = () => {
                     <Badge variant="info">{t('vaults.proxyBound')}</Badge>
                   ) : null}
                 </div>
-                <span className="text-xs text-muted">
-                  {s.preview ? <span className="font-mono">{s.preview}</span> : null}
-                  {s.last_used_at ? ` · ${t('vaults.used', { count: s.use_count })}` : ` · ${t('vaults.neverUsed')}`}
+                <span className="truncate text-xs text-muted">
+                  {s.description ? `${s.description} · ` : ''}
+                  {s.last_used_at ? t('vaults.used', { count: s.use_count }) : t('vaults.neverUsed')}
                 </span>
               </div>
               <div className="ml-auto">

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -25,7 +25,6 @@ export type VaultSecret = {
   signer_kind: string | null;
   source: string;
   description?: string | null;
-  preview: string;
   policy: Record<string, unknown>;
   last_used_at: string | null;
   use_count: number;

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1344,12 +1344,12 @@ def create_vault_secret(payload: dict) -> dict:
     policy = payload.get("policy") if isinstance(payload.get("policy"), dict) else None
     value = str(value)
     # Seal via avault before the DB transaction. The transient plaintext POST lives only here
-    # (one request, not reused) and is piped to avault's stdin; we keep only the ciphertext.
+    # (one request, not reused) and is piped to avault's stdin; Avibe keeps only the
+    # ciphertext and non-value-derived metadata.
     try:
         sealed = avault_seal(name, value.encode("utf-8"))
     except AvaultError as exc:
         raise VaultApiError(f"avault seal failed: {exc}", code="avault_failed") from exc
-    preview = vault_service.value_preview(value)
     engine = _vault_engine()
     try:
         with engine.begin() as conn:
@@ -1357,7 +1357,6 @@ def create_vault_secret(payload: dict) -> dict:
                 conn,
                 name=name,
                 sealed=sealed,
-                preview=preview,
                 group=str(payload.get("group") or vault_service.DEFAULT_GROUP),
                 tags=tags,
                 description=payload.get("description"),

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3398,17 +3398,15 @@ def cmd_vault_set(args):
         tags = list(getattr(args, "tag", None) or []) or None
         policy = _build_secret_policy(args)
         # Seal via avault BEFORE opening a DB transaction (never hold a txn across a subprocess).
-        # The plaintext goes only to avault's stdin; we keep just the ciphertext envelope + a
-        # non-secret last-4 preview.
+        # The plaintext goes only to avault's stdin; Avibe keeps only the ciphertext envelope
+        # and non-value-derived metadata.
         sealed = api.avault_seal(args.name, value.encode("utf-8"))
-        preview = vault_service.value_preview(value)
         engine = _open_vault_engine()
         with engine.begin() as conn:
             meta = vault_service.create_secret(
                 conn,
                 name=args.name,
                 sealed=sealed,
-                preview=preview,
                 group=getattr(args, "group", None) or vault_service.DEFAULT_GROUP,
                 tags=tags,
                 description=getattr(args, "description", None),


### PR DESCRIPTION
## Capability
Remove the leaky last-4 value preview from Avibe Vaults.

## What changed
- Removed the Vault secret `preview` field from storage metadata, CLI/API payloads, and the Vaults Web UI.
- Added an Alembic data migration that strips legacy `preview` keys from `vault_secrets.public_meta` while preserving other public metadata.
- Updated the custody-core plan to state that no value-derived data is stored or surfaced.

## Evidence layers updated
- Unit: updated vault service/API/CLI tests and added assertions that metadata/list payloads contain no value-derived chars.
- Migration: added an idempotent migration regression covering preview removal plus null/blank/non-JSON public metadata.
- UI build: verified the Vaults page type change with the production UI build.

## Residual manual checks
- Regression: existing rows with `public_meta.preview` lose only that key; description/pubkey/address-style metadata remains intact.
