### PR TITLE
Fix Vault access and sign CLI dispatch

### DIFF
--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -194,6 +194,36 @@ def test_vault_parser_does_not_expose_plaintext_set_command():
         parser.parse_args(["vault", "set", "OPENAI_API_KEY", "--stdin"])
 
 
+def test_vault_access_command_flag_does_not_shadow_root_command():
+    args = cli.build_parser().parse_args(
+        ["vault", "access", "OPENAI_API_KEY", "--command", "deploy sync"],
+    )
+
+    assert args.command == "vault"
+    assert args.vault_command == "access"
+    assert args.operation_command == "deploy sync"
+    assert cli._vault_cli_delivery(args)["command"] == "deploy sync"
+
+
+def test_vault_sign_command_flag_does_not_shadow_root_command():
+    args = cli.build_parser().parse_args(
+        [
+            "vault",
+            "sign",
+            "ETH_KEY",
+            "--digest",
+            "00" * 32,
+            "--command",
+            "wallet sign",
+        ],
+    )
+
+    assert args.command == "vault"
+    assert args.vault_command == "sign"
+    assert args.operation_command == "wallet sign"
+    assert cli._vault_cli_delivery(args)["command"] == "wallet sign"
+
+
 def test_discover_reports_value_free_capabilities(tmp_path, capfd, monkeypatch):
     _create_standard_secret("STANDARD_KEY")
     with cli._open_vault_engine().begin() as conn:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4669,7 +4669,11 @@ def _vault_cli_delivery(args, **fields) -> dict:
     skill = (getattr(args, "skill", None) or "").strip()
     if skill:
         delivery["skill"] = skill
-    command = getattr(args, "command", None)
+    command = getattr(args, "operation_command", None)
+    if command is None:
+        command = getattr(args, "command", None)
+        if command == "vault":
+            command = None
     if command:
         delivery["command"] = command
     egress = getattr(args, "egress", None)
@@ -10107,7 +10111,7 @@ def build_parser():
     vault_access_parser.add_argument("name", help="Static secret name to request")
     vault_access_parser.add_argument("--session-id", help="Agent Session ID. Defaults from AVIBE_SESSION_ID inside an Agent shell.")
     vault_access_parser.add_argument("--skill", help="Skill requesting the secret")
-    vault_access_parser.add_argument("--command", help="Command or operation shown to the user")
+    vault_access_parser.add_argument("--command", dest="operation_command", help="Command or operation shown to the user")
     vault_access_parser.add_argument("--egress", help="Egress description shown to the user")
     _add_json_noop(vault_access_parser)
 
@@ -10132,7 +10136,7 @@ def build_parser():
     )
     vault_sign_parser.add_argument("--session-id", help="Agent Session ID. Defaults from AVIBE_SESSION_ID inside an Agent shell.")
     vault_sign_parser.add_argument("--skill", help="Skill requesting the signature")
-    vault_sign_parser.add_argument("--command", help="Operation shown to the user")
+    vault_sign_parser.add_argument("--command", dest="operation_command", help="Operation shown to the user")
     vault_sign_parser.add_argument("--egress", help="Egress description shown to the user")
     _add_json_noop(vault_sign_parser)
 


### PR DESCRIPTION
## What
- Fix `vibe vault access --command ...` and `vibe vault sign --command ...` so the option no longer overwrites the top-level CLI dispatch field.
- Preserve the operation label in Vault request delivery metadata via `operation_command`.
- Add parser regression coverage for both affected Vault subcommands.

## Why
Live regression testing showed `vibe vault access ... --command ...` exited 0 but only printed the Web UI hint and created no request. The subcommand option used argparse's default `dest="command"`, which shadowed the root `args.command == "vault"` dispatch key.

## Evidence
- `python3 -m pytest tests/test_vault_cli.py::test_vault_access_command_flag_does_not_shadow_root_command tests/test_vault_cli.py::test_vault_sign_command_flag_does_not_shadow_root_command -q` — 2 passed
- `python3 -m pytest tests/test_vault_cli.py tests/test_vault_api.py tests/test_vault_rest.py tests/test_vault_fetch.py -q` — 217 passed
- `python3 -m ruff check vibe/cli.py tests/test_vault_cli.py` — passed

## Risk
Low. The change is scoped to argparse destination names for two Vault flags and delivery metadata assembly.
