### PR TITLE
feat(runtime): add agent resource governance MVP

### DIFF
--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -82,6 +82,7 @@ class AppCompatConfig:
     include_user_info: bool = True
     reply_enhancements: bool = True
     default_backend: str = DEFAULT_AGENT_BACKEND
+    resource_governance: dict = field(default_factory=lambda: {"mode": "auto"})
 
     def enabled_platforms(self) -> list[str]:
         enabled = self.platforms.get("enabled") if isinstance(self.platforms, dict) else None
@@ -159,4 +160,5 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
         include_time_info=v2.include_time_info,
         include_user_info=v2.include_user_info,
         reply_enhancements=v2.reply_enhancements,
+        resource_governance=v2.runtime.resource_governance,
     )

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -227,6 +227,10 @@ class AudioAsrConfig:
 class RuntimeConfig:
     default_cwd: str
     log_level: str = "INFO"
+    # Linux/cgroup v2 best-effort resource governance for aggregate agent
+    # workload. "auto" enables it only when Avibe can create and write the
+    # delegated cgroup; unsupported systems silently fall back to legacy spawn.
+    resource_governance: dict = field(default_factory=lambda: {"mode": "auto"})
 
 
 @dataclass
@@ -725,6 +729,7 @@ class V2Config:
             "runtime": {
                 "default_cwd": self.runtime.default_cwd,
                 "log_level": self.runtime.log_level,
+                "resource_governance": self.runtime.resource_governance,
             },
             "agents": {
                 "opencode": self.agents.opencode.__dict__,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2556,11 +2556,13 @@ class AgentAuthService:
         try:
             from config.v2_compat import to_app_config
             from config.v2_config import V2Config
+            from core.resource_governance import AgentResourceGovernor, config_from_runtime
             from modules.agents.opencode import OpenCodeServerManager
         except ImportError:
             return None
         try:
-            compat = to_app_config(V2Config.load())
+            v2_config = V2Config.load()
+            compat = to_app_config(v2_config)
         except Exception as err:  # noqa: BLE001
             logger.warning("V2Config.load failed in web OAuth path: %s", err)
             return None
@@ -2572,6 +2574,7 @@ class AgentAuthService:
                 binary=opencode_cfg.binary,
                 port=opencode_cfg.port,
                 request_timeout_seconds=opencode_cfg.request_timeout_seconds,
+                resource_governor=AgentResourceGovernor(config_from_runtime(v2_config)),
             )
             await server.ensure_running()
             return server

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -33,6 +33,7 @@ from modules.agents.opencode.message_processor import (
 )
 from modules.agents.opencode.utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
 from modules.im import InlineButton, InlineKeyboard, MessageContext
+from core.resource_governance import governor_from_controller
 from vibe.i18n import t as i18n_t
 from vibe.opencode_config import remove_opencode_provider_api_key
 
@@ -1092,6 +1093,10 @@ class AgentAuthService:
 
         client = ClaudeSDKClient(options=ClaudeAgentOptions(**option_kwargs))
         await client.connect()
+        governor_from_controller(self.controller).apply_to_pid(
+            get_claude_client_pid(client),
+            label="claude auth",
+        )
         return client
 
     async def _send_claude_control_request(

--- a/core/controller.py
+++ b/core/controller.py
@@ -368,6 +368,9 @@ class Controller:
 
     def _sync_config_references(self, new_config) -> None:
         self.config = new_config
+        governor = getattr(self, "_agent_resource_governor", None)
+        if governor is not None:
+            governor.update_config(getattr(new_config, "resource_governance", {"mode": "auto"}))
         self.processing_indicator.config = new_config
         self.audio_asr_service.config = new_config
         for handler_name in ("command_handler", "settings_handler", "message_handler", "session_handler"):
@@ -513,6 +516,10 @@ class Controller:
                 self.config.include_time_info = v2_config.include_time_info
                 self.config.include_user_info = v2_config.include_user_info
                 self.config.reply_enhancements = v2_config.reply_enhancements
+                self.config.resource_governance = v2_config.runtime.resource_governance
+                governor = getattr(self, "_agent_resource_governor", None)
+                if governor is not None:
+                    governor.update_config(self.config.resource_governance)
                 self.config.audio_asr = v2_config.audio_asr
                 self.config.remote_access = v2_config.remote_access
                 audio_asr_service = getattr(self, "audio_asr_service", None)

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -31,6 +31,7 @@ from config.v2_config import (
 )
 from core.avibe_cloud import avibe_cloud_url_available
 from core.caller_context import caller_env_for_platform_payload
+from core.resource_governance import governor_from_controller
 from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 
@@ -919,6 +920,10 @@ class SessionHandler(BaseHandler):
         # Connect the client
         try:
             await client.connect()
+            governor_from_controller(self.controller).apply_to_pid(
+                get_claude_client_pid(client),
+                label="claude",
+            )
         except Exception as exc:
             stderr_text = "\n".join(claude_stderr_lines)
             match = CLAUDE_NO_CONVERSATION_RE.search(stderr_text) or CLAUDE_NO_CONVERSATION_RE.search(str(exc))

--- a/core/resource_governance.py
+++ b/core/resource_governance.py
@@ -256,6 +256,7 @@ class AgentResourceGovernor:
 
     def update_config(self, config: dict[str, Any] | None) -> None:
         self.config = config or {}
+        self._base = None
         self._group = None
         self._limits = None
         self._disabled_reason = None
@@ -301,6 +302,9 @@ class AgentResourceGovernor:
             str(self.config.get("runtime_group_name") or DEFAULT_RUNTIME_GROUP_NAME).strip()
             or DEFAULT_RUNTIME_GROUP_NAME
         )
+        if runtime_group_name == group_name:
+            self._disabled_reason = "runtime-and-agent-cgroup-collide"
+            return None
         group = base / group_name
         runtime_group = base / runtime_group_name
         try:
@@ -330,20 +334,23 @@ class AgentResourceGovernor:
         return group
 
     def _base_cgroup(self, root: Path) -> Path | None:
+        runtime_group_name = (
+            str(self.config.get("runtime_group_name") or DEFAULT_RUNTIME_GROUP_NAME).strip()
+            or DEFAULT_RUNTIME_GROUP_NAME
+        )
         if self.base_cgroup is not None:
-            return self.base_cgroup
+            return self._parent_if_runtime_leaf(self.base_cgroup, runtime_group_name)
         if self._base is not None:
             return self._base
         current = current_cgroup_path(root)
         if current is None:
             return None
-        runtime_group_name = (
-            str(self.config.get("runtime_group_name") or DEFAULT_RUNTIME_GROUP_NAME).strip()
-            or DEFAULT_RUNTIME_GROUP_NAME
-        )
-        if current.name == runtime_group_name and current.parent != current:
-            return current.parent
-        return current
+        return self._parent_if_runtime_leaf(current, runtime_group_name)
+
+    def _parent_if_runtime_leaf(self, cgroup: Path, runtime_group_name: str) -> Path:
+        if cgroup.name == runtime_group_name and cgroup.parent != cgroup:
+            return cgroup.parent
+        return cgroup
 
     def _prepare_base_cgroup(self, base: Path, runtime_group: Path, root: Path) -> None:
         try:
@@ -352,6 +359,9 @@ class AgentResourceGovernor:
             is_root = False
         if is_root:
             return
+        # cgroup v2 rejects enabling domain controllers in a non-root cgroup
+        # that still has member processes. Keep Avibe in a runtime leaf and
+        # create the agent cgroup as a sibling under the now-empty parent.
         runtime_group.mkdir(exist_ok=True)
         if not (runtime_group / "cgroup.procs").exists():
             raise OSError(f"runtime cgroup.procs is unavailable in {runtime_group}")
@@ -376,6 +386,9 @@ class AgentResourceGovernor:
                     )
             if not moved:
                 break
+        remaining = _cgroup_member_pids(base)
+        if remaining:
+            raise OSError(f"runtime cgroup still has member pids after migration: {base}")
 
     def _enable_subtree_controllers(self, base: Path) -> None:
         available = set((_read_text(base / "cgroup.controllers") or "").split())
@@ -384,8 +397,8 @@ class AgentResourceGovernor:
             return
         try:
             _write_cgroup_value(base / "cgroup.subtree_control", " ".join(f"+{controller}" for controller in requested))
-        except OSError:
-            logger.debug("Failed to enable delegated cgroup controllers under %s", base, exc_info=True)
+        except OSError as exc:
+            raise OSError(f"failed to enable delegated cgroup controllers under {base}: {exc}") from exc
 
     def _configure_group(self, group: Path, limits: AgentResourceLimits) -> None:
         if not (group / "cgroup.procs").exists():

--- a/core/resource_governance.py
+++ b/core/resource_governance.py
@@ -196,6 +196,11 @@ def _cgroup_member_pids(cgroup: Path) -> list[int]:
     return pids
 
 
+def _runtime_process_tree_pids(pid: int | None = None) -> set[int]:
+    root_pid = pid or os.getpid()
+    return {root_pid, *_descendant_pids(root_pid)}
+
+
 def _descendant_pids(pid: int) -> list[int]:
     pending = [pid]
     descendants: list[int] = []
@@ -372,6 +377,10 @@ class AgentResourceGovernor:
             pids = [pid for pid in _cgroup_member_pids(base) if pid > 0]
             if not pids:
                 return
+            runtime_pids = _runtime_process_tree_pids()
+            foreign_pids = [pid for pid in pids if pid not in runtime_pids]
+            if foreign_pids:
+                raise OSError(f"runtime cgroup has non-Avibe member pids: {base}")
             moved = False
             for pid in pids:
                 try:
@@ -433,9 +442,26 @@ class AgentResourceGovernor:
 
 
 def config_from_controller(controller: Any) -> dict[str, Any]:
-    runtime_config = getattr(getattr(controller, "config", None), "resource_governance", None)
+    return config_from_runtime(getattr(controller, "config", None))
+
+
+def config_from_runtime(config: Any) -> dict[str, Any]:
+    runtime_config = getattr(config, "resource_governance", None)
     if isinstance(runtime_config, dict):
         return runtime_config
+    nested_runtime = getattr(config, "runtime", None)
+    nested_config = getattr(nested_runtime, "resource_governance", None)
+    if isinstance(nested_config, dict):
+        return nested_config
+    if isinstance(config, dict):
+        direct = config.get("resource_governance")
+        if isinstance(direct, dict):
+            return direct
+        runtime = config.get("runtime")
+        if isinstance(runtime, dict):
+            nested = runtime.get("resource_governance")
+            if isinstance(nested, dict):
+                return nested
     return {"mode": "auto"}
 
 

--- a/core/resource_governance.py
+++ b/core/resource_governance.py
@@ -20,6 +20,7 @@ DEFAULT_AGENT_OOM_SCORE_ADJ = 500
 MIN_AGENT_MEMORY_MAX_BYTES = 512 * 1024 * 1024
 MIB = 1024 * 1024
 AGENT_CONTROLLERS = ("memory", "cpu", "io", "pids")
+CONTROLLER_GOVERNOR_ATTR = "_avibe_controller_owned_resource_governor"
 
 
 @dataclass(frozen=True)
@@ -465,10 +466,20 @@ def config_from_runtime(config: Any) -> dict[str, Any]:
     return {"mode": "auto"}
 
 
+def mark_controller_resource_governor(governor: Any) -> None:
+    setattr(governor, CONTROLLER_GOVERNOR_ATTR, True)
+
+
+def is_controller_resource_governor(governor: Any) -> bool:
+    return bool(getattr(governor, CONTROLLER_GOVERNOR_ATTR, False))
+
+
 def governor_from_controller(controller: Any) -> AgentResourceGovernor:
     existing = getattr(controller, "_agent_resource_governor", None)
     if isinstance(existing, AgentResourceGovernor):
+        mark_controller_resource_governor(existing)
         return existing
     governor = AgentResourceGovernor(config_from_controller(controller))
+    mark_controller_resource_governor(governor)
     setattr(controller, "_agent_resource_governor", governor)
     return governor

--- a/core/resource_governance.py
+++ b/core/resource_governance.py
@@ -1,0 +1,365 @@
+"""Best-effort Linux cgroup v2 resource governance for agent workloads."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CGROUP_ROOT = Path("/sys/fs/cgroup")
+DEFAULT_GROUP_NAME = "avibe-agents"
+DEFAULT_AGENT_CPU_WEIGHT = 150
+DEFAULT_AGENT_IO_WEIGHT = 100
+DEFAULT_AGENT_PIDS_MAX = 512
+DEFAULT_AGENT_OOM_SCORE_ADJ = 500
+MIN_AGENT_MEMORY_MAX_BYTES = 512 * 1024 * 1024
+MIB = 1024 * 1024
+AGENT_CONTROLLERS = ("memory", "cpu", "io", "pids")
+
+
+@dataclass(frozen=True)
+class AgentResourceLimits:
+    memory_high: int | None
+    memory_max: int | None
+    cpu_weight: int = DEFAULT_AGENT_CPU_WEIGHT
+    io_weight: int = DEFAULT_AGENT_IO_WEIGHT
+    pids_max: int = DEFAULT_AGENT_PIDS_MAX
+    oom_score_adj: int = DEFAULT_AGENT_OOM_SCORE_ADJ
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _parse_memory_value(value: str | None) -> int | None:
+    if not value or value == "max":
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _round_down_mib(value: int) -> int:
+    return max(MIB, (int(value) // MIB) * MIB)
+
+
+def detect_cgroup_root() -> Path | None:
+    if os.name != "posix" or not CGROUP_ROOT.exists():
+        return None
+    if not (CGROUP_ROOT / "cgroup.controllers").exists():
+        return None
+    return CGROUP_ROOT
+
+
+def current_cgroup_path(root: Path | None = None) -> Path | None:
+    root = root or detect_cgroup_root()
+    if root is None:
+        return None
+    try:
+        lines = Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        parts = line.split(":", 2)
+        if len(parts) == 3 and parts[0] == "0":
+            rel = parts[2].strip("/")
+            return root / rel if rel else root
+    return None
+
+
+def tenant_memory_limit_bytes(cgroup: Path | None = None, root: Path | None = None) -> int | None:
+    root = root or detect_cgroup_root()
+    if root is None:
+        return None
+    cursor = cgroup or current_cgroup_path(root)
+    if cursor is None:
+        return None
+
+    root = root.resolve()
+    try:
+        cursor = cursor.resolve()
+    except OSError:
+        return None
+
+    while True:
+        limit = _parse_memory_value(_read_text(cursor / "memory.max"))
+        if limit is not None:
+            return limit
+        if cursor == root:
+            break
+        cursor = cursor.parent
+
+    meminfo = _read_text(Path("/proc/meminfo"))
+    if meminfo:
+        for line in meminfo.splitlines():
+            if line.startswith("MemTotal:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    try:
+                        return int(parts[1]) * 1024
+                    except ValueError:
+                        return None
+    return None
+
+
+def derive_agent_limits(
+    tenant_memory_bytes: int | None,
+    config: dict[str, Any] | None = None,
+) -> AgentResourceLimits:
+    config = config or {}
+
+    def _int_config(name: str, default: int) -> int:
+        value = config.get(name)
+        if isinstance(value, bool):
+            return default
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    cpu_weight = max(1, min(10_000, _int_config("agent_cpu_weight", DEFAULT_AGENT_CPU_WEIGHT)))
+    io_weight = max(1, min(10_000, _int_config("agent_io_weight", DEFAULT_AGENT_IO_WEIGHT)))
+    pids_max = max(32, _int_config("agent_pids_max", DEFAULT_AGENT_PIDS_MAX))
+    oom_score_adj = max(-1000, min(1000, _int_config("agent_oom_score_adj", DEFAULT_AGENT_OOM_SCORE_ADJ)))
+
+    explicit_max = _int_config("agent_memory_max_bytes", 0)
+    explicit_high = _int_config("agent_memory_high_bytes", 0)
+    if explicit_max > 0:
+        memory_max = _round_down_mib(explicit_max)
+        memory_high = _round_down_mib(explicit_high) if explicit_high > 0 else _round_down_mib(memory_max * 85 // 100)
+        return AgentResourceLimits(
+            memory_high=min(memory_high, memory_max),
+            memory_max=memory_max,
+            cpu_weight=cpu_weight,
+            io_weight=io_weight,
+            pids_max=pids_max,
+            oom_score_adj=oom_score_adj,
+        )
+
+    if tenant_memory_bytes is None or tenant_memory_bytes < 1024 * MIB:
+        return AgentResourceLimits(
+            memory_high=None,
+            memory_max=None,
+            cpu_weight=cpu_weight,
+            io_weight=io_weight,
+            pids_max=pids_max,
+            oom_score_adj=oom_score_adj,
+        )
+
+    avibe_reserve = max(384 * MIB, min(1024 * MIB, tenant_memory_bytes * 20 // 100))
+    system_headroom = max(256 * MIB, tenant_memory_bytes * 12 // 100)
+    memory_max = _round_down_mib(tenant_memory_bytes - avibe_reserve - system_headroom)
+    if memory_max < MIN_AGENT_MEMORY_MAX_BYTES:
+        memory_max = MIN_AGENT_MEMORY_MAX_BYTES
+    # Keep a soft throttle below the hard cap so the agent domain slows before
+    # it hits OOM, but keep enough burst room for model/tool startup spikes.
+    memory_high = _round_down_mib(memory_max * 85 // 100)
+    return AgentResourceLimits(
+        memory_high=memory_high,
+        memory_max=memory_max,
+        cpu_weight=cpu_weight,
+        io_weight=io_weight,
+        pids_max=pids_max,
+        oom_score_adj=oom_score_adj,
+    )
+
+
+def _format_cgroup_memory(value: int | None) -> str:
+    return "max" if value is None else str(int(value))
+
+
+def _write_cgroup_value(path: Path, value: str) -> None:
+    path.write_text(f"{value}\n", encoding="utf-8")
+
+
+def _descendant_pids(pid: int) -> list[int]:
+    pending = [pid]
+    descendants: list[int] = []
+    seen = {pid}
+    while pending:
+        current = pending.pop()
+        try:
+            task_dirs = list(Path(f"/proc/{current}/task").iterdir())
+        except OSError:
+            task_dirs = [Path(f"/proc/{current}/task/{current}")]
+        for task_dir in task_dirs:
+            children = _read_text(task_dir / "children")
+            if not children:
+                continue
+            for raw_child in children.split():
+                try:
+                    child = int(raw_child)
+                except ValueError:
+                    continue
+                if child in seen:
+                    continue
+                seen.add(child)
+                descendants.append(child)
+                pending.append(child)
+    return descendants
+
+
+class AgentResourceGovernor:
+    """Move backend runtime roots into one shared constrained cgroup."""
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        root: Path | None = None,
+        base_cgroup: Path | None = None,
+    ) -> None:
+        self.config = config or {}
+        self.root = root
+        self.base_cgroup = base_cgroup
+        self._group: Path | None = None
+        self._limits: AgentResourceLimits | None = None
+        self._disabled_reason: str | None = None
+
+    @property
+    def mode(self) -> str:
+        value = str(self.config.get("mode") or "auto").strip().lower()
+        return value if value in {"auto", "enabled", "disabled"} else "auto"
+
+    @property
+    def group_path(self) -> Path | None:
+        return self._group
+
+    @property
+    def limits(self) -> AgentResourceLimits | None:
+        return self._limits
+
+    def update_config(self, config: dict[str, Any] | None) -> None:
+        self.config = config or {}
+        self._group = None
+        self._limits = None
+        self._disabled_reason = None
+
+    def apply_to_pid(self, pid: int | None, *, label: str = "agent") -> bool:
+        if not isinstance(pid, int) or pid <= 0:
+            return False
+        group = self._ensure_group()
+        if group is None:
+            return False
+        moved = self._move_pid(group, pid, label=label)
+        for child_pid in _descendant_pids(pid):
+            self._move_pid(group, child_pid, label=f"{label} child", warn=False)
+        return moved
+
+    def _move_pid(self, group: Path, pid: int, *, label: str, warn: bool = True) -> bool:
+        try:
+            _write_cgroup_value(group / "cgroup.procs", str(pid))
+            self._apply_oom_score_adj(pid)
+            return True
+        except OSError as exc:
+            log = logger.warning if warn else logger.debug
+            log("Agent resource governance could not move %s pid=%s into cgroup: %s", label, pid, exc)
+            return False
+
+    def _ensure_group(self) -> Path | None:
+        if self._group is not None:
+            return self._group
+        if self.mode == "disabled":
+            self._disabled_reason = "disabled"
+            return None
+        root = self.root or detect_cgroup_root()
+        if root is None:
+            self._disabled_reason = "no-cgroup-v2"
+            return None
+        base = self.base_cgroup or current_cgroup_path(root)
+        if base is None:
+            self._disabled_reason = "unknown-current-cgroup"
+            return None
+        group_name = str(self.config.get("agent_group_name") or DEFAULT_GROUP_NAME).strip() or DEFAULT_GROUP_NAME
+        group = base / group_name
+        try:
+            self._enable_subtree_controllers(base)
+            group.mkdir(exist_ok=True)
+            limits = derive_agent_limits(tenant_memory_limit_bytes(base, root), self.config)
+            self._configure_group(group, limits)
+        except OSError as exc:
+            self._disabled_reason = str(exc)
+            if self.mode == "enabled":
+                logger.warning("Agent resource governance requested but cgroup setup failed: %s", exc)
+            else:
+                logger.info("Agent resource governance unavailable: %s", exc)
+            return None
+        self._group = group
+        self._limits = limits
+        logger.info(
+            "Agent resource governance enabled group=%s memory_high=%s memory_max=%s cpu_weight=%s io_weight=%s pids_max=%s",
+            group,
+            limits.memory_high,
+            limits.memory_max,
+            limits.cpu_weight,
+            limits.io_weight,
+            limits.pids_max,
+        )
+        return group
+
+    def _enable_subtree_controllers(self, base: Path) -> None:
+        available = set((_read_text(base / "cgroup.controllers") or "").split())
+        requested = [controller for controller in AGENT_CONTROLLERS if controller in available]
+        if not requested or not (base / "cgroup.subtree_control").exists():
+            return
+        try:
+            _write_cgroup_value(base / "cgroup.subtree_control", " ".join(f"+{controller}" for controller in requested))
+        except OSError:
+            logger.debug("Failed to enable delegated cgroup controllers under %s", base, exc_info=True)
+
+    def _configure_group(self, group: Path, limits: AgentResourceLimits) -> None:
+        if not (group / "cgroup.procs").exists():
+            raise OSError(f"cgroup.procs is unavailable in {group}")
+        if limits.memory_max is not None:
+            missing_memory_files = [
+                str(path.name) for path in (group / "memory.high", group / "memory.max") if not path.exists()
+            ]
+            if missing_memory_files:
+                raise OSError(f"memory controller unavailable in {group}: missing {', '.join(missing_memory_files)}")
+        if (group / "memory.high").exists():
+            _write_cgroup_value(group / "memory.high", _format_cgroup_memory(limits.memory_high))
+        if (group / "memory.max").exists():
+            _write_cgroup_value(group / "memory.max", _format_cgroup_memory(limits.memory_max))
+        if (group / "memory.oom.group").exists():
+            _write_cgroup_value(group / "memory.oom.group", "1")
+        if (group / "cpu.weight").exists():
+            _write_cgroup_value(group / "cpu.weight", str(limits.cpu_weight))
+        if (group / "io.weight").exists():
+            _write_cgroup_value(group / "io.weight", f"default {limits.io_weight}")
+        if (group / "pids.max").exists():
+            _write_cgroup_value(group / "pids.max", str(limits.pids_max))
+
+    def _apply_oom_score_adj(self, pid: int) -> None:
+        limits = self._limits
+        if limits is None:
+            return
+        try:
+            Path(f"/proc/{pid}/oom_score_adj").write_text(f"{limits.oom_score_adj}\n", encoding="utf-8")
+        except OSError:
+            logger.debug("Failed to apply oom_score_adj to agent pid=%s", pid, exc_info=True)
+
+
+def config_from_controller(controller: Any) -> dict[str, Any]:
+    runtime_config = getattr(getattr(controller, "config", None), "resource_governance", None)
+    if isinstance(runtime_config, dict):
+        return runtime_config
+    return {"mode": "auto"}
+
+
+def governor_from_controller(controller: Any) -> AgentResourceGovernor:
+    existing = getattr(controller, "_agent_resource_governor", None)
+    if isinstance(existing, AgentResourceGovernor):
+        return existing
+    governor = AgentResourceGovernor(config_from_controller(controller))
+    setattr(controller, "_agent_resource_governor", governor)
+    return governor

--- a/core/resource_governance.py
+++ b/core/resource_governance.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 CGROUP_ROOT = Path("/sys/fs/cgroup")
 DEFAULT_GROUP_NAME = "avibe-agents"
 DEFAULT_RUNTIME_GROUP_NAME = "avibe-runtime"
-DEFAULT_AGENT_CPU_WEIGHT = 150
-DEFAULT_AGENT_IO_WEIGHT = 100
+DEFAULT_AGENT_CPU_WEIGHT = 50
+DEFAULT_AGENT_IO_WEIGHT = 50
 DEFAULT_AGENT_PIDS_MAX = 512
 DEFAULT_AGENT_OOM_SCORE_ADJ = 500
 MIN_AGENT_MEMORY_MAX_BYTES = 512 * 1024 * 1024
@@ -270,11 +270,13 @@ class AgentResourceGovernor:
     def apply_to_pid(self, pid: int | None, *, label: str = "agent") -> bool:
         if not isinstance(pid, int) or pid <= 0:
             return False
-        group = self._ensure_group()
+        descendant_pids = _descendant_pids(pid)
+        known_agent_pids = {pid, *descendant_pids}
+        group = self._ensure_group(known_agent_pids=known_agent_pids)
         if group is None:
             return False
         moved = self._move_pid(group, pid, label=label)
-        for child_pid in _descendant_pids(pid):
+        for child_pid in descendant_pids:
             self._move_pid(group, child_pid, label=f"{label} child", warn=False)
         return moved
 
@@ -288,7 +290,7 @@ class AgentResourceGovernor:
             log("Agent resource governance could not move %s pid=%s into cgroup: %s", label, pid, exc)
             return False
 
-    def _ensure_group(self) -> Path | None:
+    def _ensure_group(self, *, known_agent_pids: set[int] | None = None) -> Path | None:
         if self._group is not None:
             return self._group
         if self.mode == "disabled":
@@ -314,7 +316,7 @@ class AgentResourceGovernor:
         group = base / group_name
         runtime_group = base / runtime_group_name
         try:
-            self._prepare_base_cgroup(base, runtime_group, root)
+            self._prepare_base_cgroup(base, runtime_group, group, root, known_agent_pids=known_agent_pids)
             self._enable_subtree_controllers(base)
             group.mkdir(exist_ok=True)
             limits = derive_agent_limits(tenant_memory_limit_bytes(base, root), self.config)
@@ -358,7 +360,15 @@ class AgentResourceGovernor:
             return cgroup.parent
         return cgroup
 
-    def _prepare_base_cgroup(self, base: Path, runtime_group: Path, root: Path) -> None:
+    def _prepare_base_cgroup(
+        self,
+        base: Path,
+        runtime_group: Path,
+        agent_group: Path,
+        root: Path,
+        *,
+        known_agent_pids: set[int] | None = None,
+    ) -> None:
         try:
             is_root = base.resolve() == root.resolve()
         except OSError:
@@ -371,27 +381,53 @@ class AgentResourceGovernor:
         runtime_group.mkdir(exist_ok=True)
         if not (runtime_group / "cgroup.procs").exists():
             raise OSError(f"runtime cgroup.procs is unavailable in {runtime_group}")
-        self._move_base_processes_to_runtime_leaf(base, runtime_group)
+        self._move_base_processes_to_runtime_leaf(
+            base,
+            runtime_group,
+            agent_group,
+            known_agent_pids=known_agent_pids,
+        )
 
-    def _move_base_processes_to_runtime_leaf(self, base: Path, runtime_group: Path) -> None:
+    def _move_base_processes_to_runtime_leaf(
+        self,
+        base: Path,
+        runtime_group: Path,
+        agent_group: Path,
+        *,
+        known_agent_pids: set[int] | None = None,
+    ) -> None:
+        known_agent_pids = known_agent_pids or set()
+        agent_group_ready = False
         for _ in range(3):
             pids = [pid for pid in _cgroup_member_pids(base) if pid > 0]
             if not pids:
                 return
             runtime_pids = _runtime_process_tree_pids()
-            foreign_pids = [pid for pid in pids if pid not in runtime_pids]
+            managed_pids = runtime_pids | known_agent_pids
+            foreign_pids = [pid for pid in pids if pid not in managed_pids]
             if foreign_pids:
                 raise OSError(f"runtime cgroup has non-Avibe member pids: {base}")
             moved = False
             for pid in pids:
+                target_group = runtime_group
+                target_label = "Avibe runtime"
+                if pid in known_agent_pids:
+                    if not agent_group_ready:
+                        agent_group.mkdir(exist_ok=True)
+                        if not (agent_group / "cgroup.procs").exists():
+                            raise OSError(f"agent cgroup.procs is unavailable in {agent_group}")
+                        agent_group_ready = True
+                    target_group = agent_group
+                    target_label = "known agent"
                 try:
-                    _write_cgroup_value(runtime_group / "cgroup.procs", str(pid))
+                    _write_cgroup_value(target_group / "cgroup.procs", str(pid))
                     moved = True
                 except OSError as exc:
                     logger.debug(
-                        "Failed to move Avibe runtime pid=%s into runtime cgroup %s: %s",
+                        "Failed to move %s pid=%s into cgroup %s: %s",
+                        target_label,
                         pid,
-                        runtime_group,
+                        target_group,
                         exc,
                     )
             if not moved:

--- a/core/resource_governance.py
+++ b/core/resource_governance.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 CGROUP_ROOT = Path("/sys/fs/cgroup")
 DEFAULT_GROUP_NAME = "avibe-agents"
+DEFAULT_RUNTIME_GROUP_NAME = "avibe-runtime"
 DEFAULT_AGENT_CPU_WEIGHT = 150
 DEFAULT_AGENT_IO_WEIGHT = 100
 DEFAULT_AGENT_PIDS_MAX = 512
@@ -182,6 +183,19 @@ def _write_cgroup_value(path: Path, value: str) -> None:
     path.write_text(f"{value}\n", encoding="utf-8")
 
 
+def _cgroup_member_pids(cgroup: Path) -> list[int]:
+    text = _read_text(cgroup / "cgroup.procs")
+    if not text:
+        return []
+    pids: list[int] = []
+    for raw_pid in text.split():
+        try:
+            pids.append(int(raw_pid))
+        except ValueError:
+            continue
+    return pids
+
+
 def _descendant_pids(pid: int) -> list[int]:
     pending = [pid]
     descendants: list[int] = []
@@ -222,6 +236,7 @@ class AgentResourceGovernor:
         self.config = config or {}
         self.root = root
         self.base_cgroup = base_cgroup
+        self._base: Path | None = None
         self._group: Path | None = None
         self._limits: AgentResourceLimits | None = None
         self._disabled_reason: str | None = None
@@ -276,13 +291,20 @@ class AgentResourceGovernor:
         if root is None:
             self._disabled_reason = "no-cgroup-v2"
             return None
-        base = self.base_cgroup or current_cgroup_path(root)
+        base = self._base_cgroup(root)
         if base is None:
             self._disabled_reason = "unknown-current-cgroup"
             return None
+        self._base = base
         group_name = str(self.config.get("agent_group_name") or DEFAULT_GROUP_NAME).strip() or DEFAULT_GROUP_NAME
+        runtime_group_name = (
+            str(self.config.get("runtime_group_name") or DEFAULT_RUNTIME_GROUP_NAME).strip()
+            or DEFAULT_RUNTIME_GROUP_NAME
+        )
         group = base / group_name
+        runtime_group = base / runtime_group_name
         try:
+            self._prepare_base_cgroup(base, runtime_group, root)
             self._enable_subtree_controllers(base)
             group.mkdir(exist_ok=True)
             limits = derive_agent_limits(tenant_memory_limit_bytes(base, root), self.config)
@@ -306,6 +328,54 @@ class AgentResourceGovernor:
             limits.pids_max,
         )
         return group
+
+    def _base_cgroup(self, root: Path) -> Path | None:
+        if self.base_cgroup is not None:
+            return self.base_cgroup
+        if self._base is not None:
+            return self._base
+        current = current_cgroup_path(root)
+        if current is None:
+            return None
+        runtime_group_name = (
+            str(self.config.get("runtime_group_name") or DEFAULT_RUNTIME_GROUP_NAME).strip()
+            or DEFAULT_RUNTIME_GROUP_NAME
+        )
+        if current.name == runtime_group_name and current.parent != current:
+            return current.parent
+        return current
+
+    def _prepare_base_cgroup(self, base: Path, runtime_group: Path, root: Path) -> None:
+        try:
+            is_root = base.resolve() == root.resolve()
+        except OSError:
+            is_root = False
+        if is_root:
+            return
+        runtime_group.mkdir(exist_ok=True)
+        if not (runtime_group / "cgroup.procs").exists():
+            raise OSError(f"runtime cgroup.procs is unavailable in {runtime_group}")
+        self._move_base_processes_to_runtime_leaf(base, runtime_group)
+
+    def _move_base_processes_to_runtime_leaf(self, base: Path, runtime_group: Path) -> None:
+        for _ in range(3):
+            pids = [pid for pid in _cgroup_member_pids(base) if pid > 0]
+            if not pids:
+                return
+            moved = False
+            for pid in pids:
+                try:
+                    _write_cgroup_value(runtime_group / "cgroup.procs", str(pid))
+                    moved = True
+                except OSError as exc:
+                    logger.debug(
+                        "Failed to move Avibe runtime pid=%s into runtime cgroup %s: %s",
+                        pid,
+                        runtime_group,
+                        exc,
+                    )
+            if not moved:
+                break
 
     def _enable_subtree_controllers(self, base: Path) -> None:
         available = set((_read_text(base / "cgroup.controllers") or "").split())

--- a/docs/plans/agent-resource-governance-mvp.md
+++ b/docs/plans/agent-resource-governance-mvp.md
@@ -1,0 +1,45 @@
+# Agent Resource Governance MVP
+
+## Background
+
+Heavy agent work can saturate a tenant's CPU, memory, and file-backed cache/I/O
+until Avibe's liveness path stops responding. Tenant-level Incus limits already
+protect the host and neighboring tenants; the missing boundary is inside one
+tenant between Avibe control-plane work and agent workload.
+
+## Goal
+
+First version: constrain the aggregate agent workload so Claude, Codex,
+OpenCode, and their spawned shell/tool subprocesses cannot consume the whole
+tenant budget. This is a best-effort Linux/cgroup v2 MVP. It must not break
+non-Linux, non-systemd, or non-delegated installs; when Avibe cannot create a
+real constrained child cgroup, it falls back to legacy process startup.
+
+## Design
+
+- Add a V2 runtime config block for resource governance, defaulting to `auto`.
+- Create one shared `avibe-agents` cgroup under the current service cgroup.
+- Set aggregate limits on that group:
+  - `memory.high` as a soft throttle
+  - `memory.max` as a hard agent-domain cap
+  - lower `cpu.weight` / `io.weight`
+  - `pids.max`
+  - `memory.oom.group=1`
+- Move backend runtime root processes into that shared group:
+  - Codex `app-server`
+  - OpenCode `serve`
+  - Claude SDK-managed CLI process after connect
+- Apply positive `oom_score_adj` to the backend root process so extreme pressure
+  prefers killing agent work over Avibe.
+
+## Non-goals
+
+- Do not move Avibe itself into a protected cgroup in this PR.
+- Do not hard-fail agent startup when cgroup setup is unavailable.
+- Do not add UI controls yet; config can be file-driven.
+
+## Follow-ups
+
+- Add Avibe protected cgroup properties via service/scope startup.
+- Add tenant-wide agent turn admission control.
+- Add an Incus pressure regression that asserts `/health` remains responsive.

--- a/docs/plans/agent-resource-governance-mvp.md
+++ b/docs/plans/agent-resource-governance-mvp.md
@@ -18,7 +18,10 @@ real constrained child cgroup, it falls back to legacy process startup.
 ## Design
 
 - Add a V2 runtime config block for resource governance, defaulting to `auto`.
-- Create one shared `avibe-agents` cgroup under the current service cgroup.
+- Create an `avibe-runtime` leaf for Avibe's own direct service processes, then
+  create one sibling `avibe-agents` cgroup for constrained agent work. This keeps
+  the parent cgroup free of internal processes before enabling cgroup v2 domain
+  controllers.
 - Set aggregate limits on that group:
   - `memory.high` as a soft throttle
   - `memory.max` as a hard agent-domain cap

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -23,6 +23,7 @@ from core.system_prompt_injection import (
     build_system_prompt_injection,
     get_enabled_agents_for_prompt,
 )
+from core.resource_governance import governor_from_controller
 from modules.agents.base import AgentRequest, BaseAgent
 from modules.agents.subagent_router import SubagentDefinition, load_codex_subagent
 from modules.agents.codex.event_handler import CodexEventHandler
@@ -722,6 +723,7 @@ class CodexAgent(BaseAgent):
             )
 
             await transport.start()
+            governor_from_controller(self.controller).apply_to_pid(getattr(transport, "pid", None), label="codex app-server")
             self._transports[cwd] = transport
             self._cwd_inodes()[cwd] = self._cwd_inode(cwd)
             self._touch_transport_activity(cwd)

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -14,6 +14,7 @@ import time
 from typing import Dict, Optional
 
 from core.avibe_cloud import avibe_cloud_url_available
+from core.resource_governance import governor_from_controller
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 from modules.agents.base import AgentRequest, BaseAgent
 
@@ -58,6 +59,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         self.opencode_config = opencode_config
 
         self._client_manager = OpenCodeClientManager(opencode_config)
+        self._client_manager.set_resource_governor(governor_from_controller(controller))
         self._session_manager = OpenCodeSessionManager(self.settings_manager, self.name)
 
         self._poll_loop = OpenCodePollLoop(self)
@@ -82,6 +84,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 binary=self.opencode_config.binary,
                 port=self.opencode_config.port,
                 request_timeout_seconds=self.opencode_config.request_timeout_seconds,
+                resource_governor=governor_from_controller(self.controller),
             )
             adopted_uncached_server = previous_server is not None
         self.opencode_config = opencode_config

--- a/modules/agents/opencode/client_manager.py
+++ b/modules/agents/opencode/client_manager.py
@@ -15,6 +15,12 @@ class OpenCodeClientManager:
         self._config = opencode_config
         self._server_manager: Optional[OpenCodeServerManager] = None
         self._lock = asyncio.Lock()
+        self._resource_governor = None
+
+    def set_resource_governor(self, governor) -> None:
+        self._resource_governor = governor
+        if self._server_manager is not None:
+            self._server_manager.resource_governor = governor
 
     async def get_server(self) -> OpenCodeServerManager:
         async with self._lock:
@@ -23,6 +29,7 @@ class OpenCodeClientManager:
                     binary=self._config.binary,
                     port=self._config.port,
                     request_timeout_seconds=self._config.request_timeout_seconds,
+                    resource_governor=self._resource_governor,
                 )
             return self._server_manager
 

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -66,10 +66,12 @@ class OpenCodeServerManager:
         binary: str = "opencode",
         port: int = DEFAULT_OPENCODE_PORT,
         request_timeout_seconds: int = 60,
+        resource_governor: Any | None = None,
     ):
         self.binary = binary
         self.port = port
         self.request_timeout_seconds = request_timeout_seconds
+        self.resource_governor = resource_governor
         self.host = DEFAULT_OPENCODE_HOST
         self._process: Optional[Process] = None
         # The event loop ``_process`` was created on. Subprocess transports
@@ -113,6 +115,7 @@ class OpenCodeServerManager:
         binary: str = "opencode",
         port: int = DEFAULT_OPENCODE_PORT,
         request_timeout_seconds: int = 60,
+        resource_governor: Any | None = None,
     ) -> "OpenCodeServerManager":
         with cls._class_lock:
             if cls._instance is None:
@@ -120,6 +123,7 @@ class OpenCodeServerManager:
                     binary=binary,
                     port=port,
                     request_timeout_seconds=request_timeout_seconds,
+                    resource_governor=resource_governor,
                 )
             elif (
                 cls._instance.binary != binary
@@ -133,6 +137,8 @@ class OpenCodeServerManager:
                     f"ignoring new params binary={binary}, port={port}, "
                     f"request_timeout_seconds={request_timeout_seconds}"
                 )
+            elif resource_governor is not None:
+                cls._instance.resource_governor = resource_governor
             return cls._instance
 
     @classmethod
@@ -141,6 +147,7 @@ class OpenCodeServerManager:
         binary: str = "opencode",
         port: int = DEFAULT_OPENCODE_PORT,
         request_timeout_seconds: int = 60,
+        resource_governor: Any | None = None,
     ) -> Optional["OpenCodeServerManager"]:
         with cls._class_lock:
             if cls._instance is not None:
@@ -164,6 +171,7 @@ class OpenCodeServerManager:
                 binary=binary,
                 port=port,
                 request_timeout_seconds=request_timeout_seconds,
+                resource_governor=resource_governor,
             )
             return cls._instance
 
@@ -400,6 +408,12 @@ class OpenCodeServerManager:
             self._pid_file.write_text(json.dumps(payload))
         except Exception as e:
             logger.debug(f"Failed to write OpenCode pid file: {e}")
+
+    def _apply_resource_governance(self, pid: int | None) -> None:
+        governor = getattr(self, "resource_governor", None)
+        apply_to_pid = getattr(governor, "apply_to_pid", None)
+        if callable(apply_to_pid):
+            apply_to_pid(pid, label="opencode serve")
 
     def _write_active_run_sessions_to_pid_file(self) -> None:
         info = self._read_pid_file()
@@ -999,6 +1013,10 @@ class OpenCodeServerManager:
                         cmd = self._get_pid_command(pid)
                         if cmd and self._is_opencode_serve_cmd(cmd, self.port):
                             self._write_pid_file(pid)
+                            self._apply_resource_governance(pid)
+                else:
+                    pid = (pid_info or {}).get("pid") if isinstance(pid_info, dict) else None
+                    self._apply_resource_governance(pid)
 
                 self._base_url = f"http://{self.host}:{self.port}"
                 return self.base_url
@@ -1097,6 +1115,7 @@ class OpenCodeServerManager:
             self._process_loop = current_loop
             if self._process and self._process.pid:
                 self._write_pid_file(self._process.pid)
+                self._apply_resource_governance(self._process.pid)
         except FileNotFoundError:
             raise RuntimeError(
                 f"OpenCode CLI not found at '{self.binary}'. Please install OpenCode or set OPENCODE_CLI_PATH."

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -125,7 +125,10 @@ class OpenCodeServerManager:
                     request_timeout_seconds=request_timeout_seconds,
                     resource_governor=resource_governor,
                 )
-            elif (
+                return cls._instance
+            if resource_governor is not None:
+                cls._instance.resource_governor = resource_governor
+            if (
                 cls._instance.binary != binary
                 or cls._instance.port != port
                 or cls._instance.request_timeout_seconds != request_timeout_seconds
@@ -137,8 +140,6 @@ class OpenCodeServerManager:
                     f"ignoring new params binary={binary}, port={port}, "
                     f"request_timeout_seconds={request_timeout_seconds}"
                 )
-            elif resource_governor is not None:
-                cls._instance.resource_governor = resource_governor
             return cls._instance
 
     @classmethod

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -110,6 +110,14 @@ class OpenCodeServerManager:
             self._lock_loop = current_loop
         return self._lock
 
+    def _maybe_update_resource_governor(self, resource_governor: Any | None) -> None:
+        if resource_governor is None:
+            return
+        if is_controller_resource_governor(resource_governor) or not is_controller_resource_governor(
+            self.resource_governor
+        ):
+            self.resource_governor = resource_governor
+
     @classmethod
     async def get_instance(
         cls,
@@ -127,11 +135,7 @@ class OpenCodeServerManager:
                     resource_governor=resource_governor,
                 )
                 return cls._instance
-            if resource_governor is not None and (
-                is_controller_resource_governor(resource_governor)
-                or not is_controller_resource_governor(cls._instance.resource_governor)
-            ):
-                cls._instance.resource_governor = resource_governor
+            cls._instance._maybe_update_resource_governor(resource_governor)
             if (
                 cls._instance.binary != binary
                 or cls._instance.port != port
@@ -156,6 +160,7 @@ class OpenCodeServerManager:
     ) -> Optional["OpenCodeServerManager"]:
         with cls._class_lock:
             if cls._instance is not None:
+                cls._instance._maybe_update_resource_governor(resource_governor)
                 return cls._instance
 
             pid_file = paths.get_logs_dir() / "opencode_server.json"

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -25,6 +25,7 @@ import aiohttp
 
 from config import paths
 from core.process_isolation import isolated_subprocess_kwargs, terminate_process_tree
+from core.resource_governance import is_controller_resource_governor
 from modules.agents.opencode.caller_context import ensure_plugin_installed, server_environment
 from modules.agents.opencode.config_reconciler import OpenCodeConfigReconciler
 from vibe import runtime
@@ -126,7 +127,10 @@ class OpenCodeServerManager:
                     resource_governor=resource_governor,
                 )
                 return cls._instance
-            if resource_governor is not None:
+            if resource_governor is not None and (
+                is_controller_resource_governor(resource_governor)
+                or not is_controller_resource_governor(cls._instance.resource_governor)
+            ):
                 cls._instance.resource_governor = resource_governor
             if (
                 cls._instance.binary != binary

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1501,6 +1501,7 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
             binary="/old/opencode",
             port=4096,
             request_timeout_seconds=60,
+            resource_governor=agent.controller._agent_resource_governor,
         )
         live_server.refresh_global_config.assert_not_awaited()
         live_server.detach_after_deferred_refresh.assert_awaited_once()
@@ -1546,6 +1547,7 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
             binary="/opencode",
             port=4096,
             request_timeout_seconds=60,
+            resource_governor=agent.controller._agent_resource_governor,
         )
         self.assertIs(agent.opencode_config, new_config)
         self.assertIs(agent.controller.config.opencode, new_config)

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1552,6 +1552,43 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
         self.assertIs(agent.opencode_config, new_config)
         self.assertIs(agent.controller.config.opencode, new_config)
 
+    async def test_web_opencode_server_uses_v2_runtime_resource_governance(self):
+        from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, V2Config
+        from modules.agents.opencode.server import OpenCodeServerManager
+
+        controller = _StubController()
+        service = AgentAuthService(controller)
+        v2_config = V2Config(
+            mode="self_host",
+            version="v2",
+            slack=SlackConfig(),
+            agents=AgentsConfig(),
+            runtime=RuntimeConfig(
+                default_cwd=".",
+                resource_governance={
+                    "mode": "enabled",
+                    "agent_group_name": "web-oauth-agents",
+                },
+            ),
+        )
+        server = SimpleNamespace(ensure_running=AsyncMock())
+
+        with (
+            patch("config.v2_config.V2Config.load", return_value=v2_config),
+            patch.object(
+                OpenCodeServerManager,
+                "get_instance",
+                AsyncMock(return_value=server),
+            ) as get_instance,
+        ):
+            result = await service._opencode_server()
+
+        self.assertIs(result, server)
+        server.ensure_running.assert_awaited_once()
+        governor = get_instance.await_args.kwargs["resource_governor"]
+        self.assertEqual(governor.mode, "enabled")
+        self.assertEqual(governor.config["agent_group_name"], "web-oauth-agents")
+
     async def test_opencode_agent_refresh_runtime_config_does_not_restart_uncached_adopted_server_on_refresh_miss(self):
         from config.v2_compat import OpenCodeCompatConfig
         from modules.agents.opencode.agent import OpenCodeAgent

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -161,6 +161,37 @@ def test_session_handler_passes_configured_claude_cli_path(monkeypatch, tmp_path
     assert getattr(client, "_vibe_runtime_session_key") == f"slack_C123:{tmp_path}"
 
 
+def test_session_handler_moves_claude_process_into_agent_cgroup(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[int, str]] = []
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self._transport = type("Transport", (), {"_process": type("Process", (), {"pid": 9753})()})()
+
+        async def connect(self) -> None:
+            return None
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+
+    monkeypatch.setattr(
+        session_handler_module,
+        "governor_from_controller",
+        lambda _controller: type(
+            "Governor",
+            (),
+            {"apply_to_pid": lambda self, pid, label="agent": calls.append((pid, label)) or True},
+        )(),
+    )
+
+    _run_session(handler, MessageContext(user_id="U123", channel_id="C123"))
+
+    assert calls == [(9753, "claude")]
+
+
 def test_session_handler_keeps_sdk_default_for_default_claude_binary(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, Any] = {}
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2924,6 +2924,7 @@ class CodexTransportCwdStalenessTests(unittest.IsolatedAsyncioTestCase):
         agent._session_locks = {}
         agent._session_mgr = SimpleNamespace(sessions_for_cwd=lambda cwd: [])
         agent.codex_config = SimpleNamespace(binary="codex", extra_args=[])
+        agent.controller = SimpleNamespace()
         return agent
 
     async def test_server_request_refreshes_transport_activity(self):
@@ -2968,6 +2969,37 @@ class CodexTransportCwdStalenessTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(result, {"approved": True})
             self.assertEqual(agent._transport_last_activity[cwd], 999.0)
+
+    async def test_get_or_create_transport_moves_app_server_into_agent_cgroup(self):
+        import tempfile
+
+        agent = self._agent()
+        calls = []
+        agent.controller._agent_resource_governor = SimpleNamespace(
+            apply_to_pid=lambda pid, label="agent": calls.append((pid, label)) or True
+        )
+        with tempfile.TemporaryDirectory() as cwd:
+            fresh = SimpleNamespace(
+                is_initialized=True,
+                pid=2468,
+                start=AsyncMock(),
+                on_notification=Mock(),
+                on_server_request=Mock(),
+            )
+            with (
+                patch.object(_MODULE, "CodexTransport", return_value=fresh),
+                patch.object(
+                    _MODULE,
+                    "governor_from_controller",
+                    return_value=SimpleNamespace(
+                        apply_to_pid=lambda pid, label="agent": calls.append((pid, label)) or True
+                    ),
+                ),
+            ):
+                result = await agent._get_or_create_transport(cwd)
+
+            self.assertIs(result, fresh)
+            self.assertEqual(calls, [(2468, "codex app-server")])
 
     async def test_cached_transport_evicted_when_cwd_inode_changes(self):
         import tempfile

--- a/tests/test_opencode_client_manager.py
+++ b/tests/test_opencode_client_manager.py
@@ -39,5 +39,6 @@ def test_reset_config_keeps_existing_server_manager_until_refresh_completes(monk
             "binary": "/old/opencode",
             "port": 4096,
             "request_timeout_seconds": 60,
+            "resource_governor": None,
         }
     ]

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1407,6 +1407,34 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertIs(manager, first)
         self.assertIs(first.resource_governor, controller_governor)
 
+    async def test_get_instance_if_managed_server_exists_allows_controller_governor_takeover(self):
+        from core.resource_governance import mark_controller_resource_governor
+
+        ui_governor = types.SimpleNamespace(apply_to_pid=lambda pid, label="agent": True)
+        controller_governor = types.SimpleNamespace(apply_to_pid=lambda pid, label="agent": True)
+        mark_controller_resource_governor(controller_governor)
+        first = OpenCodeServerManager(
+            binary="opencode",
+            port=4096,
+            request_timeout_seconds=60,
+            resource_governor=ui_governor,
+        )
+        previous = OpenCodeServerManager._instance
+        OpenCodeServerManager._instance = first
+
+        try:
+            manager = await OpenCodeServerManager.get_instance_if_managed_server_exists(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=60,
+                resource_governor=controller_governor,
+            )
+        finally:
+            OpenCodeServerManager._instance = previous
+
+        self.assertIs(manager, first)
+        self.assertIs(first.resource_governor, controller_governor)
+
     async def test_pending_detach_defers_runtime_reload_until_old_port_cleanup(self):
         manager = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
         terminated = []

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1351,6 +1351,62 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(first.binary, "/old/opencode")
         self.assertEqual(first.port, 4096)
 
+    async def test_get_instance_preserves_controller_owned_resource_governor(self):
+        from core.resource_governance import mark_controller_resource_governor
+
+        controller_governor = types.SimpleNamespace(apply_to_pid=lambda pid, label="agent": True)
+        ui_governor = types.SimpleNamespace(apply_to_pid=lambda pid, label="agent": True)
+        mark_controller_resource_governor(controller_governor)
+        first = OpenCodeServerManager(
+            binary="opencode",
+            port=4096,
+            request_timeout_seconds=60,
+            resource_governor=controller_governor,
+        )
+        previous = OpenCodeServerManager._instance
+        OpenCodeServerManager._instance = first
+
+        try:
+            manager = await OpenCodeServerManager.get_instance(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=60,
+                resource_governor=ui_governor,
+            )
+        finally:
+            OpenCodeServerManager._instance = previous
+
+        self.assertIs(manager, first)
+        self.assertIs(first.resource_governor, controller_governor)
+
+    async def test_get_instance_allows_controller_resource_governor_to_take_over(self):
+        from core.resource_governance import mark_controller_resource_governor
+
+        ui_governor = types.SimpleNamespace(apply_to_pid=lambda pid, label="agent": True)
+        controller_governor = types.SimpleNamespace(apply_to_pid=lambda pid, label="agent": True)
+        mark_controller_resource_governor(controller_governor)
+        first = OpenCodeServerManager(
+            binary="opencode",
+            port=4096,
+            request_timeout_seconds=60,
+            resource_governor=ui_governor,
+        )
+        previous = OpenCodeServerManager._instance
+        OpenCodeServerManager._instance = first
+
+        try:
+            manager = await OpenCodeServerManager.get_instance(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=60,
+                resource_governor=controller_governor,
+            )
+        finally:
+            OpenCodeServerManager._instance = previous
+
+        self.assertIs(manager, first)
+        self.assertIs(first.resource_governor, controller_governor)
+
     async def test_pending_detach_defers_runtime_reload_until_old_port_cleanup(self):
         manager = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
         terminated = []

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1330,6 +1330,27 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(calls, [(1357, "opencode serve")])
 
+    async def test_get_instance_attaches_resource_governor_when_existing_params_differ(self):
+        first = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
+        governor = types.SimpleNamespace(apply_to_pid=lambda pid, label="agent": True)
+        previous = OpenCodeServerManager._instance
+        OpenCodeServerManager._instance = first
+
+        try:
+            manager = await OpenCodeServerManager.get_instance(
+                binary="/new/opencode",
+                port=4100,
+                request_timeout_seconds=15,
+                resource_governor=governor,
+            )
+        finally:
+            OpenCodeServerManager._instance = previous
+
+        self.assertIs(manager, first)
+        self.assertIs(first.resource_governor, governor)
+        self.assertEqual(first.binary, "/old/opencode")
+        self.assertEqual(first.port, 4096)
+
     async def test_pending_detach_defers_runtime_reload_until_old_port_cleanup(self):
         manager = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
         terminated = []

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1319,6 +1319,17 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(manager.port, 4100)
         self.assertEqual(manager.request_timeout_seconds, 15)
 
+    def test_apply_resource_governance_moves_managed_server_pid(self):
+        calls = []
+        governor = types.SimpleNamespace(
+            apply_to_pid=lambda pid, label="agent": calls.append((pid, label)) or True
+        )
+        manager = OpenCodeServerManager(binary="opencode", port=4096, resource_governor=governor)
+
+        manager._apply_resource_governance(1357)
+
+        self.assertEqual(calls, [(1357, "opencode serve")])
+
     async def test_pending_detach_defers_runtime_reload_until_old_port_cleanup(self):
         manager = OpenCodeServerManager(binary="/old/opencode", port=4096, request_timeout_seconds=60)
         terminated = []

--- a/tests/test_resource_governance.py
+++ b/tests/test_resource_governance.py
@@ -163,12 +163,15 @@ def test_governor_falls_back_when_memory_controller_is_missing(
 
     governor = AgentResourceGovernor({"mode": "auto"}, root=root, base_cgroup=base)
     group = base / "avibe-agents"
+    runtime_group = base / "avibe-runtime"
     original_mkdir = Path.mkdir
 
     def mkdir_with_minimal_files(path: Path, *args, **kwargs):
         result = original_mkdir(path, *args, **kwargs)
         if path == group:
             (group / "cgroup.procs").write_text("", encoding="utf-8")
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
         return result
 
     monkeypatch.setattr(Path, "mkdir", mkdir_with_minimal_files)
@@ -190,6 +193,72 @@ def test_governor_falls_back_when_runtime_leaf_cannot_be_created(tmp_path: Path)
 
     assert governor.apply_to_pid(4321, label="test") is False
     assert governor.group_path is None
+
+
+def test_governor_falls_back_when_subtree_control_enable_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(2 * 1024 * MIB), encoding="utf-8")
+    (base / "cgroup.controllers").write_text("memory cpu io pids\n", encoding="utf-8")
+    (base / "cgroup.subtree_control").write_text("", encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "auto"}, root=root, base_cgroup=base)
+    runtime_group = base / "avibe-runtime"
+    original_mkdir = Path.mkdir
+
+    def mkdir_with_runtime_file(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
+        return result
+
+    def fake_write_cgroup_value(path: Path, value: str) -> None:
+        if path == base / "cgroup.subtree_control":
+            raise OSError("busy")
+        path.write_text(f"{value}\n", encoding="utf-8")
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_runtime_file)
+    monkeypatch.setattr("core.resource_governance._write_cgroup_value", fake_write_cgroup_value)
+
+    assert governor.apply_to_pid(4321, label="test") is False
+    assert governor.group_path is None
+    assert not (base / "avibe-agents").exists()
+
+
+def test_governor_uses_parent_when_current_cgroup_is_runtime_leaf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    runtime_group = base / "avibe-runtime"
+    runtime_group.mkdir(parents=True)
+    (base / "memory.max").write_text(str(512 * MIB), encoding="utf-8")
+    (base / "cgroup.controllers").write_text("cpu io pids\n", encoding="utf-8")
+    (base / "cgroup.subtree_control").write_text("", encoding="utf-8")
+    (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=runtime_group)
+    group = base / "avibe-agents"
+    original_mkdir = Path.mkdir
+
+    def mkdir_with_controller_files(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == group:
+            for name in ("cpu.weight", "io.weight", "pids.max", "cgroup.procs"):
+                (group / name).write_text("", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_controller_files)
+
+    assert governor.apply_to_pid(4321, label="test") is True
+    assert governor.group_path == group
+    assert not (runtime_group / "avibe-agents").exists()
+    assert (base / "cgroup.subtree_control").read_text(encoding="utf-8") == "+cpu +io +pids\n"
 
 
 def test_governor_moves_existing_descendant_pids(

--- a/tests/test_resource_governance.py
+++ b/tests/test_resource_governance.py
@@ -1,10 +1,13 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, V2Config
 from core.resource_governance import (
     MIB,
     AgentResourceGovernor,
+    config_from_controller,
     derive_agent_limits,
     tenant_memory_limit_bytes,
 )
@@ -51,6 +54,28 @@ def test_tenant_memory_limit_walks_to_parent_cap(tmp_path: Path) -> None:
     (child / "memory.max").write_text("max\n", encoding="utf-8")
 
     assert tenant_memory_limit_bytes(child, root) == 2 * 1024 * MIB
+
+
+def test_config_from_controller_reads_v2_runtime_resource_governance() -> None:
+    v2_config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(),
+        agents=AgentsConfig(),
+        runtime=RuntimeConfig(
+            default_cwd=".",
+            resource_governance={
+                "mode": "disabled",
+                "agent_group_name": "custom-agents",
+            },
+        ),
+    )
+    controller = SimpleNamespace(config=v2_config)
+
+    assert config_from_controller(controller) == {
+        "mode": "disabled",
+        "agent_group_name": "custom-agents",
+    }
 
 
 def test_governor_disabled_mode_does_not_create_group(tmp_path: Path) -> None:
@@ -138,6 +163,7 @@ def test_governor_configures_group_and_moves_pid(tmp_path: Path, monkeypatch: py
         path.write_text(f"{value}\n", encoding="utf-8")
 
     monkeypatch.setattr("core.resource_governance._write_cgroup_value", fake_write_cgroup_value)
+    monkeypatch.setattr("core.resource_governance._runtime_process_tree_pids", lambda pid=None: {1001, 1002})
 
     assert governor.apply_to_pid(4321, label="test") is True
 
@@ -193,6 +219,39 @@ def test_governor_falls_back_when_runtime_leaf_cannot_be_created(tmp_path: Path)
 
     assert governor.apply_to_pid(4321, label="test") is False
     assert governor.group_path is None
+
+
+def test_governor_falls_back_when_base_has_foreign_member_pids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(512 * MIB), encoding="utf-8")
+    (base / "cgroup.procs").write_text("1001\n2002\n", encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "auto"}, root=root, base_cgroup=base)
+    runtime_group = base / "avibe-runtime"
+    original_mkdir = Path.mkdir
+    writes: list[str] = []
+
+    def mkdir_with_runtime_file(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_runtime_file)
+    monkeypatch.setattr("core.resource_governance._runtime_process_tree_pids", lambda pid=None: {1001})
+    monkeypatch.setattr(
+        "core.resource_governance._write_cgroup_value",
+        lambda path, value: writes.append(value),
+    )
+
+    assert governor.apply_to_pid(4321, label="test") is False
+    assert governor.group_path is None
+    assert writes == []
 
 
 def test_governor_falls_back_when_subtree_control_enable_fails(

--- a/tests/test_resource_governance.py
+++ b/tests/test_resource_governance.py
@@ -20,8 +20,8 @@ def test_derive_agent_limits_uses_single_aggregate_budget() -> None:
 
     assert limits.memory_max == 2785 * MIB
     assert limits.memory_high == 2367 * MIB
-    assert limits.cpu_weight == 150
-    assert limits.io_weight == 100
+    assert limits.cpu_weight == 50
+    assert limits.io_weight == 50
     assert limits.pids_max == 512
 
 
@@ -184,8 +184,8 @@ def test_governor_configures_group_and_moves_pid(tmp_path: Path, monkeypatch: py
     assert (group / "memory.max").read_text(encoding="utf-8").strip() == str(1382 * MIB)
     assert (group / "memory.high").read_text(encoding="utf-8").strip() == str(1174 * MIB)
     assert (group / "memory.oom.group").read_text(encoding="utf-8").strip() == "1"
-    assert (group / "cpu.weight").read_text(encoding="utf-8").strip() == "150"
-    assert (group / "io.weight").read_text(encoding="utf-8").strip() == "default 100"
+    assert (group / "cpu.weight").read_text(encoding="utf-8").strip() == "50"
+    assert (group / "io.weight").read_text(encoding="utf-8").strip() == "default 50"
     assert (group / "pids.max").read_text(encoding="utf-8").strip() == "512"
 
 
@@ -263,6 +263,60 @@ def test_governor_falls_back_when_base_has_foreign_member_pids(
     assert governor.apply_to_pid(4321, label="test") is False
     assert governor.group_path is None
     assert writes == []
+
+
+def test_governor_allows_known_agent_pids_during_base_migration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(512 * MIB), encoding="utf-8")
+    (base / "cgroup.procs").write_text("1001\n5001\n5002\n", encoding="utf-8")
+    (base / "cgroup.controllers").write_text("cpu io pids\n", encoding="utf-8")
+    (base / "cgroup.subtree_control").write_text("", encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
+    group = base / "avibe-agents"
+    runtime_group = base / "avibe-runtime"
+    original_mkdir = Path.mkdir
+    runtime_writes: list[str] = []
+    agent_writes: list[str] = []
+
+    def mkdir_with_controller_files(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == group:
+            for name in ("cpu.weight", "io.weight", "pids.max", "cgroup.procs"):
+                (group / name).write_text("", encoding="utf-8")
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
+        return result
+
+    def fake_write_cgroup_value(path: Path, value: str) -> None:
+        if path == runtime_group / "cgroup.procs":
+            runtime_writes.append(value)
+        elif path == group / "cgroup.procs":
+            agent_writes.append(value)
+        else:
+            path.write_text(f"{value}\n", encoding="utf-8")
+            return
+        remaining = [pid for pid in _base_members() if pid != value]
+        (base / "cgroup.procs").write_text("\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8")
+
+    def _base_members() -> list[str]:
+        text = (base / "cgroup.procs").read_text(encoding="utf-8")
+        return [pid for pid in text.split() if pid]
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_controller_files)
+    monkeypatch.setattr("core.resource_governance._runtime_process_tree_pids", lambda pid=None: {1001})
+    monkeypatch.setattr("core.resource_governance._descendant_pids", lambda pid: [5002])
+    monkeypatch.setattr("core.resource_governance._write_cgroup_value", fake_write_cgroup_value)
+
+    assert governor.apply_to_pid(5001, label="test") is True
+    assert runtime_writes == ["1001"]
+    assert agent_writes == ["5001", "5002", "5001", "5002"]
+    assert governor.group_path == group
 
 
 def test_governor_falls_back_when_subtree_control_enable_fails(

--- a/tests/test_resource_governance.py
+++ b/tests/test_resource_governance.py
@@ -70,6 +70,7 @@ def test_governor_update_config_resets_cached_group(tmp_path: Path, monkeypatch:
 
     governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
     group = base / "avibe-agents"
+    runtime_group = base / "avibe-runtime"
     original_mkdir = Path.mkdir
 
     def mkdir_with_controller_files(path: Path, *args, **kwargs):
@@ -77,6 +78,8 @@ def test_governor_update_config_resets_cached_group(tmp_path: Path, monkeypatch:
         if path == group:
             for name in ("cpu.weight", "io.weight", "pids.max", "cgroup.procs"):
                 (group / name).write_text("", encoding="utf-8")
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
         return result
 
     monkeypatch.setattr(Path, "mkdir", mkdir_with_controller_files)
@@ -98,10 +101,13 @@ def test_governor_configures_group_and_moves_pid(tmp_path: Path, monkeypatch: py
     (base / "memory.max").write_text(str(2 * 1024 * MIB), encoding="utf-8")
     (base / "cgroup.controllers").write_text("memory cpu io pids\n", encoding="utf-8")
     (base / "cgroup.subtree_control").write_text("", encoding="utf-8")
+    (base / "cgroup.procs").write_text("1001\n1002\n", encoding="utf-8")
 
     governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
     group = base / "avibe-agents"
+    runtime_group = base / "avibe-runtime"
     original_mkdir = Path.mkdir
+    runtime_writes: list[str] = []
 
     def mkdir_with_controller_files(path: Path, *args, **kwargs):
         result = original_mkdir(path, *args, **kwargs)
@@ -116,12 +122,26 @@ def test_governor_configures_group_and_moves_pid(tmp_path: Path, monkeypatch: py
                 "cgroup.procs",
             ):
                 (group / name).write_text("", encoding="utf-8")
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
         return result
 
     monkeypatch.setattr(Path, "mkdir", mkdir_with_controller_files)
 
+    def fake_write_cgroup_value(path: Path, value: str) -> None:
+        if path == runtime_group / "cgroup.procs":
+            runtime_writes.append(value)
+            if value in {"1001", "1002"}:
+                remaining = "1002\n" if value == "1001" else ""
+                (base / "cgroup.procs").write_text(remaining, encoding="utf-8")
+            return
+        path.write_text(f"{value}\n", encoding="utf-8")
+
+    monkeypatch.setattr("core.resource_governance._write_cgroup_value", fake_write_cgroup_value)
+
     assert governor.apply_to_pid(4321, label="test") is True
 
+    assert runtime_writes == ["1001", "1002"]
     assert (base / "cgroup.subtree_control").read_text(encoding="utf-8") == "+memory +cpu +io +pids\n"
     assert (group / "cgroup.procs").read_text(encoding="utf-8") == "4321\n"
     assert (group / "memory.max").read_text(encoding="utf-8").strip() == str(1382 * MIB)
@@ -157,6 +177,21 @@ def test_governor_falls_back_when_memory_controller_is_missing(
     assert governor.group_path is None
 
 
+def test_governor_falls_back_when_runtime_leaf_cannot_be_created(tmp_path: Path) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(2 * 1024 * MIB), encoding="utf-8")
+    (base / "cgroup.controllers").write_text("memory cpu io pids\n", encoding="utf-8")
+    (base / "cgroup.subtree_control").write_text("", encoding="utf-8")
+    (base / "cgroup.procs").write_text("1001\n", encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "auto"}, root=root, base_cgroup=base)
+
+    assert governor.apply_to_pid(4321, label="test") is False
+    assert governor.group_path is None
+
+
 def test_governor_moves_existing_descendant_pids(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -168,6 +203,7 @@ def test_governor_moves_existing_descendant_pids(
 
     governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
     group = base / "avibe-agents"
+    runtime_group = base / "avibe-runtime"
     original_mkdir = Path.mkdir
     writes: list[str] = []
 
@@ -176,6 +212,8 @@ def test_governor_moves_existing_descendant_pids(
         if path == group:
             for name in ("cpu.weight", "io.weight", "pids.max", "cgroup.procs"):
                 (group / name).write_text("", encoding="utf-8")
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
         return result
 
     def fake_write_cgroup_value(path: Path, value: str) -> None:

--- a/tests/test_resource_governance.py
+++ b/tests/test_resource_governance.py
@@ -9,6 +9,8 @@ from core.resource_governance import (
     AgentResourceGovernor,
     config_from_controller,
     derive_agent_limits,
+    is_controller_resource_governor,
+    governor_from_controller,
     tenant_memory_limit_bytes,
 )
 
@@ -76,6 +78,15 @@ def test_config_from_controller_reads_v2_runtime_resource_governance() -> None:
         "mode": "disabled",
         "agent_group_name": "custom-agents",
     }
+
+
+def test_governor_from_controller_marks_long_lived_governor() -> None:
+    controller = SimpleNamespace(config=SimpleNamespace(resource_governance={"mode": "auto"}))
+
+    governor = governor_from_controller(controller)
+
+    assert is_controller_resource_governor(governor) is True
+    assert governor_from_controller(controller) is governor
 
 
 def test_governor_disabled_mode_does_not_create_group(tmp_path: Path) -> None:

--- a/tests/test_resource_governance.py
+++ b/tests/test_resource_governance.py
@@ -1,0 +1,192 @@
+from pathlib import Path
+
+import pytest
+
+from core.resource_governance import (
+    MIB,
+    AgentResourceGovernor,
+    derive_agent_limits,
+    tenant_memory_limit_bytes,
+)
+
+
+def test_derive_agent_limits_uses_single_aggregate_budget() -> None:
+    limits = derive_agent_limits(4 * 1024 * MIB)
+
+    assert limits.memory_max == 2785 * MIB
+    assert limits.memory_high == 2367 * MIB
+    assert limits.cpu_weight == 150
+    assert limits.io_weight == 100
+    assert limits.pids_max == 512
+
+
+def test_derive_agent_limits_honors_explicit_bytes() -> None:
+    limits = derive_agent_limits(
+        8 * 1024 * MIB,
+        {
+            "agent_memory_max_bytes": 1536 * MIB,
+            "agent_memory_high_bytes": 1200 * MIB,
+            "agent_cpu_weight": 250,
+            "agent_io_weight": 200,
+            "agent_pids_max": 1024,
+            "agent_oom_score_adj": 650,
+        },
+    )
+
+    assert limits.memory_max == 1536 * MIB
+    assert limits.memory_high == 1200 * MIB
+    assert limits.cpu_weight == 250
+    assert limits.io_weight == 200
+    assert limits.pids_max == 1024
+    assert limits.oom_score_adj == 650
+
+
+def test_tenant_memory_limit_walks_to_parent_cap(tmp_path: Path) -> None:
+    root = tmp_path / "cgroup"
+    child = root / "service" / "worker"
+    child.mkdir(parents=True)
+    (root / "memory.max").write_text("max\n", encoding="utf-8")
+    (root / "service").mkdir(exist_ok=True)
+    (root / "service" / "memory.max").write_text(str(2 * 1024 * MIB), encoding="utf-8")
+    (child / "memory.max").write_text("max\n", encoding="utf-8")
+
+    assert tenant_memory_limit_bytes(child, root) == 2 * 1024 * MIB
+
+
+def test_governor_disabled_mode_does_not_create_group(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+    governor = AgentResourceGovernor({"mode": "disabled"}, root=tmp_path, base_cgroup=base)
+
+    assert governor.apply_to_pid(123, label="test") is False
+    assert not (base / "avibe-agents").exists()
+
+
+def test_governor_update_config_resets_cached_group(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(512 * MIB), encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
+    group = base / "avibe-agents"
+    original_mkdir = Path.mkdir
+
+    def mkdir_with_controller_files(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == group:
+            for name in ("cpu.weight", "io.weight", "pids.max", "cgroup.procs"):
+                (group / name).write_text("", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_controller_files)
+
+    assert governor.apply_to_pid(4321, label="test") is True
+    assert governor.group_path == group
+
+    governor.update_config({"mode": "disabled"})
+
+    assert governor.group_path is None
+    assert governor.apply_to_pid(4322, label="test") is False
+
+
+def test_governor_configures_group_and_moves_pid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (root / "memory.max").write_text("max\n", encoding="utf-8")
+    (base / "memory.max").write_text(str(2 * 1024 * MIB), encoding="utf-8")
+    (base / "cgroup.controllers").write_text("memory cpu io pids\n", encoding="utf-8")
+    (base / "cgroup.subtree_control").write_text("", encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
+    group = base / "avibe-agents"
+    original_mkdir = Path.mkdir
+
+    def mkdir_with_controller_files(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == group:
+            for name in (
+                "memory.high",
+                "memory.max",
+                "memory.oom.group",
+                "cpu.weight",
+                "io.weight",
+                "pids.max",
+                "cgroup.procs",
+            ):
+                (group / name).write_text("", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_controller_files)
+
+    assert governor.apply_to_pid(4321, label="test") is True
+
+    assert (base / "cgroup.subtree_control").read_text(encoding="utf-8") == "+memory +cpu +io +pids\n"
+    assert (group / "cgroup.procs").read_text(encoding="utf-8") == "4321\n"
+    assert (group / "memory.max").read_text(encoding="utf-8").strip() == str(1382 * MIB)
+    assert (group / "memory.high").read_text(encoding="utf-8").strip() == str(1174 * MIB)
+    assert (group / "memory.oom.group").read_text(encoding="utf-8").strip() == "1"
+    assert (group / "cpu.weight").read_text(encoding="utf-8").strip() == "150"
+    assert (group / "io.weight").read_text(encoding="utf-8").strip() == "default 100"
+    assert (group / "pids.max").read_text(encoding="utf-8").strip() == "512"
+
+
+def test_governor_falls_back_when_memory_controller_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(2 * 1024 * MIB), encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "auto"}, root=root, base_cgroup=base)
+    group = base / "avibe-agents"
+    original_mkdir = Path.mkdir
+
+    def mkdir_with_minimal_files(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == group:
+            (group / "cgroup.procs").write_text("", encoding="utf-8")
+        return result
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_minimal_files)
+
+    assert governor.apply_to_pid(4321, label="test") is False
+    assert governor.group_path is None
+
+
+def test_governor_moves_existing_descendant_pids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(512 * MIB), encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
+    group = base / "avibe-agents"
+    original_mkdir = Path.mkdir
+    writes: list[str] = []
+
+    def mkdir_with_controller_files(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == group:
+            for name in ("cpu.weight", "io.weight", "pids.max", "cgroup.procs"):
+                (group / name).write_text("", encoding="utf-8")
+        return result
+
+    def fake_write_cgroup_value(path: Path, value: str) -> None:
+        if path == group / "cgroup.procs":
+            writes.append(value)
+            return
+        path.write_text(f"{value}\n", encoding="utf-8")
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_controller_files)
+    monkeypatch.setattr("core.resource_governance._descendant_pids", lambda pid: [5002, 5003])
+    monkeypatch.setattr("core.resource_governance._write_cgroup_value", fake_write_cgroup_value)
+
+    assert governor.apply_to_pid(5001, label="test") is True
+    assert writes == ["5001", "5002", "5003"]

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -107,6 +107,127 @@ def test_opencode_options_closes_server_http_session(monkeypatch):
     assert fake_manager.closed_loop is not None
 
 
+def test_opencode_options_passes_resource_governor_from_v2_runtime(monkeypatch):
+    import config.v2_compat as v2_compat
+    import modules.agents.opencode as opencode_module
+
+    captured_kwargs = {}
+
+    class _FakeManager:
+        async def ensure_running(self):
+            return "http://127.0.0.1:4096"
+
+        async def get_available_agents(self, directory):
+            return []
+
+        async def get_available_models(self, directory):
+            return {"providers": []}
+
+        async def get_providers(self):
+            return {"all": [], "connected": []}
+
+        async def get_default_config(self, directory):
+            return {}
+
+        async def close_http_session(self, *, loop=None):
+            pass
+
+    class _FakeServerManager:
+        @staticmethod
+        async def get_instance(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _FakeManager()
+
+    v2_config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(),
+        agents=AgentsConfig(),
+        runtime=RuntimeConfig(
+            default_cwd=".",
+            resource_governance={
+                "mode": "enabled",
+                "agent_group_name": "ui-agents",
+            },
+        ),
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {})
+    monkeypatch.setattr(api.V2Config, "load", staticmethod(lambda: v2_config))
+    monkeypatch.setattr(
+        v2_compat,
+        "to_app_config",
+        lambda config: SimpleNamespace(
+            opencode=SimpleNamespace(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=10,
+            )
+        ),
+    )
+    monkeypatch.setattr(opencode_module, "OpenCodeServerManager", _FakeServerManager)
+    monkeypatch.setattr(
+        opencode_module,
+        "build_reasoning_effort_options",
+        lambda models, model_key: [{"value": "__default__"}],
+    )
+
+    result = asyncio.run(api.opencode_options_async("~/workspace"))
+
+    assert result["ok"] is True
+    governor = captured_kwargs["resource_governor"]
+    assert governor.mode == "enabled"
+    assert governor.config["agent_group_name"] == "ui-agents"
+
+
+def test_opencode_get_server_passes_resource_governor_from_v2_runtime(monkeypatch):
+    import config.v2_compat as v2_compat
+    import modules.agents.opencode as opencode_module
+
+    captured_kwargs = {}
+    fake_manager = SimpleNamespace(ensure_running=AsyncMock())
+
+    class _FakeServerManager:
+        @staticmethod
+        async def get_instance(**kwargs):
+            captured_kwargs.update(kwargs)
+            return fake_manager
+
+    v2_config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(),
+        agents=AgentsConfig(),
+        runtime=RuntimeConfig(
+            default_cwd=".",
+            resource_governance={
+                "mode": "enabled",
+                "agent_group_name": "provider-ui-agents",
+            },
+        )
+    )
+    monkeypatch.setattr(api.V2Config, "load", staticmethod(lambda: v2_config))
+    monkeypatch.setattr(
+        v2_compat,
+        "to_app_config",
+        lambda config: SimpleNamespace(
+            opencode=SimpleNamespace(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=10,
+            )
+        ),
+    )
+    monkeypatch.setattr(opencode_module, "OpenCodeServerManager", _FakeServerManager)
+
+    server = asyncio.run(api._opencode_get_server())
+
+    assert server is fake_manager
+    fake_manager.ensure_running.assert_awaited_once()
+    governor = captured_kwargs["resource_governor"]
+    assert governor.mode == "enabled"
+    assert governor.config["agent_group_name"] == "provider-ui-agents"
+
+
 def test_opencode_options_filters_unconfigured_provider_models(monkeypatch, tmp_path):
     import config.v2_compat as v2_compat
     import modules.agents.opencode as opencode_module

--- a/tests/test_v2_config_platform_registry.py
+++ b/tests/test_v2_config_platform_registry.py
@@ -73,6 +73,24 @@ def test_setup_state_uses_setup_completed_flag() -> None:
     assert config.setup_state()["needs_setup"] is False
 
 
+def test_runtime_resource_governance_round_trips_through_payload() -> None:
+    config = _base_config(
+        runtime=RuntimeConfig(
+            default_cwd=".",
+            resource_governance={
+                "mode": "enabled",
+                "agent_memory_max_bytes": 1536 * 1024 * 1024,
+            },
+        )
+    )
+
+    payload = api.config_to_payload(config, include_secrets=True)
+    restored = V2Config.from_payload(payload)
+
+    assert payload["runtime"]["resource_governance"]["mode"] == "enabled"
+    assert restored.runtime.resource_governance == config.runtime.resource_governance
+
+
 def test_from_payload_migrates_legacy_setup_completed_true() -> None:
     # A payload that predates the flag (no ``setup_completed`` key) but has a
     # mode plus a credentialed enabled platform migrates to completed=True.

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3232,12 +3232,14 @@ async def opencode_options_async(cwd: str) -> dict:
     server = None
     try:
         from config.v2_compat import to_app_config
+        from core.resource_governance import AgentResourceGovernor, config_from_runtime
         from modules.agents.opencode import (
             OpenCodeServerManager,
             build_reasoning_effort_options,
         )
 
-        config = to_app_config(V2Config.load())
+        v2_config = V2Config.load()
+        config = to_app_config(v2_config)
         if not config.opencode:
             return {"ok": False, "error": "opencode disabled"}
         opencode_config = config.opencode
@@ -3269,6 +3271,7 @@ async def opencode_options_async(cwd: str) -> dict:
             binary=opencode_config.binary,
             port=opencode_config.port,
             request_timeout_seconds=opencode_config.request_timeout_seconds,
+            resource_governor=AgentResourceGovernor(config_from_runtime(v2_config)),
         )
         await asyncio.wait_for(server.ensure_running(), timeout=timeout_seconds)
         agents = await asyncio.wait_for(server.get_available_agents(expanded_cwd), timeout=timeout_seconds)
@@ -7535,9 +7538,11 @@ async def _opencode_get_server():
     into a UI-friendly error.
     """
     from config.v2_compat import to_app_config
+    from core.resource_governance import AgentResourceGovernor, config_from_runtime
     from modules.agents.opencode import OpenCodeServerManager
 
-    config = to_app_config(V2Config.load())
+    v2_config = V2Config.load()
+    config = to_app_config(v2_config)
     if not config.opencode:
         return None
     opencode_config = config.opencode
@@ -7545,6 +7550,7 @@ async def _opencode_get_server():
         binary=opencode_config.binary,
         port=opencode_config.port,
         request_timeout_seconds=opencode_config.request_timeout_seconds,
+        resource_governor=AgentResourceGovernor(config_from_runtime(v2_config)),
     )
     await server.ensure_running()
     return server

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -950,6 +950,7 @@ def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dic
         "runtime": {
             "default_cwd": config.runtime.default_cwd,
             "log_level": config.runtime.log_level,
+            "resource_governance": config.runtime.resource_governance,
         },
         "agents": {
             "opencode": config.agents.opencode.__dict__,


### PR DESCRIPTION
## Summary

Implements the first MVP for issue #738: Avibe now has a best-effort Linux/cgroup v2 agent resource governor that places aggregate agent backend work into a shared constrained `avibe-agents` cgroup when the runtime environment supports it.

This PR deliberately does not claim full liveness protection yet. It confines agent workload where possible and falls back to legacy startup on unsupported or non-delegated systems.

## What changed

- Adds `runtime.resource_governance` to v2 config and API payloads, defaulting to `mode: auto`.
- Adds `core.resource_governance` to derive aggregate agent-domain limits from the tenant memory budget and configure a shared cgroup with memory, CPU, IO, PID, OOM-group, and oom-score controls.
- Hooks the governor into the backend runtime roots:
  - Claude SDK CLI process after connect
  - Codex `app-server`
  - OpenCode `serve`, including adopted managed servers
- Moves already-existing descendant PIDs when the backend root is moved, so early shell/tool subprocesses are captured best-effort.
- Adds a short plan document describing the MVP boundary and follow-ups.

## Boundaries

- This is the constrained agent-domain MVP only.
- Protected Avibe liveness-domain settings such as `MemoryLow`, high service `CPUWeight`, protected IO latency, and negative service `OOMScoreAdjust` remain follow-up work.
- Tenant-wide agent turn admission control and Incus pressure regression are also follow-ups.
- If cgroup v2 or delegated controllers are unavailable, the runtime logs the unavailability and keeps starting agents normally.

## Evidence

- Unit: `tests/test_resource_governance.py`
- Integration-adjacent backend spawn hooks: Codex/OpenCode/Claude focused tests
- Config/API compatibility: v2 config payload round-trip tests

Validation run locally:

- `PYTHONPATH=. python3 -m pytest tests/test_resource_governance.py tests/test_agent_auth_service.py tests/test_v2_config_platform_registry.py tests/test_codex_agent.py::CodexTransportCwdStalenessTests tests/test_opencode_server.py::OpenCodeServerTests tests/test_claude_cli_path.py::test_session_handler_moves_claude_process_into_agent_cgroup -q`
- `PYTHONPATH=. uv run ruff check core/resource_governance.py core/controller.py config/v2_config.py config/v2_compat.py core/agent_auth_service.py core/handlers/session_handler.py modules/agents/codex/agent.py modules/agents/opencode/agent.py modules/agents/opencode/client_manager.py modules/agents/opencode/server.py vibe/api.py tests/test_resource_governance.py tests/test_agent_auth_service.py tests/test_v2_config_platform_registry.py tests/test_codex_agent.py tests/test_opencode_server.py tests/test_claude_cli_path.py`

## Notes

I attempted the required pre-PR reviewer run through Avibe Harness, but the spawned reviewer sessions failed before producing messages/events. No review findings were available from those runs.

Fixes #738
