### PR TITLE
fix(session): compact title prompt

### DIFF
--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -220,13 +220,13 @@ Treat these as the user pointing at that Agent or Session, and decide the action
 _SESSION_TITLE_PROMPT = """\
 
 ## Session Title
-When the topic of this Web conversation becomes clear, set one concise, human-scannable title for the current Session. Do this silently as soon as the title is obvious, without waiting for the user to ask. Before setting it, inspect the Session:
+Once this Web conversation's topic is clear, silently set one concise, human-scannable Session title without waiting for the user. First inspect:
 `vibe session get`
 
-If `metadata.title_source` is `user` or `agent`, leave the title unchanged; that means the title was deliberately set or cleared. Otherwise, set it once:
+If `metadata.title_source` is `user` or `agent`, leave the title unchanged. Otherwise set it once:
 `vibe session update --title "<short title>"`
 
-Do not mention the title update unless the user asks. Do not repeatedly rename the same Session; after you set it once, treat it as deliberate.
+Do not mention the update unless asked. After setting it, do not rename it again.
 """
 
 

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -305,6 +305,7 @@ def _injection_for(session_id, *, platform="avibe", platform_specific=None):
 
 def test_web_title_prompt_defaults_to_current_session():
     out = _injection_for("sesweb")
+    title_prompt = out[out.index("## Session Title") :]
     assert "## Session Title" in out
     assert "`vibe session get`" in out
     assert '`vibe session update --title "<short title>"`' in out
@@ -313,9 +314,10 @@ def test_web_title_prompt_defaults_to_current_session():
     assert "metadata.title_source" in out
     assert "`user` or `agent`" in out
     assert "leave the title unchanged" in out
-    assert "set one concise, human-scannable title" in out
-    assert "Do this silently as soon as the title is obvious" in out
-    assert "Do not repeatedly rename the same Session" in out
+    assert "silently set one concise, human-scannable Session title" in out
+    assert "without waiting for the user" in out
+    assert "do not rename it again" in out
+    assert len(title_prompt.strip()) < 450
     assert "not set yet" not in out
     assert "auto-generated" not in out
 


### PR DESCRIPTION
## What changed
- Compact the injected Web session title guidance from 629 characters to 412 characters.
- Keep the same behavioral contract: inspect the current Session first, preserve deliberate `user` / `agent` titles, set once when the topic is clear, and stay silent unless asked.
- Add a small length guard in the existing CLI prompt test so the section does not grow back casually.

## Why
The previous wording was effective but verbose for a prompt injected into every Web conversation. This keeps the title-setting behavior explicit while reducing repeated prompt overhead.

## Validation
- `python3 -m pytest tests/test_session_cli.py -q`
- `ruff check core/system_prompt_injection.py tests/test_session_cli.py`
- `git diff --check`

## Evidence layers
- Unit: updated `test_web_title_prompt_defaults_to_current_session`
- Contract: no scenario catalog applies
- Scenario: N/A
- Residual manual checks: measured `_SESSION_TITLE_PROMPT` before and after; reviewed prompt wording for title-source preservation and one-time behavior
