### PR TITLE
feat(chat): zoom & pan in the image lightbox

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -42,6 +42,7 @@
         "react-i18next": "^16.5.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.17.0",
+        "react-zoom-pan-pinch": "^4.0.3",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.2.0",
@@ -116,6 +117,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -282,6 +284,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -740,36 +743,12 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.3.tgz",
       "integrity": "sha512-MwEwCAr/o0agJefhC2+reBv5kfOQpMcDRUNQrRYZgWlhH8IwQcerMZrpqWyUFSyO0ebgN2cnh/w87F7G4BGSng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.7.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -779,7 +758,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1319,6 +1297,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.45.0.tgz",
       "integrity": "sha512-LAaceAtcQpVMDvldhkrQC1MSawpj7aAm1CfGg6RbyQgTDDp2fKnP1gDhjQIef3lH8W2fYeXRe66EdzaFkoGHKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "@lexical/devtools-core": "0.45.0",
@@ -1406,6 +1385,7 @@
       "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.45.0.tgz",
       "integrity": "sha512-Fo5MMErqoPlUyTw1qVMZ9kE33ZjJF957KU683tsCrrlaVisVxpboL7BbAnxWTwCcIpAsfc6AUndJJ70M9NDMGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0",
         "@lexical/selection": "0.45.0",
@@ -3131,6 +3111,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3141,6 +3122,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3202,6 +3184,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3659,6 +3642,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3851,6 +3835,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4241,6 +4226,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4797,6 +4783,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -4952,7 +4939,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5064,6 +5050,7 @@
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.45.0.tgz",
       "integrity": "sha512-z2M9C2ILPW7SopQE1aKbOFdZJbe3HvsrgWnJKveMDrSEvVjU9Hce4UpKVsAdkwY7TgY9RDuCV3+sfrGu0WkL+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lexical/internal": "0.45.0"
       }
@@ -5086,7 +5073,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6527,6 +6513,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6554,6 +6541,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -6614,6 +6602,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6623,6 +6612,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6798,6 +6788,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-zoom-pan-pinch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-4.0.3.tgz",
+      "integrity": "sha512-N2Hi6L78fFmhRra+ORpFSW7WST5x6kxpOPplIvtB0b7b+U2anpo1z1wLgaWRPS2kUSqcraRG+JgBCIlDJnqqAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/regex": {
@@ -7266,6 +7270,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7519,6 +7524,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8044,6 +8050,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,6 +49,7 @@
     "react-i18next": "^16.5.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.17.0",
+    "react-zoom-pan-pinch": "^4.0.3",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.2.0",

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -92,7 +92,7 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
           role="dialog"
           aria-modal="true"
         >
-          <div className="absolute right-4 top-4 flex items-center gap-2">
+          <div className="absolute right-4 top-4 z-10 flex items-center gap-2">
             {/* Zoom buttons: a pointer-device affordance (touch zooms by pinch).
                 stopPropagation so clicking a control doesn't also close the viewer. */}
             <Button
@@ -157,7 +157,7 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
                   step(-1);
                 }}
                 aria-label={t('chat.viewer.previous')}
-                className={`absolute left-4 top-1/2 -translate-y-1/2 rounded-full ${OVERLAY_BTN}`}
+                className={`absolute left-4 top-1/2 z-10 -translate-y-1/2 rounded-full ${OVERLAY_BTN}`}
               >
                 <ChevronLeft className="size-5" />
               </Button>
@@ -169,7 +169,7 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
                   step(1);
                 }}
                 aria-label={t('chat.viewer.next')}
-                className={`absolute right-4 top-1/2 -translate-y-1/2 rounded-full ${OVERLAY_BTN}`}
+                className={`absolute right-4 top-1/2 z-10 -translate-y-1/2 rounded-full ${OVERLAY_BTN}`}
               >
                 <ChevronRight className="size-5" />
               </Button>
@@ -191,7 +191,6 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               maxScale={5}
               centerOnInit
               doubleClick={{ mode: 'toggle' }}
-              wheel={{ step: 0.2 }}
             >
               <TransformComponent wrapperStyle={{ maxHeight: '90vh', maxWidth: '90vw', cursor: 'grab' }}>
                 <img
@@ -203,7 +202,7 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
             </TransformWrapper>
           </div>
           {pageable && (
-            <span className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 font-mono text-[11px] text-white">
+            <span className="absolute bottom-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 font-mono text-[11px] text-white">
               {index + 1} / {images.length}
             </span>
           )}

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronLeft, ChevronRight, Download, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Download, X, ZoomIn, ZoomOut } from 'lucide-react';
+import { TransformWrapper, TransformComponent, type ReactZoomPanPinchRef } from 'react-zoom-pan-pinch';
 
 import { Button } from '@/components/ui/button';
 import { handleMediaDownloadClick, mediaDownloadHref } from '@/lib/downloadMedia';
@@ -41,6 +42,9 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
 
   const open = React.useCallback((next: string) => setSrc(next), []);
   const close = React.useCallback(() => setSrc(null), []);
+  // Controls the zoom/pan transform (wired to the desktop +/- buttons). The
+  // wrapper is keyed on ``src`` so paging to another image remounts it back to 1x.
+  const transformRef = React.useRef<ReactZoomPanPinchRef>(null);
 
   const index = src ? images.indexOf(src) : -1;
   const pageable = index >= 0 && images.length > 1;
@@ -89,6 +93,32 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
           aria-modal="true"
         >
           <div className="absolute right-4 top-4 flex items-center gap-2">
+            {/* Zoom buttons: a pointer-device affordance (touch zooms by pinch).
+                stopPropagation so clicking a control doesn't also close the viewer. */}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={(e) => {
+                e.stopPropagation();
+                transformRef.current?.zoomOut();
+              }}
+              aria-label={t('chat.viewer.zoomOut')}
+              className={`hidden sm:inline-flex ${OVERLAY_BTN}`}
+            >
+              <ZoomOut className="size-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={(e) => {
+                e.stopPropagation();
+                transformRef.current?.zoomIn();
+              }}
+              aria-label={t('chat.viewer.zoomIn')}
+              className={`hidden sm:inline-flex ${OVERLAY_BTN}`}
+            >
+              <ZoomIn className="size-4" />
+            </Button>
             <Button
               asChild
               variant="ghost"
@@ -145,12 +175,33 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               </Button>
             </>
           )}
-          <img
-            src={src}
-            alt=""
-            onClick={(e) => e.stopPropagation()}
-            className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
-          />
+          {/* Zoom/pan the image IN-COMPONENT: the app viewport disables native
+              pinch-zoom (user-scalable=no, for the iOS keyboard fix), so the
+              lightbox provides its own. Mobile: pinch to zoom, drag to pan, double
+              tap to toggle. Desktop: wheel to zoom, drag to pan, double-click /
+              the +/- buttons. Keyed on src so paging resets to a fit view. The
+              wrapping div stops a click inside the image area from closing the
+              viewer (the dark backdrop around it still closes on click). */}
+          <div onClick={(e) => e.stopPropagation()}>
+            <TransformWrapper
+              key={src}
+              ref={transformRef}
+              initialScale={1}
+              minScale={1}
+              maxScale={5}
+              centerOnInit
+              doubleClick={{ mode: 'toggle' }}
+              wheel={{ step: 0.2 }}
+            >
+              <TransformComponent wrapperStyle={{ maxHeight: '90vh', maxWidth: '90vw', cursor: 'grab' }}>
+                <img
+                  src={src}
+                  alt=""
+                  className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
+                />
+              </TransformComponent>
+            </TransformWrapper>
+          </div>
           {pageable && (
             <span className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 font-mono text-[11px] text-white">
               {index + 1} / {images.length}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2040,6 +2040,8 @@
       "close": "Close",
       "previous": "Previous",
       "next": "Next",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
       "loading": "Loading…",
       "error": "Couldn't load this file.",
       "tooLarge": "File too large to preview — download it instead.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2039,6 +2039,8 @@
       "close": "关闭",
       "previous": "上一张",
       "next": "下一张",
+      "zoomIn": "放大",
+      "zoomOut": "缩小",
       "loading": "加载中…",
       "error": "无法加载该文件。",
       "tooLarge": "文件过大，无法预览，请直接下载。",


### PR DESCRIPTION
## Problem

The app viewport sets `user-scalable=no` (part of the iOS keyboard fix), so native pinch-zoom is disabled app-wide. That's fine for the chat UI, but it also means **opening a chat image gives no way to zoom in for detail** — most painful on mobile. The lightbox (`image-viewer.tsx`) only showed the image at `object-contain` with no zoom.

## Fix

In-component zoom/pan in the lightbox via `react-zoom-pan-pinch` (the app viewport can't be re-enabled per-element, so the viewer brings its own):

- **Mobile:** pinch to zoom, drag to pan, double-tap to toggle.
- **Desktop:** scroll-wheel to zoom, drag to pan, double-click to toggle, plus **+/- buttons** in the toolbar (pointer-only via `hidden sm:inline-flex` — touch uses pinch, so no button clutter there).
- Keyed on the displayed `src` so **paging to another image resets to a fit view**; `minScale 1` / `maxScale 5`. The image-area wrapper stops a click from closing the viewer while the dark backdrop around it still closes on click. Existing paging / download / close / Esc+arrows unchanged.

Adds `react-zoom-pan-pinch@^4.0.3` — a small, popular, dependency-free package (the user opted for a library over hand-rolling the gesture math).

## Evidence

- **Unit/contract:** none (presentational lightbox; no JS test runner in the UI).
- **Manual:** `npm run build` green (tsc + vite). **Gestures can't be verified statically** — needs a real-device check on the regression: mobile pinch-zoom + drag-pan + double-tap; desktop wheel-zoom + drag-pan + +/- buttons; paging resets zoom; backdrop-tap still closes. Flagging this as the residual manual check.