### PR TITLE
fix(cli): guard default state migrations from source checkouts

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -218,6 +218,9 @@ Keep entries short, factual, reusable, deduplicated, and free of secrets unless 
 
 
 def ensure_data_dirs() -> None:
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    guard_source_checkout_default_state_bootstrap()
     migrate_default_home()
     get_config_dir().mkdir(parents=True, exist_ok=True)
     get_state_dir().mkdir(parents=True, exist_ok=True)

--- a/core/chat_discovery.py
+++ b/core/chat_discovery.py
@@ -15,7 +15,7 @@ from sqlalchemy import Connection, and_, select
 
 from config import paths
 from storage.db import create_sqlite_engine
-from storage.migrations import run_migrations
+from storage.migrations import guard_source_checkout_default_state_migration, run_migrations
 from storage.models import agent_events, media_objects, messages, scope_settings, scopes, state_meta
 from storage.settings_service import make_scope_id, upsert_scope
 
@@ -152,6 +152,7 @@ def _db_path(db_path: Path | None = None) -> Path:
 
 def _ensure_sqlite(db_path: Path | None = None) -> Path:
     target = _db_path(db_path)
+    guard_source_checkout_default_state_migration(target)
     target.parent.mkdir(parents=True, exist_ok=True)
     with _migration_lock:
         if target not in _migrated_db_paths:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from config import paths
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
-from storage.migrations import run_migrations
+from storage.migrations import guard_source_checkout_default_state_migration, run_migrations
 from storage.models import agent_sessions, agents, run_definitions, scope_settings, state_meta
 
 logger = logging.getLogger(__name__)
@@ -106,6 +106,7 @@ class AgentImportResult:
 class VibeAgentStore:
     def __init__(self, db_path: Optional[Path] = None):
         self.db_path = db_path or paths.get_sqlite_state_path()
+        guard_source_checkout_default_state_migration(self.db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         if db_path is None:
             ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(paths.get_state_dir()))

--- a/storage/background.py
+++ b/storage/background.py
@@ -13,7 +13,11 @@ from sqlalchemy import func, insert, or_, select, update
 
 from config import paths
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
-from storage.migrations import background_tables_ready, initialize_background_tables
+from storage.migrations import (
+    background_tables_ready,
+    guard_source_checkout_default_state_migration,
+    initialize_background_tables,
+)
 from storage.models import agent_runs, agent_sessions, run_definitions, scopes
 from storage.pagination import PageRequest, PageResult, page_result_from_limit_plus_one
 
@@ -385,6 +389,7 @@ def reset_workbench_claimed_runs_in_connection(conn: Any, run_ids: list[str]) ->
 class SQLiteBackgroundTaskStore:
     def __init__(self, db_path: Optional[Path] = None):
         self.db_path = db_path or paths.get_sqlite_state_path()
+        guard_source_checkout_default_state_migration(self.db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         if db_path is None:
             from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config

--- a/storage/importer.py
+++ b/storage/importer.py
@@ -23,7 +23,7 @@ from config.v2_sessions import (
 from config.v2_settings import SettingsState, load_settings_state_from_json
 from storage.db import create_sqlite_engine
 from storage.lock import MigrationFileLock
-from storage.migrations import run_migrations
+from storage.migrations import guard_source_checkout_default_state_migration, run_migrations
 from storage.models import (
     agents,
     agent_sessions,
@@ -62,6 +62,7 @@ def ensure_sqlite_state(
 
     target_db = (db_path or paths.get_sqlite_state_path()).expanduser().resolve()
     target_state_dir = (state_dir or paths.get_state_dir()).expanduser().resolve()
+    guard_source_checkout_default_state_migration(target_db)
     _ensure_sqlite_target_dirs(
         target_state_dir=target_state_dir,
         target_db=target_db,

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 from importlib import import_module
 from pathlib import Path
@@ -14,6 +15,7 @@ from storage.db import create_sqlite_engine, sqlite_url
 INITIAL_REVISION = "20260501_0001"
 LATEST_SCHEMA_REVISION = "20260622_0023"
 REMOVE_LEGACY_DEFAULT_AGENT_REVISION = "20260530_0008"
+ALLOW_DEV_STATE_MIGRATION_ENV = "AVIBE_ALLOW_DEV_STATE_MIGRATION"
 INITIAL_TABLES = {
     "state_meta",
     "agents",
@@ -23,6 +25,12 @@ INITIAL_TABLES = {
     "agent_sessions",
     "runtime_records",
 }
+
+
+class UnsafeDefaultStateMigrationError(RuntimeError):
+    """Raised when source-checkout code would migrate the user's default state."""
+
+
 HEAD_TABLES = INITIAL_TABLES | {
     "run_definitions",
     "agent_runs",
@@ -113,6 +121,7 @@ def alembic_config(db_path: Path | None = None) -> Config:
 
 def run_migrations(db_path: Path | None = None, *, revision: str = "head") -> None:
     target_db = db_path or paths.get_sqlite_state_path()
+    guard_source_checkout_default_state_migration(target_db)
     cfg = alembic_config(target_db)
     _reset_unreleased_initial_schema_drift(target_db)
     _repair_unreleased_head_schema_drift(target_db)
@@ -131,11 +140,60 @@ def background_tables_ready(db_path: Path | None = None) -> bool:
 
 def initialize_background_tables(db_path: Path | None = None) -> None:
     target_db = db_path or paths.get_sqlite_state_path()
+    guard_source_checkout_default_state_migration(target_db)
     cfg = alembic_config(target_db)
     command.ensure_version(cfg)
     _repair_unreleased_head_schema_drift(target_db)
     _stamp_existing_initial_schema(target_db, cfg)
     command.upgrade(cfg, "head")
+
+
+def guard_source_checkout_default_state_migration(db_path: Path) -> None:
+    if _env_flag_enabled(ALLOW_DEV_STATE_MIGRATION_ENV):
+        return
+    if not _running_from_source_checkout():
+        return
+    if not _is_default_user_state_db(db_path):
+        return
+
+    source_root = Path(__file__).resolve().parents[1]
+    raise UnsafeDefaultStateMigrationError(
+        "Refusing to run SQLite migrations from an Avibe source checkout "
+        f"against the default user state DB at {db_path.expanduser().resolve()}. "
+        f"Source root: {source_root}. "
+        "Set AVIBE_HOME to an isolated development directory before running "
+        "worktree/source CLI commands. If you intentionally need to migrate the "
+        f"default local state from source, set {ALLOW_DEV_STATE_MIGRATION_ENV}=1."
+    )
+
+
+def guard_source_checkout_default_state_bootstrap() -> None:
+    guard_source_checkout_default_state_migration(paths.get_sqlite_state_path())
+
+
+def _running_from_source_checkout() -> bool:
+    source_root = Path(__file__).resolve().parents[1]
+    return (source_root / "pyproject.toml").exists() and (source_root / "storage" / "migrations.py").exists()
+
+
+def _is_default_user_state_db(db_path: Path) -> bool:
+    target = db_path.expanduser().resolve()
+    return target in _default_user_state_db_candidates()
+
+
+def _default_user_state_db_candidates() -> set[Path]:
+    home = Path.home().expanduser().resolve()
+    return {
+        (home / paths.AVIBE_HOME_DIRNAME / "state" / "vibe.sqlite").resolve(),
+        (home / paths.LEGACY_HOME_DIRNAME / "state" / "vibe.sqlite").resolve(),
+    }
+
+
+def _env_flag_enabled(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _reset_unreleased_initial_schema_drift(db_path: Path) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ def _isolate_vibe_remote_home(request, tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CACHE_HOME", str(isolated_home / ".cache"))
     monkeypatch.setenv("XDG_STATE_HOME", str(isolated_home / ".local" / "state"))
     monkeypatch.setenv("AVIBE_HOME", str(isolated_home / ".avibe"))
+    monkeypatch.setenv("AVIBE_ALLOW_DEV_STATE_MIGRATION", "1")
     # Keep Codex / Claude Code credential writes off the developer's real
     # home. Tests that manage these env vars themselves (e.g. the
     # ``get_codex_home`` env-precedence tests) override these via their own

--- a/tests/test_dev_state_migration_guard.py
+++ b/tests/test_dev_state_migration_guard.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config import paths
+from core import chat_discovery
+from core.vibe_agents import VibeAgentStore
+from storage import migrations
+from storage.background import SQLiteBackgroundTaskStore
+from storage.migrations import UnsafeDefaultStateMigrationError
+from vibe import cli, restart_supervisor, runtime
+
+
+def _set_default_home_guard(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    db_path = home / ".avibe" / "state" / "vibe.sqlite"
+    monkeypatch.setattr(migrations.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv(paths.AVIBE_HOME_ENV, raising=False)
+    monkeypatch.delenv(migrations.ALLOW_DEV_STATE_MIGRATION_ENV, raising=False)
+    monkeypatch.setattr(migrations, "_running_from_source_checkout", lambda: True)
+    return db_path
+
+
+def test_chat_discovery_guard_blocks_default_state_before_mkdir(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        chat_discovery._ensure_sqlite()
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_background_store_guard_blocks_default_state_before_mkdir(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        SQLiteBackgroundTaskStore()
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_vibe_agent_store_guard_blocks_default_state_before_mkdir(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        VibeAgentStore()
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_cli_start_guard_blocks_default_state_before_data_dirs(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        cli.cmd_start()
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_runtime_lock_guard_blocks_default_state_before_mkdir(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        runtime.acquire_service_instance_lock()
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_runtime_start_service_guard_blocks_default_state_before_mkdir(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        runtime.start_service(wait_for_ready=False)
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_restart_schedule_guard_blocks_default_state_before_status(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        restart_supervisor.schedule_restart(delay_seconds=60, vibe_path="/bin/vibe", trigger="test")
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+    assert not (db_path.parents[1] / "runtime").exists()
+    assert not (db_path.parents[1] / "logs").exists()
+
+
+def test_restart_job_guard_blocks_before_stopping_runtime(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+    stopped = False
+
+    def stop_runtime(*, stop_ui: bool = True):
+        nonlocal stopped
+        stopped = True
+        return True, {}, 0.0, None, True, 0.0
+
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", stop_runtime)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        restart_supervisor._run_restart_job(job_id="jobabc", delay_seconds=0, vibe_path="/bin/vibe", trigger="test")
+
+    assert stopped is False
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_runtime_ensure_dirs_guard_blocks_legacy_home_before_migration(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+    home = db_path.parents[2]
+    legacy_home = home / ".vibe_remote"
+    legacy_state = legacy_home / "state"
+    legacy_state.mkdir(parents=True)
+    (legacy_state / "settings.json").write_text('{"ok":true}', encoding="utf-8")
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        runtime.ensure_dirs()
+
+    assert legacy_home.is_dir()
+    assert not (home / ".avibe").exists()
+
+
+def test_paths_ensure_data_dirs_guard_blocks_legacy_home_before_migration(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+    home = db_path.parents[2]
+    legacy_home = home / ".vibe_remote"
+    legacy_state = legacy_home / "state"
+    legacy_state.mkdir(parents=True)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        paths.ensure_data_dirs()
+
+    assert legacy_home.is_dir()
+    assert not (home / ".avibe").exists()
+
+
+def test_runtime_ensure_config_guard_blocks_before_default_workdir(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+    home = db_path.parents[2]
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        runtime.ensure_config()
+
+    assert not (home / "work").exists()
+    assert not db_path.exists()
+    assert not db_path.parent.exists()

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -11,7 +11,8 @@ from config import paths
 from config.v2_settings import ChannelSettings, RoutingSettings, SettingsState, SettingsStore
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
 from storage.importer import JSON_IMPORT_MARKER, ensure_sqlite_state
-from storage.migrations import background_tables_ready, run_migrations
+from storage import migrations
+from storage.migrations import UnsafeDefaultStateMigrationError, background_tables_ready, run_migrations
 from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
 
@@ -97,6 +98,94 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "deleted_at" in background_columns
         version = conn.execute("select version_num from alembic_version").fetchone()
         assert version == (HEAD_REVISION,)
+
+
+def test_run_migrations_blocks_source_checkout_default_user_state(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    db_path = home / ".avibe" / "state" / "vibe.sqlite"
+
+    monkeypatch.setattr(migrations.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv(paths.AVIBE_HOME_ENV, raising=False)
+    monkeypatch.delenv(migrations.ALLOW_DEV_STATE_MIGRATION_ENV, raising=False)
+    monkeypatch.setattr(migrations, "_running_from_source_checkout", lambda: True)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError) as exc:
+        run_migrations(db_path)
+
+    message = str(exc.value)
+    assert "Refusing to run SQLite migrations from an Avibe source checkout" in message
+    assert str(db_path) in message
+    assert not db_path.exists()
+
+
+def test_run_migrations_blocks_default_state_when_override_is_falsey(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    db_path = home / ".avibe" / "state" / "vibe.sqlite"
+
+    monkeypatch.setattr(migrations.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv(paths.AVIBE_HOME_ENV, raising=False)
+    monkeypatch.setenv(migrations.ALLOW_DEV_STATE_MIGRATION_ENV, "0")
+    monkeypatch.setattr(migrations, "_running_from_source_checkout", lambda: True)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        run_migrations(db_path)
+
+    assert not db_path.exists()
+
+
+def test_ensure_sqlite_state_blocks_source_checkout_default_user_state_before_dirs(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    db_path = home / ".avibe" / "state" / "vibe.sqlite"
+
+    monkeypatch.setattr(migrations.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv(paths.AVIBE_HOME_ENV, raising=False)
+    monkeypatch.delenv(migrations.ALLOW_DEV_STATE_MIGRATION_ENV, raising=False)
+    monkeypatch.setattr(migrations, "_running_from_source_checkout", lambda: True)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        ensure_sqlite_state()
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_ensure_sqlite_state_blocks_explicit_avibe_home_pointing_at_default_state(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    avibe_home = home / ".avibe"
+    db_path = avibe_home / "state" / "vibe.sqlite"
+
+    monkeypatch.setattr(migrations.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv(paths.AVIBE_HOME_ENV, str(avibe_home))
+    monkeypatch.delenv(migrations.ALLOW_DEV_STATE_MIGRATION_ENV, raising=False)
+    monkeypatch.setattr(migrations, "_running_from_source_checkout", lambda: True)
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        ensure_sqlite_state()
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_run_migrations_allows_source_checkout_with_explicit_avibe_home(monkeypatch, tmp_path: Path) -> None:
+    avibe_home = tmp_path / "dev-home"
+    db_path = avibe_home / "state" / "vibe.sqlite"
+
+    monkeypatch.setenv(paths.AVIBE_HOME_ENV, str(avibe_home))
+    monkeypatch.delenv(migrations.ALLOW_DEV_STATE_MIGRATION_ENV, raising=False)
+    monkeypatch.setattr(migrations, "_running_from_source_checkout", lambda: True)
+
+    db_path.parent.mkdir(parents=True)
+    run_migrations()
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute("select version_num from alembic_version").fetchone()
+    assert version == (HEAD_REVISION,)
 
 
 def test_initial_migration_is_schema_snapshot() -> None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1246,6 +1246,12 @@ def _ensure_cli_sqlite_state() -> None:
     ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(paths.get_state_dir()))
 
 
+def _guard_cli_default_state_migration() -> None:
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    guard_source_checkout_default_state_bootstrap()
+
+
 def _primary_platform() -> str:
     try:
         return _ensure_config().platform
@@ -7194,6 +7200,7 @@ def _local_cli_installation_items() -> list[dict]:
 
 
 def cmd_start():
+    _guard_cli_default_state_migration()
     paths.ensure_data_dirs()
     config = _ensure_config()
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -247,6 +247,9 @@ def _run_restart_job(
     # running (a config change shouldn't tear down the open Web UI). "all"
     # (default, e.g. CLI `vibe restart` / upgrades) restarts both.
     restart_ui = scope != "service"
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    guard_source_checkout_default_state_bootstrap()
     log_path = _restart_log_path(job_id)
     safe_cwd = get_safe_cwd()
     _prune_restart_logs()
@@ -430,6 +433,9 @@ def schedule_restart(
     scope: str = "all",
     prepare_show_runtime: bool = False,
 ) -> dict:
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    guard_source_checkout_default_state_bootstrap()
     job_id = uuid.uuid4().hex[:12]
     invocation = get_restart_invocation_command(vibe_path=vibe_path)
     command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -113,6 +113,9 @@ class ServiceAlreadyRunningError(RuntimeError):
 
 
 def ensure_dirs():
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    guard_source_checkout_default_state_bootstrap()
     paths.ensure_data_dirs()
 
 
@@ -133,6 +136,9 @@ def default_config():
 
 
 def ensure_config():
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    guard_source_checkout_default_state_bootstrap()
     config_path = paths.get_config_path()
     if not config_path.exists():
         default = default_config()
@@ -234,7 +240,7 @@ def acquire_service_instance_lock() -> None:
     global _SERVICE_INSTANCE_LOCK_HANDLE
     if _SERVICE_INSTANCE_LOCK_HANDLE is not None:
         return
-    paths.ensure_data_dirs()
+    ensure_dirs()
     lock_path = get_service_lock_path()
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     lock_file = lock_path.open("a+", encoding="utf-8")
@@ -290,7 +296,7 @@ def release_service_instance_lock() -> None:
 
 def service_instance_lock_available() -> tuple[bool, int | None]:
     """Return whether the data-dir scoped service lock can be acquired."""
-    paths.ensure_data_dirs()
+    ensure_dirs()
     lock_path = get_service_lock_path()
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     lock_file = lock_path.open("a+", encoding="utf-8")
@@ -1069,6 +1075,9 @@ def start_service(
     wait_for_ready: bool = True,
     initial_ready_timeout: float = SERVICE_LOCK_READY_TIMEOUT_SECONDS,
 ):
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    guard_source_checkout_default_state_bootstrap()
     with _SERVICE_LOCK:
         pid_path = paths.get_runtime_pid_path()
         existing_pid = 0


### PR DESCRIPTION
## Summary

This PR adds a development-time guard so Avibe source checkouts and worktrees cannot accidentally migrate the user's default local state database.

The guard blocks source-checkout code when it targets the default user SQLite state DB, including both the current ~/.avibe path and the legacy ~/.vibe_remote path. Developers can still run isolated source/worktree tests by setting AVIBE_HOME to a non-default development directory. Intentional default-state migration from source requires the explicit truthy override AVIBE_ALLOW_DEV_STATE_MIGRATION=1.

## Root Cause Addressed

An unreleased migration revision can be written into the real local ~/.avibe state DB when a development checkout or worktree is run against the user's default state. Installed release builds that do not contain that revision then fail to start or serve Show Pages because Alembic cannot locate the unknown revision.

## Changes

- Guard Alembic migration entry points before they touch the default user DB.
- Guard shared data-dir bootstrap before legacy home migration or default state directory creation.
- Guard importer, chat discovery, background task store, agent store, vibe start, service start, service lock acquisition, and restart scheduling/job execution before they can touch default state.
- Treat AVIBE_ALLOW_DEV_STATE_MIGRATION as an explicit truthy opt-in only, not mere environment-variable presence.
- Keep non-default AVIBE_HOME development workflows working.

## Evidence

- Unit: SQLite migration guard tests cover default DB blocking, explicit default AVIBE_HOME blocking, falsey override blocking, isolated AVIBE_HOME success, and HOME-overridden default resolution.
- Startup/restart coverage: tests cover paths.ensure_data_dirs, vibe start, runtime service start, runtime service lock acquisition, restart scheduling, restart job execution, chat discovery, background task store, and agent store blocking before default state directories are created or runtime is stopped.
- Regression subset: previous CI-failing unit files, restart/runtime tests, and task/watch CLI tests pass locally.
- Lint: focused Ruff checks pass.

Scenario catalog: not applicable; this is a local runtime safety guard, not a catalogued product scenario.

## Residual Risk

This does not repair an already-polluted local DB. It prevents unreleased source/worktree code from creating the same class of pollution going forward.
