### PR TITLE
Speed up inbox session query

### DIFF
--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -865,86 +865,47 @@ def list_inbox_sessions(
     cursor returned as ``next_cursor``).
     """
 
-    m = messages
-
-    # Rank every message in a session by recency (any author) → latest = activity clock.
-    # Exclude the ephemeral queue/draft rows: they live in this table (Step 5)
-    # but aren't sent conversation, so a saved draft or a pending queued message
-    # must NOT bump the session to the top of the inbox or flip its "replied"
-    # badge (Codex P2).
-    any_ranked = (
-        select(
-            m.c.session_id.label("session_id"),
-            m.c.scope_id.label("scope_id"),
-            m.c.author.label("last_author"),
-            m.c.created_at.label("last_activity_at"),
-            func.row_number()
-            .over(partition_by=m.c.session_id, order_by=(m.c.created_at.desc(), m.c.id.desc()))
-            .label("rn"),
+    def _latest_message_value(
+        column_name: str,
+        *,
+        author: Optional[str] = None,
+        types: Optional[tuple[str, ...]] = None,
+        conversation_only: bool = False,
+    ) -> Any:
+        msg = messages.alias()
+        query = (
+            select(getattr(msg.c, column_name))
+            .where(msg.c.session_id == agent_sessions.c.id)
+            .where(msg.c.session_id.is_not(None))
+            .order_by(msg.c.created_at.desc(), msg.c.id.desc())
+            .limit(1)
         )
-        .where(m.c.session_id.is_not(None))
-        .where(m.c.type.notin_(NON_CONVERSATION_TYPES))
-    )
-    if platform is not None:
-        any_ranked = any_ranked.where(m.c.platform == platform)
-    any_ranked = any_ranked.subquery()
-    latest_any = select(any_ranked).where(any_ranked.c.rn == 1).subquery()
+        if platform is not None:
+            query = query.where(msg.c.platform == platform)
+        if author is not None:
+            query = query.where(msg.c.author == author)
+        if types is not None:
+            query = query.where(msg.c.type.in_(types))
+        if conversation_only:
+            query = query.where(msg.c.type.notin_(NON_CONVERSATION_TYPES))
+        return query.scalar_subquery()
 
-    # Rank agent messages by recency → latest agent reply = preview (also proves
-    # eligibility). Include ``notify`` + ``error`` as well as ``result``: a turn
-    # that FAILS persists a terminal ``error`` (or, for an interrupt/info, a
-    # ``notify``), and that failed conversation must still surface in the inbox
-    # (with its error) rather than disappear once the user leaves the Chat page
-    # (Codex P2). Unread counts below stay result-only — a failure isn't an unread
-    # reply.
-    agent_ranked = (
-        select(
-            m.c.session_id.label("session_id"),
-            m.c.content_text.label("preview_text"),
-            m.c.content_json.label("preview_json"),
-            m.c.created_at.label("preview_at"),
-            m.c.id.label("preview_id"),
-            func.row_number()
-            .over(partition_by=m.c.session_id, order_by=(m.c.created_at.desc(), m.c.id.desc()))
-            .label("rn"),
-        )
-        .where(m.c.session_id.is_not(None))
-        .where(m.c.type.in_(("result", "notify", "error")))
-    )
-    if platform is not None:
-        agent_ranked = agent_ranked.where(m.c.platform == platform)
-    agent_ranked = agent_ranked.subquery()
-    latest_agent = select(agent_ranked).where(agent_ranked.c.rn == 1).subquery()
-
-    # Latest *user* message per session (real sends only — exclude the ephemeral
-    # draft/queue/pending rows). Drives the persistent "awaiting the agent" badge:
-    # a session is awaiting a reply when the user's latest message is newer than
-    # the agent's latest reply. That stays true for the whole time the agent is
-    # working (not just the instant before it starts streaming) and survives a
-    # reload — unlike a "who literally spoke last" check that the agent's mid-turn
-    # streaming rows would immediately flip off.
-    user_ranked = (
-        select(
-            m.c.session_id.label("session_id"),
-            m.c.created_at.label("last_user_at"),
-            m.c.id.label("last_user_id"),
-            func.row_number()
-            .over(partition_by=m.c.session_id, order_by=(m.c.created_at.desc(), m.c.id.desc()))
-            .label("rn"),
-        )
-        .where(m.c.session_id.is_not(None))
-        .where(m.c.author == "user")
-        .where(m.c.type.notin_(NON_CONVERSATION_TYPES))
-    )
-    if platform is not None:
-        user_ranked = user_ranked.where(m.c.platform == platform)
-    user_ranked = user_ranked.subquery()
-    latest_user = select(user_ranked).where(user_ranked.c.rn == 1).subquery()
+    # Drive from the small session set and do top-1 index probes per session.
+    # This preserves the inbox contract while avoiding full message-window
+    # materialization as history grows.
+    last_activity_at = _latest_message_value("created_at", conversation_only=True)
+    last_author = _latest_message_value("author", conversation_only=True)
+    preview_id = _latest_message_value("id", types=("result", "notify", "error"))
+    preview_at = _latest_message_value("created_at", types=("result", "notify", "error"))
+    last_user_at = _latest_message_value("created_at", author="user", conversation_only=True)
+    last_user_id = _latest_message_value("id", author="user", conversation_only=True)
 
     # Unread agent messages per session.
+    m = messages
     unread_q = (
         select(m.c.session_id.label("session_id"), func.count().label("unread_count"))
         .where(m.c.session_id.is_not(None))
+        .where(m.c.author == "agent")
         .where(m.c.type == "result")
         .where(m.c.read_at.is_(None))
         .group_by(m.c.session_id)
@@ -953,55 +914,65 @@ def list_inbox_sessions(
         unread_q = unread_q.where(m.c.platform == platform)
     unread_sub = unread_q.subquery()
 
-    unread_count_col = func.coalesce(unread_sub.c.unread_count, 0)
-    query = (
+    unread_count_col = func.coalesce(unread_sub.c.unread_count, 0).label("unread_count")
+    session_rows = (
         select(
-            latest_agent.c.session_id,
-            latest_agent.c.preview_text,
-            latest_agent.c.preview_json,
-            latest_agent.c.preview_at,
-            latest_any.c.last_author,
-            latest_any.c.last_activity_at,
+            agent_sessions.c.id.label("session_id"),
+            last_activity_at.label("last_activity_at"),
+            last_author.label("last_author"),
             agent_sessions.c.title,
             agent_sessions.c.scope_id,
             scopes.c.native_id.label("project_id"),
             scopes.c.display_name.label("project_name"),
-            unread_count_col.label("unread_count"),
-            latest_agent.c.preview_id,
-            latest_user.c.last_user_at,
-            latest_user.c.last_user_id,
+            unread_count_col,
+            preview_id.label("preview_id"),
+            preview_at.label("preview_at"),
+            last_user_at.label("last_user_at"),
+            last_user_id.label("last_user_id"),
         )
         .select_from(
-            latest_agent.join(latest_any, latest_any.c.session_id == latest_agent.c.session_id)
-            .join(agent_sessions, agent_sessions.c.id == latest_agent.c.session_id)
-            .join(scopes, scopes.c.id == agent_sessions.c.scope_id, isouter=True)
-            .join(unread_sub, unread_sub.c.session_id == latest_agent.c.session_id, isouter=True)
-            .join(latest_user, latest_user.c.session_id == latest_agent.c.session_id, isouter=True)
+            agent_sessions.join(scopes, scopes.c.id == agent_sessions.c.scope_id, isouter=True).join(
+                unread_sub, unread_sub.c.session_id == agent_sessions.c.id, isouter=True
+            )
         )
     )
     # Archived sessions are hidden everywhere — keep them out of the inbox feed too.
-    query = query.where(agent_sessions.c.status != "archived")
-    if unread_only:
-        query = query.where(unread_count_col > 0)
+    session_rows = session_rows.where(agent_sessions.c.status != "archived")
     if only_session:
-        query = query.where(latest_agent.c.session_id == only_session)
+        session_rows = session_rows.where(agent_sessions.c.id == only_session)
+
+    session_rows_sub = session_rows.subquery()
+    query = select(session_rows_sub).where(session_rows_sub.c.preview_id.is_not(None))
+    if unread_only:
+        query = query.where(session_rows_sub.c.unread_count > 0)
     if before:
         cursor_at, _, cursor_session = before.partition("|")
         if cursor_at and cursor_session:
             query = query.where(
                 or_(
-                    latest_any.c.last_activity_at < cursor_at,
+                    session_rows_sub.c.last_activity_at < cursor_at,
                     and_(
-                        latest_any.c.last_activity_at == cursor_at,
-                        latest_agent.c.session_id < cursor_session,
+                        session_rows_sub.c.last_activity_at == cursor_at,
+                        session_rows_sub.c.session_id < cursor_session,
                     ),
                 )
             )
 
     effective_limit = min(max(int(limit), 1), 100)
     query = query.order_by(
-        latest_any.c.last_activity_at.desc(), latest_agent.c.session_id.desc()
+        session_rows_sub.c.last_activity_at.desc(), session_rows_sub.c.session_id.desc()
     ).limit(effective_limit)
+    limited_sessions = query.subquery()
+    preview_msg = messages.alias()
+    query = (
+        select(
+            limited_sessions,
+            preview_msg.c.content_text.label("preview_text"),
+            preview_msg.c.content_json.label("preview_json"),
+        )
+        .select_from(limited_sessions.join(preview_msg, preview_msg.c.id == limited_sessions.c.preview_id))
+        .order_by(limited_sessions.c.last_activity_at.desc(), limited_sessions.c.session_id.desc())
+    )
 
     rows = conn.execute(query).mappings().all()
     sessions: list[dict[str, Any]] = []

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -433,6 +433,35 @@ def test_total_unread_sums_all_sessions(isolated_state):
         assert messages_service.total_unread(conn, platform="avibe") == 3
 
 
+def test_list_inbox_sessions_unread_count_matches_session_badges(isolated_state):
+    """Inbox cards and sidebar badges use the same result-only unread semantics
+    for every visible, non-archived session."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        _seed_titled_session(conn, scope_id, "ses_a", "A")
+        _seed_titled_session(conn, scope_id, "ses_b", "B")
+        _seed_titled_session(conn, scope_id, "ses_notify", "Notify")
+        _seed_titled_session(conn, scope_id, "ses_archived", "Archived")
+        conn.execute(agent_sessions.update().where(agent_sessions.c.id == "ses_archived").values(status="archived"))
+
+        _insert_msg(conn, scope_id, "ses_a", "agent", "A result", "2026-05-30T10:00:00Z", read=False)
+        _insert_msg(conn, scope_id, "ses_a", "agent", "thinking", "2026-05-30T10:01:00Z", read=False, msg_type="assistant")
+        _insert_msg(conn, scope_id, "ses_b", "agent", "B1", "2026-05-30T10:02:00Z", read=False)
+        _insert_msg(conn, scope_id, "ses_b", "agent", "B2", "2026-05-30T10:03:00Z", read=False)
+        _insert_msg(conn, scope_id, "ses_notify", "agent", "failed", "2026-05-30T10:04:00Z", read=False, msg_type="notify")
+        _insert_msg(conn, scope_id, "ses_archived", "agent", "old", "2026-05-30T10:05:00Z", read=False)
+
+    with engine.connect() as conn:
+        feed = messages_service.list_inbox_sessions(conn, platform="avibe")["sessions"]
+        by_session = messages_service.unread_counts_by_session(conn, platform="avibe")
+
+    feed_counts = {row["session_id"]: row["unread_count"] for row in feed}
+    assert feed_counts == {"ses_notify": 0, "ses_b": 2, "ses_a": 1}
+    assert by_session == {"ses_a": 1, "ses_b": 2}
+    assert all(row["unread_count"] == by_session.get(row["session_id"], 0) for row in feed)
+
+
 def _seed_titled_session(conn, scope_id: str, session_id: str, title: str) -> None:
     now = messages_service._utc_now_iso()
     conn.execute(


### PR DESCRIPTION
## Summary

Speed up the workbench inbox feed by rewriting `list_inbox_sessions()` from whole-message window materialization to session-driven top-1 lookups. The feed still returns one visible row per non-archived session with at least one agent `result` / `notify` / `error` reply, preserves the existing cursor and response contract, and reads preview content only after the limited session set is selected.

This targets the measured `/api/inbox` latency path: real-scale data was spending about 1.3s in SQL; the verified prototypes bring the hot query shape down to tens of milliseconds on the production-sized path.

## Measured decomposition

| Subquery | Current cost | Cause | Verified fix prototype |
| --- | ---: | --- | --- |
| `agent_ranked` window | 522ms | `row_number()` materialized preview content columns across all candidate rows before keeping 176 rows | Slim ids-only selection, then join back for preview after `rn=1`: 10ms |
| in-query unread aggregate (`unread_q`) | 568ms | Missing `author='agent'`, so SQLite could not use `ix_messages_unread_session` and walked all avibe rows | Add `author='agent'`: about 0ms, same partial-index hit as `unread_counts_by_session()` |
| `any_ranked` window | 202ms | Even with `ix_messages_inbox_activity`, `row_number()` numbered all conversation rows | Drive from 209 non-archived sessions and run correlated top-1 probes: 8ms |
| `user_ranked` window | 12ms | Same window-function shape, currently smaller | Migrated to the same session-driven probe shape for consistency |

## Local benchmark

Throwaway synthetic SQLite DB, isolated under a temporary `AVIBE_HOME`, 50,000 messages across 200 sessions:

| Query shape | Median | Min | Max | Rows |
| --- | ---: | ---: | ---: | ---: |
| Old window-query SQL | 347.9ms | 345.4ms | 351.3ms | 30 |
| New session-driven function | 4.7ms | 4.5ms | 5.3ms | 30 |

No benchmark touched `~/.avibe/` production state.

## Behavior and semantics

- Preserves existing inbox eligibility: sessions without an agent reply remain hidden.
- Preserves sort order and keyset cursor semantics: `(last_activity_at DESC, session_id DESC)` and `before=<last_activity_at>|<session_id>`.
- Preserves `unread_only`, `only_session`, `platform=None`, returned fields, and `next_cursor` construction.
- Keeps the awaiting-reply badge inputs as latest user send vs latest agent preview reply.
- Aligns the in-query unread count with `unread_counts_by_session()` by filtering unread rows to `author='agent'` and `type='result'`.

The inbox indexes are platform-prefixed. The default `platform='avibe'` path is the optimized path; `platform=None` remains correct for all-platform reads but may not get the same index quality.

## Evidence layers

- Unit: `python3 -m pytest tests/test_messages_service.py -q` (existing 6 frozen inbox behavior tests plus the new unread-count alignment test)
- Lint: `ruff check storage/messages_service.py tests/test_messages_service.py`
- Contract/scenario: N/A, no external API shape change
- Residual manual: after merge, reviewer should re-time `/api/inbox` on the live instance with accumulated production-sized history
