### PR TITLE
feat(workbench): standalone Preview app, macOS-like minimize, Dock polish, Files rename

### DIFF
--- a/ui/src/apps/registry.tsx
+++ b/ui/src/apps/registry.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { CodeXml, Folder, SquareTerminal } from 'lucide-react';
+import { CodeXml, Eye, Folder, SquareTerminal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { LucideIcon } from 'lucide-react';
 
@@ -9,7 +9,7 @@ import type { LucideIcon } from 'lucide-react';
 // so opening the workbench doesn't pull file-browser / xterm code into the main
 // bundle — each loads only when its window first opens.
 
-export type AppId = 'files' | 'terminal' | 'editor';
+export type AppId = 'files' | 'terminal' | 'editor' | 'preview';
 
 export interface AppDefinition {
   id: AppId;
@@ -42,6 +42,9 @@ const TerminalBody = lazy(() =>
 );
 const EditorBody = lazy(() =>
   import('../components/workbench/EditorApp').then((m) => ({ default: m.EditorApp })),
+);
+const PreviewBody = lazy(() =>
+  import('../components/workbench/AppsPreviewPage').then((m) => ({ default: m.AppsPreviewPage })),
 );
 
 export const APP_REGISTRY: Record<AppId, AppDefinition> = {
@@ -85,6 +88,23 @@ export const APP_REGISTRY: Record<AppId, AppDefinition> = {
       </Suspense>
     ),
   },
+  // On-demand viewer opened by the File Browser (double-click an image/PDF/Office/Markdown file).
+  // Deliberately NOT in APP_LIST, so it has no permanent Dock tile — it only appears while a preview
+  // window is open (and in the Dock's minimized strip if minimized). No lockTheme: images and docs
+  // should render on the workbench's own light/dark, not be forced dark.
+  preview: {
+    id: 'preview',
+    titleKey: 'apps.preview.label',
+    icon: Eye,
+    accent: '--gold',
+    defaultSize: { width: 900, height: 640 },
+    Component: ({ windowId, params }) => (
+      <Suspense fallback={<Loading />}>
+        <PreviewBody windowId={windowId} params={params} />
+      </Suspense>
+    ),
+  },
 };
 
+// Dock launcher tiles — the resident apps. `preview` is intentionally excluded (opened on demand).
 export const APP_LIST: AppDefinition[] = [APP_REGISTRY.files, APP_REGISTRY.terminal, APP_REGISTRY.editor];

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -110,6 +110,18 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
   const style: React.CSSProperties = win.maximized
     ? { left: 0, top: 0, width: layerWidth, height: layerHeight, zIndex: win.z }
     : { left: win.bounds.x, top: win.bounds.y, width: win.bounds.width, height: win.bounds.height, zIndex: win.z };
+  // Minimize morph: shrink the window and fly it toward the Dock (bottom-left, above the sidebar's
+  // Apps button) so it's visually clear where it went — a CSS approximation of macOS's genie (a
+  // literal liquid warp needs WebGL). Restoring reverses the same transition. Exact landing doesn't
+  // matter; anchoring near the bottom-left is enough to read as "went down to the Dock".
+  if (win.minimized) {
+    const left = win.maximized ? 0 : win.bounds.x;
+    const top = win.maximized ? 0 : win.bounds.y;
+    const targetX = 96;
+    const targetY = Math.max(0, layerHeight - 44);
+    style.transform = `translate(${targetX - left}px, ${targetY - top}px) scale(0.08)`;
+    style.transformOrigin = 'top left';
+  }
 
   const lights: { key: string; color: string; Glyph: LucideIcon; onClick: () => void; label: string }[] = [
     {
@@ -163,20 +175,19 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
         wm.close(win.id);
       }}
       className={clsx(
-        'group/win absolute flex flex-col overflow-hidden border bg-surface-2 outline-none',
-        // Minimize shrinks toward the bottom-left (where the Dock lives) for a macOS-like genie;
-        // otherwise scale from center for the open/close keyframe.
-        win.minimized ? 'origin-bottom-left' : 'origin-center',
-        // Geometry animates (maximize/restore) except during a drag/resize, which must track the
-        // pointer instantly.
+        // origin-center drives the open/close keyframe; the minimize morph overrides transform-origin
+        // to top-left inline (so its translate+scale math lands the window at the Dock).
+        'group/win absolute flex flex-col overflow-hidden border bg-surface-2 outline-none origin-center',
+        // Geometry + the minimize/restore morph animate, except during a drag/resize (which must track
+        // the pointer instantly). 300ms so the fly-to-Dock reads clearly.
         dragging
           ? 'transition-[transform,opacity] duration-200 ease-out'
-          : 'transition-[left,top,width,height,transform,opacity] duration-200 ease-out',
+          : 'transition-[left,top,width,height,transform,opacity] duration-300 ease-out',
         win.maximized ? 'rounded-none' : 'rounded-xl',
         exitKind === 'close' ? 'animate-appwindow-out' : 'animate-appwindow-in',
         // Minimize = mounted hide: the body stays alive (terminal/editor state preserved) while the
-        // window scales away toward the Dock and stops taking pointer events.
-        win.minimized ? 'pointer-events-none scale-[0.18] opacity-0' : 'pointer-events-auto',
+        // window shrinks toward the Dock (inline transform above) and stops taking pointer events.
+        win.minimized ? 'pointer-events-none opacity-0' : 'pointer-events-auto',
         focused
           ? 'border-border-strong shadow-[0_28px_60px_-12px_rgba(0,0,0,0.7)]'
           : 'border-border shadow-[0_16px_40px_-16px_rgba(0,0,0,0.6)]',
@@ -226,7 +237,9 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
           <div
             key={h.dir}
             onPointerDown={(e) => startGesture(e, h.dir)}
-            className={clsx('absolute z-10', h.className)}
+            // z-30 keeps the edge/corner grips ABOVE any app-body content (a full-bleed preview,
+            // image, or overlay), so the window edges stay grabbable no matter what the app renders.
+            className={clsx('absolute z-30', h.className)}
           />
         ))}
     </div>

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -149,9 +149,11 @@ export const Dock: React.FC = () => {
 
         {minimized.length > 0 && <div className="mx-1 h-11 w-px shrink-0 self-center bg-border-strong" />}
 
-        {/* Minimized windows: an icon + the window's title so several open windows are
-            distinguishable at a glance (a true live thumbnail isn't practical — the editor/terminal
-            render to canvas — so the title carries the identification). */}
+        {/* Minimized windows render as a small window-style thumbnail (a mini titlebar with traffic
+            lights + the app icon) with the title stacked BELOW it — matching the app tiles' layout so
+            the whole row stays vertically consistent, and so a title never stretches the tile wide.
+            (A true live thumbnail isn't practical — editor/terminal render to canvas — so the icon +
+            title carry the identification.) */}
         {minimized.map((w) => {
           const def = APP_REGISTRY[w.appId];
           const Icon = def.icon;
@@ -163,10 +165,20 @@ export const Dock: React.FC = () => {
               title={label}
               aria-label={t('apps.window.restore', { defaultValue: 'Restore' })}
               onClick={() => wm.restore(w.id)}
-              className="flex h-10 w-[136px] shrink-0 items-center gap-2 self-center rounded-lg border border-border-strong bg-surface px-2.5 text-left transition hover:border-foreground/30"
+              className="group/min flex w-[64px] shrink-0 flex-col items-center gap-1"
             >
-              <Icon className="size-4 shrink-0" style={{ color: `var(${def.accent})` }} />
-              <span className="min-w-0 flex-1 truncate text-[11px] text-foreground">{label}</span>
+              <span className="flex h-9 w-14 flex-col overflow-hidden rounded-md border border-border-strong bg-surface shadow-sm transition group-hover/min:border-foreground/40">
+                {/* Faux window titlebar with the three traffic lights. */}
+                <span className="flex h-2.5 shrink-0 items-center gap-[3px] border-b border-border/70 bg-surface-2 px-1">
+                  <span className="size-1 rounded-full" style={{ backgroundColor: '#ff5f57' }} />
+                  <span className="size-1 rounded-full" style={{ backgroundColor: '#febc2e' }} />
+                  <span className="size-1 rounded-full" style={{ backgroundColor: '#28c840' }} />
+                </span>
+                <span className="grid flex-1 place-items-center">
+                  <Icon className="size-4" style={{ color: `var(${def.accent})` }} />
+                </span>
+              </span>
+              <span className="max-w-full truncate text-[10px] leading-tight text-muted">{label}</span>
             </button>
           );
         })}

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -29,7 +29,7 @@ import clsx from 'clsx';
 
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
-import { isEditableFile, isEditableMeta, previewOverlayKind, type PreviewOverlayKind } from '../../lib/filePreview';
+import { isEditableFile, isEditableMeta, previewWindowKind } from '../../lib/filePreview';
 import {
   contentUrl,
   deletePath,
@@ -148,7 +148,7 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // Quick-look image preview: a raster image opens in an in-window overlay (Finder-style) instead
   // of downloading. Kept in-window (not a portaled Dialog) so it stays inside the window's dark
   // data-theme scope and bounds.
-  const [preview, setPreview] = useState<{ path: string; name: string; kind: PreviewOverlayKind } | null>(null);
+  const [preview, setPreview] = useState<{ path: string; name: string } | null>(null);
   useEffect(() => {
     if (!preview) return;
     const onKey = (ev: KeyboardEvent) => {
@@ -264,21 +264,24 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
     if (query.trim()) runSearch(query);
   }, [cwd, navigate, query, runSearch]);
 
-  // Open: dir → navigate (and leave search); raster image / PDF / Office doc → in-window preview
-  // overlay; editable text/code file (within the size cap) → Editor window; anything else → download.
+  // Open: dir → navigate (and leave search); image / PDF / Office / Markdown → the standalone Preview
+  // window (desktop) or the in-page overlay (mobile, which has no window layer); editable text/code
+  // file (within the size cap) → Editor window; anything else → download.
   const openItem = async (item: RowItem) => {
     if (item.entry.kind === 'dir') {
       setQuery('');
       navigate(item.full);
       return;
     }
-    const overlay = previewOverlayKind(item.entry);
-    if (overlay) {
-      setPreview({ path: item.full, name: item.entry.name, kind: overlay });
+    const desktop = window.matchMedia('(min-width: 768px)').matches;
+    if (previewWindowKind(item.entry)) {
+      // Desktop opens a real, resizable Preview window (a dedicated app); mobile has no window layer,
+      // so it falls back to the in-page overlay so the file can still be viewed.
+      if (desktop) wm.openApp('preview', { title: item.entry.name, params: { path: item.full, name: item.entry.name } });
+      else setPreview({ path: item.full, name: item.entry.name });
       return;
     }
     // Mobile has no editor window layer (windows are md+), so a non-previewable file just downloads.
-    const desktop = window.matchMedia('(min-width: 768px)').matches;
     if (!desktop) {
       downloadFile(item.full);
       return;
@@ -719,12 +722,12 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
         </div>
       </div>
 
-      {/* In-window image preview overlay (Finder-style quick look). In-window, not a portaled
-          Dialog, so it stays inside the window's dark data-theme scope and bounds. */}
+      {/* MOBILE-ONLY quick-look overlay: on mobile there's no window layer, so a previewable file
+          opens here in-page instead of the standalone Preview window (desktop uses the window). */}
       {preview && (
         <div className="absolute inset-0 z-20 flex flex-col bg-surface">
           <div className="flex items-center gap-2 border-b border-border bg-surface-2/60 px-3 py-2">
-            {preview.kind === 'image' ? <ImageIcon className="size-4 shrink-0 text-muted" /> : <FileText className="size-4 shrink-0 text-muted" />}
+            <FileText className="size-4 shrink-0 text-muted" />
             <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-foreground">{preview.name}</span>
             <Button
               type="button"

--- a/ui/src/components/workbench/AppsPreviewPage.tsx
+++ b/ui/src/components/workbench/AppsPreviewPage.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from 'react-i18next';
+import { Download, Pencil } from 'lucide-react';
+
+import { useWindowManager } from '../../context/WindowManagerContext';
+import { previewKind } from '../../lib/filePreview';
+import { contentUrl, downloadFile } from '../../lib/filesApi';
+import { Button } from '../ui/button';
+import { FilePreview } from '../ui/file-preview';
+
+// The standalone "Preview" window app: a read-only viewer for images, PDFs, Office docs, and
+// Markdown, opened on demand from the File Browser (double-click) — not a Dock-resident app (it's
+// intentionally absent from APP_LIST). The window titlebar carries the filename; this body is a slim
+// action bar (Open in Editor for editable text like Markdown, plus Download) over the shared
+// <FilePreview> renderer, which classifies the file and picks the right viewer.
+export const AppsPreviewPage: React.FC<{ windowId?: string; params?: Record<string, unknown> }> = ({ params }) => {
+  const { t } = useTranslation();
+  const wm = useWindowManager();
+  const path = typeof params?.path === 'string' ? params.path : '';
+  const name = typeof params?.name === 'string' && params.name ? params.name : path.split(/[\\/]/).pop() || '';
+  // Only editable text (Markdown, among the types routed here) offers "Open in Editor"; images and
+  // Office docs have no editor form, so previewKind is null and the button is hidden.
+  const editable = name ? previewKind(name) != null : false;
+
+  if (!path) {
+    return <div className="grid h-full w-full place-items-center bg-surface text-[12px] text-muted">{t('apps.preview.empty')}</div>;
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col bg-surface">
+      <div className="flex items-center justify-end gap-1 border-b border-border bg-surface-2/60 px-2 py-1.5">
+        {editable && (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1.5 px-2 text-[12px] text-muted"
+            onClick={() => wm.openApp('editor', { title: name, params: { path, filename: name } })}
+          >
+            <Pencil className="size-3.5" /> {t('apps.preview.openInEditor')}
+          </Button>
+        )}
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-7 text-mint"
+          aria-label={t('apps.fileBrowser.download')}
+          onClick={() => downloadFile(path)}
+        >
+          <Download className="size-3.5" />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1">
+        <FilePreview source={{ url: contentUrl(path), name }} />
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/AppsPreviewPage.tsx
+++ b/ui/src/components/workbench/AppsPreviewPage.tsx
@@ -3,7 +3,7 @@ import { Download, Pencil } from 'lucide-react';
 
 import { useWindowManager } from '../../context/WindowManagerContext';
 import { previewKind } from '../../lib/filePreview';
-import { contentUrl, downloadFile } from '../../lib/filesApi';
+import { contentUrl, downloadFile, fileMeta } from '../../lib/filesApi';
 import { Button } from '../ui/button';
 import { FilePreview } from '../ui/file-preview';
 
@@ -21,6 +21,20 @@ export const AppsPreviewPage: React.FC<{ windowId?: string; params?: Record<stri
   // Office docs have no editor form, so previewKind is null and the button is hidden.
   const editable = name ? previewKind(name) != null : false;
 
+  // Open the editable file in the Editor, first fetching its current mtime so the editor's save
+  // carries a conflict baseline — matching the File Browser's Files→editor path. Without it, a
+  // change or deletion between opening and saving would be silently overwritten. Best-effort: if the
+  // meta fetch fails, still open (the editor re-reads on save), just without the baseline.
+  const openInEditor = async () => {
+    let mtime: number | null | undefined;
+    try {
+      mtime = (await fileMeta(path)).mtime;
+    } catch {
+      mtime = undefined;
+    }
+    wm.openApp('editor', { title: name, params: { path, filename: name, mtime } });
+  };
+
   if (!path) {
     return <div className="grid h-full w-full place-items-center bg-surface text-[12px] text-muted">{t('apps.preview.empty')}</div>;
   }
@@ -34,7 +48,7 @@ export const AppsPreviewPage: React.FC<{ windowId?: string; params?: Record<stri
             size="sm"
             variant="ghost"
             className="h-7 gap-1.5 px-2 text-[12px] text-muted"
-            onClick={() => wm.openApp('editor', { title: name, params: { path, filename: name } })}
+            onClick={() => void openInEditor()}
           >
             <Pencil className="size-3.5" /> {t('apps.preview.openInEditor')}
           </Button>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -685,8 +685,13 @@
       "maximize": "Maximize",
       "restore": "Restore"
     },
+    "preview": {
+      "label": "Preview",
+      "openInEditor": "Open in Editor",
+      "empty": "No file to preview."
+    },
     "fileBrowser": {
-      "label": "File Browser",
+      "label": "Files",
       "desc": "Browse, view, and edit files on this machine.",
       "placeholder": "The File Browser is being built. You'll be able to browse the whole machine, open files, and edit and save them right here.",
       "tagline": "Whole machine · view and edit",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -685,8 +685,13 @@
       "maximize": "最大化",
       "restore": "还原"
     },
+    "preview": {
+      "label": "预览",
+      "openInEditor": "用编辑器打开",
+      "empty": "没有可预览的文件。"
+    },
     "fileBrowser": {
-      "label": "文件浏览器",
+      "label": "文件",
       "desc": "浏览、查看、编辑这台机器上的文件。",
       "placeholder": "文件浏览器正在搭建中。很快你就能在这里浏览整机文件、打开文件、直接编辑并保存。",
       "tagline": "整机 · 查看与编辑",

--- a/ui/src/lib/filePreview.ts
+++ b/ui/src/lib/filePreview.ts
@@ -227,6 +227,19 @@ export function previewOverlayKind(entry: { kind: string; name: string; size: nu
   return rk === 'image' || rk === 'pdf' || rk === 'docx' || rk === 'xlsx' || rk === 'pptx' ? rk : null;
 }
 
+// What opens in the standalone Preview WINDOW: everything previewOverlayKind covers (image / PDF /
+// Office) PLUS Markdown, which renders to a read-only document view. Editable code / plain-text /
+// json / csv / svg / html still open in the editor (which carries its own preview toggle). The File
+// Browser routes a double-click here on desktop (a real window) and to an in-page overlay on mobile.
+export type PreviewWindowKind = PreviewOverlayKind | 'markdown';
+export function previewWindowKind(entry: { kind: string; name: string; size: number | null }): PreviewWindowKind | null {
+  const overlay = previewOverlayKind(entry);
+  if (overlay) return overlay;
+  if (entry.kind !== 'file') return null;
+  if (entry.size != null && entry.size > PREVIEW_MAX_BYTES) return null;
+  return previewRenderKind(entry.name) === 'markdown' ? 'markdown' : null;
+}
+
 // Shiki language id for the 'code'/'source' kinds; 'text' (no highlight) otherwise.
 export function codeLanguage(name: string, serverExt?: string | null): string {
   const b = baseName(name).toLowerCase();


### PR DESCRIPTION
## Capability

Five workbench refinements requested off the file-browser work — a standalone Preview window, a window-resize fix, a macOS-like minimize animation, nicer minimized-window tiles, and a shorter Files name.

### 1. Standalone "Preview" (预览) window app
Images / PDF / Excel / Word / PPT / **Markdown** now open in a **dedicated on-demand window** (double-click in Files) instead of an in-file-browser overlay. New `preview` registry entry + `AppsPreviewPage` (wraps the shared `FilePreview` with a Download + "Open in Editor" bar). `previewWindowKind()` classifies what routes here; code / plain-text / JSON / CSV / SVG / HTML still open in the Editor. The Preview app is **deliberately absent from `APP_LIST`**, so it has no resident Dock tile — it only appears while a preview window is open. Mobile (no window layer) keeps the in-page overlay.

### 2. Fix window resize (bug)
The old preview overlay rendered at `z-20`, above the window's `z-10` resize handles, so the bottom/side edges couldn't be grabbed while previewing. Moving preview to its own window removes the overlay; resize handles are also bumped to **`z-30`** so no app-body content can cover the window edges again (fixes the whole class, not just this instance).

### 3. macOS-like minimize animation
Windows now **shrink and fly toward the Dock** (bottom-left) with a fade, reversing on restore — a CSS approximation of macOS's genie (a literal liquid warp needs WebGL). Exact landing isn't required; it reads clearly as "went down to the Dock."

### 4. Minimized-window tiles in the Dock
Each minimized window renders as a small **window-style thumbnail** (mini titlebar with traffic lights + app icon) with the **title stacked below** — matching the app tiles and no longer stretching the tile wide with an inline title.

### 5. Rename
"File Browser" → **"Files" / "文件"**.

## Evidence layers
- **UI build:** `npm run build` (tsc + vite) green.
- **Live render verification (Chrome DevTools against the local backend):** opened Files (title shows 文件), double-clicked an image → a separate **预览** window opened (its own titlebar + download; no Dock launcher tile), minimized it → window morphed into the Dock and the minimized entry rendered as a window-thumbnail with the title stacked below. Screenshots captured for each.
- **Review:** focused correctness review of the diff (minimize-transform math for maximized + normal windows, `previewWindowKind` routing + size caps, no dead open() path, removed-import safety, Dock a11y) — no blocking findings.
- **Scenario:** no scenario catalog covers the workbench apps; none updated.

## Residual manual checks
Best exercised in the Incus regression env / after a local install: resize the Preview window from every edge/corner; the minimize morph feel; Markdown "Open in Editor"; the Preview window on light vs dark workbench theme (it intentionally has no `lockTheme`); multiple minimized windows stacking in the Dock.
