### PR TITLE
fix(workbench): drop the brand band bottom border

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -385,11 +385,11 @@ export const AppShell: React.FC = () => {
             padding and a smaller gap to the bottom cluster — to give the flex-1
             Projects list more height. Admin keeps the roomier spacing. */}
         <div className="flex h-full flex-col">
-          {/* Brand band — flush to the top edge and bordered like the chat
-              header (px-4 py-2.5) so the logo centerline lines up with the chat
-              title bar across one continuous divider. Logo is size-8 to match
-              the header's row height. */}
-          <div className="flex shrink-0 items-center gap-2.5 border-b border-border px-4 py-2.5">
+          {/* Brand band — flush to the top edge, sharing the chat header's
+              px-4 py-2.5 row height so the logo centerline lines up with the
+              chat title bar. No bottom border (it read as out of place under
+              the logo). Logo is size-8 to match the header's row height. */}
+          <div className="flex shrink-0 items-center gap-2.5 px-4 py-2.5">
             <img
               src={logoImg}
               alt="avibe logo"


### PR DESCRIPTION
## What

Removes the `border-b` under the sidebar brand band (logo + Avibe / Agent OS · 工作台).

In #729 the brand band got a bottom border so it would merge with the chat header's divider into one continuous line. Viewed on its own under the logo, that line read as out of place. Removing it; the band keeps the chat header's `px-4 py-2.5` row height, so the logo centerline still lines up with the chat title bar — only the visible divider under the logo is gone.

## Affected scenarios

Workbench + admin sidebar brand row (both shell modes share the band). No layout/spacing change beyond the 1px border.

## Evidence

- **build**: `npm run build` (tsc + vite) green
- **manual**: verified in the master Incus regression at http://127.0.0.1:15130 after #729; this is a one-token className removal (provably no behavioral change)
- residual: glance at the live sidebar to confirm the line is gone and alignment holds