### PR TITLE
fix(vaults): hydrate protected approvals for UI inbox

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -312,15 +312,11 @@ def _request_audience_from_requester(requester: Any) -> str:
     return REQUEST_AUDIENCE_UI
 
 
-def _card_hydration_policy(audience: str | None, requester: Any) -> CardHydrationPolicy:
+def _card_hydration_policy(audience: str | None) -> CardHydrationPolicy:
     normalized = _normalize_request_audience(audience)
-    requester_audience = _request_audience_from_requester(requester)
     return CardHydrationPolicy(
         audience=normalized,
-        include_protected_unlock_material=(
-            normalized == REQUEST_AUDIENCE_UI
-            and requester_audience != REQUEST_AUDIENCE_AGENT
-        ),
+        include_protected_unlock_material=normalized == REQUEST_AUDIENCE_UI,
     )
 
 
@@ -488,7 +484,7 @@ def _request_row_payload(
     requester = _loads(row.get("requester"))
     delivery = _loads(row.get("delivery"))
     card = delivery.get("card") if isinstance(delivery, dict) else None
-    policy = _card_hydration_policy(audience, requester)
+    policy = _card_hydration_policy(audience)
     if (
         policy.include_protected_unlock_material
         and row.get("status") == "pending"

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1066,7 +1066,7 @@ def test_request_inbox_hydrates_unlock_material_without_persisting_it(vault):
     assert "ct-1" not in raw_delivery
 
 
-def test_agent_created_request_never_hydrates_unlock_material(vault):
+def test_agent_created_request_hydrates_only_for_ui_inbox(vault):
     _create(vault, name="STANDARD_KEY", protection="standard", group="crypto")
     with vault.begin() as conn:
         vs.create_secret(conn, name="PROTECTED_KEY", protection="protected", group="crypto", sealed=_sealed("protected"))
@@ -1076,15 +1076,54 @@ def test_agent_created_request_never_hydrates_unlock_material(vault):
             requester={"source": "agent-cli", "session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
         )
-        ui_payload = vs.get_request(conn, req["id"])
         agent_payload = vs.get_request(conn, req["id"], audience=vs.REQUEST_AUDIENCE_AGENT)
         listed = vs.list_requests(conn)
 
-    encoded = json.dumps({"ui": ui_payload, "agent": agent_payload, "listed": listed})
-    assert "secret_unlock_material" not in encoded
-    assert "unlock_material" not in encoded
-    assert "ct-protected" not in encoded
-    assert "wm-protected" not in encoded
+    agent_encoded = json.dumps(agent_payload)
+    assert "secret_unlock_material" not in agent_encoded
+    assert "unlock_material" not in agent_encoded
+    assert "ct-protected" not in agent_encoded
+    assert "wm-protected" not in agent_encoded
+    group_option = next(option for option in listed[0]["card"]["scope_options"] if option["scope_type"] == "group")
+    assert group_option["unlock_material"] == [
+        {
+            "name": "PROTECTED_KEY",
+            "kind": "static",
+            "envelope": {
+                "ciphertext": "ct-protected",
+                "nonce": "n-protected",
+                "wrap_meta": "wm-protected",
+            },
+        }
+    ]
+
+
+def test_cli_resolve_protected_request_hydrates_only_for_ui_inbox(vault):
+    _create(vault, name="PROTECTED_KEY", protection="protected", group="crypto")
+    with vault.begin() as conn:
+        result = vs.resolve_secret_access(
+            conn,
+            "PROTECTED_KEY",
+            session_id="ses_1",
+            requester={"source": "cli", "session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        listed = vs.list_requests(conn)
+        raw_delivery = conn.execute(
+            select(vault_requests.c.delivery).where(vault_requests.c.id == result["request"]["id"])
+        ).scalar_one()
+
+    agent_encoded = json.dumps(result["request"]["card"])
+    assert result["status"] == "approval_required"
+    assert "secret_unlock_material" not in agent_encoded
+    assert "ct-1" not in agent_encoded
+    assert listed[0]["card"]["secret_unlock_material"]["envelope"] == {
+        "ciphertext": "ct-1",
+        "nonce": "n-1",
+        "wrap_meta": "wm-1",
+    }
+    assert "secret_unlock_material" not in raw_delivery
+    assert "ct-1" not in raw_delivery
 
 
 def test_resolve_access_card_uses_delivery_session_fallback(vault):


### PR DESCRIPTION
## What

Follow-up for the Codex P1 found after PR #707 was merged: the centralized vault request card hydration policy treated the original requester kind as part of the UI inbox decision.

This restores the intended split:

- agent/API/CLI request responses stay value-free when read with the agent audience
- the browser approval inbox can still hydrate protected unlock material when it reads the same pending request with the UI audience
- persisted request delivery/audit payloads remain unhydrated

## Why

The gatekeeper approval UI needs protected envelopes in the UI inbox so it can approve protected requests. The agent-facing consumer surface must not receive those envelopes in its own API/CLI response.

## Validation

- `ruff check storage/vault_service.py tests/test_vault_service.py`
- `python3 -m pytest tests/test_vault_service.py::test_agent_created_request_hydrates_only_for_ui_inbox tests/test_vault_service.py::test_cli_resolve_protected_request_hydrates_only_for_ui_inbox tests/test_vault_service.py::test_request_inbox_hydrates_unlock_material_without_persisting_it tests/test_vault_api.py::test_agent_access_request_ignores_client_source_for_hydration tests/test_vault_api.py::test_agent_access_request_does_not_return_protected_group_unlock_material -q`
- `python3 -m pytest tests/test_vault_service.py tests/test_vault_api.py tests/test_vault_cli.py tests/test_vault_rest.py -q`
