### PR TITLE
fix(regression): allow guarded source state refresh

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -667,6 +667,7 @@ def ensure_project_and_instance(
 def tenant_exec(target: RegressionTarget, command: str, *args: str, remote: str | None = None) -> list[str]:
     bash_command = (
         "set -a; [ ! -f /etc/avibe-regression.env ] || . /etc/avibe-regression.env; "
+        "VIBE_DEPLOYMENT_ENV=regression; AVIBE_ALLOW_DEV_STATE_MIGRATION=1; "
         f"set +a; cd {shlex.quote(SOURCE_DIR)} && {command}"
     )
     return incus(

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -506,6 +506,7 @@ def regression_service_unit() -> str:
         Environment=HOME={SERVICE_HOME}
         Environment=AVIBE_HOME=
         Environment=VIBE_DEPLOYMENT_ENV=regression
+        Environment=AVIBE_ALLOW_DEV_STATE_MIGRATION=1
         Environment=VIBE_INTERNAL_DISPATCH_SOCKET=/tmp/vibe_remote/dispatch.sock
         Environment=PYTHONUNBUFFERED=1
         Environment=PATH={VENV_DIR}/bin:{SERVICE_HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin
@@ -844,6 +845,7 @@ def runtime_env_payload(repo_root: Path | None = None) -> bytes:
         "SETUPTOOLS_SCM_PRETEND_VERSION": scm_version,
         "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS": scm_version,
         "REGRESSION_UI_HOST": CONTAINER_UI_HOST,
+        "AVIBE_ALLOW_DEV_STATE_MIGRATION": "1",
         "VIBE_SHOW_RUNTIME_SOURCE": regression_env("SHOW_RUNTIME_SOURCE", "github-source"),
         "VIBE_SHOW_RUNTIME_GITHUB_REPO": regression_env("SHOW_RUNTIME_GITHUB_REPO", "https://github.com/avibe-bot/vibe-show-runtime.git"),
         "VIBE_SHOW_RUNTIME_GITHUB_REF": regression_env("SHOW_RUNTIME_GITHUB_REF", "main"),

--- a/tests/test_dev_state_migration_guard.py
+++ b/tests/test_dev_state_migration_guard.py
@@ -153,3 +153,11 @@ def test_runtime_ensure_config_guard_blocks_before_default_workdir(monkeypatch, 
     assert not (home / "work").exists()
     assert not db_path.exists()
     assert not db_path.parent.exists()
+
+
+def test_regression_deployment_env_alone_does_not_bypass_default_state_guard(monkeypatch, tmp_path: Path) -> None:
+    db_path = _set_default_home_guard(monkeypatch, tmp_path)
+    monkeypatch.setenv("VIBE_DEPLOYMENT_ENV", "regression")
+
+    with pytest.raises(UnsafeDefaultStateMigrationError):
+        migrations.guard_source_checkout_default_state_migration(db_path)

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -272,6 +272,24 @@ def test_project_config_marks_regression_target() -> None:
     assert "user.avibe_regression.host_port=15200" in config
 
 
+def test_tenant_exec_exports_regression_guard_override() -> None:
+    target = incus_regression.RegressionTarget(
+        target="master",
+        slug="master",
+        project="avr-master",
+        instance="avibe-master",
+        host_port=15130,
+        ui_host="127.0.0.1",
+        ui_port=5123,
+    )
+
+    command = " ".join(incus_regression.tenant_exec(target, "/opt/avibe/venv/bin/vibe status"))
+
+    assert "[ ! -f /etc/avibe-regression.env ] || . /etc/avibe-regression.env" in command
+    assert "VIBE_DEPLOYMENT_ENV=regression" in command
+    assert "AVIBE_ALLOW_DEV_STATE_MIGRATION=1" in command
+
+
 def test_remote_ref_prefixes_resource_names_only() -> None:
     assert incus_regression.remote_ref("lab", "demo") == "lab:demo"
     assert incus_regression.remote_ref(None, "demo") == "demo"

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -244,6 +244,7 @@ def test_cloud_init_configures_systemd_service_without_source_code() -> None:
     assert "name: avibe" in data
     assert "Description=Avibe regression service" in data
     assert "Environment=VIBE_DEPLOYMENT_ENV=regression" in data
+    assert "Environment=AVIBE_ALLOW_DEV_STATE_MIGRATION=1" in data
     assert "EnvironmentFile=-/etc/avibe-regression.env" in data
     assert "ExecStart=/opt/avibe/venv/bin/python scripts/incus_regression_supervisor.py" in data
     assert "Delegate=yes" in data
@@ -514,6 +515,7 @@ def test_runtime_env_payload_maps_show_runtime_and_llm_env(monkeypatch: pytest.M
 
     assert "SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0.dev0" in payload
     assert "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=0.0.0.dev0" in payload
+    assert "AVIBE_ALLOW_DEV_STATE_MIGRATION=1" in payload
     assert "VIBE_SHOW_RUNTIME_SOURCE=github-source" in payload
     assert "VIBE_SHOW_RUNTIME_GITHUB_REF=main" in payload
     assert "REGRESSION_SLACK_CHANNEL=C123" in payload


### PR DESCRIPTION
## Summary
- allow the Incus regression service and runner-issued container CLI probes to opt into source-checkout state migrations
- keep the default-state guard strict for normal source checkouts; `VIBE_DEPLOYMENT_ENV=regression` alone still does not bypass it
- add regression coverage for both the service unit/runtime env payload, tenant exec probes, and the guard boundary

## Why
PR #759 correctly blocked source checkouts from migrating a real default user state DB, but the local Incus regression environment intentionally runs source code against its isolated `/home/avibe/.avibe` state. After the Vault migration landed, the guard stopped the regression service from booting.

## Validation
- `python3 -m pytest tests/test_incus_regression.py::test_tenant_exec_exports_regression_guard_override tests/test_incus_regression.py::test_cloud_init_configures_systemd_service_without_source_code tests/test_incus_regression.py::test_runtime_env_payload_maps_show_runtime_and_llm_env tests/test_dev_state_migration_guard.py -q`
- `python3 -m ruff check scripts/incus_regression.py tests/test_incus_regression.py tests/test_dev_state_migration_guard.py`
- `python3 -m pytest tests/test_incus_regression.py tests/test_dev_state_migration_guard.py -q`
- removed the temporary service drop-in from `avibe-master`, then refreshed the local Incus master regression environment successfully with the patched runner
- removed `AVIBE_ALLOW_DEV_STATE_MIGRATION` from the existing container env file and verified `./scripts/run_regression.sh --status` still succeeds because `tenant_exec` injects the regression guard override
- host check: `http://127.0.0.1:15130/health` returns ok and `/status` returns running
