### PR TITLE
feat(inbox): remember the last filter tab across visits

### DIFF
--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ArrowRight, CheckCheck, Filter, Inbox, Loader2, MessageSquareReply, RefreshCw, Search } from 'lucide-react';
@@ -10,8 +10,13 @@ import { formatRelativeTime } from '../../lib/relativeTime';
 import { Markdown } from '../ui/markdown';
 import { Button } from '../ui/button';
 import { WebPushControl } from './WebPushControl';
-
-type FilterMode = 'unread' | 'all';
+import {
+  readInboxFilter,
+  writeInboxFilter,
+  resolveInboxFilter,
+  INBOX_REVERT_AFTER_MS,
+  type InboxFilter as FilterMode,
+} from '../../lib/inboxFilterMemory';
 
 export const InboxPage: React.FC = () => {
   const { t } = useTranslation();
@@ -28,7 +33,47 @@ export const InboxPage: React.FC = () => {
     loadMore,
     markRead,
   } = useWorkbenchInbox();
-  const [filter, setFilter] = useState<FilterMode>('unread');
+  // Remember the tab across visits instead of always snapping back to Unread.
+  // On (re)entry resume the last tab, unless the user has been away long enough
+  // that defaulting to Unread is more useful (see resolveInboxFilter).
+  const [filter, setFilterState] = useState<FilterMode>(() => resolveInboxFilter(readInboxFilter(), Date.now()));
+
+  const setFilter = useCallback((next: FilterMode) => {
+    setFilterState(next);
+    // Persist the choice immediately; keep leftAt (it's stamped on leave below).
+    writeInboxFilter(next, readInboxFilter().leftAt);
+  }, []);
+
+  // Stamp when the user leaves the inbox (route change → unmount, app/tab
+  // backgrounded, reload/close) so the next entry can measure the absence. If
+  // they background the page itself for a long time, revert to Unread on return.
+  useEffect(() => {
+    // On entry, align storage with the tab actually shown (persists a
+    // revert-to-Unread) and clear leftAt — the user is present, not away, so a
+    // brief background-and-return isn't measured against a stale pre-entry stamp.
+    writeInboxFilter(filter, 0);
+    const markLeft = () => writeInboxFilter(readInboxFilter().tab, Date.now());
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        markLeft();
+      } else if (document.visibilityState === 'visible') {
+        const { leftAt } = readInboxFilter();
+        if (leftAt > 0 && Date.now() - leftAt > INBOX_REVERT_AFTER_MS) {
+          setFilterState('unread');
+          writeInboxFilter('unread', 0);
+        }
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pagehide', markLeft);
+    return () => {
+      markLeft();
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pagehide', markLeft);
+    };
+    // Mount/unmount only: listeners are stable and `filter` is read once on entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // The unread map is the single source of truth (loaded pagination-independent
   // and kept in sync by realtime upserts + mark-read). A session drops out of

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -57,10 +57,15 @@ export const InboxPage: React.FC = () => {
       if (document.visibilityState === 'hidden') {
         markLeft();
       } else if (document.visibilityState === 'visible') {
-        const { leftAt } = readInboxFilter();
-        if (leftAt > 0 && Date.now() - leftAt > INBOX_REVERT_AFTER_MS) {
+        const { tab, leftAt } = readInboxFilter();
+        if (leftAt === 0) return; // already marked present
+        if (Date.now() - leftAt > INBOX_REVERT_AFTER_MS) {
           setFilterState('unread');
           writeInboxFilter('unread', 0);
+        } else {
+          // Returned within the window → present again; clear the stale stamp so a
+          // later kill-without-pagehide can't measure against this old background time.
+          writeInboxFilter(tab, 0);
         }
       }
     };

--- a/ui/src/lib/inboxFilterMemory.ts
+++ b/ui/src/lib/inboxFilterMemory.ts
@@ -1,0 +1,48 @@
+// Remembers the inbox filter tab across visits. The remembered tab is resumed on
+// re-entry, EXCEPT after a long absence — then it falls back to Unread, because
+// coming back hours later you usually want to triage what's new, not resume an
+// old "All" view. Mirrors the localStorage conventions used elsewhere in the UI
+// (module-level key, best-effort try/catch).
+export type InboxFilter = 'unread' | 'all';
+
+const STORAGE_KEY = 'vibe-remote:inbox-filter';
+// How long the user must be away from the inbox before re-entry resets to Unread.
+export const INBOX_REVERT_AFTER_MS = 60 * 60 * 1000; // 1 hour
+
+interface StoredInboxFilter {
+  tab: InboxFilter;
+  // Epoch ms when the user last left the inbox; 0 = currently here / never left.
+  leftAt: number;
+}
+
+export function readInboxFilter(): StoredInboxFilter {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<StoredInboxFilter>;
+      return {
+        tab: parsed.tab === 'all' ? 'all' : 'unread',
+        leftAt: typeof parsed.leftAt === 'number' ? parsed.leftAt : 0,
+      };
+    }
+  } catch {
+    // Best-effort persistence only (private mode / SSR / corrupt value).
+  }
+  return { tab: 'unread', leftAt: 0 };
+}
+
+export function writeInboxFilter(tab: InboxFilter, leftAt: number): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ tab, leftAt }));
+  } catch {
+    // Best-effort persistence only.
+  }
+}
+
+// Decide which tab to show on (re)entry: resume the remembered tab, but fall back
+// to Unread once the user has been away longer than INBOX_REVERT_AFTER_MS. Pure,
+// so the time-based behavior is easy to reason about.
+export function resolveInboxFilter(stored: StoredInboxFilter, now: number): InboxFilter {
+  if (stored.leftAt > 0 && now - stored.leftAt > INBOX_REVERT_AFTER_MS) return 'unread';
+  return stored.tab;
+}


### PR DESCRIPTION
## Problem

The workbench inbox always snapped back to the **Unread** tab on entry (`useState('unread')`, reset on every mount). Navigating away and back — or reopening the inbox — forced users to re-select **All** every time, which is especially slow on mobile.

## Behavior (per request)

1. Remember the last selected tab.
2. Auto-revert to **Unread** only when the user has been away for more than a window (1h).
3. Otherwise resume the tab the user was last on.

## Implementation

- **`ui/src/lib/inboxFilterMemory.ts`** (new): best-effort `localStorage` of `{ tab, leftAt }` (mirrors the UI's existing module-key + try/catch convention), plus a **pure** `resolveInboxFilter(stored, now)` — resumes the tab unless `now - leftAt > INBOX_REVERT_AFTER_MS` (1h).
- **`InboxPage.tsx`**: seeds `filter` from the resolved value, persists on every tab change, and stamps `leftAt` when the user leaves — covering all return paths:
  - SPA route change → component unmount
  - tab/app backgrounded or phone lock → `visibilitychange` hidden (and on return-while-mounted, revert to Unread if the absence exceeded the window)
  - reload / close → `pagehide`
  - On entry it also re-aligns storage to the shown tab + clears `leftAt`, so a revert-to-Unread persists and a brief background-and-return isn't measured against a stale pre-entry stamp.

## Evidence

- **Unit/contract:** none added — the UI has no JS test runner (validation is `npm run build`); the time logic is isolated in the pure `resolveInboxFilter` for easy reasoning.
- **Manual:** `npm run build` green (tsc + vite). Logic-only change, no visual diff. Residual: real-device check on the regression (switch to All → leave/return within 1h stays on All; after >1h returns to Unread; fresh visit defaults to Unread).