### PR TITLE
Fix Vault provision request UI actions

### DIFF
--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -1891,6 +1891,29 @@ def test_request_wait_outputs_fulfilled_request(capfd, monkeypatch):
     assert payload["request"]["status"] == "fulfilled"
 
 
+def test_request_wait_returns_denied_without_timeout(capfd, monkeypatch):
+    def wait_mock(request_id, *, timeout, poll_interval=2.0):
+        return {"id": request_id, "status": "denied", "request_type": "provision", "secret_name": "WAIT_KEY"}
+
+    monkeypatch.setattr(cli, "_wait_for_provision", wait_mock)
+
+    assert cli.cmd_vault_request(_ns(name="WAIT_KEY", wait=30)) == 1
+    payload = json.loads(capfd.readouterr().err)
+    assert payload["code"] == "request_denied"
+    assert payload["details"]["request_id"]
+
+
+def test_wait_for_provision_returns_denied_request():
+    with cli._open_vault_engine().begin() as conn:
+        req = vault_service.create_provision_request(conn, "WAIT_KEY")
+        vault_service.deny_request(conn, req["id"])
+
+    waited = cli._wait_for_provision(req["id"], timeout=1, poll_interval=0.01)
+
+    assert waited is not None
+    assert waited["status"] == "denied"
+
+
 def test_key_export_calls_avault_and_audits(tmp_path, capfd, monkeypatch):
     from unittest.mock import Mock
 

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -108,6 +108,7 @@ export const VaultSecretForm: React.FC<{
   onCancel: () => void;
   onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
   className?: string;
+  cancelLabel?: string;
   defaultProtection?: VaultProtection;
   provisionRequestId?: string | null;
   requestSpec?: VaultRequestSpec | null;
@@ -117,6 +118,7 @@ export const VaultSecretForm: React.FC<{
   onCancel,
   onCreated,
   className,
+  cancelLabel,
   defaultProtection = 'standard',
   provisionRequestId,
   requestSpec,
@@ -770,7 +772,7 @@ export const VaultSecretForm: React.FC<{
 
         <div className="mt-1 flex justify-end gap-2">
           <Button type="button" variant="ghost" onClick={onCancel} disabled={submitting}>
-            {t('vaults.request.dismiss')}
+            {cancelLabel ?? t('vaults.request.dismiss')}
           </Button>
           <Button type="submit" disabled={!canSubmit}>
             {submitting ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -19,11 +19,15 @@ const PENDING_REQUEST_POLL_INTERVAL_MS = 5000;
 const PENDING_REQUEST_EXPIRY_GRACE_MS = 100;
 const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
 
+const messageFromError = (err: unknown) => (err instanceof Error ? err.message : String(err));
+
 const AddSecretDialog: React.FC<{
   onClose: () => void;
+  onCancel?: () => void;
+  cancelLabel?: string;
   onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
   request?: VaultRequest | null;
-}> = ({ onClose, onCreated, request }) => {
+}> = ({ onClose, onCancel, cancelLabel, onCreated, request }) => {
   const { t } = useTranslation();
   const requestCard = (request?.card ?? null) as { default_protection?: unknown; spec?: VaultRequestSpec } | null;
   const requestSpec = (requestCard?.spec ?? null) as VaultRequestSpec | null;
@@ -49,7 +53,8 @@ const AddSecretDialog: React.FC<{
           provisionRequestId={request?.id ?? null}
           requestSpec={requestSpec}
           defaultProtection={defaultProtection}
-          onCancel={onClose}
+          onCancel={onCancel ?? onClose}
+          cancelLabel={cancelLabel}
           onCreated={onCreated}
           treatExistingAsFulfilled={Boolean(request)}
         />
@@ -284,7 +289,6 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
   const [requests, setRequests] = useState<VaultRequest[]>([]);
   const [reviewing, setReviewing] = useState<VaultRequest | null>(null);
   const [provisioning, setProvisioning] = useState<VaultRequest | null>(null);
-  const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -309,21 +313,19 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
     return api.connectWorkbenchEvents({
       onConnected: (data) => {
         if (data.source === 'controller') {
-          setEventBridgeConnected(true);
           load();
         }
       },
       onEventBridgeStatus: ({ connected }) => {
-        setEventBridgeConnected(connected);
         if (connected) load();
       },
-      onError: () => setEventBridgeConnected(false),
       onVaultsUpdated: () => load(),
     });
   }, [api, load]);
 
   useEffect(() => {
-    if (eventBridgeConnected) return;
+    // CLI-created requests can arrive without a browser bridge event, so keep
+    // a light fallback poll even when SSE is connected.
     let timer: number | undefined;
     let cancelled = false;
     let inFlight = false;
@@ -368,7 +370,7 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
       document.removeEventListener('visibilitychange', refreshNow);
       window.removeEventListener('focus', refreshNow);
     };
-  }, [eventBridgeConnected, load]);
+  }, [load]);
 
   useEffect(() => {
     const expiresAt = earliestRequestExpiry(requests);
@@ -400,6 +402,22 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
       onResolved();
     },
     [reviewing, showToast, t, load, onResolved],
+  );
+
+  const denyProvisionRequest = useCallback(
+    async (request: VaultRequest) => {
+      try {
+        await api.denyVaultRequest(request.id);
+        setProvisioning(null);
+        setRequests((prev) => prev.filter((r) => r.id !== request.id));
+        showToast(t('vaults.requests.denied'), 'warning');
+        load();
+        onResolved();
+      } catch (err: unknown) {
+        showToast(messageFromError(err), 'warning');
+      }
+    },
+    [api, showToast, t, load, onResolved],
   );
 
   if (requests.length === 0) return null;
@@ -445,6 +463,10 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
         <AddSecretDialog
           request={provisioning}
           onClose={() => setProvisioning(null)}
+          onCancel={() => {
+            void denyProvisionRequest(provisioning);
+          }}
+          cancelLabel={t('vaults.approval.deny')}
           onCreated={(name, reason) => {
             setProvisioning(null);
             if (reason !== 'already_exists') {
@@ -497,8 +519,8 @@ export const VaultsPage: React.FC = () => {
     try {
       const res = await api.listVaultSecrets();
       setSecrets(res.secrets ?? []);
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
+    } catch (err: unknown) {
+      setError(messageFromError(err));
     } finally {
       setLoading(false);
     }
@@ -634,8 +656,8 @@ export const VaultsPage: React.FC = () => {
       try {
         const res = await api.getVaultAudit({ limit: 50 });
         setAudit(res.events ?? []);
-      } catch (err: any) {
-        setError(err?.message ?? String(err));
+      } catch (err: unknown) {
+        setError(messageFromError(err));
       }
     }
   }, [api, showAudit]);
@@ -646,8 +668,8 @@ export const VaultsPage: React.FC = () => {
       await api.deleteVaultSecret(name);
       showToast(t('vaults.deleted', { name }), 'success');
       refresh();
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
+    } catch (err: unknown) {
+      setError(messageFromError(err));
     }
   };
 
@@ -660,8 +682,8 @@ export const VaultsPage: React.FC = () => {
       await api.revokeVaultGrant(g.id);
       showToast(t('vaults.grants.revoked', { target: label }), 'success');
       refresh();
-    } catch (err: any) {
-      setError(err?.message ?? String(err));
+    } catch (err: unknown) {
+      setError(messageFromError(err));
     }
   };
 

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -301,7 +301,8 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
       });
       setRequests(pending);
     } catch {
-      setRequests([]);
+      // Keep the last successful snapshot. A transient poll failure should not
+      // unmount an active approval/provision dialog for a still-pending request.
     }
   }, [api]);
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -5939,7 +5939,7 @@ def _wait_for_provision(request_id: str, *, timeout: float, poll_interval: float
                 request = vault_service.get_request(conn, request_id, audience=vault_service.REQUEST_AUDIENCE_AGENT)
             except vault_service.RequestNotFoundError:
                 raise
-        if request.get("status") == "fulfilled":
+        if request.get("status") in {"fulfilled", "denied", "expired", "failed"}:
             return request
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -6005,6 +6005,36 @@ def cmd_vault_request(args):
         if wait_seconds:
             waited = _wait_for_provision(req["id"], timeout=float(wait_seconds))
             if waited:
+                if waited.get("status") == "denied":
+                    _print_task_error(
+                        TaskCliError(
+                            f"request for '{name}' was denied",
+                            code="request_denied",
+                            help_command=help_command,
+                            details={"request_id": req["id"]},
+                        )
+                    )
+                    return 1
+                if waited.get("status") == "expired":
+                    _print_task_error(
+                        TaskCliError(
+                            f"request for '{name}' expired",
+                            code="request_expired",
+                            help_command=help_command,
+                            details={"request_id": req["id"]},
+                        )
+                    )
+                    return 1
+                if waited.get("status") == "failed":
+                    _print_task_error(
+                        TaskCliError(
+                            f"request for '{name}' failed",
+                            code="request_failed",
+                            help_command=help_command,
+                            details={"request_id": req["id"]},
+                        )
+                    )
+                    return 1
                 _print_cli_payload(
                     "vault_request",
                     request_id=req["id"],


### PR DESCRIPTION
## Summary
- keep Vault pending requests refreshed even when the workbench event bridge is connected, so CLI-created provision requests appear without a full page reload
- make the provision request dialog's cancel action an actual deny flow, with the button labeled as Deny for request fulfillment
- keep inline request forms using their existing dismiss label through an explicit cancel label override

## Validation
- `npx eslint src/components/ui/vault-secret-form.tsx src/components/workbench/VaultsPage.tsx`
- `npm run build`
- Incus worktree smoke at `http://127.0.0.1:15203/vaults`: created a `vibe vault request ... --no-wait` after the Vaults page was already open, verified it appeared without reload, opened the form, clicked Deny, and confirmed `/api/vault/requests?status=pending` returned an empty list
