### PR TITLE
chore(deps): pin avault to 0.1.3 to activate Vaults P2

### DIFF
--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -33,10 +33,12 @@ class _FakeHTTPResponse:
 
 
 def _fake_avault_archive(
-    content: bytes = b"#!/bin/sh\necho avault 0.1.2\n",
+    content: bytes | None = None,
     *,
     member_name: str = "avault",
 ) -> bytes:
+    if content is None:
+        content = f"#!/bin/sh\necho avault {api.AVAULT_VERSION}\n".encode()
     raw = io.BytesIO()
     with tarfile.open(fileobj=raw, mode="w:gz") as archive:
         info = tarfile.TarInfo(member_name)
@@ -51,8 +53,10 @@ def _installable_avault_release(
     *,
     target: str = "macos-arm64",
     sha256: str | None = None,
-    content: bytes = b"#!/bin/sh\necho avault 0.1.2\n",
+    content: bytes | None = None,
 ):
+    if content is None:
+        content = f"#!/bin/sh\necho avault {api.AVAULT_VERSION}\n".encode()
     member_name = api._avault_binary_name_for_target(target)
     archive = _fake_avault_archive(content=content, member_name=member_name)
     digest = sha256 or hashlib.sha256(archive).hexdigest()

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -490,6 +490,28 @@ def test_ensure_avault_force_does_not_downgrade_compatible_binary_when_pin_is_ol
     }
 
 
+def test_ensure_avault_force_does_not_downgrade_newer_binary(monkeypatch):
+    # A user/custom avault newer than the managed pin must survive `force` prepare,
+    # even though the managed pin now satisfies the P2 gate (Codex #686 P2 finding).
+    newer = "9.9.9"
+    assert api._version_at_least(newer, api.AVAULT_VERSION)
+    monkeypatch.setattr(api, "_managed_avault_release_satisfies_p2", lambda: True)
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/usr/local/bin/avault")
+    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: newer)
+    monkeypatch.setattr(api, "install_avault", lambda force=False: pytest.fail("should not downgrade a newer avault"))
+
+    out = api.ensure_avault_installed(force=True)
+
+    assert out == {
+        "ok": True,
+        "installed": True,
+        "changed": False,
+        "path": "/usr/local/bin/avault",
+        "version": newer,
+    }
+
+
 def test_ensure_avault_upgrades_existing_binary_below_p2_minimum(monkeypatch):
     monkeypatch.setattr(api, "_managed_avault_release_satisfies_p2", lambda: True)
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -197,7 +197,11 @@ def test_create_protected_rejects_non_string_envelope_fields(monkeypatch):
 
 
 def test_agent_pubkey_reports_upgrade_required_when_managed_pin_lacks_p2(monkeypatch):
-    monkeypatch.setattr(api, "avault_status", lambda: {"installed": True, "version": api.AVAULT_VERSION})
+    # An installed avault that predates the P2 surface (below AVAULT_P2_MIN_VERSION),
+    # paired with a managed pin that also lacks P2.
+    installed_pre_p2 = "0.1.2"
+    assert not api._version_at_least(installed_pre_p2, api.AVAULT_P2_MIN_VERSION)
+    monkeypatch.setattr(api, "avault_status", lambda: {"installed": True, "version": installed_pre_p2})
     monkeypatch.setattr(api, "_managed_avault_release_satisfies_p2", lambda: False)
 
     with pytest.raises(api.VaultApiError) as exc:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -4070,6 +4070,25 @@ def ensure_avault_installed(force: bool = False) -> dict:
         existing_version = _probe_avault_version(existing) if existing else None
         existing_is_p2 = _version_at_least(existing_version, AVAULT_P2_MIN_VERSION)
         can_managed_install_p2 = _managed_avault_release_satisfies_p2()
+        # Never downgrade: keep an existing binary that is strictly newer than the
+        # managed pin, even under ``force``. ``force`` may still reinstall an equal
+        # or older managed version to repair a binary, but it must not replace a
+        # newer user/custom avault (e.g. 0.1.4) with the older managed release. A
+        # genuinely broken binary can't report a version, so it isn't matched here
+        # and still gets repaired below.
+        existing_newer_than_pin = (
+            existing_is_p2
+            and _version_at_least(existing_version, AVAULT_VERSION)
+            and not _version_at_least(AVAULT_VERSION, existing_version)
+        )
+        if existing and existing_newer_than_pin:
+            return {
+                "ok": True,
+                "installed": True,
+                "changed": False,
+                "path": existing,
+                "version": existing_version,
+            }
         if existing and not existing_is_p2 and force and not can_managed_install_p2:
             return _avault_p2_release_unavailable_result(existing=existing, existing_version=existing_version)
         if existing and (

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3733,7 +3733,7 @@ AVAULT_P2_MIN_VERSION = "0.1.3"
 # Installer pin must reference a published manifest-pinned release. It may lag
 # the P2 surface; standard sealing remains usable while P2-only entry points
 # gate on AVAULT_P2_MIN_VERSION below.
-AVAULT_VERSION = "0.1.2"
+AVAULT_VERSION = "0.1.3"
 _AVAULT_RELEASE_BASE_URL = f"https://github.com/avibe-bot/avault/releases/download/v{AVAULT_VERSION}/"
 
 


### PR DESCRIPTION
## Capability

Activate the **Vaults P2** path by bumping the avault installer pin `AVAULT_VERSION 0.1.2 → 0.1.3`.

Today `vibe/api.py` pins the managed avault install to `0.1.2` (the latest *published* release, pre-P2) while the P2 gate is `AVAULT_P2_MIN_VERSION = 0.1.3`. So `vibe runtime prepare` installs a binary that the blind-box / protected-tier entry points reject as too old. avault `master` already has the full reviewed P2 surface; bumping the pin to the published `v0.1.3` release makes `runtime prepare` install a P2-capable binary and flips `_managed_avault_release_satisfies_p2()` true.

## Depends on
- **avibe-bot/avault#12** (cuts the `v0.1.3` release). **Do not merge this until `avault v0.1.3` is published**, so the pin always references a published release (per the comment at `api.py` `AVAULT_VERSION`).

## Changes
- `vibe/api.py`: `AVAULT_VERSION → "0.1.3"`.
- `tests/test_local_deps.py`: fake-avault version now derives from `api.AVAULT_VERSION` (so happy-path install tests always match the pin instead of a hardcoded `0.1.2`; the deliberate-mismatch test keeps its explicit `0.1.1`).
- `tests/test_vault_api.py`: the "upgrade required" test now reports an installed version genuinely below `AVAULT_P2_MIN_VERSION` (decoupled from the pin, which used to coincide).

## Evidence
- Unit: `tests/test_local_deps.py` + `tests/test_vault_api.py` — 105 passed; ruff clean.
- Residual manual: regression env re-prepare + Vaults P2 (blind-box create / protected) to be exercised once `v0.1.3` is published and installed.
