### PR TITLE
fix(vaults): enforce always ask access grants

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -320,11 +320,12 @@ def _card_hydration_policy(audience: str | None) -> CardHydrationPolicy:
     )
 
 
-ACTIVE_GRANT_STATUSES = {"active", "reserved"}
+ACTIVE_GRANT_STATES = {"active", "reserved"}
+ACTIVE_GRANT_STATUSES = ACTIVE_GRANT_STATES
 
 
 def _grant_is_active(row: dict[str, Any]) -> bool:
-    if row.get("status") not in ACTIVE_GRANT_STATUSES:
+    if row.get("status") not in ACTIVE_GRANT_STATES:
         return False
     expires_at = _parse_iso_datetime(row.get("expires_at"))
     return expires_at is None or expires_at > datetime.now(timezone.utc)
@@ -1739,7 +1740,7 @@ def _expire_grant_rows(
     for row in rows:
         conn.execute(
             vault_grants.update()
-            .where(vault_grants.c.id == row["id"], vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))
+            .where(vault_grants.c.id == row["id"], vault_grants.c.status.in_(ACTIVE_GRANT_STATES))
             .values(status="expired", revoked_at=now, agent_ready=0, agent_ready_at=None)
         )
         cache.drop(row["id"])
@@ -1762,7 +1763,7 @@ def _expire_active_grants_for_secret(
 def active_grant_rows_for_secret(conn: Connection, secret_name: str) -> list[dict[str, Any]]:
     return [
         dict(row)
-        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))).mappings()
+        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES))).mappings()
         if secret_name in (_loads(row.get("member_snapshot")) or [])
     ]
 
@@ -1775,7 +1776,7 @@ def active_grant_scopes_for_session(conn: Connection, session_id: str) -> list[d
     rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.session_id == session_id)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES), vault_grants.c.session_id == session_id)
         ).mappings()
     ]
     return _unique_grant_scopes(rows)
@@ -1798,7 +1799,7 @@ def agent_release_scopes_after_rows(
     expired_rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.expires_at <= now)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES), vault_grants.c.expires_at <= now)
         ).mappings()
     ]
     if expired_rows:
@@ -1809,7 +1810,7 @@ def agent_release_scopes_after_rows(
         return []
     active_rows = [
         dict(row)
-        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))).mappings()
+        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES))).mappings()
         if grant_row_has_resident_agent_ready(dict(row))
     ]
     active_by_scope: dict[tuple[str, str], set[str]] = {}
@@ -1843,7 +1844,7 @@ def agent_release_scopes_after_rows(
             .where(
                 vault_grants.c.scope_type == scope_type,
                 vault_grants.c.scope_ref == scope_ref,
-                vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES),
+                vault_grants.c.status.in_(ACTIVE_GRANT_STATES),
             )
             .values(agent_ready=0, agent_ready_at=None)
         )
@@ -1862,7 +1863,7 @@ def expire_grant(
     if row is None:
         raise GrantNotFoundError(grant_id)
     row_dict = dict(row)
-    if row_dict.get("status") in ACTIVE_GRANT_STATUSES:
+    if row_dict.get("status") in ACTIVE_GRANT_STATES:
         _expire_grant_rows(conn, [row_dict], cache=cache, reason=reason)
         row_dict = dict(conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().one())
     return _grant_payload(conn, row_dict, cache=cache)
@@ -1910,7 +1911,7 @@ def expire_grants(conn: Connection, *, cache: VaultGrantRuntimeCache = GRANT_RUN
     rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.expires_at <= now)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES), vault_grants.c.expires_at <= now)
         ).mappings()
     ]
     return _expire_grant_rows(conn, rows, cache=cache)
@@ -2251,7 +2252,7 @@ def expire_active_grants(
 ) -> int:
     rows = [
         dict(row)
-        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))).mappings()
+        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES))).mappings()
     ]
     return _expire_grant_rows(conn, rows, cache=cache, reason=reason)
 
@@ -2266,7 +2267,7 @@ def revoke_grant(
     if row is None:
         raise GrantNotFoundError(grant_id)
     row_dict = dict(row)
-    if row_dict.get("status") not in ACTIVE_GRANT_STATUSES:
+    if row_dict.get("status") not in ACTIVE_GRANT_STATES:
         raise GrantNotActiveError(grant_id)
     now = _now()
     conn.execute(
@@ -2326,7 +2327,7 @@ def revoke_session_grants(
     rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.session_id == session_id)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES), vault_grants.c.session_id == session_id)
         ).mappings()
     ]
     now = _now()
@@ -2334,7 +2335,7 @@ def revoke_session_grants(
     for row in rows:
         result = conn.execute(
             vault_grants.update()
-            .where(vault_grants.c.id == row["id"], vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))
+            .where(vault_grants.c.id == row["id"], vault_grants.c.status.in_(ACTIVE_GRANT_STATES))
             .values(status="revoked", revoked_at=now, agent_ready=0, agent_ready_at=None)
         )
         if result.rowcount != 1:
@@ -2387,7 +2388,7 @@ def consume_one_shot_grant(
     if row is None:
         raise GrantNotFoundError(grant_id)
     row_dict = dict(row)
-    if row_dict.get("status") not in ACTIVE_GRANT_STATUSES:
+    if row_dict.get("status") not in ACTIVE_GRANT_STATES:
         raise GrantNotActiveError(grant_id)
     if not _grant_is_always_ask_for_members(conn, row_dict):
         return []
@@ -2435,8 +2436,10 @@ def _reserve_one_shot_grant(
     *,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
 ) -> dict[str, Any] | None:
-    if row.get("status") != "active" or not _grant_is_always_ask_for_members(conn, row):
+    if not _grant_is_always_ask_for_members(conn, row):
         return _grant_payload(conn, row, cache=cache)
+    if row.get("status") != "active":
+        return None
     result = conn.execute(
         vault_grants.update()
         .where(vault_grants.c.id == row["id"], vault_grants.c.status == "active")
@@ -2465,7 +2468,7 @@ def find_active_grant_for_secrets(
         dict(row)
         for row in conn.execute(
             select(vault_grants).where(
-                vault_grants.c.status == "active",
+                vault_grants.c.status.in_(ACTIVE_GRANT_STATES),
                 or_(vault_grants.c.session_id.is_(None), vault_grants.c.session_id == session_id),
             )
         ).mappings()
@@ -2477,6 +2480,8 @@ def find_active_grant_for_secrets(
         if not requested.issubset(member_set):
             continue
         payload = _grant_payload(conn, row, cache=cache)
+        if reserve_one_shot and payload.get("one_shot") is True and row.get("status") != "active":
+            continue
         standard_only = all(_require_row(conn, name).get("protection") == "standard" for name in requested)
         candidates.append((
             standard_only or bool(payload.get("delivery_ready")),
@@ -2511,7 +2516,7 @@ def resolve_secret_access(
     delivery: dict[str, Any] | None = None,
     create_request: bool = True,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
-    reserve_one_shot: bool = True,
+    reserve_one_shot: bool = False,
 ) -> dict[str, Any]:
     """Resolve an agent access attempt without exposing the value.
 

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -2218,7 +2218,9 @@ def list_grants(
 ) -> list[dict[str, Any]]:
     expire_grants(conn, cache=cache)
     query = select(vault_grants).order_by(vault_grants.c.created_at.desc(), vault_grants.c.id.desc())
-    if status is not None:
+    if status == "active":
+        query = query.where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES))
+    elif status is not None:
         query = query.where(vault_grants.c.status == status)
     if session_id is not None:
         query = query.where(or_(vault_grants.c.session_id.is_(None), vault_grants.c.session_id == session_id))
@@ -2480,7 +2482,7 @@ def find_active_grant_for_secrets(
         if not requested.issubset(member_set):
             continue
         payload = _grant_payload(conn, row, cache=cache)
-        if reserve_one_shot and payload.get("one_shot") is True and row.get("status") != "active":
+        if payload.get("one_shot") is True and row.get("status") != "active":
             continue
         standard_only = all(_require_row(conn, name).get("protection") == "standard" for name in requested)
         candidates.append((

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1176,6 +1176,8 @@ def _always_ask_request_member_rows(
     row = _require_row(conn, str(requested_secret))
     if not _secret_access_requestable(row) or not _secret_always_ask(row):
         return []
+    if not _groups_grantable(conn, [str(row.get("group_name") or "")]):
+        return []
     return [row]
 
 
@@ -1242,6 +1244,45 @@ def _ttl_cap_for_members(conn: Connection, member_names: list[str]) -> int:
     return min(caps) if caps else 900
 
 
+def _groups_grantable(conn: Connection, group_names: list[str]) -> bool:
+    names = {name for name in group_names if name}
+    if not names:
+        return False
+    grantable_groups = {
+        row["name"]
+        for row in conn.execute(select(vault_groups).where(vault_groups.c.name.in_(names))).mappings()
+        if int(row.get("grantable") or 0) == 1
+    }
+    return names.issubset(grantable_groups)
+
+
+def _secret_scope_option(
+    conn: Connection,
+    row: dict[str, Any],
+    *,
+    default_ttl_seconds: int,
+    one_shot: bool = False,
+) -> dict[str, Any] | None:
+    secret_name = str(row["name"])
+    if not _groups_grantable(conn, [str(row.get("group_name") or "")]):
+        return None
+    ttl_cap = _ttl_cap_for_members(conn, [secret_name])
+    capped_default = min(default_ttl_seconds, ttl_cap)
+    option = {
+        "scope_type": "secret",
+        "scope_ref": secret_name,
+        "default_ttl_seconds": capped_default,
+        "ttl_options_seconds": [seconds for seconds in GRANT_TTL_OPTIONS_SECONDS if seconds <= ttl_cap],
+        "session_binding_default": True,
+        "member_count": 1,
+        "member_snapshot": [secret_name],
+        "member_versions": [_member_version(row)],
+    }
+    if one_shot:
+        option["one_shot"] = True
+    return option
+
+
 def _scope_option(
     conn: Connection,
     scope_type: str,
@@ -1285,19 +1326,13 @@ def approval_card(
     always_ask = _secret_always_ask(row)
     scope_options: list[dict[str, Any]] = []
     if always_ask:
-        scope_options = [
-            {
-                "scope_type": "secret",
-                "scope_ref": secret_name,
-                "default_ttl_seconds": DEFAULT_GRANT_TTL_SECONDS["secret"],
-                "ttl_options_seconds": list(GRANT_TTL_OPTIONS_SECONDS),
-                "session_binding_default": True,
-                "member_count": 1,
-                "member_snapshot": [secret_name],
-                "member_versions": [_member_version(row)],
-                "one_shot": True,
-            }
-        ]
+        option = _secret_scope_option(
+            conn,
+            row,
+            default_ttl_seconds=DEFAULT_GRANT_TTL_SECONDS["secret"],
+            one_shot=True,
+        )
+        scope_options = [option] if option is not None else []
     if grantable and not always_ask:
         scope_options = [
             option
@@ -2321,28 +2356,33 @@ def find_active_grant_for_secret(
     return find_active_grant_for_secrets(conn, [secret_name], session_id=session_id, cache=cache)
 
 
-def _grant_is_always_ask_for_requested(
+def _grant_is_always_ask_for_members(
     conn: Connection,
     row: dict[str, Any],
-    requested: set[str],
 ) -> bool:
     members = _grant_member_names(row)
-    if set(members) != requested:
+    if len(members) != 1:
         return False
-    if len(requested) != 1:
-        return False
-    return _secret_always_ask(_require_row(conn, next(iter(requested))))
+    return _secret_always_ask(_require_row(conn, members[0]))
 
 
-def _consume_always_ask_grant(
+def consume_one_shot_grant(
     conn: Connection,
-    row: dict[str, Any],
+    grant_id: str,
     *,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
 ) -> None:
+    row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
+    if row is None:
+        raise GrantNotFoundError(grant_id)
+    row_dict = dict(row)
+    if row_dict.get("status") != "active":
+        raise GrantNotActiveError(grant_id)
+    if not _grant_is_always_ask_for_members(conn, row_dict):
+        return
     _expire_grant_rows(
         conn,
-        [row],
+        [row_dict],
         cache=cache,
         reason="grant-expired-always-ask-consumed",
     )
@@ -2395,8 +2435,6 @@ def find_active_grant_for_secrets(
         key=lambda item: (item[2], item[3]),
     )
     payload = _grant_payload(conn, row, cache=cache)
-    if _grant_is_always_ask_for_requested(conn, row, requested):
-        _consume_always_ask_grant(conn, row, cache=cache)
     return payload
 
 

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1324,8 +1324,9 @@ def approval_card(
     row = _require_row(conn, secret_name)
     group = row.get("group_name") or DEFAULT_GROUP
     always_ask = _secret_always_ask(row)
+    one_shot_access = request_type == "access" and always_ask and _secret_access_requestable(row)
     scope_options: list[dict[str, Any]] = []
-    if always_ask:
+    if one_shot_access:
         option = _secret_scope_option(
             conn,
             row,
@@ -1376,7 +1377,7 @@ def approval_card(
         "egress": egress,
         "session_id": session_id,
         "approve_once": True,
-        "one_shot": always_ask,
+        "one_shot": one_shot_access,
         "scope_options": scope_options,
         "value": None,
     }
@@ -2371,7 +2372,7 @@ def consume_one_shot_grant(
     grant_id: str,
     *,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
-) -> None:
+) -> list[dict[str, str]]:
     row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
     if row is None:
         raise GrantNotFoundError(grant_id)
@@ -2379,13 +2380,14 @@ def consume_one_shot_grant(
     if row_dict.get("status") != "active":
         raise GrantNotActiveError(grant_id)
     if not _grant_is_always_ask_for_members(conn, row_dict):
-        return
+        return []
     _expire_grant_rows(
         conn,
         [row_dict],
         cache=cache,
         reason="grant-expired-always-ask-consumed",
     )
+    return agent_release_scopes_after_rows(conn, [row_dict], cache=cache)
 
 
 def find_active_grant_for_secrets(

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1762,7 +1762,7 @@ def _expire_active_grants_for_secret(
 def active_grant_rows_for_secret(conn: Connection, secret_name: str) -> list[dict[str, Any]]:
     return [
         dict(row)
-        for row in conn.execute(select(vault_grants).where(vault_grants.c.status == "active")).mappings()
+        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))).mappings()
         if secret_name in (_loads(row.get("member_snapshot")) or [])
     ]
 
@@ -1775,7 +1775,7 @@ def active_grant_scopes_for_session(conn: Connection, session_id: str) -> list[d
     rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status == "active", vault_grants.c.session_id == session_id)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.session_id == session_id)
         ).mappings()
     ]
     return _unique_grant_scopes(rows)
@@ -1798,7 +1798,7 @@ def agent_release_scopes_after_rows(
     expired_rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status == "active", vault_grants.c.expires_at <= now)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.expires_at <= now)
         ).mappings()
     ]
     if expired_rows:
@@ -1862,7 +1862,7 @@ def expire_grant(
     if row is None:
         raise GrantNotFoundError(grant_id)
     row_dict = dict(row)
-    if row_dict.get("status") == "active":
+    if row_dict.get("status") in ACTIVE_GRANT_STATUSES:
         _expire_grant_rows(conn, [row_dict], cache=cache, reason=reason)
         row_dict = dict(conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().one())
     return _grant_payload(conn, row_dict, cache=cache)
@@ -1910,7 +1910,7 @@ def expire_grants(conn: Connection, *, cache: VaultGrantRuntimeCache = GRANT_RUN
     rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status == "active", vault_grants.c.expires_at <= now)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.expires_at <= now)
         ).mappings()
     ]
     return _expire_grant_rows(conn, rows, cache=cache)
@@ -2251,7 +2251,7 @@ def expire_active_grants(
 ) -> int:
     rows = [
         dict(row)
-        for row in conn.execute(select(vault_grants).where(vault_grants.c.status == "active")).mappings()
+        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))).mappings()
     ]
     return _expire_grant_rows(conn, rows, cache=cache, reason=reason)
 
@@ -2266,7 +2266,7 @@ def revoke_grant(
     if row is None:
         raise GrantNotFoundError(grant_id)
     row_dict = dict(row)
-    if row_dict.get("status") != "active":
+    if row_dict.get("status") not in ACTIVE_GRANT_STATUSES:
         raise GrantNotActiveError(grant_id)
     now = _now()
     conn.execute(
@@ -2326,7 +2326,7 @@ def revoke_session_grants(
     rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status == "active", vault_grants.c.session_id == session_id)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.session_id == session_id)
         ).mappings()
     ]
     now = _now()
@@ -2334,7 +2334,7 @@ def revoke_session_grants(
     for row in rows:
         result = conn.execute(
             vault_grants.update()
-            .where(vault_grants.c.id == row["id"], vault_grants.c.status == "active")
+            .where(vault_grants.c.id == row["id"], vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))
             .values(status="revoked", revoked_at=now, agent_ready=0, agent_ready_at=None)
         )
         if result.rowcount != 1:

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -320,8 +320,11 @@ def _card_hydration_policy(audience: str | None) -> CardHydrationPolicy:
     )
 
 
+ACTIVE_GRANT_STATUSES = {"active", "reserved"}
+
+
 def _grant_is_active(row: dict[str, Any]) -> bool:
-    if row.get("status") != "active":
+    if row.get("status") not in ACTIVE_GRANT_STATUSES:
         return False
     expires_at = _parse_iso_datetime(row.get("expires_at"))
     return expires_at is None or expires_at > datetime.now(timezone.utc)
@@ -1736,7 +1739,7 @@ def _expire_grant_rows(
     for row in rows:
         conn.execute(
             vault_grants.update()
-            .where(vault_grants.c.id == row["id"], vault_grants.c.status == "active")
+            .where(vault_grants.c.id == row["id"], vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))
             .values(status="expired", revoked_at=now, agent_ready=0, agent_ready_at=None)
         )
         cache.drop(row["id"])
@@ -1806,7 +1809,7 @@ def agent_release_scopes_after_rows(
         return []
     active_rows = [
         dict(row)
-        for row in conn.execute(select(vault_grants).where(vault_grants.c.status == "active")).mappings()
+        for row in conn.execute(select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES))).mappings()
         if grant_row_has_resident_agent_ready(dict(row))
     ]
     active_by_scope: dict[tuple[str, str], set[str]] = {}
@@ -1840,7 +1843,7 @@ def agent_release_scopes_after_rows(
             .where(
                 vault_grants.c.scope_type == scope_type,
                 vault_grants.c.scope_ref == scope_ref,
-                vault_grants.c.status == "active",
+                vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES),
             )
             .values(agent_ready=0, agent_ready_at=None)
         )
@@ -2353,8 +2356,15 @@ def find_active_grant_for_secret(
     *,
     session_id: str | None = None,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    reserve_one_shot: bool = False,
 ) -> dict[str, Any] | None:
-    return find_active_grant_for_secrets(conn, [secret_name], session_id=session_id, cache=cache)
+    return find_active_grant_for_secrets(
+        conn,
+        [secret_name],
+        session_id=session_id,
+        cache=cache,
+        reserve_one_shot=reserve_one_shot,
+    )
 
 
 def _grant_is_always_ask_for_members(
@@ -2377,7 +2387,7 @@ def consume_one_shot_grant(
     if row is None:
         raise GrantNotFoundError(grant_id)
     row_dict = dict(row)
-    if row_dict.get("status") != "active":
+    if row_dict.get("status") not in ACTIVE_GRANT_STATUSES:
         raise GrantNotActiveError(grant_id)
     if not _grant_is_always_ask_for_members(conn, row_dict):
         return []
@@ -2390,12 +2400,62 @@ def consume_one_shot_grant(
     return agent_release_scopes_after_rows(conn, [row_dict], cache=cache)
 
 
+def release_one_shot_reservation(
+    conn: Connection,
+    grant_id: str,
+    *,
+    cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+) -> dict[str, Any]:
+    row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
+    if row is None:
+        raise GrantNotFoundError(grant_id)
+    row_dict = dict(row)
+    if row_dict.get("status") != "reserved":
+        raise GrantNotActiveError(grant_id)
+    if not _grant_is_always_ask_for_members(conn, row_dict):
+        raise InvalidGrantError("grant is not one-shot")
+    result = conn.execute(
+        vault_grants.update()
+        .where(vault_grants.c.id == grant_id, vault_grants.c.status == "reserved")
+        .values(status="active")
+    )
+    if result.rowcount != 1:
+        raise GrantNotActiveError(grant_id)
+    audit(conn, "grant-reservation-released", grant_id=grant_id, delivery={"scope_type": row_dict["scope_type"], "scope_ref": row_dict["scope_ref"]})
+    row_dict = dict(conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().one())
+    members = _grant_member_names(row_dict)
+    if grant_row_has_resident_agent_ready(row_dict) and members:
+        cache.put(grant_id, members, expires_at=row_dict.get("expires_at"))
+    return _grant_payload(conn, row_dict, cache=cache)
+
+
+def _reserve_one_shot_grant(
+    conn: Connection,
+    row: dict[str, Any],
+    *,
+    cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+) -> dict[str, Any] | None:
+    if row.get("status") != "active" or not _grant_is_always_ask_for_members(conn, row):
+        return _grant_payload(conn, row, cache=cache)
+    result = conn.execute(
+        vault_grants.update()
+        .where(vault_grants.c.id == row["id"], vault_grants.c.status == "active")
+        .values(status="reserved")
+    )
+    if result.rowcount != 1:
+        return None
+    audit(conn, "grant-reserved-one-shot", grant_id=row["id"], delivery={"scope_type": row["scope_type"], "scope_ref": row["scope_ref"]})
+    updated = dict(conn.execute(select(vault_grants).where(vault_grants.c.id == row["id"])).mappings().one())
+    return _grant_payload(conn, updated, cache=cache)
+
+
 def find_active_grant_for_secrets(
     conn: Connection,
     secret_names: list[str],
     *,
     session_id: str | None = None,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    reserve_one_shot: bool = False,
 ) -> dict[str, Any] | None:
     expire_grants(conn, cache=cache)
     requested = {str(name) for name in secret_names if str(name)}
@@ -2437,6 +2497,8 @@ def find_active_grant_for_secrets(
         key=lambda item: (item[2], item[3]),
     )
     payload = _grant_payload(conn, row, cache=cache)
+    if reserve_one_shot and payload.get("one_shot") is True:
+        return _reserve_one_shot_grant(conn, row, cache=cache)
     return payload
 
 
@@ -2449,6 +2511,7 @@ def resolve_secret_access(
     delivery: dict[str, Any] | None = None,
     create_request: bool = True,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    reserve_one_shot: bool = True,
 ) -> dict[str, Any]:
     """Resolve an agent access attempt without exposing the value.
 
@@ -2468,7 +2531,13 @@ def resolve_secret_access(
     always_ask = _secret_always_ask(row)
     if row.get("protection") == "standard" and not always_ask:
         return {"status": "standard", "secret": _meta_payload(row), "envelope": _row_sealed(row)}
-    grant = find_active_grant_for_secret(conn, name, session_id=effective_session_id, cache=cache)
+    grant = find_active_grant_for_secret(
+        conn,
+        name,
+        session_id=effective_session_id,
+        cache=cache,
+        reserve_one_shot=reserve_one_shot,
+    )
     if grant is not None:
         return {
             "status": "standard" if row.get("protection") == "standard" else "agent_delivery_ready",

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -389,6 +389,10 @@ def _grant_row_payload(
     readiness = _grant_readiness(conn, row, cache=cache, members=members)
     grant_id = row["id"]
     runtime_members = cache.covered_names(grant_id) if readiness.active else []
+    try:
+        always_ask = len(members) == 1 and _secret_always_ask(_require_row(conn, members[0]))
+    except SecretNotFoundError:
+        always_ask = False
     return {
         "id": grant_id,
         "scope_type": row["scope_type"],
@@ -404,6 +408,7 @@ def _grant_row_payload(
         "runtime_member_count": len(runtime_members),
         "delivery_ready": readiness.delivery_ready,
         "delivery_status": readiness.delivery_status,
+        "one_shot": always_ask,
     }
 
 
@@ -611,10 +616,18 @@ def _secret_policy(row: dict[str, Any]) -> dict[str, Any]:
     return _loads(row.get("policy")) or {}
 
 
+def _secret_always_ask(row: dict[str, Any]) -> bool:
+    return bool(_secret_policy(row).get("always_ask"))
+
+
+def _secret_access_requestable(row: dict[str, Any]) -> bool:
+    return row.get("kind") != "keypair"
+
+
 def _secret_access_grantable(row: dict[str, Any]) -> bool:
     if row.get("kind") == "keypair":
         return False
-    if _secret_policy(row).get("always_ask"):
+    if _secret_always_ask(row):
         return False
     return True
 
@@ -1151,8 +1164,66 @@ def _grantable_member_rows(conn: Connection, scope_type: str, scope_ref: str) ->
     ]
 
 
+def _always_ask_request_member_rows(
+    conn: Connection,
+    scope_type: str,
+    scope_ref: str,
+    request_row: dict[str, Any],
+) -> list[dict[str, Any]]:
+    requested_secret = request_row.get("secret_name")
+    if not requested_secret or scope_type != "secret" or scope_ref != requested_secret:
+        return []
+    row = _require_row(conn, str(requested_secret))
+    if not _secret_access_requestable(row) or not _secret_always_ask(row):
+        return []
+    return [row]
+
+
+def _grantable_member_rows_for_request(
+    conn: Connection,
+    scope_type: str,
+    scope_ref: str,
+    request_id: str | None,
+) -> list[dict[str, Any]]:
+    rows = _grantable_member_rows(conn, scope_type, scope_ref)
+    if rows or not request_id:
+        return rows
+    try:
+        request_row = _load_request_for_transition(
+            conn,
+            str(request_id),
+            request_type="access",
+            allowed_statuses={"pending"},
+            wrong_type_message="grant approval must complete an access request",
+            wrong_status_message="grant approval request is not pending",
+            expired_message="grant approval request has expired",
+        )
+    except RequestNotFoundError:
+        raise
+    except InvalidRequestError:
+        raise
+    return _always_ask_request_member_rows(conn, scope_type, scope_ref, request_row)
+
+
 def grantable_member_metas(conn: Connection, scope_type: str, scope_ref: str) -> list[dict[str, Any]]:
     return [_meta_payload(row) for row in _grantable_member_rows(conn, scope_type, scope_ref)]
+
+
+def request_grantable_member_metas(
+    conn: Connection,
+    scope_type: str,
+    scope_ref: str,
+    request_id: str,
+) -> list[dict[str, Any]]:
+    return [
+        _meta_payload(row)
+        for row in _grantable_member_rows_for_request(
+            conn,
+            scope_type,
+            scope_ref,
+            request_id,
+        )
+    ]
 
 
 def _ttl_cap_for_members(conn: Connection, member_names: list[str]) -> int:
@@ -1211,8 +1282,23 @@ def approval_card(
 ) -> dict[str, Any]:
     row = _require_row(conn, secret_name)
     group = row.get("group_name") or DEFAULT_GROUP
+    always_ask = _secret_always_ask(row)
     scope_options: list[dict[str, Any]] = []
-    if grantable:
+    if always_ask:
+        scope_options = [
+            {
+                "scope_type": "secret",
+                "scope_ref": secret_name,
+                "default_ttl_seconds": DEFAULT_GRANT_TTL_SECONDS["secret"],
+                "ttl_options_seconds": list(GRANT_TTL_OPTIONS_SECONDS),
+                "session_binding_default": True,
+                "member_count": 1,
+                "member_snapshot": [secret_name],
+                "member_versions": [_member_version(row)],
+                "one_shot": True,
+            }
+        ]
+    if grantable and not always_ask:
         scope_options = [
             option
             for option in (
@@ -1255,6 +1341,7 @@ def approval_card(
         "egress": egress,
         "session_id": session_id,
         "approve_once": True,
+        "one_shot": always_ask,
         "scope_options": scope_options,
         "value": None,
     }
@@ -1272,12 +1359,13 @@ def create_access_request(
     audience: str | None = None,
 ) -> dict[str, Any]:
     row = _require_row(conn, name)
-    if not _secret_access_grantable(row):
-        raise NotGrantableError(f"{name} is not access-grantable")
+    if not _secret_access_requestable(row):
+        raise NotGrantableError(f"{name} is not access-requestable")
     payload_audience = audience or _request_audience_from_requester(requester)
     request_id = _id("vrq")
     delivery_payload = dict(delivery or {})
     requester_payload = requester if isinstance(requester, dict) else {}
+    always_ask = _secret_always_ask(row)
     card = approval_card(
         conn,
         name,
@@ -1287,6 +1375,7 @@ def create_access_request(
         egress=delivery_payload.get("egress"),
         skill=delivery_payload.get("skill") or requester_payload.get("skill"),
         session_id=requester_payload.get("session_id") or delivery_payload.get("session_id"),
+        grantable=not always_ask,
     )
     delivery_payload["card"] = card
     conn.execute(
@@ -1810,8 +1899,18 @@ def _validate_access_request_for_grant(
     requested_secret = row_dict.get("secret_name")
     if requested_secret not in live_members:
         raise InvalidRequestError("grant scope does not cover the requested secret")
+    requested_row = _require_row(conn, str(requested_secret))
+    always_ask = _secret_always_ask(requested_row)
+    if always_ask and (
+        scope_type != "secret"
+        or scope_ref != requested_secret
+        or set(live_members) != {requested_secret}
+    ):
+        raise InvalidRequestError("always_ask secrets can only approve one-shot secret access")
     requested_session_id = _request_session_id(row_dict)
     effective_session_id = requested_session_id if session_id is None and inherit_request_session else session_id
+    if always_ask:
+        effective_session_id = requested_session_id or effective_session_id
     if requested_session_id and effective_session_id and requested_session_id != effective_session_id:
         raise InvalidRequestError("grant session does not match the approval request")
     card = _request_card(row_dict)
@@ -1828,6 +1927,8 @@ def _validate_access_request_for_grant(
             if not isinstance(snapshot, list):
                 raise InvalidRequestError("grant scope has an invalid approval snapshot")
             members = [str(name) for name in snapshot if isinstance(name, str) and name]
+            if always_ask and set(members) != {requested_secret}:
+                raise InvalidRequestError("always_ask secrets can only approve one-shot secret access")
             if requested_secret not in members:
                 break
             versions = option.get("member_versions")
@@ -1982,7 +2083,7 @@ def create_grant(
         raise InvalidGrantError(f"invalid grant scope_type: {scope_type!r}")
     if not created_by_request_id:
         raise InvalidRequestError("grant creation requires an approval request")
-    live_rows = _grantable_member_rows(conn, scope_type, scope_ref)
+    live_rows = _grantable_member_rows_for_request(conn, scope_type, scope_ref, created_by_request_id)
     live_members = [row["name"] for row in live_rows]
     if not live_members:
         raise NotGrantableError(f"{scope_type}:{scope_ref} has no grantable static secrets")
@@ -2002,6 +2103,7 @@ def create_grant(
     if expected_member_names is not None and set(members) != set(expected_member_names):
         raise InvalidGrantError("resident agent DEKs must match the approved grant members")
     live_rows_by_name = {row["name"]: row for row in live_rows}
+    always_ask_grant = len(members) == 1 and _secret_always_ask(live_rows_by_name[members[0]])
     resident_cache_ready = cache_ready and any(
         live_rows_by_name[name].get("protection") != "standard" for name in members
     )
@@ -2054,13 +2156,14 @@ def create_grant(
         grant_id=grant_id,
     )
     row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().one()
-    _approve_sibling_access_requests_for_grant(
-        conn,
-        created_by_request_id=created_by_request_id,
-        members=members,
-        session_id=session_id,
-        decided_at=decided_at,
-    )
+    if not always_ask_grant:
+        _approve_sibling_access_requests_for_grant(
+            conn,
+            created_by_request_id=created_by_request_id,
+            members=members,
+            session_id=session_id,
+            decided_at=decided_at,
+        )
     if resident_cache_ready:
         cache.put(grant_id, members, expires_at=expires_at)
     return _grant_payload(conn, dict(row), cache=cache)
@@ -2218,6 +2321,33 @@ def find_active_grant_for_secret(
     return find_active_grant_for_secrets(conn, [secret_name], session_id=session_id, cache=cache)
 
 
+def _grant_is_always_ask_for_requested(
+    conn: Connection,
+    row: dict[str, Any],
+    requested: set[str],
+) -> bool:
+    members = _grant_member_names(row)
+    if set(members) != requested:
+        return False
+    if len(requested) != 1:
+        return False
+    return _secret_always_ask(_require_row(conn, next(iter(requested))))
+
+
+def _consume_always_ask_grant(
+    conn: Connection,
+    row: dict[str, Any],
+    *,
+    cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+) -> None:
+    _expire_grant_rows(
+        conn,
+        [row],
+        cache=cache,
+        reason="grant-expired-always-ask-consumed",
+    )
+
+
 def find_active_grant_for_secrets(
     conn: Connection,
     secret_names: list[str],
@@ -2264,7 +2394,10 @@ def find_active_grant_for_secrets(
         (item for item in candidates if item[1] == member_count),
         key=lambda item: (item[2], item[3]),
     )
-    return _grant_payload(conn, row, cache=cache)
+    payload = _grant_payload(conn, row, cache=cache)
+    if _grant_is_always_ask_for_requested(conn, row, requested):
+        _consume_always_ask_grant(conn, row, cache=cache)
+    return payload
 
 
 def resolve_secret_access(
@@ -2286,18 +2419,19 @@ def resolve_secret_access(
     """
     row = _require_row(conn, name)
     _reject_keypair_value_delivery(row, name)
-    if row.get("protection") == "standard":
-        return {"status": "standard", "secret": _meta_payload(row), "envelope": _row_sealed(row)}
     delivery_payload = dict(delivery or {})
     effective_session_id = (
         session_id
         or _payload_session_id(delivery_payload)
         or _payload_session_id(requester)
     )
+    always_ask = _secret_always_ask(row)
+    if row.get("protection") == "standard" and not always_ask:
+        return {"status": "standard", "secret": _meta_payload(row), "envelope": _row_sealed(row)}
     grant = find_active_grant_for_secret(conn, name, session_id=effective_session_id, cache=cache)
     if grant is not None:
         return {
-            "status": "agent_delivery_ready",
+            "status": "standard" if row.get("protection") == "standard" else "agent_delivery_ready",
             "secret": _meta_payload(row),
             "grant": grant,
             "envelope": _row_sealed(row),

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -684,7 +684,7 @@ def archive_session(conn: Connection, session_id: str) -> dict[str, Any]:
     #     then no-ops on that in-flight send), and the saved composer draft.
     from storage.messages_service import clear_draft, clear_pending, clear_queued
     from storage.vault_service import (
-        ACTIVE_GRANT_STATUSES,
+        ACTIVE_GRANT_STATES,
         agent_release_scopes_after_rows,
         expire_session_requests,
         revoke_session_grants,
@@ -697,7 +697,7 @@ def archive_session(conn: Connection, session_id: str) -> dict[str, Any]:
     revoked_vault_grant_rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.session_id == session_id)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATES), vault_grants.c.session_id == session_id)
         ).mappings()
     ]
     expire_session_requests(conn, session_id)

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -684,6 +684,7 @@ def archive_session(conn: Connection, session_id: str) -> dict[str, Any]:
     #     then no-ops on that in-flight send), and the saved composer draft.
     from storage.messages_service import clear_draft, clear_pending, clear_queued
     from storage.vault_service import (
+        ACTIVE_GRANT_STATUSES,
         agent_release_scopes_after_rows,
         expire_session_requests,
         revoke_session_grants,
@@ -696,7 +697,7 @@ def archive_session(conn: Connection, session_id: str) -> dict[str, Any]:
     revoked_vault_grant_rows = [
         dict(row)
         for row in conn.execute(
-            select(vault_grants).where(vault_grants.c.status == "active", vault_grants.c.session_id == session_id)
+            select(vault_grants).where(vault_grants.c.status.in_(ACTIVE_GRANT_STATUSES), vault_grants.c.session_id == session_id)
         ).mappings()
     ]
     expire_session_requests(conn, session_id)

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -171,6 +171,7 @@ def test_archive_reclaims_bound_resources(tmp_path: Path) -> None:
             "ARCHIVE_RESERVED_KEY",
             requester={"session_id": sid},
             delivery={"session_id": sid, "command": "python reserved.py"},
+            reserve_one_shot=True,
         )
         assert cache.has(grant["id"], "ARCHIVE_KEY")
         assert reserved["grant"]["status"] == "reserved"

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -97,6 +97,13 @@ def test_archive_reclaims_bound_resources(tmp_path: Path) -> None:
         vs.create_secret(conn, name="ARCHIVE_OTHER_KEY", protection="protected", sealed=Sealed("ct-other", "nonce-other", "wrap-other"))
         vs.create_secret(
             conn,
+            name="ARCHIVE_RESERVED_KEY",
+            protection="protected",
+            sealed=Sealed("ct-reserved", "nonce-reserved", "wrap-reserved"),
+            policy={"always_ask": True},
+        )
+        vs.create_secret(
+            conn,
             name="ARCHIVE_SIGNING_KEY",
             protection="protected",
             kind="keypair",
@@ -145,7 +152,29 @@ def test_archive_reclaims_bound_resources(tmp_path: Path) -> None:
             created_by_request_id=req["id"],
             cache=cache,
         )
+        reserved_req = vs.create_access_request(
+            conn,
+            "ARCHIVE_RESERVED_KEY",
+            requester={"session_id": sid},
+            delivery={"session_id": sid, "command": "python reserved.py"},
+        )
+        reserved_grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ARCHIVE_RESERVED_KEY",
+            session_id=sid,
+            created_by_request_id=reserved_req["id"],
+            cache=cache,
+        )
+        reserved = vs.resolve_secret_access(
+            conn,
+            "ARCHIVE_RESERVED_KEY",
+            requester={"session_id": sid},
+            delivery={"session_id": sid, "command": "python reserved.py"},
+        )
         assert cache.has(grant["id"], "ARCHIVE_KEY")
+        assert reserved["grant"]["status"] == "reserved"
+        assert cache.has(reserved_grant["id"], "ARCHIVE_RESERVED_KEY")
 
     with engine.begin() as conn:
         result = wss.archive_session(conn, sid)
@@ -153,7 +182,10 @@ def test_archive_reclaims_bound_resources(tmp_path: Path) -> None:
     assert result["status"] == "archived"
     assert result["agent_status"] == "idle"
     assert result["reclaimed"] == {"tasks": 1, "watches": 1, "runs": 2, "queued": 0}
-    assert result["revoked_vault_grant_scopes"] == [{"scope_type": "secret", "scope_ref": "ARCHIVE_KEY"}]
+    assert {(scope["scope_type"], scope["scope_ref"]) for scope in result["revoked_vault_grant_scopes"]} == {
+        ("secret", "ARCHIVE_KEY"),
+        ("secret", "ARCHIVE_RESERVED_KEY"),
+    }
 
     with engine.connect() as conn:
         live_defs = (
@@ -179,8 +211,13 @@ def test_archive_reclaims_bound_resources(tmp_path: Path) -> None:
         assert page["visibility"] == "offline"
         assert page["offline_at"] is not None
         grant_row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant["id"])).mappings().one()
+        reserved_grant_row = conn.execute(
+            select(vault_grants).where(vault_grants.c.id == reserved_grant["id"])
+        ).mappings().one()
         assert grant_row["status"] == "revoked"
+        assert reserved_grant_row["status"] == "revoked"
         assert not cache.has(grant["id"], "ARCHIVE_KEY")
+        assert not cache.has(reserved_grant["id"], "ARCHIVE_RESERVED_KEY")
         request_statuses = {
             row["id"]: row["status"]
             for row in conn.execute(

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -981,6 +981,42 @@ def test_always_ask_grant_api_maps_stale_request_preflight_to_json_error(monkeyp
     assert exc.value.status == 409
 
 
+def test_always_ask_grant_api_commits_expired_preflight_request(monkeypatch):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    api.create_vault_secret(
+        {
+            "name": "ASK_KEY",
+            "policy": {"always_ask": True},
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+    requested = api.request_vault_access({"name": "ASK_KEY", "session_id": "ses_1"})
+    with api._vault_engine().begin() as conn:
+        conn.execute(
+            vault_service.vault_requests.update()
+            .where(vault_service.vault_requests.c.id == requested["request"]["id"])
+            .values(expires_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat())
+        )
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.create_vault_grant(
+            {
+                "scope_type": "secret",
+                "scope_ref": "ASK_KEY",
+                "session_id": "ses_1",
+                "request_id": requested["request"]["id"],
+            }
+        )
+
+    assert exc.value.code == "invalid_request"
+    assert exc.value.status == 409
+    with api._vault_engine().connect() as conn:
+        stored = conn.execute(
+            select(vault_service.vault_requests.c.status).where(vault_service.vault_requests.c.id == requested["request"]["id"])
+        ).scalar_one()
+    assert stored == "expired"
+
+
 def test_fulfill_access_request_rejects_dek_or_plaintext_material(monkeypatch, avault_p2):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
@@ -1167,6 +1203,63 @@ def test_revoke_grant_keeps_agent_scope_when_other_active_grant_exists(monkeypat
     agent_release.assert_not_called()
     with api._vault_engine().connect() as conn:
         assert vault_service.find_active_grant_for_secret(conn, "GRANT_KEY", session_id="ses_2")["id"] == grant_2["id"]
+
+
+def test_consume_one_shot_keeps_agent_scope_when_other_active_grant_exists(monkeypatch):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_release = Mock(return_value={"released": True})
+    monkeypatch.setattr(api, "avault_agent_release", agent_release)
+    api.create_vault_secret(
+        {
+            "name": "ASK_KEY",
+            "protection": "protected",
+            "policy": {"always_ask": True},
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+        }
+    )
+    with api._vault_engine().begin() as conn:
+        req_1 = vault_service.create_access_request(
+            conn,
+            "ASK_KEY",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant_1 = vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            created_by_request_id=req_1["id"],
+        )
+        req_2 = vault_service.create_access_request(
+            conn,
+            "ASK_KEY",
+            requester={"session_id": "ses_2"},
+            delivery={"session_id": "ses_2"},
+        )
+        grant_2 = vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            created_by_request_id=req_2["id"],
+        )
+
+    api.consume_one_shot_grants([grant_1], reason="test")
+
+    agent_release.assert_not_called()
+    with api._vault_engine().connect() as conn:
+        statuses = {
+            row["id"]: row["status"]
+            for row in conn.execute(
+                select(vault_service.vault_grants.c.id, vault_service.vault_grants.c.status).where(
+                    vault_service.vault_grants.c.id.in_([grant_1["id"], grant_2["id"]])
+                )
+            ).mappings()
+        }
+        active = vault_service.find_active_grant_for_secret(conn, "ASK_KEY", session_id="ses_2")
+    assert statuses[grant_1["id"]] == "expired"
+    assert statuses[grant_2["id"]] == "active"
+    assert active["id"] == grant_2["id"]
+    assert active["delivery_ready"] is True
 
 
 def test_revoke_grant_releases_scope_when_remaining_members_do_not_cover_cache(monkeypatch):

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1262,6 +1262,76 @@ def test_consume_one_shot_keeps_agent_scope_when_other_active_grant_exists(monke
     assert active["delivery_ready"] is True
 
 
+def test_forced_agent_grant_cleanup_treats_reserved_grant_as_live(monkeypatch):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_release = Mock(return_value={"released": True})
+    monkeypatch.setattr(api, "avault_agent_release", agent_release)
+    api.create_vault_secret(
+        {
+            "name": "ASK_KEY",
+            "protection": "protected",
+            "policy": {"always_ask": True},
+            "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"},
+        }
+    )
+    with api._vault_engine().begin() as conn:
+        req_1 = vault_service.create_access_request(
+            conn,
+            "ASK_KEY",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant_1 = vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            created_by_request_id=req_1["id"],
+        )
+        req_2 = vault_service.create_access_request(
+            conn,
+            "ASK_KEY",
+            requester={"session_id": "ses_2"},
+            delivery={"session_id": "ses_2"},
+        )
+        grant_2 = vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_2",
+            created_by_request_id=req_2["id"],
+        )
+        reserved = vault_service.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_2",
+            requester={"session_id": "ses_2"},
+            delivery={"session_id": "ses_2"},
+            reserve_one_shot=True,
+        )
+
+    assert reserved["grant"]["id"] == grant_2["id"]
+    assert reserved["grant"]["status"] == "reserved"
+
+    api._cleanup_failed_agent_grant(
+        engine=api._vault_engine(),
+        grant=grant_1,
+        reason="test",
+        force_release_scope=True,
+    )
+
+    agent_release.assert_not_called()
+    with api._vault_engine().connect() as conn:
+        statuses = {
+            row["id"]: row["status"]
+            for row in conn.execute(
+                select(vault_service.vault_grants.c.id, vault_service.vault_grants.c.status).where(
+                    vault_service.vault_grants.c.id.in_([grant_1["id"], grant_2["id"]])
+                )
+            ).mappings()
+        }
+    assert statuses == {grant_1["id"]: "expired", grant_2["id"]: "reserved"}
+
+
 def test_revoke_grant_releases_scope_when_remaining_members_do_not_cover_cache(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     agent_release = Mock(return_value={"released": True})

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -955,6 +955,32 @@ def test_fulfill_protected_always_ask_access_uses_one_shot_resident_agent_grant(
     ]
 
 
+def test_always_ask_grant_api_maps_stale_request_preflight_to_json_error(monkeypatch):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    api.create_vault_secret(
+        {
+            "name": "ASK_KEY",
+            "policy": {"always_ask": True},
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+    requested = api.request_vault_access({"name": "ASK_KEY", "session_id": "ses_1"})
+    api.deny_vault_request(requested["request"]["id"])
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.create_vault_grant(
+            {
+                "scope_type": "secret",
+                "scope_ref": "ASK_KEY",
+                "session_id": "ses_1",
+                "request_id": requested["request"]["id"],
+            }
+        )
+
+    assert exc.value.code == "invalid_request"
+    assert exc.value.status == 409
+
+
 def test_fulfill_access_request_rejects_dek_or_plaintext_material(monkeypatch, avault_p2):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1508,6 +1508,25 @@ def test_agent_deliver_run_reuses_resident_agent_socket(monkeypatch):
     assert seen_timeout == [None]
 
 
+def test_agent_deliver_run_treats_connect_failure_as_pre_handoff(monkeypatch):
+    from vibe.avault_agent import AvaultAgentError
+
+    class FakeManager:
+        def client(self, *, timeout=None):
+            raise AvaultAgentError("failed to connect to avault agent: [Errno 2] No such file or directory")
+
+    monkeypatch.setattr(api, "_require_avault_p2_surface", lambda _feature: None)
+    monkeypatch.setattr(api, "_avault_agent_manager", lambda: FakeManager())
+
+    with pytest.raises(api.AvaultPreHandoffError):
+        api.avault_agent_deliver_run(
+            scope_type="secret",
+            scope_ref="GRANT_KEY",
+            secrets=[{"name": "GRANT_KEY", "env": "GRANT_KEY", "envelope": _sealed()}],
+            command=["python3", "-c", "pass"],
+        )
+
+
 def test_agent_deliver_fetch_uses_finite_timeout(monkeypatch):
     seen_timeout = []
 

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -908,6 +908,53 @@ def test_fulfill_access_request_relays_only_browser_dek_blindbox(monkeypatch, av
     assert "plaintext-must-not-cross-python-agent-boundary" not in encoded
 
 
+def test_fulfill_protected_always_ask_access_uses_one_shot_resident_agent_grant(monkeypatch, avault_p2):
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
+    validate_pubkey = Mock()
+    monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
+    monkeypatch.setattr(api, "validate_avault_agent_pubkey", validate_pubkey)
+    api.create_vault_secret(
+        {
+            "name": "PROTECTED_ASK",
+            "protection": "protected",
+            "policy": {"always_ask": True},
+            "sealed": {"ciphertext": "ct-protected", "nonce": "n-protected", "wrap_meta": "wm-protected"},
+        }
+    )
+    requested = api.request_vault_access({"name": "PROTECTED_ASK", "session_id": "ses_1"})
+
+    fulfilled = api.fulfill_vault_access_request(
+        requested["request"]["id"],
+        {
+            "session_id": "ses_1",
+            "agent_pubkey": {"public_key": "pk", "fingerprint": "fp"},
+            "deks": [
+                {
+                    "name": "PROTECTED_ASK",
+                    "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+                    "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+                }
+            ],
+        },
+    )
+
+    assert requested["request"]["card"]["one_shot"] is True
+    assert requested["request"]["card"]["scope_options"][0]["scope_ref"] == "PROTECTED_ASK"
+    assert fulfilled["grant"]["one_shot"] is True
+    assert fulfilled["grant"]["scope_type"] == "secret"
+    assert fulfilled["grant"]["scope_ref"] == "PROTECTED_ASK"
+    assert fulfilled["grant"]["delivery_ready"] is True
+    validate_pubkey.assert_called_once_with({"public_key": "pk", "fingerprint": "fp"})
+    assert agent_grant.call_args.kwargs["deks"] == [
+        {
+            "name": "PROTECTED_ASK",
+            "dek_blindbox": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+            "approval": {"nonce": "bm9uY2UtMTIzNDU2", "expires_at_unix": 4102444800},
+        }
+    ]
+
+
 def test_fulfill_access_request_rejects_dek_or_plaintext_material(monkeypatch, avault_p2):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -1016,6 +1016,26 @@ def test_inject_releases_standard_always_ask_grant_when_avault_fails_before_hand
     assert status == "active"
 
 
+def test_inject_uses_resolved_output_path_for_standard_always_ask_delivery(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(return_value=None)
+    monkeypatch.setattr(api, "avault_deliver_inject", deliver)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    expected = str((tmp_path / "out.env").resolve(strict=False))
+
+    code = cli.cmd_vault_inject(_ns(keys="ASK_KEY", out="~/out.env", format="dotenv", session_id="ses_cli"))
+    payload = json.loads(capfd.readouterr().out)
+
+    assert code == 0
+    assert payload["path"] == expected
+    deliver.assert_called_once_with(expected, "dotenv", [{"name": "ASK_KEY", "key": "ASK_KEY", "envelope": _sealed("ask_key")}])
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
+
+
 def test_inject_rejects_unwritable_output_before_reserving_one_shot_grant(tmp_path, capfd, monkeypatch):
     from vibe import api
 
@@ -1026,6 +1046,26 @@ def test_inject_rejects_unwritable_output_before_reserving_one_shot_grant(tmp_pa
     code = cli.cmd_vault_inject(
         _ns(keys="ASK_KEY", out=str(tmp_path / "missing" / "out.env"), format="dotenv", session_id="ses_cli")
     )
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "output_unwritable"
+    deliver.assert_not_called()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
+
+
+def test_inject_rejects_existing_directory_output_before_reserving_one_shot_grant(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_deliver_inject", deliver)
+    out = tmp_path / "out.env"
+    out.mkdir()
+
+    code = cli.cmd_vault_inject(_ns(keys="ASK_KEY", out=str(out), format="dotenv", session_id="ses_cli"))
     captured = capfd.readouterr()
 
     assert code == 1

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -1016,6 +1016,26 @@ def test_inject_releases_standard_always_ask_grant_when_avault_fails_before_hand
     assert status == "active"
 
 
+def test_inject_rejects_unwritable_output_before_reserving_one_shot_grant(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_deliver_inject", deliver)
+
+    code = cli.cmd_vault_inject(
+        _ns(keys="ASK_KEY", out=str(tmp_path / "missing" / "out.env"), format="dotenv", session_id="ses_cli")
+    )
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "output_unwritable"
+    deliver.assert_not_called()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
+
+
 def test_inject_releases_one_shot_grant_when_later_resolution_aborts_before_handoff(tmp_path, capfd, monkeypatch):
     from vibe import api
 

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -740,6 +740,56 @@ def test_inject_fast_path_reserves_protected_always_ask_grant(tmp_path, capfd, m
     assert status == "expired"
 
 
+def test_run_mixed_grants_releases_reserved_always_ask_grants_before_delivery(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant_a = _set_protected_always_ask_grant("A_ASK", session_id="ses_cli")
+    grant_b = _set_protected_always_ask_grant("B_ASK", session_id="ses_cli")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_agent_deliver_run", deliver)
+    monkeypatch.setattr(api, "avault_deliver_run", Mock())
+
+    code = cli.cmd_vault_run(_ns(env=["A_ASK", "B_ASK"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "mixed_grants"
+    deliver.assert_not_called()
+    with cli._open_vault_engine().connect() as conn:
+        statuses = {
+            row["id"]: row["status"]
+            for row in conn.execute(
+                vault_grants.select().where(vault_grants.c.id.in_([grant_a["id"], grant_b["id"]]))
+            ).mappings()
+        }
+    assert statuses == {grant_a["id"]: "active", grant_b["id"]: "active"}
+
+
+def test_inject_mixed_grants_releases_reserved_always_ask_grants_before_delivery(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant_a = _set_protected_always_ask_grant("A_ASK", session_id="ses_cli")
+    grant_b = _set_protected_always_ask_grant("B_ASK", session_id="ses_cli")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_agent_deliver_inject", deliver)
+    monkeypatch.setattr(api, "avault_deliver_inject", Mock())
+
+    code = cli.cmd_vault_inject(_ns(keys="A_ASK,B_ASK", out=str(tmp_path / "out.env"), format="dotenv", session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "mixed_grants"
+    deliver.assert_not_called()
+    with cli._open_vault_engine().connect() as conn:
+        statuses = {
+            row["id"]: row["status"]
+            for row in conn.execute(
+                vault_grants.select().where(vault_grants.c.id.in_([grant_a["id"], grant_b["id"]]))
+            ).mappings()
+        }
+    assert statuses == {grant_a["id"]: "active", grant_b["id"]: "active"}
+
+
 def test_run_reuses_reserved_grant_for_duplicate_always_ask_secret(tmp_path, capfd, monkeypatch):
     from vibe import api
 
@@ -827,6 +877,42 @@ def test_run_consumes_standard_always_ask_grant_when_child_exits_70(tmp_path, ca
         [{"name": "ASK_KEY", "env": "ASK_KEY", "envelope": _sealed("ask_key")}],
         ["python3", "-c", "raise SystemExit(70)"],
     )
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
+
+
+def test_run_consumes_standard_always_ask_grant_when_avault_errors_after_handoff(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(side_effect=api.AvaultError("timed out after possible handoff"))
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(_ns(env=["ASK_KEY"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "avault_failed"
+    deliver.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
+
+
+def test_inject_consumes_standard_always_ask_grant_when_avault_errors_after_handoff(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(side_effect=api.AvaultError("write failed after possible handoff"))
+    monkeypatch.setattr(api, "avault_deliver_inject", deliver)
+
+    code = cli.cmd_vault_inject(_ns(keys="ASK_KEY", out=str(tmp_path / "out.env"), format="dotenv", session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "avault_failed"
+    deliver.assert_called_once()
     with cli._open_vault_engine().connect() as conn:
         status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
     assert status == "expired"
@@ -974,7 +1060,7 @@ def test_run_records_protected_delivery_when_child_exits_70(capfd, monkeypatch):
     assert secret["use_count"] == 1
 
 
-def test_run_skips_delivery_audit_when_avault_returns_70(tmp_path, capfd, monkeypatch):
+def test_run_records_delivery_when_legacy_avault_returns_70(tmp_path, capfd, monkeypatch):
     from unittest.mock import Mock
 
     from vibe import api
@@ -985,10 +1071,10 @@ def test_run_skips_delivery_audit_when_avault_returns_70(tmp_path, capfd, monkey
     assert cli.cmd_vault_run(_ns(env=["NODELIVER_KEY"], command_argv=["python3", "-c", "pass"])) == 70
     cli.cmd_vault_list(_ns())
     secret = json.loads(capfd.readouterr().out)["secrets"][0]
-    assert secret["use_count"] == 0
+    assert secret["use_count"] == 1
 
 
-def test_run_releases_standard_always_ask_grant_when_avault_internal_70(tmp_path, capfd, monkeypatch):
+def test_run_releases_standard_always_ask_grant_on_explicit_pre_handoff_failure(tmp_path, capfd, monkeypatch):
     from unittest.mock import Mock
 
     from vibe import api

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -960,6 +960,26 @@ def test_run_releases_standard_always_ask_grant_when_avault_fails_before_handoff
     assert status == "active"
 
 
+def test_run_releases_one_shot_grant_when_later_resolution_aborts_before_handoff(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="ETH_KEY", sealed=_sealed("eth"), kind="keypair", signer_kind="local")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(_ns(env=["ASK_KEY", "ETH_KEY"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "keypair_not_value_deliverable"
+    deliver.assert_not_called()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
+
+
 def test_inject_consumes_standard_always_ask_grant_when_avault_errors_after_handoff(tmp_path, capfd, monkeypatch):
     from vibe import api
 
@@ -991,6 +1011,26 @@ def test_inject_releases_standard_always_ask_grant_when_avault_fails_before_hand
     assert code == 1
     assert json.loads(captured.err)["code"] == "avault_failed"
     deliver.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
+
+
+def test_inject_releases_one_shot_grant_when_later_resolution_aborts_before_handoff(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="ETH_KEY", sealed=_sealed("eth"), kind="keypair", signer_kind="local")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_deliver_inject", deliver)
+
+    code = cli.cmd_vault_inject(_ns(keys="ASK_KEY,ETH_KEY", out=str(tmp_path / "out.env"), format="dotenv", session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "keypair_not_value_deliverable"
+    deliver.assert_not_called()
     with cli._open_vault_engine().connect() as conn:
         status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
     assert status == "active"

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -108,6 +108,30 @@ def _set_group_grant(names: list[str], *, group: str = "crypto", session_id: str
         )
 
 
+def _set_always_ask_standard_grant(name: str, *, session_id: str | None = None) -> dict:
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(
+            conn,
+            name=name,
+            protection="standard",
+            sealed=_sealed(name.lower()),
+            policy={"always_ask": True},
+        )
+        req = vault_service.create_access_request(
+            conn,
+            name,
+            requester={"source": "cli", "session_id": session_id} if session_id else {"source": "cli"},
+            delivery={"session_id": session_id, "mode": "run"} if session_id else {"mode": "run"},
+        )
+        return vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref=name,
+            session_id=session_id,
+            created_by_request_id=req["id"],
+        )
+
+
 @pytest.mark.parametrize(
     "specs,expected",
     [
@@ -644,7 +668,7 @@ def test_inject_resolver_uses_session_bound_protected_grant(tmp_path):
     grant = _set_protected_grant("PROTECTED_KEY", session_id="ses_cli")
     engine = cli._open_vault_engine()
 
-    resolved_grant, secrets = cli._resolve_vault_inject_delivery(
+    resolved_grant, one_shot_grants, secrets = cli._resolve_vault_inject_delivery(
         engine,
         ["PROTECTED_KEY"],
         path=str(tmp_path / "out.env"),
@@ -653,7 +677,53 @@ def test_inject_resolver_uses_session_bound_protected_grant(tmp_path):
     )
 
     assert resolved_grant["id"] == grant["id"]
+    assert one_shot_grants == []
     assert secrets == [{"name": "PROTECTED_KEY", "key": "PROTECTED_KEY", "envelope": _sealed("protected")}]
+
+
+def test_run_does_not_consume_always_ask_grant_when_later_secret_needs_approval(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="OTHER_ASK", protection="standard", sealed=_sealed("other"), policy={"always_ask": True})
+    deliver = Mock(return_value=0)
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(
+        _ns(
+            env=["ASK_KEY", "OTHER_ASK"],
+            command_argv=["python3", "-c", "pass"],
+            session_id="ses_cli",
+        )
+    )
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "approval_required"
+    deliver.assert_not_called()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
+
+
+def test_run_consumes_standard_always_ask_grant_after_delivery(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(return_value=0)
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(_ns(env=["ASK_KEY"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+
+    assert code == 0
+    deliver.assert_called_once_with(
+        [{"name": "ASK_KEY", "env": "ASK_KEY", "envelope": _sealed("ask_key")}],
+        ["python3", "-c", "pass"],
+    )
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
 
 
 def test_run_rejects_mixed_tiers_before_creating_approval(tmp_path, capfd, monkeypatch):

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -722,6 +722,48 @@ def test_run_fast_path_reserves_protected_always_ask_grant(tmp_path, capfd, monk
     assert status == "expired"
 
 
+def test_run_fast_path_does_not_reuse_reserved_protected_always_ask_grant(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    reserved_grant = _set_protected_always_ask_grant("PROTECTED_ASK", session_id="ses_cli")
+    engine = cli._open_vault_engine()
+    with engine.begin() as conn:
+        reserved = vault_service.find_active_grant_for_secret(
+            conn,
+            "PROTECTED_ASK",
+            session_id="ses_cli",
+            reserve_one_shot=True,
+        )
+        req = vault_service.create_access_request(
+            conn,
+            "PROTECTED_ASK",
+            requester={"source": "cli", "session_id": "ses_cli"},
+            delivery={"session_id": "ses_cli", "mode": "run"},
+        )
+        active_grant = vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="PROTECTED_ASK",
+            session_id="ses_cli",
+            created_by_request_id=req["id"],
+        )
+    deliver = Mock(return_value={"exit_code": 0})
+    monkeypatch.setattr(api, "avault_agent_deliver_run", deliver)
+    monkeypatch.setattr(api, "avault_deliver_run", Mock())
+
+    code = cli.cmd_vault_run(_ns(env=["PROTECTED_ASK"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+
+    assert reserved["id"] == reserved_grant["id"]
+    assert code == 0
+    deliver.assert_called_once()
+    with engine.connect() as conn:
+        statuses = {
+            row["id"]: row["status"]
+            for row in conn.execute(vault_grants.select().where(vault_grants.c.id.in_([reserved_grant["id"], active_grant["id"]]))).mappings()
+        }
+    assert statuses == {reserved_grant["id"]: "reserved", active_grant["id"]: "expired"}
+
+
 def test_inject_fast_path_reserves_protected_always_ask_grant(tmp_path, capfd, monkeypatch):
     from vibe import api
 
@@ -900,6 +942,24 @@ def test_run_consumes_standard_always_ask_grant_when_avault_errors_after_handoff
     assert status == "expired"
 
 
+def test_run_releases_standard_always_ask_grant_when_avault_fails_before_handoff(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(side_effect=api.AvaultPreHandoffError("avault is required for vault run"))
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(_ns(env=["ASK_KEY"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "avault_failed"
+    deliver.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
+
+
 def test_inject_consumes_standard_always_ask_grant_when_avault_errors_after_handoff(tmp_path, capfd, monkeypatch):
     from vibe import api
 
@@ -916,6 +976,58 @@ def test_inject_consumes_standard_always_ask_grant_when_avault_errors_after_hand
     with cli._open_vault_engine().connect() as conn:
         status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
     assert status == "expired"
+
+
+def test_inject_releases_standard_always_ask_grant_when_avault_fails_before_handoff(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(side_effect=api.AvaultPreHandoffError("avault is required for vault inject"))
+    monkeypatch.setattr(api, "avault_deliver_inject", deliver)
+
+    code = cli.cmd_vault_inject(_ns(keys="ASK_KEY", out=str(tmp_path / "out.env"), format="dotenv", session_id="ses_cli"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "avault_failed"
+    deliver.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
+
+
+def test_expire_agent_grant_after_missing_does_not_reserve_replacement_grant(tmp_path, capfd, monkeypatch):
+    engine = cli._open_vault_engine()
+    first = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    with engine.begin() as conn:
+        req = vault_service.create_access_request(
+            conn,
+            "ASK_KEY",
+            requester={"source": "cli", "session_id": "ses_cli"},
+            delivery={"mode": "run", "session_id": "ses_cli"},
+        )
+        replacement = vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_cli",
+            created_by_request_id=req["id"],
+        )
+
+    cli._expire_agent_grant_after_missing(
+        engine,
+        first["id"],
+        ["ASK_KEY"],
+        requester={"source": "cli", "session_id": "ses_cli"},
+        delivery={"mode": "run", "session_id": "ses_cli"},
+    )
+
+    with engine.connect() as conn:
+        statuses = {
+            row["id"]: row["status"]
+            for row in conn.execute(vault_grants.select().where(vault_grants.c.id.in_([first["id"], replacement["id"]]))).mappings()
+        }
+    assert statuses == {first["id"]: "expired", replacement["id"]: "active"}
 
 
 def test_run_rejects_mixed_tiers_before_creating_approval(tmp_path, capfd, monkeypatch):

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -89,6 +89,30 @@ def _set_protected_grant(name: str, *, session_id: str | None = None) -> dict:
         )
 
 
+def _set_protected_always_ask_grant(name: str, *, session_id: str | None = None) -> dict:
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(
+            conn,
+            name=name,
+            protection="protected",
+            sealed=_sealed("protected"),
+            policy={"always_ask": True},
+        )
+        req = vault_service.create_access_request(
+            conn,
+            name,
+            requester={"source": "cli", "session_id": session_id} if session_id else {"source": "cli"},
+            delivery={"session_id": session_id, "mode": "run"} if session_id else {"mode": "run"},
+        )
+        return vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref=name,
+            session_id=session_id,
+            created_by_request_id=req["id"],
+        )
+
+
 def _set_group_grant(names: list[str], *, group: str = "crypto", session_id: str | None = None) -> dict:
     with cli._open_vault_engine().begin() as conn:
         for name in names:
@@ -681,6 +705,69 @@ def test_inject_resolver_uses_session_bound_protected_grant(tmp_path):
     assert secrets == [{"name": "PROTECTED_KEY", "key": "PROTECTED_KEY", "envelope": _sealed("protected")}]
 
 
+def test_run_fast_path_reserves_protected_always_ask_grant(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_protected_always_ask_grant("PROTECTED_ASK", session_id="ses_cli")
+    deliver = Mock(return_value={"exit_code": 0})
+    monkeypatch.setattr(api, "avault_agent_deliver_run", deliver)
+    monkeypatch.setattr(api, "avault_deliver_run", Mock())
+
+    code = cli.cmd_vault_run(_ns(env=["PROTECTED_ASK"], command_argv=["python3", "-c", "pass"], session_id="ses_cli"))
+
+    assert code == 0
+    deliver.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
+
+
+def test_inject_fast_path_reserves_protected_always_ask_grant(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_protected_always_ask_grant("PROTECTED_ASK", session_id="ses_cli")
+    deliver = Mock()
+    monkeypatch.setattr(api, "avault_agent_deliver_inject", deliver)
+    monkeypatch.setattr(api, "avault_deliver_inject", Mock())
+    out = tmp_path / "out.env"
+
+    code = cli.cmd_vault_inject(_ns(keys="PROTECTED_ASK", out=str(out), format="dotenv", session_id="ses_cli"))
+
+    assert code == 0
+    deliver.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
+
+
+def test_run_reuses_reserved_grant_for_duplicate_always_ask_secret(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(return_value={"exit_code": 0, "delivered": True})
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(
+        _ns(
+            env=["A=ASK_KEY", "B=ASK_KEY"],
+            command_argv=["python3", "-c", "pass"],
+            session_id="ses_cli",
+        )
+    )
+
+    assert code == 0
+    deliver.assert_called_once_with(
+        [
+            {"name": "ASK_KEY", "env": "A", "envelope": _sealed("ask_key")},
+            {"name": "ASK_KEY", "env": "B", "envelope": _sealed("ask_key")},
+        ],
+        ["python3", "-c", "pass"],
+    )
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
+
+
 def test_run_does_not_consume_always_ask_grant_when_later_secret_needs_approval(tmp_path, capfd, monkeypatch):
     from vibe import api
 
@@ -730,7 +817,7 @@ def test_run_consumes_standard_always_ask_grant_when_child_exits_70(tmp_path, ca
     from vibe import api
 
     grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
-    deliver = Mock(return_value=70)
+    deliver = Mock(return_value={"exit_code": 70, "delivered": True})
     monkeypatch.setattr(api, "avault_deliver_run", deliver)
 
     code = cli.cmd_vault_run(_ns(env=["ASK_KEY"], command_argv=["python3", "-c", "raise SystemExit(70)"], session_id="ses_cli"))
@@ -899,6 +986,23 @@ def test_run_skips_delivery_audit_when_avault_returns_70(tmp_path, capfd, monkey
     cli.cmd_vault_list(_ns())
     secret = json.loads(capfd.readouterr().out)["secrets"][0]
     assert secret["use_count"] == 0
+
+
+def test_run_releases_standard_always_ask_grant_when_avault_internal_70(tmp_path, capfd, monkeypatch):
+    from unittest.mock import Mock
+
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    monkeypatch.setattr(api, "avault_deliver_run", Mock(return_value={"exit_code": 70, "delivered": False}))
+
+    assert cli.cmd_vault_run(_ns(env=["ASK_KEY"], command_argv=["python3", "-c", "pass"], session_id="ses_cli")) == 70
+    cli.cmd_vault_list(_ns())
+    secret = json.loads(capfd.readouterr().out)["secrets"][0]
+    assert secret["use_count"] == 0
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "active"
 
 
 def test_run_bad_command_does_not_call_avault_or_deliver(tmp_path, capfd, monkeypatch):

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -726,6 +726,25 @@ def test_run_consumes_standard_always_ask_grant_after_delivery(tmp_path, capfd, 
     assert status == "expired"
 
 
+def test_run_consumes_standard_always_ask_grant_when_child_exits_70(tmp_path, capfd, monkeypatch):
+    from vibe import api
+
+    grant = _set_always_ask_standard_grant("ASK_KEY", session_id="ses_cli")
+    deliver = Mock(return_value=70)
+    monkeypatch.setattr(api, "avault_deliver_run", deliver)
+
+    code = cli.cmd_vault_run(_ns(env=["ASK_KEY"], command_argv=["python3", "-c", "raise SystemExit(70)"], session_id="ses_cli"))
+
+    assert code == 70
+    deliver.assert_called_once_with(
+        [{"name": "ASK_KEY", "env": "ASK_KEY", "envelope": _sealed("ask_key")}],
+        ["python3", "-c", "raise SystemExit(70)"],
+    )
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(vault_grants.select().where(vault_grants.c.id == grant["id"])).mappings().one()["status"]
+    assert status == "expired"
+
+
 def test_run_rejects_mixed_tiers_before_creating_approval(tmp_path, capfd, monkeypatch):
     _set_secret("STANDARD_KEY", "standard", tmp_path, monkeypatch, capfd)
     with cli._open_vault_engine().begin() as conn:

--- a/tests/test_vault_fetch.py
+++ b/tests/test_vault_fetch.py
@@ -412,6 +412,28 @@ def test_fetch_returns_response_even_if_one_shot_cleanup_fails(capfd, monkeypatc
     cleanup.assert_called_once()
 
 
+def test_fetch_consumes_one_shot_grant_when_avault_errors_after_possible_egress(capfd, monkeypatch):
+    from unittest.mock import Mock
+
+    from vibe import api
+
+    grant = _set_always_ask_grant("ASK_KEY", allow_host=["api.example.com"])
+    fetch = Mock(side_effect=api.AvaultError("timed out after sending request"))
+    monkeypatch.setattr(api, "avault_deliver_fetch", fetch)
+
+    code = cli.cmd_vault_fetch(_ns(auth="ASK_KEY", url="https://api.example.com/x", method="POST"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "request_failed"
+    fetch.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(
+            vault_service.vault_grants.select().where(vault_service.vault_grants.c.id == grant["id"])
+        ).mappings().one()["status"]
+    assert status == "expired"
+
+
 def test_host_allowed_is_case_insensitive():
     assert cli._host_allowed("api.github.com", ["API.GITHUB.COM"]) is True
     assert cli._host_allowed("api.github.com", [".GitHub.com"]) is True

--- a/tests/test_vault_fetch.py
+++ b/tests/test_vault_fetch.py
@@ -80,6 +80,28 @@ def _set_protected_grant(name: str, *, allow_host: list[str], session_id: str | 
         )
 
 
+def _set_always_ask_grant(name: str, *, allow_host: list[str]) -> dict:
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(
+            conn,
+            name=name,
+            sealed=_sealed(name.lower()),
+            policy={"always_ask": True, "allowed_hosts": allow_host},
+        )
+        req = vault_service.create_access_request(
+            conn,
+            name,
+            requester={"source": "cli"},
+            delivery={"mode": "fetch"},
+        )
+        return vault_service.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref=name,
+            created_by_request_id=req["id"],
+        )
+
+
 def test_fetch_passes_bearer_request_to_avault_and_writes_stdout(tmp_path, capfd, monkeypatch):
     from unittest.mock import Mock
 
@@ -368,6 +390,26 @@ def test_fetch_returns_response_even_if_audit_fails(tmp_path, capfd, monkeypatch
     assert code == 0
     assert captured.out == "ok"
     fetch.assert_called_once()
+
+
+def test_fetch_returns_response_even_if_one_shot_cleanup_fails(capfd, monkeypatch):
+    from unittest.mock import Mock
+
+    from vibe import api
+
+    _set_always_ask_grant("ASK_KEY", allow_host=["api.example.com"])
+    fetch = Mock(return_value={"status": 200, "headers": {}, "body": "ok"})
+    cleanup = Mock(side_effect=RuntimeError("db locked"))
+    monkeypatch.setattr(api, "avault_deliver_fetch", fetch)
+    monkeypatch.setattr(api, "consume_one_shot_grants", cleanup)
+
+    code = cli.cmd_vault_fetch(_ns(auth="ASK_KEY", url="https://api.example.com/x", method="POST"))
+    captured = capfd.readouterr()
+
+    assert code == 0
+    assert captured.out == "ok"
+    fetch.assert_called_once()
+    cleanup.assert_called_once()
 
 
 def test_host_allowed_is_case_insensitive():

--- a/tests/test_vault_fetch.py
+++ b/tests/test_vault_fetch.py
@@ -434,6 +434,28 @@ def test_fetch_consumes_one_shot_grant_when_avault_errors_after_possible_egress(
     assert status == "expired"
 
 
+def test_fetch_releases_one_shot_grant_when_avault_fails_before_handoff(capfd, monkeypatch):
+    from unittest.mock import Mock
+
+    from vibe import api
+
+    grant = _set_always_ask_grant("ASK_KEY", allow_host=["api.example.com"])
+    fetch = Mock(side_effect=api.AvaultPreHandoffError("avault is required for vault fetch"))
+    monkeypatch.setattr(api, "avault_deliver_fetch", fetch)
+
+    code = cli.cmd_vault_fetch(_ns(auth="ASK_KEY", url="https://api.example.com/x", method="POST"))
+    captured = capfd.readouterr()
+
+    assert code == 1
+    assert json.loads(captured.err)["code"] == "request_failed"
+    fetch.assert_called_once()
+    with cli._open_vault_engine().connect() as conn:
+        status = conn.execute(
+            vault_service.vault_grants.select().where(vault_service.vault_grants.c.id == grant["id"])
+        ).mappings().one()["status"]
+    assert status == "active"
+
+
 def test_host_allowed_is_case_insensitive():
     assert cli._host_allowed("api.github.com", ["API.GITHUB.COM"]) is True
     assert cli._host_allowed("api.github.com", [".GitHub.com"]) is True

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -14,7 +14,7 @@ from sqlalchemy import select
 
 from storage import vault_service as vs
 from storage.db import create_sqlite_engine
-from storage.models import metadata, vault_audit, vault_grants, vault_links, vault_requests, vault_secrets
+from storage.models import metadata, vault_audit, vault_grants, vault_groups, vault_links, vault_requests, vault_secrets
 from storage.vault_crypto import Sealed
 
 
@@ -1328,6 +1328,41 @@ def test_keypair_is_not_value_requestable_and_always_ask_is_not_pregrantable(vau
     assert sign_req["request_type"] == "sign"
 
 
+def test_always_ask_honors_group_grantability(vault):
+    _create(vault, name="STATIC_KEY", protection="protected", group="locked", policy={"always_ask": True})
+    with vault.begin() as conn:
+        conn.execute(vault_groups.update().where(vault_groups.c.name == "locked").values(grantable=0))
+        req = vs.create_access_request(conn, "STATIC_KEY", requester={"session_id": "ses_1"})
+        request_members = vs.request_grantable_member_metas(conn, "secret", "STATIC_KEY", req["id"])
+        with pytest.raises(vs.NotGrantableError):
+            vs.create_grant(conn, scope_type="secret", scope_ref="STATIC_KEY", created_by_request_id=req["id"])
+
+    assert req["card"]["scope_options"] == []
+    assert request_members == []
+
+
+def test_always_ask_one_shot_card_ttl_is_capped_by_group_policy(vault):
+    _create(vault, name="STATIC_KEY", protection="protected", group="strict", policy={"always_ask": True})
+    with vault.begin() as conn:
+        conn.execute(vault_groups.update().where(vault_groups.c.name == "strict").values(max_grant_ttl_seconds=120))
+        req = vs.create_access_request(conn, "STATIC_KEY", requester={"session_id": "ses_1"})
+        option = req["card"]["scope_options"][0]
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="STATIC_KEY",
+            ttl_seconds=3600,
+            created_by_request_id=req["id"],
+        )
+
+    created_at = datetime.fromisoformat(grant["created_at"])
+    expires_at = datetime.fromisoformat(grant["expires_at"])
+    assert option["one_shot"] is True
+    assert option["default_ttl_seconds"] == 120
+    assert option["ttl_options_seconds"] == []
+    assert int((expires_at - created_at).total_seconds()) == 120
+
+
 def test_standard_always_ask_routes_every_access_through_one_shot_request(vault):
     _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
     with vault.begin() as conn:
@@ -1353,6 +1388,14 @@ def test_standard_always_ask_routes_every_access_through_one_shot_request(vault)
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
         )
+        still_active = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        vs.consume_one_shot_grant(conn, grant["id"])
         second = vs.resolve_secret_access(
             conn,
             "ASK_KEY",
@@ -1360,15 +1403,17 @@ def test_standard_always_ask_routes_every_access_through_one_shot_request(vault)
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
         )
-        grant_status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
         request_rows = conn.execute(
             select(vault_requests.c.id, vault_requests.c.status).where(vault_requests.c.secret_name == "ASK_KEY")
         ).mappings().all()
+        grant_status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
 
     assert grant["one_shot"] is True
     assert delivered["status"] == "standard"
     assert delivered["grant"]["id"] == grant["id"]
     assert delivered["envelope"] == _sealed()
+    assert still_active["status"] == "standard"
+    assert still_active["grant"]["id"] == grant["id"]
     assert grant_status == "expired"
     assert second["status"] == "approval_required"
     assert second["request"]["id"] != first["request"]["id"]
@@ -1411,6 +1456,15 @@ def test_protected_always_ask_routes_every_access_through_one_shot_request(vault
             delivery={"skill": "deploy"},
             cache=cache,
         )
+        still_active = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1", "skill": "deploy"},
+            delivery={"skill": "deploy"},
+            cache=cache,
+        )
+        vs.consume_one_shot_grant(conn, grant["id"], cache=cache)
         second = vs.resolve_secret_access(
             conn,
             "ASK_KEY",
@@ -1419,14 +1473,16 @@ def test_protected_always_ask_routes_every_access_through_one_shot_request(vault
             delivery={"skill": "deploy"},
             cache=cache,
         )
-        grant_status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
         requests = conn.execute(select(vault_requests).where(vault_requests.c.secret_name == "ASK_KEY")).mappings().all()
+        grant_status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
 
     assert grant["one_shot"] is True
     assert grant["session_id"] == "ses_1"
     assert delivered["status"] == "agent_delivery_ready"
     assert delivered["grant"]["id"] == grant["id"]
     assert delivered["envelope"] == _sealed()
+    assert still_active["status"] == "agent_delivery_ready"
+    assert still_active["grant"]["id"] == grant["id"]
     assert grant_status == "expired"
     assert not cache.has(grant["id"], "ASK_KEY")
     assert second["status"] == "approval_required"

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1397,6 +1397,7 @@ def test_standard_always_ask_routes_every_access_through_one_shot_request(vault)
             session_id="ses_1",
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
+            create_request=False,
         )
         vs.consume_one_shot_grant(conn, grant["id"])
         second = vs.resolve_secret_access(
@@ -1414,9 +1415,10 @@ def test_standard_always_ask_routes_every_access_through_one_shot_request(vault)
     assert grant["one_shot"] is True
     assert delivered["status"] == "standard"
     assert delivered["grant"]["id"] == grant["id"]
+    assert delivered["grant"]["status"] == "reserved"
     assert delivered["envelope"] == _sealed()
-    assert still_active["status"] == "standard"
-    assert still_active["grant"]["id"] == grant["id"]
+    assert still_active["status"] == "approval_required"
+    assert still_active["request"] is None
     assert grant_status == "expired"
     assert second["status"] == "approval_required"
     assert second["request"]["id"] != first["request"]["id"]
@@ -1466,6 +1468,7 @@ def test_protected_always_ask_routes_every_access_through_one_shot_request(vault
             requester={"session_id": "ses_1", "skill": "deploy"},
             delivery={"skill": "deploy"},
             cache=cache,
+            create_request=False,
         )
         vs.consume_one_shot_grant(conn, grant["id"], cache=cache)
         second = vs.resolve_secret_access(
@@ -1483,13 +1486,64 @@ def test_protected_always_ask_routes_every_access_through_one_shot_request(vault
     assert grant["session_id"] == "ses_1"
     assert delivered["status"] == "agent_delivery_ready"
     assert delivered["grant"]["id"] == grant["id"]
+    assert delivered["grant"]["status"] == "reserved"
     assert delivered["envelope"] == _sealed()
-    assert still_active["status"] == "agent_delivery_ready"
-    assert still_active["grant"]["id"] == grant["id"]
+    assert still_active["status"] == "approval_required"
+    assert still_active["request"] is None
     assert grant_status == "expired"
     assert not cache.has(grant["id"], "ASK_KEY")
     assert second["status"] == "approval_required"
     assert [row["status"] for row in requests] == ["approved", "pending"]
+
+
+def test_one_shot_reservation_can_be_released_before_delivery(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        reserved = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        missing = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+            create_request=False,
+        )
+        released = vs.release_one_shot_reservation(conn, grant["id"])
+        available = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+
+    assert reserved["grant"]["status"] == "reserved"
+    assert missing["status"] == "approval_required"
+    assert missing["request"] is None
+    assert released["status"] == "active"
+    assert available["status"] == "standard"
+    assert available["grant"]["id"] == grant["id"]
+    assert available["grant"]["status"] == "reserved"
 
 
 def test_grant_creation_does_not_require_python_dek_material(vault):

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1303,6 +1303,7 @@ def test_keypair_is_not_value_requestable_and_always_ask_is_not_pregrantable(vau
         kind="keypair",
         signer_kind="local",
         public_meta=PROTECTED_SIGNING_PUBLIC_META,
+        policy={"always_ask": True},
     )
     _create(vault, name="STATIC_KEY", protection="protected", policy={"always_ask": True})
     with vault.begin() as conn:
@@ -1326,6 +1327,8 @@ def test_keypair_is_not_value_requestable_and_always_ask_is_not_pregrantable(vau
     assert req["card"]["scope_options"][0]["member_snapshot"] == ["STATIC_KEY"]
     assert req["card"]["scope_options"][0]["one_shot"] is True
     assert sign_req["request_type"] == "sign"
+    assert sign_req["card"]["one_shot"] is False
+    assert sign_req["card"]["scope_options"] == []
 
 
 def test_always_ask_honors_group_grantability(vault):

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1390,6 +1390,7 @@ def test_standard_always_ask_routes_every_access_through_one_shot_request(vault)
             session_id="ses_1",
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
         )
         still_active = vs.resolve_secret_access(
             conn,
@@ -1398,6 +1399,7 @@ def test_standard_always_ask_routes_every_access_through_one_shot_request(vault)
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
             create_request=False,
+            reserve_one_shot=True,
         )
         vs.consume_one_shot_grant(conn, grant["id"])
         second = vs.resolve_secret_access(
@@ -1460,6 +1462,7 @@ def test_protected_always_ask_routes_every_access_through_one_shot_request(vault
             requester={"session_id": "ses_1", "skill": "deploy"},
             delivery={"skill": "deploy"},
             cache=cache,
+            reserve_one_shot=True,
         )
         still_active = vs.resolve_secret_access(
             conn,
@@ -1469,6 +1472,7 @@ def test_protected_always_ask_routes_every_access_through_one_shot_request(vault
             delivery={"skill": "deploy"},
             cache=cache,
             create_request=False,
+            reserve_one_shot=True,
         )
         vs.consume_one_shot_grant(conn, grant["id"], cache=cache)
         second = vs.resolve_secret_access(
@@ -1519,6 +1523,7 @@ def test_one_shot_reservation_can_be_released_before_delivery(vault):
             session_id="ses_1",
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
         )
         missing = vs.resolve_secret_access(
             conn,
@@ -1527,6 +1532,7 @@ def test_one_shot_reservation_can_be_released_before_delivery(vault):
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
             create_request=False,
+            reserve_one_shot=True,
         )
         released = vs.release_one_shot_reservation(conn, grant["id"])
         available = vs.resolve_secret_access(
@@ -1535,6 +1541,7 @@ def test_one_shot_reservation_can_be_released_before_delivery(vault):
             session_id="ses_1",
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
         )
 
     assert reserved["grant"]["status"] == "reserved"
@@ -1544,6 +1551,95 @@ def test_one_shot_reservation_can_be_released_before_delivery(vault):
     assert available["status"] == "standard"
     assert available["grant"]["id"] == grant["id"]
     assert available["grant"]["status"] == "reserved"
+
+
+def test_resolve_secret_access_default_does_not_reserve_one_shot_grant(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        resolved = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
+
+    assert resolved["status"] == "standard"
+    assert resolved["grant"]["id"] == grant["id"]
+    assert resolved["grant"]["status"] == "active"
+    assert status == "active"
+
+
+def test_delivery_resolver_skips_reserved_one_shot_and_claims_next_active_grant(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant_1 = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        reserved = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
+        )
+        second_req = vs.create_access_request(
+            conn,
+            "ASK_KEY",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant_2 = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=second_req["id"],
+        )
+        claimed = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
+        )
+        statuses = {
+            row["id"]: row["status"]
+            for row in conn.execute(select(vault_grants.c.id, vault_grants.c.status).where(vault_grants.c.id.in_([grant_1["id"], grant_2["id"]]))).mappings()
+        }
+
+    assert reserved["grant"]["id"] == grant_1["id"]
+    assert claimed["status"] == "standard"
+    assert claimed["grant"]["id"] == grant_2["id"]
+    assert statuses == {grant_1["id"]: "reserved", grant_2["id"]: "reserved"}
 
 
 def test_reserved_one_shot_grants_are_expired_by_ttl_sweep(vault):
@@ -1569,6 +1665,7 @@ def test_reserved_one_shot_grants_are_expired_by_ttl_sweep(vault):
             session_id="ses_1",
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
         )
         conn.execute(
             vault_grants.update()
@@ -1605,6 +1702,7 @@ def test_reserved_one_shot_grants_are_revoked_with_session(vault):
             session_id="ses_1",
             requester={"session_id": "ses_1"},
             delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
         )
         count = vs.revoke_session_grants(conn, "ses_1")
         status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -96,6 +96,7 @@ def test_create_persists_no_value_derived_public_meta(vault):
 def test_standard_static_secret_is_agent_access_grantable(vault):
     _create(vault, name="STANDARD_KEY", protection="standard", group="default")
     with vault.begin() as conn:
+        resolved = vs.resolve_secret_access(conn, "STANDARD_KEY", session_id="ses_1")
         request = vs.create_access_request(conn, "STANDARD_KEY", requester={"session_id": "ses_1"})
         grant = vs.create_grant(
             conn,
@@ -117,6 +118,8 @@ def test_standard_static_secret_is_agent_access_grantable(vault):
         release_scopes = vs.agent_release_scopes_after_rows(conn, [dict(row)])
     assert int(row["agent_ready"] or 0) == 0
     assert release_scopes == []
+    assert resolved["status"] == "standard"
+    assert resolved["envelope"] == _sealed()
 
 
 def test_inactive_standard_grants_are_not_delivery_ready(vault):
@@ -1292,7 +1295,7 @@ def test_grant_can_be_intentionally_unbound_from_request_session(vault):
     assert cache.has(grant["id"], "PROTECTED_KEY")
 
 
-def test_keypair_and_always_ask_are_not_grantable(vault):
+def test_keypair_is_not_value_requestable_and_always_ask_is_not_pregrantable(vault):
     _create(
         vault,
         name="ETH_KEY",
@@ -1305,34 +1308,129 @@ def test_keypair_and_always_ask_are_not_grantable(vault):
     with vault.begin() as conn:
         with pytest.raises(vs.NotGrantableError):
             vs.create_access_request(conn, "ETH_KEY", requester={"session_id": "ses_1"})
-        with pytest.raises(vs.NotGrantableError):
-            vs.create_access_request(conn, "STATIC_KEY", requester={"session_id": "ses_1"})
+        req = vs.create_access_request(conn, "STATIC_KEY", requester={"session_id": "ses_1"})
+        meta = vs.get_secret_meta(conn, "STATIC_KEY")
+        pregrant_members = vs.grantable_member_metas(conn, "secret", "STATIC_KEY")
         requests = conn.execute(
             select(vault_requests).where(vault_requests.c.secret_name.in_(["ETH_KEY", "STATIC_KEY"]))
         ).mappings().all()
         sign_req = vs.create_sign_request(conn, "ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")
 
-    assert requests == []
+    assert meta["access_grantable"] is False
+    assert pregrant_members == []
+    assert [row["secret_name"] for row in requests] == ["STATIC_KEY"]
+    assert req["card"]["one_shot"] is True
+    assert len(req["card"]["scope_options"]) == 1
+    assert req["card"]["scope_options"][0]["scope_type"] == "secret"
+    assert req["card"]["scope_options"][0]["scope_ref"] == "STATIC_KEY"
+    assert req["card"]["scope_options"][0]["member_snapshot"] == ["STATIC_KEY"]
+    assert req["card"]["scope_options"][0]["one_shot"] is True
     assert sign_req["request_type"] == "sign"
 
 
-def test_always_ask_access_request_is_rejected_until_one_shot_approval_exists(vault):
+def test_standard_always_ask_routes_every_access_through_one_shot_request(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        assert first["status"] == "approval_required"
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        delivered = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        second = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant_status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
+        request_rows = conn.execute(
+            select(vault_requests.c.id, vault_requests.c.status).where(vault_requests.c.secret_name == "ASK_KEY")
+        ).mappings().all()
+
+    assert grant["one_shot"] is True
+    assert delivered["status"] == "standard"
+    assert delivered["grant"]["id"] == grant["id"]
+    assert delivered["envelope"] == _sealed()
+    assert grant_status == "expired"
+    assert second["status"] == "approval_required"
+    assert second["request"]["id"] != first["request"]["id"]
+    assert [(row["id"], row["status"]) for row in request_rows] == [
+        (first["request"]["id"], "approved"),
+        (second["request"]["id"], "pending"),
+    ]
+
+
+def test_protected_always_ask_routes_every_access_through_one_shot_request(vault):
     _create(vault, name="ASK_KEY", protection="protected", group="crypto", policy={"always_ask": True})
     _create(vault, name="GROUP_KEY", protection="protected", group="crypto")
+    cache = vs.VaultGrantRuntimeCache()
     with vault.begin() as conn:
         conn.execute(vault_links.insert().values(id="ln_ask", secret_name="ASK_KEY", skill_name="deploy", source="user", required=1, created_at="now"))
         conn.execute(vault_links.insert().values(id="ln_group", secret_name="GROUP_KEY", skill_name="deploy", source="user", required=1, created_at="now"))
-        with pytest.raises(vs.NotGrantableError):
-            vs.resolve_secret_access(
-                conn,
-                "ASK_KEY",
-                session_id="ses_1",
-                requester={"session_id": "ses_1", "skill": "deploy"},
-                delivery={"skill": "deploy"},
-            )
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1", "skill": "deploy"},
+            delivery={"skill": "deploy"},
+            cache=cache,
+        )
+        assert first["status"] == "approval_required"
+        assert first["request"]["card"]["scope_options"][0]["scope_ref"] == "ASK_KEY"
+        assert all(option["scope_ref"] != "crypto" for option in first["request"]["card"]["scope_options"])
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            created_by_request_id=first["request"]["id"],
+            cache=cache,
+        )
+        delivered = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1", "skill": "deploy"},
+            delivery={"skill": "deploy"},
+            cache=cache,
+        )
+        second = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1", "skill": "deploy"},
+            delivery={"skill": "deploy"},
+            cache=cache,
+        )
+        grant_status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
         requests = conn.execute(select(vault_requests).where(vault_requests.c.secret_name == "ASK_KEY")).mappings().all()
 
-    assert requests == []
+    assert grant["one_shot"] is True
+    assert grant["session_id"] == "ses_1"
+    assert delivered["status"] == "agent_delivery_ready"
+    assert delivered["grant"]["id"] == grant["id"]
+    assert delivered["envelope"] == _sealed()
+    assert grant_status == "expired"
+    assert not cache.has(grant["id"], "ASK_KEY")
+    assert second["status"] == "approval_required"
+    assert [row["status"] for row in requests] == ["approved", "pending"]
 
 
 def test_grant_creation_does_not_require_python_dek_material(vault):

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1546,6 +1546,74 @@ def test_one_shot_reservation_can_be_released_before_delivery(vault):
     assert available["grant"]["status"] == "reserved"
 
 
+def test_reserved_one_shot_grants_are_expired_by_ttl_sweep(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        reserved = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        conn.execute(
+            vault_grants.update()
+            .where(vault_grants.c.id == grant["id"])
+            .values(expires_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat())
+        )
+        vs.expire_grants(conn)
+        status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
+
+    assert reserved["grant"]["status"] == "reserved"
+    assert status == "expired"
+
+
+def test_reserved_one_shot_grants_are_revoked_with_session(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        reserved = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        count = vs.revoke_session_grants(conn, "ses_1")
+        status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
+
+    assert reserved["grant"]["status"] == "reserved"
+    assert count == 1
+    assert status == "revoked"
+
+
 def test_grant_creation_does_not_require_python_dek_material(vault):
     _create(vault, name="A_KEY", protection="protected")
     with vault.begin() as conn:

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -1585,6 +1585,76 @@ def test_resolve_secret_access_default_does_not_reserve_one_shot_grant(vault):
     assert status == "active"
 
 
+def test_non_claiming_lookup_skips_reserved_one_shot_grant(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        reserved = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
+        )
+        resolved = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+            create_request=False,
+        )
+
+    assert reserved["grant"]["id"] == grant["id"]
+    assert reserved["grant"]["status"] == "reserved"
+    assert resolved["status"] == "approval_required"
+    assert resolved["request"] is None
+
+
+def test_list_active_grants_includes_reserved_one_shot_grants(vault):
+    _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
+    with vault.begin() as conn:
+        first = vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+        )
+        grant = vs.create_grant(
+            conn,
+            scope_type="secret",
+            scope_ref="ASK_KEY",
+            session_id="ses_1",
+            created_by_request_id=first["request"]["id"],
+        )
+        vs.resolve_secret_access(
+            conn,
+            "ASK_KEY",
+            session_id="ses_1",
+            requester={"session_id": "ses_1"},
+            delivery={"session_id": "ses_1"},
+            reserve_one_shot=True,
+        )
+        active = vs.list_grants(conn)
+
+    assert [(item["id"], item["status"]) for item in active] == [(grant["id"], "reserved")]
+
+
 def test_delivery_resolver_skips_reserved_one_shot_and_claims_next_active_grant(vault):
     _create(vault, name="ASK_KEY", protection="standard", policy={"always_ask": True})
     with vault.begin() as conn:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5100,7 +5100,7 @@ def avault_sign(
     return {"signature": signature, "recovery_id": payload.get("recovery_id")}
 
 
-def avault_deliver_run(secrets: list[dict], command: list[str]) -> int:
+def avault_deliver_run(secrets: list[dict], command: list[str]) -> dict:
     """Run ``command`` with the secrets injected as env vars, inside avault.
 
     ``secrets`` is ``[{"name": <secret name>, "env": <env var>, "envelope": <Sealed>}]``.
@@ -5108,8 +5108,8 @@ def avault_deliver_run(secrets: list[dict], command: list[str]) -> int:
     plaintext never returns here. The child inherits this process's stdio so its
     output passes through; the run-secrets JSON (envelopes only, no plaintext)
     goes on avault's stdin to stay out of ``ps``. Returns the child's exit code
-    (``128 + signal`` if signalled), or raises :class:`AvaultError` if avault could
-    not start the child.
+    (``128 + signal`` if signalled) plus whether avault reached the delivery side
+    effect, or raises :class:`AvaultError` if avault could not start the child.
     """
     path = _require_avault_path()
     payload = json.dumps(
@@ -5135,7 +5135,8 @@ def avault_deliver_run(secrets: list[dict], command: list[str]) -> int:
         # avault exited before reading stdin (e.g. bad request); fall through to wait()
         # which surfaces its exit code.
         pass
-    return proc.wait()
+    exit_code = proc.wait()
+    return {"exit_code": exit_code, "delivered": exit_code != _AVAULT_INTERNAL_ERROR_CODE}
 
 
 def _agent_secret_payload(secret: dict, *, target_field: str) -> dict:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5197,14 +5197,19 @@ def avault_agent_release(*, scope_type: str, scope_ref: str) -> dict:
 
 def _agent_release_failure_is_absent(exc: AvaultError) -> bool:
     detail = str(exc).lower()
+    return _avault_agent_error_is_absent(detail)
+
+
+def _avault_agent_error_is_absent(detail: str) -> bool:
+    text = detail.lower()
     return (
-        "failed to connect to avault agent" in detail
+        "failed to connect to avault agent" in text
         and (
-            "no such file" in detail
-            or "connection refused" in detail
-            or "errno 2" in detail
-            or "errno 61" in detail
-            or "errno 111" in detail
+            "no such file" in text
+            or "connection refused" in text
+            or "errno 2" in text
+            or "errno 61" in text
+            or "errno 111" in text
         )
     )
 
@@ -5292,6 +5297,8 @@ def avault_agent_deliver_run(
             secrets=[_agent_secret_payload(secret, target_field="env") for secret in secrets],
         )
     except AvaultAgentError as exc:
+        if _avault_agent_error_is_absent(str(exc)):
+            raise AvaultPreHandoffError(str(exc)) from exc
         raise AvaultError(str(exc)) from exc
     try:
         exit_code = int(result["exit_code"])
@@ -5321,6 +5328,8 @@ def avault_agent_deliver_fetch(
             request=request,
         )
     except AvaultAgentError as exc:
+        if _avault_agent_error_is_absent(str(exc)):
+            raise AvaultPreHandoffError(str(exc)) from exc
         raise AvaultError(str(exc)) from exc
 
 
@@ -5345,6 +5354,8 @@ def avault_agent_deliver_inject(
             secrets=[_agent_secret_payload(secret, target_field="key") for secret in secrets],
         )
     except AvaultAgentError as exc:
+        if _avault_agent_error_is_absent(str(exc)):
+            raise AvaultPreHandoffError(str(exc)) from exc
         raise AvaultError(str(exc)) from exc
     if result.get("ok") is not True:
         raise AvaultError("avault agent inject returned malformed output")

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1694,6 +1694,12 @@ def _grant_ttl_seconds(grant: dict) -> int:
     return max(1, int(round(approved_lifetime)))
 
 
+def _release_one_shot_agent_grant(grant: dict | None, *, reason: str) -> None:
+    if not isinstance(grant, dict) or grant.get("one_shot") is not True:
+        return
+    release_vault_agent_scopes(_grant_scope_payload(grant), reason=reason)
+
+
 def _agent_grant_cached_all(result: dict, expected_count: int) -> bool:
     granted = result.get("granted")
     try:
@@ -1885,10 +1891,18 @@ def create_vault_grant(payload: dict) -> dict:
         ttl_seconds = int(ttl) if ttl is not None else None
     except (TypeError, ValueError) as exc:
         raise VaultApiError("ttl_seconds must be an integer", code="invalid_grant") from exc
+    request_id = payload.get("request_id") or payload.get("created_by_request_id")
+    if not request_id:
+        raise VaultApiError("request_id is required to create a grant", code="missing_request_id")
     engine = _vault_engine()
     try:
         with engine.connect() as conn:
-            grantable_members = vault_service.grantable_member_metas(conn, scope_type, scope_ref)
+            grantable_members = vault_service.request_grantable_member_metas(
+                conn,
+                scope_type,
+                scope_ref,
+                str(request_id),
+            )
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{exc}' not found", code="secret_not_found", status=404) from exc
     except vault_service.InvalidGrantError as exc:
@@ -1903,9 +1917,6 @@ def create_vault_grant(payload: dict) -> dict:
     if needs_agent_deks and provided_names != protected_member_names:
         raise VaultApiError("resident agent DEKs must match the protected grant members", code="invalid_grant")
     expected_member_names = {str(member["name"]) for member in grantable_members} if needs_agent_deks else None
-    request_id = payload.get("request_id") or payload.get("created_by_request_id")
-    if not request_id:
-        raise VaultApiError("request_id is required to create a grant", code="missing_request_id")
     expected_pubkey = payload.get("agent_pubkey") if isinstance(payload.get("agent_pubkey"), dict) else None
     if needs_agent_deks:
         try:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1700,6 +1700,30 @@ def _release_one_shot_agent_grant(grant: dict | None, *, reason: str) -> None:
     release_vault_agent_scopes(_grant_scope_payload(grant), reason=reason)
 
 
+def consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, reason: str) -> None:
+    """Expire one-shot grants after the caller has committed value delivery."""
+    from storage import vault_service
+
+    if not grants:
+        return
+    seen: set[str] = set()
+    release_scopes: list[dict[str, str]] = []
+    engine = _vault_engine()
+    with engine.begin() as conn:
+        for grant in grants:
+            if not isinstance(grant, dict) or grant.get("one_shot") is not True:
+                continue
+            grant_id = str(grant.get("id") or "")
+            if not grant_id or grant_id in seen:
+                continue
+            seen.add(grant_id)
+            with contextlib.suppress(vault_service.GrantNotActiveError, vault_service.GrantNotFoundError):
+                vault_service.consume_one_shot_grant(conn, grant_id)
+            if bool(grant.get("delivery_ready")) and str(grant.get("delivery_status") or "") != "standard_ready":
+                release_scopes.extend(_grant_scope_payload(grant))
+    release_vault_agent_scopes(release_scopes, reason=reason)
+
+
 def _agent_grant_cached_all(result: dict, expected_count: int) -> bool:
     granted = result.get("granted")
     try:
@@ -1905,6 +1929,10 @@ def create_vault_grant(payload: dict) -> dict:
             )
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{exc}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.RequestNotFoundError as exc:
+        raise VaultApiError(f"request '{exc}' not found", code="request_not_found", status=404) from exc
+    except vault_service.InvalidRequestError as exc:
+        raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
     except vault_service.InvalidGrantError as exc:
         raise VaultApiError(str(exc), code="invalid_grant") from exc
     if not grantable_members:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1878,7 +1878,7 @@ def _cleanup_failed_agent_grant(
                     active_scope_members: set[str] = set()
                     for active in conn.execute(
                         select(vault_service.vault_grants).where(
-                            vault_service.vault_grants.c.status == "active",
+                            vault_service.vault_grants.c.status.in_(vault_service.ACTIVE_GRANT_STATES),
                             vault_service.vault_grants.c.scope_type == scope["scope_type"],
                             vault_service.vault_grants.c.scope_ref == scope["scope_ref"],
                         )
@@ -4884,13 +4884,13 @@ def _version_at_least(current: str | None, minimum: str) -> bool:
 def _require_avault_p2_surface(feature: str) -> None:
     status = avault_status()
     if not status.get("installed"):
-        raise AvaultError(f"avault is required for {feature}")
+        raise AvaultPreHandoffError(f"avault is required for {feature}")
     version = status.get("version")
     if not _version_at_least(version, AVAULT_P2_MIN_VERSION):
         detail = f"{feature} requires avault >= {AVAULT_P2_MIN_VERSION}; installed {version or 'unknown'}"
         if not _managed_avault_release_satisfies_p2():
             detail = f"{detail}; managed avault install is pinned to {AVAULT_VERSION}"
-        raise AvaultError(detail)
+        raise AvaultPreHandoffError(detail)
 
 
 # ---------------------------------------------------------------------------
@@ -4911,6 +4911,10 @@ class AvaultError(Exception):
     avault is designed to keep secrets out of its stdout/stderr and errors."""
 
 
+class AvaultPreHandoffError(AvaultError):
+    """avault failed before receiving an envelope or performing delivery."""
+
+
 def _avault_detail(proc: "subprocess.CompletedProcess") -> str:
     """Best-effort, secret-free detail from a failed avault run (its stderr)."""
     raw = proc.stderr
@@ -4922,7 +4926,7 @@ def _avault_detail(proc: "subprocess.CompletedProcess") -> str:
 def _require_avault_path() -> str:
     path = _resolve_avault_cli_path()
     if not path:
-        raise AvaultError(backend_t("dependencies.avault.missing"))
+        raise AvaultPreHandoffError(backend_t("dependencies.avault.missing"))
     return path
 
 
@@ -4962,7 +4966,7 @@ def _run_avault(
             **isolated_subprocess_kwargs(),
         )
     except FileNotFoundError as exc:
-        raise AvaultError("avault binary not found") from exc
+        raise AvaultPreHandoffError("avault binary not found") from exc
     except subprocess.TimeoutExpired as exc:
         raise AvaultError("avault timed out") from exc
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1718,9 +1718,7 @@ def consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, rea
                 continue
             seen.add(grant_id)
             with contextlib.suppress(vault_service.GrantNotActiveError, vault_service.GrantNotFoundError):
-                vault_service.consume_one_shot_grant(conn, grant_id)
-            if bool(grant.get("delivery_ready")) and str(grant.get("delivery_status") or "") != "standard_ready":
-                release_scopes.extend(_grant_scope_payload(grant))
+                release_scopes.extend(vault_service.consume_one_shot_grant(conn, grant_id))
     release_vault_agent_scopes(release_scopes, reason=reason)
 
 
@@ -1919,22 +1917,31 @@ def create_vault_grant(payload: dict) -> dict:
     if not request_id:
         raise VaultApiError("request_id is required to create a grant", code="missing_request_id")
     engine = _vault_engine()
-    try:
-        with engine.connect() as conn:
+    preflight_error: Exception | None = None
+    with engine.begin() as conn:
+        try:
             grantable_members = vault_service.request_grantable_member_metas(
                 conn,
                 scope_type,
                 scope_ref,
                 str(request_id),
             )
-    except vault_service.SecretNotFoundError as exc:
-        raise VaultApiError(f"secret '{exc}' not found", code="secret_not_found", status=404) from exc
-    except vault_service.RequestNotFoundError as exc:
-        raise VaultApiError(f"request '{exc}' not found", code="request_not_found", status=404) from exc
-    except vault_service.InvalidRequestError as exc:
-        raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
-    except vault_service.InvalidGrantError as exc:
-        raise VaultApiError(str(exc), code="invalid_grant") from exc
+        except (
+            vault_service.SecretNotFoundError,
+            vault_service.RequestNotFoundError,
+            vault_service.InvalidRequestError,
+            vault_service.InvalidGrantError,
+        ) as exc:
+            preflight_error = exc
+            grantable_members = []
+    if isinstance(preflight_error, vault_service.SecretNotFoundError):
+        raise VaultApiError(f"secret '{preflight_error}' not found", code="secret_not_found", status=404) from preflight_error
+    if isinstance(preflight_error, vault_service.RequestNotFoundError):
+        raise VaultApiError(f"request '{preflight_error}' not found", code="request_not_found", status=404) from preflight_error
+    if isinstance(preflight_error, vault_service.InvalidRequestError):
+        raise VaultApiError(str(preflight_error), code="invalid_request", status=409) from preflight_error
+    if isinstance(preflight_error, vault_service.InvalidGrantError):
+        raise VaultApiError(str(preflight_error), code="invalid_grant") from preflight_error
     if not grantable_members:
         raise VaultApiError(f"{scope_type}:{scope_ref} has no grantable static secrets", code="not_grantable", status=409)
     protected_member_names = {str(member["name"]) for member in grantable_members if member.get("protection") == "protected"}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -4906,11 +4906,6 @@ def _require_avault_p2_surface(feature: str) -> None:
 # avibe's wait must outlast avault's own fetch timeout (10s connect + 30s total).
 _AVAULT_TIMEOUT_SECONDS = 20.0
 _AVAULT_FETCH_TIMEOUT_SECONDS = 60.0
-# avault exits 70 for an internal failure (bad envelope, decrypt error, store error)
-# before any delivery side effect — distinct from a delivered child's own exit code.
-_AVAULT_INTERNAL_ERROR_CODE = 70
-
-
 class AvaultError(Exception):
     """An ``avault`` invocation failed. Messages never carry secret material —
     avault is designed to keep secrets out of its stdout/stderr and errors."""
@@ -5108,8 +5103,9 @@ def avault_deliver_run(secrets: list[dict], command: list[str]) -> dict:
     plaintext never returns here. The child inherits this process's stdio so its
     output passes through; the run-secrets JSON (envelopes only, no plaintext)
     goes on avault's stdin to stay out of ``ps``. Returns the child's exit code
-    (``128 + signal`` if signalled) plus whether avault reached the delivery side
-    effect, or raises :class:`AvaultError` if avault could not start the child.
+    (``128 + signal`` if signalled). Delivery is fail-closed: once avault returns
+    an exit code, callers must treat the secret as handed to the child unless a
+    future avault protocol provides a distinct pre-handoff failure signal.
     """
     path = _require_avault_path()
     payload = json.dumps(
@@ -5136,7 +5132,7 @@ def avault_deliver_run(secrets: list[dict], command: list[str]) -> dict:
         # which surfaces its exit code.
         pass
     exit_code = proc.wait()
-    return {"exit_code": exit_code, "delivered": exit_code != _AVAULT_INTERNAL_ERROR_CODE}
+    return {"exit_code": exit_code, "delivered": True}
 
 
 def _agent_secret_payload(secret: dict, *, target_field: str) -> dict:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4745,6 +4745,14 @@ def _release_one_shot_reservations(engine, grants: list[dict] | tuple[dict, ...]
         logger.debug("failed to release one-shot vault grant reservations", exc_info=True)
 
 
+def _run_delivery_result(raw_result) -> tuple[int, bool]:
+    if isinstance(raw_result, dict):
+        exit_code = int(raw_result["exit_code"])
+        return exit_code, bool(raw_result.get("delivered", True))
+    exit_code = int(raw_result)
+    return exit_code, exit_code != 70
+
+
 def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str], *, args=None):
     from storage import vault_service
 
@@ -4752,7 +4760,12 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
     metas = _preflight_vault_run_batch(engine, mapping)
     if metas and {str(meta.get("protection") or "standard") for meta in metas.values()} == {"protected"}:
         with engine.begin() as conn:
-            common_grant = vault_service.find_active_grant_for_secrets(conn, list(mapping.values()), session_id=session_id)
+            common_grant = vault_service.find_active_grant_for_secrets(
+                conn,
+                list(mapping.values()),
+                session_id=session_id,
+                reserve_one_shot=True,
+            )
             if common_grant is not None:
                 return common_grant, [common_grant] if common_grant.get("one_shot") is True else [], [
                     {"name": vault_name, "env": env_name, "envelope": vault_service.get_protected_envelope(conn, vault_name)}
@@ -4762,14 +4775,18 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
     grant: dict | None = None
     one_shot_grants: list[dict] = []
     approval_error: TaskCliError | None = None
+    resolved_by_name: dict[str, dict] = {}
     with engine.begin() as conn:
         for env_name, vault_name in mapping.items():
-            resolved = vault_service.resolve_secret_access(
-                conn,
-                vault_name,
-                requester=requester,
-                delivery=delivery,
-            )
+            resolved = resolved_by_name.get(vault_name)
+            if resolved is None:
+                resolved = vault_service.resolve_secret_access(
+                    conn,
+                    vault_name,
+                    requester=requester,
+                    delivery=delivery,
+                )
+                resolved_by_name[vault_name] = resolved
             if resolved["status"] == "approval_required":
                 req = resolved.get("request") or {}
                 approval_error = TaskCliError(
@@ -4852,7 +4869,12 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
     metas = _preflight_vault_inject_batch(engine, names)
     if metas and {str(meta.get("protection") or "standard") for meta in metas.values()} == {"protected"}:
         with engine.begin() as conn:
-            common_grant = vault_service.find_active_grant_for_secrets(conn, names, session_id=session_id)
+            common_grant = vault_service.find_active_grant_for_secrets(
+                conn,
+                names,
+                session_id=session_id,
+                reserve_one_shot=True,
+            )
             if common_grant is not None:
                 return common_grant, [common_grant] if common_grant.get("one_shot") is True else [], [
                     {"name": name, "key": name, "envelope": vault_service.get_protected_envelope(conn, name)}
@@ -4862,14 +4884,18 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
     grant: dict | None = None
     one_shot_grants: list[dict] = []
     approval_error: TaskCliError | None = None
+    resolved_by_name: dict[str, dict] = {}
     with engine.begin() as conn:
         for name in names:
-            resolved = vault_service.resolve_secret_access(
-                conn,
-                name,
-                requester=requester,
-                delivery=delivery,
-            )
+            resolved = resolved_by_name.get(name)
+            if resolved is None:
+                resolved = vault_service.resolve_secret_access(
+                    conn,
+                    name,
+                    requester=requester,
+                    delivery=delivery,
+                )
+                resolved_by_name[name] = resolved
             if resolved["status"] == "approval_required":
                 req = resolved.get("request") or {}
                 approval_error = TaskCliError(
@@ -4986,8 +5012,9 @@ def cmd_vault_run(args):
                     ),
                 )
             exit_code = int(result["exit_code"])
+            delivered = True
         else:
-            exit_code = api.avault_deliver_run(secrets, command_argv)
+            exit_code, delivered = _run_delivery_result(api.avault_deliver_run(secrets, command_argv))
     except TaskCliError as exc:
         _release_one_shot_reservations(engine, one_shot_grants)
         _print_task_error(exc)
@@ -5007,7 +5034,6 @@ def cmd_vault_run(args):
             return 1
         _print_task_error(TaskCliError(f"avault deliver failed: {exc}", code="avault_failed", help_command=help_command))
         return 1
-    delivered = grant is not None or bool(one_shot_grants) or exit_code != 70
     if delivered:
         _consume_one_shot_grants(one_shot_grants, reason="vault-run-one-shot")
         try:
@@ -5017,6 +5043,8 @@ def cmd_vault_run(args):
                 )
         except Exception:
             pass
+    else:
+        _release_one_shot_reservations(engine, one_shot_grants)
     return exit_code
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4771,6 +4771,21 @@ def _consume_after_possible_use(grants: list[dict] | tuple[dict, ...] | None, *,
     _consume_one_shot_grants(_unique_one_shot_grants(grants), reason=reason)
 
 
+def _finish_one_shot_after_avault_error(
+    engine,
+    grants: list[dict] | tuple[dict, ...] | None,
+    exc: Exception,
+    *,
+    reason: str,
+) -> None:
+    from vibe import api
+
+    if isinstance(exc, api.AvaultPreHandoffError):
+        _release_one_shot_reservations(engine, grants)
+    else:
+        _consume_after_possible_use(grants, reason=reason)
+
+
 def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str], *, args=None):
     from storage import vault_service
 
@@ -4804,6 +4819,7 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
                     vault_name,
                     requester=requester,
                     delivery=delivery,
+                    reserve_one_shot=True,
                 )
                 resolved_by_name[vault_name] = resolved
             if resolved["status"] == "approval_required":
@@ -4869,6 +4885,7 @@ def _resolve_single_vault_delivery(
             name,
             requester=requester,
             delivery=delivery,
+            reserve_one_shot=True,
         )
     if resolved["status"] == "approval_required":
         req = resolved.get("request") or {}
@@ -4919,6 +4936,7 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
                     name,
                     requester=requester,
                     delivery=delivery,
+                    reserve_one_shot=True,
                 )
                 resolved_by_name[name] = resolved
             if resolved["status"] == "approval_required":
@@ -5056,7 +5074,7 @@ def cmd_vault_run(args):
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
-        _consume_after_possible_use(one_shot_grants, reason="vault-run-one-shot")
+        _finish_one_shot_after_avault_error(engine, one_shot_grants, exc, reason="vault-run-one-shot")
         if grant is not None and _agent_missing_grant(exc):
             requester, delivery, _session_id = _vault_cli_delivery_context(args, mode="run", command=command_argv)
             _expire_agent_grant_after_missing(
@@ -5568,10 +5586,12 @@ def cmd_vault_fetch(args):
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
-        if handoff_started:
-            _consume_after_possible_use([one_shot_grant] if one_shot_grant is not None else [], reason="vault-fetch-one-shot")
-        else:
-            _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
+        _finish_one_shot_after_avault_error(
+            engine,
+            [one_shot_grant] if one_shot_grant is not None else [],
+            exc,
+            reason="vault-fetch-one-shot",
+        )
         if engine is not None and isinstance(grant, dict) and _agent_missing_grant(exc):
             grant_id = grant.get("id")
             if grant_id:
@@ -5729,10 +5749,7 @@ def cmd_vault_inject(args):
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
-        if handoff_started:
-            _consume_after_possible_use(one_shot_grants, reason="vault-inject-one-shot")
-        else:
-            _release_one_shot_reservations(engine, one_shot_grants)
+        _finish_one_shot_after_avault_error(engine, one_shot_grants, exc, reason="vault-inject-one-shot")
         if engine is not None and isinstance(grant, dict) and _agent_missing_grant(exc):
             requester, delivery, _session_id = _vault_cli_delivery_context(
                 args,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4710,6 +4710,12 @@ def _resolve_cli_output_path(path: str) -> str:
     return str(output_path)
 
 
+def _consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, reason: str) -> None:
+    from vibe import api
+
+    api.consume_one_shot_grants(grants, reason=reason)
+
+
 def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str], *, args=None):
     from storage import vault_service
 
@@ -4719,12 +4725,13 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
         with engine.begin() as conn:
             common_grant = vault_service.find_active_grant_for_secrets(conn, list(mapping.values()), session_id=session_id)
             if common_grant is not None:
-                return common_grant, [
+                return common_grant, [common_grant] if common_grant.get("one_shot") is True else [], [
                     {"name": vault_name, "env": env_name, "envelope": vault_service.get_protected_envelope(conn, vault_name)}
                     for env_name, vault_name in mapping.items()
                 ]
     secrets = []
     grant: dict | None = None
+    one_shot_grants: list[dict] = []
     approval_error: TaskCliError | None = None
     with engine.begin() as conn:
         for env_name, vault_name in mapping.items():
@@ -4743,6 +4750,9 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
                 )
                 break
             if resolved["status"] == "standard":
+                current_grant = resolved.get("grant")
+                if isinstance(current_grant, dict) and current_grant.get("one_shot") is True:
+                    one_shot_grants.append(current_grant)
                 secrets.append({"name": vault_name, "env": env_name, "envelope": resolved["envelope"], "protected": False})
                 continue
             if resolved["status"] == "agent_delivery_ready":
@@ -4754,6 +4764,8 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
                         "protected vault run currently requires all protected secrets to share one active grant",
                         code="mixed_grants",
                     )
+                if current_grant.get("one_shot") is True:
+                    one_shot_grants.append(current_grant)
                 secrets.append({"name": vault_name, "env": env_name, "envelope": resolved["envelope"], "protected": True})
                 continue
             raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
@@ -4767,7 +4779,7 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
             code="mixed_protection_tiers",
         )
     selected = protected or standard
-    return grant, [{key: value for key, value in item.items() if key != "protected"} for item in selected]
+    return grant, one_shot_grants, [{key: value for key, value in item.items() if key != "protected"} for item in selected]
 
 
 def _resolve_single_vault_delivery(
@@ -4776,7 +4788,7 @@ def _resolve_single_vault_delivery(
     *,
     requester: dict,
     delivery: dict,
-) -> tuple[dict | None, object]:
+) -> tuple[dict | None, dict | None, object]:
     from storage import vault_service
 
     with engine.begin() as conn:
@@ -4794,9 +4806,11 @@ def _resolve_single_vault_delivery(
             details={"request_id": req.get("id")},
         )
     if resolved["status"] == "standard":
-        return None, resolved["envelope"]
+        current_grant = resolved.get("grant")
+        return None, current_grant if isinstance(current_grant, dict) and current_grant.get("one_shot") is True else None, resolved["envelope"]
     if resolved["status"] == "agent_delivery_ready":
-        return resolved["grant"], resolved["envelope"]
+        current_grant = resolved["grant"]
+        return current_grant, current_grant if current_grant.get("one_shot") is True else None, resolved["envelope"]
     raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
 
 
@@ -4809,12 +4823,13 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
         with engine.begin() as conn:
             common_grant = vault_service.find_active_grant_for_secrets(conn, names, session_id=session_id)
             if common_grant is not None:
-                return common_grant, [
+                return common_grant, [common_grant] if common_grant.get("one_shot") is True else [], [
                     {"name": name, "key": name, "envelope": vault_service.get_protected_envelope(conn, name)}
                     for name in names
                 ]
     secrets = []
     grant: dict | None = None
+    one_shot_grants: list[dict] = []
     approval_error: TaskCliError | None = None
     with engine.begin() as conn:
         for name in names:
@@ -4833,6 +4848,9 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
                 )
                 break
             if resolved["status"] == "standard":
+                current_grant = resolved.get("grant")
+                if isinstance(current_grant, dict) and current_grant.get("one_shot") is True:
+                    one_shot_grants.append(current_grant)
                 secrets.append({"name": name, "key": name, "envelope": resolved["envelope"], "protected": False})
                 continue
             if resolved["status"] == "agent_delivery_ready":
@@ -4844,6 +4862,8 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
                         "protected vault inject currently requires all protected secrets to share one active grant",
                         code="mixed_grants",
                     )
+                if current_grant.get("one_shot") is True:
+                    one_shot_grants.append(current_grant)
                 secrets.append({"name": name, "key": name, "envelope": resolved["envelope"], "protected": True})
                 continue
             raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
@@ -4857,7 +4877,7 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
             code="mixed_protection_tiers",
         )
     selected = protected or standard
-    return grant, [{key: value for key, value in item.items() if key != "protected"} for item in selected]
+    return grant, one_shot_grants, [{key: value for key, value in item.items() if key != "protected"} for item in selected]
 
 
 def cmd_vault_run(args):
@@ -4889,7 +4909,7 @@ def cmd_vault_run(args):
                 example="vibe vault run --env OPENAI_API_KEY -- python sync.py",
             )
         engine = _open_vault_engine()
-        grant, secrets = _resolve_vault_run_delivery(engine, mapping, command_argv, args=args)
+        grant, one_shot_grants, secrets = _resolve_vault_run_delivery(engine, mapping, command_argv, args=args)
     except vault_service.SecretNotFoundError as exc:
         _print_task_error(TaskCliError(f"secret '{exc}' not found", code="secret_not_found", help_command=help_command))
         return 1
@@ -4914,27 +4934,24 @@ def cmd_vault_run(args):
     try:
         if grant is not None:
             secret_env_names = {str(secret["env"]) for secret in secrets if secret.get("env")}
-            try:
-                with _AgentRunOutputBridge(
-                    sys.stdout.buffer,
-                    sys.stderr.buffer,
-                    env_exclude=secret_env_names,
-                ) as output_bridge:
-                    result = api.avault_agent_deliver_run(
-                        scope_type=grant["scope_type"],
-                        scope_ref=grant["scope_ref"],
-                        secrets=secrets,
-                        command=_agent_run_command(
-                            command_argv,
-                            stdout_path=str(output_bridge.stdout_path),
-                            stderr_path=str(output_bridge.stderr_path),
-                            stdin_path=str(output_bridge.stdin_path),
-                            env_path=str(output_bridge.env_path),
-                            keep_env_path=str(output_bridge.keep_env_path),
-                        ),
-                    )
-            finally:
-                api._release_one_shot_agent_grant(grant, reason="vault-run-one-shot")
+            with _AgentRunOutputBridge(
+                sys.stdout.buffer,
+                sys.stderr.buffer,
+                env_exclude=secret_env_names,
+            ) as output_bridge:
+                result = api.avault_agent_deliver_run(
+                    scope_type=grant["scope_type"],
+                    scope_ref=grant["scope_ref"],
+                    secrets=secrets,
+                    command=_agent_run_command(
+                        command_argv,
+                        stdout_path=str(output_bridge.stdout_path),
+                        stderr_path=str(output_bridge.stderr_path),
+                        stdin_path=str(output_bridge.stdin_path),
+                        env_path=str(output_bridge.env_path),
+                        keep_env_path=str(output_bridge.keep_env_path),
+                    ),
+                )
             exit_code = int(result["exit_code"])
         else:
             exit_code = api.avault_deliver_run(secrets, command_argv)
@@ -4960,6 +4977,7 @@ def cmd_vault_run(args):
     # failures; a returned 70 is the child's real exit code and must still be audited.
     delivered = grant is not None or exit_code != 70
     if delivered:
+        _consume_one_shot_grants(one_shot_grants, reason="vault-run-one-shot")
         try:
             with engine.begin() as conn:
                 vault_service.record_deliveries(
@@ -5394,25 +5412,23 @@ def cmd_vault_fetch(args):
             "inject": inject,
         }
         requester, delivery, _session_id = _vault_cli_delivery_context(args, mode="fetch", host=host, method=method)
-        grant, sealed = _resolve_single_vault_delivery(
+        grant, one_shot_grant, sealed = _resolve_single_vault_delivery(
             engine,
             name,
             requester=requester,
             delivery=delivery,
         )
         if grant is not None:
-            try:
-                result = api.avault_agent_deliver_fetch(
-                    scope_type=grant["scope_type"],
-                    scope_ref=grant["scope_ref"],
-                    name=name,
-                    sealed=sealed,
-                    request=request,
-                )
-            finally:
-                api._release_one_shot_agent_grant(grant, reason="vault-fetch-one-shot")
+            result = api.avault_agent_deliver_fetch(
+                scope_type=grant["scope_type"],
+                scope_ref=grant["scope_ref"],
+                name=name,
+                sealed=sealed,
+                request=request,
+            )
         else:
             result = api.avault_deliver_fetch(name, sealed, request)
+        _consume_one_shot_grants([one_shot_grant] if one_shot_grant is not None else [], reason="vault-fetch-one-shot")
         status = int(result.get("status") or 0)
         resp_body = result.get("body") or ""
 
@@ -5552,22 +5568,20 @@ def cmd_vault_inject(args):
             raise TaskCliError(f"unknown --format: {fmt!r} (dotenv|json)", code="invalid_format", help_command=help_command)
         engine = _open_vault_engine()
         resolved_out = _resolve_cli_output_path(str(out))
-        grant, secrets = _resolve_vault_inject_delivery(engine, keys, path=resolved_out, fmt=fmt, args=args)
+        grant, one_shot_grants, secrets = _resolve_vault_inject_delivery(engine, keys, path=resolved_out, fmt=fmt, args=args)
         # avault writes the 0600 file atomically; if the path is unwritable it raises and no
         # delivery is recorded.
         if grant is not None:
-            try:
-                api.avault_agent_deliver_inject(
-                    scope_type=grant["scope_type"],
-                    scope_ref=grant["scope_ref"],
-                    path=resolved_out,
-                    fmt=fmt,
-                    secrets=secrets,
-                )
-            finally:
-                api._release_one_shot_agent_grant(grant, reason="vault-inject-one-shot")
+            api.avault_agent_deliver_inject(
+                scope_type=grant["scope_type"],
+                scope_ref=grant["scope_ref"],
+                path=resolved_out,
+                fmt=fmt,
+                secrets=secrets,
+            )
         else:
             api.avault_deliver_inject(out, fmt, secrets)
+        _consume_one_shot_grants(one_shot_grants, reason="vault-inject-one-shot")
         # The file is on disk → delivered. A bookkeeping failure must not report a failed command
         # (callers would retry though the secrets are already written), so record best-effort.
         try:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4711,6 +4711,20 @@ def _resolve_cli_output_path(path: str) -> str:
     return str(output_path)
 
 
+def _preflight_cli_output_path(path: str, *, help_command: str) -> None:
+    output_path = Path(path)
+    parent = output_path.parent
+    if not parent.exists():
+        raise TaskCliError(f"output parent does not exist: {parent}", code="output_unwritable", help_command=help_command)
+    if not parent.is_dir():
+        raise TaskCliError(f"output parent is not a directory: {parent}", code="output_unwritable", help_command=help_command)
+    try:
+        with tempfile.NamedTemporaryFile(dir=str(parent), prefix=f".{output_path.name}.", delete=True):
+            pass
+    except OSError as exc:
+        raise TaskCliError(f"cannot write output file: {exc}", code="output_unwritable", help_command=help_command) from exc
+
+
 def _consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, reason: str) -> None:
     from vibe import api
 
@@ -5719,6 +5733,7 @@ def cmd_vault_inject(args):
             raise TaskCliError(f"unknown --format: {fmt!r} (dotenv|json)", code="invalid_format", help_command=help_command)
         engine = _open_vault_engine()
         resolved_out = _resolve_cli_output_path(str(out))
+        _preflight_cli_output_path(resolved_out, help_command=help_command)
         grant, one_shot_grants, secrets = _resolve_vault_inject_delivery(engine, keys, path=resolved_out, fmt=fmt, args=args)
         # avault writes the 0600 file atomically; if the path is unwritable it raises and no
         # delivery is recorded.

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4914,24 +4914,27 @@ def cmd_vault_run(args):
     try:
         if grant is not None:
             secret_env_names = {str(secret["env"]) for secret in secrets if secret.get("env")}
-            with _AgentRunOutputBridge(
-                sys.stdout.buffer,
-                sys.stderr.buffer,
-                env_exclude=secret_env_names,
-            ) as output_bridge:
-                result = api.avault_agent_deliver_run(
-                    scope_type=grant["scope_type"],
-                    scope_ref=grant["scope_ref"],
-                    secrets=secrets,
-                    command=_agent_run_command(
-                        command_argv,
-                        stdout_path=str(output_bridge.stdout_path),
-                        stderr_path=str(output_bridge.stderr_path),
-                        stdin_path=str(output_bridge.stdin_path),
-                        env_path=str(output_bridge.env_path),
-                        keep_env_path=str(output_bridge.keep_env_path),
-                    ),
-                )
+            try:
+                with _AgentRunOutputBridge(
+                    sys.stdout.buffer,
+                    sys.stderr.buffer,
+                    env_exclude=secret_env_names,
+                ) as output_bridge:
+                    result = api.avault_agent_deliver_run(
+                        scope_type=grant["scope_type"],
+                        scope_ref=grant["scope_ref"],
+                        secrets=secrets,
+                        command=_agent_run_command(
+                            command_argv,
+                            stdout_path=str(output_bridge.stdout_path),
+                            stderr_path=str(output_bridge.stderr_path),
+                            stdin_path=str(output_bridge.stdin_path),
+                            env_path=str(output_bridge.env_path),
+                            keep_env_path=str(output_bridge.keep_env_path),
+                        ),
+                    )
+            finally:
+                api._release_one_shot_agent_grant(grant, reason="vault-run-one-shot")
             exit_code = int(result["exit_code"])
         else:
             exit_code = api.avault_deliver_run(secrets, command_argv)
@@ -5398,13 +5401,16 @@ def cmd_vault_fetch(args):
             delivery=delivery,
         )
         if grant is not None:
-            result = api.avault_agent_deliver_fetch(
-                scope_type=grant["scope_type"],
-                scope_ref=grant["scope_ref"],
-                name=name,
-                sealed=sealed,
-                request=request,
-            )
+            try:
+                result = api.avault_agent_deliver_fetch(
+                    scope_type=grant["scope_type"],
+                    scope_ref=grant["scope_ref"],
+                    name=name,
+                    sealed=sealed,
+                    request=request,
+                )
+            finally:
+                api._release_one_shot_agent_grant(grant, reason="vault-fetch-one-shot")
         else:
             result = api.avault_deliver_fetch(name, sealed, request)
         status = int(result.get("status") or 0)
@@ -5550,13 +5556,16 @@ def cmd_vault_inject(args):
         # avault writes the 0600 file atomically; if the path is unwritable it raises and no
         # delivery is recorded.
         if grant is not None:
-            api.avault_agent_deliver_inject(
-                scope_type=grant["scope_type"],
-                scope_ref=grant["scope_ref"],
-                path=resolved_out,
-                fmt=fmt,
-                secrets=secrets,
-            )
+            try:
+                api.avault_agent_deliver_inject(
+                    scope_type=grant["scope_type"],
+                    scope_ref=grant["scope_ref"],
+                    path=resolved_out,
+                    fmt=fmt,
+                    secrets=secrets,
+                )
+            finally:
+                api._release_one_shot_agent_grant(grant, reason="vault-inject-one-shot")
         else:
             api.avault_deliver_inject(out, fmt, secrets)
         # The file is on disk → delivered. A bookkeeping failure must not report a failed command

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4720,21 +4720,30 @@ def _consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, re
         logger.debug("failed to consume one-shot vault grants after delivery", exc_info=True)
 
 
+def _unique_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None) -> list[dict]:
+    unique: list[dict] = []
+    seen: set[str] = set()
+    for grant in grants or []:
+        if not isinstance(grant, dict) or grant.get("one_shot") is not True:
+            continue
+        grant_id = str(grant.get("id") or "")
+        if not grant_id or grant_id in seen:
+            continue
+        seen.add(grant_id)
+        unique.append(grant)
+    return unique
+
+
 def _release_one_shot_reservations(engine, grants: list[dict] | tuple[dict, ...] | None) -> None:
+    grants = _unique_one_shot_grants(grants)
     if not grants:
         return
     from storage import vault_service
 
     try:
         with engine.begin() as conn:
-            seen: set[str] = set()
             for grant in grants:
-                if not isinstance(grant, dict) or grant.get("one_shot") is not True:
-                    continue
-                grant_id = str(grant.get("id") or "")
-                if not grant_id or grant_id in seen:
-                    continue
-                seen.add(grant_id)
+                grant_id = str(grant["id"])
                 with contextlib.suppress(
                     vault_service.GrantNotActiveError,
                     vault_service.GrantNotFoundError,
@@ -4750,7 +4759,16 @@ def _run_delivery_result(raw_result) -> tuple[int, bool]:
         exit_code = int(raw_result["exit_code"])
         return exit_code, bool(raw_result.get("delivered", True))
     exit_code = int(raw_result)
-    return exit_code, exit_code != 70
+    return exit_code, True
+
+
+def _mixed_grants_error(message: str) -> TaskCliError:
+    return TaskCliError(message, code="mixed_grants")
+
+
+def _consume_after_possible_use(grants: list[dict] | tuple[dict, ...] | None, *, reason: str) -> None:
+    """Fail closed for one-shot grants after handoff to avault/resident agent."""
+    _consume_one_shot_grants(_unique_one_shot_grants(grants), reason=reason)
 
 
 def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str], *, args=None):
@@ -4775,6 +4793,7 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
     grant: dict | None = None
     one_shot_grants: list[dict] = []
     approval_error: TaskCliError | None = None
+    pre_delivery_error: TaskCliError | None = None
     resolved_by_name: dict[str, dict] = {}
     with engine.begin() as conn:
         for env_name, vault_name in mapping.items():
@@ -4806,10 +4825,12 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
                 if grant is None:
                     grant = current_grant
                 elif grant["scope_type"] != current_grant["scope_type"] or grant["scope_ref"] != current_grant["scope_ref"]:
-                    raise TaskCliError(
+                    if current_grant.get("one_shot") is True:
+                        one_shot_grants.append(current_grant)
+                    pre_delivery_error = _mixed_grants_error(
                         "protected vault run currently requires all protected secrets to share one active grant",
-                        code="mixed_grants",
                     )
+                    break
                 if current_grant.get("one_shot") is True:
                     one_shot_grants.append(current_grant)
                 secrets.append({"name": vault_name, "env": env_name, "envelope": resolved["envelope"], "protected": True})
@@ -4818,6 +4839,9 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
     if approval_error is not None:
         _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error
+    if pre_delivery_error is not None:
+        _release_one_shot_reservations(engine, one_shot_grants)
+        raise pre_delivery_error
     protected = [item for item in secrets if item["protected"]]
     standard = [item for item in secrets if not item["protected"]]
     if protected and standard:
@@ -4884,6 +4908,7 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
     grant: dict | None = None
     one_shot_grants: list[dict] = []
     approval_error: TaskCliError | None = None
+    pre_delivery_error: TaskCliError | None = None
     resolved_by_name: dict[str, dict] = {}
     with engine.begin() as conn:
         for name in names:
@@ -4915,10 +4940,12 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
                 if grant is None:
                     grant = current_grant
                 elif grant["scope_type"] != current_grant["scope_type"] or grant["scope_ref"] != current_grant["scope_ref"]:
-                    raise TaskCliError(
+                    if current_grant.get("one_shot") is True:
+                        one_shot_grants.append(current_grant)
+                    pre_delivery_error = _mixed_grants_error(
                         "protected vault inject currently requires all protected secrets to share one active grant",
-                        code="mixed_grants",
                     )
+                    break
                 if current_grant.get("one_shot") is True:
                     one_shot_grants.append(current_grant)
                 secrets.append({"name": name, "key": name, "envelope": resolved["envelope"], "protected": True})
@@ -4927,6 +4954,9 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
     if approval_error is not None:
         _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error
+    if pre_delivery_error is not None:
+        _release_one_shot_reservations(engine, one_shot_grants)
+        raise pre_delivery_error
     protected = [item for item in secrets if item["protected"]]
     standard = [item for item in secrets if not item["protected"]]
     if protected and standard:
@@ -4990,6 +5020,7 @@ def cmd_vault_run(args):
     # returns the exit code.
     from vibe import api
 
+    handoff_started = False
     try:
         if grant is not None:
             secret_env_names = {str(secret["env"]) for secret in secrets if secret.get("env")}
@@ -4998,6 +5029,7 @@ def cmd_vault_run(args):
                 sys.stderr.buffer,
                 env_exclude=secret_env_names,
             ) as output_bridge:
+                handoff_started = True
                 result = api.avault_agent_deliver_run(
                     scope_type=grant["scope_type"],
                     scope_ref=grant["scope_ref"],
@@ -5014,13 +5046,17 @@ def cmd_vault_run(args):
             exit_code = int(result["exit_code"])
             delivered = True
         else:
+            handoff_started = True
             exit_code, delivered = _run_delivery_result(api.avault_deliver_run(secrets, command_argv))
     except TaskCliError as exc:
-        _release_one_shot_reservations(engine, one_shot_grants)
+        if handoff_started:
+            _consume_after_possible_use(one_shot_grants, reason="vault-run-one-shot")
+        else:
+            _release_one_shot_reservations(engine, one_shot_grants)
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
-        _release_one_shot_reservations(engine, one_shot_grants)
+        _consume_after_possible_use(one_shot_grants, reason="vault-run-one-shot")
         if grant is not None and _agent_missing_grant(exc):
             requester, delivery, _session_id = _vault_cli_delivery_context(args, mode="run", command=command_argv)
             _expire_agent_grant_after_missing(
@@ -5034,8 +5070,15 @@ def cmd_vault_run(args):
             return 1
         _print_task_error(TaskCliError(f"avault deliver failed: {exc}", code="avault_failed", help_command=help_command))
         return 1
+    except Exception as exc:
+        if handoff_started:
+            _consume_after_possible_use(one_shot_grants, reason="vault-run-one-shot")
+        else:
+            _release_one_shot_reservations(engine, one_shot_grants)
+        _print_task_error(exc, help_command=help_command)
+        return 1
     if delivered:
-        _consume_one_shot_grants(one_shot_grants, reason="vault-run-one-shot")
+        _consume_after_possible_use(one_shot_grants, reason="vault-run-one-shot")
         try:
             with engine.begin() as conn:
                 vault_service.record_deliveries(
@@ -5369,6 +5412,7 @@ def cmd_vault_fetch(args):
     engine = None
     grant = None
     one_shot_grant = None
+    handoff_started = False
     name = getattr(args, "auth", "")
     host = ""
     method = "GET"
@@ -5479,6 +5523,7 @@ def cmd_vault_fetch(args):
             requester=requester,
             delivery=delivery,
         )
+        handoff_started = True
         if grant is not None:
             result = api.avault_agent_deliver_fetch(
                 scope_type=grant["scope_type"],
@@ -5489,7 +5534,7 @@ def cmd_vault_fetch(args):
             )
         else:
             result = api.avault_deliver_fetch(name, sealed, request)
-        _consume_one_shot_grants([one_shot_grant] if one_shot_grant is not None else [], reason="vault-fetch-one-shot")
+        _consume_after_possible_use([one_shot_grant] if one_shot_grant is not None else [], reason="vault-fetch-one-shot")
         status = int(result.get("status") or 0)
         resp_body = result.get("body") or ""
 
@@ -5516,11 +5561,17 @@ def cmd_vault_fetch(args):
         _print_task_error(TaskCliError(str(exc), code="protected_tier_unavailable", help_command=help_command))
         return 1
     except TaskCliError as exc:
-        _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
+        if handoff_started:
+            _consume_after_possible_use([one_shot_grant] if one_shot_grant is not None else [], reason="vault-fetch-one-shot")
+        else:
+            _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
-        _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
+        if handoff_started:
+            _consume_after_possible_use([one_shot_grant] if one_shot_grant is not None else [], reason="vault-fetch-one-shot")
+        else:
+            _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
         if engine is not None and isinstance(grant, dict) and _agent_missing_grant(exc):
             grant_id = grant.get("id")
             if grant_id:
@@ -5536,7 +5587,10 @@ def cmd_vault_fetch(args):
         _print_task_error(TaskCliError(f"request failed: {exc}", code="request_failed", help_command=help_command))
         return 1
     except Exception as exc:
-        _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
+        if handoff_started:
+            _consume_after_possible_use([one_shot_grant] if one_shot_grant is not None else [], reason="vault-fetch-one-shot")
+        else:
+            _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
         _print_task_error(exc, help_command=help_command)
         return 1
 
@@ -5613,6 +5667,7 @@ def cmd_vault_inject(args):
     grant = None
     one_shot_grants: list[dict] = []
     keys: list[str] = []
+    handoff_started = False
     try:
         keys = [k.strip() for k in (getattr(args, "keys", None) or "").split(",") if k.strip()]
         keys = list(dict.fromkeys(keys))  # dedupe, preserve order: A,A is one entry + one audit
@@ -5636,6 +5691,7 @@ def cmd_vault_inject(args):
         grant, one_shot_grants, secrets = _resolve_vault_inject_delivery(engine, keys, path=resolved_out, fmt=fmt, args=args)
         # avault writes the 0600 file atomically; if the path is unwritable it raises and no
         # delivery is recorded.
+        handoff_started = True
         if grant is not None:
             api.avault_agent_deliver_inject(
                 scope_type=grant["scope_type"],
@@ -5646,7 +5702,7 @@ def cmd_vault_inject(args):
             )
         else:
             api.avault_deliver_inject(out, fmt, secrets)
-        _consume_one_shot_grants(one_shot_grants, reason="vault-inject-one-shot")
+        _consume_after_possible_use(one_shot_grants, reason="vault-inject-one-shot")
         # The file is on disk → delivered. A bookkeeping failure must not report a failed command
         # (callers would retry though the secrets are already written), so record best-effort.
         try:
@@ -5666,11 +5722,17 @@ def cmd_vault_inject(args):
         _print_task_error(TaskCliError(str(exc), code="protected_tier_unavailable", help_command=help_command))
         return 1
     except TaskCliError as exc:
-        _release_one_shot_reservations(engine, one_shot_grants)
+        if handoff_started:
+            _consume_after_possible_use(one_shot_grants, reason="vault-inject-one-shot")
+        else:
+            _release_one_shot_reservations(engine, one_shot_grants)
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
-        _release_one_shot_reservations(engine, one_shot_grants)
+        if handoff_started:
+            _consume_after_possible_use(one_shot_grants, reason="vault-inject-one-shot")
+        else:
+            _release_one_shot_reservations(engine, one_shot_grants)
         if engine is not None and isinstance(grant, dict) and _agent_missing_grant(exc):
             requester, delivery, _session_id = _vault_cli_delivery_context(
                 args,
@@ -5690,7 +5752,10 @@ def cmd_vault_inject(args):
         _print_task_error(TaskCliError(f"avault inject failed: {exc}", code="avault_failed", help_command=help_command))
         return 1
     except Exception as exc:
-        _release_one_shot_reservations(engine, one_shot_grants)
+        if handoff_started:
+            _consume_after_possible_use(one_shot_grants, reason="vault-inject-one-shot")
+        else:
+            _release_one_shot_reservations(engine, one_shot_grants)
         _print_task_error(exc, help_command=help_command)
         return 1
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4766,6 +4766,11 @@ def _mixed_grants_error(message: str) -> TaskCliError:
     return TaskCliError(message, code="mixed_grants")
 
 
+def _raise_after_releasing_one_shot_reservations(engine, grants, exc):
+    _release_one_shot_reservations(engine, grants)
+    raise exc
+
+
 def _consume_after_possible_use(grants: list[dict] | tuple[dict, ...] | None, *, reason: str) -> None:
     """Fail closed for one-shot grants after handoff to avault/resident agent."""
     _consume_one_shot_grants(_unique_one_shot_grants(grants), reason=reason)
@@ -4810,48 +4815,51 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
     approval_error: TaskCliError | None = None
     pre_delivery_error: TaskCliError | None = None
     resolved_by_name: dict[str, dict] = {}
-    with engine.begin() as conn:
-        for env_name, vault_name in mapping.items():
-            resolved = resolved_by_name.get(vault_name)
-            if resolved is None:
-                resolved = vault_service.resolve_secret_access(
-                    conn,
-                    vault_name,
-                    requester=requester,
-                    delivery=delivery,
-                    reserve_one_shot=True,
-                )
-                resolved_by_name[vault_name] = resolved
-            if resolved["status"] == "approval_required":
-                req = resolved.get("request") or {}
-                approval_error = TaskCliError(
-                    f"secret '{vault_name}' needs approval before protected delivery",
-                    code="approval_required",
-                    details={"request_id": req.get("id")},
-                )
-                break
-            if resolved["status"] == "standard":
-                current_grant = resolved.get("grant")
-                if isinstance(current_grant, dict) and current_grant.get("one_shot") is True:
-                    one_shot_grants.append(current_grant)
-                secrets.append({"name": vault_name, "env": env_name, "envelope": resolved["envelope"], "protected": False})
-                continue
-            if resolved["status"] == "agent_delivery_ready":
-                current_grant = resolved["grant"]
-                if grant is None:
-                    grant = current_grant
-                elif grant["scope_type"] != current_grant["scope_type"] or grant["scope_ref"] != current_grant["scope_ref"]:
-                    if current_grant.get("one_shot") is True:
-                        one_shot_grants.append(current_grant)
-                    pre_delivery_error = _mixed_grants_error(
-                        "protected vault run currently requires all protected secrets to share one active grant",
+    try:
+        with engine.begin() as conn:
+            for env_name, vault_name in mapping.items():
+                resolved = resolved_by_name.get(vault_name)
+                if resolved is None:
+                    resolved = vault_service.resolve_secret_access(
+                        conn,
+                        vault_name,
+                        requester=requester,
+                        delivery=delivery,
+                        reserve_one_shot=True,
+                    )
+                    resolved_by_name[vault_name] = resolved
+                if resolved["status"] == "approval_required":
+                    req = resolved.get("request") or {}
+                    approval_error = TaskCliError(
+                        f"secret '{vault_name}' needs approval before protected delivery",
+                        code="approval_required",
+                        details={"request_id": req.get("id")},
                     )
                     break
-                if current_grant.get("one_shot") is True:
-                    one_shot_grants.append(current_grant)
-                secrets.append({"name": vault_name, "env": env_name, "envelope": resolved["envelope"], "protected": True})
-                continue
-            raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
+                if resolved["status"] == "standard":
+                    current_grant = resolved.get("grant")
+                    if isinstance(current_grant, dict) and current_grant.get("one_shot") is True:
+                        one_shot_grants.append(current_grant)
+                    secrets.append({"name": vault_name, "env": env_name, "envelope": resolved["envelope"], "protected": False})
+                    continue
+                if resolved["status"] == "agent_delivery_ready":
+                    current_grant = resolved["grant"]
+                    if grant is None:
+                        grant = current_grant
+                    elif grant["scope_type"] != current_grant["scope_type"] or grant["scope_ref"] != current_grant["scope_ref"]:
+                        if current_grant.get("one_shot") is True:
+                            one_shot_grants.append(current_grant)
+                        pre_delivery_error = _mixed_grants_error(
+                            "protected vault run currently requires all protected secrets to share one active grant",
+                        )
+                        break
+                    if current_grant.get("one_shot") is True:
+                        one_shot_grants.append(current_grant)
+                    secrets.append({"name": vault_name, "env": env_name, "envelope": resolved["envelope"], "protected": True})
+                    continue
+                raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
+    except Exception as exc:
+        _raise_after_releasing_one_shot_reservations(engine, one_shot_grants, exc)
     if approval_error is not None:
         _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error
@@ -4927,48 +4935,51 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
     approval_error: TaskCliError | None = None
     pre_delivery_error: TaskCliError | None = None
     resolved_by_name: dict[str, dict] = {}
-    with engine.begin() as conn:
-        for name in names:
-            resolved = resolved_by_name.get(name)
-            if resolved is None:
-                resolved = vault_service.resolve_secret_access(
-                    conn,
-                    name,
-                    requester=requester,
-                    delivery=delivery,
-                    reserve_one_shot=True,
-                )
-                resolved_by_name[name] = resolved
-            if resolved["status"] == "approval_required":
-                req = resolved.get("request") or {}
-                approval_error = TaskCliError(
-                    f"secret '{name}' needs approval before protected delivery",
-                    code="approval_required",
-                    details={"request_id": req.get("id")},
-                )
-                break
-            if resolved["status"] == "standard":
-                current_grant = resolved.get("grant")
-                if isinstance(current_grant, dict) and current_grant.get("one_shot") is True:
-                    one_shot_grants.append(current_grant)
-                secrets.append({"name": name, "key": name, "envelope": resolved["envelope"], "protected": False})
-                continue
-            if resolved["status"] == "agent_delivery_ready":
-                current_grant = resolved["grant"]
-                if grant is None:
-                    grant = current_grant
-                elif grant["scope_type"] != current_grant["scope_type"] or grant["scope_ref"] != current_grant["scope_ref"]:
-                    if current_grant.get("one_shot") is True:
-                        one_shot_grants.append(current_grant)
-                    pre_delivery_error = _mixed_grants_error(
-                        "protected vault inject currently requires all protected secrets to share one active grant",
+    try:
+        with engine.begin() as conn:
+            for name in names:
+                resolved = resolved_by_name.get(name)
+                if resolved is None:
+                    resolved = vault_service.resolve_secret_access(
+                        conn,
+                        name,
+                        requester=requester,
+                        delivery=delivery,
+                        reserve_one_shot=True,
+                    )
+                    resolved_by_name[name] = resolved
+                if resolved["status"] == "approval_required":
+                    req = resolved.get("request") or {}
+                    approval_error = TaskCliError(
+                        f"secret '{name}' needs approval before protected delivery",
+                        code="approval_required",
+                        details={"request_id": req.get("id")},
                     )
                     break
-                if current_grant.get("one_shot") is True:
-                    one_shot_grants.append(current_grant)
-                secrets.append({"name": name, "key": name, "envelope": resolved["envelope"], "protected": True})
-                continue
-            raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
+                if resolved["status"] == "standard":
+                    current_grant = resolved.get("grant")
+                    if isinstance(current_grant, dict) and current_grant.get("one_shot") is True:
+                        one_shot_grants.append(current_grant)
+                    secrets.append({"name": name, "key": name, "envelope": resolved["envelope"], "protected": False})
+                    continue
+                if resolved["status"] == "agent_delivery_ready":
+                    current_grant = resolved["grant"]
+                    if grant is None:
+                        grant = current_grant
+                    elif grant["scope_type"] != current_grant["scope_type"] or grant["scope_ref"] != current_grant["scope_ref"]:
+                        if current_grant.get("one_shot") is True:
+                            one_shot_grants.append(current_grant)
+                        pre_delivery_error = _mixed_grants_error(
+                            "protected vault inject currently requires all protected secrets to share one active grant",
+                        )
+                        break
+                    if current_grant.get("one_shot") is True:
+                        one_shot_grants.append(current_grant)
+                    secrets.append({"name": name, "key": name, "envelope": resolved["envelope"], "protected": True})
+                    continue
+                raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
+    except Exception as exc:
+        _raise_after_releasing_one_shot_reservations(engine, one_shot_grants, exc)
     if approval_error is not None:
         _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4713,7 +4713,10 @@ def _resolve_cli_output_path(path: str) -> str:
 def _consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, reason: str) -> None:
     from vibe import api
 
-    api.consume_one_shot_grants(grants, reason=reason)
+    try:
+        api.consume_one_shot_grants(grants, reason=reason)
+    except Exception:
+        logger.debug("failed to consume one-shot vault grants after delivery", exc_info=True)
 
 
 def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str], *, args=None):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4708,11 +4708,17 @@ def _resolve_cli_output_path(path: str) -> str:
     output_path = Path(path).expanduser()
     if not output_path.is_absolute():
         output_path = Path.cwd() / output_path
-    return str(output_path)
+    return str(output_path.resolve(strict=False))
 
 
 def _preflight_cli_output_path(path: str, *, help_command: str) -> None:
     output_path = Path(path)
+    if output_path.exists() and not output_path.is_file():
+        raise TaskCliError(
+            f"output path is not a regular file: {output_path}",
+            code="output_unwritable",
+            help_command=help_command,
+        )
     parent = output_path.parent
     if not parent.exists():
         raise TaskCliError(f"output parent does not exist: {parent}", code="output_unwritable", help_command=help_command)
@@ -5747,7 +5753,7 @@ def cmd_vault_inject(args):
                 secrets=secrets,
             )
         else:
-            api.avault_deliver_inject(out, fmt, secrets)
+            api.avault_deliver_inject(resolved_out, fmt, secrets)
         _consume_after_possible_use(one_shot_grants, reason="vault-inject-one-shot")
         # The file is on disk → delivered. A bookkeeping failure must not report a failed command
         # (callers would retry though the secrets are already written), so record best-effort.
@@ -5756,7 +5762,7 @@ def cmd_vault_inject(args):
                 vault_service.record_deliveries(conn, keys, requester={"source": "cli", "pid": os.getpid()}, mode=f"inject:{fmt}")
         except Exception:
             pass
-        _print_cli_payload("vault_inject", written=True, path=resolved_out if grant is not None else str(out), format=fmt, keys=keys)
+        _print_cli_payload("vault_inject", written=True, path=resolved_out, format=fmt, keys=keys)
         return 0
     except vault_service.SecretNotFoundError as exc:
         _print_task_error(TaskCliError(f"secret '{exc}' not found", code="secret_not_found", help_command=help_command))
@@ -5780,7 +5786,7 @@ def cmd_vault_inject(args):
             requester, delivery, _session_id = _vault_cli_delivery_context(
                 args,
                 mode="inject",
-                path=_resolve_cli_output_path(str(out)),
+                path=resolved_out,
                 format=fmt,
             )
             _expire_agent_grant_after_missing(

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import contextlib
 import errno
 import getpass
 import json
@@ -4719,6 +4720,31 @@ def _consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, re
         logger.debug("failed to consume one-shot vault grants after delivery", exc_info=True)
 
 
+def _release_one_shot_reservations(engine, grants: list[dict] | tuple[dict, ...] | None) -> None:
+    if not grants:
+        return
+    from storage import vault_service
+
+    try:
+        with engine.begin() as conn:
+            seen: set[str] = set()
+            for grant in grants:
+                if not isinstance(grant, dict) or grant.get("one_shot") is not True:
+                    continue
+                grant_id = str(grant.get("id") or "")
+                if not grant_id or grant_id in seen:
+                    continue
+                seen.add(grant_id)
+                with contextlib.suppress(
+                    vault_service.GrantNotActiveError,
+                    vault_service.GrantNotFoundError,
+                    vault_service.InvalidGrantError,
+                ):
+                    vault_service.release_one_shot_reservation(conn, grant_id)
+    except Exception:
+        logger.debug("failed to release one-shot vault grant reservations", exc_info=True)
+
+
 def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: list[str], *, args=None):
     from storage import vault_service
 
@@ -4773,10 +4799,12 @@ def _resolve_vault_run_delivery(engine, mapping: dict[str, str], command_argv: l
                 continue
             raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
     if approval_error is not None:
+        _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error
     protected = [item for item in secrets if item["protected"]]
     standard = [item for item in secrets if not item["protected"]]
     if protected and standard:
+        _release_one_shot_reservations(engine, one_shot_grants)
         raise TaskCliError(
             "mixing protected and standard secrets in one vault run is not wired yet",
             code="mixed_protection_tiers",
@@ -4871,10 +4899,12 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
                 continue
             raise TaskCliError(f"unsupported vault access status: {resolved['status']}", code="vault_access_error")
     if approval_error is not None:
+        _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error
     protected = [item for item in secrets if item["protected"]]
     standard = [item for item in secrets if not item["protected"]]
     if protected and standard:
+        _release_one_shot_reservations(engine, one_shot_grants)
         raise TaskCliError(
             "mixing protected and standard secrets in one vault inject is not wired yet",
             code="mixed_protection_tiers",
@@ -4959,9 +4989,11 @@ def cmd_vault_run(args):
         else:
             exit_code = api.avault_deliver_run(secrets, command_argv)
     except TaskCliError as exc:
+        _release_one_shot_reservations(engine, one_shot_grants)
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
+        _release_one_shot_reservations(engine, one_shot_grants)
         if grant is not None and _agent_missing_grant(exc):
             requester, delivery, _session_id = _vault_cli_delivery_context(args, mode="run", command=command_argv)
             _expire_agent_grant_after_missing(
@@ -4975,10 +5007,7 @@ def cmd_vault_run(args):
             return 1
         _print_task_error(TaskCliError(f"avault deliver failed: {exc}", code="avault_failed", help_command=help_command))
         return 1
-    # One-shot avault exits 70 only on an internal failure before spawning the child, so no
-    # delivery happened there. Resident-agent protected runs raise AvaultError for agent-side
-    # failures; a returned 70 is the child's real exit code and must still be audited.
-    delivered = grant is not None or exit_code != 70
+    delivered = grant is not None or bool(one_shot_grants) or exit_code != 70
     if delivered:
         _consume_one_shot_grants(one_shot_grants, reason="vault-run-one-shot")
         try:
@@ -5311,6 +5340,7 @@ def cmd_vault_fetch(args):
     help_command = "vibe vault fetch --help"
     engine = None
     grant = None
+    one_shot_grant = None
     name = getattr(args, "auth", "")
     host = ""
     method = "GET"
@@ -5458,9 +5488,11 @@ def cmd_vault_fetch(args):
         _print_task_error(TaskCliError(str(exc), code="protected_tier_unavailable", help_command=help_command))
         return 1
     except TaskCliError as exc:
+        _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
+        _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
         if engine is not None and isinstance(grant, dict) and _agent_missing_grant(exc):
             grant_id = grant.get("id")
             if grant_id:
@@ -5476,6 +5508,7 @@ def cmd_vault_fetch(args):
         _print_task_error(TaskCliError(f"request failed: {exc}", code="request_failed", help_command=help_command))
         return 1
     except Exception as exc:
+        _release_one_shot_reservations(engine, [one_shot_grant] if one_shot_grant is not None else [])
         _print_task_error(exc, help_command=help_command)
         return 1
 
@@ -5550,6 +5583,7 @@ def cmd_vault_inject(args):
     help_command = "vibe vault inject --help"
     engine = None
     grant = None
+    one_shot_grants: list[dict] = []
     keys: list[str] = []
     try:
         keys = [k.strip() for k in (getattr(args, "keys", None) or "").split(",") if k.strip()]
@@ -5604,9 +5638,11 @@ def cmd_vault_inject(args):
         _print_task_error(TaskCliError(str(exc), code="protected_tier_unavailable", help_command=help_command))
         return 1
     except TaskCliError as exc:
+        _release_one_shot_reservations(engine, one_shot_grants)
         _print_task_error(exc)
         return 1
     except api.AvaultError as exc:
+        _release_one_shot_reservations(engine, one_shot_grants)
         if engine is not None and isinstance(grant, dict) and _agent_missing_grant(exc):
             requester, delivery, _session_id = _vault_cli_delivery_context(
                 args,
@@ -5626,6 +5662,7 @@ def cmd_vault_inject(args):
         _print_task_error(TaskCliError(f"avault inject failed: {exc}", code="avault_failed", help_command=help_command))
         return 1
     except Exception as exc:
+        _release_one_shot_reservations(engine, one_shot_grants)
         _print_task_error(exc, help_command=help_command)
         return 1
 


### PR DESCRIPTION
## What

Implement backend support for `policy.always_ask` on static Vault secrets.

- Allow always-ask static secrets to create per-use access approval requests while keeping them excluded from standing scope/group grants.
- Route standard always-ask access through approval instead of free delivery.
- Make approved always-ask access one-shot: the first successful resolver pass consumes the grant so the next value access asks again.
- Keep protected always-ask delivery on the resident-agent blind-box path and release one-shot agent scopes after delivery.
- Keep keypair value access rejected; keypairs remain sign-only.

## Why

The UI had to remove the "Always ask before each use" toggle because backend behavior was inconsistent: protected always-ask secrets were unusable and standard always-ask secrets ignored the policy.

## Evidence

- `python3 -m ruff check storage/vault_service.py vibe/api.py vibe/cli.py tests/test_vault_service.py tests/test_vault_api.py`
- `python3 -m pytest tests/test_vault*.py -q`

## Notes

No UI changes. Once this lands, the UI can submit the existing `policy.always_ask` boolean again for static secrets. Approval cards and grant payloads expose `one_shot: true` for these accesses.
