### PR TITLE
feat(vaults): route protected requests through browser fulfillment

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -487,6 +487,8 @@ def _request_row_payload(
 ) -> dict[str, Any]:
     requester = _loads(row.get("requester"))
     delivery = _loads(row.get("delivery"))
+    if isinstance(delivery, dict) and "value" in delivery:
+        delivery = {key: value for key, value in delivery.items() if key != "value"}
     card = delivery.get("card") if isinstance(delivery, dict) else None
     policy = _card_hydration_policy(audience, requester)
     if (
@@ -638,6 +640,12 @@ def _secret_agent_per_use_signable(row: dict[str, Any]) -> bool:
 def _reject_keypair_value_delivery(row: dict[str, Any], name: str) -> None:
     if row.get("kind") == "keypair":
         raise KeypairNotValueDeliverableError(f"{name} is a signing key; use vault_sign instead of value delivery")
+
+
+def _validate_released_value(value: Any) -> str:
+    if not isinstance(value, str):
+        raise InvalidRequestError("released value must be a string")
+    return value
 
 
 def audit(
@@ -990,7 +998,14 @@ def get_signing_envelope(conn: Connection, name: str) -> Sealed:
     return get_key_envelope(conn, name)
 
 
-def record_deliveries(conn: Connection, names: list[str], *, requester: Any = None, mode: str | None = None) -> None:
+def record_deliveries(
+    conn: Connection,
+    names: list[str],
+    *,
+    requester: Any = None,
+    mode: str | None = None,
+    request_id: str | None = None,
+) -> None:
     """Bump usage + write a value-free ``delivered`` audit row per name.
 
     Call this only AFTER the delivery action (child spawn / file write / stream) succeeds,
@@ -1002,7 +1017,7 @@ def record_deliveries(conn: Connection, names: list[str], *, requester: Any = No
             .where(vault_secrets.c.name == name)
             .values(last_used_at=_now(), use_count=vault_secrets.c.use_count + 1)
         )
-        audit(conn, "delivered", secret_name=name, requester=requester, delivery={"mode": mode})
+        audit(conn, "delivered", secret_name=name, requester=requester, delivery={"mode": mode}, request_id=request_id)
 
 
 def create_provision_request(
@@ -1252,6 +1267,11 @@ def approval_card(
         "scope_options": scope_options,
         "value": None,
     }
+    if row.get("protection") == "protected":
+        if request_type == "sign":
+            card["fulfillment"] = "browser_signature"
+        elif request_type == "access" and not grantable:
+            card["fulfillment"] = "browser_value"
     return card
 
 
@@ -1264,6 +1284,7 @@ def create_access_request(
     message_id: str | None = None,
     expires_at: str | None = None,
     audience: str | None = None,
+    grantable: bool = True,
 ) -> dict[str, Any]:
     row = _require_row(conn, name)
     if not _secret_access_grantable(row):
@@ -1281,6 +1302,7 @@ def create_access_request(
         egress=delivery_payload.get("egress"),
         skill=delivery_payload.get("skill") or requester_payload.get("skill"),
         session_id=requester_payload.get("session_id") or delivery_payload.get("session_id"),
+        grantable=grantable,
     )
     delivery_payload["card"] = card
     conn.execute(
@@ -1311,6 +1333,7 @@ def create_sign_request(
     delivery: dict[str, Any] | None = None,
     message_id: str | None = None,
     expires_at: str | None = None,
+    audience: str | None = None,
 ) -> dict[str, Any]:
     if scheme not in SUPPORTED_SIGNATURE_SCHEMES:
         raise InvalidRequestError(f"unsupported signature scheme: {scheme}")
@@ -1319,7 +1342,7 @@ def create_sign_request(
         raise InvalidRequestError(f"{name} is not a signing key")
     if row.get("signer_kind") not in (None, "local"):
         raise InvalidRequestError(f"{name} is not locally signable")
-    payload_audience = _request_audience_from_requester(requester)
+    payload_audience = audience or _request_audience_from_requester(requester)
     request_id = _id("vrq")
     delivery_payload = dict(delivery or {})
     requester_payload = requester if isinstance(requester, dict) else {}
@@ -1431,6 +1454,49 @@ def complete_sign_request(
         delivery={"scheme": scheme, "digest": digest, "browser_signed": bool(signature.get("browser_signed"))},
         request_id=request_id,
     )
+    updated = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().one()
+    return _request_row_payload(dict(updated), conn=conn, audience=REQUEST_AUDIENCE_AGENT)
+
+
+def complete_access_request(
+    conn: Connection,
+    request_id: str,
+    *,
+    name: str,
+    value: str,
+    requester: Any = None,
+) -> dict[str, Any]:
+    row = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().first()
+    if row is None:
+        raise RequestNotFoundError(request_id)
+    row_dict = dict(row)
+    if row_dict.get("request_type") != "access":
+        raise InvalidRequestError("value completion must target an access request")
+    if row_dict.get("status") == "pending":
+        row_dict, expired = _expire_request_if_due(conn, row_dict)
+        if expired:
+            raise InvalidRequestError("access request has expired")
+    if row_dict.get("status") != "pending":
+        raise InvalidRequestError("access request is not pending")
+    if row_dict.get("secret_name") != name:
+        raise InvalidRequestError("value secret does not match the access request")
+    secret_row = _require_row(conn, name)
+    _reject_keypair_value_delivery(secret_row, name)
+    if secret_row.get("protection") != "protected":
+        raise InvalidRequestError("value completion must target a protected static secret")
+    _validate_released_value(value)
+    _, delivery = _request_json_payloads(row_dict)
+    delivery_payload = dict(delivery) if isinstance(delivery, dict) else {}
+    completed_delivery = dict(delivery_payload)
+    completed_delivery["browser_released"] = True
+    claim = conn.execute(
+        vault_requests.update()
+        .where(vault_requests.c.id == request_id, vault_requests.c.request_type == "access", vault_requests.c.status == "pending")
+        .values(status="approved", decided_at=_now(), delivery=json.dumps(completed_delivery))
+    )
+    if claim.rowcount != 1:
+        raise InvalidRequestError("access request is not pending")
+    record_deliveries(conn, [name], requester=requester, mode="browser_release", request_id=request_id)
     updated = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().one()
     return _request_row_payload(dict(updated), conn=conn, audience=REQUEST_AUDIENCE_AGENT)
 

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -576,15 +576,36 @@ def test_get_vault_request_does_not_hydrate_protected_pending_unlock_material(mo
     _assert_no_unlock_material(fetched["request"]["card"])
 
 
-def test_agent_access_request_rejects_protected_next_version(monkeypatch):
+def test_agent_access_request_fulfilled_by_browser_value(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("protected")))
     api.create_vault_secret({"name": "PROTECTED_KEY", "protection": "protected", "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"}})
 
-    with pytest.raises(api.VaultApiError) as exc:
-        api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
+    requested = api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
+    request_id = requested["request"]["id"]
 
-    assert exc.value.code == "protected_requires_browser_sandbox"
-    assert "browser sandbox" in str(exc.value)
+    assert requested["request"]["card"]["fulfillment"] == "browser_value"
+    assert requested["request"]["card"]["scope_options"] == []
+    completed = api.fulfill_vault_request(request_id, {"value": "browser-decrypted", "requester": {"source": "browser"}})
+    fetched = api.get_vault_request(request_id)
+
+    assert completed["ok"] is True
+    assert completed["request"]["status"] == "approved"
+    assert "value" not in completed["request"]["delivery"]
+    assert fetched["result"] == {"type": "value", "value": "browser-decrypted"}
+    with api._vault_engine().connect() as conn:
+        raw_delivery = conn.execute(
+            select(vault_service.vault_requests.c.delivery).where(vault_service.vault_requests.c.id == request_id)
+        ).scalar_one()
+    assert "browser-decrypted" not in raw_delivery
+    claimed = api.claim_vault_access_result(request_id)
+    assert claimed["result"] == {"type": "value", "value": "browser-decrypted"}
+    with pytest.raises(api.VaultApiError) as exc:
+        api.claim_vault_access_result(request_id)
+    assert exc.value.code == "value_not_available"
+    with api._vault_engine().connect() as conn:
+        meta = vault_service.get_secret_meta(conn, "PROTECTED_KEY")
+    assert meta["use_count"] == 1
+    assert meta["last_used_at"] is not None
 
 
 def test_deny_vault_request_api(monkeypatch):
@@ -631,6 +652,40 @@ def test_agent_sign_request_approved_via_avault_sign(monkeypatch):
     assert completed["request"]["delivery"]["signature"] == {"signature": "ab" * 64, "recovery_id": 1}
     assert api.get_vault_request(requested["request"]["id"])["result"]["signature"] == {"signature": "ab" * 64, "recovery_id": 1}
     sign.assert_called_once_with(_sealed("key"), "00" * 32, "ecdsa-secp256k1-recoverable", name="ETH_KEY")
+
+
+def test_agent_protected_sign_request_fulfilled_by_browser_signature(monkeypatch):
+    sign = Mock()
+    monkeypatch.setattr(api, "avault_sign", sign)
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("key")))
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+        }
+    )
+
+    requested = api.request_vault_sign(
+        {"name": "ETH_KEY", "digest": "00" * 32, "scheme": "ecdsa-secp256k1-recoverable", "session_id": "ses_1"}
+    )
+    request_id = requested["request"]["id"]
+    completed = api.fulfill_vault_request(
+        request_id,
+        {"signature": {"signature": "ab" * 64, "recovery_id": 1, "browser_signed": True}},
+    )
+
+    assert requested["request"]["card"]["fulfillment"] == "browser_signature"
+    assert completed["ok"] is True
+    assert completed["request"]["status"] == "approved"
+    assert api.get_vault_request(request_id)["result"]["signature"] == {
+        "signature": "ab" * 64,
+        "recovery_id": 1,
+        "browser_signed": True,
+    }
+    sign.assert_not_called()
 
 
 def test_agent_sign_claims_request_before_avault_sign(monkeypatch):

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -199,15 +199,30 @@ def test_access_request_cli_uses_caller_session(tmp_path, capfd, monkeypatch):
     assert payload["request"]["status"] == "pending"
 
 
-def test_access_request_cli_rejects_protected_next_version(capfd):
+def test_access_request_cli_creates_protected_browser_value_request(capfd, monkeypatch):
     with cli._open_vault_engine().begin() as conn:
         vault_service.create_secret(conn, name="PROTECTED_KEY", protection="protected", sealed=_sealed("protected"))
 
-    assert cli.cmd_vault_access(_ns(name="PROTECTED_KEY")) == 1
-    payload = json.loads(capfd.readouterr().err)
+    assert cli.cmd_vault_access(_ns(name="PROTECTED_KEY")) == 0
+    payload = json.loads(capfd.readouterr().out)
 
-    assert payload["code"] == "protected_requires_browser_sandbox"
-    assert "browser sandbox" in payload["error"]
+    assert payload["kind"] == "vault_access_request"
+    assert payload["request"]["card"]["fulfillment"] == "browser_value"
+    assert payload["request"]["card"]["scope_options"] == []
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.complete_access_request(
+            conn,
+            payload["request_id"],
+            name="PROTECTED_KEY",
+            value="browser-value",
+            requester={"source": "browser"},
+        )
+    claim = Mock(return_value={"type": "value", "value": "browser-value"})
+    monkeypatch.setattr(cli, "_claim_vault_access_result_from_live_ui", claim)
+    assert cli.cmd_vault_await(_ns(request_id=payload["request_id"])) == 0
+    result = json.loads(capfd.readouterr().out)
+    assert result["result"] == {"type": "value", "value": "browser-value"}
+    claim.assert_called_once_with(payload["request_id"])
 
 
 def test_sign_request_and_await_cli_reads_approved_signature(capfd, monkeypatch):
@@ -240,6 +255,40 @@ def test_sign_request_and_await_cli_reads_approved_signature(capfd, monkeypatch)
     assert payload["kind"] == "vault_request_result"
     assert payload["status"] == "approved"
     assert payload["result"] == {"type": "signature", "signature": {"signature": "ab" * 64, "recovery_id": 1}}
+
+
+def test_protected_sign_request_and_await_cli_reads_browser_signature(capfd, monkeypatch):
+    from vibe import api
+
+    sign = Mock()
+    monkeypatch.setattr(api, "avault_sign", sign)
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(
+            conn,
+            name="ETH_KEY",
+            protection="protected",
+            kind="keypair",
+            signer_kind="local",
+            sealed=_sealed("key"),
+        )
+
+    assert cli.cmd_vault_sign(_ns(name="ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")) == 0
+    request_id = json.loads(capfd.readouterr().out)["request_id"]
+    api.fulfill_vault_request(
+        request_id,
+        {"signature": {"signature": "ab" * 64, "recovery_id": 1, "browser_signed": True}},
+    )
+
+    assert cli.cmd_vault_await(_ns(request_id=request_id)) == 0
+    payload = json.loads(capfd.readouterr().out)
+
+    assert payload["kind"] == "vault_request_result"
+    assert payload["status"] == "approved"
+    assert payload["result"] == {
+        "type": "signature",
+        "signature": {"signature": "ab" * 64, "recovery_id": 1, "browser_signed": True},
+    }
+    sign.assert_not_called()
 
 
 def test_vault_await_wait_treats_failed_request_as_terminal(capfd):

--- a/tests/test_vault_rest.py
+++ b/tests/test_vault_rest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import Mock
 
+from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
 from storage.vault_crypto import Sealed
 from tests.ui_server_test_helpers import csrf_headers
 from vibe import api
@@ -194,3 +195,49 @@ def test_rest_sign_errors_are_stable(monkeypatch):
     )
     assert not_key.status_code == 409
     assert not_key.get_json()["code"] == "not_signing_key"
+
+
+def test_rest_fulfill_protected_access_request(monkeypatch):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_REST",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_REST", "session_id": "ses_1"})
+    client = app.test_client()
+
+    response = client.post(
+        f"/api/vault/requests/{requested['request']['id']}/fulfill",
+        json={"value": "browser-value"},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["request"]["status"] == "approved"
+    assert api.get_vault_request(requested["request"]["id"])["result"] == {"type": "value", "value": "browser-value"}
+
+    claim = client.post(
+        f"/api/vault/requests/{requested['request']['id']}/claim-value",
+        json={},
+        headers={"X-Vibe-Show-Client": "cli", SHOW_CLI_EVENT_TOKEN_HEADER: show_cli_event_token()},
+    )
+    assert claim.status_code == 200
+    assert claim.get_json()["result"] == {"type": "value", "value": "browser-value"}
+
+    second_claim = client.post(
+        f"/api/vault/requests/{requested['request']['id']}/claim-value",
+        json={},
+        headers={"X-Vibe-Show-Client": "cli", SHOW_CLI_EVENT_TOKEN_HEADER: show_cli_event_token()},
+    )
+    assert second_claim.status_code == 409
+    assert second_claim.get_json()["code"] == "value_not_available"
+
+    forbidden = client.post(
+        f"/api/vault/requests/{requested['request']['id']}/claim-value",
+        json={},
+        headers=csrf_headers(client),
+    )
+    assert forbidden.status_code == 403

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1218,6 +1218,15 @@ def test_keypair_and_always_ask_are_not_grantable(vault):
     assert sign_req["request_type"] == "sign"
 
 
+def test_protected_keypair_value_delivery_still_rejected(vault):
+    _create(vault, name="ETH_KEY", protection="protected", kind="keypair", signer_kind="local")
+    with vault.begin() as conn:
+        with pytest.raises(vs.NotGrantableError):
+            vs.create_access_request(conn, "ETH_KEY")
+        with pytest.raises(vs.KeypairNotValueDeliverableError):
+            vs.resolve_secret_access(conn, "ETH_KEY")
+
+
 def test_always_ask_access_request_is_rejected_until_one_shot_approval_exists(vault):
     _create(vault, name="ASK_KEY", protection="protected", group="crypto", policy={"always_ask": True})
     _create(vault, name="GROUP_KEY", protection="protected", group="crypto")

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -76,6 +76,9 @@ logger = logging.getLogger(__name__)
 _OPENCODE_OPTIONS_CACHE: dict[str, dict] = {}
 _OPENCODE_OPTIONS_TTL_SECONDS = 30.0
 
+_VAULT_ACCESS_RESULT_LOCK = threading.RLock()
+_VAULT_ACCESS_RESULTS: dict[str, str] = {}
+
 
 _PLATFORM_SECRET_FIELDS: dict[str, tuple[str, ...]] = {
     "slack": ("bot_token", "app_token", "signing_secret"),
@@ -1495,6 +1498,10 @@ def _vault_request_result(conn, request: dict) -> dict | None:
     if request.get("status") != "approved":
         return None
     if request_type == "access":
+        with _VAULT_ACCESS_RESULT_LOCK:
+            value = _VAULT_ACCESS_RESULTS.get(str(request["id"]))
+        if value is not None:
+            return {"type": "value", "value": value}
         grant = vault_service.get_grant_created_by_request(conn, str(request["id"]))
         if grant is None:
             requester = request.get("requester") if isinstance(request.get("requester"), dict) else {}
@@ -1514,6 +1521,32 @@ def _vault_request_result(conn, request: dict) -> dict | None:
         if isinstance(signature, dict):
             return {"type": "signature", "signature": signature}
     return None
+
+
+def _store_vault_access_result(request_id: str, value: str) -> None:
+    with _VAULT_ACCESS_RESULT_LOCK:
+        _VAULT_ACCESS_RESULTS[request_id] = value
+
+
+def claim_vault_access_result(request_id: str) -> dict:
+    from storage import vault_service
+
+    engine = _vault_engine()
+    try:
+        with engine.connect() as conn:
+            request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
+    except vault_service.RequestNotFoundError as exc:
+        raise VaultApiError(f"request '{exc}' not found", code="request_not_found", status=404) from exc
+    if request.get("request_type") != "access" or request.get("status") != "approved":
+        raise VaultApiError("access request has no claimable browser value", code="value_not_available", status=409)
+    delivery = request.get("delivery") if isinstance(request.get("delivery"), dict) else {}
+    if delivery.get("browser_released") is not True:
+        raise VaultApiError("access request has no claimable browser value", code="value_not_available", status=409)
+    with _VAULT_ACCESS_RESULT_LOCK:
+        value = _VAULT_ACCESS_RESULTS.pop(request_id, None)
+    if value is None:
+        raise VaultApiError("browser-released value is no longer available", code="value_not_available", status=409)
+    return {"ok": True, "result": {"type": "value", "value": value}}
 
 
 def get_vault_request(request_id: str) -> dict:
@@ -1582,12 +1615,6 @@ def request_vault_access(payload: dict) -> dict:
     try:
         with engine.begin() as conn:
             meta = vault_service.get_secret_meta(conn, name)
-            if meta.get("protection") == "protected":
-                raise VaultApiError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
-                    status=409,
-                )
             request = vault_service.create_access_request(
                 conn,
                 name,
@@ -1595,6 +1622,7 @@ def request_vault_access(payload: dict) -> dict:
                 delivery=_vault_delivery_payload(payload),
                 expires_at=_expires_at_from_ttl(payload),
                 audience=vault_service.REQUEST_AUDIENCE_AGENT,
+                grantable=meta.get("protection") != "protected",
             )
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
@@ -1629,12 +1657,6 @@ def request_vault_sign(payload: dict) -> dict:
                     code="unsupported_signer_kind",
                     status=409,
                 )
-            if meta.get("protection") == "protected":
-                raise VaultApiError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
-                    status=409,
-                )
             request = vault_service.create_sign_request(
                 conn,
                 name,
@@ -1643,6 +1665,7 @@ def request_vault_sign(payload: dict) -> dict:
                 requester=_vault_requester_payload(payload),
                 delivery=_vault_delivery_payload(payload),
                 expires_at=_expires_at_from_ttl(payload),
+                audience=vault_service.REQUEST_AUDIENCE_AGENT,
             )
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
@@ -1651,6 +1674,63 @@ def request_vault_sign(payload: dict) -> dict:
     except vault_service.VaultServiceError as exc:
         raise VaultApiError(str(exc), code="vault_error") from exc
     return {"ok": True, "request": request}
+
+
+def fulfill_vault_request(request_id: str, payload: dict) -> dict:
+    from storage import vault_service
+
+    if not isinstance(payload, dict):
+        raise VaultApiError("payload must be an object", code="invalid_payload")
+    name = str(payload.get("name") or "").strip()
+    engine = _vault_engine()
+    try:
+        with engine.begin() as conn:
+            request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
+            if not name:
+                name = str(request.get("secret_name") or "").strip()
+            if request.get("request_type") == "sign":
+                delivery = request.get("delivery") if isinstance(request.get("delivery"), dict) else {}
+                digest = _sign_digest_from_payload(payload.get("digest") or delivery.get("digest"))
+                scheme = str(payload.get("scheme") or delivery.get("scheme") or "ecdsa-secp256k1-recoverable").strip()
+                if scheme not in vault_service.SUPPORTED_SIGNATURE_SCHEMES:
+                    raise VaultApiError(f"unsupported signature scheme: {scheme}", code="invalid_request", status=409)
+                signature = payload.get("signature")
+                if not isinstance(signature, dict):
+                    raise VaultApiError("signature payload must be an object", code="invalid_request", status=409)
+                completed = vault_service.complete_sign_request(
+                    conn,
+                    request_id,
+                    name=name,
+                    digest=digest,
+                    scheme=scheme,
+                    signature=signature,
+                    requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
+                )
+                return {"ok": True, "request": completed, "signature": signature}
+            if request.get("request_type") == "access":
+                value = payload.get("value")
+                if not isinstance(value, str):
+                    raise VaultApiError("released value must be a string", code="invalid_request", status=409)
+                completed = vault_service.complete_access_request(
+                    conn,
+                    request_id,
+                    name=name,
+                    value=value,
+                    requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
+                )
+                _store_vault_access_result(request_id, value)
+                return {"ok": True, "request": completed}
+    except vault_service.SecretNotFoundError as exc:
+        raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.RequestNotFoundError as exc:
+        raise VaultApiError(f"request '{exc}' not found", code="request_not_found", status=404) from exc
+    except vault_service.InvalidRequestError as exc:
+        raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
+    except vault_service.KeypairNotValueDeliverableError as exc:
+        raise VaultApiError(str(exc), code="keypair_not_value_deliverable", status=409) from exc
+    except vault_service.VaultServiceError as exc:
+        raise VaultApiError(str(exc), code="vault_error") from exc
+    raise VaultApiError("request type cannot be browser-fulfilled", code="invalid_request", status=409)
 
 
 def deny_vault_request(request_id: str, payload: dict | None = None) -> dict:
@@ -1990,6 +2070,7 @@ def vault_sign(payload: dict) -> dict:
                         scheme=scheme,
                         requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
                         delivery=payload.get("delivery") if isinstance(payload.get("delivery"), dict) else None,
+                        audience=vault_service.REQUEST_AUDIENCE_AGENT,
                     )
                     return {"ok": False, "code": "browser_signature_required", "request": request}
                 request_id = str(payload.get("request_id") or "")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3829,17 +3829,12 @@ def cmd_vault_access(args):
         engine = _open_vault_engine()
         with engine.begin() as conn:
             meta = vault_service.get_secret_meta(conn, name)
-            if meta.get("protection") == "protected":
-                raise TaskCliError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
-                    help_command=help_command,
-                )
             request = vault_service.create_access_request(
                 conn,
                 name,
                 requester=_vault_cli_requester(args),
                 delivery=_vault_cli_delivery(args, mode="access"),
+                grantable=meta.get("protection") != "protected",
             )
         _print_cli_payload(
             "vault_access_request",
@@ -4473,6 +4468,8 @@ def _wait_for_vault_request(request_id: str, *, timeout: float, poll_interval: f
             result = None
             if request.get("status") == "approved":
                 result = api._vault_request_result(conn, request)
+                if result is None and _vault_request_needs_value_claim(request):
+                    result = _claim_vault_access_result_or_raise(request_id)
             if request.get("status") in {"approved", "denied", "expired", "failed", "fulfilled"}:
                 return {"request": request, "result": result}
         remaining = deadline - time.monotonic()
@@ -4480,6 +4477,74 @@ def _wait_for_vault_request(request_id: str, *, timeout: float, poll_interval: f
             break
         time.sleep(min(poll_interval, remaining))
     return None
+
+
+def _vault_request_needs_value_claim(request: dict) -> bool:
+    delivery = request.get("delivery") if isinstance(request.get("delivery"), dict) else {}
+    return request.get("request_type") == "access" and delivery.get("browser_released") is True
+
+
+def _local_vault_claim_targets(request_id: str) -> list[_LocalShowEventsTarget]:
+    from urllib.parse import quote
+
+    try:
+        config = V2Config.load()
+    except Exception:
+        return []
+    status = runtime.read_status()
+    port = getattr(config.ui, "setup_port", None)
+    if not status.get("ui_pid") or not port:
+        return []
+    path = f"/api/vault/requests/{quote(request_id, safe='')}/claim-value"
+    configured_host = _ui_show_events_host(config)
+    if configured_host in {"127.0.0.1", "localhost", "[::1]"}:
+        return [_LocalShowEventsTarget(f"http://{configured_host}:{int(port)}{path}")]
+    try:
+        ui_pid = int(status["ui_pid"])
+    except (TypeError, ValueError):
+        ui_pid = None
+    return [_LocalShowEventsTarget(f"http://127.0.0.1:{int(port)}{path}", verify_ui_pid=ui_pid)]
+
+
+def _claim_vault_access_result_from_live_ui(request_id: str) -> dict | None:
+    from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-Vibe-Show-Client": "cli",
+        SHOW_CLI_EVENT_TOKEN_HEADER: show_cli_event_token(),
+    }
+    for target in _local_vault_claim_targets(request_id):
+        if target.verify_ui_pid is not None and not _show_prewarm_target_matches_ui_pid(target.url, target.verify_ui_pid):
+            continue
+        request = urllib.request.Request(target.url, data=b"{}", method="POST", headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=3) as response:
+                payload = json.loads(response.read().decode("utf-8") or "{}")
+        except urllib.error.HTTPError as exc:
+            try:
+                payload = json.loads(exc.read().decode("utf-8") or "{}")
+            except (OSError, json.JSONDecodeError, ValueError):
+                payload = {}
+            code = str(payload.get("code") or "value_not_available")
+            message = str(payload.get("message") or payload.get("error") or "browser-released value is not available")
+            raise TaskCliError(message, code=code, help_command="vibe vault await --help") from exc
+        except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(payload, dict) and payload.get("ok") is True and isinstance(payload.get("result"), dict):
+            return payload["result"]
+    return None
+
+
+def _claim_vault_access_result_or_raise(request_id: str) -> dict:
+    result = _claim_vault_access_result_from_live_ui(request_id)
+    if result is None:
+        raise TaskCliError(
+            "browser-released value is not available from the running daemon",
+            code="value_not_available",
+            help_command="vibe vault await --help",
+        )
+    return result
 
 
 def cmd_vault_request(args):
@@ -4570,12 +4635,6 @@ def cmd_vault_sign(args):
                     code="unsupported_signer_kind",
                     help_command=help_command,
                 )
-            if meta.get("protection") == "protected":
-                raise TaskCliError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
-                    help_command=help_command,
-                )
             request = vault_service.create_sign_request(
                 conn,
                 name,
@@ -4619,6 +4678,8 @@ def cmd_vault_await(args):
         with engine.begin() as conn:
             request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
             result = api._vault_request_result(conn, request)
+        if request.get("status") == "approved" and result is None and _vault_request_needs_value_claim(request):
+            result = _claim_vault_access_result_or_raise(request_id)
         if timeout > 0 and request.get("status") in {"pending", "signing"}:
             waited = _wait_for_vault_request(request_id, timeout=timeout)
             if waited is None:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -301,7 +301,7 @@ def _current_origin() -> str:
 def _is_mutation_guard_exempt() -> bool:
     if request.path in {"/auth/callback"}:
         return True
-    if _is_cli_show_event_request() or _is_cli_session_activity_request():
+    if _is_cli_show_event_request() or _is_cli_session_activity_request() or _is_cli_vault_result_request():
         return True
     return (
         request.path == "/e2e/simulate-interaction"
@@ -332,6 +332,13 @@ def _is_cli_session_activity_request() -> bool:
     return (
         _cli_local_event_token_ok()
         and re.fullmatch(r"/api/sessions/[^/]+/cli-activity", request.path or "") is not None
+    )
+
+
+def _is_cli_vault_result_request() -> bool:
+    return (
+        _cli_local_event_token_ok()
+        and re.fullmatch(r"/api/vault/requests/[^/]+/claim-value", request.path or "") is not None
     )
 
 
@@ -2769,6 +2776,28 @@ def vault_request_deny_post(request_id):
 
     try:
         return jsonify(api.deny_vault_request(request_id, request.json or {}))
+    except ValueError as exc:
+        return _vault_error_response(exc)
+
+
+@app.route("/api/vault/requests/<request_id>/fulfill", methods=["POST"])
+def vault_request_fulfill_post(request_id):
+    from vibe import api
+
+    try:
+        return jsonify(api.fulfill_vault_request(request_id, request.json or {}))
+    except ValueError as exc:
+        return _vault_error_response(exc)
+
+
+@app.route("/api/vault/requests/<request_id>/claim-value", methods=["POST"])
+def vault_request_claim_value_post(request_id):
+    if not _is_cli_vault_result_request():
+        return jsonify({"error": "forbidden"}), 403
+    from vibe import api
+
+    try:
+        return jsonify(api.claim_vault_access_result(request_id))
     except ValueError as exc:
         return _vault_error_response(exc)
 


### PR DESCRIPTION
## Summary

- Route protected Vault access/sign requests through browser fulfillment instead of the parked sandbox path.
- Add protected static value release completion, with decrypted value kept in daemon memory for agent delivery and not persisted in request delivery JSON.
- Keep standard-tier grant/sign behavior unchanged and preserve the keypair sign-only guard.

## Contract

Protected sign completion:
- Browser submits `POST /api/vault/requests/{request_id}/fulfill` with `signature` and optional `name`, `digest`, `scheme`, `requester`.
- `name`, `digest`, and `scheme` default from the stored request delivery.

Protected static access completion:
- Browser submits `POST /api/vault/requests/{request_id}/fulfill` with `value` and optional `name`, `requester`.
- The daemon records the request as approved and makes the value available to the waiting agent process through the local daemon claim path.

## Evidence

- `ruff check storage/vault_service.py vibe/api.py vibe/ui_server.py vibe/cli.py tests/test_vault_api.py tests/test_vault_cli.py tests/test_vault_service.py tests/test_vault_rest.py`
- `python3 -m pytest tests/test_vault*.py -q`
- `git diff --check`

## Notes

No frontend or sandbox code is changed.
