### PR TITLE
fix(chat): load one older page per scroll-to-top instead of cascading to the start

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1894,6 +1894,25 @@ const Transcript: React.FC<TranscriptProps> = ({
     });
   }, [needsLatestReload, scrollToBottom]);
 
+  // Re-arm the older-page loader once scrolling has settled (~150ms idle) AND the
+  // viewport is at rest out of the trigger band (scrollTop > 300, i.e. down in
+  // loaded content) — or a load just failed (no content/restore was added, so the
+  // position gate can never re-arm and we must recover anyway). Evaluating at rest
+  // is what stops a single fling from "crossing" the threshold; the in-flight guard
+  // keeps it disarmed until the load resolves. Called from the scroll handler AND
+  // from a failed load (a slow failure parked at the top emits no further scroll,
+  // so it has to schedule its own re-arm here).
+  const scheduleReArm = useCallback(() => {
+    if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
+    settleTimerRef.current = window.setTimeout(() => {
+      const node = scrollRef.current;
+      if (node && !loadingOlderPropRef.current && (node.scrollTop > 300 || loadFailedRef.current)) {
+        canLoadOlderRef.current = true;
+        loadFailedRef.current = false;
+      }
+    }, 150);
+  }, []);
+
   const handleScroll = () => {
     const el = scrollRef.current;
     if (!el) return;
@@ -1908,34 +1927,21 @@ const Transcript: React.FC<TranscriptProps> = ({
     // is free to grow). Re-capturing here keeps it current as the user scrolls.
     if (pinned) anchorRef.current = null;
     else captureAnchor();
-    // Re-arm once clearly back inside loaded content (hysteresis vs the 120 trigger),
-    // so a normal scroll-up loads one page, holds position, and waits for the next
-    // deliberate scroll to the top instead of auto-cascading through all history.
-    // Re-arm only after scrolling SETTLES (~150ms idle). A continuous fling — and
-    // the programmatic anchor-restore scroll plus any momentum overshoot it rides
-    // through the top zone — keeps resetting this, so one gesture loads exactly one
-    // older page instead of cascading. The next deliberate scroll after the pause
-    // re-arms; a failed load recovers the same way (re-arm regardless of outcome).
-    if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
-    settleTimerRef.current = window.setTimeout(() => {
-      // Re-arm only once scrolling has STOPPED and the viewport came to rest out of
-      // the trigger band, down in loaded content — not parked at the top and not
-      // mid-load. Evaluating position at rest (not live) is what makes this safe: a
-      // single fling can't "cross" the threshold the way a live scrollTop test
-      // could. After a normal load the anchor restore leaves scrollTop well past
-      // this and schedules the settle that re-arms; a fling that ends parked at the
-      // top stays disarmed, so momentum/bounce can't load another page.
-      const el = scrollRef.current;
-      if (el && !loadingOlderPropRef.current && (el.scrollTop > 300 || loadFailedRef.current)) {
-        canLoadOlderRef.current = true;
-        loadFailedRef.current = false;
-      }
-    }, 150);
+    // One older page per scroll gesture: re-arm only on settle, at rest, out of the
+    // top zone (see scheduleReArm) — a continuous fling keeps resetting it, so the
+    // anchor-restore scroll + momentum can't cascade more pages.
+    scheduleReArm();
     if (hasOlder && !loadingOlder && canLoadOlderRef.current && el.scrollTop < 120) {
       canLoadOlderRef.current = false;
       loadFailedRef.current = false;
       void Promise.resolve(loadOlderRef.current()).then((ok) => {
-        if (ok === false) loadFailedRef.current = true;
+        if (ok === false) {
+          // Fetch failed: no content/restore, viewport parked at top. A slow failure
+          // already missed the in-flight-skipped settle and won't get another scroll,
+          // so schedule the re-arm here too (it ignores position when loadFailedRef).
+          loadFailedRef.current = true;
+          scheduleReArm();
+        }
       });
     }
   };

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1803,6 +1803,12 @@ const Transcript: React.FC<TranscriptProps> = ({
   const [showJump, setShowJump] = useState(false);
   const loadOlderRef = useRef(onLoadOlder);
   const reloadLatestRef = useRef(onReloadLatest);
+  // Load ONE older page per scroll-into-the-top-zone. Disarmed on trigger and
+  // re-armed only after scrolling back down into loaded content — otherwise the
+  // top threshold stays satisfied (iOS momentum fighting the post-load anchor
+  // restore, or the restore not yet applied) and older pages cascade in until the
+  // very first message.
+  const canLoadOlderRef = useRef(true);
 
   useEffect(() => {
     loadOlderRef.current = onLoadOlder;
@@ -1886,7 +1892,12 @@ const Transcript: React.FC<TranscriptProps> = ({
     // is free to grow). Re-capturing here keeps it current as the user scrolls.
     if (pinned) anchorRef.current = null;
     else captureAnchor();
-    if (hasOlder && !loadingOlder && el.scrollTop < 120) {
+    // Re-arm once clearly back inside loaded content (hysteresis vs the 120 trigger),
+    // so a normal scroll-up loads one page, holds position, and waits for the next
+    // deliberate scroll to the top instead of auto-cascading through all history.
+    if (el.scrollTop > 300) canLoadOlderRef.current = true;
+    if (hasOlder && !loadingOlder && canLoadOlderRef.current && el.scrollTop < 120) {
+      canLoadOlderRef.current = false;
       loadOlderRef.current();
     }
   };

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -365,20 +365,23 @@ export const ChatPage: React.FC = () => {
     }
   }, [api, sessionId]);
 
-  const loadOlderMessages = useCallback(async () => {
-    if (!sessionId || !olderCursor || loadingOlderRef.current) return;
+  // Returns false only when the fetch itself failed, so the transcript scroller can
+  // re-arm and let a later scroll retry; true for success / no-op / stale session.
+  const loadOlderMessages = useCallback(async (): Promise<boolean> => {
+    if (!sessionId || !olderCursor || loadingOlderRef.current) return true;
     loadingOlderRef.current = true;
     setLoadingOlder(true);
     try {
       const res = await api.listSessionMessages(sessionId, { limit: 50, beforeId: olderCursor });
-      if (sessionId !== sessionIdRef.current) return; // switched chats mid-fetch
+      if (sessionId !== sessionIdRef.current) return true; // switched chats mid-fetch
       const older = res.messages.filter(isTranscriptMessage);
       if (older.length) {
         setMessages((prev) => mergeById(prev, older));
       }
       setOlderCursor(res.next_before_id ?? null);
+      return true;
     } catch {
-      /* keep the current transcript; another scroll can retry */
+      return false; // keep the transcript; caller re-arms so a later scroll retries
     } finally {
       if (sessionId === sessionIdRef.current) {
         loadingOlderRef.current = false;
@@ -1731,7 +1734,7 @@ interface TranscriptProps {
   working: boolean;
   hasOlder: boolean;
   loadingOlder: boolean;
-  onLoadOlder: () => void;
+  onLoadOlder: () => void | Promise<boolean>;
   needsLatestReload: boolean;
   onReloadLatest: () => Promise<boolean>;
   // Deep-link jump (P5): the message id to scroll to once it's in the DOM, a
@@ -1817,6 +1820,11 @@ const Transcript: React.FC<TranscriptProps> = ({
   // can avoid re-arming while a page load is still in flight.
   const loadingOlderPropRef = useRef(loadingOlder);
   loadingOlderPropRef.current = loadingOlder;
+  // A failed load adds no content → no anchor restore → the viewport stays at the
+  // top, where the position gate below would never re-arm. Mark it so the settle
+  // re-arms regardless of position and a later scroll can retry. Re-arming at
+  // settle (not immediately) avoids a retry storm within the same fling.
+  const loadFailedRef = useRef(false);
 
   useEffect(() => {
     loadOlderRef.current = onLoadOlder;
@@ -1918,13 +1926,17 @@ const Transcript: React.FC<TranscriptProps> = ({
       // this and schedules the settle that re-arms; a fling that ends parked at the
       // top stays disarmed, so momentum/bounce can't load another page.
       const el = scrollRef.current;
-      if (el && !loadingOlderPropRef.current && el.scrollTop > 300) {
+      if (el && !loadingOlderPropRef.current && (el.scrollTop > 300 || loadFailedRef.current)) {
         canLoadOlderRef.current = true;
+        loadFailedRef.current = false;
       }
     }, 150);
     if (hasOlder && !loadingOlder && canLoadOlderRef.current && el.scrollTop < 120) {
       canLoadOlderRef.current = false;
-      loadOlderRef.current();
+      loadFailedRef.current = false;
+      void Promise.resolve(loadOlderRef.current()).then((ok) => {
+        if (ok === false) loadFailedRef.current = true;
+      });
     }
   };
 

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1803,16 +1803,16 @@ const Transcript: React.FC<TranscriptProps> = ({
   const [showJump, setShowJump] = useState(false);
   const loadOlderRef = useRef(onLoadOlder);
   const reloadLatestRef = useRef(onReloadLatest);
-  // Load ONE older page per scroll-into-the-top-zone. Disarmed on trigger and
-  // re-armed only after scrolling back down into loaded content — otherwise the
-  // top threshold stays satisfied (iOS momentum fighting the post-load anchor
-  // restore, or the restore not yet applied) and older pages cascade in until the
-  // very first message.
+  // Load ONE older page per scroll gesture, not a cascade. The top threshold can
+  // stay satisfied across many scroll events — momentum/inertial scrolling (iOS
+  // touch AND macOS trackpad in Chrome) keeps firing while the post-load anchor
+  // restore + overshoot ride through the trigger zone — which fired older-page
+  // loads back-to-back all the way to the first message. So disarm on trigger and
+  // re-arm only once scrolling has SETTLED (a continuous fling keeps resetting the
+  // timer; a new deliberate scroll after the pause re-arms). Settle-based re-arm
+  // also recovers a failed load (it re-arms regardless of outcome).
   const canLoadOlderRef = useRef(true);
-  // Set just before the anchor-restore writes scrollTop, so the scroll event it
-  // emits doesn't count as the user "leaving the top zone" and re-arm the loader
-  // (which would let an iOS momentum fling immediately re-trigger the cascade).
-  const anchorRestoreScrollRef = useRef(false);
+  const settleTimerRef = useRef<number | null>(null);
 
   useEffect(() => {
     loadOlderRef.current = onLoadOlder;
@@ -1899,13 +1899,15 @@ const Transcript: React.FC<TranscriptProps> = ({
     // Re-arm once clearly back inside loaded content (hysteresis vs the 120 trigger),
     // so a normal scroll-up loads one page, holds position, and waits for the next
     // deliberate scroll to the top instead of auto-cascading through all history.
-    if (anchorRestoreScrollRef.current) {
-      // This scroll event came from the programmatic anchor restore, not the user —
-      // consume it without re-arming so a momentum fling can't immediately re-fire.
-      anchorRestoreScrollRef.current = false;
-    } else if (el.scrollTop > 300) {
+    // Re-arm only after scrolling SETTLES (~150ms idle). A continuous fling — and
+    // the programmatic anchor-restore scroll plus any momentum overshoot it rides
+    // through the top zone — keeps resetting this, so one gesture loads exactly one
+    // older page instead of cascading. The next deliberate scroll after the pause
+    // re-arms; a failed load recovers the same way (re-arm regardless of outcome).
+    if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
+    settleTimerRef.current = window.setTimeout(() => {
       canLoadOlderRef.current = true;
-    }
+    }, 150);
     if (hasOlder && !loadingOlder && canLoadOlderRef.current && el.scrollTop < 120) {
       canLoadOlderRef.current = false;
       loadOlderRef.current();
@@ -2008,10 +2010,7 @@ const Transcript: React.FC<TranscriptProps> = ({
       const delta = currentTop - anchor.top;
       // Sub-pixel rect noise would otherwise write scrollTop on every fire; only
       // correct a real (≥0.5px) drift so reading history stays perfectly still.
-      if (Math.abs(delta) >= 0.5) {
-        anchorRestoreScrollRef.current = true;
-        el.scrollTop += delta;
-      }
+      if (Math.abs(delta) >= 0.5) el.scrollTop += delta;
     });
     ro.observe(content);
     return () => ro.disconnect();

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1813,6 +1813,10 @@ const Transcript: React.FC<TranscriptProps> = ({
   // also recovers a failed load (it re-arms regardless of outcome).
   const canLoadOlderRef = useRef(true);
   const settleTimerRef = useRef<number | null>(null);
+  // Mirror loadingOlder so the settle timer (which closes over a stale value)
+  // can avoid re-arming while a page load is still in flight.
+  const loadingOlderPropRef = useRef(loadingOlder);
+  loadingOlderPropRef.current = loadingOlder;
 
   useEffect(() => {
     loadOlderRef.current = onLoadOlder;
@@ -1906,7 +1910,10 @@ const Transcript: React.FC<TranscriptProps> = ({
     // re-arms; a failed load recovers the same way (re-arm regardless of outcome).
     if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
     settleTimerRef.current = window.setTimeout(() => {
-      canLoadOlderRef.current = true;
+      // Stay disarmed until the in-flight load finishes — a load slower than the
+      // settle would otherwise re-arm mid-flight and let the post-load scroll
+      // re-trigger. The load's own anchor-restore scroll schedules a fresh settle.
+      if (!loadingOlderPropRef.current) canLoadOlderRef.current = true;
     }, 150);
     if (hasOlder && !loadingOlder && canLoadOlderRef.current && el.scrollTop < 120) {
       canLoadOlderRef.current = false;

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1809,6 +1809,10 @@ const Transcript: React.FC<TranscriptProps> = ({
   // restore, or the restore not yet applied) and older pages cascade in until the
   // very first message.
   const canLoadOlderRef = useRef(true);
+  // Set just before the anchor-restore writes scrollTop, so the scroll event it
+  // emits doesn't count as the user "leaving the top zone" and re-arm the loader
+  // (which would let an iOS momentum fling immediately re-trigger the cascade).
+  const anchorRestoreScrollRef = useRef(false);
 
   useEffect(() => {
     loadOlderRef.current = onLoadOlder;
@@ -1895,7 +1899,13 @@ const Transcript: React.FC<TranscriptProps> = ({
     // Re-arm once clearly back inside loaded content (hysteresis vs the 120 trigger),
     // so a normal scroll-up loads one page, holds position, and waits for the next
     // deliberate scroll to the top instead of auto-cascading through all history.
-    if (el.scrollTop > 300) canLoadOlderRef.current = true;
+    if (anchorRestoreScrollRef.current) {
+      // This scroll event came from the programmatic anchor restore, not the user —
+      // consume it without re-arming so a momentum fling can't immediately re-fire.
+      anchorRestoreScrollRef.current = false;
+    } else if (el.scrollTop > 300) {
+      canLoadOlderRef.current = true;
+    }
     if (hasOlder && !loadingOlder && canLoadOlderRef.current && el.scrollTop < 120) {
       canLoadOlderRef.current = false;
       loadOlderRef.current();
@@ -1998,7 +2008,10 @@ const Transcript: React.FC<TranscriptProps> = ({
       const delta = currentTop - anchor.top;
       // Sub-pixel rect noise would otherwise write scrollTop on every fire; only
       // correct a real (≥0.5px) drift so reading history stays perfectly still.
-      if (Math.abs(delta) >= 0.5) el.scrollTop += delta;
+      if (Math.abs(delta) >= 0.5) {
+        anchorRestoreScrollRef.current = true;
+        el.scrollTop += delta;
+      }
     });
     ro.observe(content);
     return () => ro.disconnect();

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1910,10 +1910,17 @@ const Transcript: React.FC<TranscriptProps> = ({
     // re-arms; a failed load recovers the same way (re-arm regardless of outcome).
     if (settleTimerRef.current !== null) clearTimeout(settleTimerRef.current);
     settleTimerRef.current = window.setTimeout(() => {
-      // Stay disarmed until the in-flight load finishes — a load slower than the
-      // settle would otherwise re-arm mid-flight and let the post-load scroll
-      // re-trigger. The load's own anchor-restore scroll schedules a fresh settle.
-      if (!loadingOlderPropRef.current) canLoadOlderRef.current = true;
+      // Re-arm only once scrolling has STOPPED and the viewport came to rest out of
+      // the trigger band, down in loaded content — not parked at the top and not
+      // mid-load. Evaluating position at rest (not live) is what makes this safe: a
+      // single fling can't "cross" the threshold the way a live scrollTop test
+      // could. After a normal load the anchor restore leaves scrollTop well past
+      // this and schedules the settle that re-arms; a fling that ends parked at the
+      // top stays disarmed, so momentum/bounce can't load another page.
+      const el = scrollRef.current;
+      if (el && !loadingOlderPropRef.current && el.scrollTop > 300) {
+        canLoadOlderRef.current = true;
+      }
     }, 150);
     if (hasOlder && !loadingOlder && canLoadOlderRef.current && el.scrollTop < 120) {
       canLoadOlderRef.current = false;


### PR DESCRIPTION
## Problem (reported)

Scrolling to the top of a chat transcript rapid-fires **several** older-page loads back to back and jumps straight to the very first message — instead of loading one page and holding position.

## Root cause

The history trigger fires on every scroll event while `scrollTop < 120`:

```
if (hasOlder && !loadingOlder && el.scrollTop < 120) loadOlder();
```

After a page prepends, the manual scroll-anchor (ResizeObserver) is supposed to lift `scrollTop` past the threshold so it won't re-fire. But whenever that restore doesn't take effect before the next scroll event — most reliably on **iOS momentum scrolling**, where a programmatic `scrollTop` write is fought by the in-flight fling, and also when the restore lands a frame later — `scrollTop` stays `< 120`, the condition is still true, and pages cascade in until history is exhausted. (Row keys are stable `message.id` and `mergeById` sorts correctly, so prepend/anchor math is fine; the bug is the trigger re-firing while parked in the zone.)

## Fix

Make the trigger edge-triggered with hysteresis — **one page per scroll-into-the-top-zone**:
- disarm on trigger;
- re-arm only after scrolling back down past 300px into loaded content.

A normal scroll-up loads one page and the anchor holds position; the next page needs a fresh, deliberate scroll to the top. If the restore is ever fought (momentum), the worst case is now "loaded one page, parked at top" instead of a runaway cascade. No change to progressively scrolling up through many pages.

## Evidence

- **Build:** `npm run build` green (tsc + vite).
- **Manual:** scroll behavior can't be statically verified — **needs a real-device check on the regression** (open a session with several history pages, flick to the top on iOS, confirm it loads one page and holds, no cascade to the first message; desktop scroll-up still loads progressively).