### PR TITLE
fix(wechat): suppress toolcall delivery

### DIFF
--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -32,6 +32,10 @@ class PlatformCapabilities:
     # footer) that becomes the result. One capability shared by the dispatcher and
     # the processing indicator instead of a hardcoded {"slack","discord"} literal.
     supports_status_bubble: bool = False
+    # Whether intermediate tool-call traces may be pushed to this IM transport
+    # when a user opts into "Toolcall" visibility. Platforms can keep local
+    # history/audit rows while still suppressing noisy IM delivery.
+    supports_toolcall_delivery: bool = True
 
 
 @dataclass(frozen=True)
@@ -247,6 +251,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_reaction_indicator=False,
             preferred_processing_indicator="typing",
             force_preferred_processing_indicator=True,
+            supports_toolcall_delivery=False,
         ),
     ),
     # The Vibe Remote Web UI itself, surfaced as a peer platform so the

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -280,11 +280,13 @@ class SettingsHandler(BaseHandler):
             settings_manager = self._get_settings_manager(context)
             # Toggle message type visibility
             settings_key = self._get_settings_key(context)
+            message_types = settings_manager.get_available_message_types()
+            if msg_type not in message_types:
+                return
             is_shown = settings_manager.toggle_show_message_type(settings_key, msg_type)
 
             # Update the keyboard
             user_settings = settings_manager.get_user_settings(settings_key)
-            message_types = settings_manager.get_available_message_types()
             display_names = self._message_type_display_names()
 
             buttons = []

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -173,6 +173,9 @@ class ConsolidatedMessageDispatcher:
     def _get_session_key(self, context: MessageContext) -> str:
         return self.controller._get_session_key(context)
 
+    def _supports_toolcall_delivery(self, context: MessageContext) -> bool:
+        return self._capabilities(context).supports_toolcall_delivery
+
     def _get_im_client(self, context: MessageContext):
         getter = getattr(self.controller, "get_im_client_for_context", None)
         if callable(getter):
@@ -1545,6 +1548,13 @@ class ConsolidatedMessageDispatcher:
         # assistant / tool_call messages still land in the store (product
         # requirement: the process log is complete even when a channel hides it).
         persist_agent_message(target_context, canonical_type, persist_text)
+
+        if canonical_type == "toolcall" and not self._supports_toolcall_delivery(context):
+            logger.info(
+                "Skipping toolcall delivery for platform %s; persisted local process log only.",
+                self._get_platform(context),
+            )
+            return None
 
         if settings_manager.is_message_type_hidden(settings_key, canonical_type):
             preview = text if len(text) <= 500 else f"{text[:500]}…"

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -1549,10 +1549,10 @@ class ConsolidatedMessageDispatcher:
         # requirement: the process log is complete even when a channel hides it).
         persist_agent_message(target_context, canonical_type, persist_text)
 
-        if canonical_type == "toolcall" and not self._supports_toolcall_delivery(context):
+        if canonical_type == "toolcall" and not self._supports_toolcall_delivery(target_context):
             logger.info(
                 "Skipping toolcall delivery for platform %s; persisted local process log only.",
-                self._get_platform(context),
+                self._get_platform(target_context),
             )
             return None
 

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
 
 from config import paths
+from config.platform_registry import get_platform_descriptor
 from config.v2_sessions import SessionsStore
 from config.v2_settings import SettingsStore, ChannelSettings, GuildSettings, RoutingSettings, SCOPED_KEY_SEP
 from config.v2_settings import normalize_routing_settings
@@ -380,7 +381,10 @@ class SettingsManager:
         ``system`` is intentionally excluded: system/init messages are never
         pushed to users, so there is nothing for the toggle to control.
         """
-        return ["assistant", "toolcall"]
+        message_types = ["assistant"]
+        if get_platform_descriptor(self.platform).capabilities.supports_toolcall_delivery:
+            message_types.append("toolcall")
+        return message_types
 
     def get_message_type_display_names(self) -> Dict[str, str]:
         """Get display names for message types"""

--- a/tests/test_message_dispatcher_platform_limits.py
+++ b/tests/test_message_dispatcher_platform_limits.py
@@ -128,6 +128,33 @@ class MessageDispatcherPlatformLimitTests(unittest.IsolatedAsyncioTestCase):
         persist.assert_called_once()
         self.assertEqual(persist.call_args.args[1], "toolcall")
 
+    async def test_toolcall_delivery_override_to_wechat_is_persisted_but_never_delivered(self):
+        controller = _StubController("slack")
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={
+                "delivery_override": {
+                    "platform": "wechat",
+                    "user_id": "wechat-user",
+                    "channel_id": "wechat-user",
+                }
+            },
+        )
+
+        with mock.patch("core.message_dispatcher.persist_agent_message") as persist:
+            message_id = await dispatcher.emit_agent_message(context, "toolcall", "exec_command")
+
+        self.assertIsNone(message_id)
+        self.assertEqual(controller.im_client.sent, [])
+        persist.assert_called_once()
+        persisted_context = persist.call_args.args[0]
+        self.assertEqual(persisted_context.platform, "wechat")
+        self.assertEqual(persisted_context.channel_id, "wechat-user")
+        self.assertEqual(persist.call_args.args[1], "toolcall")
+
     def test_result_split_boundary_never_exceeds_platform_limit(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController("wechat"))
 

--- a/tests/test_message_dispatcher_platform_limits.py
+++ b/tests/test_message_dispatcher_platform_limits.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -86,7 +87,7 @@ class MessageDispatcherPlatformLimitTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("".join(text for _, _, text, _ in controller.im_client.sent), long_text)
         self.assertTrue(all(len(text.encode("utf-8")) <= 1900 for _, _, text, _ in controller.im_client.sent))
 
-    async def test_wechat_long_log_message_splits_before_send_failure(self):
+    async def test_wechat_long_assistant_log_message_splits_before_send_failure(self):
         controller = _StubController("wechat")
         dispatcher = ConsolidatedMessageDispatcher(controller)
         context = MessageContext(user_id="wechat-user", channel_id="wechat-user", platform="wechat")
@@ -99,21 +100,33 @@ class MessageDispatcherPlatformLimitTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(all(len(text.encode("utf-8")) <= 1900 for _, _, text, _ in controller.im_client.sent))
         self.assertEqual(controller.im_client.edit_calls, [])
 
-    async def test_wechat_log_messages_send_individually_without_append_edit(self):
+    async def test_wechat_non_toolcall_log_messages_send_individually_without_append_edit(self):
         controller = _StubController("wechat")
         dispatcher = ConsolidatedMessageDispatcher(controller)
         context = MessageContext(user_id="wechat-user", channel_id="wechat-user", platform="wechat")
 
         first_id = await dispatcher.emit_agent_message(context, "system", "cwd: /tmp/project")
         second_id = await dispatcher.emit_agent_message(context, "assistant", "running command")
-        third_id = await dispatcher.emit_agent_message(context, "toolcall", "exec_command")
 
-        self.assertEqual((first_id, second_id, third_id), ("bot-msg-1", "bot-msg-2", "bot-msg-3"))
+        self.assertEqual((first_id, second_id), ("bot-msg-1", "bot-msg-2"))
         self.assertEqual(
             [text for _, _, text, _ in controller.im_client.sent],
-            ["cwd: /tmp/project", "running command", "exec_command"],
+            ["cwd: /tmp/project", "running command"],
         )
         self.assertEqual(controller.im_client.edit_calls, [])
+
+    async def test_wechat_toolcall_is_persisted_but_never_delivered(self):
+        controller = _StubController("wechat")
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(user_id="wechat-user", channel_id="wechat-user", platform="wechat")
+
+        with mock.patch("core.message_dispatcher.persist_agent_message") as persist:
+            message_id = await dispatcher.emit_agent_message(context, "toolcall", "exec_command")
+
+        self.assertIsNone(message_id)
+        self.assertEqual(controller.im_client.sent, [])
+        persist.assert_called_once()
+        self.assertEqual(persist.call_args.args[1], "toolcall")
 
     def test_result_split_boundary_never_exceeds_platform_limit(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController("wechat"))

--- a/tests/test_platform_registry.py
+++ b/tests/test_platform_registry.py
@@ -32,6 +32,8 @@ def test_platform_catalog_exposes_capability_flags() -> None:
     assert catalog["wechat"]["capabilities"]["supports_typing_indicator"] is True
     assert catalog["wechat"]["capabilities"]["typing_indicator_requires_clear"] is True
     assert catalog["wechat"]["capabilities"]["force_preferred_processing_indicator"] is True
+    assert catalog["wechat"]["capabilities"]["supports_toolcall_delivery"] is False
+    assert catalog["slack"]["capabilities"]["supports_toolcall_delivery"] is True
     assert catalog["lark"]["capabilities"]["supports_typing_indicator"] is False
     assert catalog["lark"]["capabilities"]["preferred_processing_indicator"] == "reaction"
     assert catalog["telegram"]["capabilities"]["supports_message_indicator_delete"] is True

--- a/tests/test_user_platform_scope.py
+++ b/tests/test_user_platform_scope.py
@@ -33,6 +33,38 @@ def test_get_users_respects_platform_scope(monkeypatch, tmp_path):
     assert set(wechat_users["users"].keys()) == {"wx1"}
 
 
+def test_wechat_settings_filter_toolcall_visibility(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+
+    settings = api.save_settings(
+        {
+            "platform": "wechat",
+            "channels": {
+                "wx-chat": {
+                    "enabled": True,
+                    "show_message_types": ["assistant", "toolcall"],
+                }
+            },
+        }
+    )
+    users = api.save_users(
+        {
+            "platform": "wechat",
+            "users": {
+                "wx-user": {
+                    "display_name": "WeChat User",
+                    "enabled": True,
+                    "show_message_types": ["assistant", "toolcall"],
+                }
+            },
+        }
+    )
+
+    assert settings["channels"]["wx-chat"]["show_message_types"] == ["assistant"]
+    assert users["users"]["wx-user"]["show_message_types"] == ["assistant"]
+
+
 def test_toggle_admin_is_scoped_per_platform(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -49,6 +49,7 @@ export interface RoutingConfigPanelProps {
   /** Vibe Agent catalog — passed already-loaded from the parent. */
   vibeAgents?: VibeAgentBrief[];
   defaultAgentName?: string | null;
+  availableMessageTypes?: string[];
   // Legacy backend-model props: no longer read here (AgentRoutePicker self-loads
   // models + effort options). Kept on the interface so existing callers still
   // type-check; a follow-up can drop them and the parents' model preloading.
@@ -92,6 +93,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
   inheritsFromKey,
   vibeAgents = [],
   defaultAgentName,
+  availableMessageTypes = ['assistant', 'toolcall'],
   footerActions,
   containerClass = 'border-t border-border/60 px-5 py-4',
 }) => {
@@ -258,7 +260,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
           </span>
         </div>
         <div className="flex flex-wrap gap-2 text-sm">
-          {['assistant', 'toolcall'].map((msgType) => {
+          {availableMessageTypes.map((msgType) => {
             const checked = (value.show_message_types || []).includes(msgType);
             const label = t(`channelList.messageType.${msgType}`);
             return (

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -20,7 +20,7 @@ import { useToast } from '../../context/ToastContext';
 import { DirectoryBrowser } from '../ui/directory-browser';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
-import { getEnabledPlatforms, platformSupportsChannels } from '../../lib/platforms';
+import { getEnabledPlatforms, platformSupportsChannels, platformSupportsToolcallDelivery } from '../../lib/platforms';
 import { hasUsableSecret } from '../../lib/secretFields';
 import { EyebrowBadge, PlatformIcon, WizardCard } from '../visual';
 import { RoutingConfigPanel } from '../shared/RoutingConfigPanel';
@@ -792,6 +792,9 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
     require_mention: null,
     require_bind: null,
   });
+
+  const availableMessageTypes = (platformId: string): string[] =>
+    platformSupportsToolcallDelivery(config, platformId) ? ['assistant', 'toolcall'] : ['assistant'];
 
   const selectedCount = channels.filter((channel) => isChannelEnabled(channel.id)).length;
   const currentRefreshMeta = refreshMetaByPlatform[platform] || {};
@@ -1642,6 +1645,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                       globalConfig={config}
                       vibeAgents={vibeAgents}
                       defaultAgentName={defaultAgentName}
+                      availableMessageTypes={availableMessageTypes(channelPlatform)}
                       showRequireMention={true}
                       inheritsFromKey={channelPlatform}
                       opencodeOptions={opencodeOptions}
@@ -1984,6 +1988,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                   globalConfig={config}
                   vibeAgents={vibeAgents}
                   defaultAgentName={defaultAgentName}
+                  availableMessageTypes={availableMessageTypes(platform)}
                   showRequireMention={true}
                   inheritsFromKey={platform}
                   opencodeOptions={opencodeOptions}

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
-import { getEnabledPlatforms } from '../../lib/platforms';
+import { getEnabledPlatforms, platformSupportsToolcallDelivery } from '../../lib/platforms';
 import { DirectoryBrowser } from '../ui/directory-browser';
 import { copyTextToClipboard } from '../../lib/utils';
 import { PlatformIcon } from '../visual';
@@ -667,6 +667,9 @@ export const UserList: React.FC = () => {
     },
   });
 
+  const availableMessageTypes = (platform: string): string[] =>
+    platformSupportsToolcallDelivery(config, platform) ? ['assistant', 'toolcall'] : ['assistant'];
+
   const totalCount = aggregated.length;
 
   // Backend label helper
@@ -882,6 +885,7 @@ export const UserList: React.FC = () => {
                       globalConfig={config}
                       vibeAgents={vibeAgents}
                       defaultAgentName={defaultAgentName}
+                      availableMessageTypes={availableMessageTypes(u.platform)}
                       showRequireMention={false}
                       opencodeOptions={opencodeOptions}
                       claudeAgents={claudeAgents}

--- a/ui/src/lib/platforms.ts
+++ b/ui/src/lib/platforms.ts
@@ -16,6 +16,7 @@ export type PlatformCapabilities = {
   supports_message_indicator_delete?: boolean;
   preferred_processing_indicator?: string;
   force_preferred_processing_indicator?: boolean;
+  supports_toolcall_delivery?: boolean;
 };
 
 export type PlatformDescriptor = {
@@ -137,6 +138,7 @@ const LEGACY_FALLBACK_CATALOG: PlatformDescriptor[] = [
       supports_message_indicator: true,
       preferred_processing_indicator: 'typing',
       force_preferred_processing_indicator: true,
+      supports_toolcall_delivery: false,
     },
   },
 ];
@@ -185,6 +187,9 @@ export const platformHasCapability = (
 
 export const platformSupportsChannels = (data: any, platform: string): boolean =>
   platformHasCapability(data, platform, 'supports_channels');
+
+export const platformSupportsToolcallDelivery = (data: any, platform: string): boolean =>
+  getPlatformDescriptor(data, platform)?.capabilities?.supports_toolcall_delivery !== false;
 
 export const platformHasCredentials = (data: any, platform: string): boolean => {
   const descriptor = getPlatformDescriptor(data, platform);

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2607,6 +2607,13 @@ def _backend_for_routing_agent(agent_name: Optional[str]) -> Optional[str]:
         store.close()
 
 
+def _normalize_show_message_types_for_platform(show_message_types: Optional[list], platform: str) -> list[str]:
+    normalized = normalize_show_message_types(show_message_types)
+    if not get_platform_descriptor(platform).capabilities.supports_toolcall_delivery:
+        return [msg_type for msg_type in normalized if msg_type != "toolcall"]
+    return normalized
+
+
 def save_settings(payload: dict) -> dict:
     store = SettingsStore.get_instance()
     platform = payload.get("platform") or _current_platform()
@@ -2616,7 +2623,9 @@ def save_settings(payload: dict) -> dict:
         for channel_id, channel_payload in (payload.get("channels") or {}).items():
             channels[channel_id] = ChannelSettings(
                 enabled=channel_payload.get("enabled", True),
-                show_message_types=normalize_show_message_types(channel_payload.get("show_message_types")),
+                show_message_types=_normalize_show_message_types_for_platform(
+                    channel_payload.get("show_message_types"), platform
+                ),
                 custom_cwd=channel_payload.get("custom_cwd"),
                 routing=_parse_routing(_normalize_backend_routing_payload(channel_payload.get("routing") or {})),
                 require_mention=channel_payload.get("require_mention"),
@@ -3355,7 +3364,7 @@ def _settings_to_payload(store: SettingsStore, platform: str) -> dict:
     for channel_id, settings in store.get_channels_for_platform(platform).items():
         payload["channels"][channel_id] = {
             "enabled": settings.enabled,
-            "show_message_types": normalize_show_message_types(settings.show_message_types),
+            "show_message_types": _normalize_show_message_types_for_platform(settings.show_message_types, platform),
             "custom_cwd": settings.custom_cwd,
             "require_mention": settings.require_mention,
             "require_bind": settings.require_bind,
@@ -3376,7 +3385,7 @@ def _settings_to_payload(store: SettingsStore, platform: str) -> dict:
             "is_admin": u.is_admin,
             "bound_at": u.bound_at,
             "enabled": u.enabled,
-            "show_message_types": u.show_message_types,
+            "show_message_types": _normalize_show_message_types_for_platform(u.show_message_types, platform),
             "custom_cwd": u.custom_cwd,
             "routing": routing_to_compat_dict(u.routing),
         }
@@ -9310,7 +9319,7 @@ def get_users(platform: Optional[str] = None) -> dict:
             "is_admin": u.is_admin,
             "bound_at": u.bound_at,
             "enabled": u.enabled,
-            "show_message_types": u.show_message_types,
+            "show_message_types": _normalize_show_message_types_for_platform(u.show_message_types, platform),
             "custom_cwd": u.custom_cwd,
             "routing": routing_to_compat_dict(u.routing),
         }
@@ -9333,7 +9342,7 @@ def save_users(payload: dict) -> dict:
             is_admin=up.get("is_admin", False),
             bound_at=up.get("bound_at", ""),
             enabled=up.get("enabled", True),
-            show_message_types=normalize_show_message_types(up.get("show_message_types")),
+            show_message_types=_normalize_show_message_types_for_platform(up.get("show_message_types"), platform),
             custom_cwd=up.get("custom_cwd"),
             routing=_parse_routing(_normalize_backend_routing_payload(up.get("routing") or {})),
             dm_chat_id=existing.dm_chat_id if existing else "",


### PR DESCRIPTION
## Summary
- add a platform capability for toolcall delivery and disable it for WeChat
- keep WeChat toolcall traces in local history while suppressing outbound IM delivery
- hide/filter the Toolcall visibility option for WeChat in API responses, IM settings, and Web UI controls

## Scenarios
- Scenario catalog: not applicable for this targeted message-delivery capability change.
- Affected scenario IDs: none.

## Evidence
- Unit: `uv run pytest tests/test_message_dispatcher_platform_limits.py tests/test_platform_registry.py tests/test_sqlite_settings_store.py tests/test_user_platform_scope.py -q`
- Unit: `uv run pytest tests/test_settings_handler.py tests/test_telegram_bot.py::test_open_settings_modal_includes_language_buttons tests/test_telegram_bot.py::test_render_settings_state_localizes_current_label tests/test_telegram_bot.py::test_settings_callback_save_updates_language_and_deletes_menu -q`
- Unit: `uv run pytest tests/test_message_dispatcher_status_bubble.py -q`
- UI build: `cd ui && npm run build`
- Lint: `uv run ruff check config/platform_registry.py core/handlers/settings_handler.py core/message_dispatcher.py modules/settings_manager.py tests/test_message_dispatcher_platform_limits.py tests/test_platform_registry.py tests/test_user_platform_scope.py vibe/api.py`
- Contract: platform catalog now exposes `supports_toolcall_delivery`, and API save/read paths filter WeChat `show_message_types` accordingly.
- Scenario: no scenario catalog update; no scenario IDs apply.
- Residual manual checks: no live WeChat regression run in this turn.

## Notes
- Pre-PR reviewer agent run was attempted but did not return; the run was requested for cancellation and no reviewer findings were available before publishing.
