### PR TITLE
feat(doctor): add runtime repair playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Forgets nothing. Holds opinions. Says thanks when you fix its bugs.
 vibe            # Start Avibe and open the Workbench
 vibe status     # Check service and configuration status
 vibe stop       # Stop the local service
-vibe doctor     # Diagnose common setup issues
+vibe doctor     # Diagnose common setup issues; use "vibe doctor repair" for explicit safe fixes
 vibe remote     # Reach your Workbench from any device via avibe.bot
 vibe agent      # Run and manage Avibe agents
 vibe task       # Schedule time-based work (cron / one-off)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -235,7 +235,7 @@ prototypes → Codex        （快速试验）
 vibe            # 启动 Avibe 并打开 Workbench
 vibe status     # 查看服务和配置状态
 vibe stop       # 停止本地服务
-vibe doctor     # 诊断常见安装问题
+vibe doctor     # 诊断常见安装问题；用 "vibe doctor repair" 显式执行安全修复
 vibe remote     # 通过 avibe.bot 从任意设备访问 Workbench
 vibe agent      # 运行和管理 Avibe agent
 vibe task       # 安排定时工作（cron / 一次性）

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -105,11 +105,22 @@ Run diagnostic checks on your configuration.
 vibe doctor
 ```
 
+Run safe first-phase repairs explicitly:
+
+```bash
+vibe doctor repair --dry-run
+vibe doctor repair home-migration --yes
+vibe doctor repair duplicate-service-processes --yes
+vibe doctor repair stale-install-runtime --yes
+vibe doctor repair stale-restart-state --yes
+```
+
 **Checks:**
 - Configuration file validity
 - Slack token configuration
 - Agent CLI availability (Claude Code, OpenCode, Codex)
-- Runtime environment
+- Runtime home migration state
+- Runtime process, install, and restart metadata state
 
 ### `vibe remote`
 

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -90,11 +90,22 @@ vibe status
 vibe doctor
 ```
 
+显式运行安全的一期修复：
+
+```bash
+vibe doctor repair --dry-run
+vibe doctor repair home-migration --yes
+vibe doctor repair duplicate-service-processes --yes
+vibe doctor repair stale-install-runtime --yes
+vibe doctor repair stale-restart-state --yes
+```
+
 **检查内容：**
 - 配置文件有效性
 - Slack token 配置
 - Agent CLI 可用性（Claude Code、OpenCode、Codex）
-- 运行时环境
+- runtime home 迁移状态
+- runtime 进程、安装来源和重启元数据状态
 
 ### `vibe remote`
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -522,7 +522,7 @@ The `vibe` executable controls the local service and async automation features.
 | `vibe stop` | Stop the service and UI; also terminates OpenCode server |
 | `vibe restart` | Stop then start again |
 | `vibe status` | Print runtime status JSON |
-| `vibe doctor` | Run diagnostics |
+| `vibe doctor` | Run diagnostics; `vibe doctor repair` applies explicit safe repairs |
 | `vibe remote` | Guided Avibe Cloud remote Web UI setup |
 | `vibe screenshot` | Capture a local desktop screenshot |
 | `vibe version` | Show installed version |
@@ -606,7 +606,18 @@ vibe doctor
 - validates config
 - checks platform credentials
 - checks backend CLI availability
-- checks runtime environment
+- checks runtime home migration state
+- checks runtime process, install, and restart metadata state
+
+Repair mode is explicit and supports dry-run:
+
+```bash
+vibe doctor repair --dry-run
+vibe doctor repair home-migration --yes
+vibe doctor repair duplicate-service-processes --yes
+vibe doctor repair stale-install-runtime --yes
+vibe doctor repair stale-restart-state --yes
+```
 
 ### `vibe remote`
 

--- a/docs/COMMANDS_ZH.md
+++ b/docs/COMMANDS_ZH.md
@@ -501,7 +501,7 @@ bind vr-a3x9k2
 | `vibe stop` | 停止服务与 UI，同时终止 OpenCode server |
 | `vibe restart` | 停止后重新启动 |
 | `vibe status` | 输出运行状态 JSON |
-| `vibe doctor` | 运行诊断 |
+| `vibe doctor` | 运行诊断；`vibe doctor repair` 显式执行安全修复 |
 | `vibe remote` | 引导式配置 Avibe Cloud 远程 Web UI |
 | `vibe screenshot` | 截取本机桌面截图 |
 | `vibe version` | 查看当前版本 |
@@ -585,7 +585,18 @@ vibe doctor
 - 校验配置
 - 检查平台凭据
 - 检查 backend CLI 是否可用
-- 检查运行环境
+- 检查 runtime home 迁移状态
+- 检查 runtime 进程、安装来源和重启元数据状态
+
+修复模式需要显式执行，并支持 dry-run：
+
+```bash
+vibe doctor repair --dry-run
+vibe doctor repair home-migration --yes
+vibe doctor repair duplicate-service-processes --yes
+vibe doctor repair stale-install-runtime --yes
+vibe doctor repair stale-restart-state --yes
+```
 
 ### `vibe remote`
 

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -857,6 +857,29 @@ def test_repair_home_migration_skips_empty_home_without_initializing(monkeypatch
     assert not (home / ".vibe_remote").exists()
 
 
+def test_repair_home_migration_fails_when_compatibility_symlink_is_missing(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    avibe_home = home / ".avibe"
+    legacy_home = home / ".vibe_remote"
+    legacy_home.mkdir(parents=True)
+    monkeypatch.delenv("AVIBE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(cli.paths, "migrate_default_home", lambda: legacy_home.rename(avibe_home) or avibe_home)
+    monkeypatch.setattr(
+        cli.paths,
+        "ensure_data_dirs",
+        lambda: (_ for _ in ()).throw(AssertionError("failed migration must not declare data dirs ready")),
+    )
+
+    result = cli._repair_home_migration()
+
+    assert result["status"] == "failed"
+    assert "compatibility symlink" in result["message"]
+    assert avibe_home.exists()
+    assert not legacy_home.exists()
+
+
 def test_repair_stale_restart_state_removes_marker(monkeypatch):
     paths.ensure_data_dirs()
     restart_path = runtime.get_restart_status_path()

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -6,6 +6,7 @@ import shlex
 import sqlite3
 import sys
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -660,6 +661,179 @@ def test_service_lifecycle_doctor_warns_when_extra_service_process_exists(monkey
 
     messages = [item["message"] for item in items if item["status"] == "warn"]
     assert any("Extra Avibe service process detected" in message and "2222" in message for message in messages)
+    warning = next(item for item in items if item.get("code") == "runtime.extra_service_process")
+    assert warning["repair"]["target"] == "duplicate-service-processes"
+
+
+def test_home_migration_doctor_warns_when_legacy_home_is_unmigrated(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    legacy_home = home / ".vibe_remote"
+    legacy_home.mkdir(parents=True)
+    monkeypatch.delenv("AVIBE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+
+    items = cli._home_migration_items()
+
+    warning = next(item for item in items if item.get("code") == "runtime.legacy_home_unmigrated")
+    assert warning["status"] == "warn"
+    assert warning["repair"]["target"] == "home-migration"
+
+
+def test_service_install_doctor_warns_when_service_uses_legacy_package(monkeypatch):
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1234)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [])
+    monkeypatch.setattr(
+        cli.runtime,
+        "get_process_command",
+        lambda pid: "/home/test/.local/share/uv/tools/vibe-remote/bin/python "
+        "/home/test/.local/share/uv/tools/vibe-remote/lib/python3.13/site-packages/vibe/service_main.py",
+    )
+
+    items = cli._service_install_family_items()
+
+    warning = next(item for item in items if item.get("code") == "runtime.stale_install_process")
+    assert warning["repair"]["target"] == "stale-install-runtime"
+
+
+def test_tool_family_detection_resolves_uv_tool_launcher_symlink(tmp_path):
+    tool_root = tmp_path / ".local" / "share" / "uv" / "tools" / "avibe-os"
+    bin_dir = tool_root / "bin"
+    bin_dir.mkdir(parents=True)
+    vibe_bin = bin_dir / "vibe"
+    vibe_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    vibe_bin.chmod(0o755)
+    shim = tmp_path / ".local" / "bin" / "vibe"
+    shim.parent.mkdir(parents=True)
+    shim.symlink_to(vibe_bin)
+
+    assert cli._tool_family_from_text(str(shim)) == cli.PACKAGE_NAME
+
+
+def test_current_cli_install_family_resolves_cached_launcher_symlink(monkeypatch, tmp_path):
+    tool_root = tmp_path / ".local" / "share" / "uv" / "tools" / "avibe-os"
+    bin_dir = tool_root / "bin"
+    bin_dir.mkdir(parents=True)
+    vibe_bin = bin_dir / "vibe"
+    vibe_bin.write_text("#!/bin/sh\n", encoding="utf-8")
+    vibe_bin.chmod(0o755)
+    shim = tmp_path / ".local" / "bin" / "vibe"
+    shim.parent.mkdir(parents=True)
+    shim.symlink_to(vibe_bin)
+    monkeypatch.setattr(cli.sys, "executable", "/usr/bin/python3")
+    monkeypatch.setenv(cli.CURRENT_VIBE_EXECUTABLE_ENV, str(shim))
+    monkeypatch.setattr(cli, "_path_entries_for_executable", lambda name: [])
+
+    assert cli._current_cli_install_family() == cli.PACKAGE_NAME
+
+
+def test_repair_duplicate_service_processes_stops_only_extra_process(monkeypatch):
+    stopped = []
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1234)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
+    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: None)
+
+    result = cli._repair_duplicate_service_processes()
+
+    assert result["status"] == "repaired"
+    assert stopped == [2222]
+    assert result["stopped_pids"] == [2222]
+
+
+def test_repair_stale_install_runtime_stops_only_legacy_extra_process(monkeypatch):
+    stopped = []
+    refreshed = []
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
+    monkeypatch.setattr(
+        cli.runtime,
+        "get_process_command",
+        lambda pid: {
+            1111: "/home/test/.local/share/uv/tools/avibe-os/bin/python service_main.py",
+            2222: "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
+        }[pid],
+    )
+    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda: (_ for _ in ()).throw(AssertionError("must not restart current owner")))
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: refreshed.append(True))
+
+    result = cli._repair_stale_install_runtime()
+
+    assert result["status"] == "repaired"
+    assert stopped == [2222]
+    assert refreshed == [True]
+
+
+def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monkeypatch):
+    stopped = []
+    statuses = []
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [])
+    monkeypatch.setattr(
+        cli.runtime,
+        "get_process_command",
+        lambda pid: "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
+    )
+    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda: 3333)
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 4444})
+    monkeypatch.setattr(cli.runtime, "write_status", lambda *args: statuses.append(args))
+
+    result = cli._repair_stale_install_runtime()
+
+    assert result["status"] == "repaired"
+    assert stopped == [1111]
+    assert result["service_pid"] == 3333
+    assert statuses == [("running", "pid=3333", 3333, 4444)]
+
+
+def test_repair_home_migration_skips_empty_home_without_initializing(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.delenv("AVIBE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+
+    result = cli._repair_home_migration()
+
+    assert result["status"] == "skipped"
+    assert not (home / ".avibe").exists()
+    assert not (home / ".vibe_remote").exists()
+
+
+def test_repair_stale_restart_state_removes_marker(monkeypatch):
+    paths.ensure_data_dirs()
+    restart_path = runtime.get_restart_status_path()
+    runtime.write_json(restart_path, {"state": "running", "supervisor_pid": 4242})
+    old_timestamp = time.time() - 120
+    os.utime(restart_path, (old_timestamp, old_timestamp))
+    monkeypatch.setattr(cli.runtime, "pid_alive", lambda pid: False)
+    refreshed = []
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: refreshed.append(True))
+
+    result = cli._repair_stale_restart_state()
+
+    assert result["status"] == "repaired"
+    assert not restart_path.exists()
+    assert refreshed == [True]
+
+
+def test_doctor_repair_dry_run_does_not_probe_runtime(monkeypatch):
+    def fail_runtime_probe(*args, **kwargs):
+        raise AssertionError("dry-run must not touch runtime probes")
+
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", fail_runtime_probe)
+
+    result = cli._repair_doctor_targets(["duplicate-service-processes"], dry_run=True)
+
+    assert result["ok"] is True
+    assert result["results"][0]["status"] == "planned"
 
 
 def test_restart_parser_accepts_delay_seconds():
@@ -668,6 +842,25 @@ def test_restart_parser_accepts_delay_seconds():
 
     assert args.command == "restart"
     assert args.delay_seconds == 60
+
+
+def test_doctor_parser_accepts_repair_target_and_dry_run():
+    parser = cli.build_parser()
+    args = parser.parse_args(["doctor", "repair", "duplicate-service-processes", "--dry-run"])
+
+    assert args.command == "doctor"
+    assert args.doctor_action == "repair"
+    assert args.doctor_repair_targets == ["duplicate-service-processes"]
+    assert args.dry_run is True
+
+
+def test_doctor_bare_dry_run_does_not_request_repair():
+    parser = cli.build_parser()
+    args = parser.parse_args(["doctor", "--dry-run"])
+
+    assert args.command == "doctor"
+    assert args.doctor_action is None
+    assert cli._doctor_repair_requested(args) is False
 
 
 def test_start_parser_accepts_start_command():

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -794,6 +794,56 @@ def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monk
     assert statuses == [("running", "pid=3333", 3333, 4444)]
 
 
+def test_repair_stale_install_runtime_restarts_after_lockless_legacy_stopped(monkeypatch):
+    stopped = []
+    statuses = []
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: None)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
+    monkeypatch.setattr(
+        cli.runtime,
+        "get_process_command",
+        lambda pid: "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
+    )
+    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda: 3333)
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 4444})
+    monkeypatch.setattr(cli.runtime, "write_status", lambda *args: statuses.append(args))
+
+    result = cli._repair_stale_install_runtime()
+
+    assert result["status"] == "repaired"
+    assert stopped == [2222]
+    assert result["service_pid"] == 3333
+    assert statuses == [("running", "pid=3333", 3333, 4444)]
+
+
+def test_repair_stale_install_runtime_reports_failed_when_restart_fails(monkeypatch):
+    stopped = []
+    refreshed = []
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [])
+    monkeypatch.setattr(
+        cli.runtime,
+        "get_process_command",
+        lambda pid: "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
+    )
+    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: refreshed.append(True))
+
+    result = cli._repair_stale_install_runtime()
+
+    assert result["status"] == "failed"
+    assert "failed to start" in result["message"]
+    assert stopped == [1111]
+    assert result["stopped_pids"] == [1111]
+    assert refreshed == [True]
+
+
 def test_repair_home_migration_skips_empty_home_without_initializing(monkeypatch, tmp_path):
     home = tmp_path / "home"
     monkeypatch.delenv("AVIBE_HOME", raising=False)

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -824,6 +824,28 @@ def test_repair_stale_restart_state_removes_marker(monkeypatch):
     assert refreshed == [True]
 
 
+def test_repair_stale_restart_state_removes_old_marker_without_start_time(monkeypatch):
+    paths.ensure_data_dirs()
+    restart_path = runtime.get_restart_status_path()
+    runtime.write_json(restart_path, {"state": "running", "supervisor_pid": 4242})
+    old_timestamp = time.time() - 120
+    os.utime(restart_path, (old_timestamp, old_timestamp))
+    monkeypatch.setattr(cli.runtime, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        cli.runtime,
+        "process_create_time",
+        lambda pid: (_ for _ in ()).throw(AssertionError("missing start time should use marker age")),
+    )
+    refreshed = []
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: refreshed.append(True))
+
+    result = cli._repair_stale_restart_state()
+
+    assert result["status"] == "repaired"
+    assert not restart_path.exists()
+    assert refreshed == [True]
+
+
 def test_doctor_repair_dry_run_does_not_probe_runtime(monkeypatch):
     def fail_runtime_probe(*args, **kwargs):
         raise AssertionError("dry-run must not touch runtime probes")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -7484,6 +7484,27 @@ def _write_refreshed_runtime_status() -> None:
         runtime.write_status("stopped", "process not running", None, ui_pid)
 
 
+def _start_service_after_repair(target: str, success_message: str, failure_message: str, *, stopped_pids: list[int]) -> dict:
+    try:
+        new_pid = runtime.start_service()
+    except Exception as exc:
+        _write_refreshed_runtime_status()
+        return _doctor_repair_result(
+            target,
+            "failed",
+            f"{failure_message}: {exc}",
+            stopped_pids=stopped_pids,
+        )
+    runtime.write_status("running", f"pid={new_pid}", new_pid, runtime.read_status().get("ui_pid"))
+    return _doctor_repair_result(
+        target,
+        "repaired",
+        success_message,
+        stopped_pids=stopped_pids,
+        service_pid=new_pid,
+    )
+
+
 def _repair_home_migration(*, dry_run: bool = False) -> dict:
     target = "home-migration"
     if os.environ.get(paths.AVIBE_HOME_ENV):
@@ -7579,14 +7600,11 @@ def _repair_duplicate_service_processes(*, dry_run: bool = False) -> dict:
             failed.append(pid)
 
     if not owner_pid and stopped and not failed:
-        new_pid = runtime.start_service()
-        runtime.write_status("running", f"pid={new_pid}", new_pid, runtime.read_status().get("ui_pid"))
-        return _doctor_repair_result(
+        return _start_service_after_repair(
             target,
-            "repaired",
             "Stopped lockless service process(es) and started a clean service.",
+            "Stopped lockless service process(es), but failed to start a clean service",
             stopped_pids=stopped,
-            service_pid=new_pid,
         )
 
     _write_refreshed_runtime_status()
@@ -7646,7 +7664,7 @@ def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
             failed_pids=failed,
         )
 
-    if owner_pid not in stale_pids or current_pids:
+    if current_pids or (owner_pid is not None and owner_pid not in stale_pids):
         _write_refreshed_runtime_status()
         return _doctor_repair_result(
             target,
@@ -7655,14 +7673,11 @@ def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
             stopped_pids=stopped,
         )
 
-    new_pid = runtime.start_service()
-    runtime.write_status("running", f"pid={new_pid}", new_pid, runtime.read_status().get("ui_pid"))
-    return _doctor_repair_result(
+    return _start_service_after_repair(
         target,
-        "repaired",
         "Stopped legacy vibe-remote service process and started the current Avibe service.",
+        "Stopped legacy vibe-remote service process, but failed to start the current Avibe service",
         stopped_pids=stopped,
-        service_pid=new_pid,
     )
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -638,10 +638,9 @@ def _restart_status_is_stale(payload: dict, path: Path) -> bool:
         supervisor_pid = payload.get("supervisor_pid")
         if isinstance(supervisor_pid, int) and runtime.pid_alive(supervisor_pid):
             started_at = payload.get("supervisor_started_at")
-            if started_at is None:
-                return False
-            current_started_at = runtime.process_create_time(supervisor_pid)
-            return current_started_at is not None and current_started_at != started_at
+            if started_at is not None:
+                current_started_at = runtime.process_create_time(supervisor_pid)
+                return current_started_at is not None and current_started_at != started_at
         try:
             age = time.time() - path.stat().st_mtime
         except OSError:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -53,6 +53,7 @@ from vibe import __version__, api, runtime
 from vibe.restart_supervisor import schedule_restart
 from vibe.screenshot import ScreenshotError, capture_screenshot
 from vibe.upgrade import (
+    CURRENT_VIBE_EXECUTABLE_ENV,
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
     build_upgrade_plan,
@@ -72,6 +73,20 @@ logger = logging.getLogger(__name__)
 UV_TOOL_PACKAGE_NAMES = (PACKAGE_NAME, LEGACY_PACKAGE_NAME)
 _TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 _FALSY_ENV_VALUES = {"0", "false", "no", "off"}
+DOCTOR_RESTART_RESULT_RETENTION_SECONDS = 10 * 60
+DOCTOR_RESTART_SEED_GRACE_SECONDS = 60.0
+DOCTOR_REPAIR_TARGETS = (
+    "home-migration",
+    "stale-install-runtime",
+    "duplicate-service-processes",
+    "stale-restart-state",
+)
+DOCTOR_REPAIR_DRY_RUN_MESSAGES = {
+    "home-migration": "Would migrate ~/.vibe_remote to ~/.avibe when safe, or recreate the legacy compatibility symlink.",
+    "stale-install-runtime": "Would stop a running legacy vibe-remote service and start the current Avibe service.",
+    "duplicate-service-processes": "Would stop extra Avibe service processes outside the service lock.",
+    "stale-restart-state": "Would remove stale restart metadata and refresh runtime status.",
+}
 
 WATCH_STARTUP_STABLE_RUNNING_SECONDS = 1.5
 WATCH_STARTUP_JITTER_BUFFER_SECONDS = 1.0
@@ -449,8 +464,226 @@ def _runtime_architecture_items() -> list[dict[str, str]]:
     return items
 
 
-def _service_lifecycle_items() -> list[dict[str, str]]:
-    items: list[dict[str, str]] = []
+def _safe_resolve(path: Path) -> Path | None:
+    try:
+        return path.expanduser().resolve()
+    except OSError:
+        return None
+
+
+def _path_points_to(path: Path, target: Path) -> bool:
+    resolved_path = _safe_resolve(path)
+    resolved_target = _safe_resolve(target)
+    return resolved_path is not None and resolved_target is not None and resolved_path == resolved_target
+
+
+def _home_migration_items() -> list[dict]:
+    items: list[dict] = []
+    explicit_home = os.environ.get(paths.AVIBE_HOME_ENV)
+    if explicit_home:
+        _add_doctor_item(
+            items,
+            "pass",
+            f"AVIBE_HOME is set explicitly: {Path(explicit_home).expanduser()}",
+            code="runtime.explicit_home",
+        )
+        return items
+
+    avibe_home = Path.home() / paths.AVIBE_HOME_DIRNAME
+    legacy_home = Path.home() / paths.LEGACY_HOME_DIRNAME
+    avibe_present = avibe_home.exists() or avibe_home.is_symlink()
+    legacy_present = legacy_home.exists() or legacy_home.is_symlink()
+
+    if not avibe_present and not legacy_present:
+        _add_doctor_item(
+            items,
+            "pass",
+            f"Default runtime home is ready to initialize at {avibe_home}",
+            code="runtime.home_ready",
+        )
+        return items
+
+    if avibe_present:
+        if legacy_home.is_symlink() and _path_points_to(legacy_home, avibe_home):
+            _add_doctor_item(
+                items,
+                "pass",
+                f"Legacy home compatibility symlink is healthy: {legacy_home} -> {avibe_home}",
+                code="runtime.legacy_home_link_ok",
+            )
+        elif not legacy_present:
+            _add_doctor_item(
+                items,
+                "warn",
+                f"Legacy home compatibility path is missing: {legacy_home}",
+                "Run `vibe doctor repair home-migration` to create the compatibility symlink.",
+                code="runtime.legacy_home_link_missing",
+                repair_target="home-migration",
+                repair_risk="low",
+            )
+        elif legacy_home.is_symlink():
+            _add_doctor_item(
+                items,
+                "warn",
+                f"Legacy home symlink does not point to the active home: {legacy_home}",
+                "Run `vibe doctor repair home-migration` to recreate the compatibility symlink.",
+                code="runtime.legacy_home_link_wrong",
+                repair_target="home-migration",
+                repair_risk="low",
+            )
+        else:
+            _add_doctor_item(
+                items,
+                "fail",
+                f"Both {avibe_home} and {legacy_home} are real directories",
+                "Back up and merge the two homes manually before running repair.",
+                code="runtime.home_conflict",
+            )
+        return items
+
+    if legacy_home.is_symlink():
+        _add_doctor_item(
+            items,
+            "warn",
+            f"Legacy home symlink exists but canonical {avibe_home} is missing",
+            "Inspect the symlink target before repair; Avibe will not guess which state to keep.",
+            code="runtime.legacy_home_symlink_without_canonical",
+        )
+        return items
+
+    _add_doctor_item(
+        items,
+        "warn",
+        f"Runtime home still uses the legacy path: {legacy_home}",
+        "Run `vibe doctor repair home-migration` to move it to ~/.avibe and keep a back-symlink.",
+        code="runtime.legacy_home_unmigrated",
+        repair_target="home-migration",
+        repair_risk="low",
+    )
+    return items
+
+
+def _tool_family_from_text(text: str | None) -> str | None:
+    candidates = [text] if text else []
+    try:
+        candidates.extend(shlex.split(text or "", posix=(os.name != "nt")))
+    except ValueError:
+        pass
+
+    for candidate in candidates:
+        normalized = (candidate or "").replace("\\", "/").lower()
+        for package_name in (PACKAGE_NAME, LEGACY_PACKAGE_NAME):
+            if f"/tools/{package_name}/" in normalized:
+                return package_name
+        if not candidate or not any(separator in candidate for separator in ("/", "\\")):
+            continue
+        resolved = _safe_resolve(Path(candidate))
+        normalized_resolved = str(resolved or "").replace("\\", "/").lower()
+        for package_name in (PACKAGE_NAME, LEGACY_PACKAGE_NAME):
+            if f"/tools/{package_name}/" in normalized_resolved:
+                return package_name
+    return None
+
+
+def _current_cli_install_family() -> str | None:
+    candidates = [
+        sys.executable,
+        os.environ.get(CURRENT_VIBE_EXECUTABLE_ENV),
+        *(str(path) for path in _path_entries_for_executable("vibe")[:1]),
+    ]
+    for candidate in candidates:
+        family = _tool_family_from_text(candidate)
+        if family:
+            return family
+    return None
+
+
+def _service_install_family_items() -> list[dict]:
+    items: list[dict] = []
+    current_family = _current_cli_install_family()
+    owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
+    service_pids = [pid for pid in [owner_pid] if pid]
+    service_pids.extend(runtime.extra_service_process_pids(owner_pid=owner_pid))
+
+    stale_pids: list[int] = []
+    for pid in sorted(set(service_pids)):
+        command = runtime.get_process_command(pid)
+        service_family = _tool_family_from_text(command)
+        if current_family == PACKAGE_NAME and service_family == LEGACY_PACKAGE_NAME:
+            stale_pids.append(pid)
+
+    if stale_pids:
+        _add_doctor_item(
+            items,
+            "warn",
+            "Running service process still comes from the legacy vibe-remote installation: "
+            f"pids={','.join(map(str, stale_pids))}",
+            "Run `vibe doctor repair stale-install-runtime` to stop the stale service and start the current Avibe install.",
+            code="runtime.stale_install_process",
+            repair_target="stale-install-runtime",
+            repair_risk="medium",
+        )
+    elif owner_pid and current_family:
+        _add_doctor_item(items, "pass", f"No legacy install mismatch detected for running service: pid={owner_pid}")
+    elif owner_pid:
+        _add_doctor_item(items, "pass", f"Current CLI install family is not a uv tool install; skipped install mismatch check: pid={owner_pid}")
+    else:
+        _add_doctor_item(items, "pass", "No running service install mismatch detected")
+    return items
+
+
+def _restart_status_is_stale(payload: dict, path: Path) -> bool:
+    state = payload.get("state")
+    if state in {"scheduled", "running"}:
+        supervisor_pid = payload.get("supervisor_pid")
+        if isinstance(supervisor_pid, int) and runtime.pid_alive(supervisor_pid):
+            started_at = payload.get("supervisor_started_at")
+            if started_at is None:
+                return False
+            current_started_at = runtime.process_create_time(supervisor_pid)
+            return current_started_at is not None and current_started_at != started_at
+        try:
+            age = time.time() - path.stat().st_mtime
+        except OSError:
+            return False
+        return age > DOCTOR_RESTART_SEED_GRACE_SECONDS
+
+    if state in {"succeeded", "failed", "error", "cancelled"}:
+        try:
+            age = time.time() - path.stat().st_mtime
+        except OSError:
+            return False
+        return age > DOCTOR_RESTART_RESULT_RETENTION_SECONDS
+    return False
+
+
+def _restart_state_items() -> list[dict]:
+    items: list[dict] = []
+    restart_path = runtime.get_restart_status_path()
+    payload = runtime.read_json(restart_path) or {}
+    if not payload:
+        _add_doctor_item(items, "pass", "No restart metadata is present", code="runtime.restart_state_absent")
+        return items
+
+    if _restart_status_is_stale(payload, restart_path):
+        state = payload.get("state") or "unknown"
+        _add_doctor_item(
+            items,
+            "warn",
+            f"Stale restart metadata is present: state={state}",
+            "Run `vibe doctor repair stale-restart-state` to clear the stale restart marker and refresh status.",
+            code="runtime.stale_restart_state",
+            repair_target="stale-restart-state",
+            repair_risk="low",
+        )
+    else:
+        state = payload.get("state") or "unknown"
+        _add_doctor_item(items, "pass", f"Restart metadata is current: state={state}")
+    return items
+
+
+def _service_lifecycle_items() -> list[dict]:
+    items: list[dict] = []
     pid_path = paths.get_runtime_pid_path()
     recorded_pid: int | None = None
     try:
@@ -470,16 +703,17 @@ def _service_lifecycle_items() -> list[dict[str, str]]:
     status_pid = status.get("service_pid")
 
     if owner_pid:
-        _add_doctor_item(items, "pass", f"Service lock owner: pid={owner_pid}")
+        _add_doctor_item(items, "pass", f"Service lock owner: pid={owner_pid}", code="runtime.service_lock_owner")
     elif lock_holder_pid:
         _add_doctor_item(
             items,
             "warn",
             f"Service lock is held by pid={lock_holder_pid}, but the owner could not be verified",
             "Run `vibe status` and inspect service logs before starting another service.",
+            code="runtime.unverified_service_lock",
         )
     else:
-        _add_doctor_item(items, "pass", "Service lock is free")
+        _add_doctor_item(items, "pass", "Service lock is free", code="runtime.service_lock_free")
 
     if owner_pid and recorded_pid != owner_pid:
         _add_doctor_item(
@@ -487,6 +721,7 @@ def _service_lifecycle_items() -> list[dict[str, str]]:
             "warn",
             f"Service pid file does not match the lock owner: pidfile={recorded_pid or 'missing'} lock_owner={owner_pid}",
             "Run `vibe restart` once the current work is idle so Avibe can rewrite runtime ownership files.",
+            code="runtime.service_pidfile_mismatch",
         )
     elif recorded_pid:
         _add_doctor_item(items, "pass", f"Service pid file points to pid={recorded_pid}")
@@ -499,6 +734,7 @@ def _service_lifecycle_items() -> list[dict[str, str]]:
             "warn",
             f"Runtime status service_pid does not match the lock owner: status={status_pid or 'missing'} lock_owner={owner_pid}",
             "Refresh status; if it remains stale, restart Avibe when safe.",
+            code="runtime.status_pid_mismatch",
         )
     elif status_pid:
         _add_doctor_item(items, "pass", f"Runtime status service_pid: {status_pid}")
@@ -510,7 +746,10 @@ def _service_lifecycle_items() -> list[dict[str, str]]:
             items,
             "warn",
             f"Extra Avibe service process detected outside the service lock: pids={','.join(map(str, extra_service_pids))}",
-            "Run `vibe stop`; if the process remains, inspect the service log before starting again.",
+            "Run `vibe doctor repair duplicate-service-processes` to stop extra service processes.",
+            code="runtime.extra_service_process",
+            repair_target="duplicate-service-processes",
+            repair_risk="medium",
         )
     elif unverified_service_pids:
         _add_doctor_item(
@@ -518,6 +757,7 @@ def _service_lifecycle_items() -> list[dict[str, str]]:
             "warn",
             f"Possible extra Avibe service process could not be matched to AVIBE_HOME: pids={','.join(map(str, unverified_service_pids))}",
             "Inspect the process environment before starting another service.",
+            code="runtime.unverified_service_process",
         )
     else:
         _add_doctor_item(items, "pass", "No extra Avibe service process detected")
@@ -6629,6 +6869,13 @@ def _doctor():
     groups = []
     summary = {"pass": 0, "warn": 0, "fail": 0}
 
+    home_items = _home_migration_items()
+    for item in home_items:
+        status = item.get("status")
+        if status in summary:
+            summary[status] += 1
+    groups.append({"name": "Runtime Home", "items": home_items})
+
     # Configuration Group
     config_items = []
     config_path = paths.get_config_path()
@@ -6916,7 +7163,12 @@ def _doctor():
         )
         summary["pass"] += 1
 
-    for item in [*_service_lifecycle_items(), *_runtime_architecture_items()]:
+    for item in [
+        *_service_lifecycle_items(),
+        *_service_install_family_items(),
+        *_restart_state_items(),
+        *_runtime_architecture_items(),
+    ]:
         runtime_items.append(item)
         status = item.get("status")
         if status in summary:
@@ -6944,10 +7196,28 @@ def _doctor():
     return result
 
 
-def _add_doctor_item(items: list[dict], status: str, message: str, action: str | None = None) -> None:
+def _add_doctor_item(
+    items: list[dict],
+    status: str,
+    message: str,
+    action: str | None = None,
+    *,
+    code: str | None = None,
+    repair_target: str | None = None,
+    repair_risk: str | None = None,
+) -> None:
     item = {"status": status, "message": message}
+    if code:
+        item["code"] = code
     if action:
         item["action"] = action
+    if repair_target:
+        item["repairable"] = True
+        item["repair"] = {
+            "target": repair_target,
+            "command": f"vibe doctor repair {repair_target}",
+            "risk": repair_risk or "medium",
+        }
     items.append(item)
 
 
@@ -7191,6 +7461,269 @@ def _local_cli_installation_items() -> list[dict]:
         )
 
     return items
+
+
+def _doctor_repair_result(target: str, status: str, message: str, **details) -> dict:
+    payload = {"target": target, "status": status, "message": message}
+    payload.update({key: value for key, value in details.items() if value is not None})
+    return payload
+
+
+def _write_refreshed_runtime_status() -> None:
+    status = runtime.read_status()
+    ui_pid = status.get("ui_pid")
+    owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
+    extra_pids = runtime.extra_service_process_pids(owner_pid=owner_pid)
+    if owner_pid:
+        detail = f"pid={owner_pid}"
+        if extra_pids:
+            detail = f"{detail}; extra_service_pids={','.join(map(str, extra_pids))}"
+        runtime.write_status("running", detail, owner_pid, ui_pid)
+    elif extra_pids:
+        runtime.write_status("degraded", f"lockless service process detected pid={extra_pids[0]}", extra_pids[0], ui_pid)
+    else:
+        runtime.write_status("stopped", "process not running", None, ui_pid)
+
+
+def _repair_home_migration(*, dry_run: bool = False) -> dict:
+    target = "home-migration"
+    if os.environ.get(paths.AVIBE_HOME_ENV):
+        return _doctor_repair_result(target, "skipped", "AVIBE_HOME is explicit; default home migration does not apply.")
+
+    avibe_home = Path.home() / paths.AVIBE_HOME_DIRNAME
+    legacy_home = Path.home() / paths.LEGACY_HOME_DIRNAME
+    avibe_present = avibe_home.exists() or avibe_home.is_symlink()
+    legacy_present = legacy_home.exists() or legacy_home.is_symlink()
+
+    if not avibe_present and not legacy_present:
+        return _doctor_repair_result(target, "skipped", "No runtime home exists yet; nothing needs migration.")
+
+    if avibe_present and legacy_present and not legacy_home.is_symlink():
+        return _doctor_repair_result(
+            target,
+            "failed",
+            "Both ~/.avibe and ~/.vibe_remote are real directories; manual merge is required.",
+        )
+
+    if not avibe_present and legacy_home.is_symlink():
+        return _doctor_repair_result(
+            target,
+            "failed",
+            "Legacy home is a symlink but ~/.avibe is missing; inspect the symlink target manually.",
+        )
+
+    if avibe_present and legacy_home.is_symlink() and _path_points_to(legacy_home, avibe_home):
+        return _doctor_repair_result(target, "skipped", "Runtime home migration is already healthy.")
+
+    if dry_run:
+        if not avibe_present and legacy_present and not legacy_home.is_symlink():
+            return _doctor_repair_result(target, "planned", "Would move ~/.vibe_remote to ~/.avibe and create a back-symlink.")
+        if avibe_present:
+            return _doctor_repair_result(target, "planned", "Would recreate the ~/.vibe_remote compatibility symlink.")
+        return _doctor_repair_result(target, "skipped", "No runtime home migration is needed.")
+
+    if avibe_present:
+        if legacy_home.is_symlink() or not legacy_present:
+            legacy_home.unlink(missing_ok=True)
+            try:
+                legacy_home.symlink_to(avibe_home, target_is_directory=True)
+            except OSError as exc:
+                return _doctor_repair_result(target, "failed", f"Failed to create compatibility symlink: {exc}")
+            return _doctor_repair_result(target, "repaired", "Created ~/.vibe_remote compatibility symlink.")
+        return _doctor_repair_result(target, "skipped", "No runtime home migration is needed.")
+
+    migrated_home = paths.migrate_default_home()
+    if _path_points_to(migrated_home, avibe_home):
+        paths.ensure_data_dirs()
+        return _doctor_repair_result(target, "repaired", "Migrated ~/.vibe_remote to ~/.avibe.")
+    return _doctor_repair_result(target, "failed", f"Default home remains at {migrated_home}; migration did not complete.")
+
+
+def _repair_stale_restart_state(*, dry_run: bool = False) -> dict:
+    target = "stale-restart-state"
+    restart_path = runtime.get_restart_status_path()
+    payload = runtime.read_json(restart_path) or {}
+    if not payload:
+        return _doctor_repair_result(target, "skipped", "No restart metadata is present.")
+    if not _restart_status_is_stale(payload, restart_path):
+        return _doctor_repair_result(target, "skipped", "Restart metadata is still current.")
+    if dry_run:
+        return _doctor_repair_result(target, "planned", "Would remove stale restart metadata and refresh runtime status.")
+    restart_path.unlink(missing_ok=True)
+    _write_refreshed_runtime_status()
+    return _doctor_repair_result(target, "repaired", "Removed stale restart metadata and refreshed runtime status.")
+
+
+def _repair_duplicate_service_processes(*, dry_run: bool = False) -> dict:
+    target = "duplicate-service-processes"
+    if runtime.service_instance_lock_attached_to_process():
+        return _doctor_repair_result(target, "failed", "Run this repair from the CLI, not from inside the service process.")
+
+    owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
+    extra_pids = runtime.extra_service_process_pids(owner_pid=owner_pid)
+    if not extra_pids:
+        return _doctor_repair_result(target, "skipped", "No extra Avibe service process was detected.")
+    if dry_run:
+        return _doctor_repair_result(
+            target,
+            "planned",
+            f"Would stop extra Avibe service process(es): {','.join(map(str, extra_pids))}.",
+            pids=extra_pids,
+        )
+
+    stopped: list[int] = []
+    failed: list[int] = []
+    for pid in extra_pids:
+        if runtime.stop_pid(pid, timeout=5):
+            stopped.append(pid)
+        else:
+            failed.append(pid)
+
+    if not owner_pid and stopped and not failed:
+        new_pid = runtime.start_service()
+        runtime.write_status("running", f"pid={new_pid}", new_pid, runtime.read_status().get("ui_pid"))
+        return _doctor_repair_result(
+            target,
+            "repaired",
+            "Stopped lockless service process(es) and started a clean service.",
+            stopped_pids=stopped,
+            service_pid=new_pid,
+        )
+
+    _write_refreshed_runtime_status()
+    if failed:
+        return _doctor_repair_result(
+            target,
+            "failed",
+            "Some extra service processes could not be stopped.",
+            stopped_pids=stopped,
+            failed_pids=failed,
+        )
+    return _doctor_repair_result(target, "repaired", "Stopped extra Avibe service process(es).", stopped_pids=stopped)
+
+
+def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
+    target = "stale-install-runtime"
+    if runtime.service_instance_lock_attached_to_process():
+        return _doctor_repair_result(target, "failed", "Run this repair from the CLI, not from inside the service process.")
+
+    current_family = _current_cli_install_family()
+    owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
+    service_pids = [pid for pid in [owner_pid] if pid]
+    service_pids.extend(runtime.extra_service_process_pids(owner_pid=owner_pid))
+    stale_pids: list[int] = []
+    current_pids: list[int] = []
+    for pid in sorted(set(service_pids)):
+        family = _tool_family_from_text(runtime.get_process_command(pid))
+        if current_family == PACKAGE_NAME and family == LEGACY_PACKAGE_NAME:
+            stale_pids.append(pid)
+        elif family == PACKAGE_NAME:
+            current_pids.append(pid)
+    if not stale_pids:
+        return _doctor_repair_result(target, "skipped", "No legacy vibe-remote service process was detected.")
+    if dry_run:
+        return _doctor_repair_result(
+            target,
+            "planned",
+            f"Would stop legacy service process(es) and start current Avibe: {','.join(map(str, stale_pids))}.",
+            pids=stale_pids,
+        )
+
+    stopped: list[int] = []
+    failed: list[int] = []
+    for pid in stale_pids:
+        if runtime.stop_pid(pid, timeout=5):
+            stopped.append(pid)
+        else:
+            failed.append(pid)
+
+    if failed:
+        _write_refreshed_runtime_status()
+        return _doctor_repair_result(
+            target,
+            "failed",
+            "Some legacy vibe-remote service processes could not be stopped.",
+            stopped_pids=stopped,
+            failed_pids=failed,
+        )
+
+    if owner_pid not in stale_pids or current_pids:
+        _write_refreshed_runtime_status()
+        return _doctor_repair_result(
+            target,
+            "repaired",
+            "Stopped legacy vibe-remote service process(es).",
+            stopped_pids=stopped,
+        )
+
+    new_pid = runtime.start_service()
+    runtime.write_status("running", f"pid={new_pid}", new_pid, runtime.read_status().get("ui_pid"))
+    return _doctor_repair_result(
+        target,
+        "repaired",
+        "Stopped legacy vibe-remote service process and started the current Avibe service.",
+        stopped_pids=stopped,
+        service_pid=new_pid,
+    )
+
+
+def _repair_doctor_targets(targets: list[str], *, dry_run: bool = False) -> dict:
+    requested_targets = targets or list(DOCTOR_REPAIR_TARGETS)
+    unknown = [target for target in requested_targets if target not in DOCTOR_REPAIR_TARGETS]
+    if unknown:
+        return {
+            "ok": False,
+            "kind": "doctor_repair",
+            "dry_run": dry_run,
+            "results": [
+                _doctor_repair_result(
+                    target,
+                    "failed",
+                    f"Unknown repair target. Known targets: {', '.join(DOCTOR_REPAIR_TARGETS)}.",
+                )
+                for target in unknown
+            ],
+        }
+
+    if dry_run:
+        return {
+            "ok": True,
+            "kind": "doctor_repair",
+            "dry_run": True,
+            "results": [
+                _doctor_repair_result(
+                    target,
+                    "planned",
+                    DOCTOR_REPAIR_DRY_RUN_MESSAGES[target],
+                )
+                for target in requested_targets
+            ],
+        }
+
+    handlers = {
+        "home-migration": _repair_home_migration,
+        "stale-install-runtime": _repair_stale_install_runtime,
+        "duplicate-service-processes": _repair_duplicate_service_processes,
+        "stale-restart-state": _repair_stale_restart_state,
+    }
+    results = [handlers[target](dry_run=dry_run) for target in requested_targets]
+    payload = {
+        "ok": not any(result["status"] == "failed" for result in results),
+        "kind": "doctor_repair",
+        "dry_run": dry_run,
+        "results": results,
+    }
+    if not dry_run:
+        payload["doctor"] = _doctor()
+    return payload
+
+
+def _confirm_doctor_repair(targets: list[str]) -> bool:
+    if not sys.stdin.isatty():
+        return False
+    target_text = ", ".join(targets or DOCTOR_REPAIR_TARGETS)
+    answer = input(f"Repair Avibe doctor target(s): {target_text}? Type 'yes' to continue: ")
+    return answer.strip().lower() == "yes"
 
 
 def cmd_start():
@@ -8275,7 +8808,42 @@ def cmd_show(args):
     )
 
 
-def cmd_doctor():
+def _doctor_repair_requested(args) -> bool:
+    return bool(
+        getattr(args, "fix", False)
+        or getattr(args, "doctor_action", None) == "repair"
+    )
+
+
+def _print_doctor_repair_result(result: dict) -> None:
+    title = "Avibe Doctor Repair"
+    if result.get("dry_run"):
+        title = f"{title} (dry run)"
+    print(f"\n  {title}")
+    print("  " + "=" * 40)
+    for item in result.get("results", []):
+        status = item.get("status")
+        if status in {"repaired", "planned"}:
+            icon = "\033[32m✓\033[0m"
+        elif status == "skipped":
+            icon = "\033[33m!\033[0m"
+        else:
+            icon = "\033[31m✗\033[0m"
+        print(f"  {icon} {item.get('target')}: {item.get('message')}")
+    print()
+
+
+def cmd_doctor(args=None):
+    if args is not None and _doctor_repair_requested(args):
+        targets = list(getattr(args, "doctor_repair_targets", []) or [])
+        dry_run = bool(getattr(args, "dry_run", False))
+        if not dry_run and not getattr(args, "yes", False) and not _confirm_doctor_repair(targets):
+            print("Doctor repair was not run. Pass --yes to confirm non-interactively.", file=sys.stderr)
+            return 2
+        result = _repair_doctor_targets(targets, dry_run=dry_run)
+        _print_doctor_repair_result(result)
+        return 0 if result.get("ok") else 1
+
     result = _doctor()
 
     # Terminal-friendly output
@@ -8675,7 +9243,26 @@ def build_parser():
     supervisor_parser.add_argument("--vibe-path")
     supervisor_parser.add_argument("--prepare-show-runtime", action="store_true")
     subparsers.add_parser("status", help="Show service status")
-    subparsers.add_parser("doctor", help="Run diagnostics")
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Run diagnostics and optional safe repairs",
+        description="Run Avibe diagnostics. Use the explicit repair action to apply common runtime fixes.",
+    )
+    doctor_parser.add_argument(
+        "doctor_action",
+        nargs="?",
+        choices=("repair",),
+        help="Run common repair playbooks instead of only reporting diagnostics.",
+    )
+    doctor_parser.add_argument(
+        "doctor_repair_targets",
+        nargs="*",
+        choices=DOCTOR_REPAIR_TARGETS,
+        help="Repair target(s). Defaults to all safe first-phase repair targets.",
+    )
+    doctor_parser.add_argument("--fix", action="store_true", help="Alias for 'vibe doctor repair'.")
+    doctor_parser.add_argument("--dry-run", action="store_true", help="Show repair actions without changing state.")
+    doctor_parser.add_argument("-y", "--yes", action="store_true", help="Confirm repair actions non-interactively.")
     subparsers.add_parser("version", help="Show version")
     subparsers.add_parser("check-update", help="Check for updates")
     subparsers.add_parser("upgrade", help="Upgrade to latest version")
@@ -9927,7 +10514,7 @@ def main():
     if args.command == "status":
         sys.exit(cmd_status())
     if args.command == "doctor":
-        sys.exit(cmd_doctor())
+        sys.exit(cmd_doctor(args))
     if args.command == "screenshot":
         sys.exit(cmd_screenshot(args))
     if args.command == "show":

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -7553,10 +7553,16 @@ def _repair_home_migration(*, dry_run: bool = False) -> dict:
         return _doctor_repair_result(target, "skipped", "No runtime home migration is needed.")
 
     migrated_home = paths.migrate_default_home()
-    if _path_points_to(migrated_home, avibe_home):
-        paths.ensure_data_dirs()
-        return _doctor_repair_result(target, "repaired", "Migrated ~/.vibe_remote to ~/.avibe.")
-    return _doctor_repair_result(target, "failed", f"Default home remains at {migrated_home}; migration did not complete.")
+    if not _path_points_to(migrated_home, avibe_home):
+        return _doctor_repair_result(target, "failed", f"Default home remains at {migrated_home}; migration did not complete.")
+    if not _path_points_to(legacy_home, avibe_home):
+        return _doctor_repair_result(
+            target,
+            "failed",
+            "Migrated ~/.vibe_remote to ~/.avibe, but failed to create the compatibility symlink.",
+        )
+    paths.ensure_data_dirs()
+    return _doctor_repair_result(target, "repaired", "Migrated ~/.vibe_remote to ~/.avibe.")
 
 
 def _repair_stale_restart_state(*, dry_run: bool = False) -> dict:


### PR DESCRIPTION
## What changed

Adds explicit Doctor repair playbooks for common 2.x -> 3.x runtime problems:

- runtime home migration / legacy `~/.vibe_remote` compatibility repair
- stale legacy `vibe-remote` service process detection and targeted cleanup
- duplicate Avibe service process cleanup
- stale restart metadata cleanup

`vibe doctor` remains diagnostic by default. Repairs require `vibe doctor repair ...` or `--fix`, support `--dry-run`, and require confirmation unless `--yes` is passed.

## Evidence

- Unit: `python3 -m pytest tests/test_vibe_cli.py tests/test_runtime_service_lock.py tests/test_upgrade_flow.py tests/test_ui_server_logs.py -q`
- Lint: `python3 -m ruff check vibe/cli.py tests/test_vibe_cli.py`
- Contract/manual: reviewer subagent pass returned `NO FINDINGS`; CLI parser smoke checked `doctor`, `doctor --dry-run`, `doctor repair --dry-run`, and targeted repair with `--yes`

## Risks / follow-ups

- Web Doctor still only runs diagnostics; UI repair buttons can be layered on top of the new repair metadata later.
- Remote access and backend-server-specific repair playbooks are intentionally left for a later phase.
