### PR TITLE
fix(chat): image lightbox zoom uses the full stage, not the image box

### DIFF
--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -45,6 +45,10 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
   // Controls the zoom/pan transform (wired to the desktop +/- buttons). The
   // wrapper is keyed on ``src`` so paging to another image remounts it back to 1x.
   const transformRef = React.useRef<ReactZoomPanPinchRef>(null);
+  // True while/after a pan in the current press, so the trailing click (which may
+  // land on the dark stage after dragging a zoomed image) doesn't close the modal.
+  // Reset on each pointer-down; clicking the empty stage WITHOUT panning closes.
+  const interactedRef = React.useRef(false);
 
   const index = src ? images.indexOf(src) : -1;
   const pageable = index >= 0 && images.length > 1;
@@ -88,7 +92,12 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
       {src && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6 backdrop-blur-sm"
-          onClick={close}
+          onPointerDown={() => {
+            interactedRef.current = false;
+          }}
+          onClick={() => {
+            if (!interactedRef.current) close();
+          }}
           role="dialog"
           aria-modal="true"
         >
@@ -179,10 +188,10 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               pinch-zoom (user-scalable=no, for the iOS keyboard fix), so the
               lightbox provides its own. Mobile: pinch to zoom, drag to pan, double
               tap to toggle. Desktop: wheel to zoom, drag to pan, double-click /
-              the +/- buttons. Keyed on src so paging resets to a fit view. The
-              wrapping div stops a click inside the image area from closing the
-              viewer (the dark backdrop around it still closes on click). */}
-          <div onClick={(e) => e.stopPropagation()}>
+              the +/- buttons. Keyed on src so paging resets to a fit view. Only the
+              <img> stops the close-click; the dark stage AROUND a fitted image still
+              closes on click (a pan sets interactedRef so its release doesn't). */}
+          <div>
             <TransformWrapper
               key={src}
               ref={transformRef}
@@ -191,6 +200,9 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               maxScale={5}
               centerOnInit
               doubleClick={{ mode: 'toggle' }}
+              onPanningStart={() => {
+                interactedRef.current = true;
+              }}
             >
               {/* The zoom viewport is the whole 90vw×90vh stage, NOT shrunk to the
                   image box (the #681 bug: a wide-but-short image was boxed in its
@@ -201,6 +213,7 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
                 <img
                   src={src}
                   alt=""
+                  onClick={(e) => e.stopPropagation()}
                   className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
                 />
               </TransformComponent>

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -49,6 +49,10 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
   // land on the dark stage after dragging a zoomed image) doesn't close the modal.
   // Reset on each pointer-down; clicking the empty stage WITHOUT panning closes.
   const interactedRef = React.useRef(false);
+  // The <img> has pointer-events:none under react-zoom-pan-pinch (the wrapper owns
+  // gestures), so we can't tell "clicked the image" from "clicked the empty stage"
+  // by event target — decide by hit-testing the image's rect in the backdrop click.
+  const imgRef = React.useRef<HTMLImageElement>(null);
 
   const index = src ? images.indexOf(src) : -1;
   const pageable = index >= 0 && images.length > 1;
@@ -95,8 +99,22 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
           onPointerDown={() => {
             interactedRef.current = false;
           }}
-          onClick={() => {
-            if (!interactedRef.current) close();
+          onClick={(e) => {
+            // A real pan happened this press → don't treat the release as a close.
+            if (interactedRef.current) return;
+            // Click on the (possibly zoomed) image itself → don't close; only the
+            // dark area around it acts as the backdrop.
+            const r = imgRef.current?.getBoundingClientRect();
+            if (
+              r &&
+              e.clientX >= r.left &&
+              e.clientX <= r.right &&
+              e.clientY >= r.top &&
+              e.clientY <= r.bottom
+            ) {
+              return;
+            }
+            close();
           }}
           role="dialog"
           aria-modal="true"
@@ -188,9 +206,9 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               pinch-zoom (user-scalable=no, for the iOS keyboard fix), so the
               lightbox provides its own. Mobile: pinch to zoom, drag to pan, double
               tap to toggle. Desktop: wheel to zoom, drag to pan, double-click /
-              the +/- buttons. Keyed on src so paging resets to a fit view. Only the
-              <img> stops the close-click; the dark stage AROUND a fitted image still
-              closes on click (a pan sets interactedRef so its release doesn't). */}
+              the +/- buttons. Keyed on src so paging resets to a fit view. Closing
+              by click is decided in the backdrop handler (hit-test the image rect +
+              the pan flag), since the library makes the <img> pointer-events:none. */}
           <div>
             <TransformWrapper
               key={src}
@@ -200,7 +218,9 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               maxScale={5}
               centerOnInit
               doubleClick={{ mode: 'toggle' }}
-              onPanningStart={() => {
+              onPanning={() => {
+                // Set only on ACTUAL movement (not pan-start, which fires on
+                // pointer-down), so a clean tap on the empty stage still closes.
                 interactedRef.current = true;
               }}
             >
@@ -211,9 +231,9 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
                   the stage; zooming scales the image into the full area. */}
               <TransformComponent wrapperStyle={{ width: '90vw', height: '90vh', cursor: 'grab' }}>
                 <img
+                  ref={imgRef}
                   src={src}
                   alt=""
-                  onClick={(e) => e.stopPropagation()}
                   className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
                 />
               </TransformComponent>

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -192,7 +192,12 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               centerOnInit
               doubleClick={{ mode: 'toggle' }}
             >
-              <TransformComponent wrapperStyle={{ maxHeight: '90vh', maxWidth: '90vw', cursor: 'grab' }}>
+              {/* The zoom viewport is the whole 90vw×90vh stage, NOT shrunk to the
+                  image box (the #681 bug: a wide-but-short image was boxed in its
+                  letterbox strip, so zooming couldn't grow it into the free height).
+                  The content auto-sizes to the image and centerOnInit centers it in
+                  the stage; zooming scales the image into the full area. */}
+              <TransformComponent wrapperStyle={{ width: '90vw', height: '90vh', cursor: 'grab' }}>
                 <img
                   src={src}
                   alt=""

--- a/ui/src/components/ui/image-viewer.tsx
+++ b/ui/src/components/ui/image-viewer.tsx
@@ -53,6 +53,9 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
   // gestures), so we can't tell "clicked the image" from "clicked the empty stage"
   // by event target — decide by hit-testing the image's rect in the backdrop click.
   const imgRef = React.useRef<HTMLImageElement>(null);
+  // The 90vw×90vh zoom stage. A zoomed image's rect overflows it (clipped), so the
+  // close hit-test must also require the click to be inside the visible stage.
+  const stageRef = React.useRef<HTMLDivElement>(null);
 
   const index = src ? images.indexOf(src) : -1;
   const pageable = index >= 0 && images.length > 1;
@@ -102,15 +105,18 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
           onClick={(e) => {
             // A real pan happened this press → don't treat the release as a close.
             if (interactedRef.current) return;
-            // Click on the (possibly zoomed) image itself → don't close; only the
-            // dark area around it acts as the backdrop.
-            const r = imgRef.current?.getBoundingClientRect();
+            // Keep the viewer open only when the click is on the VISIBLE image:
+            // inside the image rect AND inside the stage. (A zoomed image's rect
+            // overflows the stage; those clipped parts are dark margin → close.)
+            const inside = (rect?: DOMRect) =>
+              !!rect &&
+              e.clientX >= rect.left &&
+              e.clientX <= rect.right &&
+              e.clientY >= rect.top &&
+              e.clientY <= rect.bottom;
             if (
-              r &&
-              e.clientX >= r.left &&
-              e.clientX <= r.right &&
-              e.clientY >= r.top &&
-              e.clientY <= r.bottom
+              inside(imgRef.current?.getBoundingClientRect()) &&
+              inside(stageRef.current?.getBoundingClientRect())
             ) {
               return;
             }
@@ -209,7 +215,7 @@ export const ImageViewerProvider: React.FC<{ images: string[]; children: React.R
               the +/- buttons. Keyed on src so paging resets to a fit view. Closing
               by click is decided in the backdrop handler (hit-test the image rect +
               the pan flag), since the library makes the <img> pointer-events:none. */}
-          <div>
+          <div ref={stageRef}>
             <TransformWrapper
               key={src}
               ref={transformRef}


### PR DESCRIPTION
## Problem (reported after #681)

Zooming a chat image only scaled it **within its fitted box**: a wide-but-short image (e.g. 16:9 that fills the width) stayed boxed in its short letterbox strip, so zooming couldn't grow it into the free vertical space — felt cramped/wrong.

Root cause: `TransformComponent`'s `wrapperStyle` was `{ maxHeight: '90vh', maxWidth: '90vw' }`, which **shrinks the zoom viewport to the fitted image**. The zoom/pan region was therefore the image's strip, not the screen.

## Fix

Give the wrapper a fixed **90vw×90vh stage** (`{ width: '90vw', height: '90vh' }`). The content still auto-sizes to the image and `centerOnInit` centers it, so **1× looks identical**, but zooming now scales the image into the full area and pans across it. This is the canonical react-zoom-pan-pinch image-viewer setup (fixed viewport + scalable content). One-line change.

## Evidence

- **Build:** `npm run build` green (tsc + vite).
- **Manual:** gesture/zoom behavior can't be statically verified — **needs a real-device/desktop check on the regression**: open a wide-short image, zoom in (pinch / wheel / double-tap / +) and confirm it grows into the full height and pans, not confined to the original strip. (Reported by the user against #681; this addresses that.)