### PR TITLE
fix(vaults): stabilize passkey PRF setup output

### DIFF
--- a/ui/src/lib/useProtectedVault.test.ts
+++ b/ui/src/lib/useProtectedVault.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { readPasskeyPrfResult } from './useProtectedVault';
 
-function passkeyCredential(first?: ArrayBuffer | ArrayBufferView): PublicKeyCredential {
+function passkeyCredential(first?: ArrayBuffer | ArrayBufferView | number[]): PublicKeyCredential {
   return {
     getClientExtensionResults: () => ({
       prf: {
@@ -22,6 +22,12 @@ describe('protected vault WebAuthn PRF result handling', () => {
 
     expect(result.byteLength).toBe(32);
     expect(result).toEqual(new Uint8Array(32).fill(0x22));
+  });
+
+  it('accepts a plain Array PRF output from browser extension passkey providers', () => {
+    const source = Array.from({ length: 32 }, (_, index) => index + 1);
+
+    expect(readPasskeyPrfResult(passkeyCredential(source))).toEqual(Uint8Array.from(source));
   });
 
   it('rejects a present but empty PRF output at the WebAuthn boundary', () => {

--- a/ui/src/lib/useProtectedVault.test.ts
+++ b/ui/src/lib/useProtectedVault.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { readPasskeyPrfResult } from './useProtectedVault';
+
+function passkeyCredential(first?: ArrayBuffer | ArrayBufferView): PublicKeyCredential {
+  return {
+    getClientExtensionResults: () => ({
+      prf: {
+        results: first ? { first } : {},
+      },
+    }),
+  } as unknown as PublicKeyCredential;
+}
+
+describe('protected vault WebAuthn PRF result handling', () => {
+  it('copies the PRF output before handing it to the VMK wrap chain', () => {
+    const source = new Uint8Array(32).fill(0x22);
+    const backing = source.buffer as ArrayBuffer;
+    const result = readPasskeyPrfResult(passkeyCredential(backing));
+
+    structuredClone(backing, { transfer: [backing] });
+
+    expect(result.byteLength).toBe(32);
+    expect(result).toEqual(new Uint8Array(32).fill(0x22));
+  });
+
+  it('rejects a present but empty PRF output at the WebAuthn boundary', () => {
+    expect(() => readPasskeyPrfResult(passkeyCredential(new ArrayBuffer(0)))).toThrow(/passkey-prf-unavailable/);
+  });
+});

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -109,11 +109,17 @@ function toUint8(buffer: ArrayBuffer | ArrayBufferView): Uint8Array {
   return buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 }
 
-function passkeyResult(credential: PublicKeyCredential | null): Uint8Array {
-  const ext = credential?.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer } } } | undefined;
+function copyUint8(buffer: ArrayBuffer | ArrayBufferView): Uint8Array {
+  return new Uint8Array(toUint8(buffer));
+}
+
+export function readPasskeyPrfResult(credential: PublicKeyCredential | null): Uint8Array {
+  const ext = credential?.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer | ArrayBufferView } } } | undefined;
   const first = ext?.prf?.results?.first;
   if (!first) throw new Error('passkey-prf-unavailable');
-  return toUint8(first);
+  const prfOutput = copyUint8(first);
+  if (prfOutput.byteLength === 0) throw new Error('passkey-prf-unavailable');
+  return prfOutput;
 }
 
 type PasskeyEntry = { credentialId?: string; prfSalt: Uint8Array };
@@ -144,7 +150,7 @@ async function assertPasskeyPrf(entries: PasskeyEntry[]): Promise<{ prfOutput: U
     },
   })) as PublicKeyCredential | null;
   if (!assertion) throw new Error('passkey-cancelled');
-  const prfOutput = passkeyResult(assertion);
+  const prfOutput = readPasskeyPrfResult(assertion);
   const usedId = bytesToBase64(toUint8(assertion.rawId));
   const used = entries.find((entry) => entry.credentialId === usedId);
   return { prfOutput, prfSalt: used?.prfSalt ?? entries[0].prfSalt };

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -105,16 +105,18 @@ function withRpId(wrapMeta: string, rpId: string): string {
   return JSON.stringify(meta);
 }
 
-function toUint8(buffer: ArrayBuffer | ArrayBufferView): Uint8Array {
-  return buffer instanceof ArrayBuffer ? new Uint8Array(buffer) : new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+function toUint8(buffer: ArrayBuffer | ArrayBufferView | ArrayLike<number>): Uint8Array {
+  if (buffer instanceof ArrayBuffer) return new Uint8Array(buffer);
+  if (ArrayBuffer.isView(buffer)) return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  return Uint8Array.from(buffer);
 }
 
-function copyUint8(buffer: ArrayBuffer | ArrayBufferView): Uint8Array {
+function copyUint8(buffer: ArrayBuffer | ArrayBufferView | ArrayLike<number>): Uint8Array {
   return new Uint8Array(toUint8(buffer));
 }
 
 export function readPasskeyPrfResult(credential: PublicKeyCredential | null): Uint8Array {
-  const ext = credential?.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer | ArrayBufferView } } } | undefined;
+  const ext = credential?.getClientExtensionResults() as { prf?: { results?: { first?: ArrayBuffer | ArrayBufferView | ArrayLike<number> } } } | undefined;
   const first = ext?.prf?.results?.first;
   if (!first) throw new Error('passkey-prf-unavailable');
   const prfOutput = copyUint8(first);

--- a/ui/src/lib/vaultCrypto.test.ts
+++ b/ui/src/lib/vaultCrypto.test.ts
@@ -338,6 +338,19 @@ describe('vaultCrypto protected hierarchy', () => {
     expect(copies.at(-1)?.kdf).toBe('argon2id');
   });
 
+  it('keeps setup passkey PRF bytes and credential id intact through wrap_meta', async () => {
+    const vmk = newVmk();
+    const prfSalt = new Uint8Array(32).fill(0x11);
+    const prfOutput = new Uint8Array(32).fill(0x22);
+    const credentialId = '/Wz4YbtaoR9NBzQH1amGZagS0BmEdIh2dS8OIbpdN2WftQMJlny4PP4I';
+
+    const wrapMeta = await buildWrapMeta(vmk, [{ kind: 'passkey', prfOutput, prfSalt, credentialId }]);
+
+    await expect(unwrapVmk(wrapMeta, { kind: 'passkey', prfOutput })).resolves.toEqual(vmk);
+    expect(passkeyPrfSaltEntries(wrapMeta)).toEqual([{ prfSalt, credentialId }]);
+    expect(prfOutput).toEqual(new Uint8Array(32).fill(0x22));
+  });
+
   it('skips malformed authenticated VMK copies and tries the next valid copy', async () => {
     const vmk = newVmk();
     const password = 'less-secure-fallback';


### PR DESCRIPTION
## Summary
- copy the WebAuthn PRF result into a browser-owned Uint8Array before passing it into the protected VMK wrap chain
- accept ArrayBuffer, ArrayBufferView, and plain Array / array-like PRF outputs from passkey providers
- add regression coverage for detached WebAuthn PRF buffers, 1Password-style plain Array PRF outputs, and setup wrap_meta passkey round-trip with the owner-observed credential id shape

## Root cause
The failing path is protected-vault setup, after passkey creation and after the setup assertion returns PRF bytes. 1Password is a browser extension and returns `getClientExtensionResults().prf.results.first` as a plain JavaScript Array of numbers, not an ArrayBuffer. The old converter assumed anything that was not an ArrayBuffer was an ArrayBufferView and read `.buffer/.byteOffset/.byteLength`; on a plain Array those are undefined, so `new Uint8Array(undefined, undefined, undefined)` became a 0-byte PRF output. That produced the observed `passkey PRF output is empty` / `passkey-prf-unavailable` errors before any protected secret was persisted.

This is not an eval-vs-evalByCredential bug. The WebAuthn get returned the PRF; our boundary conversion dropped it. Parked PR #716's plain-eval change is orthogonal and is superseded for this incident by this type-handling fix.

The base64url-looking value in earlier temporary logs was `created.id`. The actual stored credential_id path uses rawId encoded as standard base64, so credential id encoding was not the setup abort root cause.

## Evidence
- Owner round-2 logs showed `prf.results.first` had `type: 'Array'`, no `.buffer`, no `.byteLength`, and no `.byteOffset`.
- The new plain-Array unit test failed before the fix with `passkey-prf-unavailable` and passes after `Uint8Array.from(arrayLike)` support.
- The detached-buffer test from #727 still passes, preserving the hardening that copies WebAuthn-owned bytes at the boundary.
- The vaultCrypto test feeds the owner-observed rawId base64 shape through buildWrapMeta and unwrapVmk, preserving prf_salt and credential_id.

## Validation
- ruff check
- python3 -m pytest tests/test_vault*.py
- cd ui && npm run build
- cd ui && npm run test:crypto
- cd ui && npx vitest run src/lib/useProtectedVault.test.ts
- deployed final no-debug build to local Incus regression master; service health OK at http://127.0.0.1:15130

## Evidence layers
- unit: updated UI PRF boundary and vaultCrypto round-trip tests
- contract: existing vault tests passed
- scenario: protected-vault setup failure path validated through local Incus deployment for owner final E2E
- residual manual checks: owner passkey setup retry on https://test-app.avibe.bot
