### PR TITLE
fix(vaults): prf.eval for single-passkey unlock (1Password empty-PRF on evalByCredential)

### DIFF
--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -112,26 +112,38 @@ function toUint8(buffer: ArrayBuffer | ArrayBufferView): Uint8Array {
 function passkeyResult(credential: PublicKeyCredential | null): Uint8Array {
   const ext = credential?.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer } } } | undefined;
   const first = ext?.prf?.results?.first;
+  // Treat a missing OR present-but-empty PRF result as "PRF unavailable" so the user sees a
+  // clear message instead of a raw zero-length-key error from KEK derivation.
   if (!first) throw new Error('passkey-prf-unavailable');
-  return toUint8(first);
+  const out = toUint8(first);
+  if (out.length === 0) throw new Error('passkey-prf-unavailable');
+  return out;
 }
 
 type PasskeyEntry = { credentialId?: string; prfSalt: Uint8Array };
 
 /**
- * Assert one of the vault's passkeys and extract its PRF output. Uses
- * `evalByCredential` so each credential is evaluated with its own stored salt, then
- * returns the salt of whichever credential actually responded.
+ * Assert one of the vault's passkeys and extract its PRF output.
+ *
+ * For a single passkey we request plain `prf.eval` (one salt) — the most widely supported
+ * PRF form. `prf.evalByCredential` is only needed to give *multiple* passkeys their own
+ * salt, and some authenticators (notably 1Password) return an EMPTY PRF for evalByCredential
+ * on a standalone unlock GET, which surfaced as "passkey PRF output is empty". The PRF
+ * output for a given (credential, salt) is identical whichever request form is used, so
+ * this never changes an already-stored KEK.
  */
 async function assertPasskeyPrf(entries: PasskeyEntry[]): Promise<{ prfOutput: Uint8Array; prfSalt: Uint8Array }> {
   const withId = entries.filter((entry) => entry.credentialId);
-  const evalByCredential: Record<string, { first: ArrayBuffer }> = {};
-  for (const entry of withId) {
-    evalByCredential[base64ToBase64Url(entry.credentialId as string)] = { first: bufferSource(entry.prfSalt) };
+  let extensions: AuthenticationExtensionsClientInputs;
+  if (entries.length <= 1) {
+    extensions = webAuthnPrfExtensionInput(entries[0].prfSalt) as AuthenticationExtensionsClientInputs;
+  } else {
+    const evalByCredential: Record<string, { first: ArrayBuffer }> = {};
+    for (const entry of withId) {
+      evalByCredential[base64ToBase64Url(entry.credentialId as string)] = { first: bufferSource(entry.prfSalt) };
+    }
+    extensions = { prf: { evalByCredential } } as AuthenticationExtensionsClientInputs;
   }
-  const extensions = (withId.length > 0
-    ? { prf: { evalByCredential } }
-    : webAuthnPrfExtensionInput(entries[0].prfSalt)) as AuthenticationExtensionsClientInputs;
   const assertion = (await navigator.credentials.get({
     publicKey: {
       challenge: randomChallenge(),


### PR DESCRIPTION
## Bug
Protected-tier passkey **unlock** fails with `passkey PRF output is empty` when the passkey is in 1Password. Setup succeeds, unlock returns an empty PRF.

## Cause
`assertPasskeyPrf` used `prf.evalByCredential` for any stored passkey. Some authenticators (notably 1Password) return an **empty** `prf.results.first` for `evalByCredential` on a standalone unlock GET. Setup worked because the just-created credential is applied leniently.

## Fix
- **Single passkey → plain `prf.eval`** (one salt) — the most widely supported PRF form. `evalByCredential` is kept only for the multi-passkey case (distinct per-credential salts). PRF output for a given (credential, salt) is identical either way → **no change to already-stored KEKs / VMK**.
- Treat a present-but-empty PRF result as `passkey-prf-unavailable` (clear message) instead of a raw zero-length-key error.

## Evidence
- `npm run build` green; `vaultCrypto.test.ts` 23/23.
- **Residual: needs real-1Password manual re-test** (PRF behavior is authenticator-specific; can't be unit-tested). Deploying to the local regression for the owner to re-verify passkey unlock.