### PR TITLE
fix(im): default progress display to off

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -74,6 +74,7 @@ DEFAULT_OPENCODE_ERROR_RETRY_LIMIT = 1
 DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX = 14
 MIN_CHAT_MESSAGE_FONT_SIZE_PX = 12
 MAX_CHAT_MESSAGE_FONT_SIZE_PX = 20
+DEFAULT_AGENT_PROGRESS_STYLE = "off"
 
 
 def _filter_dataclass_fields(dc_class, payload: dict) -> dict:
@@ -427,10 +428,10 @@ class V2Config:
     reply_enhancements: bool = True  # Enable quick-reply buttons
     show_pages_prompt: bool = True  # Inject Show Pages capability guidance into agent prompts
     language: str = "en"  # Global language setting (see vibe/i18n)
-    # Concise status-bubble UX for editing platforms (Slack/Discord):
-    #   "concise" (default) one self-updating bubble that becomes the result,
-    #   "verbose" legacy append/split process log, "off" no process bubble.
-    agent_progress_style: str = "concise"
+    # Progress UX for editing platforms (Slack/Discord):
+    #   "off" (default) no process bubble, "concise" one self-updating bubble,
+    #   "verbose" legacy append/split process log.
+    agent_progress_style: str = DEFAULT_AGENT_PROGRESS_STYLE
     agent_status_heartbeat_ms: int = 15000  # status-bubble elapsed-timer heartbeat
     agent_status_no_output_ms: int = 180000  # "no output for N min" hint threshold
     # True once the user has finished the setup wizard. This is the explicit
@@ -639,9 +640,9 @@ class V2Config:
 
         language = normalize_language(payload.get("language"), default="en")
 
-        agent_progress_style = payload.get("agent_progress_style", "concise")
+        agent_progress_style = payload.get("agent_progress_style", DEFAULT_AGENT_PROGRESS_STYLE)
         if agent_progress_style not in ("concise", "verbose", "off"):
-            agent_progress_style = "concise"
+            agent_progress_style = DEFAULT_AGENT_PROGRESS_STYLE
 
         def _positive_int(value, default, maximum):
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0 or value > maximum:

--- a/core/controller.py
+++ b/core/controller.py
@@ -8,7 +8,7 @@ import threading
 from typing import Optional, Dict, Any
 from config import paths
 from config.platform_registry import get_platform_descriptor
-from config.v2_config import DEFAULT_AGENT_BACKEND, DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
+from config.v2_config import DEFAULT_AGENT_BACKEND, DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS, DEFAULT_AGENT_PROGRESS_STYLE
 from modules.im import BaseIMClient, MessageContext, IMFactory
 from modules.im.multi import MultiIMClient
 from modules.agent_router import AgentRouter
@@ -903,8 +903,8 @@ class Controller:
         Currently a global config setting; per-channel overrides can layer on top
         here later without touching the dispatcher.
         """
-        value = getattr(self.config, "agent_progress_style", "concise")
-        return value if value in ("concise", "verbose", "off") else "concise"
+        value = getattr(self.config, "agent_progress_style", DEFAULT_AGENT_PROGRESS_STYLE)
+        return value if value in ("concise", "verbose", "off") else DEFAULT_AGENT_PROGRESS_STYLE
 
     def uses_concise_status_bubble(self, context: MessageContext) -> bool:
         """True when this turn renders a concise status bubble (Slack/Discord +

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 from urllib.parse import urljoin
 
 from config.platform_registry import get_platform_descriptor
+from config.v2_config import DEFAULT_AGENT_PROGRESS_STYLE
 from modules.im import MessageContext
 from modules.im.formatters.base_formatter import to_status_label
 from core.message_mirror import persist_agent_message
@@ -304,10 +305,9 @@ class ConsolidatedMessageDispatcher:
     def _progress_style(self, context: MessageContext) -> str:
         """Resolve the per-channel progress style: ``concise`` | ``verbose`` | ``off``.
 
-        Defaults to ``concise`` (the locked default for editing platforms). A
+        Defaults to ``off`` unless config explicitly enables progress display. A
         controller may expose ``get_progress_style_for_context`` once the
-        settings/UI plumbing lands; until then this returns the default and the
-        feature degrades to existing behavior only via ``_concise_progress_style``.
+        settings/UI plumbing lands; until then this returns the default.
         """
         getter = getattr(self.controller, "get_progress_style_for_context", None)
         if callable(getter):
@@ -316,8 +316,8 @@ class ConsolidatedMessageDispatcher:
                 if value in {"concise", "verbose", "off"}:
                     return value
             except Exception:
-                logger.debug("get_progress_style_for_context failed; defaulting concise", exc_info=True)
-        return "concise"
+                logger.debug("get_progress_style_for_context failed; defaulting off", exc_info=True)
+        return DEFAULT_AGENT_PROGRESS_STYLE
 
     def _concise_progress_style(self, context: MessageContext) -> str:
         """Effective progress style for the process-message path.

--- a/tests/test_message_dispatcher_status_bubble.py
+++ b/tests/test_message_dispatcher_status_bubble.py
@@ -71,7 +71,7 @@ class _EditClient:
 
 
 class _StubController:
-    def __init__(self, *, platform="slack", im_client=None, progress_style=None, backend_alive=None):
+    def __init__(self, *, platform="slack", im_client=None, progress_style="concise", backend_alive=None):
         self.config = type(
             "Config", (), {"platform": platform, "language": "en", "reply_enhancements": False}
         )()
@@ -113,6 +113,11 @@ def _dispatcher(controller, *, now=1000.0, disable_heartbeat=True):
 
 
 class StatusBubbleProcessTests(unittest.IsolatedAsyncioTestCase):
+    async def test_missing_progress_getter_defaults_off(self):
+        controller = object()
+        d = ConsolidatedMessageDispatcher(controller)
+        self.assertEqual(d._progress_style(_ctx()), "off")
+
     async def test_process_messages_replace_in_one_bubble(self):
         controller = _StubController(platform="slack")
         d = _dispatcher(controller)

--- a/tests/test_status_bubble_settings.py
+++ b/tests/test_status_bubble_settings.py
@@ -28,7 +28,7 @@ def _payload(**extra):
 class ConfigParsingTests(unittest.TestCase):
     def test_defaults(self):
         cfg = V2Config.from_payload(_payload())
-        self.assertEqual(cfg.agent_progress_style, "concise")
+        self.assertEqual(cfg.agent_progress_style, "off")
         self.assertEqual(cfg.agent_status_heartbeat_ms, 15000)
         self.assertEqual(cfg.agent_status_no_output_ms, 180000)
 
@@ -52,7 +52,7 @@ class ConfigParsingTests(unittest.TestCase):
                 agent_status_no_output_ms="nope",
             )
         )
-        self.assertEqual(cfg.agent_progress_style, "concise")
+        self.assertEqual(cfg.agent_progress_style, "off")
         self.assertEqual(cfg.agent_status_heartbeat_ms, 15000)
         self.assertEqual(cfg.agent_status_no_output_ms, 180000)
 
@@ -95,7 +95,7 @@ class ControllerGetterTests(unittest.TestCase):
 
     def test_progress_style_getter_guards_bad_value(self):
         fake = self._fake(agent_progress_style="bogus")
-        self.assertEqual(Controller.get_progress_style_for_context(fake, None), "concise")
+        self.assertEqual(Controller.get_progress_style_for_context(fake, None), "off")
 
     def test_interval_getters(self):
         fake = self._fake(agent_status_heartbeat_ms=9000, agent_status_no_output_ms=45000)

--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -121,9 +121,9 @@ export const SettingsMessagingPage: React.FC = () => {
     { value: 'message', label: t('dashboard.ackMessage'), disabled: false },
   ];
   const progressStyleOptions = [
+    { value: 'off', label: t('dashboard.agentProgressStyleOff') },
     { value: 'concise', label: t('dashboard.agentProgressStyleConcise') },
     { value: 'verbose', label: t('dashboard.agentProgressStyleVerbose') },
-    { value: 'off', label: t('dashboard.agentProgressStyleOff') },
   ];
   const includeTimeInfoEnabled = config.include_time_info !== false;
   const audioAsr = config.audio_asr || {};
@@ -337,11 +337,11 @@ export const SettingsMessagingPage: React.FC = () => {
           description={t('dashboard.agentProgressStyleHint')}
           control={
             <CompactSelect
-              value={config.agent_progress_style || 'concise'}
+              value={config.agent_progress_style || 'off'}
               onChange={(event) =>
                 void persist({
                   ...config,
-                  agent_progress_style: event.target.value || 'concise',
+                  agent_progress_style: event.target.value || 'off',
                 })
               }
               className="w-40"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1568,7 +1568,7 @@
     "showPagesPrompt": "Show Page Guidance",
     "showPagesPromptHint": "Tell agents when and how to use visual Show Pages. The vibe show CLI remains available when this is off.",
     "agentProgressStyle": "Progress display (Slack/Discord)",
-    "agentProgressStyleHint": "How agent progress is shown: a single concise status bubble that becomes the result, the verbose process log, or off.",
+    "agentProgressStyleHint": "How agent progress is shown: off, a single concise status bubble that becomes the result, or the verbose process log.",
     "agentProgressStyleConcise": "Concise",
     "agentProgressStyleVerbose": "Verbose",
     "agentProgressStyleOff": "Off",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1568,7 +1568,7 @@
     "showPagesPrompt": "Show Page 引导",
     "showPagesPromptHint": "提示 Agent 何时以及如何使用可视化 Show Page。关闭后 vibe show CLI 仍然可用。",
     "agentProgressStyle": "进度显示（Slack/Discord）",
-    "agentProgressStyleHint": "Agent 进度的呈现方式：精简状态条(最终变成结果) / 详细过程日志 / 关闭。",
+    "agentProgressStyleHint": "Agent 进度的呈现方式：关闭 / 精简状态条(最终变成结果) / 详细过程日志。",
     "agentProgressStyleConcise": "精简",
     "agentProgressStyleVerbose": "详细",
     "agentProgressStyleOff": "关闭",


### PR DESCRIPTION
## Summary
- Default Slack/Discord progress display to `off` when the config is missing or invalid.
- Keep explicit `concise` and `verbose` selections working, including UI saves.
- Make the Messaging settings dropdown and helper copy lead with Off.

## Evidence
- Unit: `python3 -m pytest tests/test_status_bubble_settings.py tests/test_status_bubble_indicator.py tests/test_message_dispatcher_status_bubble.py tests/test_api_save_config_merge.py -q`
- Contract: config parsing, controller getter, and dispatcher fallback tests cover missing/invalid values and explicit overrides.
- Scenario: settings UI now renders missing `agent_progress_style` as Off and saves Off when the select has no value.
- Residual manual checks: UI build only; no live Slack/Discord regression run for this default-only change.

## Notes
Current PyPI release `3.0.4` and tag `v3.0.4` do not include `agent_progress_style`, so this only changes the unreleased feature default.
