### PR TITLE
feat(vaults): complete protected tier backend

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -9,7 +9,7 @@ Secret values and key material never live here. Standard-tier values are sealed 
 ``avault`` before this layer stores them. Protected-tier values arrive already
 encrypted by the browser; this layer only stores the opaque ciphertext + wrap
 metadata. Scope grants persist metadata only; protected delivery material is owned by
-the resident avault agent in the follow-on, not by Python.
+the resident avault agent, not by Python.
 """
 
 from __future__ import annotations
@@ -90,7 +90,7 @@ class InvalidRequestError(VaultServiceError):
 
 
 class UnsupportedProtectionError(VaultServiceError):
-    """A caller attempted a delivery path that still needs the resident agent."""
+    """A caller attempted the wrong delivery path for a protection tier."""
 
 
 class KeypairNotValueDeliverableError(VaultServiceError):
@@ -620,13 +620,12 @@ def _secret_access_grantable(row: dict[str, Any]) -> bool:
 
 
 def _secret_agent_access_grantable(row: dict[str, Any]) -> bool:
-    return row.get("protection") == "standard" and _secret_access_grantable(row)
+    return _secret_access_grantable(row)
 
 
 def _secret_agent_per_use_signable(row: dict[str, Any]) -> bool:
     return (
         row.get("kind") == "keypair"
-        and row.get("protection") == "standard"
         and row.get("signer_kind") in (None, "local")
     )
 
@@ -898,13 +897,12 @@ def get_envelope(conn: Connection, name: str) -> Sealed:
     client (which decrypts + delivers), then records its own ``record_proxy_use``.
     Validate any policy (e.g. host allowlist) *before* delivering.
 
-    Protected delivery is intentionally not routed through this helper until the
-    resident-agent/DEK-blindbox follow-on lands; callers should use
-    :func:`resolve_secret_access` to decide whether an approval/grant is needed.
+    Protected delivery must go through :func:`resolve_secret_access` and the
+    resident avault agent so Python never opens released DEKs or plaintext.
     """
     row = _require_row(conn, name)
     if row.get("protection") != "standard":
-        raise UnsupportedProtectionError(f"{name} is protected-tier (resident grant delivery is not wired yet)")
+        raise UnsupportedProtectionError(f"{name} is protected-tier; use resident-agent grant delivery")
     _reject_keypair_value_delivery(row, name)
     return _row_sealed(row)
 
@@ -959,7 +957,7 @@ def get_envelopes(conn: Connection, names: list[str]) -> dict[str, Sealed]:
     for name in names:
         row = _require_row(conn, name)
         if row.get("protection") != "standard":
-            raise UnsupportedProtectionError(f"{name} is protected-tier (resident grant delivery is not wired yet)")
+            raise UnsupportedProtectionError(f"{name} is protected-tier; use resident-agent grant delivery")
         _reject_keypair_value_delivery(row, name)
         out[name] = _row_sealed(row)
     return out

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1899,6 +1899,59 @@ def _approve_sibling_access_requests_for_grant(
     return approved
 
 
+def restore_access_request_after_failed_grant(
+    conn: Connection,
+    *,
+    created_by_request_id: str,
+    member_names: list[str] | set[str] | tuple[str, ...],
+    session_id: str | None,
+) -> int:
+    """Make a protected grant approval retryable after resident-agent relay fails."""
+
+    members = {str(name) for name in member_names if str(name)}
+    if not created_by_request_id or not members:
+        return 0
+    approval_row = conn.execute(select(vault_requests).where(vault_requests.c.id == created_by_request_id)).mappings().first()
+    if approval_row is None or approval_row.get("status") != "approved":
+        return 0
+    decided_at = approval_row.get("decided_at")
+    target_session_id = session_id or _request_session_id(dict(approval_row))
+    rows = [
+        dict(row)
+        for row in conn.execute(
+            select(vault_requests).where(
+                vault_requests.c.request_type == "access",
+                vault_requests.c.status == "approved",
+                vault_requests.c.secret_name.in_(members),
+            )
+        ).mappings()
+        if row["id"] == created_by_request_id
+        or (
+            target_session_id
+            and row.get("decided_at") == decided_at
+            and _request_session_id(dict(row)) == target_session_id
+        )
+    ]
+    restored = 0
+    for row in rows:
+        result = conn.execute(
+            vault_requests.update()
+            .where(vault_requests.c.id == row["id"], vault_requests.c.status == "approved")
+            .values(status="pending", decided_at=None)
+        )
+        if result.rowcount != 1:
+            continue
+        audit(
+            conn,
+            "request-restored-after-grant-relay-failed",
+            secret_name=row.get("secret_name"),
+            delivery={"request_type": "access", "session_id": target_session_id},
+            request_id=row["id"],
+        )
+        restored += 1
+    return restored
+
+
 def create_grant(
     conn: Connection,
     *,

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -624,10 +624,22 @@ def _secret_agent_access_grantable(row: dict[str, Any]) -> bool:
 
 
 def _secret_agent_per_use_signable(row: dict[str, Any]) -> bool:
+    if row.get("kind") != "keypair" or row.get("signer_kind") not in (None, "local"):
+        return False
+    if row.get("protection") != "protected":
+        return True
+    signing_public_key = _public_meta(row.get("public_meta")).get("signing_public_key")
     return (
-        row.get("kind") == "keypair"
-        and row.get("signer_kind") in (None, "local")
+        isinstance(signing_public_key, dict)
+        and signing_public_key.get("curve") == "secp256k1"
+        and isinstance(signing_public_key.get("public_key"), str)
+        and bool(signing_public_key.get("public_key"))
     )
+
+
+def _reject_unsignable_keypair(row: dict[str, Any], name: str) -> None:
+    if not _secret_agent_per_use_signable(row):
+        raise InvalidRequestError(f"{name} is not per-use signable")
 
 
 def _reject_keypair_value_delivery(row: dict[str, Any], name: str) -> None:
@@ -1313,6 +1325,7 @@ def create_sign_request(
         raise InvalidRequestError(f"{name} is not a signing key")
     if row.get("signer_kind") not in (None, "local"):
         raise InvalidRequestError(f"{name} is not locally signable")
+    _reject_unsignable_keypair(row, name)
     payload_audience = _request_audience_from_requester(requester)
     request_id = _id("vrq")
     delivery_payload = dict(delivery or {})

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -102,6 +102,12 @@ def test_archive_reclaims_bound_resources(tmp_path: Path) -> None:
             kind="keypair",
             signer_kind="local",
             sealed=Sealed("ct-key", "nonce-key", "wrap-key"),
+            public_meta={
+                "signing_public_key": {
+                    "curve": "secp256k1",
+                    "public_key": "02" + "cd" * 32,
+                }
+            },
         )
         req = vs.create_access_request(conn, "ARCHIVE_KEY", requester={"session_id": sid}, delivery={"session_id": sid})
         pending_req = vs.create_access_request(

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -25,6 +25,26 @@ def _sealed(suffix: str = "1") -> Sealed:
     return Sealed(ciphertext=f"ct-{suffix}", nonce=f"n-{suffix}", wrap_meta=f"wm-{suffix}")
 
 
+def _browser_ecdsa_signature_for_digest(digest: str, *, key_value: int = 1) -> tuple[dict, dict]:
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+    private_key = ec.derive_private_key(key_value, ec.SECP256K1())
+    public_key = private_key.public_key().public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.CompressedPoint,
+    )
+    der = private_key.sign(bytes.fromhex(digest), ec.ECDSA(utils.Prehashed(hashes.SHA256())))
+    r, s = utils.decode_dss_signature(der)
+    signature = {
+        "signature": r.to_bytes(32, "big").hex() + s.to_bytes(32, "big").hex(),
+        "recovery_id": 0,
+        "browser_signed": True,
+    }
+    public_meta = {"signing_public_key": {"curve": "secp256k1", "public_key": public_key.hex()}}
+    return public_meta, signature
+
+
 def _assert_no_unlock_material(payload: object) -> None:
     encoded = json.dumps(payload)
     assert "secret_unlock_material" not in encoded
@@ -678,6 +698,8 @@ def test_agent_sign_request_accepts_protected_browser_signature(monkeypatch):
     sign = Mock()
     monkeypatch.setattr(api, "avault_sign", sign)
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("key")))
+    digest = "00" * 32
+    public_meta, signature = _browser_ecdsa_signature_for_digest(digest)
     api.create_vault_secret(
         {
             "name": "PROTECTED_ETH_KEY",
@@ -685,22 +707,22 @@ def test_agent_sign_request_accepts_protected_browser_signature(monkeypatch):
             "kind": "keypair",
             "signer_kind": "local",
             "sealed": {"ciphertext": "ct-key", "nonce": "n-key", "wrap_meta": "wm-key"},
+            "public_meta": public_meta,
         }
     )
     requested = api.request_vault_sign(
         {
             "name": "PROTECTED_ETH_KEY",
-            "digest": "00" * 32,
+            "digest": digest,
             "scheme": "ecdsa-secp256k1-recoverable",
             "session_id": "ses_1",
         }
     )
-    signature = {"signature": "ab" * 64, "recovery_id": 1, "browser_signed": True}
 
     completed = api.vault_sign(
         {
             "name": "PROTECTED_ETH_KEY",
-            "digest": "00" * 32,
+            "digest": digest,
             "scheme": "ecdsa-secp256k1-recoverable",
             "request_id": requested["request"]["id"],
             "signature": signature,
@@ -949,6 +971,51 @@ def test_fulfill_access_request_rejects_raw_material_in_deks_by_secret(monkeypat
                         "value": "plaintext-must-not-cross-python-agent-boundary",
                     }
                 },
+            },
+        )
+
+    assert exc.value.code == "invalid_grant"
+    assert "opaque blind-box metadata" in str(exc.value)
+    agent_grant.assert_not_called()
+    with api._vault_engine().connect() as conn:
+        status = conn.execute(
+            select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == requested["request"]["id"])
+        ).scalar_one()
+        grants = vault_service.list_grants(conn, status=None)
+    assert status == "pending"
+    assert grants == []
+
+
+def test_fulfill_access_request_rejects_raw_material_nested_in_dek_blindbox(monkeypatch, avault_p2):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
+    monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_KEY",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct-protected", "nonce": "n-protected", "wrap_meta": "wm-protected"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.fulfill_vault_access_request(
+            requested["request"]["id"],
+            {
+                "session_id": "ses_1",
+                "deks": [
+                    {
+                        "name": "PROTECTED_KEY",
+                        "dek_blindbox": {
+                            "scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1",
+                            "enc": "enc",
+                            "ct": "ct",
+                            "dek": "raw-dek-must-not-cross-python-agent-boundary",
+                        },
+                        "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+                    }
+                ],
             },
         )
 
@@ -1649,6 +1716,8 @@ def test_protected_sign_completion_requires_matching_request(monkeypatch):
     from unittest.mock import Mock
 
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    digest = "00" * 32
+    public_meta, signature = _browser_ecdsa_signature_for_digest(digest)
     api.create_vault_secret(
         {
             "name": "ETH_KEY",
@@ -1656,9 +1725,9 @@ def test_protected_sign_completion_requires_matching_request(monkeypatch):
             "kind": "keypair",
             "signer_kind": "local",
             "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": public_meta,
         }
     )
-    digest = "00" * 32
     with pytest.raises(api.VaultApiError) as exc:
         api.vault_sign({"name": "ETH_KEY", "digest": digest, "scheme": "ecdsa-secp256k1-recoverable", "signature": {"signature": "sig"}})
     assert exc.value.code == "missing_request_id"
@@ -1683,7 +1752,7 @@ def test_protected_sign_completion_requires_matching_request(monkeypatch):
             "digest": digest,
             "scheme": "ecdsa-secp256k1-recoverable",
             "request_id": request_id,
-            "signature": {"signature": "ab" * 64, "recovery_id": 1},
+            "signature": signature,
         }
     )
     assert result["ok"] is True
@@ -1694,6 +1763,7 @@ def test_protected_sign_completion_rejects_malformed_browser_signature(monkeypat
     from unittest.mock import Mock
 
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    public_meta, _signature = _browser_ecdsa_signature_for_digest("00" * 32)
     api.create_vault_secret(
         {
             "name": "ETH_KEY",
@@ -1701,6 +1771,7 @@ def test_protected_sign_completion_rejects_malformed_browser_signature(monkeypat
             "kind": "keypair",
             "signer_kind": "local",
             "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": public_meta,
         }
     )
     digest = "00" * 32
@@ -1718,6 +1789,85 @@ def test_protected_sign_completion_rejects_malformed_browser_signature(monkeypat
         )
 
     assert exc.value.code == "invalid_request"
+
+
+def test_protected_sign_completion_rejects_signature_that_does_not_verify(monkeypatch):
+    from unittest.mock import Mock
+
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    digest = "00" * 32
+    public_meta, _valid_signature = _browser_ecdsa_signature_for_digest(digest, key_value=1)
+    _other_public_meta, invalid_signature = _browser_ecdsa_signature_for_digest(digest, key_value=2)
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": public_meta,
+        }
+    )
+    pending = api.vault_sign({"name": "ETH_KEY", "digest": digest, "scheme": "ecdsa-secp256k1-recoverable"})
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.vault_sign(
+            {
+                "name": "ETH_KEY",
+                "digest": digest,
+                "scheme": "ecdsa-secp256k1-recoverable",
+                "request_id": pending["request"]["id"],
+                "signature": invalid_signature,
+            }
+        )
+
+    assert exc.value.code == "invalid_request"
+    assert "does not verify" in str(exc.value)
+    with api._vault_engine().connect() as conn:
+        status = conn.execute(
+            select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == pending["request"]["id"])
+        ).scalar_one()
+    assert status == "pending"
+
+
+def test_protected_sign_completion_verifies_schnorr_browser_signature(monkeypatch):
+    from unittest.mock import Mock
+
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    digest = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+    signature = {
+        "signature": "931a3386e9ec69fe1471ba85933640948c0296a79ce2d3801ad5a4d9353550aeb0a5e80358b68088bda70b46e6b77a640c1216826f96292e5799ba2bb7bf1342",
+        "browser_signed": True,
+    }
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": {
+                "signing_public_key": {
+                    "curve": "secp256k1",
+                    "public_key": "024e3b81af9c2234cad09d679ce6035ed1392347ce64ce405f5dcd36228a25de6e",
+                }
+            },
+        }
+    )
+    pending = api.vault_sign({"name": "ETH_KEY", "digest": digest, "scheme": "schnorr-secp256k1-bip340"})
+
+    result = api.vault_sign(
+        {
+            "name": "ETH_KEY",
+            "digest": digest,
+            "scheme": "schnorr-secp256k1-bip340",
+            "request_id": pending["request"]["id"],
+            "signature": signature,
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["request"]["status"] == "approved"
 
 
 def test_vault_sign_rejects_malformed_digest_before_request_or_avault(monkeypatch):

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -576,15 +576,16 @@ def test_get_vault_request_does_not_hydrate_protected_pending_unlock_material(mo
     _assert_no_unlock_material(fetched["request"]["card"])
 
 
-def test_agent_access_request_rejects_protected_next_version(monkeypatch):
+def test_agent_access_request_accepts_protected_static(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("protected")))
     api.create_vault_secret({"name": "PROTECTED_KEY", "protection": "protected", "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"}})
 
-    with pytest.raises(api.VaultApiError) as exc:
-        api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
+    requested = api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
 
-    assert exc.value.code == "protected_requires_browser_sandbox"
-    assert "browser sandbox" in str(exc.value)
+    assert requested["ok"] is True
+    assert requested["request"]["secret_name"] == "PROTECTED_KEY"
+    assert requested["request"]["card"]["protection"] == "protected"
+    _assert_no_unlock_material(requested["request"])
 
 
 def test_deny_vault_request_api(monkeypatch):
@@ -671,6 +672,50 @@ def test_agent_sign_claims_request_before_avault_sign(monkeypatch):
     )
 
     assert completed["request"]["status"] == "approved"
+
+
+def test_agent_sign_request_accepts_protected_browser_signature(monkeypatch):
+    sign = Mock()
+    monkeypatch.setattr(api, "avault_sign", sign)
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("key")))
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct-key", "nonce": "n-key", "wrap_meta": "wm-key"},
+        }
+    )
+    requested = api.request_vault_sign(
+        {
+            "name": "PROTECTED_ETH_KEY",
+            "digest": "00" * 32,
+            "scheme": "ecdsa-secp256k1-recoverable",
+            "session_id": "ses_1",
+        }
+    )
+    signature = {"signature": "ab" * 64, "recovery_id": 1, "browser_signed": True}
+
+    completed = api.vault_sign(
+        {
+            "name": "PROTECTED_ETH_KEY",
+            "digest": "00" * 32,
+            "scheme": "ecdsa-secp256k1-recoverable",
+            "request_id": requested["request"]["id"],
+            "signature": signature,
+        }
+    )
+
+    assert requested["ok"] is True
+    assert requested["request"]["card"]["protection"] == "protected"
+    assert completed["ok"] is True
+    assert completed["signature"] == signature
+    assert api.get_vault_request(requested["request"]["id"])["result"] == {"type": "signature", "signature": signature}
+    sign.assert_not_called()
+    with api._vault_engine().connect() as conn:
+        meta = vault_service.get_secret_meta(conn, "PROTECTED_ETH_KEY")
+    assert meta["use_count"] == 1
 
 
 def test_agent_sign_marks_claimed_request_failed_when_signature_validation_rejects(monkeypatch):
@@ -765,8 +810,6 @@ def test_create_and_revoke_grant_api(monkeypatch, avault_p2):
                     "name": "GRANT_KEY",
                     "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
                     "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
-                    "dek": "raw-dek-must-not-cross-python-agent-boundary",
-                    "value": "plaintext-must-not-cross-python-agent-boundary",
                 }
             ],
         }
@@ -786,6 +829,119 @@ def test_create_and_revoke_grant_api(monkeypatch, avault_p2):
     revoked = api.revoke_vault_grant(created["grant"]["id"])
     assert revoked["grant"]["status"] == "revoked"
     agent_release.assert_called_once_with(scope_type="secret", scope_ref="GRANT_KEY")
+
+
+def test_fulfill_access_request_relays_only_browser_dek_blindbox(monkeypatch, avault_p2):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
+    validate_pubkey = Mock()
+    monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
+    monkeypatch.setattr(api, "validate_avault_agent_pubkey", validate_pubkey)
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_KEY",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct-protected", "nonce": "n-protected", "wrap_meta": "wm-protected"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
+
+    fulfilled = api.fulfill_vault_access_request(
+        requested["request"]["id"],
+        {
+            "session_id": "ses_1",
+            "ttl_seconds": 300,
+            "agent_pubkey": {"public_key": "pk", "fingerprint": "fp"},
+            "deks": [
+                {
+                    "name": "PROTECTED_KEY",
+                    "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+                    "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+                }
+            ],
+        },
+    )
+
+    assert fulfilled["ok"] is True
+    assert fulfilled["result"]["type"] == "grant"
+    assert fulfilled["grant"]["delivery_ready"] is True
+    assert agent_grant.call_args.kwargs["deks"] == [
+        {
+            "name": "PROTECTED_KEY",
+            "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+            "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+        }
+    ]
+    with api._vault_engine().connect() as conn:
+        resolved = vault_service.resolve_secret_access(conn, "PROTECTED_KEY", session_id="ses_1", create_request=False)
+    assert resolved["status"] == "agent_delivery_ready"
+    validate_pubkey.assert_called_once_with({"public_key": "pk", "fingerprint": "fp"})
+    encoded = json.dumps({"fulfilled": fulfilled, "agent_deks": agent_grant.call_args.kwargs["deks"]})
+    assert "raw-dek-must-not-cross-python-agent-boundary" not in encoded
+    assert "plaintext-must-not-cross-python-agent-boundary" not in encoded
+
+
+def test_fulfill_access_request_rejects_dek_or_plaintext_material(monkeypatch, avault_p2):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
+    monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_KEY",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct-protected", "nonce": "n-protected", "wrap_meta": "wm-protected"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.fulfill_vault_access_request(
+            requested["request"]["id"],
+            {
+                "session_id": "ses_1",
+                "deks": [
+                    {
+                        "name": "PROTECTED_KEY",
+                        "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+                        "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+                        "dek": "raw-dek-must-not-cross-python-agent-boundary",
+                        "value": "plaintext-must-not-cross-python-agent-boundary",
+                    }
+                ],
+            },
+        )
+
+    assert exc.value.code == "invalid_grant"
+    assert "opaque blind-box metadata" in str(exc.value)
+    agent_grant.assert_not_called()
+    with api._vault_engine().connect() as conn:
+        status = conn.execute(
+            select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == requested["request"]["id"])
+        ).scalar_one()
+        grants = vault_service.list_grants(conn, status=None)
+    assert status == "pending"
+    assert grants == []
+
+
+def test_fulfill_access_request_rejects_protected_keypair_value_delivery(monkeypatch, avault_p2):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
+    monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+        }
+    )
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.request_vault_access({"name": "PROTECTED_ETH_KEY", "session_id": "ses_1"})
+
+    assert exc.value.code == "not_grantable"
+    agent_grant.assert_not_called()
 
 
 def test_revoke_grant_keeps_agent_scope_when_other_active_grant_exists(monkeypatch):

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -36,9 +36,15 @@ def _browser_ecdsa_signature_for_digest(digest: str, *, key_value: int = 1) -> t
     )
     der = private_key.sign(bytes.fromhex(digest), ec.ECDSA(utils.Prehashed(hashes.SHA256())))
     r, s = utils.decode_dss_signature(der)
+    recovery_id = next(
+        index
+        for index in range(4)
+        if api._secp256k1_recover_ecdsa_public_key(r, s, bytes.fromhex(digest), index)
+        == api._secp256k1_decompress_public_key(public_key)
+    )
     signature = {
         "signature": r.to_bytes(32, "big").hex() + s.to_bytes(32, "big").hex(),
-        "recovery_id": 0,
+        "recovery_id": recovery_id,
         "browser_signed": True,
     }
     public_meta = {"signing_public_key": {"curve": "secp256k1", "public_key": public_key.hex()}}
@@ -1578,7 +1584,9 @@ def test_create_grant_api_releases_scope_when_mark_ready_fails(monkeypatch, avau
     assert exc.value.code == "invalid_grant"
     agent_release.assert_called_once_with(scope_type="secret", scope_ref="GRANT_KEY")
     with api._vault_engine().connect() as conn:
+        status = conn.execute(select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == req["id"])).scalar_one()
         grants = vault_service.list_grants(conn, status=None)
+    assert status == "pending"
     assert len(grants) == 1
     assert grants[0]["status"] == "expired"
     assert grants[0]["delivery_ready"] is False
@@ -1675,6 +1683,7 @@ def test_protected_sign_requires_browser_signature(monkeypatch):
     from unittest.mock import Mock
 
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    public_meta, _signature = _browser_ecdsa_signature_for_digest("00" * 32)
     api.create_vault_secret(
         {
             "name": "ETH_KEY",
@@ -1682,6 +1691,7 @@ def test_protected_sign_requires_browser_signature(monkeypatch):
             "kind": "keypair",
             "signer_kind": "local",
             "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": public_meta,
         }
     )
     result = api.vault_sign({"name": "ETH_KEY", "digest": "00" * 32, "scheme": "ecdsa-secp256k1-recoverable"})
@@ -1691,7 +1701,7 @@ def test_protected_sign_requires_browser_signature(monkeypatch):
     assert result["request"]["card"]["scope_options"] == []
 
 
-def test_protected_sign_rejects_unsupported_scheme_before_request(monkeypatch):
+def test_protected_sign_request_requires_pinned_signing_public_key(monkeypatch):
     from unittest.mock import Mock
 
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
@@ -1702,6 +1712,30 @@ def test_protected_sign_rejects_unsupported_scheme_before_request(monkeypatch):
             "kind": "keypair",
             "signer_kind": "local",
             "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+        }
+    )
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.vault_sign({"name": "ETH_KEY", "digest": "00" * 32, "scheme": "ecdsa-secp256k1-recoverable"})
+
+    assert exc.value.code == "invalid_request"
+    assert "per-use signable" in str(exc.value)
+    assert api.get_vault_requests()["requests"] == []
+
+
+def test_protected_sign_rejects_unsupported_scheme_before_request(monkeypatch):
+    from unittest.mock import Mock
+
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    public_meta, _signature = _browser_ecdsa_signature_for_digest("00" * 32)
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": public_meta,
         }
     )
 
@@ -1823,6 +1857,46 @@ def test_protected_sign_completion_rejects_signature_that_does_not_verify(monkey
 
     assert exc.value.code == "invalid_request"
     assert "does not verify" in str(exc.value)
+    with api._vault_engine().connect() as conn:
+        status = conn.execute(
+            select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == pending["request"]["id"])
+        ).scalar_one()
+    assert status == "pending"
+
+
+def test_protected_sign_completion_rejects_wrong_recovery_id(monkeypatch):
+    from unittest.mock import Mock
+
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    digest = "00" * 32
+    public_meta, signature = _browser_ecdsa_signature_for_digest(digest, key_value=1)
+    bad_signature = dict(signature)
+    bad_signature["recovery_id"] = (int(signature["recovery_id"]) + 1) % 4
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": public_meta,
+        }
+    )
+    pending = api.vault_sign({"name": "ETH_KEY", "digest": digest, "scheme": "ecdsa-secp256k1-recoverable"})
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.vault_sign(
+            {
+                "name": "ETH_KEY",
+                "digest": digest,
+                "scheme": "ecdsa-secp256k1-recoverable",
+                "request_id": pending["request"]["id"],
+                "signature": bad_signature,
+            }
+        )
+
+    assert exc.value.code == "invalid_request"
+    assert "recovery_id" in str(exc.value)
     with api._vault_engine().connect() as conn:
         status = conn.execute(
             select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == pending["request"]["id"])

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -923,6 +923,47 @@ def test_fulfill_access_request_rejects_dek_or_plaintext_material(monkeypatch, a
     assert grants == []
 
 
+def test_fulfill_access_request_rejects_raw_material_in_deks_by_secret(monkeypatch, avault_p2):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
+    monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_KEY",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct-protected", "nonce": "n-protected", "wrap_meta": "wm-protected"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_KEY", "session_id": "ses_1"})
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.fulfill_vault_access_request(
+            requested["request"]["id"],
+            {
+                "session_id": "ses_1",
+                "deks_by_secret": {
+                    "PROTECTED_KEY": {
+                        "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+                        "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+                        "dek": "raw-dek-must-not-cross-python-agent-boundary",
+                        "value": "plaintext-must-not-cross-python-agent-boundary",
+                    }
+                },
+            },
+        )
+
+    assert exc.value.code == "invalid_grant"
+    assert "opaque blind-box metadata" in str(exc.value)
+    agent_grant.assert_not_called()
+    with api._vault_engine().connect() as conn:
+        status = conn.execute(
+            select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == requested["request"]["id"])
+        ).scalar_one()
+        grants = vault_service.list_grants(conn, status=None)
+    assert status == "pending"
+    assert grants == []
+
+
 def test_fulfill_access_request_rejects_protected_keypair_value_delivery(monkeypatch, avault_p2):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
@@ -1373,7 +1414,7 @@ def test_create_grant_api_expires_grant_when_agent_grant_fails(monkeypatch, avau
     with api._vault_engine().connect() as conn:
         status = conn.execute(select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == req["id"])).scalar_one()
         grants = vault_service.list_grants(conn, status=None)
-    assert status == "approved"
+    assert status == "pending"
     assert len(grants) == 1
     assert grants[0]["status"] == "expired"
     assert grants[0]["delivery_ready"] is False
@@ -1414,7 +1455,9 @@ def test_create_grant_api_rejects_partial_agent_cache(monkeypatch, avault_p2):
     assert exc.value.code == "avault_failed"
     assert "cached fewer DEKs" in str(exc.value)
     with api._vault_engine().connect() as conn:
+        status = conn.execute(select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == req["id"])).scalar_one()
         grants = vault_service.list_grants(conn, status=None)
+    assert status == "pending"
     assert len(grants) == 1
     assert grants[0]["status"] == "expired"
     assert grants[0]["delivery_ready"] is False

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -45,7 +45,6 @@ def _browser_ecdsa_signature_for_digest(digest: str, *, key_value: int = 1) -> t
     signature = {
         "signature": r.to_bytes(32, "big").hex() + s.to_bytes(32, "big").hex(),
         "recovery_id": recovery_id,
-        "browser_signed": True,
     }
     public_meta = {"signing_public_key": {"curve": "secp256k1", "public_key": public_key.hex()}}
     return public_meta, signature
@@ -1825,6 +1824,45 @@ def test_protected_sign_completion_rejects_malformed_browser_signature(monkeypat
     assert exc.value.code == "invalid_request"
 
 
+def test_protected_sign_completion_rejects_signature_extra_fields(monkeypatch):
+    from unittest.mock import Mock
+
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    digest = "00" * 32
+    public_meta, signature = _browser_ecdsa_signature_for_digest(digest)
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "protection": "protected",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+            "public_meta": public_meta,
+        }
+    )
+    pending = api.vault_sign({"name": "ETH_KEY", "digest": digest, "scheme": "ecdsa-secp256k1-recoverable"})
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.vault_sign(
+            {
+                "name": "ETH_KEY",
+                "digest": digest,
+                "scheme": "ecdsa-secp256k1-recoverable",
+                "request_id": pending["request"]["id"],
+                "signature": {**signature, "private_key": "raw", "dek": "raw"},
+            }
+        )
+
+    assert exc.value.code == "invalid_request"
+    assert "unsupported fields" in str(exc.value)
+    with api._vault_engine().connect() as conn:
+        row = conn.execute(
+            select(vault_service.vault_requests).where(vault_service.vault_requests.c.id == pending["request"]["id"])
+        ).mappings().one()
+    assert row["status"] == "pending"
+    assert "signature" not in json.loads(row["delivery"])
+
+
 def test_protected_sign_completion_rejects_signature_that_does_not_verify(monkeypatch):
     from unittest.mock import Mock
 
@@ -1911,7 +1949,6 @@ def test_protected_sign_completion_verifies_schnorr_browser_signature(monkeypatc
     digest = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
     signature = {
         "signature": "931a3386e9ec69fe1471ba85933640948c0296a79ce2d3801ad5a4d9353550aeb0a5e80358b68088bda70b46e6b77a640c1216826f96292e5799ba2bb7bf1342",
-        "browser_signed": True,
     }
     api.create_vault_secret(
         {

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -676,10 +676,10 @@ def test_run_rejects_missing_later_secret_before_creating_approval(capfd):
 def test_run_expires_grant_when_agent_cache_is_missing(capfd, monkeypatch):
     from vibe import api
 
-    grant = _set_protected_grant("PROTECTED_KEY")
+    grant = _set_protected_grant("PROTECTED_KEY", session_id="ses_cli")
     monkeypatch.setattr(api, "avault_agent_deliver_run", Mock(side_effect=api.AvaultError("grant is missing or expired")))
 
-    code = cli.cmd_vault_run(_ns(env=["PROTECTED_KEY"], command_argv=["python3", "-c", "pass"]))
+    code = cli.cmd_vault_run(_ns(env=["PROTECTED_KEY"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
     captured = capfd.readouterr()
 
     assert code == 1
@@ -689,6 +689,8 @@ def test_run_expires_grant_when_agent_cache_is_missing(capfd, monkeypatch):
         requests = vault_service.list_requests(conn, status="pending")
     assert status == "expired"
     assert requests[0]["secret_name"] == "PROTECTED_KEY"
+    assert requests[0]["requester"]["session_id"] == "ses_cli"
+    assert requests[0]["delivery"]["session_id"] == "ses_cli"
 
 
 def test_run_reopens_only_one_approval_when_group_agent_cache_is_missing(capfd, monkeypatch):
@@ -708,6 +710,53 @@ def test_run_reopens_only_one_approval_when_group_agent_cache_is_missing(capfd, 
     assert status == "expired"
     assert len(requests) == 1
     assert requests[0]["secret_name"] == "A_KEY"
+
+
+def test_fetch_reopens_session_bound_approval_when_agent_cache_is_missing(capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_protected_grant("PROTECTED_KEY", session_id="ses_cli")
+    with cli._open_vault_engine().begin() as conn:
+        conn.execute(
+            vault_service.vault_secrets.update()
+            .where(vault_service.vault_secrets.c.name == "PROTECTED_KEY")
+            .values(policy=json.dumps({"allowed_hosts": ["example.com"], "auth": {"type": "bearer"}}))
+        )
+    monkeypatch.setattr(api, "avault_agent_deliver_fetch", Mock(side_effect=api.AvaultError("grant is missing or expired")))
+
+    code = cli.cmd_vault_fetch(_ns(auth="PROTECTED_KEY", url="https://example.com/api", method="GET", output=None, session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "approval_required"
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+        requests = vault_service.list_requests(conn, status="pending")
+    assert status == "expired"
+    assert requests[0]["secret_name"] == "PROTECTED_KEY"
+    assert requests[0]["requester"]["session_id"] == "ses_cli"
+    assert requests[0]["delivery"]["session_id"] == "ses_cli"
+
+
+def test_inject_reopens_session_bound_approval_when_agent_cache_is_missing(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_protected_grant("PROTECTED_KEY", session_id="ses_cli")
+    monkeypatch.setattr(api, "avault_agent_deliver_inject", Mock(side_effect=api.AvaultError("grant is missing or expired")))
+    out = tmp_path / "out.env"
+
+    code = cli.cmd_vault_inject(_ns(keys="PROTECTED_KEY", out=str(out), format="dotenv", session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "approval_required"
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+        requests = vault_service.list_requests(conn, status="pending")
+    assert status == "expired"
+    assert requests[0]["secret_name"] == "PROTECTED_KEY"
+    assert requests[0]["requester"]["session_id"] == "ses_cli"
+    assert requests[0]["delivery"]["session_id"] == "ses_cli"
 
 
 def test_run_persists_protected_approval_request_without_grant(capfd):

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -588,6 +588,64 @@ def test_run_prefers_common_grant_for_protected_batch(tmp_path, capfd, monkeypat
     assert [secret["name"] for secret in deliver.call_args.kwargs["secrets"]] == ["A_KEY", "B_KEY"]
 
 
+def test_run_uses_session_bound_protected_grant(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    monkeypatch.chdir(tmp_path)
+    _set_protected_grant("PROTECTED_KEY", session_id="ses_cli")
+    deliver = Mock(return_value={"exit_code": 0, "stdout": b"", "stderr": b""})
+    monkeypatch.setattr(api, "avault_agent_deliver_run", deliver)
+    monkeypatch.setattr(api, "avault_deliver_run", Mock())
+
+    code = cli.cmd_vault_run(_ns(env=["PROTECTED_KEY"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+
+    assert code == 0
+    deliver.assert_called_once()
+    assert deliver.call_args.kwargs["secrets"][0]["name"] == "PROTECTED_KEY"
+    assert deliver.call_args.kwargs["scope_ref"] == "PROTECTED_KEY"
+
+
+def test_fetch_uses_session_bound_protected_grant(capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_protected_grant("PROTECTED_KEY", session_id="ses_cli")
+    with cli._open_vault_engine().begin() as conn:
+        row = conn.execute(vault_service.vault_secrets.select().where(vault_service.vault_secrets.c.name == "PROTECTED_KEY")).mappings().one()
+        conn.execute(
+            vault_service.vault_secrets.update()
+            .where(vault_service.vault_secrets.c.name == "PROTECTED_KEY")
+            .values(policy=json.dumps({"allowed_hosts": ["example.com"], "auth": {"type": "bearer"}}))
+        )
+    assert row["name"] == "PROTECTED_KEY"
+    deliver = Mock(return_value={"status": 200, "headers": {}, "body": "ok"})
+    monkeypatch.setattr(api, "avault_agent_deliver_fetch", deliver)
+
+    code = cli.cmd_vault_fetch(_ns(auth="PROTECTED_KEY", url="https://example.com/api", method="GET", output=None, session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 0
+    assert captured.out == "ok"
+    deliver.assert_called_once()
+    assert deliver.call_args.kwargs["scope_ref"] == grant["scope_ref"]
+    assert deliver.call_args.kwargs["sealed"] == _sealed("protected")
+
+
+def test_inject_resolver_uses_session_bound_protected_grant(tmp_path):
+    grant = _set_protected_grant("PROTECTED_KEY", session_id="ses_cli")
+    engine = cli._open_vault_engine()
+
+    resolved_grant, secrets = cli._resolve_vault_inject_delivery(
+        engine,
+        ["PROTECTED_KEY"],
+        path=str(tmp_path / "out.env"),
+        fmt="dotenv",
+        args=_ns(session_id="ses_cli"),
+    )
+
+    assert resolved_grant["id"] == grant["id"]
+    assert secrets == [{"name": "PROTECTED_KEY", "key": "PROTECTED_KEY", "envelope": _sealed("protected")}]
+
+
 def test_run_rejects_mixed_tiers_before_creating_approval(tmp_path, capfd, monkeypatch):
     _set_secret("STANDARD_KEY", "standard", tmp_path, monkeypatch, capfd)
     with cli._open_vault_engine().begin() as conn:

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -180,8 +180,8 @@ def test_discover_reports_value_free_capabilities(tmp_path, capfd, monkeypatch):
         "per_use_sign": False,
     }
     assert secrets["ETH_KEY"]["per_use_sign"] is True
-    assert secrets["PROTECTED_STATIC_KEY"]["access_grantable"] is False
-    assert secrets["PROTECTED_ETH_KEY"]["per_use_sign"] is False
+    assert secrets["PROTECTED_STATIC_KEY"]["access_grantable"] is True
+    assert secrets["PROTECTED_ETH_KEY"]["per_use_sign"] is True
     assert secrets["REMOTE_ETH_KEY"]["per_use_sign"] is False
     assert "sk-" not in json.dumps(payload)
 
@@ -199,15 +199,16 @@ def test_access_request_cli_uses_caller_session(tmp_path, capfd, monkeypatch):
     assert payload["request"]["status"] == "pending"
 
 
-def test_access_request_cli_rejects_protected_next_version(capfd):
+def test_access_request_cli_accepts_protected_static_request(capfd):
     with cli._open_vault_engine().begin() as conn:
         vault_service.create_secret(conn, name="PROTECTED_KEY", protection="protected", sealed=_sealed("protected"))
 
-    assert cli.cmd_vault_access(_ns(name="PROTECTED_KEY")) == 1
-    payload = json.loads(capfd.readouterr().err)
+    assert cli.cmd_vault_access(_ns(name="PROTECTED_KEY")) == 0
+    payload = json.loads(capfd.readouterr().out)
 
-    assert payload["code"] == "protected_requires_browser_sandbox"
-    assert "browser sandbox" in payload["error"]
+    assert payload["kind"] == "vault_access_request"
+    assert payload["request"]["secret_name"] == "PROTECTED_KEY"
+    assert payload["request"]["card"]["protection"] == "protected"
 
 
 def test_sign_request_and_await_cli_reads_approved_signature(capfd, monkeypatch):
@@ -240,6 +241,26 @@ def test_sign_request_and_await_cli_reads_approved_signature(capfd, monkeypatch)
     assert payload["kind"] == "vault_request_result"
     assert payload["status"] == "approved"
     assert payload["result"] == {"type": "signature", "signature": {"signature": "ab" * 64, "recovery_id": 1}}
+
+
+def test_sign_request_cli_accepts_protected_keypair(capfd):
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(
+            conn,
+            name="PROTECTED_ETH_KEY",
+            protection="protected",
+            kind="keypair",
+            signer_kind="local",
+            sealed=_sealed("protected-key"),
+        )
+
+    assert cli.cmd_vault_sign(_ns(name="PROTECTED_ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")) == 0
+    payload = json.loads(capfd.readouterr().out)
+
+    assert payload["kind"] == "vault_sign_request"
+    assert payload["request"]["secret_name"] == "PROTECTED_ETH_KEY"
+    assert payload["request"]["card"]["protection"] == "protected"
+    assert payload["request"]["card"]["scope_options"] == []
 
 
 def test_vault_await_wait_treats_failed_request_as_terminal(capfd):

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -51,6 +51,14 @@ def _sealed(suffix: str = "1") -> Sealed:
     return Sealed(ciphertext=f"ct-{suffix}", nonce=f"n-{suffix}", wrap_meta=f"wm-{suffix}")
 
 
+PROTECTED_SIGNING_PUBLIC_META = {
+    "signing_public_key": {
+        "curve": "secp256k1",
+        "public_key": "02" + "cd" * 32,
+    }
+}
+
+
 def _set_secret(name: str, value: str, tmp_path, monkeypatch, capfd, *, sealed: Sealed | None = None):
     from vibe import api
 
@@ -158,6 +166,7 @@ def test_discover_reports_value_free_capabilities(tmp_path, capfd, monkeypatch):
             kind="keypair",
             signer_kind="local",
             sealed=_sealed("protected-key"),
+            public_meta=PROTECTED_SIGNING_PUBLIC_META,
         )
         vault_service.create_secret(
             conn,
@@ -252,6 +261,7 @@ def test_sign_request_cli_accepts_protected_keypair(capfd):
             kind="keypair",
             signer_kind="local",
             sealed=_sealed("protected-key"),
+            public_meta=PROTECTED_SIGNING_PUBLIC_META,
         )
 
     assert cli.cmd_vault_sign(_ns(name="PROTECTED_ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")) == 0

--- a/tests/test_vault_rest.py
+++ b/tests/test_vault_rest.py
@@ -237,6 +237,28 @@ def test_rest_fulfill_access_request_route(monkeypatch):
     assert agent_grant.call_count == 1
 
 
+def test_rest_fulfill_access_request_unknown_default_scope_returns_vault_error(monkeypatch):
+    _mock_avault_p2(monkeypatch)
+    client = app.test_client()
+
+    response = client.post(
+        "/api/vault/requests/vrq_missing/fulfill-access",
+        json={
+            "deks": [
+                {
+                    "name": "PROTECTED_REST",
+                    "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+                    "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+                }
+            ],
+        },
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 404
+    assert response.get_json()["code"] == "request_not_found"
+
+
 def test_rest_sign_errors_are_stable(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     client = app.test_client()

--- a/tests/test_vault_rest.py
+++ b/tests/test_vault_rest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from unittest.mock import Mock
 
 from storage.vault_crypto import Sealed
@@ -129,6 +131,31 @@ def test_rest_requests_and_grants_routes(monkeypatch):
     assert inbox["requests"][0]["card"]["card_type"] == "approval"
 
 
+def test_rest_request_get_hydrates_browser_unlock_material_for_protected_access(monkeypatch):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_REST",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct-protected", "nonce": "n-protected", "wrap_meta": "wm-protected"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_REST", "session_id": "ses_1"})
+    client = app.test_client()
+
+    response = client.get(f"/api/vault/requests/{requested['request']['id']}")
+
+    assert response.status_code == 200
+    card = response.get_json()["request"]["card"]
+    assert card["secret_unlock_material"] == {
+        "name": "PROTECTED_REST",
+        "kind": "static",
+        "envelope": {"ciphertext": "ct-protected", "nonce": "n-protected", "wrap_meta": "wm-protected"},
+    }
+    agent_payload = api.get_vault_request(requested["request"]["id"])
+    assert "secret_unlock_material" not in json.dumps(agent_payload)
+
+
 def test_rest_grant_rejects_mismatched_request(monkeypatch):
     _mock_avault_p2(monkeypatch)
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
@@ -173,6 +200,41 @@ def test_rest_grant_rejects_mismatched_request(monkeypatch):
 
     assert response.status_code == 409
     assert response.get_json()["code"] == "invalid_request"
+
+
+def test_rest_fulfill_access_request_route(monkeypatch):
+    _mock_avault_p2(monkeypatch)
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
+    monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_REST",
+            "protection": "protected",
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_REST", "session_id": "ses_1"})
+    client = app.test_client()
+
+    response = client.post(
+        f"/api/vault/requests/{requested['request']['id']}/fulfill-access",
+        json={
+            "session_id": "ses_1",
+            "deks": [
+                {
+                    "name": "PROTECTED_REST",
+                    "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+                    "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+                }
+            ],
+        },
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["result"]["type"] == "grant"
+    assert agent_grant.call_count == 1
 
 
 def test_rest_sign_errors_are_stable(monkeypatch):

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -29,6 +29,14 @@ def _sealed(suffix: str = "1") -> Sealed:
     return Sealed(ciphertext=f"ct-{suffix}", nonce=f"n-{suffix}", wrap_meta=f"wm-{suffix}")
 
 
+PROTECTED_SIGNING_PUBLIC_META = {
+    "signing_public_key": {
+        "curve": "secp256k1",
+        "public_key": "02" + "cd" * 32,
+    }
+}
+
+
 def _create(engine, **kw):
     with engine.begin() as conn:
         return vs.create_secret(conn, sealed=_sealed(), **kw)
@@ -240,6 +248,45 @@ def test_keypair_signing_public_key_surfaces_in_masked_meta(vault):
     listed_meta = next(item for item in listed if item["name"] == "ETH_KEY")
     assert listed_meta["signing_public_key"] == {"curve": "secp256k1", "public_key": public_key}
     assert "ignored" not in listed_meta["signing_public_key"]
+
+
+def test_protected_keypair_requires_signing_public_key_for_per_use_sign(vault):
+    _create(
+        vault,
+        name="UNPINNED_KEY",
+        kind="keypair",
+        protection="protected",
+        signer_kind="local",
+    )
+
+    with vault.connect() as conn:
+        meta = vs.get_secret_meta(conn, "UNPINNED_KEY")
+        listed = vs.list_secrets(conn)
+    listed_meta = next(item for item in listed if item["name"] == "UNPINNED_KEY")
+
+    assert meta["per_use_sign"] is False
+    assert listed_meta["per_use_sign"] is False
+    assert "signing_public_key" not in meta
+    with vault.begin() as conn:
+        with pytest.raises(vs.InvalidRequestError):
+            vs.create_sign_request(conn, "UNPINNED_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")
+
+
+def test_protected_keypair_with_signing_public_key_is_per_use_signable(vault):
+    public_key = "02" + "cd" * 32
+    _create(
+        vault,
+        name="PINNED_KEY",
+        kind="keypair",
+        protection="protected",
+        signer_kind="local",
+        public_meta={"signing_public_key": {"curve": "secp256k1", "public_key": public_key}},
+    )
+
+    with vault.connect() as conn:
+        meta = vs.get_secret_meta(conn, "PINNED_KEY")
+
+    assert meta["per_use_sign"] is True
 
 
 def test_pubkey_pin_does_not_change_secret_version(vault):
@@ -1246,7 +1293,14 @@ def test_grant_can_be_intentionally_unbound_from_request_session(vault):
 
 
 def test_keypair_and_always_ask_are_not_grantable(vault):
-    _create(vault, name="ETH_KEY", protection="protected", kind="keypair", signer_kind="local")
+    _create(
+        vault,
+        name="ETH_KEY",
+        protection="protected",
+        kind="keypair",
+        signer_kind="local",
+        public_meta=PROTECTED_SIGNING_PUBLIC_META,
+    )
     _create(vault, name="STATIC_KEY", protection="protected", policy={"always_ask": True})
     with vault.begin() as conn:
         with pytest.raises(vs.NotGrantableError):
@@ -1317,7 +1371,14 @@ def test_grant_creation_rejects_expected_member_mismatch_without_claiming_reques
 def test_grant_creation_must_match_pending_access_request(vault):
     _create(vault, name="A_KEY", protection="protected")
     _create(vault, name="B_KEY", protection="protected")
-    _create(vault, name="ETH_KEY", protection="protected", kind="keypair", signer_kind="local")
+    _create(
+        vault,
+        name="ETH_KEY",
+        protection="protected",
+        kind="keypair",
+        signer_kind="local",
+        public_meta=PROTECTED_SIGNING_PUBLIC_META,
+    )
     with vault.begin() as conn:
         access_req = _access_request(conn, "A_KEY", session_id="ses_1")
         sign_req = vs.create_sign_request(conn, "ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")
@@ -1377,7 +1438,14 @@ def test_grant_creation_rejects_expired_access_request(vault):
 
 def test_rotating_protected_secret_expires_pending_access_and_sign_requests(vault):
     _create(vault, name="A_KEY", protection="protected")
-    _create(vault, name="ETH_KEY", protection="protected", kind="keypair", signer_kind="local")
+    _create(
+        vault,
+        name="ETH_KEY",
+        protection="protected",
+        kind="keypair",
+        signer_kind="local",
+        public_meta=PROTECTED_SIGNING_PUBLIC_META,
+    )
     with vault.begin() as conn:
         access_req = _access_request(conn, "A_KEY", session_id="ses_1")
         vs.rotate_secret(conn, "A_KEY", _sealed("rotated"))
@@ -1478,7 +1546,14 @@ def test_deleting_standard_secret_expires_pending_access_and_sign_requests(vault
 
 
 def test_sign_request_completion_can_only_claim_pending_once(vault):
-    _create(vault, name="ETH_KEY", protection="protected", kind="keypair", signer_kind="local")
+    _create(
+        vault,
+        name="ETH_KEY",
+        protection="protected",
+        kind="keypair",
+        signer_kind="local",
+        public_meta=PROTECTED_SIGNING_PUBLIC_META,
+    )
     digest = "00" * 32
     with vault.begin() as conn:
         sign_req = vs.create_sign_request(conn, "ETH_KEY", digest=digest, scheme="ecdsa-secp256k1-recoverable")
@@ -1560,7 +1635,14 @@ def test_claim_sign_request_prevents_concurrent_deny_before_completion(vault):
 
 
 def test_sign_request_completion_rejects_malformed_signatures(vault):
-    _create(vault, name="ETH_KEY", protection="protected", kind="keypair", signer_kind="local")
+    _create(
+        vault,
+        name="ETH_KEY",
+        protection="protected",
+        kind="keypair",
+        signer_kind="local",
+        public_meta=PROTECTED_SIGNING_PUBLIC_META,
+    )
     digest = "00" * 32
     with vault.begin() as conn:
         req = vs.create_sign_request(conn, "ETH_KEY", digest=digest, scheme="ecdsa-secp256k1-recoverable")

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1076,6 +1076,7 @@ def test_agent_created_request_hydrates_only_for_ui_inbox(vault):
             requester={"source": "agent-cli", "session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
         )
+        ui_payload = vs.get_request(conn, req["id"])
         agent_payload = vs.get_request(conn, req["id"], audience=vs.REQUEST_AUDIENCE_AGENT)
         listed = vs.list_requests(conn)
 
@@ -1084,6 +1085,10 @@ def test_agent_created_request_hydrates_only_for_ui_inbox(vault):
     assert "unlock_material" not in agent_encoded
     assert "ct-protected" not in agent_encoded
     assert "wm-protected" not in agent_encoded
+    ui_encoded = json.dumps({"ui": ui_payload, "listed": listed})
+    assert "unlock_material" in ui_encoded
+    assert "ct-protected" in ui_encoded
+    assert "wm-protected" in ui_encoded
     group_option = next(option for option in listed[0]["card"]["scope_options"] if option["scope_type"] == "group")
     assert group_option["unlock_material"] == [
         {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -117,7 +117,7 @@ export type VaultAccessFulfillmentPayload = {
   agent_pubkey?: { public_key?: string; fingerprint?: string };
   deks?: Array<{ name: string; dek_blindbox: VaultBlindBox; approval: Record<string, unknown> }>;
   agent_deks?: Array<{ name: string; dek_blindbox: VaultBlindBox; approval: Record<string, unknown> }>;
-  deks_by_secret?: Record<string, { dek_blindbox: VaultBlindBox; approval: Record<string, unknown> } | VaultBlindBox>;
+  deks_by_secret?: Record<string, { dek_blindbox: VaultBlindBox; approval: Record<string, unknown> }>;
 };
 
 export type ApiContextType = {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -108,6 +108,18 @@ export type VaultCreatePayload = {
   establishing_vmk?: boolean;
 };
 
+export type VaultAccessFulfillmentPayload = {
+  scope_type?: 'secret' | 'skill' | 'group';
+  scope_ref?: string;
+  session_id?: string | null;
+  ttl_seconds?: number;
+  this_session_only?: boolean;
+  agent_pubkey?: { public_key?: string; fingerprint?: string };
+  deks?: Array<{ name: string; dek_blindbox: VaultBlindBox; approval: Record<string, unknown> }>;
+  agent_deks?: Array<{ name: string; dek_blindbox: VaultBlindBox; approval: Record<string, unknown> }>;
+  deks_by_secret?: Record<string, { dek_blindbox: VaultBlindBox; approval: Record<string, unknown> } | VaultBlindBox>;
+};
+
 export type ApiContextType = {
   getConfig: () => Promise<any>;
   getPlatformCatalog: () => Promise<any>;
@@ -320,6 +332,7 @@ export type ApiContextType = {
   getVaultRequests: (params?: { status?: string; type?: string; limit?: number }) => Promise<{ ok: boolean; requests: VaultRequest[] }>;
   getVaultGrants: (params?: { status?: string; sessionId?: string }, opts?: { handleError?: boolean }) => Promise<{ ok: boolean; grants: VaultGrant[] }>;
   createVaultGrant: (payload: Record<string, unknown>) => Promise<{ ok: boolean; grant: VaultGrant; code?: string; message?: string }>;
+  fulfillVaultAccessRequest: (requestId: string, payload: VaultAccessFulfillmentPayload) => Promise<{ ok: boolean; request_id?: string; grant?: VaultGrant; result?: { type: string; grant?: VaultGrant }; code?: string; message?: string }>;
   revokeVaultGrant: (grantId: string) => Promise<{ ok: boolean; grant?: VaultGrant; code?: string; message?: string }>;
   signVaultDigest: (payload: Record<string, unknown>) => Promise<{ ok: boolean; signature?: Record<string, unknown>; request?: VaultRequest; code?: string; message?: string }>;
   pinVaultPubkey: (payload: Record<string, unknown>) => Promise<{ ok: boolean; secret?: VaultSecret; code?: string; message?: string }>;
@@ -2043,6 +2056,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       return getCachedJson(qs ? `/api/vault/grants?${qs}` : '/api/vault/grants', 1500, opts);
     },
     createVaultGrant: (payload) => postJson('/api/vault/grants', payload),
+    fulfillVaultAccessRequest: (requestId, payload) => postJson(`/api/vault/requests/${encodeURIComponent(requestId)}/fulfill-access`, payload),
     revokeVaultGrant: (grantId) => deleteJson(`/api/vault/grants/${encodeURIComponent(grantId)}`),
     signVaultDigest: (payload) => postJson('/api/vault/sign', payload),
     pinVaultPubkey: (payload) => postJson('/api/vault/pubkey-pin', payload),

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1516,13 +1516,14 @@ def _vault_request_result(conn, request: dict) -> dict | None:
     return None
 
 
-def get_vault_request(request_id: str) -> dict:
+def get_vault_request(request_id: str, *, audience: str | None = None) -> dict:
     from storage import vault_service
 
+    request_audience = audience or vault_service.REQUEST_AUDIENCE_AGENT
     engine = _vault_engine()
     try:
         with engine.begin() as conn:
-            request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
+            request = vault_service.get_request(conn, request_id, audience=request_audience)
             result = _vault_request_result(conn, request)
     except vault_service.RequestNotFoundError as exc:
         raise VaultApiError(f"request '{request_id}' not found", code="request_not_found", status=404) from exc
@@ -1581,13 +1582,7 @@ def request_vault_access(payload: dict) -> dict:
     engine = _vault_engine()
     try:
         with engine.begin() as conn:
-            meta = vault_service.get_secret_meta(conn, name)
-            if meta.get("protection") == "protected":
-                raise VaultApiError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
-                    status=409,
-                )
+            vault_service.get_secret_meta(conn, name)
             request = vault_service.create_access_request(
                 conn,
                 name,
@@ -1627,12 +1622,6 @@ def request_vault_sign(payload: dict) -> dict:
                 raise VaultApiError(
                     f"secret '{name}' uses signer_kind '{meta.get('signer_kind')}', which is not locally signable",
                     code="unsupported_signer_kind",
-                    status=409,
-                )
-            if meta.get("protection") == "protected":
-                raise VaultApiError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
                     status=409,
                 )
             request = vault_service.create_sign_request(
@@ -1711,6 +1700,63 @@ def _agent_grant_cached_all(result: dict, expected_count: int) -> bool:
         return int(granted) == expected_count
     except (TypeError, ValueError):
         return False
+
+
+def _grant_dek_entries_from_payload(payload: dict) -> object:
+    deks = payload.get("deks")
+    if deks is None:
+        deks = payload.get("agent_deks")
+    if deks is None and isinstance(payload.get("deks_by_secret"), dict):
+        deks = []
+        for name, dek in payload["deks_by_secret"].items():
+            if isinstance(dek, dict) and "dek_blindbox" in dek:
+                deks.append(
+                    {
+                        "name": name,
+                        "dek_blindbox": dek.get("dek_blindbox"),
+                        "approval": dek.get("approval"),
+                    }
+                )
+            else:
+                deks.append({"name": name, "dek_blindbox": dek, "approval": None})
+    return deks
+
+
+def _resident_agent_deks_from_payload(payload: dict, *, needs_agent_deks: bool) -> list[dict[str, Any]]:
+    deks = _grant_dek_entries_from_payload(payload)
+    if deks is None and not needs_agent_deks:
+        return []
+    if not isinstance(deks, list) or (needs_agent_deks and not deks):
+        raise VaultApiError("resident agent grant requires sealed DEKs", code="invalid_grant")
+    agent_deks: list[dict[str, Any]] = []
+    allowed_keys = {"name", "dek_blindbox", "approval"}
+    for item in deks:
+        if not isinstance(item, dict):
+            raise VaultApiError("resident agent grant DEKs must be objects", code="invalid_grant")
+        extra_keys = set(item) - allowed_keys
+        if extra_keys:
+            raise VaultApiError("resident agent grant DEKs must contain only opaque blind-box metadata", code="invalid_grant")
+        name = item.get("name")
+        dek_blindbox = item.get("dek_blindbox")
+        approval = item.get("approval")
+        if not isinstance(name, str) or not name or not isinstance(dek_blindbox, dict) or not isinstance(approval, dict):
+            raise VaultApiError("resident agent grant DEKs require name, dek_blindbox, and approval", code="invalid_grant")
+        agent_deks.append({"name": name, "dek_blindbox": dek_blindbox, "approval": approval})
+    return agent_deks
+
+
+def _access_request_secret_name(request_id: str) -> str:
+    from storage import vault_service
+
+    engine = _vault_engine()
+    with engine.begin() as conn:
+        request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
+    if request.get("request_type") != "access":
+        raise VaultApiError("access fulfillment must target an access request", code="invalid_request", status=409)
+    name = str(request.get("secret_name") or "").strip()
+    if not name:
+        raise VaultApiError("access request is missing a secret name", code="invalid_request", status=409)
+    return name
 
 
 def _grant_scope_payload(grant: dict) -> list[dict[str, str]]:
@@ -1805,30 +1851,7 @@ def create_vault_grant(payload: dict) -> dict:
     protected_member_names = {str(member["name"]) for member in grantable_members if member.get("protection") == "protected"}
     needs_agent_deks = bool(protected_member_names)
 
-    deks = payload.get("deks")
-    if deks is None:
-        deks = payload.get("agent_deks")
-    if deks is None and isinstance(payload.get("deks_by_secret"), dict):
-        deks = [
-            {"name": name, **dek}
-            if isinstance(dek, dict)
-            else {"name": name, "dek_blindbox": dek}
-            for name, dek in payload["deks_by_secret"].items()
-        ]
-    if deks is None and not needs_agent_deks:
-        deks = []
-    if not isinstance(deks, list) or (needs_agent_deks and not deks):
-        raise VaultApiError("resident agent grant requires sealed DEKs", code="invalid_grant")
-    agent_deks: list[dict[str, Any]] = []
-    for item in deks:
-        if not isinstance(item, dict):
-            raise VaultApiError("resident agent grant DEKs must be objects", code="invalid_grant")
-        name = item.get("name")
-        dek_blindbox = item.get("dek_blindbox")
-        approval = item.get("approval")
-        if not isinstance(name, str) or not name or not isinstance(dek_blindbox, dict) or not isinstance(approval, dict):
-            raise VaultApiError("resident agent grant DEKs require name, dek_blindbox, and approval", code="invalid_grant")
-        agent_deks.append({"name": name, "dek_blindbox": dek_blindbox, "approval": approval})
+    agent_deks = _resident_agent_deks_from_payload(payload, needs_agent_deks=needs_agent_deks)
     provided_names = {item["name"] for item in agent_deks}
     if needs_agent_deks and provided_names != protected_member_names:
         raise VaultApiError("resident agent DEKs must match the protected grant members", code="invalid_grant")
@@ -1917,6 +1940,31 @@ def create_vault_grant(payload: dict) -> dict:
             )
         raise
     return {"ok": True, "grant": grant}
+
+
+def fulfill_vault_access_request(request_id: str, payload: dict | None = None) -> dict:
+    """Approve an access request by relaying browser blind-boxed DEKs to avault.
+
+    The submitted DEKs are HPKE blind boxes addressed to the resident avault
+    agent. Python validates only metadata and forwards the opaque boxes; it never
+    opens a protected DEK or protected plaintext.
+    """
+
+    body = dict(payload) if isinstance(payload, dict) else {}
+    request_id = str(request_id or "").strip()
+    if not request_id:
+        raise VaultApiError("request_id is required to fulfill protected access", code="missing_request_id")
+    if not body.get("scope_type") or not body.get("scope_ref"):
+        body.setdefault("scope_type", "secret")
+        body.setdefault("scope_ref", _access_request_secret_name(request_id))
+    body["request_id"] = request_id
+    created = create_vault_grant(body)
+    return {
+        "ok": True,
+        "request_id": request_id,
+        "grant": created["grant"],
+        "result": {"type": "grant", "grant": created["grant"]},
+    }
 
 
 def _sign_digest_from_payload(value: object) -> str:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2069,6 +2069,17 @@ def _signature_bytes_for_verification(signature: dict[str, Any]) -> bytes:
         raise _protected_sign_invalid("signature must be hex-encoded bytes") from exc
 
 
+def _normalized_protected_signature(signature: dict[str, Any]) -> dict[str, Any]:
+    allowed_keys = {"signature", "recovery_id"}
+    extra_keys = set(signature) - allowed_keys
+    if extra_keys:
+        raise _protected_sign_invalid(f"signature payload contains unsupported fields: {', '.join(sorted(extra_keys))}")
+    normalized = {"signature": signature.get("signature")}
+    if signature.get("recovery_id") is not None:
+        normalized["recovery_id"] = signature.get("recovery_id")
+    return normalized
+
+
 def _verify_protected_ecdsa_signature(
     *,
     public_key_bytes: bytes,
@@ -2361,6 +2372,7 @@ def vault_sign(payload: dict) -> dict:
                 if not request_id:
                     raise VaultApiError("request_id is required to complete protected signing", code="missing_request_id")
                 vault_service.validate_sign_request(conn, request_id, name=name, digest=digest, scheme=scheme)
+                signature = _normalized_protected_signature(signature)
                 _verify_protected_browser_signature(meta, digest=digest, scheme=scheme, signature=signature)
                 request = vault_service.complete_sign_request(
                     conn,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1702,6 +1702,24 @@ def _agent_grant_cached_all(result: dict, expected_count: int) -> bool:
         return False
 
 
+def _restore_access_request_after_failed_agent_grant(
+    *,
+    engine: Any,
+    request_id: str,
+    member_names: list[str] | set[str] | tuple[str, ...] | None,
+    session_id: str | None,
+) -> None:
+    from storage import vault_service
+
+    with contextlib.suppress(Exception), engine.begin() as conn:
+        vault_service.restore_access_request_after_failed_grant(
+            conn,
+            created_by_request_id=str(request_id),
+            member_names=list(member_names or []),
+            session_id=session_id,
+        )
+
+
 def _grant_dek_entries_from_payload(payload: dict) -> object:
     deks = payload.get("deks")
     if deks is None:
@@ -1948,6 +1966,12 @@ def create_vault_grant(payload: dict) -> dict:
                 force_release_on_cleanup_failure=True,
                 force_release_scope=True,
             )
+            _restore_access_request_after_failed_agent_grant(
+                engine=engine,
+                request_id=str(request_id),
+                member_names=expected_member_names,
+                session_id=str(grant.get("session_id") or "") or None,
+            )
         raise VaultApiError(str(exc), code="invalid_grant") from exc
     except AvaultError as exc:
         _cleanup_failed_agent_grant(
@@ -1957,13 +1981,12 @@ def create_vault_grant(payload: dict) -> dict:
             force_release_on_cleanup_failure=True,
             force_release_scope=True,
         )
-        with contextlib.suppress(Exception), engine.begin() as conn:
-            vault_service.restore_access_request_after_failed_grant(
-                conn,
-                created_by_request_id=str(request_id),
-                member_names=list(expected_member_names or []),
-                session_id=str(grant.get("session_id") or "") or None,
-            )
+        _restore_access_request_after_failed_agent_grant(
+            engine=engine,
+            request_id=str(request_id),
+            member_names=expected_member_names,
+            session_id=str(grant.get("session_id") or "") or None,
+        )
         raise _vault_api_error_from_avault(exc, prefix="avault agent grant failed") from exc
     except Exception:
         if agent_relayed:
@@ -2080,6 +2103,14 @@ def _verify_protected_ecdsa_signature(
         public_key.verify(sig_bytes, digest_bytes, ec.ECDSA(utils.Prehashed(hashes.SHA256())))
     except InvalidSignature as exc:
         raise _protected_sign_invalid("browser signature does not verify against signing_public_key") from exc
+    if scheme == "ecdsa-secp256k1-recoverable":
+        _verify_recoverable_signature_recovery_id(
+            public_key_bytes=public_key_bytes,
+            digest_bytes=digest_bytes,
+            r=r,
+            s=s,
+            recovery_id=recovery_id,
+        )
 
 
 _SECP256K1_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
@@ -2091,12 +2122,37 @@ _SECP256K1_G = (
 _Secp256k1Point = tuple[int, int] | None
 
 
+def _secp256k1_mod_sqrt(value: int) -> int | None:
+    root = pow(value, (_SECP256K1_P + 1) // 4, _SECP256K1_P)
+    return root if pow(root, 2, _SECP256K1_P) == value % _SECP256K1_P else None
+
+
+def _secp256k1_decompress_public_key(public_key_bytes: bytes) -> _Secp256k1Point:
+    if len(public_key_bytes) == 33 and public_key_bytes[0] in {2, 3}:
+        x = int.from_bytes(public_key_bytes[1:], "big")
+        if x >= _SECP256K1_P:
+            return None
+        y = _secp256k1_mod_sqrt((pow(x, 3, _SECP256K1_P) + 7) % _SECP256K1_P)
+        if y is None:
+            return None
+        if (y % 2) != (public_key_bytes[0] & 1):
+            y = _SECP256K1_P - y
+        return (x, y)
+    if len(public_key_bytes) == 65 and public_key_bytes[0] == 4:
+        x = int.from_bytes(public_key_bytes[1:33], "big")
+        y = int.from_bytes(public_key_bytes[33:], "big")
+        if x >= _SECP256K1_P or y >= _SECP256K1_P or (pow(y, 2, _SECP256K1_P) - pow(x, 3, _SECP256K1_P) - 7) % _SECP256K1_P:
+            return None
+        return (x, y)
+    return None
+
+
 def _secp256k1_lift_x(x: int) -> _Secp256k1Point:
     if x >= _SECP256K1_P:
         return None
     y_sq = (pow(x, 3, _SECP256K1_P) + 7) % _SECP256K1_P
-    y = pow(y_sq, (_SECP256K1_P + 1) // 4, _SECP256K1_P)
-    if pow(y, 2, _SECP256K1_P) != y_sq:
+    y = _secp256k1_mod_sqrt(y_sq)
+    if y is None:
         return None
     return (x, y if y % 2 == 0 else _SECP256K1_P - y)
 
@@ -2128,6 +2184,47 @@ def _secp256k1_mul(scalar: int, point: _Secp256k1Point) -> _Secp256k1Point:
         addend = _secp256k1_add(addend, addend)
         scalar >>= 1
     return result
+
+
+def _secp256k1_recover_ecdsa_public_key(r: int, s: int, digest_bytes: bytes, recovery_id: int) -> _Secp256k1Point:
+    if not (1 <= r < _SECP256K1_N and 1 <= s < _SECP256K1_N):
+        return None
+    x = r + (recovery_id >> 1) * _SECP256K1_N
+    if x >= _SECP256K1_P:
+        return None
+    y = _secp256k1_mod_sqrt((pow(x, 3, _SECP256K1_P) + 7) % _SECP256K1_P)
+    if y is None:
+        return None
+    if (y % 2) != (recovery_id & 1):
+        y = _SECP256K1_P - y
+    point_r = (x, y)
+    if _secp256k1_mul(_SECP256K1_N, point_r) is not None:
+        return None
+    z = int.from_bytes(digest_bytes, "big") % _SECP256K1_N
+    r_inv = pow(r, -1, _SECP256K1_N)
+    return _secp256k1_mul(
+        r_inv,
+        _secp256k1_add(
+            _secp256k1_mul(s, point_r),
+            _secp256k1_mul(z, (_SECP256K1_G[0], (-_SECP256K1_G[1]) % _SECP256K1_P)),
+        ),
+    )
+
+
+def _verify_recoverable_signature_recovery_id(
+    *,
+    public_key_bytes: bytes,
+    digest_bytes: bytes,
+    r: int,
+    s: int,
+    recovery_id: int,
+) -> None:
+    expected = _secp256k1_decompress_public_key(public_key_bytes)
+    if expected is None:
+        raise _protected_sign_invalid("protected signing public key is not a valid secp256k1 point")
+    recovered = _secp256k1_recover_ecdsa_public_key(r, s, digest_bytes, recovery_id)
+    if recovered != expected:
+        raise _protected_sign_invalid("recoverable signature recovery_id does not match signing_public_key")
 
 
 def _bip340_tagged_hash(tag: str, payload: bytes) -> bytes:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1709,14 +1709,8 @@ def _grant_dek_entries_from_payload(payload: dict) -> object:
     if deks is None and isinstance(payload.get("deks_by_secret"), dict):
         deks = []
         for name, dek in payload["deks_by_secret"].items():
-            if isinstance(dek, dict) and "dek_blindbox" in dek:
-                deks.append(
-                    {
-                        "name": name,
-                        "dek_blindbox": dek.get("dek_blindbox"),
-                        "approval": dek.get("approval"),
-                    }
-                )
+            if isinstance(dek, dict):
+                deks.append({"name": name, **dek})
             else:
                 deks.append({"name": name, "dek_blindbox": dek, "approval": None})
     return deks
@@ -1749,8 +1743,11 @@ def _access_request_secret_name(request_id: str) -> str:
     from storage import vault_service
 
     engine = _vault_engine()
-    with engine.begin() as conn:
-        request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
+    try:
+        with engine.begin() as conn:
+            request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
+    except vault_service.RequestNotFoundError as exc:
+        raise VaultApiError(f"request '{request_id}' not found", code="request_not_found", status=404) from exc
     if request.get("request_type") != "access":
         raise VaultApiError("access fulfillment must target an access request", code="invalid_request", status=409)
     name = str(request.get("secret_name") or "").strip()
@@ -1928,6 +1925,13 @@ def create_vault_grant(payload: dict) -> dict:
             force_release_on_cleanup_failure=True,
             force_release_scope=True,
         )
+        with contextlib.suppress(Exception), engine.begin() as conn:
+            vault_service.restore_access_request_after_failed_grant(
+                conn,
+                created_by_request_id=str(request_id),
+                member_names=list(expected_member_names or []),
+                session_id=str(grant.get("session_id") or "") or None,
+            )
         raise _vault_api_error_from_avault(exc, prefix="avault agent grant failed") from exc
     except Exception:
         if agent_relayed:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1716,6 +1716,32 @@ def _grant_dek_entries_from_payload(payload: dict) -> object:
     return deks
 
 
+def _validate_resident_agent_dek_blindbox(blindbox: dict[str, Any]) -> dict[str, str]:
+    allowed_keys = {"scheme", "enc", "ct"}
+    if set(blindbox) != allowed_keys:
+        raise VaultApiError("resident agent grant DEKs must contain only opaque blind-box metadata", code="invalid_grant")
+    normalized: dict[str, str] = {}
+    for key in allowed_keys:
+        value = blindbox.get(key)
+        if not isinstance(value, str) or not value:
+            raise VaultApiError("resident agent grant DEK blind boxes require non-empty scheme, enc, and ct", code="invalid_grant")
+        normalized[key] = value
+    return normalized
+
+
+def _validate_resident_agent_dek_approval(approval: dict[str, Any]) -> dict[str, Any]:
+    allowed_keys = {"nonce", "expires_at_unix"}
+    if set(approval) != allowed_keys:
+        raise VaultApiError("resident agent grant DEKs must contain only opaque blind-box metadata", code="invalid_grant")
+    nonce = approval.get("nonce")
+    expires_at_unix = approval.get("expires_at_unix")
+    if not isinstance(nonce, str) or not nonce:
+        raise VaultApiError("resident agent grant DEK approvals require a non-empty nonce", code="invalid_grant")
+    if type(expires_at_unix) is not int:
+        raise VaultApiError("resident agent grant DEK approvals require expires_at_unix", code="invalid_grant")
+    return {"nonce": nonce, "expires_at_unix": expires_at_unix}
+
+
 def _resident_agent_deks_from_payload(payload: dict, *, needs_agent_deks: bool) -> list[dict[str, Any]]:
     deks = _grant_dek_entries_from_payload(payload)
     if deks is None and not needs_agent_deks:
@@ -1735,7 +1761,13 @@ def _resident_agent_deks_from_payload(payload: dict, *, needs_agent_deks: bool) 
         approval = item.get("approval")
         if not isinstance(name, str) or not name or not isinstance(dek_blindbox, dict) or not isinstance(approval, dict):
             raise VaultApiError("resident agent grant DEKs require name, dek_blindbox, and approval", code="invalid_grant")
-        agent_deks.append({"name": name, "dek_blindbox": dek_blindbox, "approval": approval})
+        agent_deks.append(
+            {
+                "name": name,
+                "dek_blindbox": _validate_resident_agent_dek_blindbox(dek_blindbox),
+                "approval": _validate_resident_agent_dek_approval(approval),
+            }
+        )
     return agent_deks
 
 
@@ -1984,6 +2016,190 @@ def _sign_digest_from_payload(value: object) -> str:
     return digest.lower()
 
 
+def _protected_sign_invalid(message: str) -> VaultApiError:
+    return VaultApiError(message, code="invalid_request", status=409)
+
+
+def _protected_signing_public_key_bytes(meta: dict) -> bytes:
+    signing_key = meta.get("signing_public_key")
+    if not isinstance(signing_key, dict):
+        raise _protected_sign_invalid("protected signing key is missing signing_public_key")
+    if signing_key.get("curve") != "secp256k1":
+        raise _protected_sign_invalid("protected signing key must use secp256k1")
+    public_key = signing_key.get("public_key")
+    if not isinstance(public_key, str) or not public_key:
+        raise _protected_sign_invalid("protected signing key is missing a public key")
+    try:
+        public_key_bytes = bytes.fromhex(public_key)
+    except ValueError as exc:
+        raise _protected_sign_invalid("protected signing public key must be hex-encoded") from exc
+    return public_key_bytes
+
+
+def _signature_bytes_for_verification(signature: dict[str, Any]) -> bytes:
+    raw_signature = signature.get("signature")
+    if not isinstance(raw_signature, str) or not raw_signature:
+        raise _protected_sign_invalid("signature payload requires a non-empty signature")
+    try:
+        return bytes.fromhex(raw_signature)
+    except ValueError as exc:
+        raise _protected_sign_invalid("signature must be hex-encoded bytes") from exc
+
+
+def _verify_protected_ecdsa_signature(
+    *,
+    public_key_bytes: bytes,
+    digest_bytes: bytes,
+    scheme: str,
+    signature: dict[str, Any],
+) -> None:
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+    sig_bytes = _signature_bytes_for_verification(signature)
+    recovery_id = signature.get("recovery_id")
+    try:
+        public_key = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256K1(), public_key_bytes)
+    except ValueError as exc:
+        raise _protected_sign_invalid("protected signing public key is not a valid secp256k1 point") from exc
+    if scheme == "ecdsa-secp256k1-recoverable":
+        if len(sig_bytes) != 64:
+            raise _protected_sign_invalid("recoverable secp256k1 signatures must be 64 bytes")
+        if type(recovery_id) is not int or recovery_id not in {0, 1, 2, 3}:
+            raise _protected_sign_invalid("recoverable secp256k1 signatures require recovery_id 0..3")
+        r = int.from_bytes(sig_bytes[:32], "big")
+        s = int.from_bytes(sig_bytes[32:], "big")
+        sig_bytes = utils.encode_dss_signature(r, s)
+    else:
+        if len(sig_bytes) < 8 or sig_bytes[0] != 0x30:
+            raise _protected_sign_invalid("DER secp256k1 signatures must be DER-encoded")
+        if recovery_id is not None:
+            raise _protected_sign_invalid("DER secp256k1 signatures must not include recovery_id")
+    try:
+        public_key.verify(sig_bytes, digest_bytes, ec.ECDSA(utils.Prehashed(hashes.SHA256())))
+    except InvalidSignature as exc:
+        raise _protected_sign_invalid("browser signature does not verify against signing_public_key") from exc
+
+
+_SECP256K1_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+_SECP256K1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+_SECP256K1_G = (
+    0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798,
+    0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8,
+)
+_Secp256k1Point = tuple[int, int] | None
+
+
+def _secp256k1_lift_x(x: int) -> _Secp256k1Point:
+    if x >= _SECP256K1_P:
+        return None
+    y_sq = (pow(x, 3, _SECP256K1_P) + 7) % _SECP256K1_P
+    y = pow(y_sq, (_SECP256K1_P + 1) // 4, _SECP256K1_P)
+    if pow(y, 2, _SECP256K1_P) != y_sq:
+        return None
+    return (x, y if y % 2 == 0 else _SECP256K1_P - y)
+
+
+def _secp256k1_add(point_a: _Secp256k1Point, point_b: _Secp256k1Point) -> _Secp256k1Point:
+    if point_a is None:
+        return point_b
+    if point_b is None:
+        return point_a
+    x1, y1 = point_a
+    x2, y2 = point_b
+    if x1 == x2 and (y1 + y2) % _SECP256K1_P == 0:
+        return None
+    if point_a == point_b:
+        slope = (3 * x1 * x1 * pow(2 * y1, -1, _SECP256K1_P)) % _SECP256K1_P
+    else:
+        slope = ((y2 - y1) * pow(x2 - x1, -1, _SECP256K1_P)) % _SECP256K1_P
+    x3 = (slope * slope - x1 - x2) % _SECP256K1_P
+    y3 = (slope * (x1 - x3) - y1) % _SECP256K1_P
+    return (x3, y3)
+
+
+def _secp256k1_mul(scalar: int, point: _Secp256k1Point) -> _Secp256k1Point:
+    result: _Secp256k1Point = None
+    addend = point
+    while scalar:
+        if scalar & 1:
+            result = _secp256k1_add(result, addend)
+        addend = _secp256k1_add(addend, addend)
+        scalar >>= 1
+    return result
+
+
+def _bip340_tagged_hash(tag: str, payload: bytes) -> bytes:
+    import hashlib
+
+    tag_hash = hashlib.sha256(tag.encode("utf-8")).digest()
+    return hashlib.sha256(tag_hash + tag_hash + payload).digest()
+
+
+def _xonly_public_key(public_key_bytes: bytes) -> bytes:
+    if len(public_key_bytes) == 32:
+        x_only = public_key_bytes
+    elif len(public_key_bytes) == 33 and public_key_bytes[0] in {2, 3}:
+        x_only = public_key_bytes[1:]
+    elif len(public_key_bytes) == 65 and public_key_bytes[0] == 4:
+        x_only = public_key_bytes[1:33]
+        x = int.from_bytes(x_only, "big")
+        y = int.from_bytes(public_key_bytes[33:], "big")
+        if x >= _SECP256K1_P or y >= _SECP256K1_P or (pow(y, 2, _SECP256K1_P) - pow(x, 3, _SECP256K1_P) - 7) % _SECP256K1_P:
+            raise _protected_sign_invalid("protected signing public key is not a valid secp256k1 point")
+    else:
+        raise _protected_sign_invalid("protected signing public key must be compressed, uncompressed, or x-only secp256k1")
+    if _secp256k1_lift_x(int.from_bytes(x_only, "big")) is None:
+        raise _protected_sign_invalid("protected signing public key is not a valid secp256k1 point")
+    return x_only
+
+
+def _verify_protected_schnorr_signature(
+    *,
+    public_key_bytes: bytes,
+    digest_bytes: bytes,
+    signature: dict[str, Any],
+) -> None:
+    sig_bytes = _signature_bytes_for_verification(signature)
+    if len(sig_bytes) != 64:
+        raise _protected_sign_invalid("BIP340 Schnorr signatures must be 64 bytes")
+    if signature.get("recovery_id") is not None:
+        raise _protected_sign_invalid("BIP340 Schnorr signatures must not include recovery_id")
+    public_key_xonly = _xonly_public_key(public_key_bytes)
+    r = int.from_bytes(sig_bytes[:32], "big")
+    s = int.from_bytes(sig_bytes[32:], "big")
+    if r >= _SECP256K1_P or s >= _SECP256K1_N:
+        raise _protected_sign_invalid("browser signature does not verify against signing_public_key")
+    point_p = _secp256k1_lift_x(int.from_bytes(public_key_xonly, "big"))
+    if point_p is None:
+        raise _protected_sign_invalid("protected signing public key is not a valid secp256k1 point")
+    challenge = int.from_bytes(_bip340_tagged_hash("BIP0340/challenge", sig_bytes[:32] + public_key_xonly + digest_bytes), "big") % _SECP256K1_N
+    point_r = _secp256k1_add(
+        _secp256k1_mul(s, _SECP256K1_G),
+        _secp256k1_mul(challenge, (point_p[0], (-point_p[1]) % _SECP256K1_P)),
+    )
+    if point_r is None or point_r[1] % 2 != 0 or point_r[0] != r:
+        raise _protected_sign_invalid("browser signature does not verify against signing_public_key")
+
+
+def _verify_protected_browser_signature(meta: dict, *, digest: str, scheme: str, signature: dict[str, Any]) -> None:
+    public_key_bytes = _protected_signing_public_key_bytes(meta)
+    digest_bytes = bytes.fromhex(digest)
+    if scheme in {"ecdsa-secp256k1-recoverable", "ecdsa-secp256k1-der"}:
+        _verify_protected_ecdsa_signature(
+            public_key_bytes=public_key_bytes,
+            digest_bytes=digest_bytes,
+            scheme=scheme,
+            signature=signature,
+        )
+        return
+    if scheme == "schnorr-secp256k1-bip340":
+        _verify_protected_schnorr_signature(public_key_bytes=public_key_bytes, digest_bytes=digest_bytes, signature=signature)
+        return
+    raise _protected_sign_invalid(f"unsupported signature scheme: {scheme}")
+
+
 def revoke_vault_grant(grant_id: str) -> dict:
     from storage import vault_service
 
@@ -2047,6 +2263,8 @@ def vault_sign(payload: dict) -> dict:
                 request_id = str(payload.get("request_id") or "")
                 if not request_id:
                     raise VaultApiError("request_id is required to complete protected signing", code="missing_request_id")
+                vault_service.validate_sign_request(conn, request_id, name=name, digest=digest, scheme=scheme)
+                _verify_protected_browser_signature(meta, digest=digest, scheme=scheme, signature=signature)
                 request = vault_service.complete_sign_request(
                     conn,
                     request_id,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3828,13 +3828,7 @@ def cmd_vault_access(args):
             raise TaskCliError(f"invalid secret name: {name!r} (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name", help_command=help_command)
         engine = _open_vault_engine()
         with engine.begin() as conn:
-            meta = vault_service.get_secret_meta(conn, name)
-            if meta.get("protection") == "protected":
-                raise TaskCliError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
-                    help_command=help_command,
-                )
+            vault_service.get_secret_meta(conn, name)
             request = vault_service.create_access_request(
                 conn,
                 name,
@@ -4568,12 +4562,6 @@ def cmd_vault_sign(args):
                 raise TaskCliError(
                     f"secret '{name}' is not locally signable",
                     code="unsupported_signer_kind",
-                    help_command=help_command,
-                )
-            if meta.get("protection") == "protected":
-                raise TaskCliError(
-                    "protected signing/access requires the browser sandbox (next version)",
-                    code="protected_requires_browser_sandbox",
                     help_command=help_command,
                 )
             request = vault_service.create_sign_request(
@@ -8116,8 +8104,9 @@ def build_parser():
         "access",
         help="Request approval to use a static secret",
         description=(
-            "Create a pending access request for a standard static secret in the current Agent Session. "
-            "The user approves it into a scope grant; then run/fetch/inject can deliver the value through avault."
+            "Create a pending access request for a static secret in the current Agent Session. "
+            "For protected secrets, the browser releases only an avault-bound DEK blind box; "
+            "then run/fetch/inject deliver the value inside avault."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         error_help_command="vibe vault access --help",
@@ -8133,8 +8122,9 @@ def build_parser():
         "sign",
         help="Request one approved signature from a keypair secret",
         description=(
-            "Create a pending per-use signing request for a standard local keypair. "
-            "The approval path signs via avault; 'vibe vault await <request-id>' returns only the resulting signature."
+            "Create a pending per-use signing request for a local keypair. "
+            "Standard keys sign via avault; protected keys sign in the browser. "
+            "'vibe vault await <request-id>' returns only the resulting public signature."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         error_help_command="vibe vault sign --help",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3889,6 +3889,16 @@ def _agent_missing_grant(exc: Exception) -> bool:
     return "grant is missing or expired" in text or "grant does not cover" in text
 
 
+def _vault_cli_delivery_context(args, *, mode: str, **extra) -> tuple[dict, dict, str | None]:
+    session_id = _vault_cli_session_id(args)
+    requester = {"source": "cli", "pid": os.getpid()}
+    delivery = {"mode": mode, **extra}
+    if session_id:
+        requester["session_id"] = session_id
+        delivery["session_id"] = session_id
+    return requester, delivery, session_id
+
+
 def _preflight_vault_names(engine, names: list[str], *, mixed_message: str, mixed_code: str = "mixed_protection_tiers") -> dict[str, dict]:
     from storage import vault_service
 
@@ -4183,13 +4193,14 @@ def _resolve_cli_output_path(path: str) -> str:
     return str(output_path)
 
 
-def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str]):
+def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str], *, args=None):
     from storage import vault_service
 
+    requester, delivery, session_id = _vault_cli_delivery_context(args, mode="run", command=command_argv)
     metas = _preflight_vault_run_batch(engine, mapping)
     if metas and {str(meta.get("protection") or "standard") for meta in metas.values()} == {"protected"}:
         with engine.begin() as conn:
-            common_grant = vault_service.find_active_grant_for_secrets(conn, list(mapping.values()))
+            common_grant = vault_service.find_active_grant_for_secrets(conn, list(mapping.values()), session_id=session_id)
             if common_grant is not None:
                 return common_grant, [
                     {"name": vault_name, "env": env_name, "envelope": vault_service.get_protected_envelope(conn, vault_name)}
@@ -4203,8 +4214,8 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
             resolved = vault_service.resolve_secret_access(
                 conn,
                 vault_name,
-                requester={"source": "cli", "pid": os.getpid()},
-                delivery={"mode": "run", "command": command_argv},
+                requester=requester,
+                delivery=delivery,
             )
             if resolved["status"] == "approval_required":
                 req = resolved.get("request") or {}
@@ -4272,13 +4283,14 @@ def _resolve_single_vault_delivery(
     raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
 
 
-def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: str):
+def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: str, args=None):
     from storage import vault_service
 
+    requester, delivery, session_id = _vault_cli_delivery_context(args, mode="inject", path=path, format=fmt)
     metas = _preflight_vault_inject_batch(engine, names)
     if metas and {str(meta.get("protection") or "standard") for meta in metas.values()} == {"protected"}:
         with engine.begin() as conn:
-            common_grant = vault_service.find_active_grant_for_secrets(conn, names)
+            common_grant = vault_service.find_active_grant_for_secrets(conn, names, session_id=session_id)
             if common_grant is not None:
                 return common_grant, [
                     {"name": name, "key": name, "envelope": vault_service.get_protected_envelope(conn, name)}
@@ -4292,8 +4304,8 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
             resolved = vault_service.resolve_secret_access(
                 conn,
                 name,
-                requester={"source": "cli", "pid": os.getpid()},
-                delivery={"mode": "inject", "path": path, "format": fmt},
+                requester=requester,
+                delivery=delivery,
             )
             if resolved["status"] == "approval_required":
                 req = resolved.get("request") or {}
@@ -4360,7 +4372,7 @@ def cmd_vault_run(args):
                 example="vibe vault run --env OPENAI_API_KEY -- python sync.py",
             )
         engine = _open_vault_engine()
-        grant, secrets = _resolve_vault_run_delivery(engine, mapping, command_argv)
+        grant, secrets = _resolve_vault_run_delivery(engine, mapping, command_argv, args=args)
     except vault_service.SecretNotFoundError as exc:
         _print_task_error(TaskCliError(f"secret '{exc}' not found", code="secret_not_found", help_command=help_command))
         return 1
@@ -4859,11 +4871,12 @@ def cmd_vault_fetch(args):
             "body": body.decode("utf-8") if isinstance(body, (bytes, bytearray)) else body,
             "inject": inject,
         }
+        requester, delivery, _session_id = _vault_cli_delivery_context(args, mode="fetch", host=host, method=method)
         grant, sealed = _resolve_single_vault_delivery(
             engine,
             name,
-            requester={"source": "cli", "pid": os.getpid()},
-            delivery={"mode": "fetch", "host": host, "method": method},
+            requester=requester,
+            delivery=delivery,
         )
         if grant is not None:
             result = api.avault_agent_deliver_fetch(
@@ -5013,7 +5026,7 @@ def cmd_vault_inject(args):
             raise TaskCliError(f"unknown --format: {fmt!r} (dotenv|json)", code="invalid_format", help_command=help_command)
         engine = _open_vault_engine()
         resolved_out = _resolve_cli_output_path(str(out))
-        grant, secrets = _resolve_vault_inject_delivery(engine, keys, path=resolved_out, fmt=fmt)
+        grant, secrets = _resolve_vault_inject_delivery(engine, keys, path=resolved_out, fmt=fmt, args=args)
         # avault writes the 0600 file atomically; if the path is unwritable it raises and no
         # delivery is recorded.
         if grant is not None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3861,6 +3861,7 @@ def _expire_agent_grant_after_missing(
     grant_id: str,
     names: list[str],
     *,
+    requester: dict | None = None,
     delivery: dict | None = None,
 ) -> dict | None:
     from storage import vault_service
@@ -3873,7 +3874,7 @@ def _expire_agent_grant_after_missing(
                 resolved = vault_service.resolve_secret_access(
                     conn,
                     name,
-                    requester={"source": "cli", "pid": os.getpid()},
+                    requester=requester or {"source": "cli", "pid": os.getpid()},
                     delivery=delivery or {},
                 )
                 if first_request is None and isinstance(resolved.get("request"), dict):
@@ -4423,11 +4424,13 @@ def cmd_vault_run(args):
         return 1
     except api.AvaultError as exc:
         if grant is not None and _agent_missing_grant(exc):
+            requester, delivery, _session_id = _vault_cli_delivery_context(args, mode="run", command=command_argv)
             _expire_agent_grant_after_missing(
                 engine,
                 grant["id"],
                 sorted(set(mapping.values())),
-                delivery={"mode": "run", "command": command_argv},
+                requester=requester,
+                delivery=delivery,
             )
             _print_task_error(TaskCliError("protected grant expired; approve the request again", code="approval_required", help_command=help_command))
             return 1
@@ -4924,7 +4927,8 @@ def cmd_vault_fetch(args):
                     engine,
                     grant_id,
                     [name],
-                    delivery={"mode": "fetch", "host": host, "method": method},
+                    requester=requester,
+                    delivery=delivery,
                 )
                 _print_task_error(TaskCliError("protected grant expired; approve the request again", code="approval_required", help_command=help_command))
                 return 1
@@ -5062,11 +5066,18 @@ def cmd_vault_inject(args):
         return 1
     except api.AvaultError as exc:
         if engine is not None and isinstance(grant, dict) and _agent_missing_grant(exc):
+            requester, delivery, _session_id = _vault_cli_delivery_context(
+                args,
+                mode="inject",
+                path=_resolve_cli_output_path(str(out)),
+                format=fmt,
+            )
             _expire_agent_grant_after_missing(
                 engine,
                 grant["id"],
                 keys,
-                delivery={"mode": "inject", "path": _resolve_cli_output_path(str(out)), "format": fmt},
+                requester=requester,
+                delivery=delivery,
             )
             _print_task_error(TaskCliError("protected grant expired; approve the request again", code="approval_required", help_command=help_command))
             return 1

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2736,9 +2736,10 @@ def vault_requests_get():
 @app.route("/api/vault/requests/<request_id>", methods=["GET"])
 def vault_request_get(request_id):
     from vibe import api
+    from storage import vault_service
 
     try:
-        return jsonify(api.get_vault_request(request_id))
+        return jsonify(api.get_vault_request(request_id, audience=vault_service.REQUEST_AUDIENCE_UI))
     except ValueError as exc:
         return _vault_error_response(exc)
 
@@ -2769,6 +2770,16 @@ def vault_request_deny_post(request_id):
 
     try:
         return jsonify(api.deny_vault_request(request_id, request.json or {}))
+    except ValueError as exc:
+        return _vault_error_response(exc)
+
+
+@app.route("/api/vault/requests/<request_id>/fulfill-access", methods=["POST"])
+def vault_request_fulfill_access_post(request_id):
+    from vibe import api
+
+    try:
+        return jsonify(api.fulfill_vault_access_request(request_id, request.json or {}))
     except ValueError as exc:
         return _vault_error_response(exc)
 


### PR DESCRIPTION
## Summary
- complete the protected-tier backend path by allowing agent access/sign requests for protected secrets
- add a narrow browser fulfillment endpoint that relays only avault-bound DEK blind boxes into the resident agent grant flow
- keep protected keypairs sign-only and reject any protected value-delivery request for keypairs
- expose the browser-facing request hydration needed to release protected DEKs while keeping agent-facing request reads value-free

## Frontend Contract
Protected sign completion:
- `POST /api/vault/sign`
- payload: `{ "name": string, "digest": string, "scheme": string, "request_id": string, "signature": { "signature": string, "recovery_id"?: number, ...publicMetadata } }`
- response includes only the public signature and the completed request; no DEK or private key material is submitted.

Protected static access fulfillment:
- browser reads `GET /api/vault/requests/<request_id>` to get protected envelope metadata in `request.card.secret_unlock_material` and, for group grants, `scope_options[].unlock_material`
- browser calls `releaseProtectedDek(..., protectedDekReleaseBlindBoxContext(name, { kind: "agent-deliver", ... }))`
- browser submits `POST /api/vault/requests/<request_id>/fulfill-access`
- payload: `{ "scope_type"?: "secret"|"skill"|"group", "scope_ref"?: string, "session_id"?: string, "ttl_seconds"?: number, "this_session_only"?: boolean, "agent_pubkey"?: { "public_key"?: string, "fingerprint"?: string }, "deks": [{ "name": string, "dek_blindbox": { "scheme": string, "enc": string, "ct": string }, "approval": object }] }`
- if `scope_type/scope_ref` are omitted, the backend defaults to the single requested secret scope
- backend rejects any DEK entry containing fields outside `name`, `dek_blindbox`, and `approval`; plaintext and raw DEKs must never be submitted

## Evidence
- `python3 -m pytest tests/test_vault*.py -q` (236 passed)
- `python3 -m ruff check storage/vault_service.py vibe/api.py vibe/cli.py vibe/ui_server.py tests/test_vault_api.py tests/test_vault_cli.py tests/test_vault_rest.py tests/test_vault_service.py`
- `cd ui && npm run build` (passes; existing Vite/Rolldown warnings from @hpke/common pure annotations/chunk size)

## Risk
- frontend approval UI still needs to call the new fulfillment endpoint; this PR wires and tests the backend/CLI contract only
- merge should wait for Codex review and CI per protected-tier gate
