### PR TITLE
fix(session): make title prompt actionable

### DIFF
--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -220,13 +220,13 @@ Treat these as the user pointing at that Agent or Session, and decide the action
 _SESSION_TITLE_PROMPT = """\
 
 ## Session Title
-When the topic of this Web conversation is clear, you may silently set one concise, human-scannable title for the current Session once. Before setting it, inspect the Session:
+When the topic of this Web conversation becomes clear, set one concise, human-scannable title for the current Session. Do this silently as soon as the title is obvious, without waiting for the user to ask. Before setting it, inspect the Session:
 `vibe session get`
 
 If `metadata.title_source` is `user` or `agent`, leave the title unchanged; that means the title was deliberately set or cleared. Otherwise, set it once:
 `vibe session update --title "<short title>"`
 
-Do not mention the title update unless the user asks, and do not repeatedly rename the same Session.
+Do not mention the title update unless the user asks. Do not repeatedly rename the same Session; after you set it once, treat it as deliberate.
 """
 
 

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -313,8 +313,9 @@ def test_web_title_prompt_defaults_to_current_session():
     assert "metadata.title_source" in out
     assert "`user` or `agent`" in out
     assert "leave the title unchanged" in out
-    assert "may silently set one concise, human-scannable title" in out
-    assert "do not repeatedly rename the same Session" in out
+    assert "set one concise, human-scannable title" in out
+    assert "Do this silently as soon as the title is obvious" in out
+    assert "Do not repeatedly rename the same Session" in out
     assert "not set yet" not in out
     assert "auto-generated" not in out
 


### PR DESCRIPTION
## What changed

This makes the injected Web session title guidance actionable instead of optional. When a Web conversation topic becomes clear, the agent is now instructed to silently set one concise title without waiting for the user to ask.

## Why

The previous wording used optional language, so agents could reasonably skip the title hygiene step even when the topic was obvious. The new wording keeps the existing protections for deliberate titles while making the default behavior clear.

## Validation

- `python3 -m pytest tests/test_session_cli.py -q`
- `ruff check core/system_prompt_injection.py tests/test_session_cli.py`

## Evidence layers

- Unit: updated `test_web_title_prompt_defaults_to_current_session`
- Contract: no scenario catalog applies
- Scenario: not applicable
- Residual manual checks: prompt diff reviewed for `user` / `agent` title-source preservation
