### PR TITLE
fix(vault): report empty run selectors clearly

### DIFF
--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -450,6 +450,16 @@ def test_run_skill_selects_skill_link_mirror_tag(monkeypatch):
     assert deliver.call_args.args[0] == [{"name": "LINKED_KEY", "env": "LINKED_KEY", "envelope": _sealed("linked")}]
 
 
+@pytest.mark.parametrize("selector", [{"tag": ["missing"]}, {"skill": ["missing"]}])
+def test_run_reports_empty_tag_or_skill_selector(capfd, selector):
+    code = cli.cmd_vault_run(_ns(**selector, command_argv=["python3", "-c", "pass"]))
+    payload = json.loads(capfd.readouterr().err)
+
+    assert code == 1
+    assert payload["code"] == "no_matching_secrets"
+    assert payload["help_command"] == "vibe vault run --help"
+
+
 def test_run_rejects_conflicting_alias_from_tag_selection(capfd, monkeypatch):
     from vibe import api
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4785,6 +4785,7 @@ def _resolve_vault_run_selectors(engine, args) -> tuple[dict[str, str], dict]:
     explicit_mapping, normalized_env_specs = _parse_env_specs_parts(env_specs)
     tag_specs = _arg_list(args, "tag")
     skill_specs = _arg_list(args, "skill")
+    selector_requested = bool(normalized_env_specs or tag_specs or skill_specs)
     selections: dict[str, str] = {}
     for env_name, vault_name in explicit_mapping.items():
         _add_vault_run_selection(selections, vault_name=vault_name, env_name=env_name)
@@ -4803,6 +4804,13 @@ def _resolve_vault_run_selectors(engine, args) -> tuple[dict[str, str], dict]:
     else:
         source_selector["tags"] = []
 
+    if not selections and selector_requested:
+        raise TaskCliError(
+            "vault run selector matched no value-deliverable secrets",
+            code="no_matching_secrets",
+            hint="Check the --env, --tag, or --skill selector, or ask the user to store/link the secret first.",
+            help_command="vibe vault run --help",
+        )
     if not selections:
         raise TaskCliError(
             "at least one --env NAME, --tag TAG, or --skill SKILL is required",


### PR DESCRIPTION
## What
- Distinguish an empty tag/skill selector result from an actually missing `vibe vault run` selector.
- Return `no_matching_secrets` with a direct hint when `--tag` / `--skill` matches no value-deliverable secrets.

## Why
During Vault regression smoke, `vibe vault run --skill ai-relay -- true` was parsed correctly, but because no stored secret had `skill:ai-relay`, the CLI reported `missing_selector`. That made it look like `--skill` was ignored.

## Evidence
- `pytest -q tests/test_vault_cli.py -k 'run_reports_empty_tag_or_skill_selector or run_skill_selects_skill_link_mirror_tag or run_expands_tags_and_skill_tags_as_union'` -> 4 passed
- `pytest -q tests/test_vault_cli.py` -> 83 passed
- `ruff check vibe/cli.py tests/test_vault_cli.py` -> passed
