### PR TITLE
fix(runtime): support delegated regression cgroups

### DIFF
--- a/core/resource_governance.py
+++ b/core/resource_governance.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from config import paths as config_paths
+
 logger = logging.getLogger(__name__)
 
 CGROUP_ROOT = Path("/sys/fs/cgroup")
@@ -21,6 +23,10 @@ MIN_AGENT_MEMORY_MAX_BYTES = 512 * 1024 * 1024
 MIB = 1024 * 1024
 AGENT_CONTROLLERS = ("memory", "cpu", "io", "pids")
 CONTROLLER_GOVERNOR_ATTR = "_avibe_controller_owned_resource_governor"
+AVIBE_RUNTIME_CWD_CMD_MARKERS = (
+    "incus_regression_supervisor.py",
+    "from vibe.ui_server import run_ui_server",
+)
 
 
 @dataclass(frozen=True)
@@ -48,6 +54,16 @@ def _parse_memory_value(value: str | None) -> int | None:
     except ValueError:
         return None
     return parsed if parsed > 0 else None
+
+
+def _parse_pid(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        pid = int(value.strip())
+    except ValueError:
+        return None
+    return pid if pid > 0 else None
 
 
 def _round_down_mib(value: int) -> int:
@@ -200,6 +216,111 @@ def _cgroup_member_pids(cgroup: Path) -> list[int]:
 def _runtime_process_tree_pids(pid: int | None = None) -> set[int]:
     root_pid = pid or os.getpid()
     return {root_pid, *_descendant_pids(root_pid)}
+
+
+def _pid_cmdline(pid: int) -> str | None:
+    try:
+        data = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return None
+    return data.replace(b"\0", b" ").decode(errors="replace").strip()
+
+
+def _first_cmd_arg(cmdline: str) -> str:
+    parts = cmdline.split(maxsplit=1)
+    return parts[0] if parts else ""
+
+
+def _is_cloudflared_cmd(cmdline: str) -> bool:
+    executable = Path(_first_cmd_arg(cmdline)).name.lower()
+    return executable in {"cloudflared", "cloudflared.exe"}
+
+
+def _pid_uid(pid: int) -> int | None:
+    status = _read_text(Path(f"/proc/{pid}/status"))
+    if not status:
+        return None
+    for line in status.splitlines():
+        if not line.startswith("Uid:"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            return None
+        try:
+            return int(parts[1])
+        except ValueError:
+            return None
+    return None
+
+
+def _pid_cwd(pid: int) -> Path | None:
+    try:
+        return Path(f"/proc/{pid}/cwd").resolve()
+    except OSError:
+        return None
+
+
+def _current_runtime_cwd() -> Path | None:
+    try:
+        return Path.cwd().resolve()
+    except OSError:
+        return None
+
+
+def _path_variants(path: Path) -> set[str]:
+    variants = {str(path)}
+    try:
+        variants.add(str(path.resolve()))
+    except OSError:
+        pass
+    return variants
+
+
+def _is_under_runtime_dir(cmdline: str) -> bool:
+    for runtime_dir in _path_variants(config_paths.get_runtime_dir()):
+        if f"{runtime_dir}/" in cmdline:
+            return True
+    return False
+
+
+def _is_managed_cloudflared(pid: int, cmdline: str) -> bool:
+    if not _is_cloudflared_cmd(cmdline):
+        return False
+    expected_pid = _parse_pid(_read_text(config_paths.get_runtime_remote_access_pid_path()))
+    if expected_pid == pid:
+        return True
+    for home_dir in _path_variants(config_paths.get_vibe_remote_dir()):
+        managed_binary = f"{home_dir}/bin/{_first_cmd_arg(cmdline).split('/')[-1]}"
+        if cmdline == managed_binary or cmdline.startswith(f"{managed_binary} "):
+            return True
+    return False
+
+
+def _is_known_avibe_runtime_member(pid: int, *, uid: int | None = None) -> bool:
+    expected_uid = os.geteuid() if uid is None else uid
+    pid_uid = _pid_uid(pid)
+    if pid_uid != expected_uid:
+        return False
+    cmdline = _pid_cmdline(pid)
+    if not cmdline:
+        return False
+    if _is_under_runtime_dir(cmdline):
+        return True
+    if _is_managed_cloudflared(pid, cmdline):
+        return True
+
+    runtime_cwd = _current_runtime_cwd()
+    pid_cwd = _pid_cwd(pid)
+    if runtime_cwd is None or pid_cwd != runtime_cwd:
+        return False
+    if f"{runtime_cwd}/main.py" in cmdline:
+        return True
+    return any(marker in cmdline for marker in AVIBE_RUNTIME_CWD_CMD_MARKERS)
+
+
+def _known_avibe_runtime_sibling_pids(pids: list[int]) -> set[int]:
+    current_uid = os.geteuid()
+    return {pid for pid in pids if _is_known_avibe_runtime_member(pid, uid=current_uid)}
 
 
 def _descendant_pids(pid: int) -> list[int]:
@@ -403,7 +524,8 @@ class AgentResourceGovernor:
             if not pids:
                 return
             runtime_pids = _runtime_process_tree_pids()
-            managed_pids = runtime_pids | known_agent_pids
+            runtime_sibling_pids = _known_avibe_runtime_sibling_pids(pids)
+            managed_pids = runtime_pids | runtime_sibling_pids | known_agent_pids
             foreign_pids = [pid for pid in pids if pid not in managed_pids]
             if foreign_pids:
                 raise OSError(f"runtime cgroup has non-Avibe member pids: {base}")

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -490,8 +490,8 @@ def profile_yaml(storage_pool: str, network: str, cpus: str, memory: str, disk: 
     )
 
 
-def cloud_init_user_data() -> str:
-    service = textwrap.dedent(
+def regression_service_unit() -> str:
+    return textwrap.dedent(
         f"""\
         [Unit]
         Description=Avibe regression service
@@ -511,6 +511,11 @@ def cloud_init_user_data() -> str:
         Environment=PATH={VENV_DIR}/bin:{SERVICE_HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin
         EnvironmentFile=-/etc/avibe-regression.env
         ExecStart={VENV_DIR}/bin/python scripts/incus_regression_supervisor.py
+        Delegate=yes
+        CPUAccounting=yes
+        IOAccounting=yes
+        MemoryAccounting=yes
+        TasksAccounting=yes
         Restart=on-failure
         RestartSec=2
         TimeoutStopSec=60
@@ -519,6 +524,10 @@ def cloud_init_user_data() -> str:
         WantedBy=multi-user.target
         """
     ).rstrip()
+
+
+def cloud_init_user_data() -> str:
+    service = regression_service_unit()
     helper = textwrap.dedent(
         f"""\
         #!/usr/bin/env bash
@@ -641,6 +650,14 @@ def ensure_project_and_instance(
                 f"ln -sfn {AVIBE_HOME} {LEGACY_HOME}; "
                 "systemctl daemon-reload"
             ),
+            remote=remote,
+        )
+    )
+    runner.run(
+        root_exec(
+            target,
+            f"cat > /etc/systemd/system/{SERVICE_NAME} <<'EOF'\n{regression_service_unit()}\nEOF\n"
+            "systemctl daemon-reload",
             remote=remote,
         )
     )

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -246,6 +246,8 @@ def test_cloud_init_configures_systemd_service_without_source_code() -> None:
     assert "Environment=VIBE_DEPLOYMENT_ENV=regression" in data
     assert "EnvironmentFile=-/etc/avibe-regression.env" in data
     assert "ExecStart=/opt/avibe/venv/bin/python scripts/incus_regression_supervisor.py" in data
+    assert "Delegate=yes" in data
+    assert "MemoryAccounting=yes" in data
     assert "/opt/avibe/source" in data
     assert "/home/avibe/.vibe_remote" in data
 

--- a/tests/test_resource_governance.py
+++ b/tests/test_resource_governance.py
@@ -3,10 +3,12 @@ from types import SimpleNamespace
 
 import pytest
 
+from config import paths
 from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, V2Config
 from core.resource_governance import (
     MIB,
     AgentResourceGovernor,
+    _is_known_avibe_runtime_member,
     config_from_controller,
     derive_agent_limits,
     is_controller_resource_governor,
@@ -87,6 +89,98 @@ def test_governor_from_controller_marks_long_lived_governor() -> None:
 
     assert is_controller_resource_governor(governor) is True
     assert governor_from_controller(controller) is governor
+
+
+def test_known_runtime_member_accepts_current_source_main(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+
+    monkeypatch.setattr("core.resource_governance._pid_uid", lambda pid: 1000)
+    monkeypatch.setattr("core.resource_governance._pid_cwd", lambda pid: source)
+    monkeypatch.setattr("core.resource_governance._current_runtime_cwd", lambda: source)
+    monkeypatch.setattr(
+        "core.resource_governance._pid_cmdline",
+        lambda pid: f"/opt/avibe/venv/bin/python {source}/main.py",
+    )
+
+    assert _is_known_avibe_runtime_member(1234, uid=1000) is True
+
+
+def test_known_runtime_member_rejects_unrelated_main_py(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "avibe" / "source"
+    other = tmp_path / "other"
+    source.mkdir(parents=True)
+    other.mkdir()
+
+    monkeypatch.setattr("core.resource_governance._pid_uid", lambda pid: 1000)
+    monkeypatch.setattr("core.resource_governance._pid_cwd", lambda pid: other)
+    monkeypatch.setattr("core.resource_governance._current_runtime_cwd", lambda: source)
+    monkeypatch.setattr(
+        "core.resource_governance._pid_cmdline",
+        lambda pid: f"/usr/bin/python {other}/main.py",
+    )
+
+    assert _is_known_avibe_runtime_member(1234, uid=1000) is False
+
+
+def test_known_runtime_member_accepts_custom_avibe_runtime_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    avibe_home = tmp_path / "data" / "avibe"
+    monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
+
+    monkeypatch.setattr("core.resource_governance._pid_uid", lambda pid: 1000)
+    monkeypatch.setattr("core.resource_governance._pid_cwd", lambda pid: None)
+    monkeypatch.setattr("core.resource_governance._current_runtime_cwd", lambda: None)
+    monkeypatch.setattr(
+        "core.resource_governance._pid_cmdline",
+        lambda pid: f"/usr/bin/node {avibe_home}/runtime/show-runtime/source/main/packages/runtime/dist/cli.js",
+    )
+
+    assert _is_known_avibe_runtime_member(1234, uid=1000) is True
+
+
+def test_known_runtime_member_accepts_custom_cloudflared_pid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    avibe_home = tmp_path / "custom-home"
+    monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
+    paths.get_runtime_dir().mkdir(parents=True)
+    paths.get_runtime_remote_access_pid_path().write_text("4321\n", encoding="utf-8")
+
+    monkeypatch.setattr("core.resource_governance._pid_uid", lambda pid: 1000)
+    monkeypatch.setattr("core.resource_governance._pid_cwd", lambda pid: None)
+    monkeypatch.setattr("core.resource_governance._current_runtime_cwd", lambda: None)
+    monkeypatch.setattr(
+        "core.resource_governance._pid_cmdline",
+        lambda pid: "/opt/cloudflare/cloudflared tunnel --no-autoupdate run",
+    )
+
+    assert _is_known_avibe_runtime_member(4321, uid=1000) is True
+
+
+def test_known_runtime_member_rejects_unowned_cloudflared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr("core.resource_governance._pid_uid", lambda pid: 1000)
+    monkeypatch.setattr("core.resource_governance._pid_cwd", lambda pid: None)
+    monkeypatch.setattr("core.resource_governance._current_runtime_cwd", lambda: None)
+    monkeypatch.setattr(
+        "core.resource_governance._pid_cmdline",
+        lambda pid: "/opt/cloudflare/cloudflared tunnel --no-autoupdate run",
+    )
+
+    assert _is_known_avibe_runtime_member(4321, uid=1000) is False
 
 
 def test_governor_disabled_mode_does_not_create_group(tmp_path: Path) -> None:
@@ -263,6 +357,57 @@ def test_governor_falls_back_when_base_has_foreign_member_pids(
     assert governor.apply_to_pid(4321, label="test") is False
     assert governor.group_path is None
     assert writes == []
+
+
+def test_governor_allows_known_runtime_sibling_pids_during_base_migration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "cgroup"
+    base = root / "service"
+    base.mkdir(parents=True)
+    (base / "memory.max").write_text(str(512 * MIB), encoding="utf-8")
+    (base / "cgroup.procs").write_text("1001\n1002\n5001\n", encoding="utf-8")
+
+    governor = AgentResourceGovernor({"mode": "enabled"}, root=root, base_cgroup=base)
+    group = base / "avibe-agents"
+    runtime_group = base / "avibe-runtime"
+    original_mkdir = Path.mkdir
+    runtime_writes: list[str] = []
+    agent_writes: list[str] = []
+
+    def mkdir_with_cgroup_procs(path: Path, *args, **kwargs):
+        result = original_mkdir(path, *args, **kwargs)
+        if path == group:
+            (group / "cgroup.procs").write_text("", encoding="utf-8")
+        if path == runtime_group:
+            (runtime_group / "cgroup.procs").write_text("", encoding="utf-8")
+        return result
+
+    def fake_write_cgroup_value(path: Path, value: str) -> None:
+        if path == runtime_group / "cgroup.procs":
+            runtime_writes.append(value)
+        elif path == group / "cgroup.procs":
+            agent_writes.append(value)
+        else:
+            path.write_text(f"{value}\n", encoding="utf-8")
+            return
+        remaining = [pid for pid in _base_members() if pid != value]
+        (base / "cgroup.procs").write_text("\n".join(remaining) + ("\n" if remaining else ""), encoding="utf-8")
+
+    def _base_members() -> list[str]:
+        text = (base / "cgroup.procs").read_text(encoding="utf-8")
+        return [pid for pid in text.split() if pid]
+
+    monkeypatch.setattr(Path, "mkdir", mkdir_with_cgroup_procs)
+    monkeypatch.setattr("core.resource_governance._runtime_process_tree_pids", lambda pid=None: {1001})
+    monkeypatch.setattr("core.resource_governance._known_avibe_runtime_sibling_pids", lambda pids: {1002})
+    monkeypatch.setattr("core.resource_governance._write_cgroup_value", fake_write_cgroup_value)
+
+    assert governor.apply_to_pid(5001, label="test") is True
+    assert runtime_writes == ["1001", "1002"]
+    assert agent_writes == ["5001", "5001"]
+    assert governor.group_path == group
 
 
 def test_governor_allows_known_agent_pids_during_base_migration(


### PR DESCRIPTION
## Summary
- keep the regression systemd service delegated on every runner update so cgroup v2 controllers are writable in regression
- allow resource governance to evacuate known Avibe runtime sibling processes before enabling child controllers
- keep the safety boundary fail-closed for unknown same-cgroup processes and add negative coverage for unrelated `main.py` commands

## Why
The merged resource-governance MVP correctly falls back when its cgroup is not delegated, but the regression unit did not grant delegation. After adding delegation, the positive path still failed because the service layout has supervisor, main, UI, and Show Runtime as sibling processes rather than one strict process tree.

## Evidence
- Unit: `python3 -m pytest tests/test_resource_governance.py tests/test_incus_regression.py::test_cloud_init_configures_systemd_service_without_source_code -q`
- Lint: `ruff check core/resource_governance.py scripts/incus_regression.py tests/test_resource_governance.py tests/test_incus_regression.py`
- Scenario: local Incus worktree regression at `http://127.0.0.1:15203`, OpenCode provider API returned ok and `opencode serve` moved into `avibe-agents`
- Manual: verified `avibe-runtime` and `avibe-agents` cgroups, subtree controllers `cpu io memory pids`, and agent limits `cpu.weight=50`, `io.weight=default 50`, `pids.max=512`, `memory.oom.group=1`

Residual risk: this is Linux cgroup-v2-only behavior; non-Linux platforms still intentionally do not use cgroups.
