### PR TITLE
fix(vaults): reject keypair fetch before policy checks

### DIFF
--- a/tests/test_vault_fetch.py
+++ b/tests/test_vault_fetch.py
@@ -120,7 +120,6 @@ def test_fetch_rejects_keypair_before_avault_delivery(capfd, monkeypatch):
             sealed=_sealed("eth"),
             kind="keypair",
             signer_kind="local",
-            policy={"allowed_hosts": ["api.example.com"]},
         )
     fetch = Mock()
     monkeypatch.setattr(api, "avault_deliver_fetch", fetch)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4561,6 +4561,11 @@ def cmd_vault_fetch(args):
         # envelope to avault, so a disallowed target never even unwraps the secret.
         with engine.connect() as conn:
             policy = vault_service.get_secret_policy(conn, name)
+            meta = vault_service.get_secret_meta(conn, name)
+            if meta.get("kind") == "keypair":
+                raise vault_service.KeypairNotValueDeliverableError(
+                    f"{name} is a signing key; use vault_sign instead of value delivery"
+                )
             allowed = policy.get("allowed_hosts") or []
             if not allowed:
                 raise TaskCliError(


### PR DESCRIPTION
## Summary
- Follow-up to #703 after it was merged: reject `kind="keypair"` in `vibe vault fetch` before fetch policy validation.
- Ensures a keypair without `allowed_hosts` still returns `keypair_not_value_deliverable` instead of `proxy_unbound`.
- Keeps fetch from reaching avault delivery for sign-only keys.

## Validation
- `python3 -m pytest tests/test_vault_fetch.py::test_fetch_rejects_keypair_before_avault_delivery -q`
- `python3 -m pytest tests/test_vault*.py -q`
- `ruff check vibe/cli.py tests/test_vault_fetch.py`
- `git diff --check`
