### PR TITLE
feat(vaults): add browser crypto library

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -112,7 +112,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -279,7 +278,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -332,6 +330,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -339,6 +362,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -878,7 +902,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.45.0.tgz",
       "integrity": "sha512-LAaceAtcQpVMDvldhkrQC1MSawpj7aAm1CfGg6RbyQgTDDp2fKnP1gDhjQIef3lH8W2fYeXRe66EdzaFkoGHKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@lexical/devtools-core": "0.45.0",
@@ -966,7 +989,6 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.45.0.tgz",
       "integrity": "sha512-Fo5MMErqoPlUyTw1qVMZ9kE33ZjJF957KU683tsCrrlaVisVxpboL7BbAnxWTwCcIpAsfc6AUndJJ70M9NDMGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0",
         "@lexical/selection": "0.45.0",
@@ -2509,7 +2531,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2520,7 +2541,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2582,7 +2602,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2972,7 +2991,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3165,7 +3183,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3535,7 +3552,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4092,7 +4108,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -4248,6 +4263,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -4359,7 +4375,6 @@
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.45.0.tgz",
       "integrity": "sha512-z2M9C2ILPW7SopQE1aKbOFdZJbe3HvsrgWnJKveMDrSEvVjU9Hce4UpKVsAdkwY7TgY9RDuCV3+sfrGu0WkL+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0"
       }
@@ -4382,6 +4397,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -5822,7 +5838,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5850,7 +5865,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -5911,7 +5925,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5921,7 +5934,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6559,7 +6571,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6813,7 +6824,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7333,7 +7343,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,10 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "@hpke/core": "^1.9.0",
+        "@hpke/dhkem-x25519": "^1.8.0",
         "@lexical/react": "^0.45.0",
+        "@noble/curves": "^2.2.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.15",
@@ -22,6 +25,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "framer-motion": "^12.26.2",
+        "hash-wasm": "^4.12.0",
         "i18next": "^25.7.4",
         "i18next-browser-languagedetector": "^8.2.0",
         "lexical": "^0.45.0",
@@ -57,7 +61,8 @@
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -107,6 +112,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -273,6 +279,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -325,31 +332,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
-      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -357,7 +339,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -571,6 +552,39 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@hpke/common": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@hpke/common/-/common-1.10.1.tgz",
+      "integrity": "sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@hpke/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/dhkem-x25519": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@hpke/dhkem-x25519/-/dhkem-x25519-1.8.0.tgz",
+      "integrity": "sha512-S1MWWkAfu+TFxySgv5+2P3O4Mx/jk7BsoplzQaA1s3sfUJVJ2UsZsSzSsMc+FXJumLXncoJFlO6mK6mDGspfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -864,6 +878,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.45.0.tgz",
       "integrity": "sha512-LAaceAtcQpVMDvldhkrQC1MSawpj7aAm1CfGg6RbyQgTDDp2fKnP1gDhjQIef3lH8W2fYeXRe66EdzaFkoGHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@lexical/devtools-core": "0.45.0",
@@ -951,6 +966,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.45.0.tgz",
       "integrity": "sha512-Fo5MMErqoPlUyTw1qVMZ9kE33ZjJF957KU683tsCrrlaVisVxpboL7BbAnxWTwCcIpAsfc6AUndJJ70M9NDMGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0",
         "@lexical/selection": "0.45.0",
@@ -988,6 +1004,33 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -2019,6 +2062,13 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -2361,6 +2411,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2369,6 +2430,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2441,6 +2509,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2451,6 +2520,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2512,6 +2582,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2782,12 +2853,126 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2873,6 +3058,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -2970,6 +3165,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3023,6 +3219,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3293,6 +3499,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -3322,6 +3535,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3500,6 +3714,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3508,6 +3732,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -3724,6 +3958,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -3852,6 +4092,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -4007,7 +4248,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -4119,6 +4359,7 @@
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.45.0.tgz",
       "integrity": "sha512-z2M9C2ILPW7SopQE1aKbOFdZJbe3HvsrgWnJKveMDrSEvVjU9Hce4UpKVsAdkwY7TgY9RDuCV3+sfrGu0WkL+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0"
       }
@@ -4141,7 +4382,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -5417,6 +5657,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
@@ -5548,6 +5802,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5561,6 +5822,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5588,6 +5850,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -5648,6 +5911,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5657,6 +5921,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6047,6 +6312,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6066,6 +6338,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -6162,6 +6448,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -6177,6 +6480,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -6246,6 +6559,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6499,6 +6813,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6832,6 +7147,96 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -6855,6 +7260,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -6911,6 +7333,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,10 +11,14 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test:crypto": "vitest run src/lib/vaultCrypto.test.ts",
     "validate:theme": "node scripts/validate-theme.mjs"
   },
   "dependencies": {
+    "@hpke/core": "^1.9.0",
+    "@hpke/dhkem-x25519": "^1.8.0",
     "@lexical/react": "^0.45.0",
+    "@noble/curves": "^2.2.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
@@ -28,6 +32,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "framer-motion": "^12.26.2",
+    "hash-wasm": "^4.12.0",
     "i18next": "^25.7.4",
     "i18next-browser-languagedetector": "^8.2.0",
     "lexical": "^0.45.0",
@@ -63,6 +68,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.9"
   }
 }

--- a/ui/src/lib/__fixtures__/p2_core_crypto.json
+++ b/ui/src/lib/__fixtures__/p2_core_crypto.json
@@ -1,0 +1,39 @@
+{
+  "blind_box": {
+    "scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1",
+    "hpke_info_utf8": "avault:blind-box:v1",
+    "aad_utf8": "hpke-x25519-hkdfsha256-aes256gcm-v1",
+    "master_key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    "public_key": "gvhYRR/emWVthJ2XlGcbHvSN1QlnHYTQTWGKKQz9Zjs=",
+    "fingerprint": "0cd6109d66dd3a5e36f072b67c7f77e00b7cf6e10bd7e574681b0af0ac8ae4b0",
+    "rng_seed_hex": "4242424242424242424242424242424242424242424242424242424242424242",
+    "plaintext_hex": "626c696e6420736563726574",
+    "box": {
+      "scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1",
+      "enc": "y5JxBydhfDn3qZTxJtkiArzKIllWj625u+9lp54ATSM=",
+      "ct": "52ffaaYq51gf/85k3WISC3mEOcOT/GvREYoXag=="
+    }
+  },
+  "signing": {
+    "private_key_hex": "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+    "digest_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    "schnorr_aux_rand_hex": "0000000000000000000000000000000000000000000000000000000000000000",
+    "schemes": [
+      {
+        "scheme": "ecdsa-secp256k1-recoverable",
+        "signature_hex": "4ca3aca3a41bc1ca96d67707e525ac6bd77ddc197a34b4c020be1ee636e29617199556ded3234058daafff2bc3153da60d402d0c71389a11a790b9f1a5862e80",
+        "recovery_id": 0
+      },
+      {
+        "scheme": "ecdsa-secp256k1-der",
+        "signature_hex": "304402204ca3aca3a41bc1ca96d67707e525ac6bd77ddc197a34b4c020be1ee636e296170220199556ded3234058daafff2bc3153da60d402d0c71389a11a790b9f1a5862e80",
+        "recovery_id": null
+      },
+      {
+        "scheme": "schnorr-secp256k1-bip340",
+        "signature_hex": "931a3386e9ec69fe1471ba85933640948c0296a79ce2d3801ad5a4d9353550aeb0a5e80358b68088bda70b46e6b77a640c1216826f96292e5799ba2bb7bf1342",
+        "recovery_id": null
+      }
+    ]
+  }
+}

--- a/ui/src/lib/vaultCrypto.test.ts
+++ b/ui/src/lib/vaultCrypto.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import { Aes256Gcm, CipherSuite, HkdfSha256 } from '@hpke/core';
+import { DhkemX25519HkdfSha256 } from '@hpke/dhkem-x25519';
+
+import vectors from './__fixtures__/p2_core_crypto.json';
+import {
+  BLIND_BOX_SCHEME,
+  base64ToBytes,
+  buildWrapMeta,
+  bytesToBase64,
+  bytesFromHex,
+  bytesToHexString,
+  derivePasskeyKek,
+  newVmk,
+  passkeyPrfSalts,
+  releaseProtectedDek,
+  sealBlindBox,
+  sealProtected,
+  signDigest,
+  SIGN_SCHEME_ECDSA_SECP256K1_DER,
+  SIGN_SCHEME_ECDSA_SECP256K1_RECOVERABLE,
+  SIGN_SCHEME_SCHNORR_SECP256K1_BIP340,
+  unwrapProtectedDek,
+  unwrapVmk,
+  webAuthnPrfExtensionInput,
+  type SignatureScheme,
+} from './vaultCrypto';
+
+type P2Vectors = typeof vectors;
+
+const p2 = vectors as P2Vectors;
+const encoder = new TextEncoder();
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const out = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(out).set(bytes);
+  return out;
+}
+
+async function hkdfSha256(ikm: Uint8Array, salt: string, info: string, length: number): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey('raw', arrayBuffer(ikm), 'HKDF', false, ['deriveBits']);
+  return new Uint8Array(
+    await crypto.subtle.deriveBits(
+      {
+        name: 'HKDF',
+        hash: 'SHA-256',
+        salt: encoder.encode(salt),
+        info: encoder.encode(info),
+      },
+      key,
+      length * 8,
+    ),
+  );
+}
+
+async function avaultVectorReceiverKey(): Promise<CryptoKeyPair> {
+  const suite = new CipherSuite({
+    kem: new DhkemX25519HkdfSha256(),
+    kdf: new HkdfSha256(),
+    aead: new Aes256Gcm(),
+  });
+  const ikm = await hkdfSha256(
+    bytesFromHex(p2.blind_box.master_key_hex),
+    'avault:blind-box:receiver-salt:v1',
+    'avault:blind-box:receiver-x25519:v1',
+    32,
+  );
+  return suite.kem.deriveKeyPair(ikm);
+}
+
+async function openBlindBox(box: { enc: string; ct: string }): Promise<Uint8Array> {
+  const suite = new CipherSuite({
+    kem: new DhkemX25519HkdfSha256(),
+    kdf: new HkdfSha256(),
+    aead: new Aes256Gcm(),
+  });
+  return new Uint8Array(
+    await suite.open(
+      {
+        recipientKey: (await avaultVectorReceiverKey()).privateKey,
+        enc: base64ToBytes(box.enc),
+        info: encoder.encode(p2.blind_box.hpke_info_utf8),
+      },
+      base64ToBytes(box.ct),
+      encoder.encode(p2.blind_box.aad_utf8),
+    ),
+  );
+}
+
+describe('vaultCrypto signing vectors', () => {
+  it('matches avault secp256k1 signatures byte-for-byte', () => {
+    for (const vector of p2.signing.schemes) {
+      const scheme = vector.scheme as SignatureScheme;
+      const result = signDigest(p2.signing.private_key_hex, p2.signing.digest_hex, scheme, {
+        schnorrAuxRand:
+          scheme === SIGN_SCHEME_SCHNORR_SECP256K1_BIP340 ? p2.signing.schnorr_aux_rand_hex : undefined,
+      });
+
+      expect(result.signature).toBe(vector.signature_hex);
+      expect(result.recovery_id).toBe(vector.recovery_id);
+    }
+  });
+
+  it('keeps the ECDSA recoverable signature as r||s plus recovery id', () => {
+    const result = signDigest(
+      p2.signing.private_key_hex,
+      p2.signing.digest_hex,
+      SIGN_SCHEME_ECDSA_SECP256K1_RECOVERABLE,
+    );
+
+    expect(result.signature).toHaveLength(128);
+    expect(result.recovery_id).toBe(0);
+  });
+
+  it('returns DER and BIP340 encodings for their wire schemes', () => {
+    const der = signDigest(p2.signing.private_key_hex, p2.signing.digest_hex, SIGN_SCHEME_ECDSA_SECP256K1_DER);
+    const schnorr = signDigest(
+      p2.signing.private_key_hex,
+      p2.signing.digest_hex,
+      SIGN_SCHEME_SCHNORR_SECP256K1_BIP340,
+      { schnorrAuxRand: p2.signing.schnorr_aux_rand_hex },
+    );
+
+    expect(der.signature.startsWith('30')).toBe(true);
+    expect(schnorr.signature).toHaveLength(128);
+    expect(der.recovery_id).toBeNull();
+    expect(schnorr.recovery_id).toBeNull();
+  });
+});
+
+describe('vaultCrypto blind boxes', () => {
+  it('opens the shared avault blind-box vector with the Phase A receiver key', async () => {
+    await expect(openBlindBox(p2.blind_box.box)).resolves.toEqual(bytesFromHex(p2.blind_box.plaintext_hex));
+  });
+
+  it('seals to the avault public key with the Phase A JSON shape', async () => {
+    const plaintext = encoder.encode('blind secret');
+    const box = await sealBlindBox(base64ToBytes(bytesToBase64(plaintext)), {
+      public_key: p2.blind_box.public_key,
+      fingerprint: p2.blind_box.fingerprint,
+    });
+
+    expect(box.scheme).toBe(BLIND_BOX_SCHEME);
+    expect(base64ToBytes(box.enc)).toHaveLength(32);
+    expect(base64ToBytes(box.ct).length).toBeGreaterThan(16);
+    expect(Object.keys(box).sort()).toEqual(['ct', 'enc', 'scheme']);
+    await expect(openBlindBox(box)).resolves.toEqual(plaintext);
+  });
+
+  it('rejects a substituted avault public key when a fingerprint is pinned', async () => {
+    await expect(
+      sealBlindBox('x', {
+        public_key: p2.blind_box.public_key,
+        fingerprint: '00'.repeat(32),
+      }),
+    ).rejects.toThrow(/fingerprint/);
+  });
+});
+
+describe('vaultCrypto protected hierarchy', () => {
+  it('unwraps the VMK with either passkey PRF or fallback password', async () => {
+    const vmk = newVmk();
+    const prfSalt = new Uint8Array(32).fill(0x11);
+    const prfOutput = new Uint8Array(32).fill(0x22);
+    const wrapMeta = await buildWrapMeta(vmk, [
+      { kind: 'passkey', prfOutput, prfSalt, credentialId: 'cred-1' },
+      { kind: 'password', password: 'less-secure-fallback', argon2id: { memorySize: 512, iterations: 2 } },
+    ]);
+
+    await expect(unwrapVmk(wrapMeta, { kind: 'passkey', prfOutput })).resolves.toEqual(vmk);
+    await expect(unwrapVmk(wrapMeta, 'less-secure-fallback')).resolves.toEqual(vmk);
+    expect(passkeyPrfSalts(wrapMeta)).toEqual([prfSalt]);
+    expect(webAuthnPrfExtensionInput(prfSalt).prf.eval.first.byteLength).toBe(32);
+  });
+
+  it('wraps a protected value with a per-record DEK and releases only that DEK', async () => {
+    const vmk = newVmk();
+    const sealed = await sealProtected(new TextEncoder().encode('protected value'), vmk);
+    const dek = await unwrapProtectedDek(sealed, vmk);
+    const released = await releaseProtectedDek(sealed, vmk, p2.blind_box.public_key);
+
+    expect(dek).toHaveLength(32);
+    expect(released.scheme).toBe(BLIND_BOX_SCHEME);
+    expect(base64ToBytes(released.enc)).toHaveLength(32);
+    expect(base64ToBytes(released.ct).length).toBe(32 + 16);
+  });
+
+  it('derives a stable passkey KEK from WebAuthn PRF output and salt', async () => {
+    const prfOutput = new Uint8Array(32).fill(7);
+    const prfSalt = new Uint8Array(32).fill(9);
+
+    expect(bytesToHexString(await derivePasskeyKek(prfOutput, prfSalt))).toBe(
+      bytesToHexString(await derivePasskeyKek(prfOutput, prfSalt)),
+    );
+  });
+});

--- a/ui/src/lib/vaultCrypto.ts
+++ b/ui/src/lib/vaultCrypto.ts
@@ -1,0 +1,616 @@
+import { Aes256Gcm, CipherSuite, HkdfSha256 } from '@hpke/core';
+import { DhkemX25519HkdfSha256 } from '@hpke/dhkem-x25519';
+import { secp256k1, schnorr } from '@noble/curves/secp256k1.js';
+import { bytesToHex, hexToBytes } from '@noble/curves/utils.js';
+import { argon2id, scrypt } from 'hash-wasm';
+
+export const BLIND_BOX_SCHEME = 'hpke-x25519-hkdfsha256-aes256gcm-v1';
+export const BLIND_BOX_HPKE_INFO = 'avault:blind-box:v1';
+export const SIGN_SCHEME_ECDSA_SECP256K1_RECOVERABLE = 'ecdsa-secp256k1-recoverable';
+export const SIGN_SCHEME_ECDSA_SECP256K1_DER = 'ecdsa-secp256k1-der';
+export const SIGN_SCHEME_SCHNORR_SECP256K1_BIP340 = 'schnorr-secp256k1-bip340';
+
+const KEY_BYTES = 32;
+const NONCE_BYTES = 12;
+const ARGON2_VERSION = 19;
+const PASSKEY_PRF_SALT_BYTES = 32;
+const PASSKEY_HKDF_INFO = 'avault:protected-vmk:kek-passkey:v1';
+
+const DEFAULT_ARGON2ID = {
+  iterations: 3,
+  memorySize: 64 * 1024,
+  parallelism: 1,
+} as const;
+
+const textEncoder = new TextEncoder();
+
+type BytesLike = Uint8Array | ArrayBuffer | ArrayBufferView;
+type HexOrBytes = BytesLike | string;
+
+export type BlindBox = {
+  scheme: typeof BLIND_BOX_SCHEME;
+  enc: string;
+  ct: string;
+};
+
+export type AvaultPublicKey = {
+  public_key: string;
+  fingerprint?: string;
+};
+
+export type ProtectedSealed = {
+  ciphertext: string;
+  nonce: string;
+  dek_nonce: string;
+  wrapped_dek: string;
+};
+
+export type Argon2idParams = {
+  iterations: number;
+  memorySize: number;
+  parallelism: number;
+};
+
+export type PasswordWrapFactor = {
+  kind: 'password';
+  password: string;
+  argon2id?: Partial<Argon2idParams>;
+};
+
+export type PasskeyWrapFactor = {
+  kind: 'passkey';
+  prfOutput: BytesLike;
+  prfSalt: BytesLike;
+  credentialId?: string;
+};
+
+export type VmkWrapFactor = PasswordWrapFactor | PasskeyWrapFactor;
+
+export type PasswordUnlockFactor = {
+  kind: 'password';
+  password: string;
+};
+
+export type PasskeyUnlockFactor = {
+  kind: 'passkey';
+  prfOutput: BytesLike;
+  prfSalt?: BytesLike;
+};
+
+export type VmkUnlockFactor = PasswordUnlockFactor | PasskeyUnlockFactor;
+
+export type SignatureScheme =
+  | typeof SIGN_SCHEME_ECDSA_SECP256K1_RECOVERABLE
+  | typeof SIGN_SCHEME_ECDSA_SECP256K1_DER
+  | typeof SIGN_SCHEME_SCHNORR_SECP256K1_BIP340;
+
+export type SignatureResult = {
+  scheme: SignatureScheme;
+  signature: string;
+  recovery_id: number | null;
+};
+
+export type SignDigestOptions = {
+  schnorrAuxRand?: HexOrBytes;
+};
+
+type WrapMeta = {
+  v: 1;
+  copies: WrapCopy[];
+};
+
+type PasswordArgon2idCopy = {
+  kind: 'password';
+  kdf: 'argon2id';
+  version: 19;
+  iterations: number;
+  memorySize: number;
+  parallelism: number;
+  salt: string;
+  nonce: string;
+  wrapped: string;
+};
+
+type PasswordScryptCopy = {
+  kind: 'password';
+  kdf: 'scrypt';
+  n: number;
+  r: number;
+  p: number;
+  salt: string;
+  nonce: string;
+  wrapped: string;
+};
+
+type PasskeyPrfCopy = {
+  kind: 'passkey';
+  kdf: 'webauthn-prf-hkdf-sha256';
+  prf_salt: string;
+  nonce: string;
+  wrapped: string;
+  credential_id?: string;
+};
+
+type WrapCopy = PasswordArgon2idCopy | PasswordScryptCopy | PasskeyPrfCopy;
+
+export type WebAuthnPrfExtensionInput = {
+  prf: {
+    eval: {
+      first: ArrayBuffer;
+    };
+  };
+};
+
+function toUint8Array(value: BytesLike, field = 'bytes'): Uint8Array {
+  if (value instanceof Uint8Array) {
+    return new Uint8Array(value);
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+  }
+  throw new TypeError(`${field} must be bytes`);
+}
+
+function toArrayBuffer(value: BytesLike): ArrayBuffer {
+  const bytes = toUint8Array(value);
+  const out = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(out).set(bytes);
+  return out;
+}
+
+function utf8(value: string): Uint8Array {
+  return textEncoder.encode(value);
+}
+
+function randomBytes(length: number): Uint8Array {
+  const out = new Uint8Array(length);
+  crypto.getRandomValues(out);
+  return out;
+}
+
+export function bytesToBase64(value: BytesLike): string {
+  const bytes = toUint8Array(value);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export function base64ToBytes(value: string): Uint8Array {
+  return Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+}
+
+export function bytesFromHex(value: string): Uint8Array {
+  return hexToBytes(value);
+}
+
+export function bytesToHexString(value: BytesLike): string {
+  return bytesToHex(toUint8Array(value));
+}
+
+function assertLength(bytes: Uint8Array, length: number, field: string): void {
+  if (bytes.length !== length) {
+    throw new Error(`${field} must be ${length} bytes`);
+  }
+}
+
+function normalizeArgon2idParams(params?: Partial<Argon2idParams>): Argon2idParams {
+  const normalized = { ...DEFAULT_ARGON2ID, ...params };
+  if (!Number.isInteger(normalized.iterations) || normalized.iterations < 1 || normalized.iterations > 10) {
+    throw new Error('argon2id iterations out of bounds');
+  }
+  if (!Number.isInteger(normalized.memorySize) || normalized.memorySize < 8 || normalized.memorySize > 256 * 1024) {
+    throw new Error('argon2id memorySize out of bounds');
+  }
+  if (!Number.isInteger(normalized.parallelism) || normalized.parallelism < 1 || normalized.parallelism > 8) {
+    throw new Error('argon2id parallelism out of bounds');
+  }
+  return normalized;
+}
+
+function validateScryptParams(n: number, r: number, p: number): void {
+  if (!Number.isInteger(n) || n < 2 || (n & (n - 1)) !== 0 || n > 2 ** 17) {
+    throw new Error('scrypt N out of bounds');
+  }
+  if (!Number.isInteger(r) || r < 1 || r > 16) {
+    throw new Error('scrypt r out of bounds');
+  }
+  if (!Number.isInteger(p) || p < 1 || p > 16) {
+    throw new Error('scrypt p out of bounds');
+  }
+}
+
+async function aesgcmEncrypt(key: BytesLike, nonce: BytesLike, data: BytesLike): Promise<Uint8Array> {
+  const cryptoKey = await crypto.subtle.importKey('raw', toArrayBuffer(key), 'AES-GCM', false, ['encrypt']);
+  const ct = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: toArrayBuffer(nonce) },
+    cryptoKey,
+    toArrayBuffer(data),
+  );
+  return new Uint8Array(ct);
+}
+
+async function aesgcmDecrypt(key: BytesLike, nonce: BytesLike, data: BytesLike): Promise<Uint8Array> {
+  const cryptoKey = await crypto.subtle.importKey('raw', toArrayBuffer(key), 'AES-GCM', false, ['decrypt']);
+  const pt = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: toArrayBuffer(nonce) },
+    cryptoKey,
+    toArrayBuffer(data),
+  );
+  return new Uint8Array(pt);
+}
+
+async function hkdfSha256(ikm: BytesLike, salt: BytesLike, info: BytesLike, length: number): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey('raw', toArrayBuffer(ikm), 'HKDF', false, ['deriveBits']);
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: toArrayBuffer(salt),
+      info: toArrayBuffer(info),
+    },
+    key,
+    length * 8,
+  );
+  return new Uint8Array(bits);
+}
+
+async function kekPasswordArgon2id(password: string, salt: BytesLike, params?: Partial<Argon2idParams>): Promise<Uint8Array> {
+  const normalized = normalizeArgon2idParams(params);
+  return (await argon2id({
+    password: utf8(password),
+    salt: toUint8Array(salt),
+    iterations: normalized.iterations,
+    memorySize: normalized.memorySize,
+    parallelism: normalized.parallelism,
+    hashLength: KEY_BYTES,
+    outputType: 'binary',
+  })) as Uint8Array;
+}
+
+async function kekPasswordScrypt(password: string, salt: BytesLike, n: number, r: number, p: number): Promise<Uint8Array> {
+  validateScryptParams(n, r, p);
+  return (await scrypt({
+    password: utf8(password),
+    salt: toUint8Array(salt),
+    costFactor: n,
+    blockSize: r,
+    parallelism: p,
+    hashLength: KEY_BYTES,
+    outputType: 'binary',
+  })) as Uint8Array;
+}
+
+export async function derivePasskeyKek(prfOutput: BytesLike, prfSalt: BytesLike): Promise<Uint8Array> {
+  const output = toUint8Array(prfOutput, 'passkey PRF output');
+  const salt = toUint8Array(prfSalt, 'passkey PRF salt');
+  assertLength(output, KEY_BYTES, 'passkey PRF output');
+  assertLength(salt, PASSKEY_PRF_SALT_BYTES, 'passkey PRF salt');
+  return hkdfSha256(output, salt, utf8(PASSKEY_HKDF_INFO), KEY_BYTES);
+}
+
+export function newVmk(): Uint8Array {
+  return randomBytes(KEY_BYTES);
+}
+
+export function newPasskeyPrfSalt(): Uint8Array {
+  return randomBytes(PASSKEY_PRF_SALT_BYTES);
+}
+
+export function webAuthnPrfExtensionInput(prfSalt: BytesLike): WebAuthnPrfExtensionInput {
+  const salt = toUint8Array(prfSalt, 'passkey PRF salt');
+  assertLength(salt, PASSKEY_PRF_SALT_BYTES, 'passkey PRF salt');
+  return { prf: { eval: { first: toArrayBuffer(salt) } } };
+}
+
+function parseWrapMeta(wrapMeta: string | WrapMeta): WrapMeta {
+  const parsed = typeof wrapMeta === 'string' ? JSON.parse(wrapMeta) : wrapMeta;
+  if (parsed?.v !== 1 || !Array.isArray(parsed.copies)) {
+    throw new Error('invalid protected wrap_meta');
+  }
+  return parsed as WrapMeta;
+}
+
+function normalizeWrapFactors(factors: VmkWrapFactor[] | string[]): VmkWrapFactor[] {
+  return factors.map((factor) => (typeof factor === 'string' ? { kind: 'password', password: factor } : factor));
+}
+
+async function passwordCopy(vmk: BytesLike, factor: PasswordWrapFactor): Promise<PasswordArgon2idCopy> {
+  const salt = randomBytes(16);
+  const nonce = randomBytes(NONCE_BYTES);
+  const params = normalizeArgon2idParams(factor.argon2id);
+  const kek = await kekPasswordArgon2id(factor.password, salt, params);
+  try {
+    const wrapped = await aesgcmEncrypt(kek, nonce, toUint8Array(vmk, 'VMK'));
+    return {
+      kind: 'password',
+      kdf: 'argon2id',
+      version: ARGON2_VERSION,
+      iterations: params.iterations,
+      memorySize: params.memorySize,
+      parallelism: params.parallelism,
+      salt: bytesToBase64(salt),
+      nonce: bytesToBase64(nonce),
+      wrapped: bytesToBase64(wrapped),
+    };
+  } finally {
+    kek.fill(0);
+  }
+}
+
+async function passkeyCopy(vmk: BytesLike, factor: PasskeyWrapFactor): Promise<PasskeyPrfCopy> {
+  const prfSalt = toUint8Array(factor.prfSalt, 'passkey PRF salt');
+  assertLength(prfSalt, PASSKEY_PRF_SALT_BYTES, 'passkey PRF salt');
+  const nonce = randomBytes(NONCE_BYTES);
+  const kek = await derivePasskeyKek(factor.prfOutput, prfSalt);
+  try {
+    const wrapped = await aesgcmEncrypt(kek, nonce, toUint8Array(vmk, 'VMK'));
+    return {
+      kind: 'passkey',
+      kdf: 'webauthn-prf-hkdf-sha256',
+      prf_salt: bytesToBase64(prfSalt),
+      nonce: bytesToBase64(nonce),
+      wrapped: bytesToBase64(wrapped),
+      ...(factor.credentialId ? { credential_id: factor.credentialId } : {}),
+    };
+  } finally {
+    kek.fill(0);
+  }
+}
+
+export async function buildWrapMeta(vmk: BytesLike, factors: VmkWrapFactor[] | string[]): Promise<string> {
+  const vmkBytes = toUint8Array(vmk, 'VMK');
+  assertLength(vmkBytes, KEY_BYTES, 'VMK');
+  const normalized = normalizeWrapFactors(factors);
+  if (normalized.length === 0) {
+    throw new Error('at least one protected unlock factor is required');
+  }
+
+  const copies: WrapCopy[] = [];
+  for (const factor of normalized) {
+    copies.push(factor.kind === 'password' ? await passwordCopy(vmkBytes, factor) : await passkeyCopy(vmkBytes, factor));
+  }
+  return JSON.stringify({ v: 1, copies } satisfies WrapMeta);
+}
+
+export async function addPasswordCopy(
+  wrapMeta: string,
+  vmk: BytesLike,
+  password: string,
+  argon2idParams?: Partial<Argon2idParams>,
+): Promise<string> {
+  const meta = parseWrapMeta(wrapMeta);
+  meta.copies.push(await passwordCopy(vmk, { kind: 'password', password, argon2id: argon2idParams }));
+  return JSON.stringify(meta);
+}
+
+export async function addPasskeyCopy(
+  wrapMeta: string,
+  vmk: BytesLike,
+  prfOutput: BytesLike,
+  prfSalt: BytesLike,
+  credentialId?: string,
+): Promise<string> {
+  const meta = parseWrapMeta(wrapMeta);
+  meta.copies.push(await passkeyCopy(vmk, { kind: 'passkey', prfOutput, prfSalt, credentialId }));
+  return JSON.stringify(meta);
+}
+
+async function unwrapPasswordCopy(copy: PasswordArgon2idCopy | PasswordScryptCopy, password: string): Promise<Uint8Array> {
+  const salt = base64ToBytes(copy.salt);
+  const nonce = base64ToBytes(copy.nonce);
+  const wrapped = base64ToBytes(copy.wrapped);
+  const kek =
+    copy.kdf === 'argon2id'
+      ? await kekPasswordArgon2id(password, salt, {
+          iterations: copy.iterations,
+          memorySize: copy.memorySize,
+          parallelism: copy.parallelism,
+        })
+      : await kekPasswordScrypt(password, salt, copy.n, copy.r, copy.p);
+  try {
+    return await aesgcmDecrypt(kek, nonce, wrapped);
+  } finally {
+    kek.fill(0);
+  }
+}
+
+async function unwrapPasskeyCopy(copy: PasskeyPrfCopy, factor: PasskeyUnlockFactor): Promise<Uint8Array> {
+  const prfSalt = base64ToBytes(copy.prf_salt);
+  if (factor.prfSalt && bytesToBase64(factor.prfSalt) !== copy.prf_salt) {
+    throw new Error('passkey PRF salt does not match copy');
+  }
+  const kek = await derivePasskeyKek(factor.prfOutput, prfSalt);
+  try {
+    return await aesgcmDecrypt(kek, base64ToBytes(copy.nonce), base64ToBytes(copy.wrapped));
+  } finally {
+    kek.fill(0);
+  }
+}
+
+export async function unwrapVmk(wrapMeta: string | WrapMeta, factor: VmkUnlockFactor | string): Promise<Uint8Array> {
+  const meta = parseWrapMeta(wrapMeta);
+  const normalized: VmkUnlockFactor = typeof factor === 'string' ? { kind: 'password', password: factor } : factor;
+  for (const copy of meta.copies) {
+    try {
+      if (normalized.kind === 'password' && copy.kind === 'password') {
+        return await unwrapPasswordCopy(copy, normalized.password);
+      }
+      if (normalized.kind === 'passkey' && copy.kind === 'passkey') {
+        return await unwrapPasskeyCopy(copy, normalized);
+      }
+    } catch {
+      // Wrong factor or corrupt copy; try the next independent VMK copy.
+    }
+  }
+  throw new Error('no protected VMK copy could be unwrapped');
+}
+
+export function passkeyPrfSalts(wrapMeta: string | WrapMeta): Uint8Array[] {
+  return parseWrapMeta(wrapMeta)
+    .copies.filter((copy): copy is PasskeyPrfCopy => copy.kind === 'passkey')
+    .map((copy) => base64ToBytes(copy.prf_salt));
+}
+
+export async function sealProtected(value: BytesLike, vmk: BytesLike): Promise<ProtectedSealed> {
+  const vmkBytes = toUint8Array(vmk, 'VMK');
+  assertLength(vmkBytes, KEY_BYTES, 'VMK');
+  const dek = randomBytes(KEY_BYTES);
+  try {
+    const valueNonce = randomBytes(NONCE_BYTES);
+    const ciphertext = await aesgcmEncrypt(dek, valueNonce, toUint8Array(value, 'value'));
+    const dekNonce = randomBytes(NONCE_BYTES);
+    const wrappedDek = await aesgcmEncrypt(vmkBytes, dekNonce, dek);
+    return {
+      ciphertext: bytesToBase64(ciphertext),
+      nonce: bytesToBase64(valueNonce),
+      dek_nonce: bytesToBase64(dekNonce),
+      wrapped_dek: bytesToBase64(wrappedDek),
+    };
+  } finally {
+    dek.fill(0);
+  }
+}
+
+export async function unwrapProtectedDek(sealed: ProtectedSealed, vmk: BytesLike): Promise<Uint8Array> {
+  const vmkBytes = toUint8Array(vmk, 'VMK');
+  assertLength(vmkBytes, KEY_BYTES, 'VMK');
+  return aesgcmDecrypt(vmkBytes, base64ToBytes(sealed.dek_nonce), base64ToBytes(sealed.wrapped_dek));
+}
+
+export async function openProtected(sealed: ProtectedSealed, vmk: BytesLike): Promise<Uint8Array> {
+  const dek = await unwrapProtectedDek(sealed, vmk);
+  try {
+    return await aesgcmDecrypt(dek, base64ToBytes(sealed.nonce), base64ToBytes(sealed.ciphertext));
+  } finally {
+    dek.fill(0);
+  }
+}
+
+export async function releaseProtectedDek(sealed: ProtectedSealed, vmk: BytesLike, publicKey: AvaultPublicKey | string): Promise<BlindBox> {
+  const dek = await unwrapProtectedDek(sealed, vmk);
+  try {
+    return await sealBlindBox(dek, publicKey);
+  } finally {
+    dek.fill(0);
+  }
+}
+
+function hpkeSuite(): CipherSuite {
+  return new CipherSuite({
+    kem: new DhkemX25519HkdfSha256(),
+    kdf: new HkdfSha256(),
+    aead: new Aes256Gcm(),
+  });
+}
+
+function publicKeyBytes(publicKey: AvaultPublicKey | string): Uint8Array {
+  return base64ToBytes(typeof publicKey === 'string' ? publicKey : publicKey.public_key);
+}
+
+export async function avaultPublicKeyFingerprint(publicKey: AvaultPublicKey | string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', toArrayBuffer(publicKeyBytes(publicKey)));
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export async function sealBlindBox(plaintext: BytesLike | string, publicKey: AvaultPublicKey | string): Promise<BlindBox> {
+  const suite = hpkeSuite();
+  const publicKeyRaw = publicKeyBytes(publicKey);
+  assertLength(publicKeyRaw, KEY_BYTES, 'avault public key');
+  if (typeof publicKey !== 'string' && publicKey.fingerprint) {
+    const actual = await avaultPublicKeyFingerprint(publicKey);
+    if (actual !== publicKey.fingerprint.toLowerCase()) {
+      throw new Error('avault public key fingerprint mismatch');
+    }
+  }
+
+  const recipientPublicKey = await suite.kem.deserializePublicKey(publicKeyRaw);
+  const pt = typeof plaintext === 'string' ? utf8(plaintext) : toUint8Array(plaintext, 'plaintext');
+  const sealed = await suite.seal(
+    { recipientPublicKey, info: utf8(BLIND_BOX_HPKE_INFO) },
+    pt,
+    utf8(BLIND_BOX_SCHEME),
+  );
+  return {
+    scheme: BLIND_BOX_SCHEME,
+    enc: bytesToBase64(new Uint8Array(sealed.enc)),
+    ct: bytesToBase64(new Uint8Array(sealed.ct)),
+  };
+}
+
+function normalizeDigest(digest: BytesLike | string): Uint8Array {
+  const bytes = typeof digest === 'string' ? hexToBytes(digest) : toUint8Array(digest, 'digest');
+  assertLength(bytes, KEY_BYTES, 'digest');
+  return bytes;
+}
+
+function normalizePrivateKey(privateKey: BytesLike | string): Uint8Array {
+  const bytes = typeof privateKey === 'string' ? hexToBytes(privateKey) : toUint8Array(privateKey, 'private key');
+  assertLength(bytes, KEY_BYTES, 'private key');
+  if (!secp256k1.utils.isValidSecretKey(bytes)) {
+    throw new Error('invalid secp256k1 private key');
+  }
+  return bytes;
+}
+
+function normalizeHexOrBytes(value: HexOrBytes, field: string): Uint8Array {
+  return typeof value === 'string' ? hexToBytes(value) : toUint8Array(value, field);
+}
+
+export function signDigest(
+  privateKey: HexOrBytes,
+  digest: HexOrBytes,
+  scheme: SignatureScheme,
+  options: SignDigestOptions = {},
+): SignatureResult {
+  const key = normalizePrivateKey(privateKey);
+  const msg = normalizeDigest(digest);
+  if (scheme === SIGN_SCHEME_ECDSA_SECP256K1_RECOVERABLE) {
+    const recovered = secp256k1.sign(msg, key, { prehash: false, lowS: true, format: 'recovered' });
+    return {
+      scheme,
+      signature: bytesToHex(recovered.slice(1)),
+      recovery_id: recovered[0] ?? null,
+    };
+  }
+  if (scheme === SIGN_SCHEME_ECDSA_SECP256K1_DER) {
+    return {
+      scheme,
+      signature: bytesToHex(secp256k1.sign(msg, key, { prehash: false, lowS: true, format: 'der' })),
+      recovery_id: null,
+    };
+  }
+  if (scheme === SIGN_SCHEME_SCHNORR_SECP256K1_BIP340) {
+    const aux = options.schnorrAuxRand
+      ? normalizeHexOrBytes(options.schnorrAuxRand, 'schnorr aux randomness')
+      : undefined;
+    if (aux) {
+      assertLength(aux, KEY_BYTES, 'schnorr aux randomness');
+    }
+    return {
+      scheme,
+      signature: bytesToHex(schnorr.sign(msg, key, aux)),
+      recovery_id: null,
+    };
+  }
+  throw new Error('unsupported signing scheme');
+}
+
+export async function signProtectedDigest(
+  sealedKey: ProtectedSealed,
+  vmk: BytesLike,
+  digest: BytesLike | string,
+  scheme: SignatureScheme,
+  options: SignDigestOptions = {},
+): Promise<SignatureResult> {
+  const privateKey = await openProtected(sealedKey, vmk);
+  try {
+    return signDigest(privateKey, digest, scheme, options);
+  } finally {
+    privateKey.fill(0);
+  }
+}

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -28,5 +28,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- add the browser-side Vaults crypto library for avault Phase A blind-box sealing, protected VMK/DEK wrapping, protected DEK release, and secp256k1 digest signing
- copy the shared avault `p2_core_crypto.json` vector into UI tests and assert byte-exact signing plus HPKE decryptability against the avault contract
- add focused Vitest coverage and the required crypto/runtime dependencies

## Capability
Vaults browser crypto library for avault-compatible blind boxes, protected-tier factor unlock, per-record DEK release, and protected ETH/BTC signing.

Scenario IDs: none; Vaults browser crypto does not currently have a scenario catalog entry.

## Evidence
- Unit: `npm run test:crypto`
- Contract: shared avault `p2_core_crypto.json` vectors for all signing schemes, avault blind-box open vector, and browser-sealed blind-box decryptability
- Scenario: not applicable; no scenario catalog exists for this library-only surface
- Residual manual checks: `npm run build`; targeted eslint on `src/lib/vaultCrypto.ts` and `src/lib/vaultCrypto.test.ts`

## Notes
- This PR intentionally does not add React UI components.
- Full `npm run lint` still fails on pre-existing UI lint debt outside this diff; changed files pass targeted eslint.
