### PR TITLE
perf(ui): drive workbench updates from SSE

### DIFF
--- a/core/inbox_events.py
+++ b/core/inbox_events.py
@@ -22,6 +22,16 @@ logger = logging.getLogger(__name__)
 RUNS_UPDATED_EVENT = "runs.updated"
 VAULTS_UPDATED_EVENT = "vaults.updated"
 WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT = "workbench.events.bridge.status"
+_CONTROLLER_PROCESS = False
+
+
+def mark_controller_process() -> None:
+    global _CONTROLLER_PROCESS
+    _CONTROLLER_PROCESS = True
+
+
+def is_controller_process() -> bool:
+    return _CONTROLLER_PROCESS
 
 
 class InboxEventBus:

--- a/core/inbox_events.py
+++ b/core/inbox_events.py
@@ -19,6 +19,9 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+RUNS_UPDATED_EVENT = "runs.updated"
+VAULTS_UPDATED_EVENT = "vaults.updated"
+
 
 class InboxEventBus:
     def __init__(self) -> None:
@@ -63,3 +66,58 @@ class InboxEventBus:
 # Process-wide singleton (Controller process). ``message_mirror`` publishes;
 # ``internal_server`` subscribes.
 bus = InboxEventBus()
+
+
+def run_updated_payload(
+    *,
+    run_id: str,
+    status: str,
+    run_type: str | None = None,
+    session_id: str | None = None,
+    definition_id: str | None = None,
+    updated_at: str | None = None,
+    cancel_requested: bool | None = None,
+) -> dict[str, Any]:
+    """Minimal run-lifecycle payload for browser refetch-on-event consumers."""
+
+    payload: dict[str, Any] = {"run_id": run_id, "status": status}
+    if run_type:
+        payload["run_type"] = run_type
+    if session_id:
+        payload["session_id"] = session_id
+    if definition_id:
+        payload["definition_id"] = definition_id
+    if updated_at:
+        payload["updated_at"] = updated_at
+    if cancel_requested is not None:
+        payload["cancel_requested"] = cancel_requested
+    return payload
+
+
+def vaults_updated_payload(
+    *,
+    scope: str,
+    request_id: str | None = None,
+    request_status: str | None = None,
+    grant_id: str | None = None,
+    grant_status: str | None = None,
+    secret_name: str | None = None,
+) -> dict[str, Any]:
+    """Minimal vault-state payload for browser refetch-on-event consumers."""
+
+    payload: dict[str, Any] = {"scope": scope}
+    if request_id:
+        payload["request_id"] = request_id
+    if request_status:
+        payload["request_status"] = request_status
+    if grant_id:
+        payload["grant_id"] = grant_id
+    if grant_status:
+        payload["grant_status"] = grant_status
+    if secret_name:
+        payload["secret_name"] = secret_name
+    return payload
+
+
+def publish_run_updated(**kwargs: Any) -> None:
+    bus.publish(RUNS_UPDATED_EVENT, run_updated_payload(**kwargs))

--- a/core/inbox_events.py
+++ b/core/inbox_events.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 RUNS_UPDATED_EVENT = "runs.updated"
 VAULTS_UPDATED_EVENT = "vaults.updated"
+WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT = "workbench.events.bridge.status"
 
 
 class InboxEventBus:
@@ -41,6 +42,10 @@ class InboxEventBus:
     def unsubscribe(self, sub_id: int) -> None:
         with self._lock:
             self._subscribers.pop(sub_id, None)
+
+    def subscriber_count(self) -> int:
+        with self._lock:
+            return len(self._subscribers)
 
     def publish(self, event_type: str, data: Any) -> None:
         """Fan ``(event_type, data)`` out to every subscriber. No-op when none."""

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -71,6 +71,9 @@ def create_app(controller: "Controller") -> FastAPI:
     Factored out so tests can mount the same routes against a fake
     controller without spinning up uvicorn.
     """
+    from core.inbox_events import mark_controller_process
+
+    mark_controller_process()
 
     app = FastAPI(
         title="avibe internal dispatch",

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -430,6 +430,28 @@ def create_app(controller: "Controller") -> FastAPI:
             headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
         )
 
+    @app.post("/internal/events")
+    async def _publish_event(request: Request) -> Any:
+        """Publish an allowlisted notification into the Controller event bus.
+
+        Local child processes cannot share ``core.inbox_events.bus`` directly,
+        but they can reach this permission-restricted Unix socket and reuse the
+        same Controller -> UI-server -> browser SSE path.
+        """
+        from core.inbox_events import RUNS_UPDATED_EVENT, VAULTS_UPDATED_EVENT, bus
+
+        payload = await _safe_json(request)
+        if not isinstance(payload, dict):
+            return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_payload"})
+        event_type = str(payload.get("type") or "").strip()
+        data = payload.get("data")
+        if event_type not in {RUNS_UPDATED_EVENT, VAULTS_UPDATED_EVENT}:
+            return JSONResponse(status_code=400, content={"ok": False, "error": "unsupported_event_type"})
+        if not isinstance(data, dict):
+            return JSONResponse(status_code=400, content={"ok": False, "error": "invalid_event_data"})
+        bus.publish(event_type, data)
+        return {"ok": True}
+
     @app.post("/internal/cancel/{session_id}")
     async def _cancel(session_id: str) -> Any:
         """HTTP adapter: delegate Stop to the turn owner (FSM, Phase 1b) and map its

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1382,9 +1382,12 @@ class TaskExecutionStore:
         error: Optional[str] = None,
     ) -> None:
         if self._sqlite is not None:
-            from storage.background import complete_coalesced_agent_runs_for_workbench_in_connection
+            from storage.background import (
+                complete_coalesced_agent_runs_for_workbench_in_connection,
+                run_update_event_transaction,
+            )
 
-            with self._sqlite.engine.begin() as conn:
+            with run_update_event_transaction(self._sqlite.engine) as conn:
                 complete_coalesced_agent_runs_for_workbench_in_connection(
                     conn,
                     run_ids,

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -748,6 +748,7 @@ class SessionTurnManager:
         from core.inbox_events import bus
         from core.workbench_media import file_attachments_from_specs, resolve_attachment_specs
         from storage import messages_service
+        from storage.background import run_update_event_transaction
         from storage.db import create_sqlite_engine
 
         if not session_id:
@@ -767,7 +768,7 @@ class SessionTurnManager:
         claimed_agent_run_ids: list[str] = []
         try:
             engine = create_sqlite_engine()
-            with engine.begin() as conn:
+            with run_update_event_transaction(engine) as conn:
                 rows = messages_service.list_queued(conn, session_id)
                 if not rows:
                     return False
@@ -949,7 +950,7 @@ class SessionTurnManager:
                 retry_agent_run_flush = False
                 try:
                     engine = create_sqlite_engine()
-                    with engine.begin() as conn:
+                    with run_update_event_transaction(engine) as conn:
                         claimed_run_ids = _claim_agent_run_segment_and_retire_queue(
                             conn,
                             run_ids=pending_agent_run_ids,
@@ -995,7 +996,7 @@ class SessionTurnManager:
                         from storage.background import reset_workbench_claimed_runs_in_connection
 
                         engine = create_sqlite_engine()
-                        with engine.begin() as conn:
+                        with run_update_event_transaction(engine) as conn:
                             reset_workbench_claimed_runs_in_connection(conn, claimed_agent_run_ids)
                             _restore_queued_rows(conn, pending_scheduled_segment)
                     except Exception:

--- a/storage/background.py
+++ b/storage/background.py
@@ -106,6 +106,53 @@ def _status_query_values(status: str) -> list[str]:
     return values or [normalized]
 
 
+def _publish_run_rows_updated(rows: list[Any]) -> None:
+    if not rows:
+        return
+    try:
+        from core.inbox_events import publish_run_updated
+    except Exception:
+        logger.debug("failed to import run event publisher", exc_info=True)
+        return
+    for raw_row in rows:
+        if raw_row is None:
+            continue
+        row = dict(raw_row)
+        run_id = str(row.get("id") or "").strip()
+        if not run_id:
+            continue
+        try:
+            publish_run_updated(
+                run_id=run_id,
+                status=normalize_run_status(row.get("status")),
+                run_type=row.get("run_type"),
+                session_id=row.get("session_id"),
+                definition_id=row.get("definition_id"),
+                updated_at=row.get("updated_at"),
+                cancel_requested=bool(row.get("cancel_requested")),
+            )
+        except Exception:
+            logger.debug("failed to publish runs.updated for %s", run_id, exc_info=True)
+
+
+def _run_rows_for_ids(conn: Any, run_ids: list[str]) -> list[Any]:
+    normalized_ids: list[str] = []
+    seen: set[str] = set()
+    for raw_run_id in run_ids:
+        run_id = str(raw_run_id or "").strip()
+        if not run_id or run_id in seen:
+            continue
+        seen.add(run_id)
+        normalized_ids.append(run_id)
+    if not normalized_ids:
+        return []
+    return list(conn.execute(select(agent_runs).where(agent_runs.c.id.in_(normalized_ids))).mappings())
+
+
+def _publish_run_ids_updated_from_connection(conn: Any, run_ids: list[str]) -> None:
+    _publish_run_rows_updated(_run_rows_for_ids(conn, run_ids))
+
+
 def _like_contains_pattern(value: str) -> str:
     escaped = (
         value.replace(_LIKE_ESCAPE, _LIKE_ESCAPE + _LIKE_ESCAPE)
@@ -174,6 +221,7 @@ def complete_coalesced_agent_runs_for_workbench_in_connection(
         result = conn.execute(update(agent_runs).where(agent_runs.c.id == run_id).values(**values))
         if result.rowcount:
             completed_ids.append(run_id)
+    _publish_run_ids_updated_from_connection(conn, completed_ids)
     return completed_ids
 
 
@@ -238,6 +286,7 @@ def claim_queued_runs_for_workbench_in_connection(
         )
         if not result.rowcount:
             raise RuntimeError(f"failed to claim queued agent run {run_id}")
+    _publish_run_ids_updated_from_connection(conn, normalized_run_ids)
     return normalized_run_ids
 
 
@@ -352,12 +401,14 @@ def inspect_queued_runs_for_workbench_in_connection(conn: Any, run_ids: list[str
             .where(agent_runs.c.status.in_(_status_query_values("queued")))
             .values(status="canceled", completed_at=now, updated_at=now)
         )
+        _publish_run_ids_updated_from_connection(conn, cancel_requested_run_ids)
     return queued_run_ids, stale_run_ids
 
 
 def reset_workbench_claimed_runs_in_connection(conn: Any, run_ids: list[str]) -> None:
     now = _utc_now_iso()
     seen: set[str] = set()
+    changed_ids: list[str] = []
     for raw_run_id in run_ids:
         run_id = str(raw_run_id or "").strip()
         if not run_id or run_id in seen:
@@ -384,6 +435,8 @@ def reset_workbench_claimed_runs_in_connection(conn: Any, run_ids: list[str]) ->
             .where(agent_runs.c.id == run_id)
             .values(**values)
         )
+        changed_ids.append(run_id)
+    _publish_run_ids_updated_from_connection(conn, changed_ids)
 
 
 class SQLiteBackgroundTaskStore:
@@ -563,6 +616,7 @@ class SQLiteBackgroundTaskStore:
 
     def enqueue_run(self, payload: dict[str, Any]) -> None:
         values = self._run_values(payload)
+        row_to_publish = None
         with self.engine.begin() as conn:
             existing = conn.execute(
                 select(agent_runs.c.id).where(agent_runs.c.id == values["id"]).limit(1)
@@ -571,6 +625,10 @@ class SQLiteBackgroundTaskStore:
                 conn.execute(update(agent_runs).where(agent_runs.c.id == values["id"]).values(**values))
             else:
                 conn.execute(insert(agent_runs).values(**values))
+            row_to_publish = dict(
+                conn.execute(select(agent_runs).where(agent_runs.c.id == values["id"]).limit(1)).mappings().one()
+            )
+        _publish_run_rows_updated([row_to_publish])
 
     def list_runs(self, *, status: Optional[str] = None) -> list[dict[str, Any]]:
         stmt = self._runs_query(status=status).order_by(agent_runs.c.created_at, agent_runs.c.id)
@@ -820,6 +878,7 @@ class SQLiteBackgroundTaskStore:
 
     def cancel_run(self, run_id: str, *, requested_at: Optional[str] = None) -> bool:
         now = requested_at or _utc_now_iso()
+        row_to_publish = None
         with self.engine.begin() as conn:
             row = conn.execute(select(agent_runs.c.status).where(agent_runs.c.id == run_id).limit(1)).mappings().first()
             if not row:
@@ -838,9 +897,16 @@ class SQLiteBackgroundTaskStore:
                 .where(agent_runs.c.id == run_id)
                 .values(**values)
             )
-            return bool(result.rowcount)
+            if result.rowcount:
+                row_to_publish = dict(
+                    conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().one()
+                )
+        _publish_run_rows_updated([row_to_publish])
+        return row_to_publish is not None
 
     def claim_pending_run(self, run_id: str, *, started_at: str) -> Optional[dict[str, Any]]:
+        row_to_publish = None
+        payload = None
         with self.engine.begin() as conn:
             row = conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().first()
             if not row:
@@ -851,17 +917,25 @@ class SQLiteBackgroundTaskStore:
                     .where(agent_runs.c.id == run_id)
                     .values(status="canceled", completed_at=started_at, updated_at=started_at)
                 )
-                return None
-            result = conn.execute(
-                update(agent_runs)
-                .where(agent_runs.c.id == run_id)
-                .where(agent_runs.c.status.in_(_status_query_values("queued")))
-                .values(status="running", started_at=started_at, updated_at=started_at)
-            )
-            if not result.rowcount:
-                return None
-            row = conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().first()
-            return self._run_from_row(row) if row else None
+                row_to_publish = dict(
+                    conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().one()
+                )
+                payload = None
+            else:
+                result = conn.execute(
+                    update(agent_runs)
+                    .where(agent_runs.c.id == run_id)
+                    .where(agent_runs.c.status.in_(_status_query_values("queued")))
+                    .values(status="running", started_at=started_at, updated_at=started_at)
+                )
+                if not result.rowcount:
+                    return None
+                row = conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().first()
+                if row:
+                    row_to_publish = dict(row)
+                    payload = self._run_from_row(row)
+        _publish_run_rows_updated([row_to_publish])
+        return payload
 
     def update_run_status(
         self,
@@ -939,8 +1013,14 @@ class SQLiteBackgroundTaskStore:
             values["callback_run_id"] = callback_run_id
         if callback_completed_at is not None:
             values["callback_completed_at"] = callback_completed_at
+        row_to_publish = None
         with self.engine.begin() as conn:
-            conn.execute(update(agent_runs).where(agent_runs.c.id == run_id).values(**values))
+            result = conn.execute(update(agent_runs).where(agent_runs.c.id == run_id).values(**values))
+            if result.rowcount:
+                row_to_publish = dict(
+                    conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().one()
+                )
+        _publish_run_rows_updated([row_to_publish])
 
     def update_callback_status(
         self,
@@ -992,6 +1072,7 @@ class SQLiteBackgroundTaskStore:
             merged = dict(existing.get("metadata") or {})
             merged.update(metadata)
             values["metadata_json"] = _json_dumps(merged)
+        row_to_publish = None
         with self.engine.begin() as conn:
             result = conn.execute(
                 update(agent_runs)
@@ -999,7 +1080,12 @@ class SQLiteBackgroundTaskStore:
                 .where(agent_runs.c.status.in_(_status_query_values("running")))
                 .values(**values)
             )
-            return bool(result.rowcount)
+            if result.rowcount:
+                row_to_publish = dict(
+                    conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().one()
+                )
+        _publish_run_rows_updated([row_to_publish])
+        return row_to_publish is not None
 
     def claim_queued_run_for_workbench(
         self,
@@ -1053,15 +1139,26 @@ class SQLiteBackgroundTaskStore:
             if terminal_status:
                 values["status"] = normalize_run_status(terminal_status)
                 values["completed_at"] = now
-            conn.execute(
+            result = conn.execute(
                 update(agent_runs)
                 .where(agent_runs.c.id == run_id)
                 .values(**values)
             )
+            if terminal_status and result.rowcount:
+                updated = conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().one()
+                _publish_run_rows_updated([updated])
 
     def recover_processing_runs(self) -> None:
         with self.engine.begin() as conn:
             now = _utc_now_iso()
+            rows = list(
+                conn.execute(
+                    select(agent_runs.c.id)
+                    .where(agent_runs.c.status.in_(_status_query_values("running")))
+                    .where(agent_runs.c.run_type != "watch_runtime")
+                ).mappings()
+            )
+            recovered_ids = [str(row["id"]) for row in rows]
             conn.execute(
                 update(agent_runs)
                 .where(agent_runs.c.status.in_(_status_query_values("running")))
@@ -1069,6 +1166,7 @@ class SQLiteBackgroundTaskStore:
                 .values(status="queued", started_at=None, pid=None, updated_at=now)
             )
             _refresh_recovered_coalesced_workbench_runs_in_connection(conn, now=now)
+            _publish_run_ids_updated_from_connection(conn, recovered_ids)
 
     def write_watch_runtime(self, payload: dict[str, Any], *, updated_at: str) -> None:
         watches = payload.get("watches", {}) if isinstance(payload, dict) else {}

--- a/storage/background.py
+++ b/storage/background.py
@@ -110,7 +110,7 @@ def _publish_run_rows_updated(rows: list[Any]) -> None:
     if not rows:
         return
     try:
-        from core.inbox_events import publish_run_updated
+        from core.inbox_events import RUNS_UPDATED_EVENT, bus, run_updated_payload
     except Exception:
         logger.debug("failed to import run event publisher", exc_info=True)
         return
@@ -122,7 +122,7 @@ def _publish_run_rows_updated(rows: list[Any]) -> None:
         if not run_id:
             continue
         try:
-            publish_run_updated(
+            payload = run_updated_payload(
                 run_id=run_id,
                 status=normalize_run_status(row.get("status")),
                 run_type=row.get("run_type"),
@@ -131,6 +131,14 @@ def _publish_run_rows_updated(rows: list[Any]) -> None:
                 updated_at=row.get("updated_at"),
                 cancel_requested=bool(row.get("cancel_requested")),
             )
+            bus.publish(RUNS_UPDATED_EVENT, payload)
+            if bus.subscriber_count() == 0:
+                try:
+                    from vibe import internal_client
+
+                    internal_client.publish_event_sync(RUNS_UPDATED_EVENT, payload, timeout=1.5)
+                except Exception:
+                    logger.debug("failed to bridge runs.updated for %s", run_id, exc_info=True)
         except Exception:
             logger.debug("failed to publish runs.updated for %s", run_id, exc_info=True)
 

--- a/storage/background.py
+++ b/storage/background.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -94,6 +95,7 @@ RUN_STATUS_ALIASES: dict[str, str] = {
 _LIKE_ESCAPE = "\\"
 DEFINITION_STATUS_COUNTS = ("all", "enabled", "disabled")
 RUN_STATUS_COUNTS = ("all", "queued", "running", "succeeded", "failed", "canceled")
+_DEFERRED_RUN_EVENT_ROWS_KEY = "avibe.deferred_run_event_rows"
 
 
 def normalize_run_status(status: Any) -> str:
@@ -143,6 +145,41 @@ def _publish_run_rows_updated(rows: list[Any]) -> None:
             logger.debug("failed to publish runs.updated for %s", run_id, exc_info=True)
 
 
+def _defer_run_rows_updated_from_connection(conn: Any, rows: list[Any]) -> None:
+    if not rows:
+        return
+    pending = conn.info.setdefault(_DEFERRED_RUN_EVENT_ROWS_KEY, {})
+    for raw_row in rows:
+        if raw_row is None:
+            continue
+        row = dict(raw_row)
+        run_id = str(row.get("id") or "").strip()
+        if run_id:
+            pending[run_id] = row
+
+
+def pop_deferred_run_event_rows_from_connection(conn: Any) -> list[dict[str, Any]]:
+    pending = conn.info.pop(_DEFERRED_RUN_EVENT_ROWS_KEY, {})
+    if not isinstance(pending, dict):
+        return []
+    return [dict(row) for row in pending.values() if row is not None]
+
+
+@contextmanager
+def run_update_event_transaction(engine: Any):
+    """Commit DB writes before publishing deferred ``runs.updated`` snapshots."""
+
+    pending_rows: list[dict[str, Any]] = []
+    with engine.begin() as conn:
+        try:
+            yield conn
+            pending_rows = pop_deferred_run_event_rows_from_connection(conn)
+        except Exception:
+            conn.info.pop(_DEFERRED_RUN_EVENT_ROWS_KEY, None)
+            raise
+    _publish_run_rows_updated(pending_rows)
+
+
 def _run_rows_for_ids(conn: Any, run_ids: list[str]) -> list[Any]:
     normalized_ids: list[str] = []
     seen: set[str] = set()
@@ -157,8 +194,8 @@ def _run_rows_for_ids(conn: Any, run_ids: list[str]) -> list[Any]:
     return list(conn.execute(select(agent_runs).where(agent_runs.c.id.in_(normalized_ids))).mappings())
 
 
-def _publish_run_ids_updated_from_connection(conn: Any, run_ids: list[str]) -> None:
-    _publish_run_rows_updated(_run_rows_for_ids(conn, run_ids))
+def _defer_run_ids_updated_from_connection(conn: Any, run_ids: list[str]) -> None:
+    _defer_run_rows_updated_from_connection(conn, _run_rows_for_ids(conn, run_ids))
 
 
 def _like_contains_pattern(value: str) -> str:
@@ -229,7 +266,7 @@ def complete_coalesced_agent_runs_for_workbench_in_connection(
         result = conn.execute(update(agent_runs).where(agent_runs.c.id == run_id).values(**values))
         if result.rowcount:
             completed_ids.append(run_id)
-    _publish_run_ids_updated_from_connection(conn, completed_ids)
+    _defer_run_ids_updated_from_connection(conn, completed_ids)
     return completed_ids
 
 
@@ -294,7 +331,7 @@ def claim_queued_runs_for_workbench_in_connection(
         )
         if not result.rowcount:
             raise RuntimeError(f"failed to claim queued agent run {run_id}")
-    _publish_run_ids_updated_from_connection(conn, normalized_run_ids)
+    _defer_run_ids_updated_from_connection(conn, normalized_run_ids)
     return normalized_run_ids
 
 
@@ -409,7 +446,7 @@ def inspect_queued_runs_for_workbench_in_connection(conn: Any, run_ids: list[str
             .where(agent_runs.c.status.in_(_status_query_values("queued")))
             .values(status="canceled", completed_at=now, updated_at=now)
         )
-        _publish_run_ids_updated_from_connection(conn, cancel_requested_run_ids)
+        _defer_run_ids_updated_from_connection(conn, cancel_requested_run_ids)
     return queued_run_ids, stale_run_ids
 
 
@@ -444,7 +481,7 @@ def reset_workbench_claimed_runs_in_connection(conn: Any, run_ids: list[str]) ->
             .values(**values)
         )
         changed_ids.append(run_id)
-    _publish_run_ids_updated_from_connection(conn, changed_ids)
+    _defer_run_ids_updated_from_connection(conn, changed_ids)
 
 
 class SQLiteBackgroundTaskStore:
@@ -1109,11 +1146,11 @@ class SQLiteBackgroundTaskStore:
         *,
         started_at: Optional[str] = None,
     ) -> list[str]:
-        with self.engine.begin() as conn:
+        with run_update_event_transaction(self.engine) as conn:
             return claim_queued_runs_for_workbench_in_connection(conn, run_ids, started_at=started_at)
 
     def inspect_queued_runs_for_workbench(self, run_ids: list[str]) -> tuple[list[str], list[str]]:
-        with self.engine.begin() as conn:
+        with run_update_event_transaction(self.engine) as conn:
             return inspect_queued_runs_for_workbench_in_connection(conn, run_ids)
 
     def record_run_message(
@@ -1126,6 +1163,7 @@ class SQLiteBackgroundTaskStore:
         updated_at: Optional[str] = None,
     ) -> None:
         now = updated_at or _utc_now_iso()
+        row_to_publish = None
         with self.engine.begin() as conn:
             row = conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().first()
             if not row:
@@ -1153,11 +1191,13 @@ class SQLiteBackgroundTaskStore:
                 .values(**values)
             )
             if terminal_status and result.rowcount:
-                updated = conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().one()
-                _publish_run_rows_updated([updated])
+                row_to_publish = dict(
+                    conn.execute(select(agent_runs).where(agent_runs.c.id == run_id).limit(1)).mappings().one()
+                )
+        _publish_run_rows_updated([row_to_publish])
 
     def recover_processing_runs(self) -> None:
-        with self.engine.begin() as conn:
+        with run_update_event_transaction(self.engine) as conn:
             now = _utc_now_iso()
             rows = list(
                 conn.execute(
@@ -1174,7 +1214,7 @@ class SQLiteBackgroundTaskStore:
                 .values(status="queued", started_at=None, pid=None, updated_at=now)
             )
             _refresh_recovered_coalesced_workbench_runs_in_connection(conn, now=now)
-            _publish_run_ids_updated_from_connection(conn, recovered_ids)
+            _defer_run_ids_updated_from_connection(conn, recovered_ids)
 
     def write_watch_runtime(self, payload: dict[str, Any], *, updated_at: str) -> None:
         watches = payload.get("watches", {}) if isinstance(payload, dict) else {}

--- a/storage/background.py
+++ b/storage/background.py
@@ -110,7 +110,7 @@ def _publish_run_rows_updated(rows: list[Any]) -> None:
     if not rows:
         return
     try:
-        from core.inbox_events import RUNS_UPDATED_EVENT, bus, run_updated_payload
+        from core.inbox_events import RUNS_UPDATED_EVENT, bus, is_controller_process, run_updated_payload
     except Exception:
         logger.debug("failed to import run event publisher", exc_info=True)
         return
@@ -132,7 +132,7 @@ def _publish_run_rows_updated(rows: list[Any]) -> None:
                 cancel_requested=bool(row.get("cancel_requested")),
             )
             bus.publish(RUNS_UPDATED_EVENT, payload)
-            if bus.subscriber_count() == 0:
+            if bus.subscriber_count() == 0 and not is_controller_process():
                 try:
                     from vibe import internal_client
 

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -996,8 +996,8 @@ def fulfill_pending_provision_requests_for_secret(
     name: str,
     *,
     decided_at: str | None = None,
-) -> None:
-    conn.execute(
+) -> int:
+    result = conn.execute(
         vault_requests.update()
         .where(
             vault_requests.c.request_type == "provision",
@@ -1006,6 +1006,7 @@ def fulfill_pending_provision_requests_for_secret(
         )
         .values(status="fulfilled", decided_at=decided_at or _now())
     )
+    return int(result.rowcount or 0)
 
 
 def create_secret(

--- a/tests/test_inbox_bridge.py
+++ b/tests/test_inbox_bridge.py
@@ -9,6 +9,7 @@ def test_inbox_bridge_publishes_controller_bridge_status(monkeypatch):
     from vibe import inbox_bridge
 
     published = []
+    inbox_bridge._bridge_connected = False
 
     async def stream_events():
         yield "connected", {}
@@ -24,9 +25,30 @@ def test_inbox_bridge_publishes_controller_bridge_status(monkeypatch):
     with pytest.raises(asyncio.CancelledError):
         asyncio.run(inbox_bridge.run_inbox_bridge())
 
+    assert inbox_bridge.is_bridge_connected() is False
     assert published == [
         ("workbench.events.bridge.status", {"connected": True}),
         ("connected", {}),
         ("runs.updated", {"run_id": "run_1", "status": "queued"}),
+        ("workbench.events.bridge.status", {"connected": False}),
+    ]
+
+
+def test_inbox_bridge_tracks_current_status(monkeypatch):
+    from vibe import inbox_bridge
+
+    published = []
+    inbox_bridge._bridge_connected = False
+    monkeypatch.setattr(inbox_bridge.broker, "publish", lambda event_type, data: published.append((event_type, data)))
+
+    inbox_bridge._set_bridge_connected(True)
+    assert inbox_bridge.is_bridge_connected() is True
+
+    inbox_bridge._set_bridge_connected(True)
+    inbox_bridge._set_bridge_connected(False)
+
+    assert inbox_bridge.is_bridge_connected() is False
+    assert published == [
+        ("workbench.events.bridge.status", {"connected": True}),
         ("workbench.events.bridge.status", {"connected": False}),
     ]

--- a/tests/test_inbox_bridge.py
+++ b/tests/test_inbox_bridge.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def test_inbox_bridge_publishes_controller_bridge_status(monkeypatch):
+    from vibe import inbox_bridge
+
+    published = []
+
+    async def stream_events():
+        yield "connected", {}
+        yield "runs.updated", {"run_id": "run_1", "status": "queued"}
+
+    async def stop_after_disconnect(_delay):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(inbox_bridge.internal_client, "stream_events", stream_events)
+    monkeypatch.setattr(inbox_bridge.broker, "publish", lambda event_type, data: published.append((event_type, data)))
+    monkeypatch.setattr(inbox_bridge.asyncio, "sleep", stop_after_disconnect)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(inbox_bridge.run_inbox_bridge())
+
+    assert published == [
+        ("workbench.events.bridge.status", {"connected": True}),
+        ("connected", {}),
+        ("runs.updated", {"run_id": "run_1", "status": "queued"}),
+        ("workbench.events.bridge.status", {"connected": False}),
+    ]

--- a/tests/test_inbox_events.py
+++ b/tests/test_inbox_events.py
@@ -132,9 +132,11 @@ def test_sqlite_background_store_publishes_run_updates(tmp_path):
 
 
 def test_sqlite_background_store_bridges_run_updates_without_local_subscribers(tmp_path, monkeypatch):
+    from core import inbox_events
     from storage.background import SQLiteBackgroundTaskStore
 
     bridged = []
+    monkeypatch.setattr(inbox_events, "_CONTROLLER_PROCESS", False)
     monkeypatch.setattr(
         "vibe.internal_client.publish_event_sync",
         lambda event_type, data, **kwargs: bridged.append((event_type, data, kwargs)),
@@ -167,3 +169,31 @@ def test_sqlite_background_store_bridges_run_updates_without_local_subscribers(t
             {"timeout": 1.5},
         )
     ]
+
+
+def test_sqlite_background_store_does_not_bridge_controller_self_updates(tmp_path, monkeypatch):
+    from core import inbox_events
+    from storage.background import SQLiteBackgroundTaskStore
+
+    bridged = []
+    monkeypatch.setattr(inbox_events, "_CONTROLLER_PROCESS", True)
+    monkeypatch.setattr(
+        "vibe.internal_client.publish_event_sync",
+        lambda event_type, data, **kwargs: bridged.append((event_type, data, kwargs)),
+    )
+    store = SQLiteBackgroundTaskStore(tmp_path / "state.sqlite")
+    try:
+        store.enqueue_run(
+            {
+                "id": "run_evt_controller",
+                "request_type": "agent_run",
+                "status": "queued",
+                "message": "hello",
+                "created_at": "2026-07-04T00:00:00+00:00",
+                "updated_at": "2026-07-04T00:00:00+00:00",
+            }
+        )
+    finally:
+        store.close()
+
+    assert bridged == []

--- a/tests/test_inbox_events.py
+++ b/tests/test_inbox_events.py
@@ -129,3 +129,41 @@ def test_sqlite_background_store_publishes_run_updates(tmp_path):
     assert failed[0] == "runs.updated"
     assert failed[1]["run_id"] == "run_evt_1"
     assert failed[1]["status"] == "failed"
+
+
+def test_sqlite_background_store_bridges_run_updates_without_local_subscribers(tmp_path, monkeypatch):
+    from storage.background import SQLiteBackgroundTaskStore
+
+    bridged = []
+    monkeypatch.setattr(
+        "vibe.internal_client.publish_event_sync",
+        lambda event_type, data, **kwargs: bridged.append((event_type, data, kwargs)),
+    )
+    store = SQLiteBackgroundTaskStore(tmp_path / "state.sqlite")
+    try:
+        store.enqueue_run(
+            {
+                "id": "run_evt_bridge",
+                "request_type": "agent_run",
+                "status": "queued",
+                "message": "hello",
+                "created_at": "2026-07-04T00:00:00+00:00",
+                "updated_at": "2026-07-04T00:00:00+00:00",
+            }
+        )
+    finally:
+        store.close()
+
+    assert bridged == [
+        (
+            "runs.updated",
+            {
+                "run_id": "run_evt_bridge",
+                "status": "queued",
+                "run_type": "agent_run",
+                "updated_at": "2026-07-04T00:00:00+00:00",
+                "cancel_requested": False,
+            },
+            {"timeout": 1.5},
+        )
+    ]

--- a/tests/test_inbox_events.py
+++ b/tests/test_inbox_events.py
@@ -71,3 +71,61 @@ def test_unsubscribe_stops_delivery():
 def test_publish_without_subscribers_is_noop():
     # No loop captured, no subscribers — must not raise (boot / headless path).
     InboxEventBus().publish("inbox.session.updated", {"x": 1})
+
+
+def test_sqlite_background_store_publishes_run_updates(tmp_path):
+    async def scenario():
+        from core import inbox_events
+        from storage.background import SQLiteBackgroundTaskStore
+
+        sub_id, queue = inbox_events.bus.subscribe()
+        store = SQLiteBackgroundTaskStore(tmp_path / "state.sqlite")
+        try:
+            store.enqueue_run(
+                {
+                    "id": "run_evt_1",
+                    "request_type": "agent_run",
+                    "status": "queued",
+                    "message": "hello",
+                    "created_at": "2026-07-04T00:00:00+00:00",
+                    "updated_at": "2026-07-04T00:00:00+00:00",
+                    "session_id": "ses_evt",
+                }
+            )
+            queued = await asyncio.wait_for(queue.get(), timeout=1.0)
+
+            claimed = store.claim_pending_run("run_evt_1", started_at="2026-07-04T00:00:01+00:00")
+            assert claimed is not None
+            running = await asyncio.wait_for(queue.get(), timeout=1.0)
+
+            store.update_run_status(
+                "run_evt_1",
+                status="failed",
+                updated_at="2026-07-04T00:00:02+00:00",
+                completed_at="2026-07-04T00:00:02+00:00",
+                error="boom",
+            )
+            failed = await asyncio.wait_for(queue.get(), timeout=1.0)
+            return queued, running, failed
+        finally:
+            store.close()
+            inbox_events.bus.unsubscribe(sub_id)
+
+    queued, running, failed = asyncio.run(scenario())
+    assert queued == (
+        "runs.updated",
+        {
+            "run_id": "run_evt_1",
+            "status": "queued",
+            "run_type": "agent_run",
+            "session_id": "ses_evt",
+            "updated_at": "2026-07-04T00:00:00+00:00",
+            "cancel_requested": False,
+        },
+    )
+    assert running[0] == "runs.updated"
+    assert running[1]["run_id"] == "run_evt_1"
+    assert running[1]["status"] == "running"
+    assert failed[0] == "runs.updated"
+    assert failed[1]["run_id"] == "run_evt_1"
+    assert failed[1]["status"] == "failed"

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -160,6 +160,8 @@ def test_create_app_exposes_minimal_endpoints():
     assert ("/internal/reconcile-platforms", ("POST",)) in routes
     assert ("/internal/cancel/{session_id}", ("POST",)) in routes
     assert ("/internal/dispatch", ("POST",)) in routes
+    assert ("/internal/events", ("GET",)) in routes
+    assert ("/internal/events", ("POST",)) in routes
 
 
 # ---------------------------------------------------------------------
@@ -179,6 +181,39 @@ def test_health_endpoint():
     resp = asyncio.run(_health_round_trip())
     assert resp.status_code == 200
     assert resp.json() == {"ok": True, "service": "vibe-remote-internal", "version": 1}
+
+
+async def _publish_event_round_trip():
+    from core import inbox_events
+
+    app = internal_server.create_app(_build_controller_double())
+    transport = httpx.ASGITransport(app=app)
+    sub_id, queue = inbox_events.bus.subscribe()
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            resp = await client.post(
+                "/internal/events",
+                json={
+                    "type": "vaults.updated",
+                    "data": {"scope": "request", "request_id": "vreq_1", "request_status": "pending"},
+                },
+            )
+            bad_resp = await client.post("/internal/events", json={"type": "unsupported", "data": {}})
+        event = await asyncio.wait_for(queue.get(), timeout=1.0)
+        return resp, bad_resp, event
+    finally:
+        inbox_events.bus.unsubscribe(sub_id)
+
+
+def test_publish_event_endpoint_emits_allowlisted_bus_event():
+    resp, bad_resp, event = asyncio.run(_publish_event_round_trip())
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert bad_resp.status_code == 400
+    assert event == (
+        "vaults.updated",
+        {"scope": "request", "request_id": "vreq_1", "request_status": "pending"},
+    )
 
 
 def test_reconcile_platforms_endpoint_calls_controller(monkeypatch):

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -2342,6 +2342,32 @@ def test_inspect_queued_runs_finalizes_cancel_requested_queued_agent_run(monkeyp
     assert stored["completed_at"] is not None
 
 
+def test_claim_queued_runs_publishes_after_commit(monkeypatch, tmp_path) -> None:
+    import storage.background as background_module
+
+    _make_avibe_session(monkeypatch, tmp_path)
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="placeholder",
+        message="queued run",
+        agent_name="codex",
+        metadata={"workbench_queue_holds_run": True},
+    )
+    bg = request_store._sqlite
+    assert bg is not None
+
+    observed_statuses: list[str | None] = []
+
+    def capture_publish(_rows):
+        stored = bg.get_run(request.id)
+        observed_statuses.append(stored["status"] if stored else None)
+
+    monkeypatch.setattr(background_module, "_publish_run_rows_updated", capture_publish)
+
+    assert bg.claim_queued_runs_for_workbench([request.id]) == [request.id]
+    assert observed_statuses == ["running"]
+
+
 def test_drain_requests_reserves_watch_create_per_run_before_session_validation(tmp_path: Path) -> None:
     request_store = TaskExecutionStore(tmp_path / "task_requests")
     request = request_store.enqueue_definition_run(

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -383,6 +383,36 @@ def test_secret_exists_response_commits_stale_pending_provision_cleanup(monkeypa
     assert stale_status == "fulfilled"
 
 
+def test_secret_exists_response_publishes_when_fulfilling_stale_provisions(monkeypatch):
+    published = []
+    monkeypatch.setattr(
+        "vibe.sse_broker.broker.publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
+    monkeypatch.setattr("vibe.internal_client.publish_event_sync", lambda *args, **kwargs: None)
+    seal = Mock(side_effect=[_sealed("first"), _sealed("second")])
+    monkeypatch.setattr(api, "avault_seal_blind_box", seal)
+    with api._vault_engine().begin() as conn:
+        req = vault_service.create_provision_request(conn, "GH_TOKEN")
+
+    payload = {
+        "name": "GH_TOKEN",
+        "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        "provision_request_id": req["id"],
+    }
+    api.create_vault_secret(payload)
+    published.clear()
+    with api._vault_engine().begin() as conn:
+        stale = vault_service.create_provision_request(conn, "GH_TOKEN")
+        conn.execute(vault_requests.update().where(vault_requests.c.id == stale["id"]).values(status="pending"))
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.create_vault_secret({**payload, "blind_box": {**payload["blind_box"], "enc": "enc2", "ct": "ct2"}})
+
+    assert exc.value.code == "secret_exists"
+    assert ("vaults.updated", {"scope": "secret", "request_status": "fulfilled", "secret_name": "GH_TOKEN"}) in published
+
+
 def test_duplicate_name_conflict(monkeypatch):
     from unittest.mock import Mock
 

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -116,6 +116,7 @@ def test_create_vault_secret_publishes_update_event(monkeypatch):
         "vibe.sse_broker.broker.publish",
         lambda event_type, data: published.append((event_type, data)),
     )
+    monkeypatch.setattr("vibe.internal_client.publish_event_sync", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
 
     api.create_vault_secret(
@@ -1581,6 +1582,12 @@ def test_revoke_grant_releases_only_that_grant_id(monkeypatch):
 
 
 def test_consume_one_shot_releases_only_that_grant_id(monkeypatch):
+    published = []
+    monkeypatch.setattr(
+        "vibe.sse_broker.broker.publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
+    monkeypatch.setattr("vibe.internal_client.publish_event_sync", lambda *args, **kwargs: None)
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     agent_release = Mock(return_value={"released": True})
     monkeypatch.setattr(api, "avault_agent_release", agent_release)
@@ -1608,9 +1615,19 @@ def test_consume_one_shot_releases_only_that_grant_id(monkeypatch):
         )
         grant_2 = _grant_from_request(conn, req_2)
 
+    published.clear()
     api.consume_one_shot_grants([grant_1], reason="test")
 
     agent_release.assert_called_once_with(grant_id=grant_1["id"])
+    assert (
+        "vaults.updated",
+        {
+            "scope": "grant",
+            "request_id": grant_1["request_id"],
+            "grant_id": grant_1["id"],
+            "grant_status": "expired",
+        },
+    ) in published
     with api._vault_engine().connect() as conn:
         statuses = {
             row["id"]: row["status"]

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -110,6 +110,24 @@ def test_create_list_delete_roundtrip(monkeypatch):
     assert api.get_vault_secrets()["secrets"] == []
 
 
+def test_create_vault_secret_publishes_update_event(monkeypatch):
+    published = []
+    monkeypatch.setattr(
+        "vibe.sse_broker.broker.publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
+
+    api.create_vault_secret(
+        {
+            "name": "EVENT_KEY",
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+
+    assert ("vaults.updated", {"scope": "secret", "secret_name": "EVENT_KEY"}) in published
+
+
 def test_standard_rest_create_rejects_plaintext_value(monkeypatch):
     from unittest.mock import Mock
 

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -1625,6 +1625,56 @@ def test_inject_reopens_session_bound_approval_when_agent_cache_is_missing(tmp_p
     assert requests[0]["card"]["grant_options"][0]["purpose"] == "inject"
 
 
+def test_fetch_resolver_publishes_pending_request_when_approval_required(monkeypatch):
+    published = []
+    monkeypatch.setattr(cli, "_publish_cli_vaults_updated", lambda **kwargs: published.append(kwargs))
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="PROTECTED_KEY", protection="protected", sealed=_sealed("protected"))
+
+    with pytest.raises(cli.TaskCliError) as exc_info:
+        cli._resolve_single_vault_delivery(
+            cli._open_vault_engine(),
+            "PROTECTED_KEY",
+            requester={"source": "cli", "session_id": "ses_cli"},
+            delivery={"session_id": "ses_cli", "mode": "fetch"},
+            purpose="fetch",
+        )
+
+    assert exc_info.value.code == "approval_required"
+    assert len(published) == 1
+    request = published[0]["request"]
+    assert published[0]["scope"] == "request"
+    assert request["status"] == "pending"
+    assert request["secret_name"] == "PROTECTED_KEY"
+    assert request["delivery"]["session_id"] == "ses_cli"
+    assert request["card"]["grant_options"][0]["purpose"] == "fetch"
+
+
+def test_inject_resolver_publishes_pending_request_when_approval_required(tmp_path, monkeypatch):
+    published = []
+    monkeypatch.setattr(cli, "_publish_cli_vaults_updated", lambda **kwargs: published.append(kwargs))
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="PROTECTED_KEY", protection="protected", sealed=_sealed("protected"))
+
+    with pytest.raises(cli.TaskCliError) as exc_info:
+        cli._resolve_vault_inject_delivery(
+            cli._open_vault_engine(),
+            ["PROTECTED_KEY"],
+            path=str(tmp_path / "out.env"),
+            fmt="dotenv",
+            args=_ns(session_id="ses_cli"),
+        )
+
+    assert exc_info.value.code == "approval_required"
+    assert len(published) == 1
+    request = published[0]["request"]
+    assert published[0]["scope"] == "request"
+    assert request["status"] == "pending"
+    assert request["secret_name"] == "PROTECTED_KEY"
+    assert request["delivery"]["session_id"] == "ses_cli"
+    assert request["card"]["grant_options"][0]["purpose"] == "inject"
+
+
 def test_run_persists_protected_approval_request_without_grant(capfd):
     with cli._open_vault_engine().begin() as conn:
         vault_service.create_secret(conn, name="PROTECTED_KEY", protection="protected", sealed=_sealed("protected"))

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -67,7 +67,7 @@ export const AgentsPage: React.FC = () => {
   const { showToast } = useToast();
   const [agentsTab, setAgentsTab] = useState<AgentsTabKey>('definitions');
   const [runningActiveCount, setRunningActiveCount] = useState<number | null>(null);
-  const [eventsConnected, setEventsConnected] = useState(false);
+  const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
   const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
   const [defaultName, setDefaultName] = useState<string | null>(null);
   const [selected, setSelected] = useState<VibeAgentFull | null>(null);
@@ -143,11 +143,17 @@ export const AgentsPage: React.FC = () => {
   useEffect(() => {
     if (agentsTab === 'running') return;
     return api.connectWorkbenchEvents({
-      onConnected: () => {
-        setEventsConnected(true);
-        fetchRunningActiveCount();
+      onConnected: (data) => {
+        if (data.source === 'controller') {
+          setEventBridgeConnected(true);
+          fetchRunningActiveCount();
+        }
       },
-      onError: () => setEventsConnected(false),
+      onEventBridgeStatus: ({ connected }) => {
+        setEventBridgeConnected(connected);
+        if (connected) fetchRunningActiveCount();
+      },
+      onError: () => setEventBridgeConnected(false),
       onRunsUpdated: () => fetchRunningActiveCount(),
       onTurnStart: () => fetchRunningActiveCount(),
       onTurnEnd: () => fetchRunningActiveCount(),
@@ -156,7 +162,7 @@ export const AgentsPage: React.FC = () => {
   }, [api, agentsTab, fetchRunningActiveCount]);
 
   useEffect(() => {
-    if (agentsTab === 'running' || eventsConnected) return;
+    if (agentsTab === 'running' || eventBridgeConnected) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -201,7 +207,7 @@ export const AgentsPage: React.FC = () => {
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventsConnected, agentsTab, fetchRunningActiveCount]);
+  }, [eventBridgeConnected, agentsTab, fetchRunningActiveCount]);
 
   const selectAgent = useCallback(
     async (name: string, openDetail = false) => {

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -67,6 +67,7 @@ export const AgentsPage: React.FC = () => {
   const { showToast } = useToast();
   const [agentsTab, setAgentsTab] = useState<AgentsTabKey>('definitions');
   const [runningActiveCount, setRunningActiveCount] = useState<number | null>(null);
+  const [eventsConnected, setEventsConnected] = useState(false);
   const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
   const [defaultName, setDefaultName] = useState<string | null>(null);
   const [selected, setSelected] = useState<VibeAgentFull | null>(null);
@@ -122,36 +123,85 @@ export const AgentsPage: React.FC = () => {
     if (!selected) setDetailOpen(false);
   }, [selected]);
 
-  // Fetch the active-count for the Running tab badge. Runs once on mount
-  // and polls every 8s so the pill reflects live state without hammering the server.
-  useEffect(() => {
-    let cancelled = false;
-    const fetchCount = async () => {
-      try {
-        const result = await api.getRunningAgents();
-        if (!cancelled) {
-          if (result.ok && result.counts) {
-            setRunningActiveCount((result.counts as any).active ?? 0);
-          } else {
-            setRunningActiveCount(null); // unreachable → show "—"
-          }
-        }
-      } catch {
-        // Any fetch failure (unreachable/401/500): show "—" rather than a stale
-        // count, matching the tab body's explicit unreachable handling.
-        if (!cancelled) setRunningActiveCount(null);
+  const fetchRunningActiveCount = useCallback(async () => {
+    try {
+      const result = await api.getRunningAgents();
+      if (result.ok && result.counts) {
+        setRunningActiveCount((result.counts as any).active ?? 0);
+      } else {
+        setRunningActiveCount(null);
       }
+    } catch {
+      setRunningActiveCount(null);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    if (agentsTab !== 'running') void fetchRunningActiveCount();
+  }, [agentsTab, fetchRunningActiveCount]);
+
+  useEffect(() => {
+    if (agentsTab === 'running') return;
+    return api.connectWorkbenchEvents({
+      onConnected: () => {
+        setEventsConnected(true);
+        fetchRunningActiveCount();
+      },
+      onError: () => setEventsConnected(false),
+      onRunsUpdated: () => fetchRunningActiveCount(),
+      onTurnStart: () => fetchRunningActiveCount(),
+      onTurnEnd: () => fetchRunningActiveCount(),
+      onSessionStatus: () => fetchRunningActiveCount(),
+    });
+  }, [api, agentsTab, fetchRunningActiveCount]);
+
+  useEffect(() => {
+    if (agentsTab === 'running' || eventsConnected) return;
+    let timer: number | undefined;
+    let cancelled = false;
+    let inFlight = false;
+    let pendingWake = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') {
+        timer = window.setTimeout(tick, 8000);
+        return;
+      }
+      if (inFlight) {
+        pendingWake = true;
+        return;
+      }
+      inFlight = true;
+      window.clearTimeout(timer);
+      try {
+        await fetchRunningActiveCount();
+      } finally {
+        inFlight = false;
+      }
+      if (cancelled) return;
+      if (pendingWake) {
+        pendingWake = false;
+        void tick();
+        return;
+      }
+      timer = window.setTimeout(tick, 8000);
     };
-    fetchCount();
-    // While the Running tab is open it already polls the same endpoint (4s), so
-    // skip the redundant badge poll then; one fetch on tab-switch keeps the pill
-    // fresh enough (it re-runs on the next switch back to Definitions).
-    const id = agentsTab === 'running' ? null : window.setInterval(fetchCount, 8000);
+
+    const refreshNow = () => {
+      if (document.visibilityState === 'visible') void tick();
+    };
+
+    void tick();
+    document.addEventListener('visibilitychange', refreshNow);
+    window.addEventListener('focus', refreshNow);
     return () => {
       cancelled = true;
-      if (id != null) window.clearInterval(id);
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', refreshNow);
+      window.removeEventListener('focus', refreshNow);
     };
-  }, [api, agentsTab]);
+  }, [eventsConnected, agentsTab, fetchRunningActiveCount]);
 
   const selectAgent = useCallback(
     async (name: string, openDetail = false) => {

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -181,6 +181,14 @@ export const HarnessPage: React.FC = () => {
     refresh();
   }, [refresh]);
 
+  useEffect(() => {
+    return api.connectWorkbenchEvents({
+      onRunsUpdated: () => {
+        void refresh();
+      },
+    });
+  }, [api, refresh]);
+
   // Resolve agent_name → backend/model/effort for the detail panels: the
   // task/watch payload stores only the name. Fetched once on mount.
   const [agentsByName, setAgentsByName] = useState<Record<string, VibeAgentBrief>>({});

--- a/ui/src/components/workbench/RunningAgentsTab.tsx
+++ b/ui/src/components/workbench/RunningAgentsTab.tsx
@@ -28,7 +28,7 @@ import {
   type Backend,
 } from '../../lib/backendAccent';
 
-// Degraded-mode refresh cadence while SSE is disconnected.
+// Snapshot refresh cadence for degraded fallback and live rows that age without events.
 const POLL_INTERVAL_MS = 4000;
 
 // Humanize elapsed_seconds: 12 → "12s", 185 → "3m", 3700 → "1h"
@@ -201,8 +201,9 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
     });
   }, [api, fetchData]);
 
+  const hasLiveRows = agents.length > 0;
   useEffect(() => {
-    if (eventBridgeConnected) return;
+    if (eventBridgeConnected && !hasLiveRows) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -247,7 +248,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventBridgeConnected, fetchData]);
+  }, [eventBridgeConnected, fetchData, hasLiveRows]);
 
   if (loading) {
     return (

--- a/ui/src/components/workbench/RunningAgentsTab.tsx
+++ b/ui/src/components/workbench/RunningAgentsTab.tsx
@@ -28,7 +28,7 @@ import {
   type Backend,
 } from '../../lib/backendAccent';
 
-// How often to refresh while mounted (ms)
+// Degraded-mode refresh cadence while SSE is disconnected.
 const POLL_INTERVAL_MS = 4000;
 
 // Humanize elapsed_seconds: 12 → "12s", 185 → "3m", 3700 → "1h"
@@ -102,6 +102,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
   const [agents, setAgents] = useState<RunningAgent[]>([]);
   const [unreachable, setUnreachable] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [eventsConnected, setEventsConnected] = useState(false);
   // Guards against setState after unmount: an in-flight poll can resolve after
   // the user leaves the Running tab (the component unmounts) — without this the
   // resolved fetch would call setState on an unmounted component.
@@ -176,16 +177,71 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
     [api, fetchData, showToast, t],
   );
 
-  // Initial fetch
   useEffect(() => {
     fetchData(false);
   }, [fetchData]);
 
-  // Polling interval
   useEffect(() => {
-    const id = window.setInterval(() => fetchData(true), POLL_INTERVAL_MS);
-    return () => window.clearInterval(id);
-  }, [fetchData]);
+    return api.connectWorkbenchEvents({
+      onConnected: () => {
+        setEventsConnected(true);
+        fetchData(true);
+      },
+      onError: () => setEventsConnected(false),
+      onRunsUpdated: () => fetchData(true),
+      onTurnStart: () => fetchData(true),
+      onTurnEnd: () => fetchData(true),
+      onSessionStatus: () => fetchData(true),
+    });
+  }, [api, fetchData]);
+
+  useEffect(() => {
+    if (eventsConnected) return;
+    let timer: number | undefined;
+    let cancelled = false;
+    let inFlight = false;
+    let pendingWake = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') {
+        timer = window.setTimeout(tick, POLL_INTERVAL_MS);
+        return;
+      }
+      if (inFlight) {
+        pendingWake = true;
+        return;
+      }
+      inFlight = true;
+      window.clearTimeout(timer);
+      try {
+        await fetchData(true);
+      } finally {
+        inFlight = false;
+      }
+      if (cancelled) return;
+      if (pendingWake) {
+        pendingWake = false;
+        void tick();
+        return;
+      }
+      timer = window.setTimeout(tick, POLL_INTERVAL_MS);
+    };
+
+    const refreshNow = () => {
+      if (document.visibilityState === 'visible') void tick();
+    };
+
+    void tick();
+    document.addEventListener('visibilitychange', refreshNow);
+    window.addEventListener('focus', refreshNow);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', refreshNow);
+      window.removeEventListener('focus', refreshNow);
+    };
+  }, [eventsConnected, fetchData]);
 
   if (loading) {
     return (

--- a/ui/src/components/workbench/RunningAgentsTab.tsx
+++ b/ui/src/components/workbench/RunningAgentsTab.tsx
@@ -30,6 +30,7 @@ import {
 
 // Degraded-mode refresh cadence while SSE is disconnected.
 const POLL_INTERVAL_MS = 4000;
+const LIVENESS_POLL_INTERVAL_MS = 30000;
 const RENDER_TICK_INTERVAL_MS = 1000;
 
 type DisplayRunningAgent = RunningAgent & {
@@ -222,8 +223,12 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
     return () => window.clearInterval(timer);
   }, [hasElapsedRows]);
 
+  // SSE covers lifecycle writes, and the render ticker covers elapsed labels.
+  // External process death/orphan detection is a sampled snapshot, so keep a
+  // low-rate reconciliation poll only while visible rows can go stale.
   useEffect(() => {
-    if (eventBridgeConnected) return;
+    const intervalMs = eventBridgeConnected ? LIVENESS_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
+    if (eventBridgeConnected && agents.length === 0) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -232,7 +237,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
     const tick = async () => {
       if (cancelled) return;
       if (document.visibilityState !== 'visible') {
-        timer = window.setTimeout(tick, POLL_INTERVAL_MS);
+        timer = window.setTimeout(tick, intervalMs);
         return;
       }
       if (inFlight) {
@@ -252,7 +257,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
         void tick();
         return;
       }
-      timer = window.setTimeout(tick, POLL_INTERVAL_MS);
+      timer = window.setTimeout(tick, intervalMs);
     };
 
     const refreshNow = () => {
@@ -268,7 +273,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventBridgeConnected, fetchData]);
+  }, [agents.length, eventBridgeConnected, fetchData]);
 
   if (loading) {
     return (

--- a/ui/src/components/workbench/RunningAgentsTab.tsx
+++ b/ui/src/components/workbench/RunningAgentsTab.tsx
@@ -28,8 +28,13 @@ import {
   type Backend,
 } from '../../lib/backendAccent';
 
-// Snapshot refresh cadence for degraded fallback and live rows that age without events.
+// Degraded-mode refresh cadence while SSE is disconnected.
 const POLL_INTERVAL_MS = 4000;
+const RENDER_TICK_INTERVAL_MS = 1000;
+
+type DisplayRunningAgent = RunningAgent & {
+  elapsed_observed_at: number;
+};
 
 // Humanize elapsed_seconds: 12 → "12s", 185 → "3m", 3700 → "1h"
 function formatElapsed(seconds: number | null): string {
@@ -71,6 +76,12 @@ function sortAgents(agents: RunningAgent[]): RunningAgent[] {
   });
 }
 
+function currentElapsedSeconds(agent: DisplayRunningAgent, now: number): number | null {
+  if (agent.elapsed_seconds == null) return null;
+  const age = Math.max(0, (now - agent.elapsed_observed_at) / 1000);
+  return agent.elapsed_seconds + age;
+}
+
 // Per-state presentation, in one place: the state dot/badge AND the End button
 // label/icon/confirm-policy all key off this map instead of parallel ternaries.
 type RunState = 'active' | 'idle' | 'orphan';
@@ -99,7 +110,8 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
   const { t } = useTranslation();
   const api = useApi();
   const { showToast } = useToast();
-  const [agents, setAgents] = useState<RunningAgent[]>([]);
+  const [agents, setAgents] = useState<DisplayRunningAgent[]>([]);
+  const [renderNow, setRenderNow] = useState(() => Date.now());
   const [unreachable, setUnreachable] = useState(false);
   const [loading, setLoading] = useState(true);
   const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
@@ -125,8 +137,10 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
           setAgents([]);
           onActiveCountChange?.(null);
         } else {
+          const observedAt = Date.now();
           setUnreachable(false);
-          setAgents(sortAgents(result.agents ?? []));
+          setRenderNow(observedAt);
+          setAgents(sortAgents(result.agents ?? []).map((agent) => ({ ...agent, elapsed_observed_at: observedAt })));
           onActiveCountChange?.((result.counts as any)?.active ?? 0);
         }
       } catch {
@@ -201,9 +215,15 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
     });
   }, [api, fetchData]);
 
-  const hasLiveRows = agents.length > 0;
+  const hasElapsedRows = agents.some((agent) => agent.elapsed_seconds != null);
   useEffect(() => {
-    if (eventBridgeConnected && !hasLiveRows) return;
+    if (!hasElapsedRows) return;
+    const timer = window.setInterval(() => setRenderNow(Date.now()), RENDER_TICK_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [hasElapsedRows]);
+
+  useEffect(() => {
+    if (eventBridgeConnected) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -248,7 +268,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventBridgeConnected, fetchData, hasLiveRows]);
+  }, [eventBridgeConnected, fetchData]);
 
   if (loading) {
     return (
@@ -315,6 +335,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
           // same key the sort uses; no positional index.
           key={identityKey(agent)}
           agent={agent}
+          renderNow={renderNow}
           onEnd={endAgent}
         />
       ))}
@@ -327,11 +348,12 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
 // ---------------------------------------------------------------------------
 
 interface RunningAgentRowProps {
-  agent: RunningAgent;
+  agent: DisplayRunningAgent;
+  renderNow: number;
   onEnd: (agent: RunningAgent) => Promise<void>;
 }
 
-const RunningAgentRow: React.FC<RunningAgentRowProps> = ({ agent, onEnd }) => {
+const RunningAgentRow: React.FC<RunningAgentRowProps> = ({ agent, renderNow, onEnd }) => {
   const { t } = useTranslation();
   const isOrphan = agent.state === 'orphan';
   const [ending, setEnding] = useState(false);
@@ -380,6 +402,7 @@ const RunningAgentRow: React.FC<RunningAgentRowProps> = ({ agent, onEnd }) => {
     BACKEND_LABEL[agent.backend as Backend] ?? agent.backend;
   const backendClass =
     BACKEND_ICON_CLASS[agent.backend as Backend] ?? 'text-muted';
+  const elapsedSeconds = currentElapsedSeconds(agent, renderNow);
 
   const canOpenChat = agent.openable_in_chat && !!agent.session_id;
 
@@ -405,13 +428,13 @@ const RunningAgentRow: React.FC<RunningAgentRowProps> = ({ agent, onEnd }) => {
         {/* Elapsed — "busy {{elapsed}}" while a turn is in flight (the backend
             anchors this to the turn-start baseline, not last-chunk time), else
             "idle {{elapsed}}". */}
-        {agent.elapsed_seconds != null && (
+        {elapsedSeconds != null && (
           <span className="font-mono text-[11px] text-muted">
             {t(
               agent.state === 'active'
                 ? 'agents.running.busy'
                 : 'agents.running.idleElapsed',
-              { elapsed: formatElapsed(agent.elapsed_seconds) },
+              { elapsed: formatElapsed(elapsedSeconds) },
             )}
           </span>
         )}

--- a/ui/src/components/workbench/RunningAgentsTab.tsx
+++ b/ui/src/components/workbench/RunningAgentsTab.tsx
@@ -102,7 +102,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
   const [agents, setAgents] = useState<RunningAgent[]>([]);
   const [unreachable, setUnreachable] = useState(false);
   const [loading, setLoading] = useState(true);
-  const [eventsConnected, setEventsConnected] = useState(false);
+  const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
   // Guards against setState after unmount: an in-flight poll can resolve after
   // the user leaves the Running tab (the component unmounts) — without this the
   // resolved fetch would call setState on an unmounted component.
@@ -183,11 +183,17 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
 
   useEffect(() => {
     return api.connectWorkbenchEvents({
-      onConnected: () => {
-        setEventsConnected(true);
-        fetchData(true);
+      onConnected: (data) => {
+        if (data.source === 'controller') {
+          setEventBridgeConnected(true);
+          fetchData(true);
+        }
       },
-      onError: () => setEventsConnected(false),
+      onEventBridgeStatus: ({ connected }) => {
+        setEventBridgeConnected(connected);
+        if (connected) fetchData(true);
+      },
+      onError: () => setEventBridgeConnected(false),
       onRunsUpdated: () => fetchData(true),
       onTurnStart: () => fetchData(true),
       onTurnEnd: () => fetchData(true),
@@ -196,7 +202,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
   }, [api, fetchData]);
 
   useEffect(() => {
-    if (eventsConnected) return;
+    if (eventBridgeConnected) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -241,7 +247,7 @@ export const RunningAgentsTab: React.FC<RunningAgentsTabProps> = ({ onActiveCoun
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventsConnected, fetchData]);
+  }, [eventBridgeConnected, fetchData]);
 
   if (loading) {
     return (

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -286,6 +286,7 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
   const [requests, setRequests] = useState<VaultRequest[]>([]);
   const [reviewing, setReviewing] = useState<VaultRequest | null>(null);
   const [provisioning, setProvisioning] = useState<VaultRequest | null>(null);
+  const [eventsConnected, setEventsConnected] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -302,12 +303,68 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
     }
   }, [api]);
 
-  // Poll so a request an agent raises while the hub is open appears without a manual refresh.
   useEffect(() => {
     load();
-    const id = setInterval(load, 5000);
-    return () => clearInterval(id);
   }, [load]);
+
+  useEffect(() => {
+    return api.connectWorkbenchEvents({
+      onConnected: () => {
+        setEventsConnected(true);
+        load();
+      },
+      onError: () => setEventsConnected(false),
+      onVaultsUpdated: () => load(),
+    });
+  }, [api, load]);
+
+  useEffect(() => {
+    if (eventsConnected) return;
+    let timer: number | undefined;
+    let cancelled = false;
+    let inFlight = false;
+    let pendingWake = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') {
+        timer = window.setTimeout(tick, 5000);
+        return;
+      }
+      if (inFlight) {
+        pendingWake = true;
+        return;
+      }
+      inFlight = true;
+      window.clearTimeout(timer);
+      try {
+        await load();
+      } finally {
+        inFlight = false;
+      }
+      if (cancelled) return;
+      if (pendingWake) {
+        pendingWake = false;
+        void tick();
+        return;
+      }
+      timer = window.setTimeout(tick, 5000);
+    };
+
+    const refreshNow = () => {
+      if (document.visibilityState === 'visible') void tick();
+    };
+
+    void tick();
+    document.addEventListener('visibilitychange', refreshNow);
+    window.addEventListener('focus', refreshNow);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', refreshNow);
+      window.removeEventListener('focus', refreshNow);
+    };
+  }, [eventsConnected, load]);
 
   const handleOutcome = useCallback(
     (outcome: ApprovalOutcome) => {
@@ -415,6 +472,7 @@ export const VaultsPage: React.FC = () => {
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [activeSkills, setActiveSkills] = useState<string[]>([]);
   const [now, setNow] = useState(() => Date.now());
+  const [eventsConnected, setEventsConnected] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -441,6 +499,65 @@ export const VaultsPage: React.FC = () => {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    return api.connectWorkbenchEvents({
+      onConnected: () => {
+        setEventsConnected(true);
+        refresh();
+      },
+      onError: () => setEventsConnected(false),
+      onVaultsUpdated: () => refresh(),
+    });
+  }, [api, refresh]);
+
+  useEffect(() => {
+    if (eventsConnected) return;
+    let timer: number | undefined;
+    let cancelled = false;
+    let inFlight = false;
+    let pendingWake = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') {
+        timer = window.setTimeout(tick, 5000);
+        return;
+      }
+      if (inFlight) {
+        pendingWake = true;
+        return;
+      }
+      inFlight = true;
+      window.clearTimeout(timer);
+      try {
+        await refresh();
+      } finally {
+        inFlight = false;
+      }
+      if (cancelled) return;
+      if (pendingWake) {
+        pendingWake = false;
+        void tick();
+        return;
+      }
+      timer = window.setTimeout(tick, 5000);
+    };
+
+    const refreshNow = () => {
+      if (document.visibilityState === 'visible') void tick();
+    };
+
+    void tick();
+    document.addEventListener('visibilitychange', refreshNow);
+    window.addEventListener('focus', refreshNow);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', refreshNow);
+      window.removeEventListener('focus', refreshNow);
+    };
+  }, [eventsConnected, refresh]);
 
   // Tick once a second while there are live grants: advance the countdown and
   // drop any grant that has reached its expiry. The backend's status=active

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -324,8 +324,9 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
     });
   }, [api, load]);
 
+  const hasPendingRequests = requests.length > 0;
   useEffect(() => {
-    if (eventBridgeConnected) return;
+    if (eventBridgeConnected && !hasPendingRequests) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -370,7 +371,7 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventBridgeConnected, load]);
+  }, [eventBridgeConnected, load, hasPendingRequests]);
 
   const handleOutcome = useCallback(
     (outcome: ApprovalOutcome) => {

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -286,7 +286,7 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
   const [requests, setRequests] = useState<VaultRequest[]>([]);
   const [reviewing, setReviewing] = useState<VaultRequest | null>(null);
   const [provisioning, setProvisioning] = useState<VaultRequest | null>(null);
-  const [eventsConnected, setEventsConnected] = useState(false);
+  const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -309,17 +309,23 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
 
   useEffect(() => {
     return api.connectWorkbenchEvents({
-      onConnected: () => {
-        setEventsConnected(true);
-        load();
+      onConnected: (data) => {
+        if (data.source === 'controller') {
+          setEventBridgeConnected(true);
+          load();
+        }
       },
-      onError: () => setEventsConnected(false),
+      onEventBridgeStatus: ({ connected }) => {
+        setEventBridgeConnected(connected);
+        if (connected) load();
+      },
+      onError: () => setEventBridgeConnected(false),
       onVaultsUpdated: () => load(),
     });
   }, [api, load]);
 
   useEffect(() => {
-    if (eventsConnected) return;
+    if (eventBridgeConnected) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -364,7 +370,7 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventsConnected, load]);
+  }, [eventBridgeConnected, load]);
 
   const handleOutcome = useCallback(
     (outcome: ApprovalOutcome) => {
@@ -472,7 +478,7 @@ export const VaultsPage: React.FC = () => {
   const [activeTags, setActiveTags] = useState<string[]>([]);
   const [activeSkills, setActiveSkills] = useState<string[]>([]);
   const [now, setNow] = useState(() => Date.now());
-  const [eventsConnected, setEventsConnected] = useState(false);
+  const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -502,17 +508,23 @@ export const VaultsPage: React.FC = () => {
 
   useEffect(() => {
     return api.connectWorkbenchEvents({
-      onConnected: () => {
-        setEventsConnected(true);
-        refresh();
+      onConnected: (data) => {
+        if (data.source === 'controller') {
+          setEventBridgeConnected(true);
+          refresh();
+        }
       },
-      onError: () => setEventsConnected(false),
+      onEventBridgeStatus: ({ connected }) => {
+        setEventBridgeConnected(connected);
+        if (connected) refresh();
+      },
+      onError: () => setEventBridgeConnected(false),
       onVaultsUpdated: () => refresh(),
     });
   }, [api, refresh]);
 
   useEffect(() => {
-    if (eventsConnected) return;
+    if (eventBridgeConnected) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -557,7 +569,7 @@ export const VaultsPage: React.FC = () => {
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventsConnected, refresh]);
+  }, [eventBridgeConnected, refresh]);
 
   // Tick once a second while there are live grants: advance the countdown and
   // drop any grant that has reached its expiry. The backend's status=active

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -14,6 +14,10 @@ import { useToast } from '../../context/ToastContext';
 import { VaultApprovalCard, type ApprovalOutcome } from '../ui/vault-approval-card';
 import { VaultSecretForm } from '../ui/vault-secret-form';
 
+const PENDING_REQUEST_POLL_INTERVAL_MS = 5000;
+const PENDING_REQUEST_EXPIRY_GRACE_MS = 100;
+const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
+
 const AddSecretDialog: React.FC<{
   onClose: () => void;
   onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
@@ -150,6 +154,17 @@ function remaining(expiresAt: string, now: number): { h: number; m: number; s: n
 function isExpired(expiresAt: string, now: number): boolean {
   const end = Date.parse(expiresAt);
   return !Number.isNaN(end) && end <= now;
+}
+
+function earliestRequestExpiry(requests: VaultRequest[]): number | null {
+  let earliest: number | null = null;
+  for (const request of requests) {
+    if (!request.expires_at) continue;
+    const expiresAt = Date.parse(request.expires_at);
+    if (Number.isNaN(expiresAt)) continue;
+    earliest = earliest == null ? expiresAt : Math.min(earliest, expiresAt);
+  }
+  return earliest;
 }
 
 /** Compact mm:ss / h:mm:ss countdown for a grant chip (design.pen `y4rw5Q` shows `12:34`). */
@@ -324,9 +339,8 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
     });
   }, [api, load]);
 
-  const hasPendingRequests = requests.length > 0;
   useEffect(() => {
-    if (eventBridgeConnected && !hasPendingRequests) return;
+    if (eventBridgeConnected) return;
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -335,7 +349,7 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
     const tick = async () => {
       if (cancelled) return;
       if (document.visibilityState !== 'visible') {
-        timer = window.setTimeout(tick, 5000);
+        timer = window.setTimeout(tick, PENDING_REQUEST_POLL_INTERVAL_MS);
         return;
       }
       if (inFlight) {
@@ -355,7 +369,7 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
         void tick();
         return;
       }
-      timer = window.setTimeout(tick, 5000);
+      timer = window.setTimeout(tick, PENDING_REQUEST_POLL_INTERVAL_MS);
     };
 
     const refreshNow = () => {
@@ -371,7 +385,20 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventBridgeConnected, load, hasPendingRequests]);
+  }, [eventBridgeConnected, load]);
+
+  useEffect(() => {
+    const expiresAt = earliestRequestExpiry(requests);
+    if (expiresAt == null) return;
+    const delay = Math.min(
+      Math.max(0, expiresAt - Date.now() + PENDING_REQUEST_EXPIRY_GRACE_MS),
+      MAX_BROWSER_TIMEOUT_MS,
+    );
+    const timer = window.setTimeout(() => {
+      void load();
+    }, delay);
+    return () => window.clearTimeout(timer);
+  }, [requests, load]);
 
   const handleOutcome = useCallback(
     (outcome: ApprovalOutcome) => {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -666,6 +666,23 @@ export type WorkbenchEventHandlers = {
   onSessionStatus?: (data: { session_id: string; agent_status: 'idle' | 'running' | 'failed' }) => void;
   // The send-while-busy queue for a session changed (enqueue / flush / remove).
   onQueueUpdated?: (data: { session_id: string }) => void;
+  onRunsUpdated?: (data: {
+    run_id: string;
+    status: HarnessRunStatus;
+    run_type?: string;
+    session_id?: string;
+    definition_id?: string;
+    updated_at?: string;
+    cancel_requested?: boolean;
+  }) => void;
+  onVaultsUpdated?: (data: {
+    scope: string;
+    request_id?: string;
+    request_status?: string;
+    grant_id?: string;
+    grant_status?: string;
+    secret_name?: string;
+  }) => void;
   onAny?: (event: WorkbenchEventEnvelope) => void;
   onError?: (err: Event) => void;
 };
@@ -1543,7 +1560,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     eventSourceRef.current = source;
     source.addEventListener('connected', (e: MessageEvent) => {
       try {
-        eventConnectionRef.current = JSON.parse(e.data) as { sub_id: number };
+        const parsed = JSON.parse(e.data) as { sub_id?: number; type?: string; data?: unknown };
+        eventConnectionRef.current = { sub_id: typeof parsed.sub_id === 'number' ? parsed.sub_id : -1 };
       } catch (err) {
         console.error('[workbench-events] connected parse failed', err, e.data);
         eventConnectionRef.current = null;
@@ -1636,7 +1654,41 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         handlers.onQueueUpdated?.(envelope.data);
       });
     });
+    source.addEventListener('runs.updated', (e: MessageEvent) => {
+      const envelope = parseWorkbenchEnvelope<{
+        run_id: string;
+        status: HarnessRunStatus;
+        run_type?: string;
+        session_id?: string;
+        definition_id?: string;
+        updated_at?: string;
+        cancel_requested?: boolean;
+      }>(e.data);
+      if (!envelope) return;
+      clearReadCacheMatching((path) => path.startsWith('/api/harness'));
+      dispatchToWorkbenchHandlers((handlers) => {
+        handlers.onAny?.(envelope);
+        handlers.onRunsUpdated?.(envelope.data);
+      });
+    });
+    source.addEventListener('vaults.updated', (e: MessageEvent) => {
+      const envelope = parseWorkbenchEnvelope<{
+        scope: string;
+        request_id?: string;
+        request_status?: string;
+        grant_id?: string;
+        grant_status?: string;
+        secret_name?: string;
+      }>(e.data);
+      if (!envelope) return;
+      clearReadCacheMatching((path) => path.startsWith('/api/vault/'));
+      dispatchToWorkbenchHandlers((handlers) => {
+        handlers.onAny?.(envelope);
+        handlers.onVaultsUpdated?.(envelope.data);
+      });
+    });
     source.onerror = (err) => {
+      eventConnectionRef.current = null;
       dispatchToWorkbenchHandlers((handlers) => handlers.onError?.(err));
     };
   };

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -641,7 +641,8 @@ export type WorkbenchEventEnvelope<T = unknown> = {
 };
 
 export type WorkbenchEventHandlers = {
-  onConnected?: (data: { sub_id: number }) => void;
+  onConnected?: (data: { sub_id: number; source?: 'browser' | 'controller' }) => void;
+  onEventBridgeStatus?: (data: { connected: boolean }) => void;
   onMessageNew?: (data: WorkbenchMessage) => void;
   onSessionActivity?: (data: { session_id: string; scope_id: string | null; event: string; title?: string | null }) => void;
   onInboxUnreadChanged?: (data: {
@@ -1435,7 +1436,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const readCacheRef = useRef(new Map<string, { expiresAt: number; promise: Promise<any> }>());
   const eventSourceRef = useRef<EventSource | null>(null);
   const eventHandlersRef = useRef(new Set<WorkbenchEventHandlers>());
-  const eventConnectionRef = useRef<{ sub_id: number } | null>(null);
+  const eventConnectionRef = useRef<{ sub_id: number; source?: 'browser' | 'controller' } | null>(null);
+  const eventBridgeConnectedRef = useRef(false);
 
   const handleApiError = async (res: Response, path: string) => {
     let errorMessage = `Request failed: ${path} (${res.status})`;
@@ -1548,6 +1550,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     eventSourceRef.current?.close();
     eventSourceRef.current = null;
     eventConnectionRef.current = null;
+    eventBridgeConnectedRef.current = false;
   };
 
   const ensureWorkbenchEventSource = (options?: { reconnect?: boolean }) => {
@@ -1561,7 +1564,15 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     source.addEventListener('connected', (e: MessageEvent) => {
       try {
         const parsed = JSON.parse(e.data) as { sub_id?: number; type?: string; data?: unknown };
-        eventConnectionRef.current = { sub_id: typeof parsed.sub_id === 'number' ? parsed.sub_id : -1 };
+        const sourceKind = typeof parsed.sub_id === 'number' ? 'browser' : 'controller';
+        eventConnectionRef.current = {
+          sub_id: typeof parsed.sub_id === 'number' ? parsed.sub_id : -1,
+          source: sourceKind,
+        };
+        if (sourceKind === 'controller') {
+          eventBridgeConnectedRef.current = true;
+          dispatchToWorkbenchHandlers((handlers) => handlers.onEventBridgeStatus?.({ connected: true }));
+        }
       } catch (err) {
         console.error('[workbench-events] connected parse failed', err, e.data);
         eventConnectionRef.current = null;
@@ -1687,8 +1698,19 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         handlers.onVaultsUpdated?.(envelope.data);
       });
     });
+    source.addEventListener('workbench.events.bridge.status', (e: MessageEvent) => {
+      const envelope = parseWorkbenchEnvelope<{ connected: boolean }>(e.data);
+      if (!envelope) return;
+      eventBridgeConnectedRef.current = envelope.data.connected;
+      dispatchToWorkbenchHandlers((handlers) => {
+        handlers.onAny?.(envelope);
+        handlers.onEventBridgeStatus?.(envelope.data);
+      });
+    });
     source.onerror = (err) => {
       eventConnectionRef.current = null;
+      eventBridgeConnectedRef.current = false;
+      dispatchToWorkbenchHandlers((handlers) => handlers.onEventBridgeStatus?.({ connected: false }));
       dispatchToWorkbenchHandlers((handlers) => handlers.onError?.(err));
     };
   };
@@ -2270,10 +2292,24 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     connectWorkbenchEvents: (handlers, options) => {
       eventHandlersRef.current.add(handlers);
       ensureWorkbenchEventSource(options);
-      if (eventConnectionRef.current) {
+      if (
+        eventConnectionRef.current &&
+        (eventConnectionRef.current.source !== 'controller' || eventBridgeConnectedRef.current)
+      ) {
         queueMicrotask(() => {
-          if (eventHandlersRef.current.has(handlers) && eventConnectionRef.current) {
+          if (
+            eventHandlersRef.current.has(handlers) &&
+            eventConnectionRef.current &&
+            (eventConnectionRef.current.source !== 'controller' || eventBridgeConnectedRef.current)
+          ) {
             handlers.onConnected?.(eventConnectionRef.current);
+          }
+        });
+      }
+      if (eventBridgeConnectedRef.current) {
+        queueMicrotask(() => {
+          if (eventHandlersRef.current.has(handlers)) {
+            handlers.onEventBridgeStatus?.({ connected: true });
           }
         });
       }

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1329,17 +1329,22 @@ def _publish_vaults_updated(
         from core.inbox_events import VAULTS_UPDATED_EVENT, vaults_updated_payload
         from vibe.sse_broker import broker
 
-        broker.publish(
-            VAULTS_UPDATED_EVENT,
-            vaults_updated_payload(
-                scope=scope,
-                request_id=request_id,
-                request_status=request_status,
-                grant_id=grant_id,
-                grant_status=grant_status,
-                secret_name=secret_name,
-            ),
+        payload = vaults_updated_payload(
+            scope=scope,
+            request_id=request_id,
+            request_status=request_status,
+            grant_id=grant_id,
+            grant_status=grant_status,
+            secret_name=secret_name,
         )
+        broker.publish(VAULTS_UPDATED_EVENT, payload)
+        if broker.subscriber_count() == 0:
+            try:
+                from vibe import internal_client
+
+                internal_client.publish_event_sync(VAULTS_UPDATED_EVENT, payload, timeout=1.5)
+            except Exception:
+                logger.debug("vaults.updated bridge publish failed", exc_info=True)
     except Exception:
         logger.debug("vaults.updated publish failed", exc_info=True)
 
@@ -1850,6 +1855,7 @@ def consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, rea
         return
     seen: set[str] = set()
     release_scopes: list[dict[str, str]] = []
+    consumed_grants: list[dict[str, str | None]] = []
     engine = _vault_engine()
     with engine.begin() as conn:
         for grant in grants:
@@ -1861,7 +1867,15 @@ def consume_one_shot_grants(grants: list[dict] | tuple[dict, ...] | None, *, rea
             seen.add(grant_id)
             with contextlib.suppress(vault_service.GrantNotActiveError, vault_service.GrantNotFoundError):
                 release_scopes.extend(vault_service.consume_one_shot_grant(conn, grant_id))
+                consumed_grants.append({"id": grant_id, "request_id": str(grant.get("request_id") or "") or None})
     release_vault_agent_scopes(release_scopes, reason=reason)
+    for grant in consumed_grants:
+        _publish_vaults_updated(
+            scope="grant",
+            grant_id=grant["id"],
+            grant_status="expired",
+            request_id=grant.get("request_id"),
+        )
 
 
 def _agent_grant_cached_all(result: dict, expected_count: int) -> bool:
@@ -2583,6 +2597,8 @@ def vault_sign(payload: dict) -> dict:
     if not vault_crypto.is_valid_secret_name(name):
         raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name")
     engine = _vault_engine()
+    protected_response: dict | None = None
+    protected_event: dict | None = None
     try:
         with engine.begin() as conn:
             meta = vault_service.get_secret_meta(conn, name)
@@ -2606,39 +2622,41 @@ def vault_sign(payload: dict) -> dict:
                         requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
                         delivery=payload.get("delivery") if isinstance(payload.get("delivery"), dict) else None,
                     )
-                    _publish_vaults_updated(
-                        scope="request",
-                        request_id=request.get("id"),
-                        request_status=request.get("status"),
-                        secret_name=request.get("secret_name"),
+                    protected_event = {
+                        "scope": "request",
+                        "request_id": request.get("id"),
+                        "request_status": request.get("status"),
+                        "secret_name": request.get("secret_name"),
+                    }
+                    protected_response = {"ok": False, "code": "browser_signature_required", "request": request}
+                else:
+                    request_id = str(payload.get("request_id") or "")
+                    if not request_id:
+                        raise VaultApiError("request_id is required to complete protected signing", code="missing_request_id")
+                    vault_service.validate_sign_request(conn, request_id, name=name, digest=digest, scheme=scheme)
+                    signature = _normalized_protected_signature(signature)
+                    _verify_protected_browser_signature(meta, digest=digest, scheme=scheme, signature=signature)
+                    request = vault_service.complete_sign_request(
+                        conn,
+                        request_id,
+                        name=name,
+                        digest=digest,
+                        scheme=scheme,
+                        signature=signature,
+                        requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
                     )
-                    return {"ok": False, "code": "browser_signature_required", "request": request}
+                    protected_event = {
+                        "scope": "request",
+                        "request_id": request.get("id") or request_id,
+                        "request_status": request.get("status"),
+                        "secret_name": request.get("secret_name"),
+                    }
+                    protected_response = {"ok": True, "signature": signature, "request": request}
+            else:
                 request_id = str(payload.get("request_id") or "")
-                if not request_id:
-                    raise VaultApiError("request_id is required to complete protected signing", code="missing_request_id")
-                vault_service.validate_sign_request(conn, request_id, name=name, digest=digest, scheme=scheme)
-                signature = _normalized_protected_signature(signature)
-                _verify_protected_browser_signature(meta, digest=digest, scheme=scheme, signature=signature)
-                request = vault_service.complete_sign_request(
-                    conn,
-                    request_id,
-                    name=name,
-                    digest=digest,
-                    scheme=scheme,
-                    signature=signature,
-                    requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
-                )
-                _publish_vaults_updated(
-                    scope="request",
-                    request_id=request.get("id") or request_id,
-                    request_status=request.get("status"),
-                    secret_name=request.get("secret_name"),
-                )
-                return {"ok": True, "signature": signature, "request": request}
-            request_id = str(payload.get("request_id") or "")
-            if request_id:
-                vault_service.claim_sign_request(conn, request_id, name=name, digest=digest, scheme=scheme)
-            key_envelope = vault_service.get_key_envelope(conn, name)
+                if request_id:
+                    vault_service.claim_sign_request(conn, request_id, name=name, digest=digest, scheme=scheme)
+                key_envelope = vault_service.get_key_envelope(conn, name)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
     except vault_service.RequestNotFoundError as exc:
@@ -2647,6 +2665,11 @@ def vault_sign(payload: dict) -> dict:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
     except vault_service.VaultServiceError as exc:
         raise VaultApiError(str(exc), code="vault_error") from exc
+
+    if protected_response is not None:
+        if protected_event is not None:
+            _publish_vaults_updated(**protected_event)
+        return protected_response
 
     def _fail_claimed_request(reason: str) -> None:
         request_id = str(payload.get("request_id") or "")

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1314,6 +1314,36 @@ class VaultApiError(ValueError):
         self.status = status
 
 
+def _publish_vaults_updated(
+    *,
+    scope: str,
+    request_id: str | None = None,
+    request_status: str | None = None,
+    grant_id: str | None = None,
+    grant_status: str | None = None,
+    secret_name: str | None = None,
+) -> None:
+    """Publish a UI-server-local vault update event for refetch-on-event pages."""
+
+    try:
+        from core.inbox_events import VAULTS_UPDATED_EVENT, vaults_updated_payload
+        from vibe.sse_broker import broker
+
+        broker.publish(
+            VAULTS_UPDATED_EVENT,
+            vaults_updated_payload(
+                scope=scope,
+                request_id=request_id,
+                request_status=request_status,
+                grant_id=grant_id,
+                grant_status=grant_status,
+                secret_name=secret_name,
+            ),
+        )
+    except Exception:
+        logger.debug("vaults.updated publish failed", exc_info=True)
+
+
 def _vault_api_error_from_avault(exc: "AvaultError", *, prefix: str) -> VaultApiError:
     message = str(exc)
     if "requires avault >=" in message:
@@ -1475,6 +1505,12 @@ def create_vault_secret(payload: dict) -> dict:
         raise VaultApiError(str(exc), code="vault_already_initialized", status=409) from exc
     except vault_service.VaultServiceError as exc:
         raise VaultApiError(str(exc), code="vault_error") from exc
+    _publish_vaults_updated(
+        scope="secret",
+        secret_name=meta.get("name") or name,
+        request_id=str(payload.get("provision_request_id") or "") or None,
+        request_status="fulfilled" if payload.get("provision_request_id") else None,
+    )
     return {"ok": True, "secret": meta}
 
 
@@ -1491,6 +1527,7 @@ def delete_vault_secret(name: str) -> dict:
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
     release_vault_agent_scopes(release_scopes, reason="delete_vault_secret")
+    _publish_vaults_updated(scope="secret", secret_name=name)
     return {"ok": True, "removed": True, "name": name}
 
 
@@ -1684,6 +1721,12 @@ def request_vault_access(payload: dict) -> dict:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
     except vault_service.VaultServiceError as exc:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
+    _publish_vaults_updated(
+        scope="request",
+        request_id=request.get("id"),
+        request_status=request.get("status"),
+        secret_name=request.get("secret_name"),
+    )
     return {"ok": True, "request": request}
 
 
@@ -1726,6 +1769,12 @@ def request_vault_sign(payload: dict) -> dict:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
     except vault_service.VaultServiceError as exc:
         raise VaultApiError(str(exc), code="vault_error") from exc
+    _publish_vaults_updated(
+        scope="request",
+        request_id=request.get("id"),
+        request_status=request.get("status"),
+        secret_name=request.get("secret_name"),
+    )
     return {"ok": True, "request": request}
 
 
@@ -1746,6 +1795,12 @@ def deny_vault_request(request_id: str, payload: dict | None = None) -> dict:
         raise VaultApiError(f"request '{request_id}' not found", code="request_not_found", status=404) from exc
     except vault_service.InvalidRequestError as exc:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
+    _publish_vaults_updated(
+        scope="request",
+        request_id=request.get("id") or str(request_id),
+        request_status=request.get("status"),
+        secret_name=request.get("secret_name"),
+    )
     return {"ok": True, "request": request}
 
 
@@ -2108,6 +2163,13 @@ def create_vault_grant(payload: dict) -> dict:
     except vault_service.InvalidGrantError as exc:
         raise VaultApiError(str(exc), code="invalid_grant") from exc
     if not needs_agent_deks:
+        _publish_vaults_updated(
+            scope="grant",
+            request_id=request_id,
+            request_status="approved",
+            grant_id=grant.get("id"),
+            grant_status=grant.get("status"),
+        )
         return {"ok": True, "grant": grant}
     agent_relayed = False
     try:
@@ -2165,6 +2227,13 @@ def create_vault_grant(payload: dict) -> dict:
                 force_release_scope=True,
             )
         raise
+    _publish_vaults_updated(
+        scope="grant",
+        request_id=request_id,
+        request_status="approved",
+        grant_id=grant.get("id"),
+        grant_status=grant.get("status"),
+    )
     return {"ok": True, "grant": grant}
 
 
@@ -2487,6 +2556,12 @@ def revoke_vault_grant(grant_id: str) -> dict:
     except vault_service.GrantNotActiveError as exc:
         raise VaultApiError(f"grant '{grant_id}' is not active", code="grant_not_active", status=409) from exc
     release_vault_agent_scopes(release_scopes, reason=f"revoke_vault_grant:{grant_id}")
+    _publish_vaults_updated(
+        scope="grant",
+        grant_id=grant.get("id") or grant_id,
+        grant_status=grant.get("status"),
+        request_id=grant.get("request_id"),
+    )
     return {"ok": True, "grant": grant}
 
 
@@ -2531,6 +2606,12 @@ def vault_sign(payload: dict) -> dict:
                         requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
                         delivery=payload.get("delivery") if isinstance(payload.get("delivery"), dict) else None,
                     )
+                    _publish_vaults_updated(
+                        scope="request",
+                        request_id=request.get("id"),
+                        request_status=request.get("status"),
+                        secret_name=request.get("secret_name"),
+                    )
                     return {"ok": False, "code": "browser_signature_required", "request": request}
                 request_id = str(payload.get("request_id") or "")
                 if not request_id:
@@ -2546,6 +2627,12 @@ def vault_sign(payload: dict) -> dict:
                     scheme=scheme,
                     signature=signature,
                     requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
+                )
+                _publish_vaults_updated(
+                    scope="request",
+                    request_id=request.get("id") or request_id,
+                    request_status=request.get("status"),
+                    secret_name=request.get("secret_name"),
                 )
                 return {"ok": True, "signature": signature, "request": request}
             request_id = str(payload.get("request_id") or "")
@@ -2567,7 +2654,13 @@ def vault_sign(payload: dict) -> dict:
             return
         with contextlib.suppress(Exception):
             with engine.begin() as conn:
-                vault_service.fail_sign_request(conn, request_id, reason=reason)
+                request = vault_service.fail_sign_request(conn, request_id, reason=reason)
+            _publish_vaults_updated(
+                scope="request",
+                request_id=request.get("id") or request_id,
+                request_status=request.get("status"),
+                secret_name=request.get("secret_name"),
+            )
 
     try:
         signature = avault_sign(key_envelope, digest, scheme, name=name)
@@ -2592,6 +2685,12 @@ def vault_sign(payload: dict) -> dict:
         except vault_service.InvalidRequestError as exc:
             _fail_claimed_request("signature_rejected")
             raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
+        _publish_vaults_updated(
+            scope="request",
+            request_id=request.get("id") or request_id,
+            request_status=request.get("status"),
+            secret_name=request.get("secret_name"),
+        )
         return {"ok": True, "signature": signature, "request": request}
     try:
         with engine.begin() as conn:
@@ -2622,6 +2721,7 @@ def store_vault_pubkey_pin(payload: dict) -> dict:
             meta = vault_service.store_pubkey_pin(conn, name, pin)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
+    _publish_vaults_updated(scope="secret", secret_name=meta.get("name") or name)
     return {"ok": True, "secret": meta}
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1500,11 +1500,14 @@ def create_vault_secret(payload: dict) -> dict:
     except vault_service.InvalidSecretNameError as exc:
         raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name") from exc
     except vault_service.SecretExistsError as exc:
+        fulfilled_count = 0
         try:
             with engine.begin() as conn:
-                vault_service.fulfill_pending_provision_requests_for_secret(conn, name)
+                fulfilled_count = vault_service.fulfill_pending_provision_requests_for_secret(conn, name)
         except Exception:
             logger.warning("failed to settle pending provision requests for existing secret %s", name, exc_info=True)
+        if fulfilled_count > 0:
+            _publish_vaults_updated(scope="secret", secret_name=name, request_status="fulfilled")
         raise VaultApiError(f"secret '{name}' already exists", code="secret_exists", status=409) from exc
     except vault_service.VaultAlreadyInitializedError as exc:
         raise VaultApiError(str(exc), code="vault_already_initialized", status=409) from exc

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -5643,6 +5643,8 @@ def _resolve_single_vault_delivery(
         )
     if resolved["status"] == "approval_required":
         req = resolved.get("request") or {}
+        if isinstance(req, dict):
+            _publish_cli_vaults_updated(scope="request", request=req)
         raise TaskCliError(
             f"secret '{name}' needs approval before protected delivery",
             code="approval_required",
@@ -5696,6 +5698,7 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
     grant: dict | None = None
     one_shot_grants: list[dict] = []
     approval_error: TaskCliError | None = None
+    approval_request_to_publish: dict | None = None
     pre_delivery_error: TaskCliError | None = None
     resolved_by_name: dict[str, dict] = {}
     try:
@@ -5714,6 +5717,8 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
                     resolved_by_name[name] = resolved
                 if resolved["status"] == "approval_required":
                     req = resolved.get("request") or {}
+                    if isinstance(req, dict):
+                        approval_request_to_publish = req
                     approval_error = TaskCliError(
                         f"secret '{name}' needs approval before protected delivery",
                         code="approval_required",
@@ -5745,6 +5750,7 @@ def _resolve_vault_inject_delivery(engine, names: list[str], *, path: str, fmt: 
     except Exception as exc:
         _raise_after_releasing_one_shot_reservations(engine, one_shot_grants, exc)
     if approval_error is not None:
+        _publish_cli_vaults_updated(scope="request", request=approval_request_to_publish)
         _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error
     if pre_delivery_error is not None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4678,6 +4678,37 @@ def _vault_cli_delivery(args, **fields) -> dict:
     return delivery
 
 
+def _publish_cli_vaults_updated(
+    *,
+    scope: str,
+    request: dict | None = None,
+    grant: dict | None = None,
+    secret_name: str | None = None,
+) -> None:
+    """Best-effort bridge for CLI/agent vault writes into browser SSE."""
+
+    if request is None and grant is None and not secret_name:
+        return
+    try:
+        from core.inbox_events import VAULTS_UPDATED_EVENT, vaults_updated_payload
+        from vibe import internal_client
+
+        internal_client.publish_event_sync(
+            VAULTS_UPDATED_EVENT,
+            vaults_updated_payload(
+                scope=scope,
+                request_id=str(request.get("id") or "") if request else None,
+                request_status=str(request.get("status") or "") if request else None,
+                grant_id=str(grant.get("id") or "") if grant else None,
+                grant_status=str(grant.get("status") or "") if grant else None,
+                secret_name=secret_name or (str(request.get("secret_name") or "") if request else None),
+            ),
+            timeout=1.5,
+        )
+    except Exception:
+        logger.debug("failed to publish CLI vault update event", exc_info=True)
+
+
 def _is_env_name(name: str) -> bool:
     """ASCII shell/env identifier: a letter or underscore, then letters/digits/underscores."""
     if not name or not name[0].isascii() or not (name[0].isalpha() or name[0] == "_"):
@@ -4891,6 +4922,7 @@ def cmd_vault_rm(args):
             vault_service.delete_secret(conn, args.name)
             release_scopes = vault_service.agent_release_scopes_after_rows(conn, grant_rows)
         api.release_vault_agent_scopes(release_scopes, reason="vault_rm")
+        _publish_cli_vaults_updated(scope="secret", secret_name=args.name)
         _print_cli_payload("vault_secret", removed=True, name=args.name)
         return 0
     except vault_service.SecretNotFoundError:
@@ -4918,6 +4950,7 @@ def cmd_vault_access(args):
                 requester=_vault_cli_requester(args),
                 delivery=_vault_cli_delivery(args, mode="access"),
             )
+        _publish_cli_vaults_updated(scope="request", request=request)
         _print_cli_payload(
             "vault_access_request",
             request_id=request["id"],
@@ -4958,7 +4991,7 @@ def _expire_agent_grant_after_missing(
             source_selector = delivery_payload.get("source_selector")
             if isinstance(source_selector, dict):
                 try:
-                    return vault_service.create_access_request(
+                    first_request = vault_service.create_access_request(
                         conn,
                         source_selector=source_selector,
                         requester=requester or {"source": "cli", "pid": os.getpid()},
@@ -4967,19 +5000,23 @@ def _expire_agent_grant_after_missing(
                     )
                 except vault_service.NotGrantableError:
                     pass
-            for name in names:
-                resolved = vault_service.resolve_secret_access(
-                    conn,
-                    name,
-                    requester=requester or {"source": "cli", "pid": os.getpid()},
-                    delivery=delivery or {},
-                    purpose=purpose,
-                )
-                if first_request is None and isinstance(resolved.get("request"), dict):
-                    first_request = resolved["request"]
-                    break
+            if first_request is None:
+                for name in names:
+                    resolved = vault_service.resolve_secret_access(
+                        conn,
+                        name,
+                        requester=requester or {"source": "cli", "pid": os.getpid()},
+                        delivery=delivery or {},
+                        purpose=purpose,
+                    )
+                    if first_request is None and isinstance(resolved.get("request"), dict):
+                        first_request = resolved["request"]
+                        break
     except Exception:
         pass
+    else:
+        _publish_cli_vaults_updated(scope="grant", grant={"id": grant_id, "status": "expired"})
+        _publish_cli_vaults_updated(scope="request", request=first_request)
     return first_request
 
 
@@ -5418,6 +5455,7 @@ def _resolve_vault_run_delivery(
         if str(metas[name].get("protection") or "standard") == "protected"
     ]
     standard_approval_error: TaskCliError | None = None
+    approval_request_to_publish: dict | None = None
     if metas and not protected_names:
         with engine.begin() as conn:
             standard_names = list(dict.fromkeys(mapping.values()))
@@ -5443,12 +5481,14 @@ def _resolve_vault_run_delivery(
                     delivery=delivery,
                     purpose="run",
                 )
+                approval_request_to_publish = req
                 standard_approval_error = TaskCliError(
                     "standard always_ask secrets need approval before vault run delivery",
                     code="approval_required",
                     details={"request_id": req.get("id"), "secret_names": approval_names},
                 )
         if standard_approval_error is not None:
+            _publish_cli_vaults_updated(scope="request", request=approval_request_to_publish)
             raise standard_approval_error
     secrets = []
     grant: dict | None = None
@@ -5519,6 +5559,7 @@ def _resolve_vault_run_delivery(
                             delivery=request_delivery,
                             purpose="run",
                         )
+                        approval_request_to_publish = req
                         approval_error = TaskCliError(
                             "protected secrets need approval before vault run delivery",
                             code="approval_required",
@@ -5552,6 +5593,8 @@ def _resolve_vault_run_delivery(
                     resolved_by_name[vault_name] = resolved
                 if resolved["status"] == "approval_required":
                     req = resolved.get("request") or {}
+                    if isinstance(req, dict):
+                        approval_request_to_publish = req
                     approval_error = TaskCliError(
                         f"secret '{vault_name}' needs approval before protected delivery",
                         code="approval_required",
@@ -5573,6 +5616,7 @@ def _resolve_vault_run_delivery(
     except Exception as exc:
         _raise_after_releasing_one_shot_reservations(engine, one_shot_grants, exc)
     if approval_error is not None:
+        _publish_cli_vaults_updated(scope="request", request=approval_request_to_publish)
         _release_one_shot_reservations(engine, one_shot_grants)
         raise approval_error
     return grant, one_shot_grants, secrets
@@ -5927,6 +5971,7 @@ def cmd_vault_request(args):
                 spec=spec,
                 requester={"source": "cli", "pid": os.getpid()},
             )
+        _publish_cli_vaults_updated(scope="request", request=req, secret_name=name)
         if req.get("status") == "fulfilled":
             # Secret already existed — no point waiting.
             _print_cli_payload(
@@ -6009,6 +6054,7 @@ def cmd_vault_sign(args):
                 requester=_vault_cli_requester(args),
                 delivery=_vault_cli_delivery(args, mode="sign"),
             )
+        _publish_cli_vaults_updated(scope="request", request=request)
         _print_cli_payload(
             "vault_sign_request",
             request_id=request["id"],

--- a/vibe/inbox_bridge.py
+++ b/vibe/inbox_bridge.py
@@ -31,6 +31,19 @@ logger = logging.getLogger(__name__)
 # it so a long-down controller doesn't busy-spin.
 _BACKOFF_INITIAL = 1.0
 _BACKOFF_MAX = 15.0
+_bridge_connected = False
+
+
+def is_bridge_connected() -> bool:
+    return _bridge_connected
+
+
+def _set_bridge_connected(connected: bool) -> None:
+    global _bridge_connected
+    if _bridge_connected == connected:
+        return
+    _bridge_connected = connected
+    broker.publish(WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT, {"connected": connected})
 
 
 async def run_inbox_bridge() -> None:
@@ -42,18 +55,17 @@ async def run_inbox_bridge() -> None:
     """
 
     backoff = _BACKOFF_INITIAL
-    bridge_connected = False
     while True:
         try:
             async for event_type, data in internal_client.stream_events():
                 # A flowing event proves the link is healthy → reset backoff so
                 # the next genuine drop reconnects promptly.
                 backoff = _BACKOFF_INITIAL
-                if event_type == "connected" and not bridge_connected:
-                    bridge_connected = True
-                    broker.publish(WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT, {"connected": True})
+                if event_type == "connected":
+                    _set_bridge_connected(True)
                 broker.publish(event_type, data)
         except asyncio.CancelledError:
+            _set_bridge_connected(False)
             raise
         except internal_client.InternalServerUnavailable:
             logger.debug("inbox bridge: controller socket unavailable; retry in %.1fs", backoff)
@@ -61,8 +73,6 @@ async def run_inbox_bridge() -> None:
             logger.warning("inbox bridge: stream error; retry in %.1fs", backoff, exc_info=True)
         else:
             logger.debug("inbox bridge: controller feed closed; reconnect in %.1fs", backoff)
-        if bridge_connected:
-            bridge_connected = False
-            broker.publish(WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT, {"connected": False})
+        _set_bridge_connected(False)
         await asyncio.sleep(backoff)
         backoff = min(backoff * 2, _BACKOFF_MAX)

--- a/vibe/inbox_bridge.py
+++ b/vibe/inbox_bridge.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from core.inbox_events import WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT
 from vibe import internal_client
 from vibe.sse_broker import broker
 
@@ -41,12 +42,16 @@ async def run_inbox_bridge() -> None:
     """
 
     backoff = _BACKOFF_INITIAL
+    bridge_connected = False
     while True:
         try:
             async for event_type, data in internal_client.stream_events():
                 # A flowing event proves the link is healthy → reset backoff so
                 # the next genuine drop reconnects promptly.
                 backoff = _BACKOFF_INITIAL
+                if event_type == "connected" and not bridge_connected:
+                    bridge_connected = True
+                    broker.publish(WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT, {"connected": True})
                 broker.publish(event_type, data)
         except asyncio.CancelledError:
             raise
@@ -56,5 +61,8 @@ async def run_inbox_bridge() -> None:
             logger.warning("inbox bridge: stream error; retry in %.1fs", backoff, exc_info=True)
         else:
             logger.debug("inbox bridge: controller feed closed; reconnect in %.1fs", backoff)
+        if bridge_connected:
+            bridge_connected = False
+            broker.publish(WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT, {"connected": False})
         await asyncio.sleep(backoff)
         backoff = min(backoff * 2, _BACKOFF_MAX)

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -184,6 +184,69 @@ async def stream_events(
         raise InternalServerUnavailable(str(exc)) from exc
 
 
+async def publish_event(
+    event_type: str,
+    data: dict[str, Any],
+    *,
+    socket_path: Optional[Path] = None,
+    timeout: float = 5.0,
+) -> dict[str, Any]:
+    """Ask the Controller process to publish an allowlisted SSE notification."""
+
+    target = (socket_path or default_socket_path()).expanduser().resolve()
+    if not target.exists():
+        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
+
+    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://localhost",
+            timeout=httpx.Timeout(timeout, connect=2.0),
+        ) as client:
+            resp = await client.post("/internal/events", json={"type": event_type, "data": data})
+            if resp.status_code >= 400:
+                detail = await resp.aread()
+                raise InternalServerUnavailable(f"events publish returned {resp.status_code}: {detail!r}")
+            return resp.json()
+    except InternalServerUnavailable:
+        raise
+    except _SOCKET_ERRORS as exc:
+        raise InternalServerUnavailable(str(exc)) from exc
+
+
+def publish_event_sync(
+    event_type: str,
+    data: dict[str, Any],
+    *,
+    socket_path: Optional[Path] = None,
+    timeout: float = 5.0,
+) -> dict[str, Any]:
+    """Synchronous wrapper for CLI/child-process notification publishers."""
+
+    target = (socket_path or default_socket_path()).expanduser().resolve()
+    if not target.exists():
+        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
+
+    transport = httpx.HTTPTransport(uds=str(target))
+    try:
+        with httpx.Client(
+            transport=transport,
+            base_url="http://localhost",
+            timeout=httpx.Timeout(timeout, connect=2.0),
+        ) as client:
+            resp = client.post("/internal/events", json={"type": event_type, "data": data})
+            if resp.status_code >= 400:
+                raise InternalServerUnavailable(
+                    f"events publish returned {resp.status_code}: {resp.content!r}"
+                )
+            return resp.json()
+    except InternalServerUnavailable:
+        raise
+    except _SOCKET_ERRORS as exc:
+        raise InternalServerUnavailable(str(exc)) from exc
+
+
 async def dispatch_async(
     payload: dict[str, Any],
     *,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6277,6 +6277,8 @@ async def workbench_events():
 
     from fastapi.responses import StreamingResponse
 
+    from core.inbox_events import WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT
+    from vibe.inbox_bridge import is_bridge_connected
     from vibe.sse_broker import broker
 
     async def generate():
@@ -6286,6 +6288,15 @@ async def workbench_events():
             # subsequent debug logs / cancel calls if we ever need them.
             yield ": stream connected\n\n"
             yield f"event: connected\ndata: {{\"sub_id\": {sub_id}}}\n\n"
+            payload = json.dumps(
+                {
+                    "type": WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT,
+                    "data": {"connected": is_bridge_connected()},
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            yield f"event: {WORKBENCH_EVENTS_BRIDGE_STATUS_EVENT}\ndata: {payload}\n\n"
             while True:
                 try:
                     event_type, payload = await asyncio.wait_for(queue.get(), timeout=15.0)


### PR DESCRIPTION
## Capability

Replaces the historical page-level polling on Running Agents, Vaults, and the Agents running-count badge with refetch-on-SSE events. Run lifecycle writes now emit `runs.updated`; vault mutations emit `vaults.updated` from Web API paths and from CLI/agent vault request paths through the internal controller event bus.

Closes #763.

## Polling -> Push Cost

| Page | Before | After |
|---|---|---|
| RunningAgents | 4s full-list poll | SSE `runs.updated` / turn / session events; local elapsed ticker; degraded poll only while disconnected |
| Vaults | 5s vault/request poll plus local 1s countdown | SSE `vaults.updated`; degraded poll while disconnected; local grant countdown; one scheduled refetch at the earliest known pending request expiry |
| Agents | 8s running-count poll | SSE run / turn / session events; degraded poll only while disconnected |

## Time-Driven State

The zero steady-state request invariant applies to connected-SSE data fetching. Time-derived UI state is handled separately:

- Running Agents elapsed labels advance from the fetched elapsed snapshot plus the browser's local observed time; this is a local render ticker and performs zero network requests.
- Running Agents orphan/process liveness has no known expiry timestamp. Restoring a connected-SSE periodic snapshot poll would reintroduce steady-state requests, so this PR keeps event-driven refresh plus disconnected degraded polling; explicit liveness events are a follow-up if we want external-kill detection while SSE remains healthy.
- Vault grant countdowns remain local-only.
- Pending vault-request expiry is server-owned data with a known timestamp, so the page schedules one refetch for the earliest known `expires_at` in the current dataset.
- Provision requests fulfilled by an already-existing secret now emit `vaults.updated` after the cleanup commit.

## Event Freshness Boundaries

- Mounted Harness views subscribe to `runs.updated` and use the same `refresh()` path as manual reloads, instead of only clearing cached promises.
- `runs.updated` snapshots from connection-scoped helper paths are deferred until the owning transaction commits, so browser refetches cannot race stale rows.
- Late bridge-status replay is deferred as a follow-up. Late subscribers stay on degraded polling until the next bridge status change, so this is not a blocker for the SSE data-freshness path.

## Publish / Emit Audit

| Callsite | Event path | Transaction verdict |
|---|---|---|
| `core/inbox_events.publish_run_updated` | `bus.publish(runs.updated, ...)` | Helper only; currently unused by this PR's DB writers, so no open transaction boundary applies. |
| `core/internal_server._publish_event` | child process -> Controller `bus.publish` | Safe: endpoint performs no DB writes and only republishes already-committed child-process events. |
| `storage/background._publish_run_rows_updated` | `bus.publish(runs.updated, ...)`; CLI fallback `internal_client.publish_event_sync` | Safe: direct callers collect rows inside `engine.begin()` and publish after the `with` exits; connection-scoped callers queue rows and flush through `run_update_event_transaction` after commit. |
| `storage/background` connection helpers | `complete_coalesced_agent_runs_for_workbench_in_connection`, `claim_queued_runs_for_workbench_in_connection`, `inspect_queued_runs_for_workbench_in_connection`, `reset_workbench_claimed_runs_in_connection`, `recover_processing_runs` | Safe: all use `_defer_run_ids_updated_from_connection`; owning transaction wrappers publish only after commit. |
| `vibe/api._publish_vaults_updated` | UI `broker.publish(vaults.updated, ...)`; no-subscriber fallback `internal_client.publish_event_sync` | Safe: audited callers publish after their `engine.begin()` blocks, including create/delete secret, access/sign request creation, deny, grant consume/approve/revoke, protected sign completion/failure, pubkey pin, and SecretExists provision fulfillment. |
| `vibe/cli._publish_cli_vaults_updated` | CLI `internal_client.publish_event_sync(vaults.updated, ...)` | Safe: audited callers publish after their write transaction exits: `vault rm/access/request/sign`, agent missing-grant expiry, `vault run`, `vault fetch`, and `vault inject` approval-request paths. |
| `vibe/inbox_bridge.run_inbox_bridge` | Controller stream -> UI `broker.publish`; bridge status publish | Safe: no DB writes; relays events that have already reached the Controller event bus. |
| `vibe/internal_client.publish_event` / `publish_event_sync` | transport helper to `/internal/events` | Safe: no DB writes; transaction ordering is owned by each caller and audited above. |

No third publish-before-commit instance was found in the PR-added publish/emit paths.

## Evidence Layers

| Layer | Evidence |
|---|---|
| Unit | `tests/test_inbox_events.py`; `tests/test_inbox_bridge.py`; `tests/test_scheduled_tasks.py::test_claim_queued_runs_publishes_after_commit`; `tests/test_internal_server.py::test_publish_event_endpoint_emits_allowlisted_bus_event`; `tests/test_vault_api.py::test_create_vault_secret_publishes_update_event`; focused vault CLI request tests |
| Contract | `/api/events` client contract extended in `ApiContext`; controller `/internal/events` POST is allowlisted to `runs.updated` / `vaults.updated`; `cd ui && npm run build` passes |
| Scenario | N/A - no scenario catalog entry for this perf path |
| Residual manual | Reviewer should verify SSE-connected run/vault freshness on a live instance and degraded polling after killing SSE |

## SSE Connected Signal

The pages now derive a local connected signal from `connectWorkbenchEvents` `onConnected` / `onError` plus controller bridge status changes. Fallback timers use the StatusContext-style self-rescheduling `setTimeout`, single in-flight guard, and `visibilityState` guard while disconnected.
