### PR TITLE
fix(workbench): sidebar polish — align brand band, collapsible capabilities, search into Projects header

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -384,22 +384,28 @@ export const AppShell: React.FC = () => {
             sidebar, so it runs a tighter vertical rhythm than admin — less outer
             padding and a smaller gap to the bottom cluster — to give the flex-1
             Projects list more height. Admin keeps the roomier spacing. */}
-        <div className={clsx('flex h-full flex-col justify-between px-4', shellMode === 'workbench' ? 'gap-4 py-4' : 'gap-6 py-5')}>
-          {/* Top: Brand + Workspace label + Nav list */}
-          {/* Workbench mounts a search field right under the brand; tighter gap to
-              keep the dense nav compact. Admin keeps the wider gap-6. */}
-          <div className={clsx('flex min-h-0 flex-1 flex-col', shellMode === 'workbench' ? 'gap-3' : 'gap-6')}>
-            <div className="flex items-center gap-2.5 px-1 py-2">
-              <img
-                src={logoImg}
-                alt="avibe logo"
-                className="size-9 rounded-lg border border-mint/35 bg-mint/[0.08] object-cover shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]"
-              />
-              <div className="min-w-0">
-                <div className="truncate text-[13px] font-semibold text-foreground">{t('appShell.title')}</div>
-                <div className="truncate text-[11px] text-muted">{t('appShell.subtitle')}</div>
-              </div>
+        <div className="flex h-full flex-col">
+          {/* Brand band — flush to the top edge and bordered like the chat
+              header (px-4 py-2.5) so the logo centerline lines up with the chat
+              title bar across one continuous divider. Logo is size-8 to match
+              the header's row height. */}
+          <div className="flex shrink-0 items-center gap-2.5 border-b border-border px-4 py-2.5">
+            <img
+              src={logoImg}
+              alt="avibe logo"
+              className="size-8 rounded-lg border border-mint/35 bg-mint/[0.08] object-cover shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]"
+            />
+            <div className="min-w-0 leading-tight">
+              <div className="truncate text-[13px] font-semibold text-foreground">{t('appShell.title')}</div>
+              <div className="truncate text-[11px] text-muted">{t('appShell.subtitle')}</div>
             </div>
+          </div>
+
+          {/* Middle: workspace label + nav list (scrolls). Carries the
+              horizontal + top padding the outer container used to own; workbench
+              runs a tighter rhythm than admin to give the flex-1 Projects list
+              more height. */}
+          <div className={clsx('flex min-h-0 flex-1 flex-col px-4', shellMode === 'workbench' ? 'gap-3 pt-3' : 'gap-6 pt-4')}>
 
             {shellMode === 'admin' && items.length > 0 && (
               <div className="flex flex-col gap-2">
@@ -417,8 +423,10 @@ export const AppShell: React.FC = () => {
           {/* Bottom (design.pen NbPMq): row 1 = [Apps | Settings] two equal
               buttons; row 2 = [version … run-dot]. Admin keeps its quick-toggles
               + hostname between the rows. The whole bottom cluster sits at the
-              sidebar's level (z-10) and is covered by a maximized window. */}
-          <div className="relative flex flex-col gap-3">
+              sidebar's level (z-10) and is covered by a maximized window. The
+              outer container no longer owns padding (the brand band is flush to
+              the top edge), so this cluster carries its own px-4 + bottom pad. */}
+          <div className={clsx('relative flex flex-col gap-3 px-4', shellMode === 'workbench' ? 'pb-4' : 'pb-5')}>
             {/* Row 1 — Apps (Dock trigger, left) paired with the mode switch
                 (right). The Dock rises ABOVE the Apps button, clear of the
                 centered Chat composer. Workbench → Settings (control panel);

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -380,12 +380,15 @@ export const AppShell: React.FC = () => {
           The Apps button no longer floats on top in full-screen (a Dock redesign comes later);
           un-maximize to reach it. */}
       <aside className="fixed inset-y-0 left-0 z-10 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
-        <div className="flex h-full flex-col justify-between gap-6 px-4 py-5">
+        {/* Workbench packs more rows (search/inbox/capabilities/projects) into the
+            sidebar, so it runs a tighter vertical rhythm than admin — less outer
+            padding and a smaller gap to the bottom cluster — to give the flex-1
+            Projects list more height. Admin keeps the roomier spacing. */}
+        <div className={clsx('flex h-full flex-col justify-between px-4', shellMode === 'workbench' ? 'gap-4 py-4' : 'gap-6 py-5')}>
           {/* Top: Brand + Workspace label + Nav list */}
-          {/* Workbench mounts a search field right under the brand, so use the
-              same gap as the sidebar's own rows (gap-4) for an even rhythm; admin
-              keeps the wider gap-6 to separate the brand from its labelled nav. */}
-          <div className={clsx('flex min-h-0 flex-1 flex-col', shellMode === 'workbench' ? 'gap-4' : 'gap-6')}>
+          {/* Workbench mounts a search field right under the brand; tighter gap to
+              keep the dense nav compact. Admin keeps the wider gap-6. */}
+          <div className={clsx('flex min-h-0 flex-1 flex-col', shellMode === 'workbench' ? 'gap-3' : 'gap-6')}>
             <div className="flex items-center gap-2.5 px-1 py-2">
               <img
                 src={logoImg}

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -433,7 +433,7 @@ export const AppShell: React.FC = () => {
                 Control Panel → Back to Workbench, the mint counterpart. */}
             <div className="flex items-stretch gap-2">
               <AppsLauncher />
-              {shellMode === 'workbench' ? (
+              {shellMode === 'workbench' && (
                 <Link
                   to="/admin/dashboard"
                   title={t('appShell.openControlPanel')}
@@ -442,16 +442,22 @@ export const AppShell: React.FC = () => {
                 >
                   <Settings className="size-[18px] text-muted group-hover:text-foreground" />
                 </Link>
-              ) : (
-                <Link
-                  to="/"
-                  className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-mint/30 bg-mint/[0.06] px-3 py-2.5 text-[13px] font-semibold text-mint transition hover:bg-mint/[0.12]"
-                >
-                  <ArrowLeft className="size-3.5" />
-                  <span>{t('appShell.backToWorkbench')}</span>
-                </Link>
               )}
             </div>
+
+            {/* Back-to-Workbench (admin only) gets its own full-width row below
+                Apps. As a half-width button beside Apps, the English "Workbench"
+                label + arrow overflowed the 240px sidebar; a full row fits every
+                locale. */}
+            {shellMode === 'admin' && (
+              <Link
+                to="/"
+                className="flex items-center justify-center gap-2 rounded-lg border border-mint/30 bg-mint/[0.06] px-3 py-2.5 text-[13px] font-semibold text-mint transition hover:bg-mint/[0.12]"
+              >
+                <ArrowLeft className="size-3.5 shrink-0" />
+                <span className="truncate">{t('appShell.backToWorkbench')}</span>
+              </Link>
+            )}
 
             {/* Language / theme / account quick-toggles only show in the
                 Control Panel, which is the operational surface. The

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -54,6 +54,8 @@ const CAPABILITY_NAV: CapabilityNavItem[] = [
   { to: '/vaults', i18nKey: 'workbench.nav.vaults', icon: KeyRound },
 ];
 
+const CAPS_COLLAPSED_KEY = 'vibe-remote:caps-collapsed';
+
 // 360px floating popover that opens when the user hovers the Inbox entry.
 // Mirrors design.pen KmQ1L — header + a few session cards + footer "open full
 // inbox" link. Pure presentational; data comes from <WorkbenchInboxProvider>.
@@ -669,6 +671,25 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
   const [popoverOpen, setPopoverOpen] = useState(false);
   const closeTimer = useRef<number | null>(null);
   const [showNewProject, setShowNewProject] = useState(false);
+  // Capabilities section is collapsible to free room for Projects; the choice is
+  // remembered (best-effort localStorage, same convention as the other toggles).
+  const [capsCollapsed, setCapsCollapsed] = useState<boolean>(() => {
+    try {
+      return window.localStorage.getItem(CAPS_COLLAPSED_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+  const toggleCaps = () =>
+    setCapsCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(CAPS_COLLAPSED_KEY, next ? '1' : '0');
+      } catch {
+        /* best-effort */
+      }
+      return next;
+    });
 
   // Small open/close delays so the popover doesn't flicker as the cursor
   // brushes through the inbox row on its way somewhere else, and survives
@@ -720,22 +741,8 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
   // popover stays OUT of any overflow box below, so it is never clipped.
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2.5">
-      {/* Search field — the sidebar's first item (Brand lives in AppShell).
-          Field-style button per design.pen XErMu: search glyph + muted
-          placeholder + ⌘K pill; opens the ⌘K command palette. */}
-      <Button
-        type="button"
-        variant="ghost"
-        onClick={onOpenSearch}
-        className="h-auto w-full justify-start gap-2 rounded-lg border border-border-strong bg-foreground/[0.03] px-3 py-2.5 text-left font-normal transition hover:bg-foreground/[0.05]"
-      >
-        <Search className="size-3.5 shrink-0 text-muted" />
-        <span className="flex-1 truncate text-[13px] text-muted">{t('workbench.search.entry')}</span>
-        <kbd className="shrink-0 rounded-[5px] border border-border bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[11px] font-medium leading-none text-muted">
-          ⌘K
-        </kbd>
-      </Button>
-
+      {/* Search moved to a compact icon in the Projects header (left of the add
+          button) to reclaim this full row for the Projects list. ⌘K still works. */}
       {/* Inbox entry — hover opens the floating popover (portaled above the chat). */}
       <Popover open={popoverOpen} onOpenChange={(open) => { if (!open) setPopoverOpen(false); }}>
         <PopoverAnchor asChild>
@@ -781,10 +788,17 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
       </Popover>
 
       <div className="flex flex-col gap-1.5">
-        <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
-          {t('workbench.capabilitiesLabel')}
-        </div>
-        <nav className="flex flex-col gap-0.5">
+        <button
+          type="button"
+          onClick={toggleCaps}
+          aria-expanded={!capsCollapsed}
+          className="group flex items-center gap-1 px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted transition-colors hover:text-foreground"
+        >
+          <span className="flex-1 text-left">{t('workbench.capabilitiesLabel')}</span>
+          <ChevronDown className={clsx('size-3.5 shrink-0 transition-transform', capsCollapsed && '-rotate-90')} />
+        </button>
+        {!capsCollapsed && (
+          <nav className="flex flex-col gap-0.5">
           {CAPABILITY_NAV.map(({ to, i18nKey, icon: Icon }) => (
             <NavLink
               key={to}
@@ -806,7 +820,8 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
               )}
             </NavLink>
           ))}
-        </nav>
+          </nav>
+        )}
       </div>
 
       {/* Projects section — design.pen b8wX2. Header row carries the
@@ -817,18 +832,32 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
           <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
             {t('workbench.projectsLabel')}
           </span>
-          {/* Borderless ghost icon button (design-system Button) — bumped from
-              a 22px bordered box to a roomier 28px tap target. */}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-7 shrink-0 text-muted hover:text-foreground"
-            aria-label={t('workbench.addProject')}
-            onClick={() => setShowNewProject(true)}
-          >
-            <FolderPlus className="size-4" />
-          </Button>
+          {/* Borderless ghost icon buttons (design-system Button) — search +
+              add, grouped on the right. Search moved here from a full-width
+              row above to reclaim that space for the Projects list; ⌘K still
+              works. Both are roomy 28px tap targets. */}
+          <div className="flex items-center gap-0.5">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0 text-muted hover:text-foreground"
+              aria-label={t('workbench.search.entry')}
+              onClick={onOpenSearch}
+            >
+              <Search className="size-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0 text-muted hover:text-foreground"
+              aria-label={t('workbench.addProject')}
+              onClick={() => setShowNewProject(true)}
+            >
+              <FolderPlus className="size-4" />
+            </Button>
+          </div>
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto pr-0.5">

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -719,7 +719,7 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
   // project list) scrolls; Inbox + Capabilities stay pinned. The Inbox hover
   // popover stays OUT of any overflow box below, so it is never clipped.
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex min-h-0 flex-1 flex-col gap-2.5">
       {/* Search field — the sidebar's first item (Brand lives in AppShell).
           Field-style button per design.pen XErMu: search glyph + muted
           placeholder + ⌘K pill; opens the ⌘K command palette. */}
@@ -780,7 +780,7 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
         />
       </Popover>
 
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1.5">
         <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
           {t('workbench.capabilitiesLabel')}
         </div>
@@ -791,7 +791,7 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
               to={to}
               className={({ isActive }) =>
                 clsx(
-                  'group flex items-center gap-2.5 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors',
+                  'group flex items-center gap-2.5 rounded-lg px-3 py-2 text-[13px] font-medium transition-colors',
                   isActive
                     ? 'border border-mint/30 bg-mint/[0.08] text-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.5)]'
                     : 'border border-transparent text-muted hover:bg-foreground/[0.04] hover:text-foreground',

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -783,12 +783,12 @@
     }
   },
   "appShell": {
-    "title": "Avibe OS",
+    "title": "Avibe",
     "subtitle": "Agent OS · Workbench",
     "workspaceLabel": "Settings",
     "moreSettings": "More Settings",
     "openControlPanel": "Settings",
-    "backToWorkbench": "Back to Workbench",
+    "backToWorkbench": "Workbench",
     "newSession": "New",
     "navigationLabel": "Console",
     "statusLabel": "Service status",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -783,12 +783,12 @@
     }
   },
   "appShell": {
-    "title": "Avibe OS",
-    "subtitle": "Agent操作系统 · 工作台",
+    "title": "Avibe",
+    "subtitle": "Agent OS · 工作台",
     "workspaceLabel": "设置",
     "moreSettings": "更多设置",
     "openControlPanel": "设置",
-    "backToWorkbench": "返回工作台",
+    "backToWorkbench": "工作台",
     "newSession": "新建",
     "navigationLabel": "控制台",
     "statusLabel": "服务状态",


### PR DESCRIPTION
## What

Sidebar polish pass addressing the **Page Feedback** on the workbench left
rail — the Projects area was cramped (too little vertical room) and the brand
header sat lower than the chat title bar. Two commits:

**1. Density (initial)** — tighter vertical rhythm:
- root section gap `gap-4 → gap-2.5`; capability section gap + item padding trimmed
- AppShell sidebar container padding tightened (workbench runs a tighter rhythm than admin)
- net: Projects list (`flex-1`) gains height

**2. Structure (this batch)**:
- **Brand band aligned with the chat header** — the brand row is now a flush
  top band (`border-b`, `px-4 py-2.5`, logo `size-8`) that mirrors the chat
  header, so the logo centerline lines up with the chat title bar across one
  continuous divider. Removes the outer container's oversized top/bottom padding.
- **Collapsible Capabilities** — the 能力 / Capabilities header is a toggle
  (chevron rotates -90° when collapsed); state persists in `localStorage`
  (`vibe-remote:caps-collapsed`). Collapsing reclaims height for Projects.
- **Search moved into the Projects header** — removed the full-width "search
  messages" row; search is now a compact ghost icon grouped left of the add (+)
  button. ⌘K still opens the palette.
- **Brand copy** — title `Avibe OS → Avibe`; zh subtitle `Agent OS · 工作台`;
  settings back-link `返回工作台 → 工作台`.

All reclaimed bands flow into the `flex-1` Projects list.

## Affected scenarios

Workbench desktop sidebar (brand / inbox / capabilities / projects), settings
back-to-workbench link. No mobile-nav or admin-nav behavior change beyond the
shared brand band + container padding.

## Evidence

- **unit/contract**: n/a (presentational + a localStorage toggle)
- **build**: `npm run build` (tsc + vite) green in the worktree
- **manual**: faithful HTML mock rendered + screenshotted — brand band divider
  collinear with the chat-header divider; capabilities collapse/expand; search
  icon + add grouped in the Projects header; Projects list visibly taller.
  Capabilities-collapsed persistence and ⌘K verified against code paths.
- **residual**: live workbench check of the localStorage persistence across
  reloads + the collapse animation on real Chrome/Safari.
