### PR TITLE
feat(ui): windowed Apps — per-app theme, editor file picker/new-file, Dock + window polish

### DIFF
--- a/ui/src/apps/registry.tsx
+++ b/ui/src/apps/registry.tsx
@@ -21,6 +21,12 @@ export interface AppDefinition {
   defaultSize: { width: number; height: number };
   /** The window body. Receives the owning window id and its launch params. */
   Component: React.FC<{ windowId: string; params?: Record<string, unknown> }>;
+  /**
+   * Lock this app's window to a fixed theme regardless of the global light/dark. The Editor and
+   * Terminal stay dark (a code editor and a shell are conventionally dark); the File Browser omits
+   * this and follows the workbench theme.
+   */
+  lockTheme?: 'dark';
 }
 
 const Loading: React.FC = () => {
@@ -57,6 +63,7 @@ export const APP_REGISTRY: Record<AppId, AppDefinition> = {
     icon: SquareTerminal,
     accent: '--mint',
     defaultSize: { width: 820, height: 540 },
+    lockTheme: 'dark',
     Component: () => (
       <Suspense fallback={<Loading />}>
         {/* Each windowed terminal takes a bounded, reused session slot internally so
@@ -71,6 +78,7 @@ export const APP_REGISTRY: Record<AppId, AppDefinition> = {
     icon: CodeXml,
     accent: '--violet',
     defaultSize: { width: 1000, height: 640 },
+    lockTheme: 'dark',
     Component: ({ windowId, params }) => (
       <Suspense fallback={<Loading />}>
         <EditorBody windowId={windowId} params={params} />

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -218,12 +218,11 @@ const FloatingApps: React.FC = () => {
   const anyMaximized = windows.some((w) => w.maximized && !w.minimized);
   if (!anyMaximized) return null;
   return (
-    // data-theme="dark" so the floating Dock popover matches the always-dark windows it sits over.
     // A solid rounded backing + shadow makes it read as a clean floating Dock launcher (design
     // If1Tt shows the pill clean) so the maximized app's content behind it — the editor activity
-    // bar, the file-browser rail — doesn't bleed through the translucent pill.
+    // bar, the file-browser rail — doesn't bleed through the translucent pill. It follows the
+    // workbench theme like the windows it sits over (no longer forced dark).
     <div
-      data-theme="dark"
       className="fixed bottom-5 left-4 z-30 hidden w-[184px] rounded-full bg-surface-3 shadow-[0_10px_34px_-8px_rgba(0,0,0,0.7)] md:flex"
     >
       <AppsLauncher />

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -128,6 +128,10 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
       // Keyboard chords resolve their target window from the DOM-focused element via
       // this id, so they act on the window you're actually typing in (not just the top).
       data-window-id={win.id}
+      // Per-app theme: the File Browser follows the global light/dark; the Editor and Terminal
+      // lock to dark (VS Code-style) via their registry `lockTheme`. `data-theme` re-cascades that
+      // token set to this window's subtree; an omitted (undefined) value inherits the global theme.
+      data-theme={def.lockTheme}
       // Minimized windows stay mounted (to preserve their body state) but go fully
       // inert: hidden from assistive tech, out of the tab order, non-interactive —
       // and React/the browser moves focus out automatically.

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -32,19 +32,11 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
   // CSS owns the timing). Minimizing is a pure mounted hide (see className) so the
   // window body — terminal session, editor buffer — stays alive and intact.
   const [exitKind, setExitKind] = useState<'close' | null>(null);
-  // Briefly enable a geometry transition while a maximize/restore toggle is animating (see the
-  // className), then drop it so a drag/resize stays instant (a transition there would lag the pointer).
-  const [animatingMax, setAnimatingMax] = useState(false);
-  const maxMounted = useRef(false);
-  useEffect(() => {
-    if (!maxMounted.current) {
-      maxMounted.current = true;
-      return;
-    }
-    setAnimatingMax(true);
-    const id = window.setTimeout(() => setAnimatingMax(false), 220);
-    return () => window.clearTimeout(id);
-  }, [win.maximized]);
+  // Animate window GEOMETRY (maximize/restore) but NOT during a drag/resize, which must track the
+  // pointer instantly. `dragging` is state (not a ref) so the transition is enabled in the SAME render
+  // that changes the bounds — otherwise the geometry jumps before the transition class arrives and
+  // maximize/restore don't animate at all.
+  const [dragging, setDragging] = useState(false);
 
   // Keep a visible window reachable when the geometry around it changes without a
   // drag: the layer shrinking, or the window being restored / un-maximized after the
@@ -85,6 +77,7 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
     // titlebar/handle stops propagation, so the root's own focus handler won't run.
     rootRef.current?.focus({ preventScroll: true });
     draggingRef.current = true;
+    setDragging(true);
     const startX = e.clientX;
     const startY = e.clientY;
     const start = { ...win.bounds };
@@ -101,6 +94,7 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
     };
     const onUp = () => {
       draggingRef.current = false;
+      setDragging(false);
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
     };
@@ -172,11 +166,11 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
         // Minimize shrinks toward the bottom-left (where the Dock lives) for a macOS-like genie;
         // otherwise scale from center for the open/close keyframe.
         win.minimized ? 'origin-bottom-left' : 'origin-center',
-        // Animate geometry ONLY while a maximize/restore toggle is in flight — a transition during a
-        // drag/resize would lag the pointer.
-        animatingMax
-          ? 'transition-[left,top,width,height,transform,opacity] duration-200 ease-out'
-          : 'transition-[transform,opacity] duration-200 ease-out',
+        // Geometry animates (maximize/restore) except during a drag/resize, which must track the
+        // pointer instantly.
+        dragging
+          ? 'transition-[transform,opacity] duration-200 ease-out'
+          : 'transition-[left,top,width,height,transform,opacity] duration-200 ease-out',
         win.maximized ? 'rounded-none' : 'rounded-xl',
         exitKind === 'close' ? 'animate-appwindow-out' : 'animate-appwindow-in',
         // Minimize = mounted hide: the body stays alive (terminal/editor state preserved) while the

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -32,6 +32,19 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
   // CSS owns the timing). Minimizing is a pure mounted hide (see className) so the
   // window body — terminal session, editor buffer — stays alive and intact.
   const [exitKind, setExitKind] = useState<'close' | null>(null);
+  // Briefly enable a geometry transition while a maximize/restore toggle is animating (see the
+  // className), then drop it so a drag/resize stays instant (a transition there would lag the pointer).
+  const [animatingMax, setAnimatingMax] = useState(false);
+  const maxMounted = useRef(false);
+  useEffect(() => {
+    if (!maxMounted.current) {
+      maxMounted.current = true;
+      return;
+    }
+    setAnimatingMax(true);
+    const id = window.setTimeout(() => setAnimatingMax(false), 220);
+    return () => window.clearTimeout(id);
+  }, [win.maximized]);
 
   // Keep a visible window reachable when the geometry around it changes without a
   // drag: the layer shrinking, or the window being restored / un-maximized after the
@@ -156,12 +169,19 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
       }}
       className={clsx(
         'group/win absolute flex flex-col overflow-hidden border bg-surface-2 outline-none',
-        'origin-center transition-[transform,opacity] duration-200 ease-out',
+        // Minimize shrinks toward the bottom-left (where the Dock lives) for a macOS-like genie;
+        // otherwise scale from center for the open/close keyframe.
+        win.minimized ? 'origin-bottom-left' : 'origin-center',
+        // Animate geometry ONLY while a maximize/restore toggle is in flight — a transition during a
+        // drag/resize would lag the pointer.
+        animatingMax
+          ? 'transition-[left,top,width,height,transform,opacity] duration-200 ease-out'
+          : 'transition-[transform,opacity] duration-200 ease-out',
         win.maximized ? 'rounded-none' : 'rounded-xl',
         exitKind === 'close' ? 'animate-appwindow-out' : 'animate-appwindow-in',
-        // Minimize = mounted hide: the body stays alive (terminal/editor state
-        // preserved) while the window scales away and stops taking pointer events.
-        win.minimized ? 'pointer-events-none scale-90 opacity-0' : 'pointer-events-auto',
+        // Minimize = mounted hide: the body stays alive (terminal/editor state preserved) while the
+        // window scales away toward the Dock and stops taking pointer events.
+        win.minimized ? 'pointer-events-none scale-[0.18] opacity-0' : 'pointer-events-auto',
         focused
           ? 'border-border-strong shadow-[0_28px_60px_-12px_rgba(0,0,0,0.7)]'
           : 'border-border shadow-[0_16px_40px_-16px_rgba(0,0,0,0.6)]',

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -6,11 +6,12 @@ import clsx from 'clsx';
 import { APP_LIST, APP_REGISTRY, type AppId } from '../../apps/registry';
 import { useWindowManager } from '../../context/WindowManagerContext';
 
-// The unified Dock panel: app launcher + running indicators + minimized-window
-// thumbnails. Headless of how it's revealed — the AppsLauncher trigger floats it
-// above the bottom-left Apps button (hover = preview, click = pin). A running app's
-// tile reveals a ＋ (and right-click menu) to open another window — windows are
-// multi-instance, so this is the explicit path to a second Files/Terminal/Editor.
+// The unified Dock panel: app launcher + running indicators + minimized windows.
+// Headless of how it's revealed — the AppsLauncher trigger floats it above the bottom-left
+// Apps button (hover = preview, click = pin). A running app's tile reveals a ＋ (and right-click
+// menu) to open another window — windows are multi-instance, so this is the explicit path to a
+// second Files/Terminal/Editor. Each app tile carries its name (macOS-style label) and each
+// minimized window shows its title so the user can tell several open windows apart.
 export const Dock: React.FC = () => {
   const { t } = useTranslation();
   const wm = useWindowManager();
@@ -61,49 +62,57 @@ export const Dock: React.FC = () => {
   return (
     <div className="relative">
       {menuApp && <div className="fixed inset-0 z-0" onClick={() => setMenuApp(null)} aria-hidden />}
-      <div className="relative flex items-center gap-2 rounded-2xl border border-border-strong bg-surface-2/95 p-2 shadow-[0_24px_64px_-12px_rgba(0,0,0,0.65)] backdrop-blur-xl">
+      <div className="relative flex items-end gap-2 rounded-2xl border border-border-strong bg-surface-2/95 p-2 shadow-[0_24px_64px_-12px_rgba(0,0,0,0.65)] backdrop-blur-xl">
         {APP_LIST.map((app) => {
           const Icon = app.icon;
           const running = windows.some((w) => w.appId === app.id);
           const active = focusedApp === app.id;
           return (
-            <div key={app.id} className="group/tile relative flex flex-col items-center gap-1.5">
-              <button
-                type="button"
-                title={t(app.titleKey)}
-                aria-label={t(app.titleKey)}
-                onClick={(e) => (e.metaKey || e.ctrlKey || e.altKey ? openNew(app.id) : activate(app.id))}
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  setMenuApp((cur) => (cur === app.id ? null : app.id));
-                }}
-                className={clsx(
-                  'grid size-12 place-items-center rounded-xl border transition',
-                  active ? 'border-2 bg-foreground/[0.07]' : 'border-border bg-foreground/[0.03] hover:bg-foreground/[0.07]',
-                )}
-                style={active ? { borderColor: `var(${app.accent})` } : undefined}
-              >
-                <Icon className="size-6" style={{ color: `var(${app.accent})` }} />
-              </button>
-              <span className="size-1.5 rounded-full" style={{ backgroundColor: running ? `var(${app.accent})` : 'transparent' }} />
+            <div key={app.id} className="group/tile flex w-[60px] flex-col items-center gap-1">
+              {/* Icon wrapper is the positioning context for the ＋ affordance so it pins to the
+                  icon's corner (not the wider labelled tile). */}
+              <div className="relative">
+                <button
+                  type="button"
+                  title={t(app.titleKey)}
+                  aria-label={t(app.titleKey)}
+                  onClick={(e) => (e.metaKey || e.ctrlKey || e.altKey ? openNew(app.id) : activate(app.id))}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setMenuApp((cur) => (cur === app.id ? null : app.id));
+                  }}
+                  className={clsx(
+                    'grid size-10 place-items-center rounded-xl border transition',
+                    active ? 'border-2 bg-foreground/[0.07]' : 'border-border bg-foreground/[0.03] hover:bg-foreground/[0.07]',
+                  )}
+                  style={active ? { borderColor: `var(${app.accent})` } : undefined}
+                >
+                  <Icon className="size-5" style={{ color: `var(${app.accent})` }} />
+                </button>
 
-              {/* ＋ reveals on hover and directly opens another window (the one-click affordance the
-                  label advertises). The New Window / Show All Windows menu is the tile's right-click. */}
-              <button
-                type="button"
-                title={t('apps.dock.newWindow')}
-                aria-label={t('apps.dock.newWindow')}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openNew(app.id);
-                }}
-                className={clsx(
-                  'absolute -right-1 -top-1 grid size-4 place-items-center rounded-full border border-border-strong bg-surface-2 text-muted shadow transition hover:text-foreground',
-                  menuApp === app.id ? 'opacity-100' : 'opacity-0 group-hover/tile:opacity-100',
-                )}
-              >
-                <Plus className="size-2.5" strokeWidth={3} />
-              </button>
+                {/* ＋ reveals on hover and directly opens another window (the one-click affordance the
+                    label advertises). The New Window / Show All Windows menu is the tile's right-click. */}
+                <button
+                  type="button"
+                  title={t('apps.dock.newWindow')}
+                  aria-label={t('apps.dock.newWindow')}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openNew(app.id);
+                  }}
+                  className={clsx(
+                    'absolute -right-1 -top-1 grid size-4 place-items-center rounded-full border border-border-strong bg-surface-2 text-muted shadow transition hover:text-foreground',
+                    menuApp === app.id ? 'opacity-100' : 'opacity-0 group-hover/tile:opacity-100',
+                  )}
+                >
+                  <Plus className="size-2.5" strokeWidth={3} />
+                </button>
+              </div>
+
+              {/* App name (macOS-style labelled tile) + running indicator. The name also surfaces on
+                  hover via the icon button's title, in case it's truncated. */}
+              <span className="max-w-full truncate text-[10px] leading-tight text-muted">{t(app.titleKey)}</span>
+              <span className="size-1 rounded-full" style={{ backgroundColor: running ? `var(${app.accent})` : 'transparent' }} />
 
               {menuApp === app.id && (
                 <div
@@ -138,28 +147,26 @@ export const Dock: React.FC = () => {
           );
         })}
 
-        {minimized.length > 0 && <div className="mx-1 h-11 w-px shrink-0 bg-border-strong" />}
+        {minimized.length > 0 && <div className="mx-1 h-11 w-px shrink-0 self-center bg-border-strong" />}
 
+        {/* Minimized windows: an icon + the window's title so several open windows are
+            distinguishable at a glance (a true live thumbnail isn't practical — the editor/terminal
+            render to canvas — so the title carries the identification). */}
         {minimized.map((w) => {
           const def = APP_REGISTRY[w.appId];
           const Icon = def.icon;
+          const label = w.title ?? t(def.titleKey);
           return (
             <button
               key={w.id}
               type="button"
-              title={w.title ?? t(def.titleKey)}
+              title={label}
               aria-label={t('apps.window.restore', { defaultValue: 'Restore' })}
               onClick={() => wm.restore(w.id)}
-              className="flex h-[52px] w-[76px] shrink-0 flex-col overflow-hidden rounded-lg border border-border-strong bg-surface transition hover:border-foreground/30"
+              className="flex h-10 w-[136px] shrink-0 items-center gap-2 self-center rounded-lg border border-border-strong bg-surface px-2.5 text-left transition hover:border-foreground/30"
             >
-              <span className="flex items-center gap-1 bg-surface-2 px-1.5 py-1">
-                {['#ff5f57', '#febc2e', '#28c840'].map((c) => (
-                  <span key={c} className="size-1 rounded-full" style={{ backgroundColor: c }} />
-                ))}
-              </span>
-              <span className="flex flex-1 items-center justify-center">
-                <Icon className="size-4" style={{ color: `var(${def.accent})` }} />
-              </span>
+              <Icon className="size-4 shrink-0" style={{ color: `var(${def.accent})` }} />
+              <span className="min-w-0 flex-1 truncate text-[11px] text-foreground">{label}</span>
             </button>
           );
         })}

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -68,7 +68,7 @@ export const Dock: React.FC = () => {
           const running = windows.some((w) => w.appId === app.id);
           const active = focusedApp === app.id;
           return (
-            <div key={app.id} className="group/tile flex w-[60px] flex-col items-center gap-1">
+            <div key={app.id} className="group/tile relative flex w-[60px] flex-col items-center gap-1">
               {/* Icon wrapper is the positioning context for the ＋ affordance so it pins to the
                   icon's corner (not the wider labelled tile). */}
               <div className="relative">

--- a/ui/src/components/apps/WindowLayer.tsx
+++ b/ui/src/components/apps/WindowLayer.tsx
@@ -71,12 +71,10 @@ export const WindowLayer: React.FC = () => {
     <div
       ref={ref}
       aria-hidden={!anyShown}
-      // The windowed apps (Editor / Terminal / File Browser) are ALWAYS dark — they're
-      // dark-only in the design (dnYPx / iwYIX / nknn2) with hardcoded-dark content areas
-      // (Monaco, xterm), so a light global theme would otherwise paint light chrome around
-      // dark content (and make the welcome text unreadable). `data-theme="dark"` re-cascades
-      // the dark token set to this whole subtree regardless of the app theme.
-      data-theme="dark"
+      // The windowed apps (Editor / Terminal / File Browser) follow the workbench light/dark
+      // theme: they're built on the shared semantic tokens, Monaco is themed from resolvedTheme,
+      // and xterm carries its own light/dark palette — so the layer inherits the ambient theme
+      // rather than forcing dark (the design frames dnYPx / iwYIX / nknn2 are the dark variant).
       // Spans the FULL viewport (no longer offset past the sidebar): windows can move over
       // the sidebar and maximize fills the whole screen. The sidebar's bottom Apps/Dock
       // cluster sits above this layer (z-30) so it stays reachable under a maximized window.

--- a/ui/src/components/apps/WindowLayer.tsx
+++ b/ui/src/components/apps/WindowLayer.tsx
@@ -71,10 +71,9 @@ export const WindowLayer: React.FC = () => {
     <div
       ref={ref}
       aria-hidden={!anyShown}
-      // The windowed apps (Editor / Terminal / File Browser) follow the workbench light/dark
-      // theme: they're built on the shared semantic tokens, Monaco is themed from resolvedTheme,
-      // and xterm carries its own light/dark palette — so the layer inherits the ambient theme
-      // rather than forcing dark (the design frames dnYPx / iwYIX / nknn2 are the dark variant).
+      // Theme is per-window now (AppWindow sets it from each app's registry `lockTheme`): the File
+      // Browser follows the workbench light/dark, while the Editor and Terminal stay dark like a VS
+      // Code editor / a terminal. So the layer itself no longer forces a theme — each window opts in.
       // Spans the FULL viewport (no longer offset past the sidebar): windows can move over
       // the sidebar and maximize fills the whole screen. The sidebar's bottom Apps/Dock
       // cluster sits above this layer (z-30) so it stays reachable under a maximized window.

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -1,19 +1,30 @@
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
 import { Blocks, Bug, Clock, CodeXml, FilePlus, Files, FolderOpen, GitBranch, Search, Settings, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
-import { useWindowCloseGuard, useWindowManager } from '../../context/WindowManagerContext';
-import { downloadFile, fileBrowserErrorMessage, fileMeta, isPlainEntryName, joinPath, listDir, parentDir, writeFile, type FsEntry } from '../../lib/filesApi';
+import { useWindowCloseGuard } from '../../context/WindowManagerContext';
+import { downloadFile, fileMeta, joinPath, parentDir, writeFile, type FsEntry } from '../../lib/filesApi';
 import { isEditableFile } from '../../lib/filePreview';
 import { FileTree } from './FileTree';
+import { FilePicker, type FilePickerMode } from './FilePicker';
 
 const FileEditorPane = lazy(() => import('./FileEditorPane').then((m) => ({ default: m.FileEditorPane })));
 
 // A tab carries the file's mtime captured at open time, so saving stays conditional on it
 // (writeFile's expected_mtime) and the backend can surface a conflict instead of silently
-// clobbering newer on-disk content.
-type Tab = { path: string; name: string; mtime: number | null };
+// clobbering newer on-disk content. `path` is null for an unsaved "untitled" buffer (a VS
+// Code-style new file): it lives only in memory until the first save picks a location. Tabs are
+// keyed by a synthetic `id` (not the path) so an untitled tab survives becoming a saved file.
+type Tab = { id: string; path: string | null; name: string; mtime: number | null };
+
+// A pending file dialog, rendered as the in-window FilePicker overlay.
+type PickerState = {
+  mode: FilePickerMode;
+  initialPath: string | null;
+  defaultName?: string;
+  onConfirm: (result: { path: string; name?: string }) => Promise<void> | void;
+};
 
 // Human language label for the status bar (design dnYPx shows e.g. "TypeScript React").
 const LANGUAGE_LABEL: Record<string, string> = {
@@ -62,23 +73,36 @@ function languageLabel(filename: string | undefined): string | undefined {
 }
 
 // The Editor IDE (design dnYPx + welcome w0qoC): activity bar + collapsible explorer tree +
-// editor tabs + Monaco + cyan status bar; a VS-Code-style welcome when nothing is open.
-// Monaco is fully integrated here. Files opens a file via openApp('editor', { params: { path } }).
+// editor tabs + Monaco + cyan status bar; a VS-Code-style welcome when nothing is open. Monaco is
+// fully integrated here. Files opens a file via openApp('editor', { params: { path } }). Open
+// Folder / Save use the in-window FilePicker (browsing the real filesystem), and New File opens an
+// untitled buffer that picks its location only on first save.
 export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, unknown> }> = ({ windowId, params }) => {
   const { t } = useTranslation();
-  const wm = useWindowManager();
   const [root, setRoot] = useState<string | null>(null);
   const [tabs, setTabs] = useState<Tab[]>([]);
-  const [active, setActive] = useState<string | null>(null);
-  const [dirty, setDirty] = useState<Record<string, boolean>>({});
+  const [active, setActive] = useState<string | null>(null); // active tab id
+  const [dirty, setDirty] = useState<Record<string, boolean>>({}); // keyed by tab id
   const [cursor, setCursor] = useState<{ line: number; col: number } | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [picker, setPicker] = useState<PickerState | null>(null);
+  const tabSeq = useRef(0);
+  const untitledSeq = useRef(0);
+  // Latest tabs for dedup / id-resolution outside the setState updater (avoids side effects in a
+  // reducer while still keying on the synthetic id).
+  const tabsRef = useRef<Tab[]>(tabs);
+  tabsRef.current = tabs;
 
   const openFile = useCallback((path: string, name: string, mtime: number | null) => {
     setRoot((r) => r ?? parentDir(path));
-    setTabs((ts) => (ts.some((x) => x.path === path) ? ts : [...ts, { path, name, mtime }]));
     setCursor(null);
-    setActive(path);
+    const existing = tabsRef.current.find((x) => x.path === path);
+    if (existing) {
+      setActive(existing.id);
+      return;
+    }
+    const id = `t${++tabSeq.current}`;
+    setTabs((ts) => [...ts, { id, path, name, mtime }]);
+    setActive(id);
   }, []);
 
   // The explorer tree emits a clicked entry. Gate it like the File Browser: only a regular,
@@ -122,68 +146,86 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
   const anyDirty = Object.values(dirty).some(Boolean);
   useWindowCloseGuard(windowId, anyDirty ? t('apps.editor.confirmDiscardClose') : null);
 
-  const closeTab = (path: string) => {
+  const closeTab = (id: string) => {
     // Closing a dirty tab drops its in-memory buffer (only the window-level guard existed before),
     // so confirm first when there are unsaved edits.
-    if (dirty[path] && !window.confirm(t('apps.editor.confirmDiscardClose'))) return;
-    setTabs((ts) => {
-      const rest = ts.filter((x) => x.path !== path);
-      setActive((cur) => (cur === path ? (rest.length ? rest[rest.length - 1].path : null) : cur));
-      return rest;
-    });
+    if (dirty[id] && !window.confirm(t('apps.editor.confirmDiscardClose'))) return;
+    const rest = tabsRef.current.filter((x) => x.id !== id);
+    setTabs(rest);
+    if (active === id) setActive(rest.length ? rest[rest.length - 1].id : null);
     setDirty((d) => {
       const n = { ...d };
-      delete n[path];
+      delete n[id];
       return n;
     });
   };
 
-  // Prompt for + validate a folder, set it as the explorer root, and RETURN it (or null) so
-  // callers like New File can continue the flow with the chosen folder.
-  const openFolder = async (): Promise<string | null> => {
-    const p = window.prompt(t('apps.editor.openFolderPrompt'));
-    const path = p?.trim();
-    if (!path) return null;
-    // Validate it's a listable directory before swapping the explorer root, so a typo doesn't
-    // leave the tree stuck on a bad/non-existent path.
-    try {
-      await listDir(path);
-      setError(null);
-      setRoot(path);
-      return path;
-    } catch (e: unknown) {
-      setError(fileBrowserErrorMessage(e, t, t('apps.fileBrowser.errors.listFailed')));
-      return null;
-    }
-  };
-  const newFile = async () => {
-    // From the welcome state there's no folder yet: prompt for one and CONTINUE creating the file
-    // in it (rather than behaving like a bare "Open Folder").
-    const dir = root ?? (await openFolder());
-    if (!dir) return;
-    const raw = window.prompt(t('apps.fileBrowser.newFilePrompt'));
-    if (raw == null) return;
-    const name = raw.trim();
-    if (name === '') return;
-    if (!isPlainEntryName(name)) {
-      setError(t('apps.fileBrowser.errors.invalid_name'));
-      return;
-    }
-    const full = joinPath(dir, name);
-    try {
-      // create-only: the backend atomically refuses (errors.exists) if the name is taken, so a
-      // typo can never truncate an existing file.
-      const result = await writeFile(full, '', undefined, true);
-      openFile(full, name, result.mtime);
-    } catch (e: unknown) {
-      setError(fileBrowserErrorMessage(e, t, t('apps.fileBrowser.errors.saveFailed')));
-    }
-  };
+  // Open Folder: pick a folder via the in-window FilePicker (no manual path typing), set it as the
+  // explorer root. The picker only resolves to listable folders, so no extra validation is needed.
+  const openFolder = useCallback(() => {
+    setPicker({
+      mode: 'open-directory',
+      initialPath: root,
+      onConfirm: ({ path }) => {
+        setRoot(path);
+        setPicker(null);
+      },
+    });
+  }, [root]);
+
+  // New File: open an empty untitled buffer (VS Code-style). It has no path until the first save.
+  const newFile = useCallback(() => {
+    const id = `t${++tabSeq.current}`;
+    setTabs((ts) => [...ts, { id, path: null, name: t('apps.editor.untitled', { n: ++untitledSeq.current }), mtime: null }]);
+    setActive(id);
+    setCursor(null);
+  }, [t]);
+
+  // Save As (for an untitled buffer): pick a folder + filename, write create-only (so it can't
+  // clobber an existing file), then re-point the tab at the chosen path. A name clash throws
+  // errors.exists, which keeps the picker open with the message so the user can rename.
+  const saveAs = useCallback(
+    (tabId: string, text: string) => {
+      setPicker({
+        mode: 'save-file',
+        initialPath: root,
+        onConfirm: async ({ path, name }) => {
+          const full = joinPath(path, name as string);
+          const result = await writeFile(full, text, undefined, true);
+          setTabs((ts) => ts.map((x) => (x.id === tabId ? { ...x, path: full, name: name as string, mtime: result.mtime } : x)));
+          setRoot((r) => r ?? path);
+          setPicker(null);
+        },
+      });
+    },
+    [root],
+  );
+
+  // ⌘O Open Folder · ⌘N New File — only while THIS editor window holds focus (several windows can
+  // be open). Capture phase + preventDefault so ⌘O doesn't fall through to the browser's open dialog.
+  useEffect(() => {
+    if (!windowId) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+      const k = e.key.toLowerCase();
+      if (k !== 'o' && k !== 'n') return;
+      if (picker) return; // a dialog is already open
+      const winEl = (document.activeElement as Element | null)?.closest('[data-window-id]');
+      if (winEl?.getAttribute('data-window-id') !== windowId) return;
+      e.preventDefault();
+      if (k === 'o') openFolder();
+      else newFile();
+    };
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [windowId, openFolder, newFile, picker]);
 
   const ACTIVITY = [Files, Search, GitBranch, Bug, Blocks];
+  const showWelcome = root == null && tabs.length === 0;
+  const activeName = tabs.find((x) => x.id === active)?.name;
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col bg-surface">
+    <div className="relative flex h-full min-h-0 w-full flex-col bg-surface">
       <div className="flex min-h-0 flex-1">
         {/* Activity bar */}
         <div className="flex w-12 shrink-0 flex-col items-center justify-between border-r border-border bg-surface-3 py-3">
@@ -210,52 +252,46 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
                 <FolderOpen className="size-3.5" />
                 {t('apps.editor.openFolder')}
               </button>
-              {/* Folder-validation errors (bad path / permission) must surface here too — the
-                  main-area error banner only renders once a folder is open. */}
-              {error && (
-                <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-2 py-1.5 text-[11.5px] text-destructive">
-                  {error}
-                </div>
-              )}
             </div>
           ) : (
             <div className="min-h-0 flex-1 overflow-y-auto px-1 pb-2">
-              <FileTree rootPath={root} rootName={root.split('/').filter(Boolean).pop() || root} activePath={active} onOpenFile={onTreeOpen} />
+              <FileTree rootPath={root} rootName={root.split('/').filter(Boolean).pop() || root} activePath={tabs.find((x) => x.id === active)?.path ?? null} onOpenFile={onTreeOpen} />
             </div>
           )}
         </div>
 
-        {/* Main area: welcome (no folder) · tabs + Monaco (file open) · select-a-file hint (folder, no file). */}
+        {/* Main area: welcome (nothing open) · tabs + Monaco (a file or untitled buffer open) ·
+            select-a-file hint (folder open, no tab). */}
         <div className="flex min-w-0 flex-1 flex-col bg-surface">
-          {root == null ? (
-            <Welcome onOpenFolder={openFolder} onNewFile={newFile} onOpenFiles={() => wm.openApp('files')} />
+          {showWelcome ? (
+            <Welcome onOpenFolder={openFolder} onNewFile={newFile} />
           ) : (
             <>
               {tabs.length > 0 && (
                 <div className="flex items-center overflow-x-auto border-b border-border bg-surface-2">
                   {tabs.map((tab) => (
                     <div
-                      key={tab.path}
+                      key={tab.id}
                       className={clsx(
                         'group/tab flex shrink-0 items-center gap-2 border-r border-border px-3 py-2 text-[12px] transition',
-                        active === tab.path ? 'bg-surface text-foreground shadow-[inset_0_2px_0_0_var(--cyan)]' : 'text-muted hover:bg-foreground/[0.04]',
+                        active === tab.id ? 'bg-surface text-foreground shadow-[inset_0_2px_0_0_var(--cyan)]' : 'text-muted hover:bg-foreground/[0.04]',
                       )}
                     >
                       <button
                         type="button"
                         onClick={() => {
-                          if (tab.path !== active) setCursor(null);
-                          setActive(tab.path);
+                          if (tab.id !== active) setCursor(null);
+                          setActive(tab.id);
                         }}
                         className="flex items-center gap-1.5"
                       >
                         <CodeXml className="size-3.5 text-cyan" />
                         {tab.name}
-                        {dirty[tab.path] && <span className="size-1.5 rounded-full bg-mint" />}
+                        {dirty[tab.id] && <span className="size-1.5 rounded-full bg-mint" />}
                       </button>
                       <button
                         type="button"
-                        onClick={() => closeTab(tab.path)}
+                        onClick={() => closeTab(tab.id)}
                         aria-label={t('common.close')}
                         className="grid size-4 place-items-center rounded text-muted opacity-0 transition hover:bg-foreground/10 hover:text-foreground group-hover/tab:opacity-100"
                       >
@@ -266,22 +302,21 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
                 </div>
               )}
 
-              {error && <div className="border-b border-destructive/40 bg-destructive/[0.06] px-3 py-1.5 text-[11.5px] text-destructive">{error}</div>}
-
               <div className="relative min-h-0 flex-1">
                 {tabs.length === 0 ? (
                   <div className="grid h-full place-items-center text-[12.5px] text-muted">{t('apps.editor.selectFileHint')}</div>
                 ) : (
                   tabs.map((tab) => (
-                    <div key={tab.path} className={clsx('absolute inset-0', active === tab.path ? 'block' : 'hidden')}>
+                    <div key={tab.id} className={clsx('absolute inset-0', active === tab.id ? 'block' : 'hidden')}>
                       <Suspense fallback={<div className="grid h-full place-items-center text-[12px] text-muted">{t('common.loading')}</div>}>
                         <FileEditorPane
                           path={tab.path}
                           filename={tab.name}
                           mtime={tab.mtime}
                           chromeless
-                          onDirtyChange={(d) => setDirty((prev) => (prev[tab.path] === d ? prev : { ...prev, [tab.path]: d }))}
-                          onCursor={active === tab.path ? (line, col) => setCursor({ line, col }) : undefined}
+                          onDirtyChange={(d) => setDirty((prev) => (prev[tab.id] === d ? prev : { ...prev, [tab.id]: d }))}
+                          onCursor={active === tab.id ? (line, col) => setCursor({ line, col }) : undefined}
+                          onSaveAs={(textValue) => saveAs(tab.id, textValue)}
                         />
                       </Suspense>
                     </div>
@@ -302,22 +337,31 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
           <>
             <span className="ml-auto tabular-nums">{t('apps.editor.lineCol', { line: cursor?.line ?? 1, col: cursor?.col ?? 1 })}</span>
             <span>{t('apps.editor.spaces', { n: 2 })}</span>
-            <span className="truncate">{languageLabel(tabs.find((x) => x.path === active)?.name) ?? t('apps.editor.plainText')}</span>
+            <span className="truncate">{languageLabel(activeName) ?? t('apps.editor.plainText')}</span>
           </>
         ) : (
           <span className="ml-auto truncate opacity-80">{t('apps.editor.label')}</span>
         )}
       </div>
+
+      {picker && (
+        <FilePicker
+          mode={picker.mode}
+          initialPath={picker.initialPath}
+          defaultName={picker.defaultName}
+          onCancel={() => setPicker(null)}
+          onConfirm={picker.onConfirm}
+        />
+      )}
     </div>
   );
 };
 
-const Welcome: React.FC<{ onOpenFolder: () => void; onNewFile: () => void; onOpenFiles: () => void }> = ({ onOpenFolder, onNewFile, onOpenFiles }) => {
+const Welcome: React.FC<{ onOpenFolder: () => void; onNewFile: () => void }> = ({ onOpenFolder, onNewFile }) => {
   const { t } = useTranslation();
   const actions: { Icon: typeof FolderOpen; color: string; label: string; onClick: () => void; sc?: string }[] = [
     { Icon: FolderOpen, color: 'text-cyan', label: t('apps.editor.openFolder'), onClick: onOpenFolder, sc: '⌘O' },
     { Icon: FilePlus, color: 'text-mint', label: t('apps.fileBrowser.newFile'), onClick: onNewFile, sc: '⌘N' },
-    { Icon: Files, color: 'text-violet', label: t('apps.editor.browseFiles'), onClick: onOpenFiles },
   ];
   return (
     <div className="grid min-w-0 flex-1 place-items-center bg-surface p-10">

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -88,22 +88,22 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
   const [picker, setPicker] = useState<PickerState | null>(null);
   const tabSeq = useRef(0);
   const untitledSeq = useRef(0);
-  // Latest tabs for dedup / id-resolution outside the setState updater (avoids side effects in a
-  // reducer while still keying on the synthetic id).
-  const tabsRef = useRef<Tab[]>(tabs);
-  tabsRef.current = tabs;
 
   const openFile = useCallback((path: string, name: string, mtime: number | null) => {
     setRoot((r) => r ?? parentDir(path));
     setCursor(null);
-    const existing = tabsRef.current.find((x) => x.path === path);
-    if (existing) {
-      setActive(existing.id);
-      return;
-    }
-    const id = `t${++tabSeq.current}`;
-    setTabs((ts) => [...ts, { id, path, name, mtime }]);
-    setActive(id);
+    setTabs((ts) => {
+      // Dedup inside the updater so two concurrent opens of the same file (e.g. a fast double-click
+      // firing two fileMeta requests) can't both append a tab — both see the same current `ts`.
+      const existing = ts.find((x) => x.path === path);
+      if (existing) {
+        setActive(existing.id);
+        return ts;
+      }
+      const id = `t${++tabSeq.current}`;
+      setActive(id);
+      return [...ts, { id, path, name, mtime }];
+    });
   }, []);
 
   // The explorer tree emits a clicked entry. Gate it like the File Browser: only a regular,
@@ -159,9 +159,11 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
     // Closing a dirty tab drops its in-memory buffer (only the window-level guard existed before),
     // so confirm first when there are unsaved edits.
     if (dirty[id] && !window.confirm(t('apps.editor.confirmDiscardClose'))) return;
-    const rest = tabsRef.current.filter((x) => x.id !== id);
-    setTabs(rest);
-    if (active === id) setActive(rest.length ? rest[rest.length - 1].id : null);
+    setTabs((ts) => {
+      const rest = ts.filter((x) => x.id !== id);
+      setActive((cur) => (cur === id ? (rest.length ? rest[rest.length - 1].id : null) : cur));
+      return rest;
+    });
     setDirty((d) => {
       const n = { ...d };
       delete n[id];

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -3,7 +3,7 @@ import { Blocks, Bug, Clock, CodeXml, FilePlus, Files, FolderOpen, GitBranch, Se
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
-import { useWindowCloseGuard } from '../../context/WindowManagerContext';
+import { useWindowCloseGuard, useWindowManager } from '../../context/WindowManagerContext';
 import { downloadFile, fileMeta, joinPath, parentDir, writeFile, type FsEntry } from '../../lib/filesApi';
 import { isEditableFile } from '../../lib/filePreview';
 import { FileTree } from './FileTree';
@@ -79,6 +79,7 @@ function languageLabel(filename: string | undefined): string | undefined {
 // untitled buffer that picks its location only on first save.
 export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, unknown> }> = ({ windowId, params }) => {
   const { t } = useTranslation();
+  const wm = useWindowManager();
   const [root, setRoot] = useState<string | null>(null);
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [active, setActive] = useState<string | null>(null); // active tab id
@@ -209,16 +210,16 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       const k = e.key.toLowerCase();
       if (k !== 'o' && k !== 'n') return;
-      if (picker) return; // a dialog is already open
-      const winEl = (document.activeElement as Element | null)?.closest('[data-window-id]');
-      if (winEl?.getAttribute('data-window-id') !== windowId) return;
+      // Only the frontmost editor window, and not while its own dialog is open. Scope by the window
+      // manager's focused id (not DOM focus) so the shortcut keeps working after a dialog closes.
+      if (picker || wm.focusedId !== windowId) return;
       e.preventDefault();
       if (k === 'o') openFolder();
       else newFile();
     };
     window.addEventListener('keydown', onKey, true);
     return () => window.removeEventListener('keydown', onKey, true);
-  }, [windowId, openFolder, newFile, picker]);
+  }, [windowId, openFolder, newFile, picker, wm.focusedId]);
 
   const ACTIVITY = [Files, Search, GitBranch, Bug, Blocks];
   const showWelcome = root == null && tabs.length === 0;
@@ -240,7 +241,27 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
         {/* Explorer — ALWAYS present (design w0qoC keeps it in the welcome state): an
             empty "No folder opened + Open Folder" state when no folder, else the file tree. */}
         <div className="flex w-[220px] shrink-0 flex-col overflow-hidden border-r border-border bg-surface-2">
-          <div className="px-3 pb-1 pt-2.5 font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">{t('apps.editor.explorer')}</div>
+          <div className="flex items-center gap-0.5 px-3 pb-1 pt-2.5">
+            <span className="flex-1 truncate font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">{t('apps.editor.explorer')}</span>
+            <button
+              type="button"
+              onClick={newFile}
+              title={`${t('apps.fileBrowser.newFile')} (⌘N)`}
+              aria-label={t('apps.fileBrowser.newFile')}
+              className="grid size-5 place-items-center rounded text-muted transition hover:bg-foreground/10 hover:text-foreground"
+            >
+              <FilePlus className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={openFolder}
+              title={`${t('apps.editor.openFolder')} (⌘O)`}
+              aria-label={t('apps.editor.openFolder')}
+              className="grid size-5 place-items-center rounded text-muted transition hover:bg-foreground/10 hover:text-foreground"
+            >
+              <FolderOpen className="size-3.5" />
+            </button>
+          </div>
           {root == null ? (
             <div className="flex flex-col gap-2 px-3 py-2">
               <div className="text-[12px] text-muted">{t('apps.editor.noFolder')}</div>

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -147,6 +147,14 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
   const anyDirty = Object.values(dirty).some(Boolean);
   useWindowCloseGuard(windowId, anyDirty ? t('apps.editor.confirmDiscardClose') : null);
 
+  // Reflect the active file in the window title, so the Dock + titlebar identify which file this
+  // editor window holds (important when several editor windows are open). Clears to the app title
+  // when nothing is open. setTitle no-ops when unchanged, so this can run on every tab change.
+  useEffect(() => {
+    if (windowId) wm.setTitle(windowId, tabs.find((x) => x.id === active)?.name);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [windowId, active, tabs]);
+
   const closeTab = (id: string) => {
     // Closing a dirty tab drops its in-memory buffer (only the window-level guard existed before),
     // so confirm first when there are unsaved edits.

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -226,7 +226,7 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
         </div>
 
         {/* Main area: welcome (no folder) · tabs + Monaco (file open) · select-a-file hint (folder, no file). */}
-        <div className="flex min-w-0 flex-1 flex-col bg-[#0b0b14]">
+        <div className="flex min-w-0 flex-1 flex-col bg-surface">
           {root == null ? (
             <Welcome onOpenFolder={openFolder} onNewFile={newFile} onOpenFiles={() => wm.openApp('files')} />
           ) : (
@@ -238,7 +238,7 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
                       key={tab.path}
                       className={clsx(
                         'group/tab flex shrink-0 items-center gap-2 border-r border-border px-3 py-2 text-[12px] transition',
-                        active === tab.path ? 'bg-[#0b0b14] text-foreground shadow-[inset_0_2px_0_0_var(--cyan)]' : 'text-muted hover:bg-foreground/[0.04]',
+                        active === tab.path ? 'bg-surface text-foreground shadow-[inset_0_2px_0_0_var(--cyan)]' : 'text-muted hover:bg-foreground/[0.04]',
                       )}
                     >
                       <button
@@ -320,7 +320,7 @@ const Welcome: React.FC<{ onOpenFolder: () => void; onNewFile: () => void; onOpe
     { Icon: Files, color: 'text-violet', label: t('apps.editor.browseFiles'), onClick: onOpenFiles },
   ];
   return (
-    <div className="grid min-w-0 flex-1 place-items-center bg-[#0b0b14] p-10">
+    <div className="grid min-w-0 flex-1 place-items-center bg-surface p-10">
       <div className="flex w-[440px] max-w-full flex-col gap-6">
         <div className="flex items-center gap-3.5">
           <span className="grid size-14 place-items-center rounded-2xl border border-cyan/60 bg-cyan-soft">

--- a/ui/src/components/workbench/FileEditorPane.tsx
+++ b/ui/src/components/workbench/FileEditorPane.tsx
@@ -215,10 +215,10 @@ export const FileEditorPane: React.FC<{
               language={language}
               path={monacoPath}
               readOnly={readOnly}
-              // Monaco is JS-themed (it can't read the app's `data-theme` CSS), so drive its light/
-              // dark from resolvedTheme — the Editor window now follows the workbench theme like the
-              // rest of the windowed apps (no longer forced dark).
-              dark={resolvedTheme === 'dark'}
+              // Monaco is JS-themed (it can't read the window's `data-theme="dark"` CSS), so in the
+              // IDE (chromeless = the dark-locked Editor window) force the dark theme; otherwise a
+              // light global theme would leave a white Monaco slab inside the dark window (dnYPx is dark).
+              dark={chromeless || resolvedTheme === 'dark'}
               onChange={(value) => setText(value)}
               onSave={() => void save()}
               onCursorChange={onCursor}

--- a/ui/src/components/workbench/FileEditorPane.tsx
+++ b/ui/src/components/workbench/FileEditorPane.tsx
@@ -215,10 +215,10 @@ export const FileEditorPane: React.FC<{
               language={language}
               path={monacoPath}
               readOnly={readOnly}
-              // Monaco is JS-themed (it can't read the window's `data-theme="dark"` CSS), so in the
-              // IDE (chromeless = the always-dark Editor window) force the dark theme; otherwise a
-              // light global theme leaves a white Monaco slab inside a dark window (design dnYPx is dark).
-              dark={chromeless || resolvedTheme === 'dark'}
+              // Monaco is JS-themed (it can't read the app's `data-theme` CSS), so drive its light/
+              // dark from resolvedTheme — the Editor window now follows the workbench theme like the
+              // rest of the windowed apps (no longer forced dark).
+              dark={resolvedTheme === 'dark'}
               onChange={(value) => setText(value)}
               onSave={() => void save()}
               onCursorChange={onCursor}

--- a/ui/src/components/workbench/FileEditorPane.tsx
+++ b/ui/src/components/workbench/FileEditorPane.tsx
@@ -76,7 +76,8 @@ function monacoLanguage(filename: string): string | undefined {
 // the new window saves against the current revision (this pane may have saved
 // since the row was opened), not the stale metadata the row carried.
 export const FileEditorPane: React.FC<{
-  path: string;
+  /** null = an unsaved "untitled" buffer (no file yet); ⌘S routes through onSaveAs (save-as). */
+  path: string | null;
   filename: string;
   mtime: number | null;
   readOnly?: boolean;
@@ -93,7 +94,12 @@ export const FileEditorPane: React.FC<{
   chromeless?: boolean;
   /** Live 1-based cursor position, surfaced in the IDE status bar. */
   onCursor?: (line: number, column: number) => void;
-}> = ({ path, filename, mtime, readOnly = false, onPopOut, windowId, onDirtyChange, chromeless = false, onCursor }) => {
+  /**
+   * Untitled buffers (path === null) call this with the buffer text on save; the parent runs the
+   * save-as picker + write, then re-points this pane at the chosen path.
+   */
+  onSaveAs?: (text: string) => void;
+}> = ({ path, filename, mtime, readOnly = false, onPopOut, windowId, onDirtyChange, chromeless = false, onCursor, onSaveAs }) => {
   const { t } = useTranslation();
   const { resolvedTheme } = useTheme();
   const [text, setText] = useState<string | null>(null);
@@ -105,10 +111,18 @@ export const FileEditorPane: React.FC<{
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     setError(null);
-    setText(null);
     setSavedMtime(mtime);
+    // Untitled buffer (no path yet): start empty with no fetch. Saving opens the save-as picker;
+    // once written, the parent re-points this pane at the real path and this effect re-runs to read it.
+    if (path === null) {
+      setText('');
+      setOriginal('');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setText(null);
     readText(path)
       .then((body) => {
         if (cancelled) return;
@@ -138,16 +152,23 @@ export const FileEditorPane: React.FC<{
   // other looking dirty and false-conflicting. Prefix a per-instance id; keep the file
   // extension so Monaco's TS worker still picks JSX/TSX for .tsx/.jsx.
   const editorUid = useId();
-  const monacoPath = `${editorUid.replace(/:/g, '')}/${path.replace(/^\/+/, '')}`;
+  const monacoPath = `${editorUid.replace(/:/g, '')}/${(path ?? 'untitled').replace(/^\/+/, '')}`;
 
   // Veto closing the owning window while there are unsaved edits (the close unmounts
   // this pane and the buffer only lives in React state). No-op for the full-page route.
   useWindowCloseGuard(windowId, dirty ? t('apps.editor.confirmDiscardClose') : null);
 
   async function save() {
+    if (text === null || saving || readOnly) return;
+    // Untitled: hand the buffer text up so the parent runs the save-as picker + write (an empty new
+    // file is allowed to be saved, unlike a clean existing file which skips the no-op PUT below).
+    if (path === null) {
+      onSaveAs?.(text);
+      return;
+    }
     // ⌘S reaches here even when the buffer is clean (the visible Save button is disabled but the
     // Monaco command isn't); skip the no-op PUT so it doesn't bump mtime / wake file watchers.
-    if (text === null || saving || readOnly || !dirty) return;
+    if (!dirty) return;
     setSaving(true);
     setError(null);
     try {

--- a/ui/src/components/workbench/FilePicker.tsx
+++ b/ui/src/components/workbench/FilePicker.tsx
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronRight, File as FileIcon, Folder, FolderPlus, Loader2, X } from 'lucide-react';
+import clsx from 'clsx';
+
+import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
+import {
+  fileBrowserErrorMessage,
+  isPlainEntryName,
+  joinPath,
+  listDir,
+  makeDir,
+  pathCrumbs,
+  systemFavorites,
+  type Favorite,
+  type FsEntry,
+} from '../../lib/filesApi';
+import { Button } from '../ui/button';
+
+export type FilePickerMode = 'open-directory' | 'save-file';
+
+function sortEntries(entries: FsEntry[]): FsEntry[] {
+  return [...entries].sort((a, b) => (a.kind === b.kind ? a.name.localeCompare(b.name) : a.kind === 'dir' ? -1 : 1));
+}
+
+// An in-app file/folder picker that browses the agent machine's filesystem via /api/files. A
+// browser can't open a native OS dialog that returns a *server-side* path, so this is the web
+// equivalent of VS Code's file dialog: navigate folders, then pick a folder (open-directory) or a
+// folder + filename (save-file). Name-only — no size/modified columns — so it stays a lean
+// navigator and doesn't duplicate the Finder's display helpers. Rendered inside the owning
+// (dark-locked) Editor window, so it inherits that theme and stays scoped to the window.
+export const FilePicker: React.FC<{
+  mode: FilePickerMode;
+  /** Folder to start in; falls back to the first project, then the home favorite. */
+  initialPath?: string | null;
+  /** save-file: pre-filled filename. */
+  defaultName?: string;
+  onCancel: () => void;
+  /**
+   * open-directory → result = { path: <folder> }; save-file → { path: <folder>, name }.
+   * Async: THROW to keep the dialog open and surface the message (e.g. the name already exists).
+   */
+  onConfirm: (result: { path: string; name?: string }) => Promise<void> | void;
+}> = ({ mode, initialPath, defaultName, onCancel, onConfirm }) => {
+  const { t } = useTranslation();
+  const { projects } = useWorkbenchProjectsTree();
+  const [cwd, setCwd] = useState('');
+  const [entries, setEntries] = useState<FsEntry[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sysFavs, setSysFavs] = useState<Favorite[]>([]);
+  const [name, setName] = useState(defaultName ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  // Inline new-folder input (rather than a window.prompt, matching the "no manual typing" intent).
+  const [newFolder, setNewFolder] = useState<string | null>(null);
+
+  const navSeq = useRef(0);
+  const navigate = useCallback(
+    (path: string) => {
+      const seq = ++navSeq.current;
+      setLoading(true);
+      setError(null);
+      setNewFolder(null);
+      listDir(path)
+        .then((r) => {
+          if (seq !== navSeq.current) return;
+          setCwd(r.path);
+          setEntries(sortEntries(r.entries));
+        })
+        .catch((e: unknown) => {
+          if (seq === navSeq.current) setError(fileBrowserErrorMessage(e, t, t('apps.fileBrowser.errors.listFailed')));
+        })
+        .finally(() => {
+          if (seq === navSeq.current) setLoading(false);
+        });
+    },
+    [t],
+  );
+
+  // Pick a sensible starting folder once: the caller's initial path, else the first project, else
+  // the home favorite.
+  useEffect(() => {
+    let cancelled = false;
+    if (initialPath) {
+      navigate(initialPath);
+      return;
+    }
+    systemFavorites()
+      .then((favs) => {
+        if (cancelled) return;
+        setSysFavs(favs);
+        const start = projects?.[0]?.folder_path || favs.find((f) => f.key === 'home')?.path;
+        if (start) navigate(start);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  // Favorites for the rail (loaded above when there's no initialPath; fetch here otherwise).
+  useEffect(() => {
+    if (sysFavs.length === 0) systemFavorites().then(setSysFavs).catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const crumbs = cwd ? pathCrumbs(cwd) : [];
+  const projectFavs = (projects || []).filter((p) => !!p.folder_path).map((p) => ({ label: p.display_name, path: p.folder_path as string }));
+
+  const createFolder = async (folderName: string) => {
+    const trimmed = folderName.trim();
+    if (!trimmed) {
+      setNewFolder(null);
+      return;
+    }
+    if (!isPlainEntryName(trimmed)) {
+      setError(t('apps.fileBrowser.errors.invalid_name'));
+      return;
+    }
+    try {
+      await makeDir(joinPath(cwd, trimmed));
+      setNewFolder(null);
+      navigate(cwd);
+    } catch (e: unknown) {
+      setError(fileBrowserErrorMessage(e, t, t('apps.fileBrowser.errors.createFolderFailed')));
+    }
+  };
+
+  const runConfirm = async (result: { path: string; name?: string }) => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm(result);
+    } catch (e: unknown) {
+      setError(fileBrowserErrorMessage(e, t, t('apps.fileBrowser.errors.saveFailed')));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const confirm = () => {
+    if (!cwd || submitting) return;
+    if (mode === 'open-directory') {
+      void runConfirm({ path: cwd });
+      return;
+    }
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    if (!isPlainEntryName(trimmed)) {
+      setError(t('apps.fileBrowser.errors.invalid_name'));
+      return;
+    }
+    void runConfirm({ path: cwd, name: trimmed });
+  };
+
+  const canConfirm = !!cwd && !submitting && (mode === 'open-directory' || name.trim() !== '');
+
+  return (
+    // Scoped to the owning window (absolute, not a body portal) so it inherits the window's theme.
+    <div className="absolute inset-0 z-30 grid place-items-center bg-black/50 p-5" onClick={onCancel} role="presentation">
+      <div
+        className="flex h-[420px] w-[600px] max-w-full max-h-full flex-col overflow-hidden rounded-xl border border-border-strong bg-surface-2 shadow-[0_24px_64px_-12px_rgba(0,0,0,0.7)]"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        {/* Title + close */}
+        <div className="flex items-center gap-2 border-b border-border px-3.5 py-2.5">
+          <span className="flex-1 truncate text-[13px] font-semibold text-foreground">
+            {t(mode === 'open-directory' ? 'apps.picker.openFolderTitle' : 'apps.picker.saveFileTitle')}
+          </span>
+          <Button type="button" size="icon" variant="ghost" className="size-7 text-muted" aria-label={t('common.close')} onClick={onCancel}>
+            <X className="size-4" />
+          </Button>
+        </div>
+
+        {/* Breadcrumb + New Folder */}
+        <div className="flex items-center gap-2 border-b border-border bg-surface-2/60 px-3 py-1.5">
+          <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
+            {crumbs.map((c, i) => (
+              <span key={c.path} className="flex shrink-0 items-center">
+                {i > 0 && <ChevronRight className="size-3 shrink-0 text-muted" />}
+                <button
+                  type="button"
+                  onClick={() => navigate(c.path)}
+                  className="max-w-[150px] truncate rounded px-1.5 py-0.5 text-[12px] text-muted transition hover:bg-foreground/[0.06] hover:text-foreground"
+                >
+                  {c.label}
+                </button>
+              </span>
+            ))}
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 shrink-0 gap-1.5 px-2 text-[12px] text-muted"
+            disabled={!cwd}
+            onClick={() => setNewFolder('')}
+          >
+            <FolderPlus className="size-3.5" /> {t('apps.picker.newFolder')}
+          </Button>
+        </div>
+
+        {error && <div className="border-b border-destructive/40 bg-destructive/[0.06] px-3 py-1.5 text-[11.5px] text-destructive">{error}</div>}
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          {/* Rail: favorites + projects */}
+          <aside className="hidden w-[150px] shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border bg-surface-2/40 p-2 sm:flex">
+            {sysFavs.length > 0 && <RailTitle>{t('apps.fileBrowser.favorites')}</RailTitle>}
+            {sysFavs.map((f) => (
+              <RailRow key={f.path} label={f.path.split('/').filter(Boolean).pop() || f.path} active={cwd === f.path} onClick={() => navigate(f.path)} />
+            ))}
+            {projectFavs.length > 0 && <RailTitle>{t('apps.fileBrowser.projects')}</RailTitle>}
+            {projectFavs.map((f) => (
+              <RailRow key={f.path} label={f.label} active={cwd === f.path} onClick={() => navigate(f.path)} />
+            ))}
+          </aside>
+
+          {/* Listing — folders navigate on click; files are shown (dimmed) for context only. */}
+          <div className="min-h-0 flex-1 overflow-y-auto p-1">
+            {newFolder !== null && (
+              <input
+                autoFocus
+                value={newFolder}
+                onChange={(e) => setNewFolder(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void createFolder(newFolder);
+                  else if (e.key === 'Escape') setNewFolder(null);
+                }}
+                onBlur={() => void createFolder(newFolder)}
+                placeholder={t('apps.picker.newFolderName')}
+                className="mb-1 w-full rounded-md border border-cyan/50 bg-surface px-2 py-1.5 text-[12.5px] text-foreground placeholder:text-muted focus:outline-none"
+              />
+            )}
+            {loading && entries === null && (
+              <div className="grid place-items-center py-8">
+                <Loader2 className="size-4 animate-spin text-muted" />
+              </div>
+            )}
+            {entries && entries.length === 0 && newFolder === null && (
+              <div className="px-3 py-8 text-center text-[12px] text-muted">{t('apps.fileBrowser.empty')}</div>
+            )}
+            {entries?.map((e) => {
+              const isDir = e.kind === 'dir';
+              return (
+                <button
+                  key={e.name}
+                  type="button"
+                  disabled={!isDir}
+                  onClick={() => isDir && navigate(joinPath(cwd, e.name))}
+                  className={clsx(
+                    'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[12.5px] transition',
+                    isDir ? 'text-foreground hover:bg-foreground/[0.06]' : 'cursor-default text-muted/60',
+                  )}
+                >
+                  {isDir ? <Folder className="size-4 shrink-0 text-cyan" /> : <FileIcon className="size-4 shrink-0 text-muted" />}
+                  <span className="truncate">{e.name}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Footer: (save) filename input + Cancel / Confirm */}
+        <div className="flex items-center gap-2 border-t border-border px-3.5 py-2.5">
+          {mode === 'save-file' && (
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') confirm();
+              }}
+              placeholder={t('apps.picker.fileName')}
+              className="min-w-0 flex-1 rounded-md border border-border bg-surface px-2.5 py-1.5 font-mono text-[12.5px] text-foreground placeholder:text-muted focus:border-cyan/60 focus:outline-none"
+            />
+          )}
+          {mode === 'open-directory' && <span className="flex-1" />}
+          <Button type="button" size="sm" variant="ghost" className="h-8 px-3 text-[12.5px]" onClick={onCancel}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="button" size="sm" variant="brand" className="h-8 gap-1.5 px-3.5 text-[12.5px]" disabled={!canConfirm} onClick={confirm}>
+            {submitting && <Loader2 className="size-3.5 animate-spin" />}
+            {t(mode === 'open-directory' ? 'apps.picker.selectFolder' : 'apps.picker.save')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const RailTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="px-1 pb-0.5 pt-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.16em] text-muted">{children}</div>
+);
+
+const RailRow: React.FC<{ label: string; active: boolean; onClick: () => void }> = ({ label, active, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={clsx(
+      'flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12px] transition',
+      active ? 'bg-cyan-soft text-foreground' : 'text-muted hover:bg-foreground/[0.04] hover:text-foreground',
+    )}
+  >
+    <Folder className="size-3.5 shrink-0 text-muted" />
+    <span className="truncate">{label}</span>
+  </button>
+);

--- a/ui/src/components/workbench/FilePicker.tsx
+++ b/ui/src/components/workbench/FilePicker.tsx
@@ -53,6 +53,9 @@ export const FilePicker: React.FC<{
   const [submitting, setSubmitting] = useState(false);
   // Inline new-folder input (rather than a window.prompt, matching the "no manual typing" intent).
   const [newFolder, setNewFolder] = useState<string | null>(null);
+  // Hidden entries are off by default but toggleable, so dot-dirs (.config, .git, …) stay reachable
+  // — the picker is the only way to navigate now (there's no manual path field).
+  const [showHidden, setShowHidden] = useState(false);
 
   const navSeq = useRef(0);
   const navigate = useCallback(
@@ -61,7 +64,7 @@ export const FilePicker: React.FC<{
       setLoading(true);
       setError(null);
       setNewFolder(null);
-      listDir(path)
+      listDir(path, showHidden)
         .then((r) => {
           if (seq !== navSeq.current) return;
           setCwd(r.path);
@@ -74,7 +77,7 @@ export const FilePicker: React.FC<{
           if (seq === navSeq.current) setLoading(false);
         });
     },
-    [t],
+    [showHidden, t],
   );
 
   // Pick a sensible starting folder once: the caller's initial path, else the first project, else
@@ -103,6 +106,11 @@ export const FilePicker: React.FC<{
     if (sysFavs.length === 0) systemFavorites().then(setSysFavs).catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // Re-list the current folder when the hidden toggle flips.
+  useEffect(() => {
+    if (cwd) navigate(cwd);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showHidden]);
 
   const crumbs = cwd ? pathCrumbs(cwd) : [];
   const projectFavs = (projects || []).filter((p) => !!p.folder_path).map((p) => ({ label: p.display_name, path: p.folder_path as string }));
@@ -190,6 +198,10 @@ export const FilePicker: React.FC<{
               </span>
             ))}
           </div>
+          <label className="flex shrink-0 items-center gap-1 text-[11px] text-muted" title={t('apps.fileBrowser.showHidden')}>
+            <input type="checkbox" checked={showHidden} onChange={(e) => setShowHidden(e.target.checked)} className="size-3" />
+            {t('apps.fileBrowser.showHidden')}
+          </label>
           <Button
             type="button"
             size="sm"
@@ -228,7 +240,9 @@ export const FilePicker: React.FC<{
                   if (e.key === 'Enter') void createFolder(newFolder);
                   else if (e.key === 'Escape') setNewFolder(null);
                 }}
-                onBlur={() => void createFolder(newFolder)}
+                // Blur abandons the inline input — only Enter creates the folder, so cancelling the
+                // picker (which blurs the input first) can't silently makeDir a folder.
+                onBlur={() => setNewFolder(null)}
                 placeholder={t('apps.picker.newFolderName')}
                 className="mb-1 w-full rounded-md border border-cyan/50 bg-surface px-2 py-1.5 text-[12.5px] text-foreground placeholder:text-muted focus:outline-none"
               />
@@ -266,6 +280,8 @@ export const FilePicker: React.FC<{
         <div className="flex items-center gap-2 border-t border-border px-3.5 py-2.5">
           {mode === 'save-file' && (
             <input
+              // Autofocus so ⌘S-from-Monaco lands here, not behind the modal in the editor buffer.
+              autoFocus
               value={name}
               onChange={(e) => setName(e.target.value)}
               onKeyDown={(e) => {

--- a/ui/src/components/workbench/TerminalTabs.tsx
+++ b/ui/src/components/workbench/TerminalTabs.tsx
@@ -29,7 +29,7 @@ function getSessionId(identity: string | null, key?: string): string {
   }
 }
 
-type Tab = { key: number; slot: number | null };
+type Tab = { key: number; slot: number | null; title?: string };
 
 // DELETE a slot-backed terminal session, then release its slot ONLY on a confirmed teardown
 // (HTTP ok or 404). If the delete failed (expired auth, CSRF/origin rejection, network error, 5xx)
@@ -62,6 +62,17 @@ export const TerminalTabs: React.FC<{ windowed?: boolean }> = ({ windowed = fals
   // Per-tab connection status (reported by each TerminalView). The tab bar shows the ACTIVE tab's
   // status merged with the persistence badge into ONE chip — there's no standalone status row.
   const [statuses, setStatuses] = useState<Record<number, TerminalStatus>>({});
+  // Inline tab rename: the tab being renamed + its draft label (double-click a tab to start).
+  const [editing, setEditing] = useState<{ key: number; value: string } | null>(null);
+  const commitRename = () => {
+    setEditing((cur) => {
+      if (cur) {
+        const v = cur.value.trim();
+        setTabs((ts) => ts.map((x) => (x.key === cur.key ? { ...x, title: v || undefined } : x)));
+      }
+      return null;
+    });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -151,10 +162,33 @@ export const TerminalTabs: React.FC<{ windowed?: boolean }> = ({ windowed = fals
                 tab.key === active ? 'bg-surface text-foreground shadow-[inset_0_-2px_0_0_var(--mint)]' : 'text-muted hover:bg-foreground/[0.05]',
               )}
             >
-              <button type="button" onClick={() => setActive(tab.key)} className="flex items-center gap-1.5">
-                <SquareTerminal className="size-3.5 text-mint" />
-                {t('apps.terminal.tabTitle', { n: i + 1 })}
-              </button>
+              {editing && editing.key === tab.key ? (
+                <span className="flex items-center gap-1.5">
+                  <SquareTerminal className="size-3.5 shrink-0 text-mint" />
+                  <input
+                    autoFocus
+                    value={editing.value}
+                    onChange={(e) => setEditing({ key: tab.key, value: e.target.value })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') commitRename();
+                      else if (e.key === 'Escape') setEditing(null);
+                    }}
+                    onBlur={commitRename}
+                    className="w-20 bg-transparent text-[12px] text-foreground focus:outline-none"
+                  />
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setActive(tab.key)}
+                  onDoubleClick={() => setEditing({ key: tab.key, value: tab.title ?? t('apps.terminal.tabTitle', { n: i + 1 }) })}
+                  title={t('apps.terminal.renameHint')}
+                  className="flex items-center gap-1.5"
+                >
+                  <SquareTerminal className="size-3.5 text-mint" />
+                  {tab.title ?? t('apps.terminal.tabTitle', { n: i + 1 })}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() => closeTab(tab.key)}

--- a/ui/src/components/workbench/TerminalTabs.tsx
+++ b/ui/src/components/workbench/TerminalTabs.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { acquireTerminalSlot, releaseTerminalSlot } from '../../lib/terminalSlots';
+import type { TerminalStatus } from './TerminalView';
 
 // Lazy so xterm.js stays out of the main bundle until a terminal opens.
 const TerminalView = lazy(() => import('./TerminalView').then((m) => ({ default: m.TerminalView })));
@@ -58,6 +59,9 @@ export const TerminalTabs: React.FC<{ windowed?: boolean }> = ({ windowed = fals
   // Whether sessions actually persist (tmux available) — reported by TerminalView's ready frame.
   // Drives the tab-bar badge so it never falsely promises persistence for a plain-shell fallback.
   const [persistent, setPersistent] = useState(false);
+  // Per-tab connection status (reported by each TerminalView). The tab bar shows the ACTIVE tab's
+  // status merged with the persistence badge into ONE chip — there's no standalone status row.
+  const [statuses, setStatuses] = useState<Record<number, TerminalStatus>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -88,6 +92,12 @@ export const TerminalTabs: React.FC<{ windowed?: boolean }> = ({ windowed = fals
     setActive(tab.key);
   };
   const closeTab = (key: number) => {
+    setStatuses((m) => {
+      if (!(key in m)) return m;
+      const next = { ...m };
+      delete next[key];
+      return next;
+    });
     setTabs((ts) => {
       const tab = ts.find((x) => x.key === key);
       if (tab) disposeTab(tab);
@@ -130,7 +140,7 @@ export const TerminalTabs: React.FC<{ windowed?: boolean }> = ({ windowed = fals
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col bg-surface">
-      {/* Tab bar (iwYIX): tabs + ＋, persistent badge on the right. */}
+      {/* Tab bar (iwYIX): tabs + ＋, combined status + persistence chip on the right. */}
       <div className="flex items-center gap-1 border-b border-border bg-surface-2/70 px-2 py-1">
         <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
           {tabs.map((tab, i) => (
@@ -165,11 +175,32 @@ export const TerminalTabs: React.FC<{ windowed?: boolean }> = ({ windowed = fals
             <Plus className="size-3.5" strokeWidth={2.5} />
           </button>
         </div>
-        {persistent && (
-          <span className="shrink-0 rounded-full border border-mint/30 bg-mint/[0.08] px-2 py-0.5 text-[10px] font-medium text-mint">
-            {t('apps.terminal.persistent')}
-          </span>
-        )}
+        {/* One chip merges connection status + persistence (Alex: "connected" must not take its
+            own row). Connected + tmux-backed shows the persistence label with a green dot; else it
+            shows the connection status. Terminating states also get a reconnect inside the body. */}
+        {(() => {
+          const st = statuses[active] ?? 'connecting';
+          const persistentReady = persistent && st === 'ready';
+          const dotClass =
+            st === 'ready'
+              ? 'bg-mint'
+              : st === 'connecting'
+                ? 'bg-amber-400'
+                : st === 'closed' || st === 'error'
+                  ? 'bg-destructive'
+                  : 'bg-muted';
+          return (
+            <span
+              className={clsx(
+                'flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-medium',
+                persistentReady ? 'border-mint/30 bg-mint/[0.08] text-mint' : 'border-border bg-surface text-muted',
+              )}
+            >
+              <span className={clsx('size-1.5 rounded-full', dotClass)} />
+              {persistentReady ? t('apps.terminal.persistent') : t(`apps.terminal.status.${st}`)}
+            </span>
+          );
+        })()}
       </div>
 
       {/* Panels: all tabs stay mounted so switching preserves each shell; hidden ones use
@@ -181,7 +212,11 @@ export const TerminalTabs: React.FC<{ windowed?: boolean }> = ({ windowed = fals
             <div key={tab.key} className={clsx('absolute inset-0', tab.key === active ? 'block' : 'hidden')}>
               {sid == null ? loading : (
                 <Suspense fallback={loading}>
-                  <TerminalView sessionId={sid} onPersistent={setPersistent} />
+                  <TerminalView
+                    sessionId={sid}
+                    onPersistent={setPersistent}
+                    onStatus={(s) => setStatuses((m) => (m[tab.key] === s ? m : { ...m, [tab.key]: s }))}
+                  />
                 </Suspense>
               )}
             </div>

--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -3,20 +3,57 @@ import { useTranslation } from 'react-i18next';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
-import clsx from 'clsx';
 import { RotateCw } from 'lucide-react';
 
 import { Button } from '../ui/button';
+import { useTheme } from '../../context/ThemeContext';
 
 // xterm.js wired to the /api/terminal/{id} WebSocket. Protocol (locked with the
 // backend): client sends raw stdin as BINARY frames and JSON control as TEXT
 // frames ({type:"resize",cols,rows}); server sends PTY output as BINARY and
 // {type:"ready"|"exit"} as TEXT. Lazy-loaded by AppsTerminalPage so xterm stays
 // out of the main bundle.
-type Status = 'connecting' | 'ready' | 'closed' | 'disabled' | 'error';
+export type TerminalStatus = 'connecting' | 'ready' | 'closed' | 'disabled' | 'error';
 
 const ENC = new TextEncoder();
 const MAX_BUSY_RETRIES = 3; // auto-retry a transient "busy" (1013) close this many times
+
+// xterm palettes per app theme. The windows are no longer forced dark, so the terminal
+// follows the workbench light/dark theme. The light ANSI set is darkened so coloured
+// output stays legible on a light background; dark keeps xterm's default ANSI over a
+// near-black surface.
+const XTERM_THEME = {
+  dark: {
+    background: '#0b0b12',
+    foreground: '#e4e4e7',
+    cursor: '#e4e4e7',
+    cursorAccent: '#0b0b12',
+    selectionBackground: 'rgba(148,163,184,0.35)',
+  },
+  light: {
+    background: '#ffffff',
+    foreground: '#1f2328',
+    cursor: '#1f2328',
+    cursorAccent: '#ffffff',
+    selectionBackground: 'rgba(84,174,255,0.30)',
+    black: '#24292f',
+    red: '#cf222e',
+    green: '#116329',
+    yellow: '#7d4e00',
+    blue: '#0969da',
+    magenta: '#8250df',
+    cyan: '#1b7c83',
+    white: '#6e7781',
+    brightBlack: '#57606a',
+    brightRed: '#a40e26',
+    brightGreen: '#1a7f37',
+    brightYellow: '#633c01',
+    brightBlue: '#218bff',
+    brightMagenta: '#a475f9',
+    brightCyan: '#3192aa',
+    brightWhite: '#8c959f',
+  },
+} as const;
 
 // Accessory key bar for phones (their soft keyboards lack these). Each button sends the raw
 // byte sequence the PTY expects; Ctrl is a sticky modifier. Labels go through i18n (the
@@ -38,8 +75,14 @@ function buildWsUrl(sessionId: string): string {
   return `${proto}://${window.location.host}/api/terminal/${encodeURIComponent(sessionId)}`;
 }
 
-export const TerminalView: React.FC<{ sessionId: string; onPersistent?: (persistent: boolean) => void }> = ({ sessionId, onPersistent }) => {
+export const TerminalView: React.FC<{
+  sessionId: string;
+  onPersistent?: (persistent: boolean) => void;
+  /** Report connection status up so the tab bar can show one combined status + persistence chip. */
+  onStatus?: (status: TerminalStatus, exitCode: number | null) => void;
+}> = ({ sessionId, onPersistent, onStatus }) => {
   const { t } = useTranslation();
+  const { resolvedTheme } = useTheme();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -51,21 +94,34 @@ export const TerminalView: React.FC<{ sessionId: string; onPersistent?: (persist
   // the WS effect (which doesn't depend on the prop) always calls the latest callback.
   const onPersistentRef = useRef(onPersistent);
   onPersistentRef.current = onPersistent;
-  const [status, setStatus] = useState<Status>('connecting');
+  // Construct the terminal with the CURRENT theme without making the theme a dependency of the
+  // WS effect — otherwise every light/dark toggle would tear down and reconnect the shell.
+  const themeRef = useRef(resolvedTheme);
+  themeRef.current = resolvedTheme;
+  const [status, setStatus] = useState<TerminalStatus>('connecting');
   const [exitCode, setExitCode] = useState<number | null>(null);
   const [reconnectKey, setReconnectKey] = useState(0);
+
+  // Surface connection status to the parent (tab bar). The standalone status row inside the
+  // body was removed — only the terminating states render an in-body overlay (below).
+  const onStatusRef = useRef(onStatus);
+  onStatusRef.current = onStatus;
+  useEffect(() => {
+    onStatusRef.current?.(status, exitCode);
+  }, [status, exitCode]);
 
   useEffect(() => {
     const term = new Terminal({
       fontSize: 13,
       fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
       cursorBlink: true,
-      theme: { background: '#0b0b12' },
+      theme: XTERM_THEME[themeRef.current],
       allowProposedApi: true,
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
     termRef.current = term;
+    const settleTimers: number[] = [];
     const refit = () => {
       const el = containerRef.current;
       // Skip when the container is hidden (a background tab uses display:none → 0×0): fitting to
@@ -79,14 +135,24 @@ export const TerminalView: React.FC<{ sessionId: string; onPersistent?: (persist
         /* container not measured yet */
       }
     };
+    // A single fit can land before BOTH the layout and xterm's own character-cell metrics have
+    // settled. On some browsers (notably Safari) the cell size finalises a frame or two after
+    // open while the CONTAINER box never changes again — so the ResizeObserver never fires to
+    // correct an initial under-fit, and the terminal stays only a few rows tall with the rest of
+    // the window blank ("only the top third renders"). Re-fit across the next couple of frames
+    // plus a short tail of timeouts so the row count converges no matter when metrics settle;
+    // once it's correct, fit() is a no-op.
+    const settle = () => {
+      refit();
+      requestAnimationFrame(() => {
+        refit();
+        requestAnimationFrame(refit);
+      });
+      settleTimers.push(window.setTimeout(refit, 120), window.setTimeout(refit, 360));
+    };
     if (containerRef.current) {
       term.open(containerRef.current);
-      refit();
-      // The window opens with a scale transition (transform doesn't change layout size,
-      // so the container's height is already real) but the first fit can still land before
-      // the panel is laid out — refit on the next frame so xterm uses the FULL height
-      // instead of getting stuck a few rows tall (the "only top half / can't scroll" bug).
-      requestAnimationFrame(refit);
+      settle();
     }
 
     const onData = term.onData((data: string) => {
@@ -124,6 +190,9 @@ export const TerminalView: React.FC<{ sessionId: string; onPersistent?: (persist
             busyRetriesRef.current = 0; // a successful attach resets the transient-retry budget
             setStatus('ready');
             onPersistentRef.current?.(!!msg.persistent);
+            // The shell is live and about to paint its first content — settle the fit again so a
+            // late cell-metric correction doesn't leave the terminal a few rows tall.
+            settle();
           } else if (msg.type === 'exit') {
             setExitCode(typeof msg.code === 'number' ? msg.code : null);
             setStatus('closed');
@@ -158,6 +227,7 @@ export const TerminalView: React.FC<{ sessionId: string; onPersistent?: (persist
 
     return () => {
       if (retryTimerRef.current != null) window.clearTimeout(retryTimerRef.current);
+      for (const id of settleTimers) window.clearTimeout(id);
       ro.disconnect();
       onData.dispose();
       onResize.dispose();
@@ -180,6 +250,12 @@ export const TerminalView: React.FC<{ sessionId: string; onPersistent?: (persist
     };
   }, [sessionId, reconnectKey]);
 
+  // Follow live theme toggles without recreating the terminal (which would drop the shell).
+  useEffect(() => {
+    const term = termRef.current;
+    if (term) term.options.theme = XTERM_THEME[resolvedTheme];
+  }, [resolvedTheme]);
+
   const sendKey = (k: { seq?: string; ctrl?: boolean }) => {
     if (k.ctrl) {
       ctrlStickyRef.current = !ctrlStickyRef.current;
@@ -190,41 +266,44 @@ export const TerminalView: React.FC<{ sessionId: string; onPersistent?: (persist
     termRef.current?.focus();
   };
 
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center gap-2 border-b border-border px-3 py-1.5 text-[11.5px] text-muted">
-        <span
-          className={clsx(
-            'size-2 shrink-0 rounded-full',
-            status === 'ready' ? 'bg-mint' : status === 'connecting' ? 'bg-amber-400' : 'bg-muted',
-          )}
-        />
-        <span>
-          {t(`apps.terminal.status.${status}`)}
-          {status === 'closed' && exitCode != null ? ` · ${t('apps.terminal.exitCode', { code: exitCode })}` : ''}
-        </span>
-        {(status === 'closed' || status === 'error') && (
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            className="ml-auto h-6 gap-1 px-2 text-[11px]"
-            onClick={() => {
-              busyRetriesRef.current = 0;
-              setReconnectKey((k) => k + 1);
-            }}
-          >
-            <RotateCw className="size-3" /> {t('apps.terminal.reconnect')}
-          </Button>
-        )}
-      </div>
+  const termBg = XTERM_THEME[resolvedTheme].background;
+  const reconnect = () => {
+    busyRetriesRef.current = 0;
+    setReconnectKey((k) => k + 1);
+  };
 
+  return (
+    <div className="flex h-full min-h-0 flex-col" style={{ backgroundColor: termBg }}>
       {status === 'disabled' ? (
         <div className="grid flex-1 place-items-center p-6 text-center text-[12.5px] text-muted">
           <div className="max-w-md">{t('apps.terminal.disabled')}</div>
         </div>
       ) : (
-        <div ref={containerRef} className="min-h-0 flex-1 overflow-hidden bg-[#0b0b12] p-1.5" />
+        <div className="relative min-h-0 flex-1">
+          <div ref={containerRef} className="absolute inset-0 overflow-hidden p-1.5" />
+          {(status === 'closed' || status === 'error') && (
+            // The "connected" status no longer occupies its own row — it lives in the tab bar.
+            // Only the terminating states surface in the body, as a centred overlay that offers
+            // a reconnect (the dimmed last output stays visible underneath).
+            <div className="absolute inset-0 grid place-items-center bg-surface/85 p-6 text-center backdrop-blur-[1px]">
+              <div className="flex flex-col items-center gap-3">
+                <span className="text-[12.5px] text-muted">
+                  {t(`apps.terminal.status.${status}`)}
+                  {status === 'closed' && exitCode != null ? ` · ${t('apps.terminal.exitCode', { code: exitCode })}` : ''}
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 gap-1.5 px-3 text-[12px]"
+                  onClick={reconnect}
+                >
+                  <RotateCw className="size-3" /> {t('apps.terminal.reconnect')}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
       )}
 
       {status !== 'disabled' && (

--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -6,7 +6,6 @@ import '@xterm/xterm/css/xterm.css';
 import { RotateCw } from 'lucide-react';
 
 import { Button } from '../ui/button';
-import { useTheme } from '../../context/ThemeContext';
 
 // xterm.js wired to the /api/terminal/{id} WebSocket. Protocol (locked with the
 // backend): client sends raw stdin as BINARY frames and JSON control as TEXT
@@ -18,42 +17,16 @@ export type TerminalStatus = 'connecting' | 'ready' | 'closed' | 'disabled' | 'e
 const ENC = new TextEncoder();
 const MAX_BUSY_RETRIES = 3; // auto-retry a transient "busy" (1013) close this many times
 
-// xterm palettes per app theme. The windows are no longer forced dark, so the terminal
-// follows the workbench light/dark theme. The light ANSI set is darkened so coloured
-// output stays legible on a light background; dark keeps xterm's default ANSI over a
-// near-black surface.
-const XTERM_THEME = {
-  dark: {
-    background: '#0b0b12',
-    foreground: '#e4e4e7',
-    cursor: '#e4e4e7',
-    cursorAccent: '#0b0b12',
-    selectionBackground: 'rgba(148,163,184,0.35)',
-  },
-  light: {
-    background: '#ffffff',
-    foreground: '#1f2328',
-    cursor: '#1f2328',
-    cursorAccent: '#ffffff',
-    selectionBackground: 'rgba(84,174,255,0.30)',
-    black: '#24292f',
-    red: '#cf222e',
-    green: '#116329',
-    yellow: '#7d4e00',
-    blue: '#0969da',
-    magenta: '#8250df',
-    cyan: '#1b7c83',
-    white: '#6e7781',
-    brightBlack: '#57606a',
-    brightRed: '#a40e26',
-    brightGreen: '#1a7f37',
-    brightYellow: '#633c01',
-    brightBlue: '#218bff',
-    brightMagenta: '#a475f9',
-    brightCyan: '#3192aa',
-    brightWhite: '#8c959f',
-  },
-} as const;
+// The terminal window is theme-locked to dark (registry lockTheme: a shell is conventionally
+// dark, like a code editor), so xterm carries a fixed dark palette regardless of the global theme.
+const TERMINAL_BG = '#0b0b12';
+const TERMINAL_THEME = {
+  background: TERMINAL_BG,
+  foreground: '#e4e4e7',
+  cursor: '#e4e4e7',
+  cursorAccent: TERMINAL_BG,
+  selectionBackground: 'rgba(148,163,184,0.35)',
+};
 
 // Accessory key bar for phones (their soft keyboards lack these). Each button sends the raw
 // byte sequence the PTY expects; Ctrl is a sticky modifier. Labels go through i18n (the
@@ -82,7 +55,6 @@ export const TerminalView: React.FC<{
   onStatus?: (status: TerminalStatus, exitCode: number | null) => void;
 }> = ({ sessionId, onPersistent, onStatus }) => {
   const { t } = useTranslation();
-  const { resolvedTheme } = useTheme();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -94,10 +66,6 @@ export const TerminalView: React.FC<{
   // the WS effect (which doesn't depend on the prop) always calls the latest callback.
   const onPersistentRef = useRef(onPersistent);
   onPersistentRef.current = onPersistent;
-  // Construct the terminal with the CURRENT theme without making the theme a dependency of the
-  // WS effect — otherwise every light/dark toggle would tear down and reconnect the shell.
-  const themeRef = useRef(resolvedTheme);
-  themeRef.current = resolvedTheme;
   const [status, setStatus] = useState<TerminalStatus>('connecting');
   const [exitCode, setExitCode] = useState<number | null>(null);
   const [reconnectKey, setReconnectKey] = useState(0);
@@ -115,7 +83,7 @@ export const TerminalView: React.FC<{
       fontSize: 13,
       fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
       cursorBlink: true,
-      theme: XTERM_THEME[themeRef.current],
+      theme: TERMINAL_THEME,
       allowProposedApi: true,
     });
     const fit = new FitAddon();
@@ -250,12 +218,6 @@ export const TerminalView: React.FC<{
     };
   }, [sessionId, reconnectKey]);
 
-  // Follow live theme toggles without recreating the terminal (which would drop the shell).
-  useEffect(() => {
-    const term = termRef.current;
-    if (term) term.options.theme = XTERM_THEME[resolvedTheme];
-  }, [resolvedTheme]);
-
   const sendKey = (k: { seq?: string; ctrl?: boolean }) => {
     if (k.ctrl) {
       ctrlStickyRef.current = !ctrlStickyRef.current;
@@ -266,14 +228,13 @@ export const TerminalView: React.FC<{
     termRef.current?.focus();
   };
 
-  const termBg = XTERM_THEME[resolvedTheme].background;
   const reconnect = () => {
     busyRetriesRef.current = 0;
     setReconnectKey((k) => k + 1);
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col" style={{ backgroundColor: termBg }}>
+    <div className="flex h-full min-h-0 flex-col" style={{ backgroundColor: TERMINAL_BG }}>
       {status === 'disabled' ? (
         <div className="grid flex-1 place-items-center p-6 text-center text-[12.5px] text-muted">
           <div className="max-w-md">{t('apps.terminal.disabled')}</div>

--- a/ui/src/context/WindowManagerContext.tsx
+++ b/ui/src/context/WindowManagerContext.tsx
@@ -45,6 +45,9 @@ export interface WindowManagerValue {
   toggleMaximize: (id: string) => void;
   /** Patch a window's bounds (used by drag + resize). */
   setBounds: (id: string, bounds: Partial<WindowBounds>) => void;
+  /** Set (or clear) a window's title — e.g. the Editor reflecting its active file so several open
+   *  windows are distinguishable in the Dock + titlebar. No-op when the title is unchanged. */
+  setTitle: (id: string, title: string | undefined) => void;
   /**
    * Register (or clear, by passing null) a guard a window body uses to veto closing.
    * The getter returns a confirm message when closing would lose work, else null.
@@ -157,6 +160,16 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
     setWindows((prev) => prev.map((w) => (w.id === id ? { ...w, bounds: { ...w.bounds, ...patch } } : w)));
   }, []);
 
+  const setTitle = useCallback((id: string, title: string | undefined) => {
+    // Return the SAME array reference when nothing changes so a body that calls this every render
+    // (the Editor, on active-tab change) can't trigger a re-render loop.
+    setWindows((prev) => {
+      const w = prev.find((x) => x.id === id);
+      if (!w || w.title === title) return prev;
+      return prev.map((x) => (x.id === id ? { ...x, title } : x));
+    });
+  }, []);
+
   const focusedId = useMemo(() => {
     const visible = windows.filter((w) => !w.minimized);
     if (visible.length === 0) return null;
@@ -174,10 +187,11 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
       restore,
       toggleMaximize,
       setBounds,
+      setTitle,
       setCloseGuard,
       confirmClose,
     }),
-    [windows, focusedId, openApp, close, focus, minimize, restore, toggleMaximize, setBounds, setCloseGuard, confirmClose],
+    [windows, focusedId, openApp, close, focus, minimize, restore, toggleMaximize, setBounds, setTitle, setCloseGuard, confirmClose],
   );
 
   return <WindowManagerContext.Provider value={value}>{children}</WindowManagerContext.Provider>;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -716,7 +716,8 @@
         "right": "→",
         "interrupt": "^C",
         "pipe": "|"
-      }
+      },
+      "renameHint": "Double-click to rename"
     },
     "picker": {
       "openFolderTitle": "Open Folder",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -626,7 +626,8 @@
       "saveBeforePopOut": "Save before opening in a window",
       "confirmDiscardClose": "Discard unsaved changes and close this window?",
       "selectAll": "Select all",
-      "copyAll": "Copy all"
+      "copyAll": "Copy all",
+      "untitled": "Untitled-{{n}}"
     },
     "dock": {
       "newInstanceHint": "⌘-click for a new window",
@@ -716,6 +717,15 @@
         "interrupt": "^C",
         "pipe": "|"
       }
+    },
+    "picker": {
+      "openFolderTitle": "Open Folder",
+      "saveFileTitle": "Save File",
+      "selectFolder": "Select Folder",
+      "save": "Save",
+      "fileName": "File name",
+      "newFolder": "New Folder",
+      "newFolderName": "Folder name"
     }
   },
   "appShell": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -716,7 +716,8 @@
         "right": "→",
         "interrupt": "^C",
         "pipe": "|"
-      }
+      },
+      "renameHint": "双击重命名"
     },
     "picker": {
       "openFolderTitle": "打开文件夹",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -626,7 +626,8 @@
       "saveBeforePopOut": "请先保存，再在新窗口中打开",
       "confirmDiscardClose": "放弃未保存的更改并关闭此窗口？",
       "selectAll": "全选",
-      "copyAll": "全部复制"
+      "copyAll": "全部复制",
+      "untitled": "未命名-{{n}}"
     },
     "dock": {
       "newInstanceHint": "⌘ 点击可新建窗口",
@@ -716,6 +717,15 @@
         "interrupt": "^C",
         "pipe": "|"
       }
+    },
+    "picker": {
+      "openFolderTitle": "打开文件夹",
+      "saveFileTitle": "保存文件",
+      "selectFolder": "选择此文件夹",
+      "save": "保存",
+      "fileName": "文件名",
+      "newFolder": "新建文件夹",
+      "newFolderName": "文件夹名称"
     }
   },
   "appShell": {


### PR DESCRIPTION
Windowed desktop "Apps" polish across several rounds of live feedback on #691.

## What changed

**Terminal**
- Fixed the "only the top third renders" bug: a fit race where the first fit lands before
  xterm's cell metrics settle (notably Safari) and the container box never changes again, so
  the ResizeObserver never corrects it. Re-fit across a couple of frames + a short timeout tail.
- The "Connected" status no longer takes its own row — merged with the persistence badge into a
  single tab-bar chip; terminating states get an in-body reconnect overlay.
- Tabs are renamable (double-click to edit the label).

**Per-app theme** (revised from "all windows follow theme")
- File Browser window follows the workbench light/dark theme.
- Editor + Terminal windows are locked dark (a code editor / a shell are conventionally dark),
  via a new per-app `lockTheme` on the app registry applied as `data-theme` by AppWindow.

**Editor**
- Open Folder now uses an in-app FilePicker that browses the agent machine's filesystem
  (a browser can't return a server path from a native OS dialog) — favorites/projects rail +
  breadcrumb + inline new-folder. Reused for save.
- New File opens an empty untitled buffer; the location + name are chosen only on the first
  save (create-only write). Tabs are keyed by a synthetic id so an untitled tab survives
  becoming a saved file.
- ⌘O / ⌘N wired (scoped to the focused editor window); persistent New File / Open Folder
  actions in the explorer header; removed the redundant "Browse Files" welcome action.
- The window title tracks the active file, so several editor windows are distinguishable.

**Dock**
- App tiles: smaller icon + the app name as a label (and on hover).
- Minimized windows show their title (file name / app name) so open windows are distinguishable.

**Window animations (macOS-like)**
- Maximize/restore smoothly transitions geometry (only while toggling, so drag/resize stays
  instant); minimize scales toward the bottom-left Dock corner instead of a plain shrink.

## Evidence
- **Unit:** `npm run build` (tsc+vite) green; 34 vitest (terminalSlots / windowBounds / vaultCrypto) green.
- **Manual (real browser):** verified in the local Incus regression env — per-app theme (File
  Browser light-follows; Editor + Terminal stay dark in a light workbench); editor open-folder
  picker (navigate → select → tree loads); New File → type → ⌘S → save-as picker → file written →
  tab re-pointed → tree shows it; Dock app labels + minimized-window title tile; terminal tab
  rename; terminal fills with 200 lines of output. (Codex's Chrome plugin was wedged this session,
  so the visual gate was done via chrome-devtools rather than the Codex browser tool.)
- **Residual:** the macOS-like maximize/minimize animations are motion, best confirmed live.

Follow-up (tracked separately): a true live thumbnail for minimized windows, and a literal genie
minimize animation, were intentionally scoped out (heavy/impractical) in favor of title-tile + scale.
