### PR TITLE
fix(vaults): make keypairs sign-only

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -74,6 +74,10 @@ class UnsupportedProtectionError(VaultServiceError):
     """A caller attempted a delivery path that still needs the resident agent."""
 
 
+class KeypairNotValueDeliverableError(VaultServiceError):
+    """A signing key was requested through a value-delivery path."""
+
+
 class InvalidGrantError(VaultServiceError):
     pass
 
@@ -442,6 +446,11 @@ def _secret_is_grantable(row: dict[str, Any]) -> bool:
     return True
 
 
+def _reject_keypair_value_delivery(row: dict[str, Any], name: str) -> None:
+    if row.get("kind") == "keypair":
+        raise KeypairNotValueDeliverableError(f"{name} is a signing key; use vault_sign instead of value delivery")
+
+
 def audit(
     conn: Connection,
     event: str,
@@ -713,6 +722,7 @@ def get_envelope(conn: Connection, name: str) -> Sealed:
     row = _require_row(conn, name)
     if row.get("protection") != "standard":
         raise UnsupportedProtectionError(f"{name} is protected-tier (resident grant delivery is not wired yet)")
+    _reject_keypair_value_delivery(row, name)
     return _row_sealed(row)
 
 
@@ -720,6 +730,7 @@ def get_protected_envelope(conn: Connection, name: str) -> Sealed:
     row = _require_row(conn, name)
     if row.get("protection") != "protected":
         raise UnsupportedProtectionError(f"{name} is standard-tier")
+    _reject_keypair_value_delivery(row, name)
     return _row_sealed(row)
 
 
@@ -766,6 +777,7 @@ def get_envelopes(conn: Connection, names: list[str]) -> dict[str, Sealed]:
         row = _require_row(conn, name)
         if row.get("protection") != "standard":
             raise UnsupportedProtectionError(f"{name} is protected-tier (resident grant delivery is not wired yet)")
+        _reject_keypair_value_delivery(row, name)
         out[name] = _row_sealed(row)
     return out
 
@@ -1897,6 +1909,7 @@ def resolve_secret_access(
     expire the grant and re-run this resolver to create a fresh approval request.
     """
     row = _require_row(conn, name)
+    _reject_keypair_value_delivery(row, name)
     if row.get("protection") == "standard":
         return {"status": "standard", "secret": _meta_payload(row), "envelope": _row_sealed(row)}
     delivery_payload = dict(delivery or {})

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -231,6 +231,13 @@ def _meta_payload(row: dict[str, Any]) -> dict[str, Any]:
             for key, value in pubkey_pin.items()
             if key in {"public_key", "fingerprint", "attested_at", "attestation"}
         }
+    signing_public_key = public_meta.get("signing_public_key")
+    if isinstance(signing_public_key, dict):
+        payload["signing_public_key"] = {
+            key: value
+            for key, value in signing_public_key.items()
+            if key in {"curve", "public_key"}
+        }
     return payload
 
 

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -195,6 +195,22 @@ def test_run_calls_avault_with_env_mapping_and_records_delivery(tmp_path, capfd,
     assert secret["last_used_at"] is not None
 
 
+def test_run_rejects_keypair_before_avault_delivery(capfd, monkeypatch):
+    from vibe import api
+
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="ETH_KEY", sealed=_sealed("eth"), kind="keypair", signer_kind="local")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(_ns(env=["ETH_KEY"], command_argv=["python3", "-c", "pass"]))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "keypair_not_value_deliverable"
+    deliver.assert_not_called()
+
+
 def test_run_delivers_protected_secret_under_agent_grant(tmp_path, capfd, monkeypatch):
     from vibe import api
 

--- a/tests/test_vault_export_inject.py
+++ b/tests/test_vault_export_inject.py
@@ -106,6 +106,24 @@ def test_inject_calls_avault_and_records_delivery(tmp_path, capfd, monkeypatch, 
     assert secrets["B_KEY"]["use_count"] == 1
 
 
+def test_inject_rejects_keypair_before_avault_delivery(tmp_path, capfd, monkeypatch):
+    from unittest.mock import Mock
+
+    from vibe import api
+
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="ETH_KEY", sealed=_sealed("eth"), kind="keypair", signer_kind="local")
+    inject = Mock()
+    monkeypatch.setattr(api, "avault_deliver_inject", inject)
+
+    code = cli.cmd_vault_inject(_ns(keys="ETH_KEY", out=str(tmp_path / "secrets.env"), format="dotenv"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "keypair_not_value_deliverable"
+    inject.assert_not_called()
+
+
 def test_inject_uses_agent_delivery_for_protected_grant(tmp_path, capfd, monkeypatch):
     from unittest.mock import Mock
 

--- a/tests/test_vault_fetch.py
+++ b/tests/test_vault_fetch.py
@@ -108,6 +108,31 @@ def test_fetch_passes_bearer_request_to_avault_and_writes_stdout(tmp_path, capfd
         assert vault_service.get_secret_meta(conn, "GH_PAT")["use_count"] == 1
 
 
+def test_fetch_rejects_keypair_before_avault_delivery(capfd, monkeypatch):
+    from unittest.mock import Mock
+
+    from vibe import api
+
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(
+            conn,
+            name="ETH_KEY",
+            sealed=_sealed("eth"),
+            kind="keypair",
+            signer_kind="local",
+            policy={"allowed_hosts": ["api.example.com"]},
+        )
+    fetch = Mock()
+    monkeypatch.setattr(api, "avault_deliver_fetch", fetch)
+
+    code = cli.cmd_vault_fetch(_ns(auth="ETH_KEY", url="https://api.example.com/v1/thing"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "keypair_not_value_deliverable"
+    fetch.assert_not_called()
+
+
 def test_fetch_uses_agent_delivery_for_protected_grant(capfd, monkeypatch):
     from unittest.mock import Mock
 

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -110,6 +110,32 @@ def test_pubkey_pin_metadata_round_trips_through_masked_meta(vault):
     assert "ignored" not in listed_meta["avault_pubkey_pin"]
 
 
+def test_keypair_signing_public_key_surfaces_in_masked_meta(vault):
+    public_key = "02" + "cd" * 32
+    _create(
+        vault,
+        name="ETH_KEY",
+        kind="keypair",
+        signer_kind="local",
+        public_meta={
+            "signing_public_key": {
+                "curve": "secp256k1",
+                "public_key": public_key,
+                "ignored": "nope",
+            }
+        },
+    )
+
+    with vault.connect() as conn:
+        meta = vs.get_secret_meta(conn, "ETH_KEY")
+        listed = vs.list_secrets(conn)
+
+    assert meta["signing_public_key"] == {"curve": "secp256k1", "public_key": public_key}
+    listed_meta = next(item for item in listed if item["name"] == "ETH_KEY")
+    assert listed_meta["signing_public_key"] == {"curve": "secp256k1", "public_key": public_key}
+    assert "ignored" not in listed_meta["signing_public_key"]
+
+
 def test_pubkey_pin_does_not_change_secret_version(vault):
     _create(vault, name="A_KEY", protection="protected", group="crypto")
     with vault.begin() as conn:

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -147,6 +147,18 @@ def test_get_envelopes_validates_batch_before_returning(vault):
         vs.get_envelopes(conn, ["A_KEY", "NOPE"])
 
 
+def test_keypair_is_not_value_deliverable(vault):
+    _create(vault, name="ETH_KEY", kind="keypair", signer_kind="local")
+    with vault.connect() as conn:
+        with pytest.raises(vs.KeypairNotValueDeliverableError):
+            vs.get_envelope(conn, "ETH_KEY")
+        with pytest.raises(vs.KeypairNotValueDeliverableError):
+            vs.get_envelopes(conn, ["ETH_KEY"])
+        with pytest.raises(vs.KeypairNotValueDeliverableError):
+            vs.resolve_secret_access(conn, "ETH_KEY")
+        assert vs.get_key_envelope(conn, "ETH_KEY") == _sealed()
+
+
 def test_record_deliveries_bumps_usage_and_audits(vault):
     _create(vault, name="DB_URL")
     with vault.begin() as conn:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4254,6 +4254,9 @@ def cmd_vault_run(args):
     except vault_service.SecretNotFoundError as exc:
         _print_task_error(TaskCliError(f"secret '{exc}' not found", code="secret_not_found", help_command=help_command))
         return 1
+    except vault_service.KeypairNotValueDeliverableError as exc:
+        _print_task_error(TaskCliError(str(exc), code="keypair_not_value_deliverable", help_command=help_command))
+        return 1
     except vault_service.UnsupportedProtectionError as exc:
         _print_task_error(TaskCliError(str(exc), code="protected_tier_unavailable", help_command=help_command))
         return 1
@@ -4635,6 +4638,9 @@ def cmd_vault_fetch(args):
     except vault_service.SecretNotFoundError:
         _print_task_error(TaskCliError(f"secret '{args.auth}' not found", code="secret_not_found", help_command=help_command))
         return 1
+    except vault_service.KeypairNotValueDeliverableError as exc:
+        _print_task_error(TaskCliError(str(exc), code="keypair_not_value_deliverable", help_command=help_command))
+        return 1
     except vault_service.UnsupportedProtectionError as exc:
         _print_task_error(TaskCliError(str(exc), code="protected_tier_unavailable", help_command=help_command))
         return 1
@@ -4775,6 +4781,9 @@ def cmd_vault_inject(args):
         return 0
     except vault_service.SecretNotFoundError as exc:
         _print_task_error(TaskCliError(f"secret '{exc}' not found", code="secret_not_found", help_command=help_command))
+        return 1
+    except vault_service.KeypairNotValueDeliverableError as exc:
+        _print_task_error(TaskCliError(str(exc), code="keypair_not_value_deliverable", help_command=help_command))
         return 1
     except vault_service.UnsupportedProtectionError as exc:
         _print_task_error(TaskCliError(str(exc), code="protected_tier_unavailable", help_command=help_command))


### PR DESCRIPTION
## What

Make Vault keypair secrets sign-only across value-delivery paths, and surface saved signing public keys in masked metadata.

## Why

A standard `kind='keypair'` row stores its private key as a standard envelope. Before this change, value delivery could pass that envelope to avault through `vibe vault run`, `inject`, or `fetch`, making the private key deliverable as an ordinary secret value. This PR blocks keypairs from value delivery before any avault open/decrypt path. It is a focused prerequisite for #701.

The #701 UI also needs to recover the saved non-secret signing public key after creation. `_meta_payload` now exposes `public_meta.signing_public_key` as a top-level masked field.

## Behavior

- `resolve_secret_access`, single envelope reads, and batch envelope reads reject keypairs with `KeypairNotValueDeliverableError`.
- CLI value delivery maps that to `keypair_not_value_deliverable` for `vibe vault run`, `vibe vault inject`, and `vibe vault fetch`.
- Standard keypairs still sign through `vault_sign` / `avault sign` via the dedicated key envelope path.
- Masked secret payloads include `signing_public_key: { curve, public_key }` when stored under `public_meta.signing_public_key`.

## Evidence

- Unit: focused keypair rejection tests for service, run, inject, and fetch.
- Unit: existing standard keypair signing test still passes.
- Unit: masked metadata test for keypair `signing_public_key`.
- Contract: `python3 -m pytest tests/test_vault*.py -q` (199 passed)
- Lint: `ruff check storage/vault_service.py vibe/cli.py tests/test_vault_service.py tests/test_vault_cli.py tests/test_vault_export_inject.py tests/test_vault_fetch.py`
- Residual manual checks: none; backend-only guard/metadata exposure.
