### PR TITLE
feat(ui): error boundaries so a render crash can't white-screen the workbench

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -385,15 +385,15 @@ function App() {
             <WorkbenchInboxProvider>
               <WorkbenchProjectsProvider>
                 <ComposerBridgeProvider>
-                  <BrowserRouter>
-                    {/* Top-level backstop: catches a crash in the shell/providers themselves (the
-                        per-page and per-window boundaries handle the rest) so the app can never go
-                        to a blank white screen. */}
-                    <ErrorBoundary variant="page">
+                  {/* Top-level backstop: wraps the whole router subtree AND the agentation overlay
+                      (the per-page and per-window boundaries handle the rest) so a crash anywhere
+                      below the providers can never reach a blank white screen. */}
+                  <ErrorBoundary variant="page">
+                    <BrowserRouter>
                       <AppRoutes />
-                    </ErrorBoundary>
-                  </BrowserRouter>
-                  <AgentationToggle />
+                    </BrowserRouter>
+                    <AgentationToggle />
+                  </ErrorBoundary>
                 </ComposerBridgeProvider>
               </WorkbenchProjectsProvider>
             </WorkbenchInboxProvider>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { Wizard } from './components/Wizard';
 import { AppShell } from './components/AppShell';
+import { ErrorBoundary } from './components/ui/error-boundary';
 import { Workbench } from './components/Workbench';
 import { InboxPage } from './components/workbench/InboxPage';
 import { SearchPage } from './components/workbench/SearchPage';
@@ -385,7 +386,12 @@ function App() {
               <WorkbenchProjectsProvider>
                 <ComposerBridgeProvider>
                   <BrowserRouter>
-                    <AppRoutes />
+                    {/* Top-level backstop: catches a crash in the shell/providers themselves (the
+                        per-page and per-window boundaries handle the rest) so the app can never go
+                        to a blank white screen. */}
+                    <ErrorBoundary variant="page">
+                      <AppRoutes />
+                    </ErrorBoundary>
                   </BrowserRouter>
                   <AgentationToggle />
                 </ComposerBridgeProvider>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -378,6 +378,10 @@ function AppRoutes() {
 
 function App() {
   return (
+    // Outermost backstop — OUTSIDE every provider, so a crash in a provider itself is contained too
+    // (the per-page and per-window boundaries handle granular containment inside). ThemeProvider sets
+    // data-theme on <html>, so the fallback still picks up the theme even from out here.
+    <ErrorBoundary variant="page">
     <ThemeProvider>
       <StatusProvider>
         <ToastProvider>
@@ -385,15 +389,10 @@ function App() {
             <WorkbenchInboxProvider>
               <WorkbenchProjectsProvider>
                 <ComposerBridgeProvider>
-                  {/* Top-level backstop: wraps the whole router subtree AND the agentation overlay
-                      (the per-page and per-window boundaries handle the rest) so a crash anywhere
-                      below the providers can never reach a blank white screen. */}
-                  <ErrorBoundary variant="page">
-                    <BrowserRouter>
-                      <AppRoutes />
-                    </BrowserRouter>
-                    <AgentationToggle />
-                  </ErrorBoundary>
+                  <BrowserRouter>
+                    <AppRoutes />
+                  </BrowserRouter>
+                  <AgentationToggle />
                 </ComposerBridgeProvider>
               </WorkbenchProjectsProvider>
             </WorkbenchInboxProvider>
@@ -401,6 +400,7 @@ function App() {
         </ToastProvider>
       </StatusProvider>
     </ThemeProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -509,8 +509,9 @@ export const AppShell: React.FC = () => {
       >
         <div className="mx-auto w-full px-4 py-5 md:px-10 md:py-8">
           {/* A crashing page only replaces the content area — the sidebar + chrome stay usable, and
-              navigating elsewhere (resetKeys on the path) clears the error without a manual retry. */}
-          <ErrorBoundary variant="page" resetKeys={[location.pathname]}>
+              navigating elsewhere clears the error without a manual retry. Key on location.key (not
+              just pathname) so a query-only navigation (e.g. /search?q=…) also resets. */}
+          <ErrorBoundary variant="page" resetKeys={[location.key]}>
             <Outlet />
           </ErrorBoundary>
         </div>

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -13,6 +13,7 @@ import { ThemeToggle } from './ThemeToggle';
 import { VersionBadge } from './VersionBadge';
 import { WorkbenchSidebar } from './workbench/WorkbenchSidebar';
 import { AppsLauncher } from './AppsLauncher';
+import { ErrorBoundary } from './ui/error-boundary';
 import { WindowManagerProvider } from '../context/WindowManagerContext';
 import { WindowLayer } from './apps/WindowLayer';
 import { NewSessionSheet } from './workbench/NewSessionSheet';
@@ -507,7 +508,11 @@ export const AppShell: React.FC = () => {
         )}
       >
         <div className="mx-auto w-full px-4 py-5 md:px-10 md:py-8">
-          <Outlet />
+          {/* A crashing page only replaces the content area — the sidebar + chrome stay usable, and
+              navigating elsewhere (resetKeys on the path) clears the error without a manual retry. */}
+          <ErrorBoundary variant="page" resetKeys={[location.pathname]}>
+            <Outlet />
+          </ErrorBoundary>
         </div>
       </main>
 

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -6,6 +6,7 @@ import { Minus, Plus, X, type LucideIcon } from 'lucide-react';
 import { APP_REGISTRY } from '../../apps/registry';
 import { useWindowManager, type WindowInstance } from '../../context/WindowManagerContext';
 import { clampToLayer, resizeBounds, type ResizeDir } from '../../lib/windowBounds';
+import { ErrorBoundary } from '../ui/error-boundary';
 
 const RESIZE_HANDLES: { dir: ResizeDir; className: string }[] = [
   { dir: 'n', className: 'left-2 right-2 top-0 h-1.5 cursor-ns-resize' },
@@ -213,7 +214,11 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        <Body windowId={win.id} params={win.params} />
+        {/* A crashing app only takes down its own window — the shell + other windows stay usable, and
+            "Retry" remounts just this app. */}
+        <ErrorBoundary variant="inline">
+          <Body windowId={win.id} params={win.params} />
+        </ErrorBoundary>
       </div>
 
       {!win.maximized &&

--- a/ui/src/components/ui/error-boundary.tsx
+++ b/ui/src/components/ui/error-boundary.tsx
@@ -7,13 +7,13 @@ import { Button } from './button';
 
 // A React error boundary: catches a render error in its subtree and shows a recoverable card instead
 // of letting the throw unmount the whole app (a blank white screen). Wrap independent regions — each
-// windowed app, the routed page area, and the app root — so one crashing component only takes down
-// its own region, and the rest of the workbench stays usable.
+// windowed app, the routed page area, and the whole provider stack — so one crashing component only
+// takes down its own region, and the rest of the workbench stays usable.
 //
 // Error boundaries only catch errors thrown during render/lifecycle of their children — not in event
 // handlers or async callbacks (those should be try/caught at the call site).
 
-type FallbackRender = (args: { error: Error; reset: () => void }) => React.ReactNode;
+type FallbackRender = (args: { error: unknown; reset: () => void }) => React.ReactNode;
 
 type Props = {
   children: React.ReactNode;
@@ -21,16 +21,18 @@ type Props = {
   fallback?: FallbackRender;
   /**
    * When any value here changes (compared with Object.is), a caught error auto-clears. Pass STABLE
-   * values only — e.g. the route path so navigating away from a crashed page recovers. An unstable
+   * values only — e.g. the route key so navigating away from a crashed page recovers. An unstable
    * value (a fresh object/array each render) would reset → re-throw → reset in an infinite loop.
    */
   resetKeys?: unknown[];
   /** `page` fills a tall content area; `inline` is compact for an in-window app body. */
   variant?: 'page' | 'inline';
-  onError?: (error: Error, info: React.ErrorInfo) => void;
+  onError?: (error: unknown, info: React.ErrorInfo) => void;
 };
 
-type State = { error: Error | null };
+// `hasError` is tracked separately from the value so a thrown falsy value (`throw null` / `''` / `0`
+// is legal JS and possible from third-party code) is still contained instead of falling through.
+type State = { hasError: boolean; error: unknown };
 
 function resetKeysChanged(a: unknown[] | undefined, b: unknown[] | undefined): boolean {
   if (a === b) return false;
@@ -39,13 +41,13 @@ function resetKeysChanged(a: unknown[] | undefined, b: unknown[] | undefined): b
 }
 
 export class ErrorBoundary extends React.Component<Props, State> {
-  state: State = { error: null };
+  state: State = { hasError: false, error: null };
 
-  static getDerivedStateFromError(error: Error): State {
-    return { error };
+  static getDerivedStateFromError(error: unknown): State {
+    return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+  componentDidCatch(error: unknown, info: React.ErrorInfo): void {
     // The boundary swallows the throw so it can never white-screen the app — but the detail must not
     // be lost, so always surface it to the console (and any wired reporter via onError).
     // eslint-disable-next-line no-console
@@ -54,18 +56,17 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prev: Props): void {
-    if (this.state.error && resetKeysChanged(prev.resetKeys, this.props.resetKeys)) {
+    if (this.state.hasError && resetKeysChanged(prev.resetKeys, this.props.resetKeys)) {
       this.reset();
     }
   }
 
-  reset = (): void => this.setState({ error: null });
+  reset = (): void => this.setState({ hasError: false, error: null });
 
   render(): React.ReactNode {
-    const { error } = this.state;
-    if (error) {
-      if (this.props.fallback) return this.props.fallback({ error, reset: this.reset });
-      return <ErrorFallback error={error} reset={this.reset} variant={this.props.variant ?? 'page'} />;
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback({ error: this.state.error, reset: this.reset });
+      return <ErrorFallback error={this.state.error} reset={this.reset} variant={this.props.variant ?? 'page'} />;
     }
     return this.props.children;
   }
@@ -73,8 +74,9 @@ export class ErrorBoundary extends React.Component<Props, State> {
 
 // Kept dependency-light on purpose: this renders precisely when something else just threw, so it must
 // not itself rely on app data that might be the cause. i18n `t` returns the key if missing (no throw).
-const ErrorFallback: React.FC<{ error: Error; reset: () => void; variant: 'page' | 'inline' }> = ({ error, reset, variant }) => {
+const ErrorFallback: React.FC<{ error: unknown; reset: () => void; variant: 'page' | 'inline' }> = ({ error, reset, variant }) => {
   const { t } = useTranslation();
+  const detail = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
   return (
     <div className={clsx('grid h-full w-full place-items-center bg-surface p-6 text-center', variant === 'page' && 'min-h-[60vh]')}>
       <div className="flex max-w-sm flex-col items-center gap-3">
@@ -83,9 +85,9 @@ const ErrorFallback: React.FC<{ error: Error; reset: () => void; variant: 'page'
         </span>
         <div className="text-[15px] font-semibold text-foreground">{t('errorBoundary.title')}</div>
         <div className="text-[12.5px] text-muted">{t('errorBoundary.body')}</div>
-        {error.message && (
-          <div className="max-w-full truncate rounded bg-surface-3 px-2 py-1 font-mono text-[11px] text-muted" title={error.message}>
-            {error.message}
+        {detail && (
+          <div className="max-w-full truncate rounded bg-surface-3 px-2 py-1 font-mono text-[11px] text-muted" title={detail}>
+            {detail}
           </div>
         )}
         <div className="mt-1 flex items-center gap-2">

--- a/ui/src/components/ui/error-boundary.tsx
+++ b/ui/src/components/ui/error-boundary.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, RotateCcw } from 'lucide-react';
+import clsx from 'clsx';
+
+import { Button } from './button';
+
+// A React error boundary: catches a render error in its subtree and shows a recoverable card instead
+// of letting the throw unmount the whole app (a blank white screen). Wrap independent regions — each
+// windowed app, the routed page area, and the app root — so one crashing component only takes down
+// its own region, and the rest of the workbench stays usable.
+//
+// Error boundaries only catch errors thrown during render/lifecycle of their children — not in event
+// handlers or async callbacks (those should be try/caught at the call site).
+
+type FallbackRender = (args: { error: Error; reset: () => void }) => React.ReactNode;
+
+type Props = {
+  children: React.ReactNode;
+  /** Custom fallback; defaults to a recoverable card that fills its container. */
+  fallback?: FallbackRender;
+  /**
+   * When any value here changes (compared with Object.is), a caught error auto-clears. Pass STABLE
+   * values only — e.g. the route path so navigating away from a crashed page recovers. An unstable
+   * value (a fresh object/array each render) would reset → re-throw → reset in an infinite loop.
+   */
+  resetKeys?: unknown[];
+  /** `page` fills a tall content area; `inline` is compact for an in-window app body. */
+  variant?: 'page' | 'inline';
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+};
+
+type State = { error: Error | null };
+
+function resetKeysChanged(a: unknown[] | undefined, b: unknown[] | undefined): boolean {
+  if (a === b) return false;
+  if (!a || !b || a.length !== b.length) return true;
+  return a.some((value, i) => !Object.is(value, b[i]));
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    // The boundary swallows the throw so it can never white-screen the app — but the detail must not
+    // be lost, so always surface it to the console (and any wired reporter via onError).
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught a render error:', error, info.componentStack);
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prev: Props): void {
+    if (this.state.error && resetKeysChanged(prev.resetKeys, this.props.resetKeys)) {
+      this.reset();
+    }
+  }
+
+  reset = (): void => this.setState({ error: null });
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.fallback) return this.props.fallback({ error, reset: this.reset });
+      return <ErrorFallback error={error} reset={this.reset} variant={this.props.variant ?? 'page'} />;
+    }
+    return this.props.children;
+  }
+}
+
+// Kept dependency-light on purpose: this renders precisely when something else just threw, so it must
+// not itself rely on app data that might be the cause. i18n `t` returns the key if missing (no throw).
+const ErrorFallback: React.FC<{ error: Error; reset: () => void; variant: 'page' | 'inline' }> = ({ error, reset, variant }) => {
+  const { t } = useTranslation();
+  return (
+    <div className={clsx('grid h-full w-full place-items-center bg-surface p-6 text-center', variant === 'page' && 'min-h-[60vh]')}>
+      <div className="flex max-w-sm flex-col items-center gap-3">
+        <span className="grid size-12 shrink-0 place-items-center rounded-2xl border border-gold/40 bg-gold/[0.08]">
+          <AlertTriangle className="size-6 text-gold" />
+        </span>
+        <div className="text-[15px] font-semibold text-foreground">{t('errorBoundary.title')}</div>
+        <div className="text-[12.5px] text-muted">{t('errorBoundary.body')}</div>
+        {error.message && (
+          <div className="max-w-full truncate rounded bg-surface-3 px-2 py-1 font-mono text-[11px] text-muted" title={error.message}>
+            {error.message}
+          </div>
+        )}
+        <div className="mt-1 flex items-center gap-2">
+          <Button type="button" size="sm" variant="brand" className="gap-1.5" onClick={reset}>
+            <RotateCcw className="size-3.5" /> {t('errorBoundary.retry')}
+          </Button>
+          <Button type="button" size="sm" variant="outline" onClick={() => window.location.reload()}>
+            {t('errorBoundary.reload')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -7,6 +7,12 @@
     "step2": "Choose “Add to Home Screen”",
     "dismiss": "Collapse"
   },
+  "errorBoundary": {
+    "title": "Something went wrong",
+    "body": "This part of the app hit an unexpected error. The rest still works — retry, or reload the page.",
+    "retry": "Retry",
+    "reload": "Reload page"
+  },
   "common": {
     "back": "Back",
     "continue": "Continue",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -7,6 +7,12 @@
     "step2": "选「添加到主屏幕」",
     "dismiss": "收起"
   },
+  "errorBoundary": {
+    "title": "出了点问题",
+    "body": "这部分遇到了意外错误。其他功能仍可正常使用——可以重试，或刷新页面。",
+    "retry": "重试",
+    "reload": "刷新页面"
+  },
   "common": {
     "back": "返回",
     "continue": "继续",


### PR DESCRIPTION
## Capability

Adds React **error boundaries** so a single render crash can no longer white-screen the whole workbench.

Background: a user hit a blank white screen when a **stale cached frontend bundle** threw during render in cross-file search (one keystroke). The bytes were stale, but the real fragility is that the app had **no error boundary** — any uncaught render error unmounts the entire tree to a blank page.

This adds a reusable `<ErrorBoundary>` and wraps three independent regions so a crash is contained + recoverable instead of fatal:

- **Per windowed app** (`AppWindow`) — a crashing File Browser / Editor / Terminal only takes down its own window; the shell + other windows stay usable; **Retry** remounts just that app. (This is the user's actual incident — the editor is a windowed app.)
- **Per routed page** (`AppShell` Outlet) — a page crash keeps the sidebar + chrome; navigating elsewhere auto-clears it (`resetKeys` on the route path).
- **Top-level backstop** (`App` root) — catches a shell/provider crash so the app can never reach a blank screen; **Reload page** recovers.

The fallback is a small recoverable card (Retry + Reload page), kept dependency-light on purpose since it renders exactly when something else just threw.

## Evidence layers

- **Unit / contract**: none added — the UI has no React-component test infra (only pure-function vitest tests), and CLAUDE.md says not to introduce a new test framework. The boundary uses the canonical `getDerivedStateFromError` + `componentDidCatch` pattern.
- **Build**: `cd ui && npm run build` (tsc -b + vite) green; i18n `errorBoundary.*` added to en + zh.
- **Review**: self-reviewed (stable-`resetKeys` infinite-loop guard documented; fallback is dependency-light). Codex review pending on this PR.
- **Residual manual checks**: ⚠️ live browser verification not run (local Incus regression empty/unpaired this session). Recommend a manual pass: force a render throw in a windowed app → only that window shows the card + Retry recovers; the shell + other windows stay alive; a page-route throw keeps the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
