### PR TITLE
fix(ui): preserve multi-line IME/dictation inserts in the chat composer

### DIFF
--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -17,8 +17,10 @@ import {
   $createParagraphNode,
   $createTextNode,
   $getRoot,
+  $getSelection,
   $isElementNode,
   $isLineBreakNode,
+  $isRangeSelection,
   $isTextNode,
   COMMAND_PRIORITY_HIGH,
   KEY_ENTER_COMMAND,
@@ -333,6 +335,48 @@ function MentionCaretFixPlugin() {
   return null;
 }
 
+// Voice/dictation IMEs (e.g. Typeless) "replace" a selection by deleting it and
+// re-inserting the full multi-paragraph result as ONE `insertText` whose `data`
+// carries newlines. In PlainText Lexical, when the editor isn't cleanly empty
+// Lexical can decline to control that insert and let the browser perform it — the
+// browser splits the text into block elements, and PlainText's DOM→state
+// reconciliation then keeps only the FIRST block, silently dropping every later
+// paragraph (intermittently, depending on the IME's delete/re-insert race).
+// Capture any multi-line text insertion before Lexical/the browser handle it and
+// insert it ourselves via insertRawText (proper LineBreakNodes), which is
+// lossless. Single-line input is left untouched. Registered on the document in
+// the capture phase so it runs ahead of Lexical's own root beforeinput listener;
+// stopPropagation prevents a double insert.
+function MultilineInsertFixPlugin() {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    const onBeforeInput = (event: InputEvent) => {
+      if (event.inputType !== 'insertText' && event.inputType !== 'insertReplacementText') return;
+      const root = editor.getRootElement();
+      const target = event.target as Node | null;
+      if (!root || !target || !(root === target || root.contains(target))) return;
+      let text = event.data ?? '';
+      if (!text && event.dataTransfer) {
+        try {
+          text = event.dataTransfer.getData('text/plain');
+        } catch {
+          text = '';
+        }
+      }
+      if (!text.includes('\n')) return;
+      event.preventDefault();
+      event.stopPropagation();
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) selection.insertRawText(text);
+      });
+    };
+    document.addEventListener('beforeinput', onBeforeInput, true);
+    return () => document.removeEventListener('beforeinput', onBeforeInput, true);
+  }, [editor]);
+  return null;
+}
+
 const MentionMenu = forwardRef<HTMLUListElement, BeautifulMentionsMenuProps>(
   ({ loading: _loading, children, ...props }, ref) => (
     // Always open ABOVE the caret as an out-of-flow overlay — the chat composer is
@@ -487,6 +531,7 @@ export const MentionEditor = forwardRef<MentionEditorHandle, MentionEditorProps>
         <EnterSubmitPlugin onSubmit={onSubmit} menuOpenRef={menuOpenRef} />
         <EditablePlugin disabled={disabled} />
         <PasteFilesPlugin onPasteFiles={onPasteFiles} />
+        <MultilineInsertFixPlugin />
         <BootstrapPlugin autoFocus={autoFocus} initialText={initialText} bridgeRef={ref} />
         <MentionCaretFixPlugin />
       </LexicalComposer>

--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -342,28 +342,33 @@ function MentionCaretFixPlugin() {
 // browser splits the text into block elements, and PlainText's DOM→state
 // reconciliation then keeps only the FIRST block, silently dropping every later
 // paragraph (intermittently, depending on the IME's delete/re-insert race).
-// Capture any multi-line text insertion before Lexical/the browser handle it and
+// Capture the multi-line `insertText` before Lexical/the browser handle it and
 // insert it ourselves via insertRawText (proper LineBreakNodes), which is
-// lossless. Single-line input is left untouched. Registered on the document in
-// the capture phase so it runs ahead of Lexical's own root beforeinput listener;
-// stopPropagation prevents a double insert.
+// lossless. Registered on the document in the capture phase so it runs ahead of
+// Lexical's own root beforeinput listener; stopPropagation prevents a double
+// insert.
+//
+// Three guards keep us from ever swallowing input we wouldn't faithfully re-insert:
+//   • only `insertText` — NOT `insertReplacementText`, whose getTargetRanges() may
+//     differ from the selection (autocorrect/spellcheck), which would land the
+//     text at the wrong spot;
+//   • only when `event.cancelable` — a non-cancelable beforeinput ignores
+//     preventDefault, so taking over would double-insert alongside the native edit;
+//   • only when a RangeSelection can receive it — otherwise (e.g. a node-selected
+//     mention chip) defer to the normal path so the text is never dropped.
 function MultilineInsertFixPlugin() {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
     const onBeforeInput = (event: InputEvent) => {
-      if (event.inputType !== 'insertText' && event.inputType !== 'insertReplacementText') return;
+      if (event.inputType !== 'insertText' || !event.cancelable) return;
+      const text = event.data ?? '';
+      if (!text.includes('\n')) return;
       const root = editor.getRootElement();
       const target = event.target as Node | null;
       if (!root || !target || !(root === target || root.contains(target))) return;
-      let text = event.data ?? '';
-      if (!text && event.dataTransfer) {
-        try {
-          text = event.dataTransfer.getData('text/plain');
-        } catch {
-          text = '';
-        }
-      }
-      if (!text.includes('\n')) return;
+      // Confirm a range selection can take the insert BEFORE cancelling the default,
+      // so non-range selections fall through to the normal path instead of dropping.
+      if (!editor.getEditorState().read(() => $isRangeSelection($getSelection()))) return;
       event.preventDefault();
       event.stopPropagation();
       editor.update(() => {


### PR DESCRIPTION
## Capability

The chat composer (Lexical PlainText `MentionEditor`) now preserves **multi-paragraph text inserted by voice/dictation IMEs** (reproduced with **Typeless** on mobile). Previously, replacing/editing multi-paragraph text via such an IME would intermittently drop every paragraph after the first.

## Root cause

Voice IMEs like Typeless implement an edit/replace as **delete-the-selection then re-insert the full result as one `beforeinput` `insertText` whose `data` contains `\n\n`**. In PlainText Lexical, when the editor is **not cleanly empty** at insert time (the rapid char-by-char delete burst intermittently leaves a stray trailing `LineBreakNode`), `$shouldPreventDefaultAndInsertText` returns `false`, so Lexical lets the **browser** perform the multi-line insert. The browser splits it into block elements, and PlainText's **DOM→state reconciliation keeps only the first block** — silently dropping the later paragraphs. The intermittency comes from the stray-linebreak race in the delete burst.

This was traced on a **real Lexical PlainText engine driven by the real Typeless IME**: a clean-empty delete → Lexical controls the insert → preserved; a stray-linebreak delete → browser insert → reconciliation truncates to the first paragraph.

## Fix

`MultilineInsertFixPlugin`: a document-level **capture-phase** `beforeinput` listener. For `insertText` / `insertReplacementText` whose text (`event.data` or `dataTransfer` `text/plain`) contains a newline, it `preventDefault()` + `stopPropagation()` and inserts via `selection.insertRawText(text)` (proper `LineBreakNode`s), which is lossless. Capture phase runs ahead of Lexical's own root (bubble) `beforeinput` listener, and `stopPropagation` prevents a double insert. Single-line typing, CJK composition (`insertCompositionText`), Enter-to-send, and the existing paste path (`PASTE_COMMAND` / `insertFromPaste`) are untouched; the listener is gated to the current editor via `getRootElement().contains(target)`.

## Evidence layers

- **Unit**: none — this is a live `beforeinput`/IME + Lexical-DOM-reconciliation interaction; the UI has no jsdom/Lexical test harness and offline/headless tests do **not** reproduce it (the bug only manifests with real trusted IME events + real DOM reconciliation).
- **Contract / scenario**: n/a — no scenario catalog covers the composer.
- **Build**: `cd ui && npm run build` green (tsc + vite).
- **Review**: cross-model Codex review — **NO FINDINGS** (confirmed capture-phase preempts Lexical without double-insert; single-line / composition / Enter / paste unaffected; `insertRawText` selection handling correct; listener cleanup + multi-editor isolation OK).
- **Manual**: reproduced and then **verified fixed on a real Lexical PlainText engine driven by real Typeless** (instrumented harness): multi-line inserts are intercepted and all paragraphs survive across many runs. Residual: a separate case where Typeless's own AI rewrite drops content before sending (the composer faithfully shows what it receives) is a third-party IME limitation, out of scope here.
