### PR TITLE
fix(terminal): resize the PTY to fill the window (SIGWINCH + send size on connect)

### DIFF
--- a/core/terminal_service.py
+++ b/core/terminal_service.py
@@ -444,6 +444,16 @@ class TerminalService:
         cols = max(1, min(int(cols), 1000))
         payload = struct.pack("HHHH", rows, cols, 0, 0)
         await asyncio.to_thread(fcntl.ioctl, connection.master_fd, termios.TIOCSWINSZ, payload)
+        # TIOCSWINSZ updates the PTY winsize, but the kernel only raises SIGWINCH on the
+        # slave's foreground process group — and our child has none. open() spawns it with
+        # start_new_session=True and the slave dup'd onto its std fds (never opened by the
+        # session leader), so the slave is not the child's controlling terminal. Without
+        # SIGWINCH the tmux client (and any SIGWINCH-driven TUI) never re-reads the new size,
+        # so the pane stays pinned at tmux's 80x24 default no matter how large the browser
+        # window grows — the "output only fills the top of the window" bug. Deliver the signal
+        # to the child's process group ourselves. (A controlling terminal would make this
+        # native, but that needs a preexec_fn we deliberately avoid; see open() for why.)
+        _signal_winch(connection.process.pid)
         connection.touch()
 
     async def _write_all(self, fd: int, data: bytes) -> None:
@@ -755,4 +765,18 @@ def _close_fd(fd: int) -> None:
     try:
         os.close(fd)
     except OSError:
+        pass
+
+
+def _signal_winch(pid: int) -> None:
+    """Send SIGWINCH to a terminal child's process group so it re-reads the PTY size.
+
+    The child is its own session/group leader (start_new_session=True), so its pgid equals
+    its pid and the group holds the tmux client (or fallback shell and, with job control
+    disabled for want of a controlling terminal, its foreground job). A child that has
+    already exited is a no-op, not an error.
+    """
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGWINCH)
+    except (ProcessLookupError, PermissionError, OSError):
         pass

--- a/tests/test_terminal_backend.py
+++ b/tests/test_terminal_backend.py
@@ -346,6 +346,39 @@ async def _terminal_resize_applies_winsize(monkeypatch, tmp_path):
         await service.shutdown()
 
 
+def test_terminal_resize_signals_winch_to_child_group(monkeypatch, tmp_path):
+    asyncio.run(_terminal_resize_signals_winch(monkeypatch, tmp_path))
+
+
+async def _terminal_resize_signals_winch(monkeypatch, tmp_path):
+    # The PTY child has no controlling terminal (start_new_session + dup'd slave), so the
+    # kernel never raises SIGWINCH on a winsize change. resize() must deliver it to the
+    # child's process group itself, or the tmux client never re-reads the new size.
+    (tmp_path / "home").mkdir()
+    monkeypatch.setenv("SHELL", "/bin/sh")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(terminal_service, "resolve_tmux_binary", lambda: None)
+    calls: list[tuple[int, int]] = []
+    real_killpg = terminal_service.os.killpg
+    monkeypatch.setattr(terminal_service.os, "killpg", lambda pgid, sig: calls.append((pgid, sig)))
+    service = TerminalService(idle_timeout_seconds=60, max_sessions=2)
+    connection = await service.open("winch")
+    try:
+        expected_pgid = os.getpgid(connection.process.pid)
+        await service.resize(connection, cols=120, rows=40)
+        assert calls == [(expected_pgid, signal.SIGWINCH)]
+    finally:
+        monkeypatch.setattr(terminal_service.os, "killpg", real_killpg)
+        await service.close(connection)
+        await service.shutdown()
+
+
+def test_signal_winch_ignores_missing_process():
+    # A resize that races a just-exited child must be a no-op, not an error: getpgid on an
+    # unknown pid raises ProcessLookupError, which _signal_winch is expected to swallow.
+    terminal_service._signal_winch(2**31 - 1)
+
+
 def test_terminal_tmux_launch_command_uses_safe_session():
     cmd = _tmux_launch_command("/tmp/tmux", sanitize_session_id("../bad session!"))
 

--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -90,6 +90,24 @@ export const TerminalView: React.FC<{
     term.loadAddon(fit);
     termRef.current = term;
     const settleTimers: number[] = [];
+    let resizeSendTimer: number | null = null;
+    // Push the CURRENT terminal size to the PTY. The backend only learns the size from these
+    // messages, and xterm's onResize fires ONLY on a change — so a no-op fit (the size already
+    // settled before connect/reconnect) would otherwise never tell the PTY, leaving it at the
+    // default 24x80. A maximized window then shows the shell using only the top ~24 rows with a
+    // big blank area below (and the cursor stuck partway up).
+    const sendSize = () => {
+      const term = termRef.current;
+      const ws = wsRef.current;
+      if (term && ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', cols: term.cols, rows: term.rows }));
+      }
+    };
+    // Debounced so a maximize/restore animation's flurry of fits sends just the final size.
+    const queueSendSize = () => {
+      if (resizeSendTimer != null) window.clearTimeout(resizeSendTimer);
+      resizeSendTimer = window.setTimeout(sendSize, 80);
+    };
     const refit = () => {
       const el = containerRef.current;
       // Skip when the container is hidden (a background tab uses display:none → 0×0): fitting to
@@ -102,6 +120,8 @@ export const TerminalView: React.FC<{
       } catch {
         /* container not measured yet */
       }
+      // Always (re)send the fitted size — covers the no-op fit at connect/reconnect that onResize misses.
+      queueSendSize();
     };
     // A single fit can land before BOTH the layout and xterm's own character-cell metrics have
     // settled. On some browsers (notably Safari) the cell size finalises a frame or two after
@@ -133,11 +153,6 @@ export const TerminalView: React.FC<{
       }
       ws.send(ENC.encode(out));
     });
-    const onResize = term.onResize(({ cols, rows }: { cols: number; rows: number }) => {
-      const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'resize', cols, rows }));
-    });
-
     setStatus('connecting');
     setExitCode(null);
     const ws = new WebSocket(buildWsUrl(sessionId));
@@ -195,10 +210,10 @@ export const TerminalView: React.FC<{
 
     return () => {
       if (retryTimerRef.current != null) window.clearTimeout(retryTimerRef.current);
+      if (resizeSendTimer != null) window.clearTimeout(resizeSendTimer);
       for (const id of settleTimers) window.clearTimeout(id);
       ro.disconnect();
       onData.dispose();
-      onResize.dispose();
       // Detach handlers before closing. A closing socket's onclose can fire asynchronously
       // *after* its replacement has already reported 'ready' (reconnect / effect remount);
       // left attached, the stale onclose would mark the live terminal 'closed' or schedule a


### PR DESCRIPTION
## What

Fixes the windowed **Terminal** app bug where a maximized (or otherwise resized) terminal renders the shell in only the top ~24 rows, leaving a large blank area below and the cursor unable to reach the bottom — output never fills the window and you have to scroll manually.

## Root cause

The terminal child is spawned in `core/terminal_service.py` with `start_new_session=True` and the PTY **slave dup'd onto its std fds** (not opened by the session leader), so the slave never becomes the child's controlling terminal. The kernel therefore has **no foreground process group to deliver `SIGWINCH` to** when `TIOCSWINSZ` changes the winsize. The ioctl silently updates the PTY size, but the tmux client (and any `SIGWINCH`-driven program) never re-reads it, so the pane stays pinned at tmux's `80x24` default no matter how large the browser window is.

A second, independent gap: the frontend only pushed the size on xterm's *change-only* `onResize`. On a (re)connect the fit has already settled, so a no-op fit fired no event and the backend was never told the real size — most visible after reconnecting to a persisted tmux session.

## Fix

- **Backend** (`core/terminal_service.py`): after the resize ioctl, send `SIGWINCH` to the child's process group (`_signal_winch`) so the new size actually propagates. A controlling terminal would make this native, but that needs a `preexec_fn` we deliberately avoid (fork-deadlock rationale in `open()`).
- **Frontend** (`ui/src/components/workbench/TerminalView.tsx`): `refit()` now always pushes a debounced size frame (`{type:resize,cols,rows}`) on connect / reconnect / resize, replacing the change-only `onResize` sender — so a no-op fit on reattach still informs the backend.

## Evidence

- **Unit:** `tests/test_terminal_backend.py` — added `test_terminal_resize_signals_winch_to_child_group` (resize delivers `SIGWINCH` to the child's pgid) and `test_signal_winch_ignores_missing_process` (dead-pid no-op); existing `test_terminal_resize_applies_winsize` still green. **49 passed.**
- **Manual (Incus regression, maximized terminal):** isolated repro confirmed `ioctl` alone leaves the tmux client at `80x24` while `ioctl + SIGWINCH` resizes it to `210x45`. End-to-end after deploy: `stty size` reports **`45 210`** (was `24 80`), and a long command fills to the **bottom row** with the cursor at the very bottom — no blank gap.
- **Contract / scenario:** n/a (no scenario catalog for the terminal PTY path).
- **UI build:** unchanged from the already-built frontend commit; backend-only change requires no rebuild.
