### PR TITLE
Fix live Agent Run cancellation from CLI

### DIFF
--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1239,6 +1239,59 @@ class TaskExecutionStore:
             return True
         return False
 
+    def mark_run_canceled(self, run_id: str, *, completed_at: Optional[str] = None) -> bool:
+        now = completed_at or _utc_now_iso()
+        existing = self.get_run(run_id)
+        if existing is None:
+            return False
+        cancel_requested_at = str(existing.get("cancel_requested_at") or now)
+        if self._sqlite is not None:
+            self._sqlite.update_run_status(
+                run_id,
+                status="canceled",
+                completed_at=now,
+                updated_at=now,
+                cancel_requested=True,
+                cancel_requested_at=cancel_requested_at,
+            )
+            return True
+
+        for state in ("pending", "processing", "completed"):
+            source_path = self._request_path(run_id, state=state)
+            if not source_path.exists():
+                continue
+            try:
+                payload = json.loads(source_path.read_text(encoding="utf-8"))
+            except Exception:
+                payload = {"id": run_id}
+            if not isinstance(payload, dict):
+                payload = {"id": run_id}
+            payload.update(
+                {
+                    "id": run_id,
+                    "status": "canceled",
+                    "cancel_requested": True,
+                    "cancel_requested_at": payload.get("cancel_requested_at") or now,
+                    "completed_at": now,
+                    "updated_at": now,
+                }
+            )
+            completed_path = self._request_path(run_id, state="completed")
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=self.completed_dir,
+                suffix=".tmp",
+                delete=False,
+                encoding="utf-8",
+            ) as handle:
+                json.dump(payload, handle, indent=2)
+                tmp_path = Path(handle.name)
+            tmp_path.replace(completed_path)
+            if state != "completed":
+                source_path.unlink(missing_ok=True)
+            return True
+        return False
+
     def claim(self, request_id: str) -> Optional[TaskExecutionRequest]:
         if self._sqlite is not None:
             now = _utc_now_iso()

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import redirect_stderr
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -51,6 +51,11 @@ def _parse_agent_run(argv: list[str]):
 def _parse_agent(argv: list[str]):
     parser = cli.build_parser()
     return parser.parse_args(["agent", *argv])
+
+
+def _parse_runs_cancel(argv: list[str]):
+    parser = cli.build_parser()
+    return parser.parse_args(["runs", "cancel", *argv])
 
 
 def _capture_stderr_json(func, *args):
@@ -1441,6 +1446,235 @@ def test_hook_send_enqueues_request(tmp_path: Path, capsys) -> None:
     assert payload["session_key"] == "slack::channel::C123::thread::171717.123"
     assert payload["post_to"] == "channel"
     assert (request_root / "pending" / f"{payload['execution_id']}.json").exists()
+
+
+def test_runs_cancel_running_agent_run_stops_live_turn_and_marks_canceled(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    request_store = cli.TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="ses_live_cancel",
+        message="keep working",
+        agent_name="worker",
+        callback_session_id="ses_callback",
+    )
+    assert request_store.claim(request.id) is not None
+    cancel_dispatch = AsyncMock(
+        return_value={
+            "status_code": 200,
+            "body": {"ok": True, "session_id": "ses_live_cancel", "status": "cancel_requested"},
+        }
+    )
+
+    with (
+        patch("vibe.cli._task_request_store", return_value=request_store),
+        patch("vibe.internal_client.cancel_dispatch", cancel_dispatch),
+    ):
+        result = cli.cmd_runs_cancel(_parse_runs_cancel([request.id]))
+
+    assert result == 0
+    cancel_dispatch.assert_awaited_once_with("ses_live_cancel")
+    saved = request_store.get_run(request.id)
+    assert saved is not None
+    assert saved["status"] == "canceled"
+    assert saved["completed_at"] is not None
+    assert saved["cancel_requested"] is True
+    assert saved["callback_status"] == "pending"
+    pending_callbacks = request_store.list_pending_callbacks()
+    assert [item["id"] for item in pending_callbacks] == [request.id]
+    assert pending_callbacks[0]["status"] == "canceled"
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cancel_code"] == "live_cancel_confirmed"
+    assert payload["cancel_result"]["live_cancel_confirmed"] is True
+    assert payload["cancel_result"]["run_terminalized"] is True
+    assert payload["run"]["status"] == "canceled"
+
+
+def test_runs_cancel_running_agent_run_reports_recorded_only_when_controller_unavailable(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from vibe import internal_client
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    request_store = cli.TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="ses_controller_down",
+        message="keep working",
+        agent_name="worker",
+    )
+    assert request_store.claim(request.id) is not None
+    cancel_dispatch = AsyncMock(side_effect=internal_client.InternalServerUnavailable("missing socket"))
+
+    with (
+        patch("vibe.cli._task_request_store", return_value=request_store),
+        patch("vibe.internal_client.cancel_dispatch", cancel_dispatch),
+    ):
+        result = cli.cmd_runs_cancel(_parse_runs_cancel([request.id]))
+
+    assert result == 0
+    cancel_dispatch.assert_awaited_once_with("ses_controller_down")
+    saved = request_store.get_run(request.id)
+    assert saved is not None
+    assert saved["status"] == "running"
+    assert saved["completed_at"] is None
+    assert saved["cancel_requested"] is True
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cancel_code"] == "cancel_request_recorded_only"
+    assert payload["cancel_result"]["reason_code"] == "internal_unavailable"
+    assert payload["cancel_result"]["live_cancel_confirmed"] is False
+    assert payload["run"]["status"] == "running"
+
+
+def test_runs_cancel_running_agent_run_reports_recorded_only_when_backend_refuses_stop(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    request_store = cli.TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="ses_stop_failed",
+        message="keep working",
+        agent_name="worker",
+    )
+    assert request_store.claim(request.id) is not None
+    cancel_dispatch = AsyncMock(
+        return_value={
+            "status_code": 409,
+            "body": {"ok": False, "code": "stop_failed", "reason": "interrupt_failed"},
+        }
+    )
+
+    with (
+        patch("vibe.cli._task_request_store", return_value=request_store),
+        patch("vibe.internal_client.cancel_dispatch", cancel_dispatch),
+    ):
+        result = cli.cmd_runs_cancel(_parse_runs_cancel([request.id]))
+
+    assert result == 0
+    cancel_dispatch.assert_awaited_once_with("ses_stop_failed")
+    saved = request_store.get_run(request.id)
+    assert saved is not None
+    assert saved["status"] == "running"
+    assert saved["cancel_requested"] is True
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cancel_code"] == "cancel_request_recorded_only"
+    assert payload["cancel_result"]["reason_code"] == "stop_failed"
+    assert payload["cancel_result"]["detail"]["controller_status_code"] == 409
+
+
+def test_runs_cancel_running_agent_run_reports_recorded_only_when_no_live_turn(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    request_store = cli.TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="ses_no_live_turn",
+        message="keep working",
+        agent_name="worker",
+    )
+    assert request_store.claim(request.id) is not None
+    cancel_dispatch = AsyncMock(
+        return_value={
+            "status_code": 404,
+            "body": {"ok": False, "code": "not_in_flight", "session_id": "ses_no_live_turn"},
+        }
+    )
+
+    with (
+        patch("vibe.cli._task_request_store", return_value=request_store),
+        patch("vibe.internal_client.cancel_dispatch", cancel_dispatch),
+    ):
+        result = cli.cmd_runs_cancel(_parse_runs_cancel([request.id]))
+
+    assert result == 0
+    cancel_dispatch.assert_awaited_once_with("ses_no_live_turn")
+    saved = request_store.get_run(request.id)
+    assert saved is not None
+    assert saved["status"] == "running"
+    assert saved["cancel_requested"] is True
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cancel_code"] == "cancel_request_recorded_only"
+    assert payload["cancel_result"]["reason_code"] == "not_in_flight"
+    assert payload["cancel_result"]["detail"]["controller_status_code"] == 404
+
+
+def test_runs_cancel_running_agent_run_does_not_overwrite_already_finished_turn(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    request_store = cli.TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="ses_already_finished",
+        message="keep working",
+        agent_name="worker",
+    )
+    assert request_store.claim(request.id) is not None
+    cancel_dispatch = AsyncMock(
+        return_value={
+            "status_code": 200,
+            "body": {"ok": True, "session_id": "ses_already_finished", "status": "already_finished"},
+        }
+    )
+
+    with (
+        patch("vibe.cli._task_request_store", return_value=request_store),
+        patch("vibe.internal_client.cancel_dispatch", cancel_dispatch),
+    ):
+        result = cli.cmd_runs_cancel(_parse_runs_cancel([request.id]))
+
+    assert result == 0
+    cancel_dispatch.assert_awaited_once_with("ses_already_finished")
+    saved = request_store.get_run(request.id)
+    assert saved is not None
+    assert saved["status"] == "running"
+    assert saved["completed_at"] is None
+    assert saved["cancel_requested"] is True
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cancel_code"] == "cancel_request_recorded_only"
+    assert payload["cancel_result"]["reason_code"] == "already_finished"
+    assert payload["cancel_result"]["live_cancel_confirmed"] is False
+    assert payload["run"]["status"] == "running"
+
+
+def test_runs_cancel_queued_agent_run_does_not_call_live_controller(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    request_store = cli.TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="ses_queued_cancel",
+        message="queued work",
+        agent_name="worker",
+    )
+    cancel_dispatch = AsyncMock()
+
+    with (
+        patch("vibe.cli._task_request_store", return_value=request_store),
+        patch("vibe.internal_client.cancel_dispatch", cancel_dispatch),
+    ):
+        result = cli.cmd_runs_cancel(_parse_runs_cancel([request.id]))
+
+    assert result == 0
+    cancel_dispatch.assert_not_awaited()
+    saved = request_store.get_run(request.id)
+    assert saved is not None
+    assert saved["status"] == "canceled"
+    assert saved["cancel_requested"] is True
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cancel_code"] == "queued_canceled"
+    assert payload["run"]["status"] == "canceled"
 
 
 def test_hook_send_allows_unresolved_legacy_scope_backend(tmp_path: Path, capsys) -> None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3931,13 +3931,158 @@ def cmd_runs_show(args):
     return 0
 
 
+def _run_type(run: dict | None) -> str:
+    if not isinstance(run, dict):
+        return ""
+    return str(run.get("run_type") or run.get("request_type") or "").strip()
+
+
+def _run_session_id(run: dict | None) -> str:
+    if not isinstance(run, dict):
+        return ""
+    return str(run.get("session_id") or "").strip()
+
+
+def _should_attempt_live_run_cancel(run: dict | None) -> bool:
+    if not isinstance(run, dict):
+        return False
+    return (
+        _run_type(run) == "agent_run"
+        and normalize_run_status(run.get("status")) == "running"
+        and bool(_run_session_id(run))
+    )
+
+
+def _recorded_only_cancel_result(*, reason_code: str, detail: object | None = None) -> dict:
+    result = {
+        "code": "cancel_request_recorded_only",
+        "live_cancel_attempted": reason_code not in {"not_running_agent_run", "missing_session_id"},
+        "live_cancel_confirmed": False,
+        "reason_code": reason_code,
+        "message": "Cancel request was recorded, but no live backend turn was stopped.",
+    }
+    if detail is not None:
+        result["detail"] = detail
+    return result
+
+
+def _initial_cancel_result(run: dict | None) -> dict:
+    if not isinstance(run, dict):
+        return _recorded_only_cancel_result(reason_code="run_not_found")
+    status = normalize_run_status(run.get("status"))
+    if status == "queued":
+        return {
+            "code": "queued_canceled",
+            "live_cancel_attempted": False,
+            "live_cancel_confirmed": False,
+            "message": "Queued run was canceled before it started.",
+        }
+    if _run_type(run) != "agent_run" or status != "running":
+        return _recorded_only_cancel_result(reason_code="not_running_agent_run")
+    if not _run_session_id(run):
+        return _recorded_only_cancel_result(reason_code="missing_session_id")
+    return {
+        "code": "cancel_request_recorded",
+        "live_cancel_attempted": False,
+        "live_cancel_confirmed": False,
+        "message": "Cancel request was recorded.",
+    }
+
+
+def _live_cancel_failure_code(status_code: int | None, body: object) -> str:
+    body_code = ""
+    body_status = ""
+    if isinstance(body, dict):
+        body_code = str(body.get("code") or "").strip()
+        body_status = str(body.get("status") or "").strip()
+    if body_code == "not_in_flight" or status_code == 404:
+        return "not_in_flight"
+    if body_code == "stop_failed" or status_code == 409:
+        return "stop_failed"
+    if body_status:
+        return body_status
+    if status_code is None:
+        return body_code or "live_cancel_failed"
+    if status_code >= 500:
+        return body_code or "internal_error"
+    return body_code or "live_cancel_not_confirmed"
+
+
+def _live_cancel_was_confirmed(status_code: int | None, body: object) -> bool:
+    if status_code is None or status_code < 200 or status_code >= 300:
+        return False
+    if isinstance(body, dict) and body.get("ok") is False:
+        return False
+    if not isinstance(body, dict):
+        return False
+    return str(body.get("status") or "").strip() in {"cancel_requested", "stale_released"}
+
+
+async def _request_live_run_cancel(session_id: str) -> dict:
+    from vibe import internal_client
+
+    return await internal_client.cancel_dispatch(session_id)
+
+
+def _cancel_live_agent_run(store: TaskExecutionStore, run: dict) -> dict:
+    session_id = _run_session_id(run)
+    from vibe import internal_client
+
+    try:
+        controller_result = asyncio.run(_request_live_run_cancel(session_id))
+    except internal_client.InternalServerUnavailable as exc:
+        return _recorded_only_cancel_result(reason_code="internal_unavailable", detail=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return _recorded_only_cancel_result(reason_code="live_cancel_failed", detail=str(exc))
+
+    status_code = controller_result.get("status_code")
+    try:
+        normalized_status_code = int(status_code) if status_code is not None else None
+    except (TypeError, ValueError):
+        normalized_status_code = None
+    body = controller_result.get("body") or {}
+    if not _live_cancel_was_confirmed(normalized_status_code, body):
+        return _recorded_only_cancel_result(
+            reason_code=_live_cancel_failure_code(normalized_status_code, body),
+            detail={
+                "controller_status_code": normalized_status_code,
+                "controller_response": body,
+            },
+        )
+
+    run_terminalized = store.mark_run_canceled(str(run.get("id") or ""))
+    return {
+        "code": "live_cancel_confirmed",
+        "live_cancel_attempted": True,
+        "live_cancel_confirmed": True,
+        "run_terminalized": run_terminalized,
+        "controller_status_code": normalized_status_code,
+        "controller_response": body,
+        "message": "Live backend turn was stopped and the run was marked canceled.",
+    }
+
+
 def cmd_runs_cancel(args):
-    canceled = _task_request_store().cancel_run(args.run_id)
+    store = _task_request_store()
+    existing = store.get_run(args.run_id)
+    if existing is None:
+        _print_task_error(TaskCliError(f"run '{args.run_id}' not found", code="run_not_found", details={"run_id": args.run_id}))
+        return 1
+    canceled = store.cancel_run(args.run_id)
     if not canceled:
         _print_task_error(TaskCliError(f"run '{args.run_id}' not found", code="run_not_found", details={"run_id": args.run_id}))
         return 1
-    run = _task_request_store().get_run(args.run_id)
-    _print_cli_payload("agent_run", cancel_requested=True, run=_run_payload(run or {"id": args.run_id}))
+    cancel_result = _initial_cancel_result(existing)
+    if _should_attempt_live_run_cancel(existing):
+        cancel_result = _cancel_live_agent_run(store, existing)
+    run = store.get_run(args.run_id)
+    _print_cli_payload(
+        "agent_run",
+        cancel_requested=True,
+        cancel_code=cancel_result["code"],
+        cancel_result=cancel_result,
+        run=_run_payload(run or {"id": args.run_id}),
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary
- Make `vibe runs cancel <run_id>` call the controller cancel path for running direct Agent Runs with a session id.
- Mark the run terminal `canceled` only when the controller confirms a stop or stale turn release.
- Return structured `cancel_result` codes when only the DB cancel request was recorded, including controller unavailable, no live turn, backend stop failure, and already-finished races.

## Evidence layers
- Unit: updated CLI/store cancellation tests for queued, live-confirmed, controller-unavailable, stop-failed, no-live-turn, and already-finished race cases.
- Contract: preserved existing internal cancel endpoint semantics and verified selected internal-server cancel tests.
- Scenario: not applicable; no scenario catalog entry for Harness run cancellation.
- Residual manual checks: live Incus/manual backend cancellation not run in this turn.

## Validation
- `python3 -m pytest tests/test_cli_task_command.py tests/test_scheduled_tasks.py`
- `python3 -m pytest tests/test_internal_server.py::test_scheduled_gate_cancel_stops_scheduled_run tests/test_internal_server.py::test_cancel_returns_404_when_session_not_in_flight tests/test_internal_server.py::test_cancel_keeps_turn_when_backend_interrupt_failed`
- `python3 -m ruff check vibe/cli.py core/scheduled_tasks.py tests/test_cli_task_command.py`
