### PR TITLE
feat(vaults): serve protected signing sandbox origin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,7 @@ jobs:
           npm ci
           npm run validate:theme
           npm run build
+          npm run build:sandbox
 
       - uses: actions/setup-python@v6
         with:
@@ -61,10 +62,30 @@ jobs:
           pip install build
           python -m build --wheel
 
+      - name: Verify bundled UI assets
+        run: |
+          python - <<'PY'
+          import zipfile
+          from pathlib import Path
+
+          wheels = sorted(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"Expected exactly one wheel, found {len(wheels)}")
+
+          with zipfile.ZipFile(wheels[0]) as wheel:
+              names = set(wheel.namelist())
+          for path in ("vibe/ui/dist/index.html", "vibe/ui/dist-sandbox/index.html"):
+              if path not in names:
+                  raise SystemExit(f"Wheel is missing {path}")
+              print(path)
+          PY
+
       - uses: actions/upload-artifact@v5
         with:
           name: ui-dist-linux
-          path: ui/dist
+          path: |
+            ui/dist
+            ui/dist-sandbox
           if-no-files-found: error
           retention-days: 1
 
@@ -87,12 +108,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # hatchling force-includes ui/dist into the (editable) install, so it must
-      # exist before `pip install -e .`.
+      # hatchling force-includes UI build outputs into the (editable) install,
+      # so they must exist before `pip install -e .`.
       - uses: actions/download-artifact@v5
         with:
           name: ui-dist-linux
-          path: ui/dist
+          path: ui
 
       - uses: actions/setup-python@v6
         with:
@@ -151,7 +172,7 @@ jobs:
       - uses: actions/download-artifact@v5
         with:
           name: ui-dist-linux
-          path: ui/dist
+          path: ui
 
       - uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -134,6 +134,7 @@ jobs:
         run: |
           npm ci
           npm run build
+          npm run build:sandbox
 
       - name: Download Show Runtime bundles
         uses: actions/download-artifact@v6
@@ -213,7 +214,7 @@ jobs:
             echo "Skipping legacy vibe-remote shim for $TAG"
           fi
 
-      - name: Verify package Show Runtime manifest
+      - name: Verify package UI assets and Show Runtime manifest
         run: |
           python - <<'PY'
           import zipfile
@@ -238,6 +239,10 @@ jobs:
               raise SystemExit("Wheel unexpectedly contains Show Runtime archives:\n" + "\n".join(sorted(archives)))
           if "vibe/show_runtime_manifest.json" not in names:
               raise SystemExit("Wheel is missing vibe/show_runtime_manifest.json")
+          if "vibe/ui/dist/index.html" not in names:
+              raise SystemExit("Wheel is missing vibe/ui/dist/index.html")
+          if "vibe/ui/dist-sandbox/index.html" not in names:
+              raise SystemExit("Wheel is missing vibe/ui/dist-sandbox/index.html")
           PY
 
       - name: Run release install and upgrade regressions

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -110,6 +110,7 @@ jobs:
         run: |
           npm ci
           npm run build
+          npm run build:sandbox
 
       - name: Download Show Runtime bundles
         uses: actions/download-artifact@v6
@@ -137,7 +138,7 @@ jobs:
           pip install build
           python -m build
 
-      - name: Verify bundled Show Runtime archives
+      - name: Verify bundled assets and Show Runtime manifest
         run: |
           python - <<'PY'
           import sys
@@ -159,8 +160,14 @@ jobs:
               raise SystemExit("Wheel unexpectedly contains Show Runtime archives:\n" + "\n".join(sorted(archives)))
           if "vibe/show_runtime_manifest.json" not in names:
               raise SystemExit("Wheel is missing vibe/show_runtime_manifest.json")
+          if "vibe/ui/dist/index.html" not in names:
+              raise SystemExit("Wheel is missing vibe/ui/dist/index.html")
+          if "vibe/ui/dist-sandbox/index.html" not in names:
+              raise SystemExit("Wheel is missing vibe/ui/dist-sandbox/index.html")
 
           print("vibe/show_runtime_manifest.json")
+          print("vibe/ui/dist/index.html")
+          print("vibe/ui/dist-sandbox/index.html")
           PY
 
       - name: Add Show Runtime release assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app/ui
 COPY ui/package.json ui/package-lock.json ./
 RUN npm ci --ignore-scripts
 COPY ui/ .
-RUN npm run build
+RUN npm run build && npm run build:sandbox
 
 
 # ============================================================
@@ -27,6 +27,7 @@ COPY . .
 
 # Copy built UI from stage 1
 COPY --from=ui-builder /app/ui/dist /app/ui/dist
+COPY --from=ui-builder /app/ui/dist-sandbox /app/ui/dist-sandbox
 
 # hatch-vcs needs git to determine version; .git is excluded by .dockerignore.
 # Use SETUPTOOLS_SCM_PRETEND_VERSION to provide a fake version for the build.

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -290,8 +290,9 @@ class AgentsConfig:
 
 @dataclass
 class UiConfig:
-    setup_host: str = "127.0.0.1"
+    setup_host: str = "localhost"
     setup_port: int = 5123
+    vault_sandbox_port: int = 5124
     open_browser: bool = True
     chat_message_font_size: int = DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX
 
@@ -552,6 +553,12 @@ class V2Config:
             )
         except (TypeError, ValueError):
             ui.chat_message_font_size = DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX
+        try:
+            ui.vault_sandbox_port = int(ui.vault_sandbox_port)
+            if ui.vault_sandbox_port <= 0 or ui.vault_sandbox_port > 65535:
+                ui.vault_sandbox_port = UiConfig.vault_sandbox_port
+        except (TypeError, ValueError):
+            ui.vault_sandbox_port = UiConfig.vault_sandbox_port
 
         remote_access_payload = payload.get("remote_access") or {}
         if not isinstance(remote_access_payload, dict):

--- a/docs/plans/vaults-sandbox-serving-contract.md
+++ b/docs/plans/vaults-sandbox-serving-contract.md
@@ -1,0 +1,59 @@
+# Vaults protected signing sandbox serving contract
+
+This is the B-local serving contract for the protected-tier Vault signing
+sandbox. It intentionally does not add tunnel, cloudflared, or
+`/.well-known/webauthn` behavior; those are B-full follow-ups.
+
+## Origin
+
+- Main app: `http://localhost:5123` by default (`ui.setup_port`).
+- Sandbox app: `http://localhost:5124` by default (`ui.vault_sandbox_port`).
+- The daemon binds the sandbox listener to loopback only. A different port is a
+  different web origin, while WebAuthn RP ID `localhost` remains port-agnostic.
+- Passkey-capable B-local flows should open/embed using `localhost`, not raw
+  `127.0.0.1`, because browsers reject IP-address RP IDs for this path.
+
+## Build Contract
+
+- Sandbox source root: `ui/sandbox/`.
+- Vite config: `ui/vite.sandbox.config.ts`.
+- Build command: `cd ui && npm run build:sandbox`.
+- Build output: `ui/dist-sandbox/`.
+- The packaged wheel/sdist includes `ui/dist-sandbox` as `vibe/ui/dist-sandbox`,
+  alongside the main app's `ui/dist`.
+
+The backend currently ships a minimal placeholder sandbox entry so the build and
+packaging contract is real before the gatekeeper lands the frontend app. The
+frontend owner should replace `ui/sandbox/src/main.tsx` with the postMessage
+signing sandbox and keep the output path and build script unchanged.
+
+## Serving and CSP
+
+The sandbox origin serves only the sandbox bundle. It does not expose main-app
+assets, routes, or `/api/*`. The main app remains the only caller of
+`POST /api/vault/sign`; the sandbox receives `{record, wrap_meta, digest,
+scheme}` through postMessage and returns only the signature through postMessage.
+
+Sandbox CSP:
+
+```text
+default-src 'none';
+script-src 'self' 'wasm-unsafe-eval';
+style-src 'self';
+img-src 'self' data:;
+font-src 'self';
+media-src 'none';
+connect-src 'none';
+worker-src 'self';
+child-src 'none';
+frame-src 'none';
+manifest-src 'none';
+object-src 'none';
+base-uri 'none';
+form-action 'none';
+navigate-to 'none';
+frame-ancestors http://localhost:5123
+```
+
+`'wasm-unsafe-eval'` is present for the browser-side KDF/crypto wasm path. There
+is no inline script permission and no network egress (`connect-src 'none'`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ version-file = "vibe/_version.py"
 
 [tool.hatch.build]
 # Include generated assets even though they are in .gitignore (build artifacts)
-artifacts = ["ui/dist/**", "vibe/show_runtime_manifest.json", "vibe/tmux_runtime_manifest.json"]
+artifacts = ["ui/dist/**", "ui/dist-sandbox/**", "vibe/show_runtime_manifest.json", "vibe/tmux_runtime_manifest.json"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["vibe", "config", "core", "modules", "storage"]
@@ -97,6 +97,7 @@ packages = ["vibe", "config", "core", "modules", "storage"]
 [tool.hatch.build.targets.wheel.force-include]
 "main.py" = "vibe/service_main.py"
 "ui/dist" = "vibe/ui/dist"
+"ui/dist-sandbox" = "vibe/ui/dist-sandbox"
 
 [tool.hatch.build.targets.sdist]
 # Include ui/dist for source distribution
@@ -108,6 +109,7 @@ include = [
     "storage/**",
     "main.py",
     "ui/dist/**",
+    "ui/dist-sandbox/**",
     "vibe/show_runtime_manifest.json",
     "vibe/tmux_runtime_manifest.json",
     "README.md",

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -347,6 +347,15 @@ def tcp_endpoint(host: str, port: int) -> str:
     return f"tcp:[{unbracket_host(host)}]:{port}" if is_ipv6_host(host) else f"tcp:{host}:{port}"
 
 
+def url_host(host: str) -> str:
+    unbracketed = unbracket_host(host)
+    return f"[{unbracketed}]" if is_ipv6_host(host) else unbracketed
+
+
+def http_origin(host: str, port: int) -> str:
+    return f"http://{url_host(host)}:{port}"
+
+
 def ensure_host_port_available(host: str, port: int) -> None:
     family = socket.AF_INET6 if is_ipv6_host(host) else socket.AF_INET
     with socket.socket(family, socket.SOCK_STREAM) as sock:
@@ -884,7 +893,7 @@ def runtime_env_payload(repo_root: Path | None = None, target: RegressionTarget 
         "OPENAI_API_BASE": os.environ.get("OPENAI_API_BASE", ""),
     }
     if target is not None:
-        mappings["VIBE_VAULT_SANDBOX_MAIN_ORIGIN"] = f"http://{target.ui_host}:{target.host_port}"
+        mappings["VIBE_VAULT_SANDBOX_MAIN_ORIGIN"] = http_origin(target.ui_host, target.host_port)
     for key, value in os.environ.items():
         if key == "REGRESSION_UI_HOST":
             continue
@@ -934,7 +943,7 @@ def write_runtime_env(runner: Runner, target: RegressionTarget, *, repo_root: Pa
 
 
 def update_runtime_env_derived_values(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
-    sandbox_origin = f"http://{target.ui_host}:{target.host_port}"
+    sandbox_origin = http_origin(target.ui_host, target.host_port)
     script = textwrap.dedent("""
         import shlex
         import sys
@@ -1509,8 +1518,8 @@ def cmd_up(args: argparse.Namespace) -> int:
 def print_summary(target: RegressionTarget) -> None:
     print("")
     print("Incus regression environment is ready:")
-    print(f"  URL: http://{target.ui_host}:{target.host_port}")
-    print(f"  Vault sandbox URL: http://{target.ui_host}:{target.vault_sandbox_host_port}")
+    print(f"  URL: {http_origin(target.ui_host, target.host_port)}")
+    print(f"  Vault sandbox URL: {http_origin(target.ui_host, target.vault_sandbox_host_port)}")
     print(f"  Target: {target.target}")
     print(f"  Project: {target.project}")
     print(f"  Instance: {target.instance}")

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -416,11 +416,16 @@ def allocate_worktree_port(repo_root: Path, ui_host: str, start: int, end: int, 
     raise RegressionError(f"No available worktree regression port in range {start}-{end}.")
 
 
-def mapped_worktree_port(repo_root: Path, slug: str) -> int | None:
+def mapped_worktree_ports(repo_root: Path, slug: str) -> tuple[int | None, int | None]:
     item = (load_worktree_mapping(repo_root).get("worktrees") or {}).get(slug)
-    if isinstance(item, dict) and isinstance(item.get("host_port"), int):
-        return item["host_port"]
-    return None
+    if not isinstance(item, dict):
+        return None, None
+    host_port = item.get("host_port")
+    sandbox_host_port = item.get("vault_sandbox_host_port")
+    return (
+        host_port if isinstance(host_port, int) else None,
+        sandbox_host_port if isinstance(sandbox_host_port, int) else None,
+    )
 
 
 def resolve_target(
@@ -438,9 +443,11 @@ def resolve_target(
     if args.target == MASTER_TARGET:
         slug = "master"
         host_port = args.host_port or env_int("REGRESSION_PORT") or DEFAULT_MASTER_HOST_PORT
+        mapped_vault_sandbox_host_port = None
     else:
         slug = worktree_slug(repo_root, args.slug)
-        host_port = args.host_port or mapped_worktree_port(repo_root, slug)
+        mapped_host_port, mapped_vault_sandbox_host_port = mapped_worktree_ports(repo_root, slug)
+        host_port = args.host_port or mapped_host_port
         if host_port is None and allocate_port:
             host_port = allocate_worktree_port(
                 repo_root,
@@ -455,6 +462,7 @@ def resolve_target(
     vault_sandbox_host_port = (
         getattr(args, "vault_sandbox_host_port", None)
         or env_int("REGRESSION_VAULT_SANDBOX_PORT")
+        or mapped_vault_sandbox_host_port
         or (host_port + 1 if host_port else DEFAULT_VAULT_SANDBOX_PORT)
     )
     vault_sandbox_port = getattr(args, "vault_sandbox_port", None) or vault_sandbox_host_port

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -388,9 +388,14 @@ def allocated_worktree_ports(repo_root: Path) -> set[int]:
     payload = load_worktree_mapping(repo_root)
     ports: set[int] = set()
     for item in (payload.get("worktrees") or {}).values():
-        if isinstance(item, dict) and isinstance(item.get("host_port"), int):
-            ports.add(item["host_port"])
-        if isinstance(item, dict) and isinstance(item.get("vault_sandbox_host_port"), int):
+        if not isinstance(item, dict):
+            continue
+        host_port = item.get("host_port")
+        if isinstance(host_port, int):
+            ports.add(host_port)
+            if not isinstance(item.get("vault_sandbox_host_port"), int):
+                ports.add(host_port + 1)
+        if isinstance(item.get("vault_sandbox_host_port"), int):
             ports.add(item["vault_sandbox_host_port"])
     return ports
 
@@ -868,7 +873,7 @@ def runtime_env_payload(repo_root: Path | None = None, target: RegressionTarget 
         "OPENAI_API_BASE": os.environ.get("OPENAI_API_BASE", ""),
     }
     if target is not None:
-        mappings["VIBE_VAULT_SANDBOX_MAIN_ORIGIN"] = f"http://localhost:{target.host_port}"
+        mappings["VIBE_VAULT_SANDBOX_MAIN_ORIGIN"] = f"http://{target.ui_host}:{target.host_port}"
     for key, value in os.environ.items():
         if key == "REGRESSION_UI_HOST":
             continue

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -63,6 +63,7 @@ DEFAULT_WORKTREE_PORT_START = 15200
 DEFAULT_WORKTREE_PORT_END = 15399
 ENV_FILE_NAME = ".env.regression"
 ENV_PREFIX = "REGRESSION_"
+VAULT_SANDBOX_MAIN_ORIGIN_ENV = "VIBE_VAULT_SANDBOX_MAIN_ORIGIN"
 SLUG_RE = re.compile(r"^[a-z][a-z0-9-]{1,38}[a-z0-9]$")
 
 
@@ -799,11 +800,13 @@ def compute_fingerprints(repo_root: Path) -> dict:
     ui_source_parts = [
         tree_hash(repo_root / "ui" / "src"),
         tree_hash(repo_root / "ui" / "public"),
+        tree_hash(repo_root / "ui" / "sandbox"),
         file_hash(
             repo_root,
             [
                 "ui/index.html",
                 "ui/vite.config.ts",
+                "ui/vite.sandbox.config.ts",
                 "ui/tsconfig.json",
                 "ui/tsconfig.app.json",
                 "ui/tsconfig.node.json",
@@ -920,6 +923,42 @@ def write_runtime_env(runner: Runner, target: RegressionTarget, *, repo_root: Pa
         ),
         input_bytes=b"" if runner.dry_run else runtime_env_payload(repo_root, target),
     )
+
+
+def update_runtime_env_derived_values(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
+    sandbox_origin = f"http://{target.ui_host}:{target.host_port}"
+    script = textwrap.dedent("""
+        import shlex
+        import sys
+        from pathlib import Path
+
+        path = Path(sys.argv[1])
+        key = sys.argv[2]
+        value = sys.argv[3]
+        lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+        prefix = key + "="
+        replacement = f"{key}={shlex.quote(value)}"
+        changed = False
+        output = []
+        for line in lines:
+            if line.startswith(prefix):
+                output.append(replacement)
+                changed = True
+            else:
+                output.append(line)
+        if not changed:
+            output.append(replacement)
+        path.write_text("\\n".join(output) + "\\n", encoding="utf-8")
+    """).strip()
+    command = textwrap.dedent(f"""
+        set -e
+        path=/etc/avibe-regression.env
+        touch "$path"
+        python3 - "$path" {shlex.quote(VAULT_SANDBOX_MAIN_ORIGIN_ENV)} {shlex.quote(sandbox_origin)}
+        chown root:{SERVICE_USER} "$path"
+        chmod 0640 "$path"
+    """).strip()
+    runner.run(root_exec(target, command, remote=remote), input_bytes=script.encode("utf-8"))
 
 
 def read_existing_fingerprints(runner: Runner, target: RegressionTarget, *, remote: str | None) -> dict:
@@ -1434,6 +1473,7 @@ def cmd_up(args: argparse.Namespace) -> int:
             write_runtime_env(runner, target, repo_root=repo_root, remote=args.remote)
         else:
             print("No regression env file loaded; preserving existing runtime env file.")
+            update_runtime_env_derived_values(runner, target, remote=args.remote)
         sync_source(runner, target, repo_root, remote=args.remote, clean=args.clean, include_ui_dist=args.no_build_ui)
         fingerprints = compute_fingerprints(repo_root)
         previous_fingerprints = read_existing_fingerprints(runner, target, remote=args.remote)

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -56,6 +56,7 @@ DEFAULT_BASE_SOURCE_IMAGE = "images:ubuntu/24.04/cloud"
 DEFAULT_NETWORK = "incusbr0"
 DEFAULT_STORAGE_POOL = "default"
 DEFAULT_UI_PORT = 5123
+DEFAULT_VAULT_SANDBOX_PORT = 5124
 CONTAINER_UI_HOST = "127.0.0.1"
 DEFAULT_MASTER_HOST_PORT = 15130
 DEFAULT_WORKTREE_PORT_START = 15200
@@ -78,6 +79,8 @@ class RegressionTarget:
     host_port: int
     ui_host: str
     ui_port: int
+    vault_sandbox_host_port: int = DEFAULT_VAULT_SANDBOX_PORT
+    vault_sandbox_port: int = DEFAULT_VAULT_SANDBOX_PORT
 
 
 class Runner:
@@ -387,17 +390,20 @@ def allocated_worktree_ports(repo_root: Path) -> set[int]:
     for item in (payload.get("worktrees") or {}).values():
         if isinstance(item, dict) and isinstance(item.get("host_port"), int):
             ports.add(item["host_port"])
+        if isinstance(item, dict) and isinstance(item.get("vault_sandbox_host_port"), int):
+            ports.add(item["vault_sandbox_host_port"])
     return ports
 
 
 def allocate_worktree_port(repo_root: Path, ui_host: str, start: int, end: int, *, dry_run: bool, preflight: bool) -> int:
     used = allocated_worktree_ports(repo_root)
     for port in range(start, end + 1):
-        if port in used:
+        if port in used or port + 1 in used:
             continue
         if not dry_run and preflight:
             try:
                 ensure_host_port_available(ui_host, port)
+                ensure_host_port_available(ui_host, port + 1)
             except RegressionError:
                 continue
         return port
@@ -440,14 +446,22 @@ def resolve_target(
             )
         if host_port is None:
             host_port = 0
+    vault_sandbox_host_port = (
+        getattr(args, "vault_sandbox_host_port", None)
+        or env_int("REGRESSION_VAULT_SANDBOX_PORT")
+        or (host_port + 1 if host_port else DEFAULT_VAULT_SANDBOX_PORT)
+    )
+    vault_sandbox_port = getattr(args, "vault_sandbox_port", None) or vault_sandbox_host_port
     return RegressionTarget(
         target=args.target,
         slug=slug,
         project=project_name_for(args.target, slug),
         instance=instance_name_for(args.target, slug),
         host_port=host_port,
+        vault_sandbox_host_port=vault_sandbox_host_port,
         ui_host=ui_host,
         ui_port=ui_port,
+        vault_sandbox_port=vault_sandbox_port,
     )
 
 
@@ -464,6 +478,7 @@ def project_create_config(target: RegressionTarget) -> list[str]:
         f"user.avibe_regression.slug={target.slug}",
         f"user.avibe_regression.instance={target.instance}",
         f"user.avibe_regression.host_port={target.host_port}",
+        f"user.avibe_regression.vault_sandbox_host_port={target.vault_sandbox_host_port}",
     ]
 
 
@@ -588,10 +603,25 @@ def proxy_device_args(target: RegressionTarget, *, remote: str | None = None) ->
     ]
 
 
+def vault_sandbox_proxy_device_args(target: RegressionTarget, *, remote: str | None = None) -> list[str]:
+    return [
+        "config",
+        "device",
+        "add",
+        remote_ref(remote, target.instance),
+        "vault-sandbox",
+        "proxy",
+        f"listen={tcp_endpoint(target.ui_host, target.vault_sandbox_host_port)}",
+        f"connect=tcp:127.0.0.1:{target.vault_sandbox_port}",
+    ]
+
+
 def ensure_proxy_device(runner: Runner, target: RegressionTarget, *, remote: str | None) -> None:
     instance_ref = remote_ref(remote, target.instance)
     runner.run(incus("config", "device", "remove", instance_ref, "ui", project=target.project), check=False)
+    runner.run(incus("config", "device", "remove", instance_ref, "vault-sandbox", project=target.project), check=False)
     runner.run(incus(*proxy_device_args(target, remote=remote), project=target.project))
+    runner.run(incus(*vault_sandbox_proxy_device_args(target, remote=remote), project=target.project))
 
 
 def ensure_project_and_instance(
@@ -692,6 +722,7 @@ def source_excludes(*, include_ui_dist: bool = False) -> tuple[str, ...]:
     ]
     if not include_ui_dist:
         excludes.append("ui/dist")
+        excludes.append("ui/dist-sandbox")
     return tuple(excludes)
 
 
@@ -817,7 +848,7 @@ def write_metadata(runner: Runner, target: RegressionTarget, repo_root: Path, fi
     runner.run(root_exec(target, command, remote=remote))
 
 
-def runtime_env_payload(repo_root: Path | None = None) -> bytes:
+def runtime_env_payload(repo_root: Path | None = None, target: RegressionTarget | None = None) -> bytes:
     scm_version = "0.0.0.dev0"
     if repo_root is not None:
         sha = commit_sha(repo_root)
@@ -836,6 +867,8 @@ def runtime_env_payload(repo_root: Path | None = None) -> bytes:
         "OPENAI_BASE_URL": os.environ.get("OPENAI_BASE_URL", ""),
         "OPENAI_API_BASE": os.environ.get("OPENAI_API_BASE", ""),
     }
+    if target is not None:
+        mappings["VIBE_VAULT_SANDBOX_MAIN_ORIGIN"] = f"http://localhost:{target.host_port}"
     for key, value in os.environ.items():
         if key == "REGRESSION_UI_HOST":
             continue
@@ -880,7 +913,7 @@ def write_runtime_env(runner: Runner, target: RegressionTarget, *, repo_root: Pa
             f"cat > /etc/avibe-regression.env && chown root:{SERVICE_USER} /etc/avibe-regression.env && chmod 0640 /etc/avibe-regression.env",
             project=target.project,
         ),
-        input_bytes=b"" if runner.dry_run else runtime_env_payload(repo_root),
+        input_bytes=b"" if runner.dry_run else runtime_env_payload(repo_root, target),
     )
 
 
@@ -1053,7 +1086,12 @@ def run_prepare_state(runner: Runner, target: RegressionTarget, *, reset_mode: s
 
 def instance_ui_dist_exists(runner: Runner, target: RegressionTarget, *, remote: str | None) -> bool:
     result = runner.run(
-        tenant_exec(target, "test -d ui/dist && test -f ui/dist/index.html", remote=remote),
+        tenant_exec(
+            target,
+            "test -d ui/dist && test -f ui/dist/index.html && "
+            "test -d ui/dist-sandbox && test -f ui/dist-sandbox/index.html",
+            remote=remote,
+        ),
         check=False,
     )
     return result.returncode == 0
@@ -1075,6 +1113,9 @@ def normalize_runtime_config(runner: Runner, target: RegressionTarget, *, remote
             changed = True
         if ui.get("setup_port") != {target.ui_port!r}:
             ui["setup_port"] = {target.ui_port!r}
+            changed = True
+        if ui.get("vault_sandbox_port") != {target.vault_sandbox_port!r}:
+            ui["vault_sandbox_port"] = {target.vault_sandbox_port!r}
             changed = True
         if not changed:
             raise SystemExit(0)
@@ -1127,7 +1168,7 @@ def update_dependencies_and_build(
             or ui_deps_changed
             or previous_fingerprints.get("ui_source") != next_fingerprints.get("ui_source")
         ):
-            runner.run(tenant_exec(target, "cd ui && npm run build", remote=remote))
+            runner.run(tenant_exec(target, "cd ui && npm run build && npm run build:sandbox", remote=remote))
         else:
             print("UI source fingerprint unchanged; skipping npm run build.")
     if python_changed:
@@ -1146,6 +1187,7 @@ def restart_and_verify(runner: Runner, target: RegressionTarget, *, remote: str 
                 f"systemctl is-active --quiet {SERVICE_NAME} && "
                 f"curl -fsS http://127.0.0.1:{target.ui_port}/health >/dev/null && "
                 f"curl -fsS http://127.0.0.1:{target.ui_port}/status | grep -q '\"state\":\"running\"' && "
+                f"curl -fsS http://127.0.0.1:{target.vault_sandbox_port}/ >/dev/null && "
                 "exit 0; "
                 "sleep 2; "
                 f"done; journalctl -u {SERVICE_NAME} --no-pager -n 120; exit 1"
@@ -1172,6 +1214,7 @@ def update_worktree_mapping(repo_root: Path, target: RegressionTarget) -> None:
         "project": target.project,
         "instance": target.instance,
         "host_port": target.host_port,
+        "vault_sandbox_host_port": target.vault_sandbox_host_port,
         "updated_at": datetime.now(timezone.utc).isoformat(),
         "branch": branch_name(repo_root),
         "commit": commit_sha(repo_root),
@@ -1190,6 +1233,7 @@ def reserve_worktree_mapping(repo_root: Path, target: RegressionTarget) -> None:
             "project": target.project,
             "instance": target.instance,
             "host_port": target.host_port,
+            "vault_sandbox_host_port": target.vault_sandbox_host_port,
             "reserved_at": datetime.now(timezone.utc).isoformat(),
             "branch": branch_name(repo_root),
         }
@@ -1340,6 +1384,7 @@ def cmd_up(args: argparse.Namespace) -> int:
         if not args.dry_run and not target_exists and args.remote is None:
             try:
                 ensure_host_port_available(target.ui_host, target.host_port)
+                ensure_host_port_available(target.ui_host, target.vault_sandbox_host_port)
             except RegressionError as exc:
                 # A reachable incus client would have reported the instance as existing
                 # above and skipped this preflight. The usual macOS cause is that `incus`
@@ -1412,6 +1457,7 @@ def print_summary(target: RegressionTarget) -> None:
     print("")
     print("Incus regression environment is ready:")
     print(f"  URL: http://{target.ui_host}:{target.host_port}")
+    print(f"  Vault sandbox URL: http://{target.ui_host}:{target.vault_sandbox_host_port}")
     print(f"  Target: {target.target}")
     print(f"  Project: {target.project}")
     print(f"  Instance: {target.instance}")
@@ -1527,8 +1573,10 @@ def add_target_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--slug", help="Explicit worktree slug for --target worktree.")
     parser.add_argument("--env-file", type=Path)
     parser.add_argument("--host-port", type=int, help="Host port for the Web UI proxy.")
+    parser.add_argument("--vault-sandbox-host-port", type=int, help="Host port for the Vault signing sandbox proxy.")
     parser.add_argument("--ui-host", help="Host/interface for the Incus UI proxy. Defaults to REGRESSION_PORT_BIND_HOST or 127.0.0.1 after env loading.")
     parser.add_argument("--ui-port", type=int, default=DEFAULT_UI_PORT)
+    parser.add_argument("--vault-sandbox-port", type=int, default=DEFAULT_VAULT_SANDBOX_PORT)
     parser.add_argument("--worktree-port-start", type=int, default=DEFAULT_WORKTREE_PORT_START)
     parser.add_argument("--worktree-port-end", type=int, default=DEFAULT_WORKTREE_PORT_END)
 

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -676,6 +676,22 @@ def test_runtime_env_payload_maps_vault_sandbox_main_origin() -> None:
     assert "VIBE_VAULT_SANDBOX_MAIN_ORIGIN=http://127.0.0.1:15130" in payload
 
 
+def test_runtime_env_payload_brackets_ipv6_sandbox_main_origin() -> None:
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="::1",
+        ui_port=5123,
+    )
+
+    payload = incus_regression.runtime_env_payload(target=target).decode()
+
+    assert "VIBE_VAULT_SANDBOX_MAIN_ORIGIN='http://[::1]:15130'" in payload
+
+
 def test_load_env_file_accepts_export_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env_file = tmp_path / ".env.regression"
     env_file.write_text("export REGRESSION_SLACK_CHANNEL=C123\n", encoding="utf-8")
@@ -1145,6 +1161,32 @@ def test_update_runtime_env_derived_values_preserves_existing_env() -> None:
     assert 'chown root:avibe "$path"' in joined_command
     assert 'chmod 0640 "$path"' in joined_command
     assert b"shlex.quote(value)" in inputs[0]
+
+
+def test_update_runtime_env_derived_values_brackets_ipv6_origin() -> None:
+    commands = []
+
+    class RecordingRunner:
+        dry_run = True
+
+        def run(self, command, *, input_bytes=None, **kwargs):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0)
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="::1",
+        ui_port=5123,
+    )
+
+    incus_regression.update_runtime_env_derived_values(RecordingRunner(), target, remote=None)
+
+    joined_command = " ".join(commands[0])
+    assert "'http://[::1]:15130'" in joined_command
 
 
 def test_cleanup_stale_deletes_missing_worktree_mapping(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -220,6 +220,41 @@ def test_worktree_target_reuses_mapped_port_without_allocation(tmp_path: Path, m
     assert target.host_port == 15234
 
 
+def test_worktree_allocation_reserves_legacy_implicit_sandbox_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = tmp_path / ".runtime" / "incus-regression"
+    runtime.mkdir(parents=True)
+    (runtime / "worktrees.json").write_text(
+        json.dumps({"schema_version": 1, "worktrees": {"old-branch": {"host_port": 15200}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(incus_regression, "git_common_root", lambda repo_root: repo_root)
+    preflight_calls: list[tuple[str, int]] = []
+    monkeypatch.setattr(
+        incus_regression,
+        "ensure_host_port_available",
+        lambda host, port: preflight_calls.append((host, port)),
+    )
+
+    target = incus_regression.resolve_target(
+        argparse.Namespace(
+            target="worktree",
+            slug="new-branch",
+            host_port=None,
+            ui_host="127.0.0.1",
+            ui_port=5123,
+            worktree_port_start=15200,
+            worktree_port_end=15205,
+        ),
+        tmp_path,
+        dry_run=False,
+        preflight_ports=True,
+    )
+
+    assert target.host_port == 15202
+    assert target.vault_sandbox_host_port == 15203
+    assert preflight_calls == [("127.0.0.1", 15202), ("127.0.0.1", 15203)]
+
+
 def test_worktree_maintenance_target_does_not_allocate_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(incus_regression, "allocate_worktree_port", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not allocate for maintenance")))
 
@@ -574,7 +609,7 @@ def test_runtime_env_payload_maps_vault_sandbox_main_origin() -> None:
 
     payload = incus_regression.runtime_env_payload(target=target).decode()
 
-    assert "VIBE_VAULT_SANDBOX_MAIN_ORIGIN=http://localhost:15130" in payload
+    assert "VIBE_VAULT_SANDBOX_MAIN_ORIGIN=http://127.0.0.1:15130" in payload
 
 
 def test_load_env_file_accepts_export_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -557,6 +557,32 @@ def test_ui_public_assets_are_part_of_source_fingerprint(tmp_path: Path) -> None
     assert before != after
 
 
+def test_ui_sandbox_assets_are_part_of_source_fingerprint(tmp_path: Path) -> None:
+    (tmp_path / "ui" / "src").mkdir(parents=True)
+    (tmp_path / "ui" / "public").mkdir(parents=True)
+    (tmp_path / "ui" / "sandbox" / "src").mkdir(parents=True)
+    (tmp_path / "ui" / "sandbox" / "src" / "main.tsx").write_text("one\n", encoding="utf-8")
+
+    before = incus_regression.compute_fingerprints(tmp_path)["ui_source"]
+    (tmp_path / "ui" / "sandbox" / "src" / "main.tsx").write_text("two\n", encoding="utf-8")
+    after = incus_regression.compute_fingerprints(tmp_path)["ui_source"]
+
+    assert before != after
+
+
+def test_ui_sandbox_config_is_part_of_source_fingerprint(tmp_path: Path) -> None:
+    (tmp_path / "ui" / "src").mkdir(parents=True)
+    (tmp_path / "ui" / "public").mkdir(parents=True)
+    (tmp_path / "ui" / "sandbox").mkdir(parents=True)
+    (tmp_path / "ui" / "vite.sandbox.config.ts").write_text("one\n", encoding="utf-8")
+
+    before = incus_regression.compute_fingerprints(tmp_path)["ui_source"]
+    (tmp_path / "ui" / "vite.sandbox.config.ts").write_text("two\n", encoding="utf-8")
+    after = incus_regression.compute_fingerprints(tmp_path)["ui_source"]
+
+    assert before != after
+
+
 def test_runtime_env_payload_maps_show_runtime_and_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REGRESSION_SHOW_RUNTIME_GITHUB_REF", "main")
     monkeypatch.setenv("REGRESSION_SLACK_CHANNEL", "C123")
@@ -1048,6 +1074,39 @@ def test_write_runtime_env_uses_stdin_not_command_line() -> None:
     assert "chmod 0640 /etc/avibe-regression.env" in joined_command
     assert b"VIBE_SHOW_RUNTIME_SOURCE" in inputs[0]
     assert "OPENAI_API_KEY" not in joined_command
+
+
+def test_update_runtime_env_derived_values_preserves_existing_env() -> None:
+    commands = []
+    inputs = []
+
+    class RecordingRunner:
+        dry_run = True
+
+        def run(self, command, *, input_bytes=None, **kwargs):
+            commands.append(command)
+            inputs.append(input_bytes)
+            return subprocess.CompletedProcess(command, 0)
+
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    incus_regression.update_runtime_env_derived_values(RecordingRunner(), target, remote="lab")
+
+    joined_command = " ".join(commands[0])
+    assert commands[0][:5] == ["incus", "--project", "avr-master", "exec", "lab:avibe-master"]
+    assert "VIBE_VAULT_SANDBOX_MAIN_ORIGIN" in joined_command
+    assert "http://127.0.0.1:15130" in joined_command
+    assert 'chown root:avibe "$path"' in joined_command
+    assert 'chmod 0640 "$path"' in joined_command
+    assert b"shlex.quote(value)" in inputs[0]
 
 
 def test_cleanup_stale_deletes_missing_worktree_mapping(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1557,6 +1616,7 @@ def test_up_stops_old_service_before_mutating_runtime(tmp_path: Path, monkeypatc
     monkeypatch.setattr(incus_regression, "ensure_project_and_instance", record("ensure_project_and_instance"))
     monkeypatch.setattr(incus_regression, "stop_service_for_update", record("stop_service_for_update"))
     monkeypatch.setattr(incus_regression, "write_runtime_env", record("write_runtime_env"))
+    monkeypatch.setattr(incus_regression, "update_runtime_env_derived_values", record("update_runtime_env_derived_values"))
     monkeypatch.setattr(incus_regression, "should_seed_state", lambda *args, **kwargs: False)
     monkeypatch.setattr(incus_regression, "sync_source", record("sync_source"))
     monkeypatch.setattr(incus_regression, "compute_fingerprints", lambda repo_root: {})
@@ -1625,6 +1685,7 @@ def test_up_preserves_runtime_env_when_existing_target_has_no_env_file(tmp_path:
     monkeypatch.setattr(incus_regression, "ensure_project_and_instance", record("ensure_project_and_instance"))
     monkeypatch.setattr(incus_regression, "stop_service_for_update", record("stop_service_for_update"))
     monkeypatch.setattr(incus_regression, "write_runtime_env", record("write_runtime_env"))
+    monkeypatch.setattr(incus_regression, "update_runtime_env_derived_values", record("update_runtime_env_derived_values"))
     monkeypatch.setattr(incus_regression, "should_seed_state", lambda *args, **kwargs: False)
     monkeypatch.setattr(incus_regression, "sync_source", record("sync_source"))
     monkeypatch.setattr(incus_regression, "compute_fingerprints", lambda repo_root: {})
@@ -1663,6 +1724,9 @@ def test_up_preserves_runtime_env_when_existing_target_has_no_env_file(tmp_path:
 
     assert incus_regression.cmd_up(args) == 0
     assert "write_runtime_env" not in calls
+    assert "update_runtime_env_derived_values" in calls
+    assert calls.index("stop_service_for_update") < calls.index("update_runtime_env_derived_values")
+    assert calls.index("update_runtime_env_derived_values") < calls.index("sync_source")
     assert calls.index("stop_service_for_update") < calls.index("sync_source")
 
 

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -220,6 +220,44 @@ def test_worktree_target_reuses_mapped_port_without_allocation(tmp_path: Path, m
     assert target.host_port == 15234
 
 
+def test_worktree_target_reuses_mapped_sandbox_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = tmp_path / ".runtime" / "incus-regression"
+    runtime.mkdir(parents=True)
+    (runtime / "worktrees.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "worktrees": {
+                    "demo-branch": {
+                        "host_port": 15234,
+                        "vault_sandbox_host_port": 15390,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(incus_regression, "git_common_root", lambda repo_root: repo_root)
+    monkeypatch.setattr(incus_regression, "allocate_worktree_port", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should reuse mapped ports")))
+
+    target = incus_regression.resolve_target(
+        argparse.Namespace(
+            target="worktree",
+            slug="demo-branch",
+            host_port=None,
+            ui_host="127.0.0.1",
+            ui_port=5123,
+            worktree_port_start=15200,
+            worktree_port_end=15399,
+        ),
+        tmp_path,
+        dry_run=False,
+    )
+
+    assert target.host_port == 15234
+    assert target.vault_sandbox_host_port == 15390
+
+
 def test_worktree_allocation_reserves_legacy_implicit_sandbox_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     runtime = tmp_path / ".runtime" / "incus-regression"
     runtime.mkdir(parents=True)

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -40,6 +40,8 @@ def test_master_target_uses_stable_project_instance_and_port(monkeypatch: pytest
     assert target.project == "avr-master"
     assert target.instance == "avibe-master"
     assert target.host_port == 15130
+    assert target.vault_sandbox_host_port == 15131
+    assert target.vault_sandbox_port == 15131
 
 
 def test_master_target_uses_env_host_port(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -60,6 +62,7 @@ def test_master_target_uses_env_host_port(monkeypatch: pytest.MonkeyPatch) -> No
     )
 
     assert target.host_port == 15131
+    assert target.vault_sandbox_host_port == 15132
 
 
 def test_master_target_ignores_legacy_env_host_port(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -164,6 +167,7 @@ def test_worktree_target_slug_includes_path_hash(monkeypatch: pytest.MonkeyPatch
     assert target.project.startswith("avr-wt-feature-show-runtime-")
     assert target.instance.startswith("avibe-wt-feature-show-runtime-")
     assert target.host_port == 15234
+    assert target.vault_sandbox_host_port == 15235
 
 
 def test_remote_worktree_target_skips_local_port_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -186,6 +190,7 @@ def test_remote_worktree_target_skips_local_port_preflight(monkeypatch: pytest.M
     )
 
     assert target.host_port == 15200
+    assert target.vault_sandbox_host_port == 15201
 
 
 def test_worktree_target_reuses_mapped_port_without_allocation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -267,6 +272,7 @@ def test_project_config_marks_regression_target() -> None:
     assert "restricted.devices.proxy=allow" in config
     assert "user.avibe_regression.target=worktree" in config
     assert "user.avibe_regression.host_port=15200" in config
+    assert "user.avibe_regression.vault_sandbox_host_port=5124" in config
 
 
 def test_remote_ref_prefixes_resource_names_only() -> None:
@@ -356,7 +362,13 @@ def test_existing_instance_proxy_device_is_refreshed() -> None:
 
     rendered = [" ".join(command) for command, _ in commands]
     assert "incus --project avr-master config device remove avibe-master ui" in rendered
+    assert "incus --project avr-master config device remove avibe-master vault-sandbox" in rendered
     assert any("incus --project avr-master config device add avibe-master ui proxy listen=tcp:127.0.0.1:15131" in command for command in rendered)
+    assert any(
+        "incus --project avr-master config device add avibe-master vault-sandbox proxy listen=tcp:127.0.0.1:5124"
+        in command
+        for command in rendered
+    )
 
 
 def test_build_base_uses_publishable_temp_instance() -> None:
@@ -408,7 +420,9 @@ def test_source_exclude_drops_runtime_and_dependency_dirs() -> None:
     assert incus_regression.should_exclude(".runtime/state.json")
     assert incus_regression.should_exclude("ui/node_modules/pkg/index.js")
     assert incus_regression.should_exclude("ui/dist/assets/app.js")
+    assert incus_regression.should_exclude("ui/dist-sandbox/assets/app.js")
     assert not incus_regression.should_exclude("ui/dist/assets/app.js", include_ui_dist=True)
+    assert not incus_regression.should_exclude("ui/dist-sandbox/assets/app.js", include_ui_dist=True)
     assert incus_regression.should_exclude("pkg/__pycache__/x.pyc")
     assert incus_regression.should_exclude(".env")
     assert incus_regression.should_exclude(".env.regression")
@@ -456,6 +470,9 @@ def test_source_tar_can_include_existing_ui_dist_when_build_is_skipped(tmp_path:
     (tmp_path / "ui" / "dist" / "assets").mkdir(parents=True)
     (tmp_path / "ui" / "dist" / "index.html").write_text("<html></html>\n", encoding="utf-8")
     (tmp_path / "ui" / "dist" / "assets" / "app.js").write_text("console.log('ok')\n", encoding="utf-8")
+    (tmp_path / "ui" / "dist-sandbox" / "assets").mkdir(parents=True)
+    (tmp_path / "ui" / "dist-sandbox" / "index.html").write_text("<html></html>\n", encoding="utf-8")
+    (tmp_path / "ui" / "dist-sandbox" / "assets" / "sandbox.js").write_text("console.log('ok')\n", encoding="utf-8")
 
     payload = incus_regression.build_source_tar(tmp_path, include_ui_dist=True)
     with tarfile.open(fileobj=io.BytesIO(payload), mode="r") as archive:
@@ -463,6 +480,8 @@ def test_source_tar_can_include_existing_ui_dist_when_build_is_skipped(tmp_path:
 
     assert "ui/dist/index.html" in names
     assert "ui/dist/assets/app.js" in names
+    assert "ui/dist-sandbox/index.html" in names
+    assert "ui/dist-sandbox/assets/sandbox.js" in names
 
 
 def test_sync_source_clears_stale_files_even_without_clean(tmp_path: Path) -> None:
@@ -540,6 +559,22 @@ def test_runtime_env_payload_forces_container_ui_host(monkeypatch: pytest.Monkey
     assert "REGRESSION_UI_HOST=127.0.0.1" in payload
     assert "REGRESSION_UI_HOST=192.168.2.3" not in payload
     assert "REGRESSION_UI_HOST=10.1.2.3" not in payload
+
+
+def test_runtime_env_payload_maps_vault_sandbox_main_origin() -> None:
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    payload = incus_regression.runtime_env_payload(target=target).decode()
+
+    assert "VIBE_VAULT_SANDBOX_MAIN_ORIGIN=http://localhost:15130" in payload
 
 
 def test_load_env_file_accepts_export_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1210,7 +1245,7 @@ def test_up_checks_host_port_preflight_for_new_local_instance(tmp_path: Path, mo
     )
 
     assert incus_regression.cmd_up(args) == 0
-    assert preflight_calls == [("127.0.0.1", 15130)]
+    assert preflight_calls == [("127.0.0.1", 15130), ("127.0.0.1", 15131)]
 
 
 def test_up_checks_seed_env_before_target_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1707,6 +1742,7 @@ def test_up_reserves_worktree_port_under_mapping_lock(tmp_path: Path, monkeypatc
     monkeypatch.setattr(incus_regression, "load_env_file", lambda repo_root, env_file: None)
     monkeypatch.setattr(incus_regression, "require_incus", lambda: None)
     monkeypatch.setattr(incus_regression, "Runner", ExistingRunner)
+    monkeypatch.setattr(incus_regression, "ensure_host_port_available", lambda *args, **kwargs: None)
     monkeypatch.setattr(incus_regression, "worktree_mapping_lock", mapping_lock)
     original_reserve_worktree_mapping = incus_regression.reserve_worktree_mapping
 
@@ -1760,6 +1796,7 @@ def test_up_reserves_worktree_port_under_mapping_lock(tmp_path: Path, monkeypatc
     payload = json.loads((tmp_path / ".runtime" / "incus-regression" / "worktrees.json").read_text(encoding="utf-8"))
     mapping = payload["worktrees"]["demo-branch"]
     assert mapping["host_port"] == 15200
+    assert mapping["vault_sandbox_host_port"] == 15201
     assert mapping["project"] == "avr-wt-demo-branch"
     assert "updated_at" in mapping
 
@@ -1788,6 +1825,8 @@ def test_normalize_runtime_config_updates_host_and_port() -> None:
     assert "ui.get(\"setup_host\") != '127.0.0.1'" in joined
     assert 'ui.get("setup_port") != 6123' in joined
     assert 'ui["setup_port"] = 6123' in joined
+    assert 'ui.get("vault_sandbox_port") != 5124' in joined
+    assert 'ui["vault_sandbox_port"] = 5124' in joined
 
 
 def test_stop_service_for_update_ignores_missing_service() -> None:
@@ -1880,7 +1919,7 @@ def test_force_ui_rebuilds_even_when_fingerprints_match() -> None:
 
     joined = "\n".join(commands)
     assert "cd ui && npm ci" in joined
-    assert "cd ui && npm run build" in joined
+    assert "cd ui && npm run build && npm run build:sandbox" in joined
     assert "pip install -e ." not in joined
 
 
@@ -1890,7 +1929,7 @@ def test_missing_ui_dist_overrides_no_build_ui_before_editable_install() -> None
     class RecordingRunner:
         def run(self, command, **kwargs):
             commands.append(" ".join(command))
-            if "test -d ui/dist" in commands[-1]:
+            if "test -d ui/dist && test -f ui/dist/index.html" in commands[-1]:
                 return subprocess.CompletedProcess(command, 1)
             return subprocess.CompletedProcess(command, 0)
 
@@ -1919,7 +1958,9 @@ def test_missing_ui_dist_overrides_no_build_ui_before_editable_install() -> None
     install_index = next(i for i, command in enumerate(commands) if "pip install -e ." in command)
     build_index = next(i for i, command in enumerate(commands) if "npm run build" in command)
     assert "test -d ui/dist && test -f ui/dist/index.html" in joined
+    assert "test -d ui/dist-sandbox && test -f ui/dist-sandbox/index.html" in joined
     assert "cd ui && npm ci" in joined
+    assert "npm run build && npm run build:sandbox" in joined
     assert build_index < install_index
 
 
@@ -1929,7 +1970,7 @@ def test_missing_ui_dist_rebuilds_even_when_python_is_unchanged() -> None:
     class RecordingRunner:
         def run(self, command, **kwargs):
             commands.append(" ".join(command))
-            if "test -d ui/dist" in commands[-1]:
+            if "test -d ui/dist && test -f ui/dist/index.html" in commands[-1]:
                 return subprocess.CompletedProcess(command, 1)
             return subprocess.CompletedProcess(command, 0)
 
@@ -1956,7 +1997,8 @@ def test_missing_ui_dist_rebuilds_even_when_python_is_unchanged() -> None:
 
     joined = "\n".join(commands)
     assert "test -d ui/dist && test -f ui/dist/index.html" in joined
-    assert "cd ui && npm run build" in joined
+    assert "test -d ui/dist-sandbox && test -f ui/dist-sandbox/index.html" in joined
+    assert "cd ui && npm run build && npm run build:sandbox" in joined
     assert "pip install -e ." not in joined
 
 

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -623,7 +623,7 @@ def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
         in payload["next_actions"]
     )
     assert (tmp_path / "show" / "ses123" / "index.html").exists()
-    assert captured["url"] == "http://127.0.0.1:5123/api/show/sessions/ses123/prewarm"
+    assert captured["url"] == "http://localhost:5123/api/show/sessions/ses123/prewarm"
     assert captured["payload"] == {}
     assert captured["timeout"] == 3
 
@@ -920,7 +920,7 @@ def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
     assert public_payload["previous_private_url"] == "https://alex.avibe.bot/show/ses123/"
     share_path = "/" + public_payload["public_url"].split("https://alex.avibe.bot/", 1)[1]
     assert prewarmed[-1] == (
-        "http://127.0.0.1:5123/api/show/sessions/ses123/prewarm",
+        "http://localhost:5123/api/show/sessions/ses123/prewarm",
         {"base_path": share_path},
     )
 
@@ -930,7 +930,7 @@ def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
     assert private_payload["visibility"] == "private"
     assert private_payload["active_url"] == "https://alex.avibe.bot/show/ses123/"
     assert private_payload["previous_public_url"] == public_payload["public_url"]
-    assert prewarmed[-1] == ("http://127.0.0.1:5123/api/show/sessions/ses123/prewarm", {})
+    assert prewarmed[-1] == ("http://localhost:5123/api/show/sessions/ses123/prewarm", {})
 
 
 def test_show_status_and_update_default_to_caller_session(monkeypatch, tmp_path, capsys):
@@ -1145,7 +1145,7 @@ def test_show_mark_cli_posts_to_live_ui_when_running(monkeypatch, tmp_path, caps
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["event"]["id"] == "show_evt_live"
-    assert captured["url"] == "http://127.0.0.1:5123/api/show/sessions/ses123/events"
+    assert captured["url"] == "http://localhost:5123/api/show/sessions/ses123/events"
     assert captured["client"] == "cli"
     assert captured["cli_token"] == show_cli_event_token()
     assert captured["payload"]["type"] == "assistant.mark.created"

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import threading
 
 from config.v2_config import (
@@ -12,6 +13,7 @@ from config.v2_config import (
     V2Config,
 )
 from vibe import runtime
+from vibe import ui_server
 from vibe.ui_server import app
 
 from tests.ui_server_test_helpers import csrf_headers
@@ -43,6 +45,12 @@ class _NoopThread:
         # Skip the actual subprocess respawn; the unit test only asserts
         # the bind host computed before the thread is started.
         return None
+
+
+class _ImmediateThread(_NoopThread):
+    def start(self) -> None:
+        if self._target is not None:
+            self._target(*self._args, **self._kwargs)
 
 
 def test_ui_reload_overrides_bind_host_when_tunnel_enabled(monkeypatch):
@@ -128,3 +136,44 @@ def test_ui_reload_uses_requested_host_when_tunnel_disabled(monkeypatch):
     assert response.status_code == 200
     assert captured["requested_host"] == "192.168.1.5"
     assert captured["enabled"] is False
+
+
+def test_ui_reload_stops_old_vault_sandbox_before_old_ui_shutdown(monkeypatch, tmp_path):
+    events: list[str] = []
+
+    class FakeProcess:
+        pid = 4242
+
+    class FakeServer:
+        should_exit = False
+
+    def fake_popen(*args, **kwargs):
+        events.append("spawn")
+        return FakeProcess()
+
+    def fake_stop_sandbox():
+        events.append("stop_sandbox")
+
+    monkeypatch.setattr("core.services.settings.load_config", lambda *a, **k: _config_with_tunnel(enabled=False))
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(ui_server, "_stop_vault_sandbox_server", fake_stop_sandbox)
+    monkeypatch.setattr(ui_server, "_server", FakeServer())
+    monkeypatch.setattr("config.paths.get_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr("config.paths.get_runtime_ui_pid_path", lambda: tmp_path / "ui.pid")
+    monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 1111})
+    monkeypatch.setattr(runtime, "write_status", lambda *args, **kwargs: events.append("status"))
+    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: events.append("sleep"))
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "localhost", "port": 5123},
+        headers=csrf_headers(client, "http://localhost:5123"),
+        base_url="http://localhost:5123",
+    )
+
+    assert response.status_code == 200
+    assert events[:3] == ["stop_sandbox", "spawn", "status"]
+    assert events[-1] == "sleep"
+    assert ui_server._server.should_exit is True

--- a/tests/test_vault_sandbox_serving.py
+++ b/tests/test_vault_sandbox_serving.py
@@ -111,6 +111,14 @@ def test_vault_sandbox_main_origin_can_be_overridden_for_regression_proxy(monkey
     assert ui_server._vault_sandbox_main_origin(None, "localhost", 5123) == "http://localhost:5123"
 
 
+def test_vault_sandbox_bind_host_follows_wildcard_ui_host():
+    assert ui_server._vault_sandbox_bind_host("0.0.0.0") == "0.0.0.0"
+    assert ui_server._vault_sandbox_bind_host("*") == "0.0.0.0"
+    assert ui_server._vault_sandbox_bind_host("::") == "::"
+    assert ui_server._vault_sandbox_bind_host("localhost") == "127.0.0.1"
+    assert ui_server._vault_sandbox_bind_host("127.0.0.1") == "127.0.0.1"
+
+
 def test_vault_sandbox_lifespan_starts_second_listener(monkeypatch):
     calls = []
     config = type("Config", (), {"ui": UiConfig(vault_sandbox_port=6124)})()

--- a/tests/test_vault_sandbox_serving.py
+++ b/tests/test_vault_sandbox_serving.py
@@ -102,6 +102,12 @@ def test_vault_sandbox_main_origin_uses_configured_loopback_host():
     assert ui_server._vault_sandbox_main_origin(None, "bad host", 5123) == "http://localhost:5123"
 
 
+def test_vault_sandbox_main_origin_uses_running_ui_port():
+    config = type("Config", (), {"ui": UiConfig(setup_host="localhost", setup_port=5123)})()
+
+    assert ui_server._vault_sandbox_main_origin(config, "127.0.0.1", 6000) == "http://localhost:6000"
+
+
 def test_vault_sandbox_main_origin_can_be_overridden_for_regression_proxy(monkeypatch):
     monkeypatch.setenv(ui_server.VAULT_SANDBOX_MAIN_ORIGIN_ENV, "http://localhost:15130")
 
@@ -111,12 +117,20 @@ def test_vault_sandbox_main_origin_can_be_overridden_for_regression_proxy(monkey
     assert ui_server._vault_sandbox_main_origin(None, "localhost", 5123) == "http://localhost:5123"
 
 
-def test_vault_sandbox_bind_host_follows_wildcard_ui_host():
-    assert ui_server._vault_sandbox_bind_host("0.0.0.0") == "0.0.0.0"
-    assert ui_server._vault_sandbox_bind_host("*") == "0.0.0.0"
-    assert ui_server._vault_sandbox_bind_host("::") == "::"
+def test_vault_sandbox_bind_host_stays_loopback_only():
+    assert ui_server._vault_sandbox_bind_host("0.0.0.0") == "127.0.0.1"
+    assert ui_server._vault_sandbox_bind_host("*") == "127.0.0.1"
+    assert ui_server._vault_sandbox_bind_host("::") == "::1"
+    assert ui_server._vault_sandbox_bind_host("2001:db8::1") == "::1"
     assert ui_server._vault_sandbox_bind_host("localhost") == "127.0.0.1"
     assert ui_server._vault_sandbox_bind_host("127.0.0.1") == "127.0.0.1"
+
+
+def test_vault_sandbox_port_moves_when_default_conflicts_with_ui_port():
+    config = type("Config", (), {"ui": UiConfig(vault_sandbox_port=5124)})()
+
+    assert ui_server._vault_sandbox_port_for_ui(config, 5124) == 5125
+    assert ui_server._vault_sandbox_port_for_ui(config, 5123) == 5124
 
 
 def test_vault_sandbox_lifespan_starts_second_listener(monkeypatch):

--- a/tests/test_vault_sandbox_serving.py
+++ b/tests/test_vault_sandbox_serving.py
@@ -46,7 +46,7 @@ def test_vault_sandbox_serves_bundle_with_hardened_csp(monkeypatch, tmp_path):
     assert "unsafe-inline" not in csp
     assert index.headers["x-content-type-options"] == "nosniff"
     assert index.headers["referrer-policy"] == "no-referrer"
-    assert index.headers["cross-origin-resource-policy"] == "same-origin"
+    assert index.headers["cross-origin-resource-policy"] == "cross-origin"
     assert "publickey-credentials-get=(self)" in index.headers["permissions-policy"]
 
 

--- a/tests/test_vault_sandbox_serving.py
+++ b/tests/test_vault_sandbox_serving.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from config.v2_config import UiConfig, V2Config
+from tests.test_api_save_config_merge import _full_config_payload
+from vibe import runtime
+from vibe import ui_server
+
+
+def test_vault_sandbox_serves_bundle_with_hardened_csp(monkeypatch, tmp_path):
+    sandbox_dist = tmp_path / "dist-sandbox"
+    assets = sandbox_dist / "assets"
+    assets.mkdir(parents=True)
+    (sandbox_dist / "index.html").write_text(
+        '<div id="root"></div><script type="module" src="/assets/app.js"></script>',
+        encoding="utf-8",
+    )
+    (assets / "app.js").write_text("postMessage({ready:true}, '*')", encoding="utf-8")
+    monkeypatch.setattr(ui_server, "get_ui_sandbox_dist_path", lambda: sandbox_dist)
+    monkeypatch.setattr(ui_server, "VAULT_SANDBOX_MAIN_ORIGIN", "http://localhost:5123")
+
+    client = TestClient(ui_server.vault_sandbox_app, base_url="http://localhost:5124")
+    index = client.get("/")
+    asset = client.get("/assets/app.js")
+
+    assert index.status_code == 200
+    assert index.headers["cache-control"] == "no-store, private"
+    assert asset.status_code == 200
+    assert asset.text == "postMessage({ready:true}, '*')"
+    assert asset.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+    csp = index.headers["content-security-policy"]
+    assert "default-src 'none'" in csp
+    assert "script-src 'self' 'wasm-unsafe-eval'" in csp
+    assert "connect-src 'none'" in csp
+    assert "media-src 'none'" in csp
+    assert "child-src 'none'" in csp
+    assert "frame-src 'none'" in csp
+    assert "manifest-src 'none'" in csp
+    assert "object-src 'none'" in csp
+    assert "base-uri 'none'" in csp
+    assert "form-action 'none'" in csp
+    assert "navigate-to 'none'" in csp
+    assert csp.endswith("frame-ancestors http://localhost:5123")
+    assert "unsafe-inline" not in csp
+    assert index.headers["x-content-type-options"] == "nosniff"
+    assert index.headers["referrer-policy"] == "no-referrer"
+    assert index.headers["cross-origin-resource-policy"] == "same-origin"
+    assert "publickey-credentials-get=(self)" in index.headers["permissions-policy"]
+
+
+def test_vault_sandbox_does_not_expose_main_app_routes_or_api(monkeypatch, tmp_path):
+    sandbox_dist = tmp_path / "dist-sandbox"
+    sandbox_dist.mkdir()
+    (sandbox_dist / "index.html").write_text("<html>sandbox</html>", encoding="utf-8")
+    monkeypatch.setattr(ui_server, "get_ui_sandbox_dist_path", lambda: sandbox_dist)
+
+    client = TestClient(ui_server.vault_sandbox_app, base_url="http://localhost:5124")
+
+    assert client.get("/api/vault/sign").status_code == 404
+    assert client.post("/api/vault/sign", json={}).status_code == 404
+    assert client.get("/dashboard").status_code == 404
+
+
+def test_vault_sandbox_missing_bundle_is_service_unavailable(monkeypatch, tmp_path):
+    monkeypatch.setattr(ui_server, "get_ui_sandbox_dist_path", lambda: tmp_path / "missing")
+
+    response = TestClient(ui_server.vault_sandbox_app, base_url="http://localhost:5124").get("/")
+
+    assert response.status_code == 503
+    assert response.headers["cache-control"] == "no-store, private"
+    assert response.headers["content-security-policy"].endswith(f"frame-ancestors {ui_server.VAULT_SANDBOX_MAIN_ORIGIN}")
+
+
+def test_vault_sandbox_port_defaults_and_config_override():
+    assert ui_server._configured_vault_sandbox_port(None) == 5124
+    assert ui_server._configured_vault_sandbox_port(type("Config", (), {"ui": UiConfig(vault_sandbox_port=6124)})()) == 6124
+
+
+def test_vault_sandbox_port_config_is_normalized():
+    base_payload = _full_config_payload()
+    base_payload["ui"]["vault_sandbox_port"] = "6124"
+
+    assert V2Config.from_payload(base_payload).ui.vault_sandbox_port == 6124
+
+    invalid_payload = _full_config_payload()
+    invalid_payload["ui"]["vault_sandbox_port"] = 70000
+    assert V2Config.from_payload(invalid_payload).ui.vault_sandbox_port == 5124
+
+
+def test_vault_sandbox_fresh_config_defaults_to_localhost():
+    assert UiConfig().setup_host == "localhost"
+    config = type("Config", (), {"ui": UiConfig(), "remote_access": None})()
+    assert runtime.effective_ui_bind_host(config) == "127.0.0.1"
+
+
+def test_vault_sandbox_main_origin_uses_configured_loopback_host():
+    assert ui_server._vault_sandbox_main_origin(None, "localhost", 5123) == "http://localhost:5123"
+    assert ui_server._vault_sandbox_main_origin(None, "127.0.0.1", 5123) == "http://127.0.0.1:5123"
+    assert ui_server._vault_sandbox_main_origin(None, "::1", 5123) == "http://[::1]:5123"
+    assert ui_server._vault_sandbox_main_origin(None, "bad host", 5123) == "http://localhost:5123"
+
+
+def test_vault_sandbox_main_origin_can_be_overridden_for_regression_proxy(monkeypatch):
+    monkeypatch.setenv(ui_server.VAULT_SANDBOX_MAIN_ORIGIN_ENV, "http://localhost:15130")
+
+    assert ui_server._vault_sandbox_main_origin(None, "127.0.0.1", 5123) == "http://localhost:15130"
+
+    monkeypatch.setenv(ui_server.VAULT_SANDBOX_MAIN_ORIGIN_ENV, "javascript:alert(1)")
+    assert ui_server._vault_sandbox_main_origin(None, "localhost", 5123) == "http://localhost:5123"
+
+
+def test_vault_sandbox_lifespan_starts_second_listener(monkeypatch):
+    calls = []
+    config = type("Config", (), {"ui": UiConfig(vault_sandbox_port=6124)})()
+    monkeypatch.setattr(ui_server, "_vault_sandbox_config", config)
+    monkeypatch.setattr(ui_server, "_vault_sandbox_ui_host", "127.0.0.1")
+    monkeypatch.setattr(ui_server, "_vault_sandbox_ui_port", 5123)
+    monkeypatch.setattr(
+        ui_server,
+        "_start_vault_sandbox_server",
+        lambda next_config, *, ui_host, ui_port: calls.append((next_config, ui_host, ui_port)),
+    )
+
+    with TestClient(ui_server.app):
+        pass
+
+    assert calls == [(config, "127.0.0.1", 5123)]

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-sandbox
 dist-ssr
 *.local
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test:crypto": "vitest run src/lib/vaultCrypto.test.ts",
-    "validate:theme": "node scripts/validate-theme.mjs"
+    "validate:theme": "node scripts/validate-theme.mjs",
+    "build:sandbox": "vite build --config vite.sandbox.config.ts"
   },
   "dependencies": {
     "@hpke/core": "^1.9.0",

--- a/ui/sandbox/index.html
+++ b/ui/sandbox/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Avibe Vault Signing Sandbox</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/sandbox/src/main.tsx
+++ b/ui/sandbox/src/main.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from 'react-dom/client'
+
+function SandboxPlaceholder() {
+  return <div data-vault-sandbox-ready="false" />
+}
+
+createRoot(document.getElementById('root') as HTMLElement).render(<SandboxPlaceholder />)

--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -107,7 +107,7 @@ const buildConfigPayload = (data: any, enabledPlatformOverride?: string[]) => {
   ui: {
     // Preserve existing ui config
     ...data.ui,
-    setup_host: data.ui?.setup_host || '127.0.0.1',
+    setup_host: data.ui?.setup_host || 'localhost',
     setup_port: data.ui?.setup_port || 5123,
   },
   // Preserve existing update config entirely

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -54,7 +54,7 @@ export const SettingsServicePage: React.FC = () => {
     setUiMessage(null);
     try {
       const uiPayload = {
-        setup_host: config.ui?.setup_host || '127.0.0.1',
+        setup_host: config.ui?.setup_host || 'localhost',
         setup_port: config.ui?.setup_port || 5123,
       };
       await api.saveConfig({ ui: { ...(config.ui || {}), ...uiPayload } });
@@ -209,9 +209,9 @@ export const SettingsServicePage: React.FC = () => {
             <div className="grid grid-cols-[120px_96px_auto] items-center gap-2">
               <CompactField
                 aria-label={t('dashboard.host')}
-                value={config?.ui?.setup_host || '127.0.0.1'}
+                value={config?.ui?.setup_host || 'localhost'}
                 onChange={(event) => {
-                  const host = event.target.value || '127.0.0.1';
+                  const host = event.target.value || 'localhost';
                   setUiMessage(null);
                   setConfig((prev: any) => ({
                     ...(prev || {}),

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -457,7 +457,7 @@ const buildConfigPayload = (data: any) => {
     gateway: data.gateway,
     ui: {
       ...data.ui,
-      setup_host: data.ui?.setup_host || '127.0.0.1',
+      setup_host: data.ui?.setup_host || 'localhost',
       setup_port: data.ui?.setup_port || 5123,
     },
     update: data.update

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -571,7 +571,7 @@
   "accessBlocked": {
     "title": "Can't open the control panel here",
     "body": "Avibe is running, but it refused to open the control panel at this address.",
-    "hint": "Open Avibe from your https://<your-slug>.avibe.bot link, or use http://127.0.0.1:5123 on the machine running Avibe. A raw LAN or Tailscale IP is blocked while remote access is on.",
+    "hint": "Open Avibe from your https://<your-slug>.avibe.bot link, or use http://localhost:5123 on the machine running Avibe. A raw LAN or Tailscale IP is blocked while remote access is on.",
     "codeLabel": "Reason",
     "retry": "Retry"
   },
@@ -583,7 +583,7 @@
     "session_archived": "This session is archived, so its Show Page can't be changed.",
     "project_no_folder": "This project has no local folder configured.",
     "project_not_found": "Project not found.",
-    "remote_access_host_mismatch": "This address can't open the Avibe control panel. Open it from your https://<your-slug>.avibe.bot link, or http://127.0.0.1:5123 on the machine running Avibe.",
+    "remote_access_host_mismatch": "This address can't open the Avibe control panel. Open it from your https://<your-slug>.avibe.bot link, or http://localhost:5123 on the machine running Avibe.",
     "remote_access_config_unavailable": "Avibe couldn't read its configuration. Check that the service is healthy and try again.",
     "remote_access_public_url_invalid": "Remote access is misconfigured (the public URL is invalid). Re-pair this device or fix the remote-access settings.",
     "remote_access_session_secret_missing": "Remote access is misconfigured (missing session secret). Re-pair this device to restore access.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -571,7 +571,7 @@
   "accessBlocked": {
     "title": "无法在此地址打开控制台",
     "body": "Avibe 正在运行，但拒绝在当前地址打开控制台。",
-    "hint": "请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Avibe 的机器上访问 http://127.0.0.1:5123。开启远程访问时，直接用局域网或 Tailscale IP 会被拦截。",
+    "hint": "请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Avibe 的机器上访问 http://localhost:5123。开启远程访问时，直接用局域网或 Tailscale IP 会被拦截。",
     "codeLabel": "原因",
     "retry": "重试"
   },
@@ -583,7 +583,7 @@
     "session_archived": "该会话已归档，无法修改它的展示页面。",
     "project_no_folder": "这个项目没有配置本地文件夹。",
     "project_not_found": "找不到这个项目。",
-    "remote_access_host_mismatch": "这个地址无法打开 Avibe 控制台。请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Avibe 的机器上访问 http://127.0.0.1:5123。",
+    "remote_access_host_mismatch": "这个地址无法打开 Avibe 控制台。请用你的 https://<你的子域>.avibe.bot 链接打开，或在运行 Avibe 的机器上访问 http://localhost:5123。",
     "remote_access_config_unavailable": "Avibe 无法读取配置。请确认服务运行正常后重试。",
     "remote_access_public_url_invalid": "远程访问配置有误（公网地址无效）。请重新配对此设备或修正远程访问设置。",
     "remote_access_session_secret_missing": "远程访问配置有误（缺少会话密钥）。请重新配对此设备以恢复访问。",

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -41,8 +41,8 @@ const WEBAUTHN_USER_HANDLE = new TextEncoder().encode('avibe-vault');
 
 /**
  * WebAuthn needs a secure context and a domain RP ID. Browsers reject raw IP RP IDs
- * (the default local `http://127.0.0.1:5123` workflow), so the passkey path is only
- * offered on `localhost` or an HTTPS domain (e.g. the tunnel); elsewhere we fall back
+ * so the passkey path is only offered on `localhost` or an HTTPS domain
+ * (e.g. the tunnel); elsewhere we fall back
  * to the password, which is the recovery root anyway.
  */
 export function webauthnAvailable(): boolean {

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -28,6 +28,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
+  "include": ["src", "sandbox/src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vite.sandbox.config.ts"]
 }

--- a/ui/vite.sandbox.config.ts
+++ b/ui/vite.sandbox.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  root: fileURLToPath(new URL('./sandbox', import.meta.url)),
+  publicDir: false,
+  build: {
+    outDir: fileURLToPath(new URL('./dist-sandbox', import.meta.url)),
+    emptyOutDir: true,
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+})

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -62,6 +62,20 @@ def get_ui_dist_path() -> Path:
     return dev_ui_path
 
 
+def get_ui_sandbox_dist_path() -> Path:
+    """Get the path to the protected Vault signing sandbox dist directory."""
+    project_root = get_project_root()
+    dev_sandbox_path = project_root / "ui" / "dist-sandbox"
+    if dev_sandbox_path.exists():
+        return dev_sandbox_path
+
+    package_sandbox_path = get_package_root() / "ui" / "dist-sandbox"
+    if package_sandbox_path.exists():
+        return package_sandbox_path
+
+    return dev_sandbox_path
+
+
 def get_service_main_path() -> Path:
     """Get the path to the main service entry point."""
     # First check if we're in development mode (main.py exists at project root)
@@ -972,18 +986,14 @@ def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) 
     propagate the host from the inbound request without persisting it first;
     when omitted we fall back to ``config.ui.setup_host``.
     """
-    setup_host = (requested_host if requested_host is not None else config.ui.setup_host) or "127.0.0.1"
+    setup_host = (requested_host if requested_host is not None else config.ui.setup_host) or "localhost"
+    normalized = setup_host.strip()
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    if normalized.lower() == "localhost":
+        return "::1" if resolve_localhost_family() == "inet6" else "127.0.0.1"
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     if cloud is not None and cloud.enabled:
-        normalized = setup_host.strip()
-        if normalized.startswith("[") and normalized.endswith("]"):
-            normalized = normalized[1:-1]
-        # "localhost" is ambiguous on dual-stack hosts and may even be
-        # exclusively IPv6. Resolve once and bind to a literal loopback that
-        # matches the family _origin_host_for_pairing will hand cloudflared,
-        # so the two sides cannot disagree without widening the local socket.
-        if normalized.lower() == "localhost":
-            return "::1" if resolve_localhost_family() == "inet6" else "127.0.0.1"
         try:
             address = ipaddress.ip_address(normalized)
         except ValueError:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7897,23 +7897,14 @@ def _vault_sandbox_main_origin(config: V2Config | None, fallback_host: str, fall
         return override
     ui = getattr(config, "ui", None)
     host = getattr(ui, "setup_host", None) or fallback_host
-    port = getattr(ui, "setup_port", None) or fallback_port
-    try:
-        port = int(port)
-    except (TypeError, ValueError):
-        port = fallback_port
-    return _origin_for_host_port(host, port)
+    return _origin_for_host_port(host, fallback_port)
 
 
 def _vault_sandbox_bind_host(ui_host: str) -> str:
     normalized = (ui_host or "").strip()
     if normalized.startswith("[") and normalized.endswith("]"):
         normalized = normalized[1:-1]
-    if normalized in {"", "0.0.0.0", "*"}:
-        return "0.0.0.0"
-    if normalized == "::":
-        return "::"
-    if ":" in normalized and normalized not in {"0.0.0.0", "*"}:
+    if normalized == "::" or ":" in normalized:
         return "::1"
     return "127.0.0.1"
 
@@ -8213,6 +8204,23 @@ def _configured_vault_sandbox_port(config: V2Config | None) -> int:
     return port
 
 
+def _vault_sandbox_port_for_ui(config: V2Config | None, ui_port: int) -> int:
+    sandbox_port = _configured_vault_sandbox_port(config)
+    if sandbox_port != ui_port:
+        return sandbox_port
+    fallback_port = ui_port + 1
+    if fallback_port > 65535:
+        fallback_port = ui_port - 1
+    if fallback_port <= 0:
+        return sandbox_port
+    logger.warning(
+        "Vault signing sandbox port %s matches the UI port; using adjacent port %s",
+        sandbox_port,
+        fallback_port,
+    )
+    return fallback_port
+
+
 def _start_vault_sandbox_server(config: V2Config | None, *, ui_host: str, ui_port: int) -> None:
     global VAULT_SANDBOX_MAIN_ORIGIN, _vault_sandbox_server, _vault_sandbox_thread
     if _vault_sandbox_thread is not None and _vault_sandbox_thread.is_alive():
@@ -8220,11 +8228,7 @@ def _start_vault_sandbox_server(config: V2Config | None, *, ui_host: str, ui_por
 
     import uvicorn
 
-    sandbox_port = _configured_vault_sandbox_port(config)
-    if sandbox_port == ui_port:
-        logger.warning("Vault signing sandbox disabled because ui.vault_sandbox_port matches setup_port=%s", ui_port)
-        return
-
+    sandbox_port = _vault_sandbox_port_for_ui(config, ui_port)
     VAULT_SANDBOX_MAIN_ORIGIN = _vault_sandbox_main_origin(config, ui_host, ui_port)
     sandbox_host = _vault_sandbox_bind_host(ui_host)
     bound_socket: socket.socket | None = None

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7939,7 +7939,7 @@ def _with_vault_sandbox_headers(response: FastAPIResponse) -> FastAPIResponse:
     response.headers["Content-Security-Policy"] = _vault_sandbox_csp()
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["Referrer-Policy"] = "no-referrer"
-    response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
+    response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
     response.headers["Permissions-Policy"] = (
         "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), "
         "payment=(), usb=(), publickey-credentials-create=(self), publickey-credentials-get=(self)"

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7909,6 +7909,10 @@ def _vault_sandbox_bind_host(ui_host: str) -> str:
     normalized = (ui_host or "").strip()
     if normalized.startswith("[") and normalized.endswith("]"):
         normalized = normalized[1:-1]
+    if normalized in {"", "0.0.0.0", "*"}:
+        return "0.0.0.0"
+    if normalized == "::":
+        return "::"
     if ":" in normalized and normalized not in {"0.0.0.0", "*"}:
         return "::1"
     return "127.0.0.1"

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -26,7 +26,7 @@ from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse, urlspli
 
 import psutil
 from aiohttp import ClientSession, WSMsgType
-from fastapi import Request as FastAPIRequest, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request as FastAPIRequest, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response as FastAPIResponse
 
 from vibe.ui_compat import CompatApp, Response, TEST_REMOTE_ADDR_HEADER, g, jsonify, redirect, request, send_file
@@ -44,7 +44,7 @@ from core.show_session_events import show_event_payload_session_mismatch
 from core.terminal_service import TERMINAL_SUPPORTED, TerminalService, TerminalServiceError, sanitize_session_id
 from modules.agents.catalog import AGENT_BACKENDS, supports_runtime_refresh
 from vibe.i18n import get_supported_languages, t
-from vibe.runtime import get_ui_dist_path, get_working_dir
+from vibe.runtime import get_ui_dist_path, get_ui_sandbox_dist_path, get_working_dir
 from vibe.sentry_integration import init_sentry
 
 logger = logging.getLogger(__name__)
@@ -54,9 +54,15 @@ logger = logging.getLogger(__name__)
 mimetypes.add_type("application/manifest+json", ".webmanifest")
 
 app = CompatApp(title="avibe UI", docs_url=None, redoc_url=None, openapi_url=None)
+vault_sandbox_app = FastAPI(title="avibe Vault signing sandbox", docs_url=None, redoc_url=None, openapi_url=None)
 
 # Global server instance for graceful shutdown on reload
 _server = None
+_vault_sandbox_server = None
+_vault_sandbox_thread: threading.Thread | None = None
+_vault_sandbox_config: V2Config | None = None
+_vault_sandbox_ui_host = "127.0.0.1"
+_vault_sandbox_ui_port = 5123
 SLOW_API_REQUEST_MS = float(os.environ.get("VIBE_UI_SLOW_API_MS", "2000"))
 SHOW_RUNTIME_SLOW_REQUEST_MS = float(os.environ.get("VIBE_SHOW_RUNTIME_SLOW_REQUEST_MS", "1000"))
 _SHOW_RUNTIME_REQUEST_HEADER_ALLOWLIST = {
@@ -144,6 +150,14 @@ LOG_SOURCES = (
     ("ui_stdout", "ui_stdout.log", lambda: paths.get_runtime_dir() / "ui_stdout.log"),
     ("ui_stderr", "ui_stderr.log", lambda: paths.get_runtime_dir() / "ui_stderr.log"),
 )
+
+VAULT_SANDBOX_DEFAULT_PORT = 5124
+VAULT_SANDBOX_IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable"
+VAULT_SANDBOX_INDEX_CACHE_CONTROL = "no-store, private"
+VAULT_SANDBOX_STATIC_CACHE_CONTROL = "public, max-age=3600"
+VAULT_SANDBOX_MAIN_ORIGIN = f"http://localhost:{VAULT_SANDBOX_DEFAULT_PORT - 1}"
+VAULT_SANDBOX_MAIN_ORIGIN_ENV = "VIBE_VAULT_SANDBOX_MAIN_ORIGIN"
+VAULT_SANDBOX_HOST_RE = re.compile(r"^[A-Za-z0-9.-]+$")
 
 
 def _env_int(name: str, default: int) -> int:
@@ -3506,6 +3520,7 @@ def ui_reload():
         stderr_path = config_paths.get_runtime_dir() / "ui_stderr.log"
         stdout = stdout_path.open("ab")
         stderr = stderr_path.open("ab")
+        _stop_vault_sandbox_server()
         process = subprocess.Popen(
             [sys.executable, "-c", command],
             stdout=stdout,
@@ -7845,6 +7860,160 @@ def serve_static(path):
     return jsonify({"error": "not_found"}), 404
 
 
+def _origin_host_for_header(host: str | None) -> str:
+    normalized = (host or "").strip()
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    if normalized in {"", "0.0.0.0", "::", "*"}:
+        return "localhost"
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return normalized if VAULT_SANDBOX_HOST_RE.fullmatch(normalized) else "localhost"
+    return f"[{address.compressed}]" if address.version == 6 else address.compressed
+
+
+def _origin_for_host_port(host: str | None, port: int) -> str:
+    return f"http://{_origin_host_for_header(host)}:{port}"
+
+
+def _sanitize_vault_sandbox_main_origin(value: str) -> str | None:
+    normalized = value.strip().rstrip("/")
+    if not normalized:
+        return None
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    if parsed.path or parsed.query or parsed.fragment:
+        return None
+    if any(ord(char) < 32 or ord(char) == 127 for char in normalized):
+        return None
+    return normalized
+
+
+def _vault_sandbox_main_origin(config: V2Config | None, fallback_host: str, fallback_port: int) -> str:
+    override = _sanitize_vault_sandbox_main_origin(os.environ.get(VAULT_SANDBOX_MAIN_ORIGIN_ENV, ""))
+    if override:
+        return override
+    ui = getattr(config, "ui", None)
+    host = getattr(ui, "setup_host", None) or fallback_host
+    port = getattr(ui, "setup_port", None) or fallback_port
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        port = fallback_port
+    return _origin_for_host_port(host, port)
+
+
+def _vault_sandbox_bind_host(ui_host: str) -> str:
+    normalized = (ui_host or "").strip()
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    if ":" in normalized and normalized not in {"0.0.0.0", "*"}:
+        return "::1"
+    return "127.0.0.1"
+
+
+def _vault_sandbox_csp() -> str:
+    return (
+        "default-src 'none'; "
+        "script-src 'self' 'wasm-unsafe-eval'; "
+        "style-src 'self'; "
+        "img-src 'self' data:; "
+        "font-src 'self'; "
+        "media-src 'none'; "
+        "connect-src 'none'; "
+        "worker-src 'self'; "
+        "child-src 'none'; "
+        "frame-src 'none'; "
+        "manifest-src 'none'; "
+        "object-src 'none'; "
+        "base-uri 'none'; "
+        "form-action 'none'; "
+        "navigate-to 'none'; "
+        f"frame-ancestors {VAULT_SANDBOX_MAIN_ORIGIN}"
+    )
+
+
+def _with_vault_sandbox_headers(response: FastAPIResponse) -> FastAPIResponse:
+    response.headers["Content-Security-Policy"] = _vault_sandbox_csp()
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
+    response.headers["Permissions-Policy"] = (
+        "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), "
+        "payment=(), usb=(), publickey-credentials-create=(self), publickey-credentials-get=(self)"
+    )
+    return response
+
+
+@vault_sandbox_app.middleware("http")
+async def add_vault_sandbox_security_headers(starlette_request: FastAPIRequest, call_next: Callable[..., Any]):
+    response = await call_next(starlette_request)
+    return _with_vault_sandbox_headers(response)
+
+
+def _vault_sandbox_not_found() -> FastAPIResponse:
+    return FastAPIResponse("Not Found", status_code=404, media_type="text/plain; charset=utf-8")
+
+
+def _vault_sandbox_missing_bundle() -> FastAPIResponse:
+    response = FastAPIResponse(
+        "Vault signing sandbox bundle is not built.",
+        status_code=503,
+        media_type="text/plain; charset=utf-8",
+    )
+    response.headers["Cache-Control"] = "no-store, private"
+    return response
+
+
+@vault_sandbox_app.api_route(
+    "/api",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+)
+@vault_sandbox_app.api_route(
+    "/api/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+)
+async def vault_sandbox_api_not_found(path: str = "") -> FastAPIResponse:
+    return _vault_sandbox_not_found()
+
+
+@vault_sandbox_app.get("/")
+@vault_sandbox_app.get("/{path:path}")
+async def serve_vault_sandbox_static(path: str = "") -> FastAPIResponse:
+    """Serve only the protected Vault signing sandbox bundle."""
+    if path.startswith("api/") or path == "api":
+        return _vault_sandbox_not_found()
+
+    sandbox_dist = get_ui_sandbox_dist_path()
+    if not (sandbox_dist / "index.html").is_file():
+        return _vault_sandbox_missing_bundle()
+
+    relative_path = path.strip("/")
+    if not relative_path or relative_path == "index.html":
+        file_path = sandbox_dist / "index.html"
+    else:
+        file_path = sandbox_dist / relative_path
+
+    resolved_dist = sandbox_dist.resolve()
+    resolved_path = file_path.resolve()
+    if resolved_path != resolved_dist and resolved_dist not in resolved_path.parents:
+        return _vault_sandbox_not_found()
+    if not resolved_path.is_file():
+        return _vault_sandbox_not_found()
+
+    mime_type, _ = mimetypes.guess_type(str(resolved_path))
+    response = send_file(resolved_path, mimetype=mime_type or "application/octet-stream")
+    if resolved_path.name == "index.html":
+        response.headers["Cache-Control"] = VAULT_SANDBOX_INDEX_CACHE_CONTROL
+    elif relative_path.startswith("assets/"):
+        response.headers["Cache-Control"] = VAULT_SANDBOX_IMMUTABLE_CACHE_CONTROL
+    else:
+        response.headers["Cache-Control"] = VAULT_SANDBOX_STATIC_CACHE_CONTROL
+    return response
+
+
 # =============================================================================
 # Server Entry Point
 # =============================================================================
@@ -8026,9 +8195,107 @@ def _bind_ui_socket(host: str, port: int) -> socket.socket:
     return sock
 
 
+def _configured_vault_sandbox_port(config: V2Config | None) -> int:
+    ui = getattr(config, "ui", None)
+    raw_port = getattr(ui, "vault_sandbox_port", VAULT_SANDBOX_DEFAULT_PORT)
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring invalid ui.vault_sandbox_port=%r", raw_port)
+        return VAULT_SANDBOX_DEFAULT_PORT
+    if port <= 0 or port > 65535:
+        logger.warning("Ignoring out-of-range ui.vault_sandbox_port=%r", raw_port)
+        return VAULT_SANDBOX_DEFAULT_PORT
+    return port
+
+
+def _start_vault_sandbox_server(config: V2Config | None, *, ui_host: str, ui_port: int) -> None:
+    global VAULT_SANDBOX_MAIN_ORIGIN, _vault_sandbox_server, _vault_sandbox_thread
+    if _vault_sandbox_thread is not None and _vault_sandbox_thread.is_alive():
+        return
+
+    import uvicorn
+
+    sandbox_port = _configured_vault_sandbox_port(config)
+    if sandbox_port == ui_port:
+        logger.warning("Vault signing sandbox disabled because ui.vault_sandbox_port matches setup_port=%s", ui_port)
+        return
+
+    VAULT_SANDBOX_MAIN_ORIGIN = _vault_sandbox_main_origin(config, ui_host, ui_port)
+    sandbox_host = _vault_sandbox_bind_host(ui_host)
+    bound_socket: socket.socket | None = None
+    try:
+        bound_socket = _bind_ui_socket(sandbox_host, sandbox_port)
+    except OSError as exc:
+        logger.warning(
+            "Vault signing sandbox unavailable at http://%s:%s: %s",
+            sandbox_host,
+            sandbox_port,
+            exc,
+        )
+        return
+
+    uvicorn_config = uvicorn.Config(
+        vault_sandbox_app,
+        host=sandbox_host,
+        port=sandbox_port,
+        log_config=None,
+        access_log=False,
+        loop="asyncio",
+        lifespan="on",
+        workers=1,
+    )
+    server = uvicorn.Server(uvicorn_config)
+
+    def _run() -> None:
+        try:
+            server.run(sockets=[bound_socket])
+        except Exception:
+            logger.warning("Vault signing sandbox server exited unexpectedly", exc_info=True)
+
+    _vault_sandbox_server = server
+    _vault_sandbox_thread = threading.Thread(target=_run, daemon=True, name="vault-signing-sandbox")
+    _vault_sandbox_thread.start()
+    logger.info(
+        "Vault signing sandbox serving at http://%s:%s with frame-ancestors %s",
+        sandbox_host,
+        sandbox_port,
+        VAULT_SANDBOX_MAIN_ORIGIN,
+    )
+
+
+def _stop_vault_sandbox_server() -> None:
+    global _vault_sandbox_server, _vault_sandbox_thread
+    server, thread = _vault_sandbox_server, _vault_sandbox_thread
+    _vault_sandbox_server = None
+    _vault_sandbox_thread = None
+    if server is not None:
+        server.should_exit = True
+    if thread is not None and thread.is_alive():
+        thread.join(timeout=5)
+        if thread.is_alive():
+            logger.warning("Vault signing sandbox server did not stop within timeout")
+
+
+async def _start_vault_sandbox_from_lifespan() -> None:
+    _start_vault_sandbox_server(
+        _vault_sandbox_config,
+        ui_host=_vault_sandbox_ui_host,
+        ui_port=_vault_sandbox_ui_port,
+    )
+
+
+async def _stop_vault_sandbox_from_lifespan() -> None:
+    _stop_vault_sandbox_server()
+
+
+app.add_event_handler("startup", _start_vault_sandbox_from_lifespan)
+app.add_event_handler("shutdown", _stop_vault_sandbox_from_lifespan)
+
+
 def run_ui_server(host: str, port: int) -> None:
     """Start the FastAPI UI server."""
-    global _server
+    global _server, _vault_sandbox_config, _vault_sandbox_ui_host, _vault_sandbox_ui_port
     import time
     import uvicorn
 
@@ -8068,6 +8335,9 @@ def run_ui_server(host: str, port: int) -> None:
             )
             bound_socket = _bind_ui_socket(host, port)
             _server = uvicorn.Server(uvicorn_config)
+            _vault_sandbox_config = config
+            _vault_sandbox_ui_host = host
+            _vault_sandbox_ui_port = port
             # Reconcile remote_access in the background so cloudflared download/
             # connector start does not block /health and the rest of the UI
             # from coming up after restart/reload.
@@ -8082,6 +8352,7 @@ def run_ui_server(host: str, port: int) -> None:
         except OSError as e:
             if bound_socket is not None:
                 bound_socket.close()
+            _stop_vault_sandbox_server()
             if e.errno == 48 and attempt < 9:  # Address already in use (macOS)
                 print(f"Port {port} in use, retrying in 1s... (attempt {attempt + 1})")
                 time.sleep(1)


### PR DESCRIPTION
## What changed

This implements the backend/build/packaging side of the Vault protected signing sandbox B-local track:

- Adds a second loopback-only FastAPI/uvicorn origin for the sandbox bundle.
- Serves only the sandbox build output from that origin, with no main app routes, assets, or `/api/*` access.
- Adds the sandbox Vite build contract and packages `ui/dist-sandbox` into the wheel/sdist alongside `ui/dist`.
- Keeps signing on the existing `vault_sign` / sign-request completion flow; no new crypto or sign endpoint.

B-full tunnel, cloudflared, `/.well-known/webauthn`, WalletConnect, and hardware-wallet work are intentionally not touched.

## Gatekeeper contract

Default origins:

- Main app: `http://localhost:5123`
- Sandbox app: `http://localhost:5124`
- Sandbox port config: `ui.vault_sandbox_port`, default `5124`

Build contract:

- Source root: `ui/sandbox/`
- Vite config: `ui/vite.sandbox.config.ts`
- Build script: `cd ui && npm run build:sandbox`
- Output dir: `ui/dist-sandbox/`
- Packaged path: `vibe/ui/dist-sandbox`

Default sandbox CSP:

```text
default-src 'none';
script-src 'self' 'wasm-unsafe-eval';
style-src 'self';
img-src 'self' data:;
font-src 'self';
media-src 'none';
connect-src 'none';
worker-src 'self';
child-src 'none';
frame-src 'none';
manifest-src 'none';
object-src 'none';
base-uri 'none';
form-action 'none';
navigate-to 'none';
frame-ancestors http://localhost:5123
```

`frame-ancestors` is computed from the configured main UI origin, with the fresh default set to `localhost`. Regression can override it via `VIBE_VAULT_SANDBOX_MAIN_ORIGIN` because the host proxy port differs from the in-container UI port.

## Evidence

- Unit: sandbox serving/CSP/no-main-api tests, UI reload lifecycle test, config normalization tests, Incus runner port/build tests.
- Contract: `docs/plans/vaults-sandbox-serving-contract.md` documents the B-local serving contract.
- Scenario IDs: none; this is backend serving/build packaging and does not add a scenario-cataloged user flow yet.
- Residual manual: true end-to-end signing still needs the gatekeeper frontend app to replace the placeholder sandbox and add the main-app iframe/postMessage client.

Validation run locally after rebasing onto current `origin/master`:

- `uv run pytest tests/test_vault_sandbox_serving.py tests/test_ui_server_reload.py tests/test_ui_server_fastapi.py tests/test_api_save_config_merge.py tests/test_incus_regression.py -q`
- `uv run ruff check ...changed Python files...`
- `cd ui && npm run build && npm run build:sandbox`
- `uv build --wheel --out-dir /tmp/avibe-sandbox-wheel` plus wheel zip check for both `vibe/ui/dist/index.html` and `vibe/ui/dist-sandbox/index.html`

Notes: Vite still prints the existing HPKE/Rolldown pure-annotation and large-chunk warnings, but the build exits 0.
