### PR TITLE
feat(vaults-ui): align Vaults page to approved design (tier/signing badges + grouped view)

### DIFF
--- a/ui/src/components/ui/combobox.tsx
+++ b/ui/src/components/ui/combobox.tsx
@@ -31,6 +31,9 @@ interface ComboboxProps {
   emptyText?: string
   allowCustomValue?: boolean
   className?: string
+  commitOnClose?: boolean
+  createLabel?: (value: string) => string
+  createHeading?: string
 }
 
 export function Combobox({
@@ -42,6 +45,9 @@ export function Combobox({
   emptyText = "No results found.",
   allowCustomValue = true,
   className,
+  commitOnClose = false,
+  createLabel,
+  createHeading,
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false)
   const [inputValue, setInputValue] = React.useState("")
@@ -69,9 +75,9 @@ export function Combobox({
     <Popover
       open={open}
       onOpenChange={(next) => {
-        if (!next) {
-          // Commit a typed custom value on close so it isn't lost if the user
-          // tabs/clicks away without picking the "Use ..." item.
+        // Only opt-in consumers (commitOnClose) commit a typed custom value on
+        // close; default keeps every other combobox's behavior unchanged.
+        if (!next && commitOnClose) {
           if (allowCustomValue && inputValue && inputValue !== value) onValueChange(inputValue)
           setInputValue("")
         }
@@ -122,7 +128,7 @@ export function Combobox({
                       value === inputValue ? "opacity-100" : "opacity-0"
                     )}
                   />
-                  Use "{inputValue}"
+                  {createLabel ? createLabel(inputValue) : `Use "${inputValue}"`}
                 </CommandItem>
               </CommandGroup>
             )}
@@ -151,7 +157,7 @@ export function Combobox({
             )}
             {/* Show custom value option if input doesn't match existing options */}
             {allowCustomValue && inputValue && !inputMatchesOption && filteredOptions.length > 0 && (
-              <CommandGroup heading="Custom">
+              <CommandGroup heading={createHeading ?? "Custom"}>
                 <CommandItem
                   value={`custom-${inputValue}`}
                   onSelect={() => {
@@ -166,7 +172,7 @@ export function Combobox({
                       value === inputValue ? "opacity-100" : "opacity-0"
                     )}
                   />
-                  Use "{inputValue}"
+                  {createLabel ? createLabel(inputValue) : `Use "${inputValue}"`}
                 </CommandItem>
               </CommandGroup>
             )}

--- a/ui/src/components/ui/combobox.tsx
+++ b/ui/src/components/ui/combobox.tsx
@@ -66,7 +66,18 @@ export function Combobox({
   )
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          // Commit a typed custom value on close so it isn't lost if the user
+          // tabs/clicks away without picking the "Use ..." item.
+          if (allowCustomValue && inputValue && inputValue !== value) onValueChange(inputValue)
+          setInputValue("")
+        }
+        setOpen(next)
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -7,6 +7,7 @@ import { ApiError, useApi, type DependencyItem } from '@/context/ApiContext';
 import { cn } from '@/lib/utils';
 import { sealBlindBox, standardCreateBlindBoxContext } from '@/lib/vaultCrypto';
 import { Button } from './button';
+import { Combobox } from './combobox';
 import { Input } from './input';
 
 const AVAULT_P2_MIN_VERSION = '0.1.3';
@@ -49,6 +50,7 @@ export const VaultSecretForm: React.FC<{
   className?: string;
   defaultProtection?: VaultProtection;
   treatExistingAsFulfilled?: boolean;
+  groups?: string[];
 }> = ({
   fixedName,
   onCancel,
@@ -56,6 +58,7 @@ export const VaultSecretForm: React.FC<{
   className,
   defaultProtection = 'standard',
   treatExistingAsFulfilled = false,
+  groups = [],
 }) => {
   const { t } = useTranslation();
   const api = useApi();
@@ -199,7 +202,14 @@ export const VaultSecretForm: React.FC<{
       </label>
       <label className="flex flex-col gap-1.5 text-sm font-medium">
         {t('vaults.dialog.group')}
-        <Input value={group} onChange={(event) => setGroup(event.target.value)} />
+        <Combobox
+          options={groups.map((g) => ({ value: g, label: g }))}
+          value={group}
+          onValueChange={setGroup}
+          allowCustomValue
+          placeholder={t('vaults.dialog.groupPlaceholder')}
+          searchPlaceholder={t('vaults.dialog.groupSearch')}
+        />
       </label>
       <label className="flex flex-col gap-1.5 text-sm font-medium">
         {t('vaults.dialog.description')}

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { FormEvent } from 'react';
-import { Eye, EyeOff, Loader2 } from 'lucide-react';
+import { Eye, EyeOff, Loader2, Server, ShieldCheck } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { ApiError, useApi, type DependencyItem } from '@/context/ApiContext';
@@ -212,24 +212,34 @@ export const VaultSecretForm: React.FC<{
       </label>
       <div className="flex flex-col gap-1.5 text-sm font-medium">
         <span>{t('vaults.dialog.protection')}</span>
-        <div className="grid grid-cols-2 rounded-lg border border-border bg-surface-2 p-1">
-          {(['protected', 'standard'] as const).map((option) => (
-            <Button
-              key={option}
-              type="button"
-              variant={protection === option ? 'secondary' : 'ghost'}
-              size="sm"
-              className="h-auto whitespace-normal px-3 py-2 text-left"
-              aria-pressed={protection === option}
-              onClick={() => setProtection(option)}
-            >
-              {option === 'protected' ? t('vaults.dialog.protectedProtection') : t('vaults.dialog.standardProtection')}
-            </Button>
-          ))}
+        <div className="grid grid-cols-2 gap-2.5">
+          {(
+            [
+              { key: 'standard', icon: Server, title: t('vaults.dialog.standardProtection'), desc: t('vaults.dialog.standardHelp') },
+              { key: 'protected', icon: ShieldCheck, title: t('vaults.dialog.protectedProtection'), desc: t('vaults.dialog.protectedHelp') },
+            ] as const
+          ).map(({ key, icon: Icon, title, desc }) => {
+            const selected = protection === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => setProtection(key)}
+                className={cn(
+                  'flex flex-col gap-1.5 rounded-lg border p-3 text-left transition-colors',
+                  selected ? 'border-mint bg-mint-soft' : 'border-border bg-surface hover:bg-surface-2',
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <Icon className={cn('size-4', selected ? 'text-mint' : 'text-muted')} />
+                  <span className="text-sm font-semibold text-foreground">{title}</span>
+                </span>
+                <span className="text-xs font-normal text-muted-foreground">{desc}</span>
+              </button>
+            );
+          })}
         </div>
-        <span className="text-xs text-muted-foreground">
-          {protection === 'protected' ? t('vaults.dialog.protectedHelp') : t('vaults.dialog.standardHelp')}
-        </span>
       </div>
       {protection === 'protected' && (
         <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-sm text-warning">

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -207,6 +207,9 @@ export const VaultSecretForm: React.FC<{
           value={group}
           onValueChange={setGroup}
           allowCustomValue
+          commitOnClose
+          createLabel={(v) => t('vaults.dialog.groupCreate', { name: v })}
+          createHeading={t('vaults.dialog.groupCreateHeading')}
           placeholder={t('vaults.dialog.groupPlaceholder')}
           searchPlaceholder={t('vaults.dialog.groupSearch')}
         />

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { History, KeyRound, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { History, KeyRound, Loader2, Plus, RefreshCw, Trash2, Wallet } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { CapabilityTabs } from './CapabilityTabs';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
@@ -33,6 +33,56 @@ const AddSecretDialog: React.FC<{
   );
 };
 
+type ViewMode = 'all' | 'group';
+
+const hasProxy = (s: VaultSecret): boolean => {
+  const hosts = (s.policy as { allowed_hosts?: string[] })?.allowed_hosts;
+  return Array.isArray(hosts) && hosts.length > 0;
+};
+
+const SecretRow: React.FC<{ secret: VaultSecret; onDelete: (name: string) => void }> = ({ secret: s, onDelete }) => {
+  const { t } = useTranslation();
+  const isKeypair = s.kind === 'keypair';
+  const isProtected = s.protection === 'protected';
+  return (
+    <div className="flex items-center gap-3.5 rounded-xl border border-border bg-surface px-4 py-3">
+      <div
+        className={`flex size-9 shrink-0 items-center justify-center rounded-lg ${
+          isKeypair ? 'bg-violet/10 text-violet' : 'bg-accent/10 text-accent'
+        }`}
+      >
+        {isKeypair ? <Wallet className="size-4" /> : <KeyRound className="size-4" />}
+      </div>
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="truncate font-mono text-sm font-semibold">{s.name}</span>
+          {isProtected ? (
+            <Badge variant="warning">{t('vaults.protected')}</Badge>
+          ) : (
+            <Badge variant="secondary">{t('vaults.standard')}</Badge>
+          )}
+          {isKeypair ? (
+            <Badge variant="outline">
+              <Wallet className="size-3" />
+              {t('vaults.signing')}
+            </Badge>
+          ) : null}
+          {hasProxy(s) ? <Badge variant="info">{t('vaults.proxyBound')}</Badge> : null}
+        </div>
+        <span className="truncate text-xs text-muted">
+          {s.description ? `${s.description} · ` : ''}
+          {s.last_used_at ? t('vaults.used', { count: s.use_count }) : t('vaults.neverUsed')}
+        </span>
+      </div>
+      <div className="ml-auto">
+        <Button variant="ghost" size="icon" onClick={() => onDelete(s.name)} aria-label={t('vaults.delete')}>
+          <Trash2 className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
 export const VaultsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
@@ -43,6 +93,7 @@ export const VaultsPage: React.FC = () => {
   const [adding, setAdding] = useState(false);
   const [showAudit, setShowAudit] = useState(false);
   const [audit, setAudit] = useState<VaultAuditEvent[]>([]);
+  const [view, setView] = useState<ViewMode>('all');
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -60,6 +111,15 @@ export const VaultsPage: React.FC = () => {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  const groups = useMemo(() => {
+    const byGroup = new Map<string, VaultSecret[]>();
+    for (const s of secrets) {
+      const key = s.group || 'default';
+      (byGroup.get(key) ?? byGroup.set(key, []).get(key)!).push(s);
+    }
+    return [...byGroup.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [secrets]);
 
   const toggleAudit = useCallback(async () => {
     const next = !showAudit;
@@ -110,6 +170,16 @@ export const VaultsPage: React.FC = () => {
       {error && (
         <div className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>
       )}
+      {secrets.length > 0 ? (
+        <div className="flex items-center gap-1 self-start rounded-lg border border-border bg-surface p-1">
+          <Button variant={view === 'all' ? 'secondary' : 'ghost'} size="sm" onClick={() => setView('all')}>
+            {t('vaults.view.all')}
+          </Button>
+          <Button variant={view === 'group' ? 'secondary' : 'ghost'} size="sm" onClick={() => setView('group')}>
+            {t('vaults.view.byGroup')}
+          </Button>
+        </div>
+      ) : null}
       {loading && secrets.length === 0 ? (
         <div className="flex items-center gap-2 px-1 text-sm text-muted">
           <Loader2 className="size-4 animate-spin" />
@@ -117,32 +187,24 @@ export const VaultsPage: React.FC = () => {
         </div>
       ) : secrets.length === 0 ? (
         <div className="rounded-2xl border border-border bg-surface p-8 text-center text-sm text-muted">{t('vaults.empty')}</div>
+      ) : view === 'group' ? (
+        <div className="flex flex-col gap-4">
+          {groups.map(([group, items]) => (
+            <div key={group} className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 px-1 text-xs font-semibold text-muted">
+                <span>{group}</span>
+                <span className="font-normal">{t('vaults.secretCount', { count: items.length })}</span>
+              </div>
+              {items.map((s) => (
+                <SecretRow key={s.name} secret={s} onDelete={onDelete} />
+              ))}
+            </div>
+          ))}
+        </div>
       ) : (
         <div className="flex flex-col gap-2">
           {secrets.map((s) => (
-            <div key={s.name} className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3">
-              <KeyRound className="size-4 shrink-0 text-muted" />
-              <div className="flex min-w-0 flex-col">
-                <div className="flex items-center gap-2">
-                  <span className="truncate font-mono text-sm font-semibold">{s.name}</span>
-                  <Badge variant="secondary">{s.group}</Badge>
-                  {s.protection === 'protected' && <Badge variant="warning">{t('vaults.protected')}</Badge>}
-                  {Array.isArray((s.policy as { allowed_hosts?: string[] })?.allowed_hosts) &&
-                  ((s.policy as { allowed_hosts?: string[] }).allowed_hosts?.length ?? 0) > 0 ? (
-                    <Badge variant="info">{t('vaults.proxyBound')}</Badge>
-                  ) : null}
-                </div>
-                <span className="truncate text-xs text-muted">
-                  {s.description ? `${s.description} · ` : ''}
-                  {s.last_used_at ? t('vaults.used', { count: s.use_count }) : t('vaults.neverUsed')}
-                </span>
-              </div>
-              <div className="ml-auto">
-                <Button variant="ghost" size="icon" onClick={() => onDelete(s.name)} aria-label={t('vaults.delete')}>
-                  <Trash2 className="size-4" />
-                </Button>
-              </div>
-            </div>
+            <SecretRow key={s.name} secret={s} onDelete={onDelete} />
           ))}
         </div>
       )}

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -63,7 +63,7 @@ const SecretRow: React.FC<{ secret: VaultSecret; onDelete: (name: string) => voi
             <Badge variant="secondary">{t('vaults.standard')}</Badge>
           )}
           {isKeypair ? (
-            <Badge variant="outline">
+            <Badge variant="outline" className="border-violet/40 bg-violet-soft text-violet">
               <Wallet className="size-3" />
               {t('vaults.signing')}
             </Badge>

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -13,7 +13,8 @@ import { VaultSecretForm } from '../ui/vault-secret-form';
 const AddSecretDialog: React.FC<{
   onClose: () => void;
   onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
-}> = ({ onClose, onCreated }) => {
+  groups: string[];
+}> = ({ onClose, onCreated, groups }) => {
   const { t } = useTranslation();
 
   return (
@@ -27,7 +28,7 @@ const AddSecretDialog: React.FC<{
         <DialogHeader>
           <DialogTitle>{t('vaults.dialog.title')}</DialogTitle>
         </DialogHeader>
-        <VaultSecretForm onCancel={onClose} onCreated={onCreated} />
+        <VaultSecretForm onCancel={onClose} onCreated={onCreated} groups={groups} />
       </DialogContent>
     </Dialog>
   );
@@ -228,6 +229,7 @@ export const VaultsPage: React.FC = () => {
       )}
       {adding && (
         <AddSecretDialog
+          groups={groups.map(([g]) => g)}
           onClose={() => setAdding(false)}
           onCreated={(name, reason) => {
             if (reason === 'already_exists') return;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2087,6 +2087,8 @@
       "p2UnavailableStandardFallback": "Browser-side sealing requires avault {{version}} or newer. Installed: {{installed}}. Standard secrets can still be saved through the local avault seal fallback.",
       "browserSealingPending": "Browser-side sealing requires a compatible avault release. This UI never sends plaintext values to Python.",
       "group": "Group",
+      "groupPlaceholder": "Pick or create a group",
+      "groupSearch": "Search or type a new group",
       "description": "Description",
       "allowHosts": "Allowed hosts (for vault fetch)",
       "allowHostsHelp": "Comma-separated. Required to use this secret via the brokered HTTP proxy; '.example.com' matches subdomains.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2064,6 +2064,13 @@
     "proxyBound": "Proxy-bound",
     "used": "used {{count}}×",
     "neverUsed": "never used",
+    "standard": "Standard",
+    "signing": "Signing",
+    "secretCount": "{{count}} secrets",
+    "view": {
+      "all": "All",
+      "byGroup": "By group"
+    },
     "delete": "Delete",
     "deleteConfirm": "Delete secret \"{{name}}\"? Agents will no longer be able to use it.",
     "deleted": "Deleted {{name}}",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2089,6 +2089,8 @@
       "group": "Group",
       "groupPlaceholder": "Pick or create a group",
       "groupSearch": "Search or type a new group",
+      "groupCreate": "Use \"{{name}}\"",
+      "groupCreateHeading": "New group",
       "description": "Description",
       "allowHosts": "Allowed hosts (for vault fetch)",
       "allowHostsHelp": "Comma-separated. Required to use this secret via the brokered HTTP proxy; '.example.com' matches subdomains.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2088,6 +2088,8 @@
       "group": "分组",
       "groupPlaceholder": "选择或新建分组",
       "groupSearch": "搜索或输入新分组",
+      "groupCreate": "使用「{{name}}」",
+      "groupCreateHeading": "新建分组",
       "description": "描述",
       "allowHosts": "允许的域名（用于 vault fetch）",
       "allowHostsHelp": "逗号分隔。通过认证代理使用该密钥时必填；'.example.com' 匹配子域。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2086,6 +2086,8 @@
       "p2UnavailableStandardFallback": "浏览器侧封装需要 avault {{version}} 或更新版本。当前安装：{{installed}}。标准密钥仍可通过本机 avault seal fallback 保存。",
       "browserSealingPending": "浏览器侧封箱需要兼容的 avault 发布版。这个 UI 永远不会把明文值发送给 Python。",
       "group": "分组",
+      "groupPlaceholder": "选择或新建分组",
+      "groupSearch": "搜索或输入新分组",
       "description": "描述",
       "allowHosts": "允许的域名（用于 vault fetch）",
       "allowHostsHelp": "逗号分隔。通过认证代理使用该密钥时必填；'.example.com' 匹配子域。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2063,6 +2063,13 @@
     "proxyBound": "已绑定代理",
     "used": "已使用 {{count}} 次",
     "neverUsed": "从未使用",
+    "standard": "标准档",
+    "signing": "签名",
+    "secretCount": "{{count}} 个密钥",
+    "view": {
+      "all": "全部",
+      "byGroup": "按分组"
+    },
     "delete": "删除",
     "deleteConfirm": "删除密钥「{{name}}」？Agent 将无法再使用它。",
     "deleted": "已删除 {{name}}",


### PR DESCRIPTION
Aligns the Vaults list page to the approved design.pen hub frame — the frontend-only parts that don't depend on backend work still in flight.

**Capability**: richer Vaults list matching the design.
- tier badge always shown (Standard / Protected), not just Protected
- signing badge for `kind=keypair` (violet, Wallet icon)
- proxy-bound badge retained
- per-row icon coloured by kind (static=accent, keypair=violet) in a soft chip
- All / By group view toggle with grouped rendering
- no value-derived data shown (preview already removed in #670)

**Out of scope (follow-ups)**: active-grants section, pending-requests inbox, chain (ETH/BTC) badge — these need backend APIs from the resident-agent follow-on (#677) + a small masked-payload addition (surface keypair algo/chain). Approval card / protected unlock+setup are separate components, also gated on #677.

**Evidence**: unit n/a (presentational); `cd ui && npm run build` passes; i18n en+zh added; manual: list renders with badges + group toggle. Reuses existing ui primitives (Badge variants, Button) + design tokens (violet/accent/cyan via @theme).