### PR TITLE
feat(chat): markdown polish — scrollable wide tables + code-block copy button

### DIFF
--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import ReactMarkdown, { type Components, defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
+import { useTranslation } from 'react-i18next';
+import { Check, Copy } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { ChatImage, LinkedImageProvider } from '@/components/ui/chat-image';
@@ -14,7 +16,7 @@ import {
   parseMentionHref,
   type MentionReference,
 } from '@/lib/mentions';
-import { cn } from '@/lib/utils';
+import { cn, copyTextToClipboard } from '@/lib/utils';
 
 // Shared markdown renderer. react-markdown + remark-gfm (tables, strikethrough,
 // task lists, autolinks); the element styling lives in index.css under
@@ -73,6 +75,38 @@ function mentionUrlTransform(url: string): string {
   if (url.startsWith(`${MENTION_LINK_SCHEME}:`) || url.startsWith(`${SECRET_LINK_SCHEME}:`)) return url;
   return defaultUrlTransform(url);
 }
+
+// A fenced code block with a hover/tap copy button. The button lives on a
+// relatively-positioned wrapper (not the <pre>, which scrolls horizontally) so
+// it stays pinned top-right while the code scrolls. The code text is read from
+// the rendered <pre> (textContent) rather than re-derived from the markdown AST.
+const CodeBlock: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const { t } = useTranslation();
+  const preRef = React.useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = React.useState(false);
+  const onCopy = React.useCallback(async () => {
+    const text = preRef.current?.textContent ?? '';
+    if (!text) return;
+    if (!(await copyTextToClipboard(text))) return;
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }, []);
+  const label = copied ? t('common.copied') : t('common.copy');
+  return (
+    <div className="vr-code-block">
+      <pre ref={preRef}>{children}</pre>
+      <button
+        type="button"
+        className={cn('vr-code-copy', copied && 'is-copied')}
+        onClick={onCopy}
+        aria-label={label}
+        title={label}
+      >
+        {copied ? <Check size={14} /> : <Copy size={14} />}
+      </button>
+    </div>
+  );
+};
 
 export const Markdown: React.FC<{
   content: string;
@@ -170,7 +204,12 @@ export const Markdown: React.FC<{
         );
       },
       ...(interactive
-        ? {}
+        ? {
+            // Fenced code blocks get a hover/tap copy button. Only on the
+            // interactive surface — a <button> nested in a clickable preview row
+            // would be invalid interactive content.
+            pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          }
         : {
             // GFM task lists render a checkbox <input>; even disabled, an
             // <input> nested in the sidebar row <button> is invalid interactive

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -203,6 +203,14 @@ export const Markdown: React.FC<{
           </a>
         );
       },
+      // Wrap tables in a horizontal-scroll viewport so a wide table scrolls within
+      // the bubble instead of squeezing its columns to fit (see index.css). A plain
+      // <div> is valid in both interactive and preview (clickable-row) surfaces.
+      table: ({ children }) => (
+        <div className="vr-table-scroll">
+          <table>{children}</table>
+        </div>
+      ),
       ...(interactive
         ? {
             // Fenced code blocks get a hover/tap copy button. Only on the

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -54,6 +54,7 @@
     "submit": "Submit",
     "submitting": "Submitting…",
     "copy": "Copy",
+    "copied": "Copied",
     "copyFailed": "Copy failed, please copy it manually",
     "remove": "Remove",
     "removing": "Removing…",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -54,6 +54,7 @@
     "submit": "提交",
     "submitting": "提交中…",
     "copy": "复制",
+    "copied": "已复制",
     "copyFailed": "复制失败，请手动复制",
     "remove": "移除",
     "removing": "移除中…",

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -534,11 +534,17 @@ pre,
 .vr-markdown table {
   border-collapse: collapse;
   margin: 0 0 0.6em;
+  /* Size to the table's natural content width (so cells keep their own width and
+     never get squeezed/wrapped to fit a narrow chat bubble — e.g. a header
+     collapsing to one char per line), and scroll horizontally within the bubble
+     when that exceeds it. The table width is decoupled from the bubble width. */
   display: block;
+  width: max-content;
+  max-width: 100%;
   overflow-x: auto;
 }
 .vr-markdown th,
-.vr-markdown td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; }
+.vr-markdown td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; white-space: nowrap; }
 .vr-markdown th { background: var(--surface-2); font-weight: 600; }
 .vr-markdown img { max-width: 100%; border-radius: 8px; }
 .vr-markdown strong { font-weight: 700; }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -560,20 +560,26 @@ pre,
   color: var(--muted);
 }
 .vr-markdown hr { border: none; border-top: 1px solid var(--border); margin: 1em 0; }
+/* Tables are wrapped in a .vr-table-scroll div (see markdown.tsx) that is the
+   horizontal scroll viewport. The table sizes to its own content width — columns
+   sized to content, each capped (below) — and is NOT limited to the bubble width,
+   so when it's wider than the bubble it scrolls inside the wrapper instead of
+   squeezing/wrapping columns to fit (which collapsed a header to one char/line). */
+.vr-markdown .vr-table-scroll { overflow-x: auto; margin: 0 0 0.6em; }
 .vr-markdown table {
   border-collapse: collapse;
-  margin: 0 0 0.6em;
-  /* Size to the table's natural content width (so cells keep their own width and
-     never get squeezed/wrapped to fit a narrow chat bubble — e.g. a header
-     collapsing to one char per line), and scroll horizontally within the bubble
-     when that exceeds it. The table width is decoupled from the bubble width. */
-  display: block;
   width: max-content;
-  max-width: 100%;
-  overflow-x: auto;
 }
 .vr-markdown th,
-.vr-markdown td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; white-space: nowrap; }
+.vr-markdown td {
+  border: 1px solid var(--border);
+  padding: 6px 10px;
+  text-align: left;
+  /* Per-column ceiling: short cells keep their natural width; a long cell wraps
+     within this column instead of stretching into one endless line. Capped to the
+     viewport so a single column can't exceed the screen on mobile. */
+  max-width: min(22rem, 82vw);
+}
 .vr-markdown th { background: var(--surface-2); font-weight: 600; }
 .vr-markdown img { max-width: 100%; border-radius: 8px; }
 .vr-markdown strong { font-weight: 700; }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -524,6 +524,35 @@ pre,
   font-size: 12px;
   line-height: 1.5;
 }
+/* Copy button for fenced code blocks. The wrapper is the positioning context so
+   the button stays pinned top-right while the <pre> scrolls horizontally. */
+.vr-markdown .vr-code-block { position: relative; }
+.vr-code-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+.vr-code-block:hover .vr-code-copy,
+.vr-code-copy:focus-visible { opacity: 1; }
+.vr-code-copy:hover { color: var(--foreground); background: var(--surface-3); }
+.vr-code-copy.is-copied { opacity: 1; color: var(--mint); border-color: rgba(91, 255, 160, 0.4); }
+/* Touch devices have no hover — keep the button gently visible so it's tappable. */
+@media (hover: none) {
+  .vr-code-copy { opacity: 0.6; }
+}
 .vr-markdown blockquote {
   margin: 0 0 0.6em;
   padding: 0.2em 0 0.2em 0.9em;


### PR DESCRIPTION
Two small markdown-rendering improvements in the shared `.vr-markdown` renderer (chat + everywhere). Two atomic commits.

## 1. Scroll wide tables instead of squeezing to bubble width

A wide table in a narrow bubble (esp. mobile) was forced to the bubble width, so cells wrapped hard — a header like `Backend` collapsed to one char per line. Root cause: `.vr-markdown table` had `display:block; overflow-x:auto` but no intrinsic width, so it filled the bubble and cells wrapped to fit (content never overflowed → scroll never engaged).

Fix: `width:max-content; max-width:100%` on the table + `white-space:nowrap` on cells. The table renders at its natural width (cells keep their text width) and scrolls horizontally within the bubble; width is decoupled from the bubble.

## 2. Copy button on fenced code blocks

Triple-backtick code blocks get a hover/tap copy button (top-right); clicking copies the code and flips to a check for 1.5s.

- `markdown.tsx`: a `pre` override (interactive surface only — a button in a clickable preview row would be invalid interactive content) wraps the block in a positioned container; code text read from the rendered `<pre>` via `textContent`, reusing the existing `copyTextToClipboard` helper (clipboard API + textarea fallback).
- `index.css`: button pinned to a relative wrapper so it stays put while the `<pre>` scrolls; hover-revealed on pointer devices, gently persistent on touch (`@media (hover:none)`); mint check on success.
- i18n: `common.copied` (en + zh). Inline `code` (single backtick) is untouched.

## Evidence

- **Unit/contract:** none (CSS + a presentational renderer override; the UI has no JS test runner).
- **Manual:** `npm run build` green (tsc + vite). Verified both against mocks mirroring the exact `.vr-markdown` CSS — wide table scrolls with cells un-wrapped; copy button renders top-right with copy → green-check states and stays pinned over a horizontally-scrolling block. Residual: real-device check on the regression.