### PR TITLE
fix(show-runtime): reap global manager in tests to prevent Node/esbuild leak

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -1019,6 +1019,18 @@ async def prewarm_show_page_session(session_id: str, *, base_path: str | None = 
 
 def set_show_runtime_manager_for_tests(manager: ShowRuntimeManager | None) -> None:
     global _manager
+    previous = _manager
+    # Stop the manager we are replacing before dropping the reference. Serving-path
+    # tests that never install a fake cause get_show_runtime_manager() to lazily
+    # create the real manager, which spawns a Node cli.js + esbuild subprocess tree
+    # when a runtime is installed locally. If a later test swaps the global without
+    # stopping it first, the reference is lost, the atexit cleanup at process exit
+    # can no longer reap it, and the subprocess tree leaks for the machine's lifetime.
+    if previous is not None and previous is not manager:
+        try:
+            previous.stop()
+        except Exception:  # pragma: no cover - defensive cleanup
+            logger.debug("failed to stop previous show runtime manager", exc_info=True)
     _manager = manager
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,3 +91,27 @@ def _reset_oauth_runtime_state():
     yield
     for cache in caches:
         cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_show_runtime_manager():
+    """Stop and clear any global Show Runtime manager spawned during a test.
+
+    The Show Runtime manager is a process-global singleton. Serving-path tests
+    that do not install a fake manager cause ``get_show_runtime_manager()`` to
+    lazily create the real manager, which spawns a Node ``cli.js`` + ``esbuild``
+    subprocess tree whenever a runtime is installed on the machine. Without an
+    explicit teardown the reference can be overwritten by a later test's
+    ``set_show_runtime_manager_for_tests`` swap; the ``atexit`` cleanup at pytest
+    exit then no longer sees it, and the Node/esbuild tree leaks for the lifetime
+    of the machine. Reset after every test so no real subprocess can outlive it.
+    """
+    yield
+    try:
+        from core import show_runtime
+    except Exception:
+        return
+    try:
+        show_runtime.set_show_runtime_manager_for_tests(None)
+    except Exception:
+        pass

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -69,6 +69,25 @@ def _show_runtime_node_version(monkeypatch):
     monkeypatch.setattr("core.show_runtime._node_version", lambda node: (22, 16, 0))
 
 
+def test_set_show_runtime_manager_stops_previous_manager():
+    # Swapping the global manager must stop the one it replaces so a real
+    # Node/esbuild subprocess tree can never be orphaned (and then leak past the
+    # atexit cleanup) when a later test installs a fake or resets the global.
+    import core.show_runtime as srt
+
+    first = _FakeShowRuntimeManager()
+    second = _FakeShowRuntimeManager()
+    srt.set_show_runtime_manager_for_tests(first)
+    try:
+        srt.set_show_runtime_manager_for_tests(second)
+        assert first.stopped is True
+        assert second.stopped is False
+    finally:
+        srt.set_show_runtime_manager_for_tests(None)
+    # Resetting to None also stops the manager being dropped.
+    assert second.stopped is True
+
+
 def _create_show_page(session_id: str, visibility: str) -> str | None:
     page_dir = ensure_show_page_dir(session_id)
     (page_dir / "index.html").write_text("<!doctype html><title>Show</title><h1>Show Page</h1>", encoding="utf-8")


### PR DESCRIPTION
## Capability
Show Runtime test lifecycle — eliminates a Node \`cli.js\` + \`esbuild\` subprocess leak originating from the unit suite.

## Problem
The Show Runtime manager is a process-global singleton (\`core/show_runtime._manager\`). Serving-path tests that don't install a fake cause \`get_show_runtime_manager()\` to lazily create the **real** manager, which spawns a Node \`cli.js\` + \`esbuild\` subprocess tree when a runtime is installed locally. Nothing stopped that global at test teardown, and a later test's \`set_show_runtime_manager_for_tests(...)\` swap dropped the reference — so the \`atexit.register(stop_show_runtime_manager)\` cleanup at pytest exit could no longer see it. The orphaned subprocess tree then leaked for the lifetime of the machine (observed: a 3+ day old orphaned esbuild service from a \`test_public_show_page_redirect\` run).

## Fix
1. \`core/show_runtime.py\` — \`set_show_runtime_manager_for_tests\` now stops the manager it replaces before reassigning, so swapping the global never orphans a running process.
2. \`tests/conftest.py\` — new autouse fixture \`_reset_show_runtime_manager\` resets the global manager after every test, so any real subprocess spawned during a test is reaped (covers all test files, future-proof).
3. \`tests/test_ui_show_pages.py\` — regression test for the swap/reset stop behavior.

## Evidence layers
- **Unit:** new \`test_set_show_runtime_manager_stops_previous_manager\` (swap + reset-to-None both stop the dropped manager). \`tests/test_ui_show_pages.py\` runs 94 passed; the 11 \`runtime_git_missing\` failures are pre-existing on \`master\` (environment quirk where git is not resolvable in the isolated test), confirmed unrelated by stashing this change.
- **Contract/scenario:** no scenario catalog applies to this internal lifecycle fix.
- **Manual:** ran the full \`test_ui_show_pages.py\` and confirmed the run left **zero** \`node\`/\`esbuild\` survivors under its pytest tmp dir (previously such runs orphaned 2 processes each).

## Residual / follow-up
\`_AVAULT_AGENT_MANAGER\` (\`vibe/api.py\`) is an analogous lazily-spawned singleton with **no** atexit cleanup. It is mocked in all current tests (no confirmed leak), so it is intentionally left out of this focused fix and noted as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)