### PR TITLE
feat(vaults): add protected VMK read endpoint

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -629,6 +629,16 @@ def list_secrets(conn: Connection, *, group: str | None = None) -> list[dict[str
     return [_meta_payload(dict(row)) for row in conn.execute(query).mappings()]
 
 
+def latest_protected_vmk_wrap_meta(conn: Connection) -> str | None:
+    """Return the newest protected-tier VMK wrap metadata as opaque JSON text."""
+    return conn.execute(
+        select(vault_secrets.c.wrap_meta)
+        .where(vault_secrets.c.protection == "protected", vault_secrets.c.wrap_meta.is_not(None))
+        .order_by(vault_secrets.c.updated_at.desc(), vault_secrets.c.created_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+
 def rotate_secret(
     conn: Connection,
     name: str,

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -176,6 +176,49 @@ def test_create_protected_stores_browser_envelope_without_avault(monkeypatch):
     assert json.loads(row["wrap_meta"]) == {"v": 1, "wrapped_dek": "dek"}
 
 
+def test_get_vault_vmk_returns_latest_protected_wrap_meta(monkeypatch):
+    from unittest.mock import Mock
+
+    assert api.get_vault_vmk() == {"ok": True, "exists": False, "wrap_meta": None}
+
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("standard")))
+    api.create_vault_secret(
+        {
+            "name": "STANDARD_KEY",
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+    assert api.get_vault_vmk() == {"ok": True, "exists": False, "wrap_meta": None}
+
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_OLD",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct-old", "nonce": "n-old", "wrap_meta": '{"vmk":"old"}'},
+        }
+    )
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_NEW",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct-new", "nonce": "n-new", "wrap_meta": '{"vmk":"new"}'},
+        }
+    )
+    with api._vault_engine().begin() as conn:
+        conn.execute(
+            vault_secrets.update()
+            .where(vault_secrets.c.name == "PROTECTED_OLD")
+            .values(updated_at="2026-01-01T00:00:00+00:00")
+        )
+        conn.execute(
+            vault_secrets.update()
+            .where(vault_secrets.c.name == "PROTECTED_NEW")
+            .values(updated_at="2026-01-02T00:00:00+00:00")
+        )
+
+    assert api.get_vault_vmk() == {"ok": True, "exists": True, "wrap_meta": '{"vmk":"new"}'}
+
+
 def test_create_protected_rejects_non_string_envelope_fields(monkeypatch):
     from unittest.mock import Mock
 

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -82,6 +82,12 @@ type VaultSealedEnvelope = {
   wrap_meta: string | Record<string, unknown>;
 };
 
+export type VaultVmkResult = {
+  ok: boolean;
+  exists: boolean;
+  wrap_meta: string | null;
+};
+
 export type VaultCreatePayload = {
   name: string;
   protection?: 'standard' | 'protected';
@@ -301,6 +307,7 @@ export type ApiContextType = {
   setDefaultVibeAgent: (name: string) => Promise<{ ok: boolean; default_agent_name: string; agent: VibeAgentBrief }>;
   removeVibeAgent: (name: string) => Promise<{ ok: boolean; code?: string; message?: string; references?: Record<string, number>; removed_agent?: string }>;
   listVaultSecrets: (params?: { group?: string }) => Promise<{ ok: boolean; secrets: VaultSecret[] }>;
+  getVaultVmk: () => Promise<VaultVmkResult>;
   getVaultPubkey: () => Promise<{ ok: boolean; public_key: string; fingerprint: string }>;
   getVaultAgentPubkey: () => Promise<{ ok: boolean; public_key: string; fingerprint: string }>;
   createVaultSecret: (payload: VaultCreatePayload, opts?: { handleError?: boolean }) => Promise<{ ok: boolean; secret?: VaultSecret; code?: string; message?: string }>;
@@ -2010,6 +2017,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       const qs = search.toString();
       return getCachedJson(qs ? `/api/vault/secrets?${qs}` : '/api/vault/secrets', 1500);
     },
+    getVaultVmk: () => getJson('/api/vault/vmk'),
     getVaultPubkey: () => getCachedJson('/api/vault/pubkey', 1500),
     getVaultAgentPubkey: () => getCachedJson('/api/vault/agent/pubkey', 1500),
     createVaultSecret: (payload, opts) => postJson('/api/vault/secrets', payload, opts),

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1354,6 +1354,15 @@ def get_vault_agent_pubkey() -> dict:
         raise _vault_api_error_from_avault(exc, prefix="avault agent pubkey failed") from exc
 
 
+def get_vault_vmk() -> dict:
+    from storage import vault_service
+
+    engine = _vault_engine()
+    with engine.connect() as conn:
+        wrap_meta = vault_service.latest_protected_vmk_wrap_meta(conn)
+    return {"ok": True, "exists": wrap_meta is not None, "wrap_meta": wrap_meta}
+
+
 def _sealed_from_payload(payload: dict):
     from storage.vault_crypto import Sealed
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2692,6 +2692,13 @@ def vault_agent_pubkey_get():
         return _vault_error_response(exc)
 
 
+@app.route("/api/vault/vmk", methods=["GET"])
+def vault_vmk_get():
+    from vibe import api
+
+    return jsonify(api.get_vault_vmk())
+
+
 @app.route("/api/vault/secrets", methods=["POST"])
 def vault_secrets_post():
     from vibe import api


### PR DESCRIPTION
## Summary
- add `GET /api/vault/vmk` to return the latest protected-tier VMK `wrap_meta` as opaque JSON text
- expose `getVaultVmk()` and its typed response in the Web UI API context
- cover empty vault, standard-only vault, and latest protected-secret selection in vault API tests

## Validation
- `ruff check storage/vault_service.py vibe/api.py vibe/ui_server.py tests/test_vault_api.py`
- `python3 -m pytest tests/test_vault_api.py -q`
- `npm run build` in `ui/`

## Evidence layers
- Unit: updated `tests/test_vault_api.py`
- Contract: focused API response shape for VMK wrap metadata reuse
- Scenario: protected-secret browser session reuse path can discover existing VMK wrap metadata
- Residual manual checks: none; endpoint is read-only and passes opaque ciphertext through unchanged
