### PR TITLE
perf(ui-server): gzip JSON API responses

### DIFF
--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -19,6 +19,18 @@ from tests.test_api_save_config_merge import _full_config_payload
 from tests.ui_server_test_helpers import csrf_headers
 
 
+def _raw_client_get(client, path: str, *, headers: dict[str, str] | None = None):
+    request_headers = {TEST_REMOTE_ADDR_HEADER: "127.0.0.1"}
+    request_headers.update(headers or {})
+    with client._client.stream(
+        "GET",
+        f"http://127.0.0.1{path}",
+        headers=request_headers,
+    ) as response:
+        body = b"".join(response.iter_raw())
+    return response, body
+
+
 def test_websocket_echo_is_disabled_by_default(monkeypatch):
     monkeypatch.delenv("VIBE_UI_ENABLE_WS_ECHO", raising=False)
 
@@ -713,6 +725,104 @@ def test_static_ui_asset_gzip_skips_small_and_binary_files(monkeypatch, tmp_path
     assert binary_response.content == png
     assert "Content-Encoding" not in binary_response.headers
     assert "Vary" not in binary_response.headers
+
+
+def test_json_api_gzip_uses_shared_response_rules(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+
+    client = app.test_client()
+    identity_response = client.get("/api/config", headers={"Accept-Encoding": ""})
+    original = identity_response.content
+
+    assert identity_response.status_code == 200
+    assert identity_response.is_json
+    assert len(original) >= ui_server._SHOW_RUNTIME_COMPRESSIBLE_MIN_BYTES
+    assert "Content-Encoding" not in identity_response.headers
+    assert "Accept-Encoding" in identity_response.headers["Vary"]
+
+    gzip_disabled_response = client.get("/api/config", headers={"Accept-Encoding": "br, gzip;q=0"})
+    assert gzip_disabled_response.status_code == 200
+    assert gzip_disabled_response.content == original
+    assert "Content-Encoding" not in gzip_disabled_response.headers
+    assert "Accept-Encoding" in gzip_disabled_response.headers["Vary"]
+
+    gzip_client = app.test_client()
+    gzip_response, compressed = _raw_client_get(
+        gzip_client,
+        "/api/config",
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert gzip_response.status_code == 200
+    assert gzip_response.headers["Content-Encoding"] == "gzip"
+    assert gzip_response.headers["Content-Length"] == str(len(compressed))
+    assert "Accept-Encoding" in gzip_response.headers["Vary"]
+    assert gzip.decompress(compressed) == original
+    assert any(header.startswith("vibe_csrf_token=") for header in gzip_response.headers.get_list("Set-Cookie"))
+
+
+def test_json_api_gzip_skips_small_responses(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+
+    response = app.test_client().get("/api/csrf-token", headers={"Accept-Encoding": "gzip"})
+
+    assert response.status_code == 200
+    assert response.is_json
+    assert len(response.content) < ui_server._SHOW_RUNTIME_COMPRESSIBLE_MIN_BYTES
+    assert "Content-Encoding" not in response.headers
+
+
+def test_json_api_gzip_skips_sse_streaming_response():
+    from fastapi.responses import StreamingResponse
+
+    async def generate():
+        yield b": stream connected\n\n"
+
+    response = StreamingResponse(generate(), media_type="text/event-stream")
+
+    with app.test_request_context("/api/events", headers={"Accept-Encoding": "gzip"}):
+        compressed_response = ui_server._compress_materialized_api_response(response)
+
+    assert compressed_response is response
+    assert "Content-Encoding" not in response.headers
+    assert response.media_type == "text/event-stream"
+
+    body = b"event: message\ndata: {}\n\n" * 100
+    materialized = ui_server.Response(content=body, mimetype="text/event-stream")
+    with app.test_request_context("/api/events", headers={"Accept-Encoding": "gzip"}):
+        materialized_response = ui_server._compress_materialized_api_response(materialized)
+
+    assert materialized_response is materialized
+    assert materialized_response.body == body
+    assert "Content-Encoding" not in materialized_response.headers
+
+
+def test_json_api_gzip_skips_attachments_and_existing_encoding():
+    body = b'{"items":[' + (b'"payload",' * 300) + b'"end"]}'
+    attachment = ui_server.Response(
+        content=body,
+        mimetype="application/json",
+        headers={"Content-Disposition": "attachment; filename=data.json"},
+    )
+    with app.test_request_context("/api/export", headers={"Accept-Encoding": "gzip"}):
+        attachment_response = ui_server._compress_materialized_api_response(attachment)
+
+    assert attachment_response is attachment
+    assert attachment_response.body == body
+    assert "Content-Encoding" not in attachment_response.headers
+    assert "Vary" not in attachment_response.headers
+
+    encoded = ui_server.Response(
+        content=body,
+        mimetype="application/json",
+        headers={"Content-Encoding": "br"},
+    )
+    with app.test_request_context("/api/precompressed", headers={"Accept-Encoding": "gzip"}):
+        encoded_response = ui_server._compress_materialized_api_response(encoded)
+
+    assert encoded_response is encoded
+    assert encoded_response.body == body
+    assert encoded_response.headers["Content-Encoding"] == "br"
 
 
 def test_run_maybe_async_offloads_sync_handlers_without_losing_context():

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1842,6 +1842,11 @@ def protect_mutating_ui_requests():
 
 
 @app.after_request
+def compress_materialized_api_response(response: Response) -> Response:
+    return _compress_materialized_api_response(response)
+
+
+@app.after_request
 def add_api_timing_headers(response: Response) -> Response:
     started_at = getattr(g, "api_request_started_at", None)
     if started_at is None:
@@ -7582,6 +7587,10 @@ def _compress_response_content(content: bytes, headers: dict[str, str], starlett
         return content
     if _response_header(headers, "content-encoding"):
         return content
+    if _show_response_is_attachment(_response_header(headers, "content-disposition")):
+        return content
+    if starlette_request.headers.get("upgrade", "").lower() == "websocket":
+        return content
     content_type = _response_header(headers, "content-type") or ""
     if not _show_response_is_compressible(content_type):
         return content
@@ -7594,7 +7603,24 @@ def _compress_response_content(content: bytes, headers: dict[str, str], starlett
     _remove_response_header(headers, "content-length")
     _remove_response_header(headers, "etag")
     _set_response_header(headers, "Content-Encoding", "gzip")
+    _set_response_header(headers, "Content-Length", str(len(compressed)))
     return compressed
+
+
+def _compress_materialized_api_response(response: Response) -> Response:
+    if not (request.path or "").startswith("/api/"):
+        return response
+    body = getattr(response, "body", None)
+    if body is None:
+        return response
+    if not isinstance(body, bytes | bytearray | memoryview):
+        return response
+    content = bytes(body)
+    compressed = _compress_response_content(content, response.headers, request._request)
+    if compressed is content:
+        return response
+    response.body = compressed
+    return response
 
 
 def _accept_encoding_allows_gzip(accept_encoding: str | None) -> bool:
@@ -7633,6 +7659,8 @@ def _show_response_is_compressible(content_type: str | None) -> bool:
     if not content_type:
         return False
     lowered = content_type.lower()
+    if "text/event-stream" in lowered:
+        return False
     return any(
         marker in lowered
         for marker in (


### PR DESCRIPTION
## What changed

Gzip compression now applies to full-body JSON API responses through the shared UI response hook path. Large API payloads sent through the Cloudflare tunnel can shrink before they leave the user's machine instead of relying only on visitor-edge compression.

The implementation reuses the existing shared compression helper from the static asset work and adds only a thin materialized-response adapter for API responses. The shared helper now also skips attachments, existing Content-Encoding, WebSocket upgrades, and text/event-stream responses.

## Measured impact

Earlier scouting measured uncompressed API payloads at about 39,720 bytes for /api/inbox and 9,229 bytes for /api/config, with gzip expected around 75-80 percent smaller.

Hermetic test-client proof on this branch for /api/config:

- identity: 8,107 bytes
- gzip: 1,633 bytes
- ratio: 20.1 percent of the original payload
- decompressed gzip body exactly matched the original JSON

## Route coverage and safety

Compat routes and bridged native UI routes both pass through the after-request hook chain, so inbox, config, agents, projects bootstrap, and current native file routes inherit the same compression decision point when they return a full materialized response.

SSE remains out of scope: /api/events returns a StreamingResponse without a materialized body, and text/event-stream is explicitly non-compressible even if a future response is materialized.

No native-route gap was found for the current native UI routes: the existing native endpoints in vibe/ui_server.py use _dispatch_native_ui_request, which runs through vibe/ui_compat.py dispatch_native_request and the shared after-request hooks. A future raw FastAPI route that bypasses this bridge would still need to opt into the hook chain separately.

## Evidence layers

- Unit: python3 -m pytest tests/test_ui_server_fastapi.py -q
- Lint: ruff check vibe/ui_server.py tests/test_ui_server_fastapi.py
- Contract: N/A, no external API schema change
- Scenario: N/A, response transport optimization only
- Residual manual check: after merge, verify live /api/inbox returns content-encoding: gzip when requested through the UI tunnel
