### PR TITLE
Fix Vault mixed-case secret names

### DIFF
--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -50,7 +50,7 @@ class QuickReplyButton:
 class SecretRequest:
     """A ``$<NAME>`` dynamic-ask marker found in agent reply text (Vaults).
 
-    The agent writes ``$<OPENAI_API_KEY>`` to ask the user for a secret; the value is
+    The agent writes ``$<openAiKey>`` to ask the user for a secret; the value is
     filled through a trusted UI channel, never the chat. The marker stays in ``.text``
     so the web transcript can render it as a secure input card; IM replaces it with a
     deep link in the platform formatter.
@@ -119,10 +119,10 @@ _PLAIN_LINKS_ONLY_RE = re.compile(r"(?:\s*\[[^\]]+\]\(" + _PLAIN_URL + r"\)\s*)+
 _SILENT_BLOCK_RE = re.compile(r"<silent\b[^>]*>.*?</silent\s*>", re.IGNORECASE | re.DOTALL)
 _UNTERMINATED_SILENT_RE = re.compile(r"<silent\b[^>]*>.*\Z", re.IGNORECASE | re.DOTALL)
 
-# Dynamic secret-ask markers: ``$<OPENAI_API_KEY>`` (ENV-style name). Matched only
+# Dynamic secret-ask markers: ``$<openAiKey>`` (case-preserving shell name). Matched only
 # outside fenced/inline code so a marker shown in an example isn't treated as a real
 # request — code spans are masked first.
-_SECRET_REQUEST_RE = re.compile(r"\$<([A-Z][A-Z0-9_]*)>")
+_SECRET_REQUEST_RE = re.compile(r"\$<([A-Za-z_][A-Za-z0-9_]*)>")
 _CODE_SPAN_RE = re.compile(r"```.*?```|~~~.*?~~~|`[^`\n]*`", re.DOTALL)
 
 

--- a/docs/plans/vaults-design-alignment.md
+++ b/docs/plans/vaults-design-alignment.md
@@ -58,7 +58,7 @@ mint factor-safety note; Cancel. Again **no `<form>`** — onClick buttons.
   key), not two big cards. Use a segmented control (reuse the existing
   Tabs/segmented primitive, or build one consistent with the design system).
 - **Field order**: Kind → Name → Value → Protection → Group → **Advanced**.
-- Name hint: "Uppercase A–Z 0–9 _ · globally unique".
+- Name hint: "Letters, numbers, underscore · case preserved".
 - Value: input + eye toggle; placeholder "Paste the secret value".
 - Protection: two cards Standard / Protected, exact copy — Standard
   "Machine-encrypted. Headless use OK. For API keys.", Protected "Unlocked in

--- a/docs/plans/vaults-grant-delivery-refactor.md
+++ b/docs/plans/vaults-grant-delivery-refactor.md
@@ -63,7 +63,7 @@ plaintext for delivery.
 
 `vault_secrets` should keep:
 
-- `name`: globally unique env-style secret name.
+- `name`: globally unique, case-preserving shell-style secret name; case-only duplicates are rejected.
 - `kind`: `static` or `keypair`.
 - `protection`: `standard` or `protected`.
 - `tags`: JSON array of strings.

--- a/docs/plans/vaults-p0-implementation.md
+++ b/docs/plans/vaults-p0-implementation.md
@@ -58,7 +58,7 @@ vault_groups = Table(
 vault_secrets = Table(
     "vault_secrets", metadata,
     Column("id", String, primary_key=True),
-    Column("name", String, nullable=False, unique=True),     # ^[A-Z][A-Z0-9_]*$
+    Column("name", String, nullable=False, unique=True),     # ^[A-Za-z_][A-Za-z0-9_]*$, case-preserving
     Column("group_name", String, ForeignKey("vault_groups.name"), nullable=False, server_default="default"),
     Column("tags", Text),                                    # JSON array
     Column("kind", String, nullable=False, server_default="static"),        # static | keypair (P2)

--- a/docs/plans/vaults.md
+++ b/docs/plans/vaults.md
@@ -114,7 +114,7 @@ already exists as the seam to harden — but we don't pay for it now.
 | column | notes |
 | --- | --- |
 | `id`, `created_at`, `updated_at` | |
-| `name` | **UNIQUE**, ENV-style `^[A-Z][A-Z0-9_]*$` — the reference key |
+| `name` | **UNIQUE**, case-preserving shell name `^[A-Za-z_][A-Za-z0-9_]*$`; case-only duplicates are rejected |
 | `group` | nullable, default `"default"` — org + unlock-scope, **not** part of the name |
 | `tags` | JSON array, optional |
 | `kind` | `static` \| `keypair` |

--- a/storage/alembic/versions/20260704_0027_vault_secret_name_case_index.py
+++ b/storage/alembic/versions/20260704_0027_vault_secret_name_case_index.py
@@ -41,15 +41,93 @@ def _ensure_no_case_only_duplicates() -> None:
         )
 
 
-def upgrade() -> None:
-    if not _table_exists("vault_secrets"):
+def _ensure_no_pending_provision_case_only_duplicates() -> None:
+    if not _table_exists("vault_requests"):
         return
-    _ensure_no_case_only_duplicates()
-    op.get_bind().exec_driver_sql(
-        "create unique index if not exists uq_vault_secrets_name_folded on vault_secrets (lower(name))"
+    bind = op.get_bind()
+    duplicate = bind.exec_driver_sql(
+        """
+        select lower(secret_name) as folded_name, group_concat(distinct secret_name) as names
+        from vault_requests
+        where request_type = 'provision'
+          and status = 'pending'
+          and secret_name is not null
+        group by lower(secret_name)
+        having count(distinct secret_name) > 1
+        limit 1
+        """
+    ).first()
+    if duplicate is not None:
+        raise RuntimeError(
+            "cannot add vault pending provision folded-name guard; "
+            f"case-only pending requests already exist for {duplicate[0]!r}: {duplicate[1]}"
+        )
+
+
+def _create_pending_provision_case_triggers() -> None:
+    if not _table_exists("vault_requests"):
+        return
+    bind = op.get_bind()
+    bind.exec_driver_sql(
+        """
+        create trigger if not exists trg_vault_requests_pending_provision_name_case_insert
+        before insert on vault_requests
+        when new.request_type = 'provision'
+          and new.status = 'pending'
+          and new.secret_name is not null
+          and exists (
+            select 1
+            from vault_requests
+            where request_type = 'provision'
+              and status = 'pending'
+              and secret_name is not null
+              and lower(secret_name) = lower(new.secret_name)
+              and secret_name <> new.secret_name
+          )
+        begin
+          select raise(abort, 'vault pending provision name case conflict');
+        end
+        """
+    )
+    bind.exec_driver_sql(
+        """
+        create trigger if not exists trg_vault_requests_pending_provision_name_case_update
+        before update of request_type, status, secret_name on vault_requests
+        when new.request_type = 'provision'
+          and new.status = 'pending'
+          and new.secret_name is not null
+          and exists (
+            select 1
+            from vault_requests
+            where id <> new.id
+              and request_type = 'provision'
+              and status = 'pending'
+              and secret_name is not null
+              and lower(secret_name) = lower(new.secret_name)
+              and secret_name <> new.secret_name
+          )
+        begin
+          select raise(abort, 'vault pending provision name case conflict');
+        end
+        """
     )
 
 
+def upgrade() -> None:
+    if not _table_exists("vault_secrets"):
+        _ensure_no_pending_provision_case_only_duplicates()
+        _create_pending_provision_case_triggers()
+        return
+    bind = op.get_bind()
+    _ensure_no_case_only_duplicates()
+    bind.exec_driver_sql("create unique index if not exists uq_vault_secrets_name_folded on vault_secrets (lower(name))")
+    _ensure_no_pending_provision_case_only_duplicates()
+    _create_pending_provision_case_triggers()
+
+
 def downgrade() -> None:
+    bind = op.get_bind()
+    bind.exec_driver_sql("drop trigger if exists trg_vault_requests_pending_provision_name_case_update")
+    bind.exec_driver_sql("drop trigger if exists trg_vault_requests_pending_provision_name_case_insert")
     if _table_exists("vault_secrets"):
         op.drop_index("uq_vault_secrets_name_folded", table_name="vault_secrets", if_exists=True)

--- a/storage/alembic/versions/20260704_0027_vault_secret_name_case_index.py
+++ b/storage/alembic/versions/20260704_0027_vault_secret_name_case_index.py
@@ -1,0 +1,55 @@
+"""enforce case-folded vault secret name uniqueness
+
+Revision ID: 20260704_0027
+Revises: 20260703_0026
+Create Date: 2026-07-04
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260704_0027"
+down_revision = "20260703_0026"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    bind = op.get_bind()
+    return bind.exec_driver_sql(
+        "select 1 from sqlite_master where type = 'table' and name = ?",
+        (name,),
+    ).first() is not None
+
+
+def _ensure_no_case_only_duplicates() -> None:
+    bind = op.get_bind()
+    duplicate = bind.exec_driver_sql(
+        """
+        select lower(name) as folded_name, group_concat(name, ', ') as names
+        from vault_secrets
+        group by lower(name)
+        having count(*) > 1
+        limit 1
+        """
+    ).first()
+    if duplicate is not None:
+        raise RuntimeError(
+            "cannot add vault secret folded-name uniqueness index; "
+            f"case-only duplicates already exist for {duplicate[0]!r}: {duplicate[1]}"
+        )
+
+
+def upgrade() -> None:
+    if not _table_exists("vault_secrets"):
+        return
+    _ensure_no_case_only_duplicates()
+    op.get_bind().exec_driver_sql(
+        "create unique index if not exists uq_vault_secrets_name_folded on vault_secrets (lower(name))"
+    )
+
+
+def downgrade() -> None:
+    if _table_exists("vault_secrets"):
+        op.drop_index("uq_vault_secrets_name_folded", table_name="vault_secrets", if_exists=True)

--- a/storage/models.py
+++ b/storage/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy import (
     Column,
+    DDL,
     Float,
     ForeignKey,
     Index,
@@ -11,6 +12,7 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    event,
     func,
     text,
 )
@@ -509,6 +511,57 @@ vault_requests = Table(
     Column("decided_at", String, nullable=True),
     Column("expires_at", String, nullable=True),
     Index("ix_vault_requests_status_created", "status", "created_at"),
+)
+event.listen(
+    vault_requests,
+    "after_create",
+    DDL(
+        """
+        create trigger if not exists trg_vault_requests_pending_provision_name_case_insert
+        before insert on vault_requests
+        when new.request_type = 'provision'
+          and new.status = 'pending'
+          and new.secret_name is not null
+          and exists (
+            select 1
+            from vault_requests
+            where request_type = 'provision'
+              and status = 'pending'
+              and secret_name is not null
+              and lower(secret_name) = lower(new.secret_name)
+              and secret_name <> new.secret_name
+          )
+        begin
+          select raise(abort, 'vault pending provision name case conflict');
+        end
+        """
+    ),
+)
+event.listen(
+    vault_requests,
+    "after_create",
+    DDL(
+        """
+        create trigger if not exists trg_vault_requests_pending_provision_name_case_update
+        before update of request_type, status, secret_name on vault_requests
+        when new.request_type = 'provision'
+          and new.status = 'pending'
+          and new.secret_name is not null
+          and exists (
+            select 1
+            from vault_requests
+            where id <> new.id
+              and request_type = 'provision'
+              and status = 'pending'
+              and secret_name is not null
+              and lower(secret_name) = lower(new.secret_name)
+              and secret_name <> new.secret_name
+          )
+        begin
+          select raise(abort, 'vault pending provision name case conflict');
+        end
+        """
+    ),
 )
 
 # Metadata + audit of active unlock grants. Key material is NEVER stored here;

--- a/storage/models.py
+++ b/storage/models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    func,
     text,
 )
 
@@ -467,7 +468,9 @@ vault_secrets = Table(
     metadata,
     Column("id", String, primary_key=True),
     # Globally unique, case-preserving shell name ``^[A-Za-z_][A-Za-z0-9_]*$``.
-    # Application logic rejects case-only duplicates so lookup stays exact.
+    # The exact UNIQUE(name) keeps existing exact lookup semantics, while the
+    # unique lower(name) expression index below atomically rejects case-only
+    # duplicates so exact lookup stays unambiguous under concurrent creates.
     Column("name", String, nullable=False),
     Column("tags", Text, nullable=True),  # JSON array
     Column("kind", String, nullable=False, server_default="static"),  # static | keypair (P2)
@@ -488,6 +491,7 @@ vault_secrets = Table(
     UniqueConstraint("name", name="uq_vault_secrets_name"),
     Index("ix_vault_secrets_name_kind", "name", "kind"),
 )
+Index("uq_vault_secrets_name_folded", func.lower(vault_secrets.c.name), unique=True)
 
 # One queue for everything that needs a human: P0 uses ``provision`` (dynamic ask via
 # ``$<NAME>``); ``access``/``sign``/``proxy``/``keygen`` are P1+.

--- a/storage/models.py
+++ b/storage/models.py
@@ -466,7 +466,8 @@ vault_secrets = Table(
     "vault_secrets",
     metadata,
     Column("id", String, primary_key=True),
-    # Globally-unique reference key, ENV-style ``^[A-Z][A-Z0-9_]*$``.
+    # Globally unique, case-preserving shell name ``^[A-Za-z_][A-Za-z0-9_]*$``.
+    # Application logic rejects case-only duplicates so lookup stays exact.
     Column("name", String, nullable=False),
     Column("tags", Text, nullable=True),  # JSON array
     Column("kind", String, nullable=False, server_default="static"),  # static | keypair (P2)

--- a/storage/vault_crypto.py
+++ b/storage/vault_crypto.py
@@ -2,7 +2,7 @@
 
 P1 moved **all value cryptography out of Python** into the ``avault`` custody core
 (design: avibe ``docs/plans/avault-custody-core.md`` §18). This module is now
-intentionally tiny: it owns only the ENV-style secret-name rule and the
+intentionally tiny: it owns only the shell-style secret-name rule and the
 :class:`Sealed` envelope shape that the ``vault_secrets`` table stores and that the
 avault client (``vibe/api.py``) produces (``avault seal``) and hands back to avault
 to deliver. No keys, no plaintext, and no cryptography ever live here anymore — the
@@ -21,7 +21,8 @@ from dataclasses import dataclass
 # The wrap scheme avault stamps into wrap_meta. Kept here only as a documented
 # reference for the stored envelope; nothing in Python reads or enforces it.
 WRAP_SCHEME = "machine-aesgcm-v1"
-_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+SECRET_NAME_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]*$"
+_NAME_RE = re.compile(SECRET_NAME_PATTERN)
 
 
 class VaultCryptoError(Exception):
@@ -43,5 +44,5 @@ class Sealed:
 
 
 def is_valid_secret_name(name: str | None) -> bool:
-    """ENV-style names only: an uppercase letter then uppercase/digit/underscore."""
+    """Case-preserving shell identifiers only."""
     return bool(name and _NAME_RE.match(name))

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -124,6 +124,13 @@ class SecretExistsError(VaultServiceError):
     pass
 
 
+class SecretNameCaseConflictError(VaultServiceError):
+    def __init__(self, name: str, existing_name: str):
+        self.name = name
+        self.existing_name = existing_name
+        super().__init__(f"secret name {name!r} conflicts with existing name {existing_name!r}")
+
+
 class SecretNotFoundError(VaultServiceError):
     pass
 
@@ -267,6 +274,19 @@ def _find_secret_name_case_insensitive(conn: Connection, name: str) -> str | Non
     return conn.execute(
         select(vault_secrets.c.name)
         .where(func.lower(vault_secrets.c.name) == _secret_name_case_key(name))
+        .limit(1)
+    ).scalar_one_or_none()
+
+
+def _find_pending_provision_name_case_insensitive(conn: Connection, name: str) -> str | None:
+    return conn.execute(
+        select(vault_requests.c.secret_name)
+        .where(
+            vault_requests.c.request_type == "provision",
+            vault_requests.c.status == "pending",
+            func.lower(vault_requests.c.secret_name) == _secret_name_case_key(name),
+        )
+        .order_by(vault_requests.c.created_at.desc(), vault_requests.c.id.desc())
         .limit(1)
     ).scalar_one_or_none()
 
@@ -1067,7 +1087,9 @@ def create_secret(
         raise VaultServiceError("signer_kind is only valid for keypair secrets")
     provision_row: dict[str, Any] | None = None
     existing_name = _find_secret_name_case_insensitive(conn, name)
-    existing_secret = existing_name is not None
+    existing_secret = existing_name == name
+    if existing_name is not None and existing_name != name:
+        raise SecretNameCaseConflictError(name, existing_name)
     if provision_request_id:
         _expire_pending_requests(conn)
         provision_row = _load_request_row(conn, provision_request_id)
@@ -1432,8 +1454,11 @@ def create_provision_request(
     now = _now()
     existing_name = _find_secret_name_case_insensitive(conn, name)
     if existing_name is not None and existing_name != name:
-        raise SecretExistsError(name)
+        raise SecretNameCaseConflictError(name, existing_name)
     already = existing_name == name
+    pending_name = _find_pending_provision_name_case_insensitive(conn, name)
+    if pending_name is not None and pending_name != name:
+        raise SecretNameCaseConflictError(name, pending_name)
     status = "fulfilled" if already else "pending"
     normalized_spec = normalize_provision_spec(spec)
     card = _secure_input_card(name, request_id=request_id, reason=reason, spec=normalized_spec)

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1146,9 +1146,13 @@ def create_secret(
             )
         )
     except IntegrityError as exc:
-        # Two concurrent creates (e.g. Web dialog + inline card) can both pass the existence
-        # check above; the loser hits the UNIQUE(name) constraint here. Surface it as the same
-        # SecretExistsError → 409 so the racing already-fulfilled ask is handled, not a 500.
+        # Two concurrent creates (e.g. Web dialog + inline card) can both pass the
+        # existence check above; the loser hits the exact UNIQUE(name) or the
+        # folded-name unique index here. Re-read the winning name so callers keep
+        # the same exact-duplicate vs case-conflict semantics instead of seeing a 500.
+        existing_name = _find_secret_name_case_insensitive(conn, name)
+        if existing_name is not None and existing_name != name:
+            raise SecretNameCaseConflictError(name, existing_name) from exc
         raise SecretExistsError(name) from exc
     audit(conn, "created", secret_name=name)
     decided_at = _now()

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1103,6 +1103,9 @@ def create_secret(
             raise SecretExistsError(name)
         if provision_row.get("status") != "pending":
             raise InvalidRequestError("provision request is not pending")
+    pending_name = _find_pending_provision_name_case_insensitive(conn, name)
+    if pending_name is not None and pending_name != name:
+        raise SecretNameCaseConflictError(name, pending_name)
     if existing_secret:
         raise SecretExistsError(name)
 

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -291,6 +291,51 @@ def _find_pending_provision_name_case_insensitive(conn: Connection, name: str) -
     ).scalar_one_or_none()
 
 
+def _preflight_secret_create_name(
+    conn: Connection,
+    *,
+    name: str,
+    provision_request_id: str | None = None,
+) -> tuple[dict[str, Any] | None, bool]:
+    existing_name = _find_secret_name_case_insensitive(conn, name)
+    existing_secret = existing_name == name
+    if existing_name is not None and existing_name != name:
+        raise SecretNameCaseConflictError(name, existing_name)
+    provision_row: dict[str, Any] | None = None
+    if provision_request_id:
+        _expire_pending_requests(conn)
+        provision_row = _load_request_row(conn, provision_request_id)
+        if provision_row.get("request_type") != "provision":
+            raise InvalidRequestError("secret create must complete a provision request")
+        if provision_row.get("secret_name") != name:
+            raise InvalidRequestError("provision request secret name does not match")
+        if provision_row.get("status") == "expired":
+            raise InvalidRequestError("provision request has expired")
+        if provision_row.get("status") == "fulfilled" and existing_secret:
+            raise SecretExistsError(name)
+        if provision_row.get("status") != "pending":
+            raise InvalidRequestError("provision request is not pending")
+    pending_name = _find_pending_provision_name_case_insensitive(conn, name)
+    if pending_name is not None and pending_name != name:
+        raise SecretNameCaseConflictError(name, pending_name)
+    if existing_secret:
+        raise SecretExistsError(name)
+    return provision_row, bool(existing_secret)
+
+
+def preflight_secret_create(
+    conn: Connection,
+    *,
+    name: str,
+    provision_request_id: str | None = None,
+) -> None:
+    """Validate name/request conflicts before a caller performs expensive sealing."""
+
+    if not vault_crypto.is_valid_secret_name(name):
+        raise InvalidSecretNameError(name)
+    _preflight_secret_create_name(conn, name=name, provision_request_id=provision_request_id)
+
+
 def _loads(raw: str | None) -> Any:
     if not raw:
         return None
@@ -1085,29 +1130,11 @@ def create_secret(
         raise VaultServiceError(f"invalid vault secret kind: {kind!r}")
     if kind != "keypair" and signer_kind is not None:
         raise VaultServiceError("signer_kind is only valid for keypair secrets")
-    provision_row: dict[str, Any] | None = None
-    existing_name = _find_secret_name_case_insensitive(conn, name)
-    existing_secret = existing_name == name
-    if existing_name is not None and existing_name != name:
-        raise SecretNameCaseConflictError(name, existing_name)
-    if provision_request_id:
-        _expire_pending_requests(conn)
-        provision_row = _load_request_row(conn, provision_request_id)
-        if provision_row.get("request_type") != "provision":
-            raise InvalidRequestError("secret create must complete a provision request")
-        if provision_row.get("secret_name") != name:
-            raise InvalidRequestError("provision request secret name does not match")
-        if provision_row.get("status") == "expired":
-            raise InvalidRequestError("provision request has expired")
-        if provision_row.get("status") == "fulfilled" and existing_secret:
-            raise SecretExistsError(name)
-        if provision_row.get("status") != "pending":
-            raise InvalidRequestError("provision request is not pending")
-    pending_name = _find_pending_provision_name_case_insensitive(conn, name)
-    if pending_name is not None and pending_name != name:
-        raise SecretNameCaseConflictError(name, pending_name)
-    if existing_secret:
-        raise SecretExistsError(name)
+    provision_row, _existing_secret = _preflight_secret_create_name(
+        conn,
+        name=name,
+        provision_request_id=provision_request_id,
+    )
 
     if establishing_vmk and protection == "protected":
         # Atomic single-init guard: this runs inside the write transaction (SQLite
@@ -1474,19 +1501,25 @@ def create_provision_request(
         delivery_payload["reason"] = reason
     if normalized_spec:
         delivery_payload["spec"] = normalized_spec
-    conn.execute(
-        vault_requests.insert().values(
-            id=request_id,
-            request_type="provision",
-            secret_name=name,
-            requester=json.dumps(requester) if requester is not None else None,
-            delivery=json.dumps(delivery_payload),
-            status=status,
-            message_id=message_id,
-            created_at=now,
-            decided_at=now if already else None,
+    try:
+        conn.execute(
+            vault_requests.insert().values(
+                id=request_id,
+                request_type="provision",
+                secret_name=name,
+                requester=json.dumps(requester) if requester is not None else None,
+                delivery=json.dumps(delivery_payload),
+                status=status,
+                message_id=message_id,
+                created_at=now,
+                decided_at=now if already else None,
+            )
         )
-    )
+    except IntegrityError as exc:
+        pending_name = _find_pending_provision_name_case_insensitive(conn, name)
+        if pending_name is not None and pending_name != name:
+            raise SecretNameCaseConflictError(name, pending_name) from exc
+        raise VaultServiceError("failed to create provision request") from exc
     audit(conn, "provision_requested", secret_name=name, requester=requester, request_id=request_id)
     return {
         "id": request_id,

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlsplit
 
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
@@ -255,6 +255,20 @@ def _parse_iso_datetime(value: str | None) -> datetime | None:
 
 def _id(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+def _secret_name_case_key(name: str) -> str:
+    # Secret names are ASCII shell identifiers, so SQL lower() and Python lower()
+    # have the same case-folding behavior for the enforced domain.
+    return name.lower()
+
+
+def _find_secret_name_case_insensitive(conn: Connection, name: str) -> str | None:
+    return conn.execute(
+        select(vault_secrets.c.name)
+        .where(func.lower(vault_secrets.c.name) == _secret_name_case_key(name))
+        .limit(1)
+    ).scalar_one_or_none()
 
 
 def _loads(raw: str | None) -> Any:
@@ -1052,7 +1066,8 @@ def create_secret(
     if kind != "keypair" and signer_kind is not None:
         raise VaultServiceError("signer_kind is only valid for keypair secrets")
     provision_row: dict[str, Any] | None = None
-    existing_secret = conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.name == name)).first() is not None
+    existing_name = _find_secret_name_case_insensitive(conn, name)
+    existing_secret = existing_name is not None
     if provision_request_id:
         _expire_pending_requests(conn)
         provision_row = _load_request_row(conn, provision_request_id)
@@ -1411,9 +1426,14 @@ def create_provision_request(
     ``request --wait`` would block forever (a create for an existing name is rejected,
     so nothing would ever flip a pending row).
     """
+    if not vault_crypto.is_valid_secret_name(name):
+        raise InvalidSecretNameError(name)
     request_id = _id("vrq")
     now = _now()
-    already = conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.name == name)).first() is not None
+    existing_name = _find_secret_name_case_insensitive(conn, name)
+    if existing_name is not None and existing_name != name:
+        raise SecretExistsError(name)
+    already = existing_name == name
     status = "fulfilled" if already else "pending"
     normalized_spec = normalize_provision_spec(spec)
     card = _secure_input_card(name, request_id=request_id, reason=reason, spec=normalized_spec)

--- a/tests/test_reply_enhancer_secret_requests.py
+++ b/tests/test_reply_enhancer_secret_requests.py
@@ -10,7 +10,7 @@ def _names(text: str) -> list[str]:
 
 
 def test_extracts_marker():
-    assert _names("I need $<OPENAI_API_KEY> to continue.") == ["OPENAI_API_KEY"]
+    assert _names("I need $<openAiKey> to continue.") == ["openAiKey"]
 
 
 def test_marker_stays_in_text_for_frontend():
@@ -33,8 +33,8 @@ def test_ignored_inside_fenced_code():
 
 
 def test_invalid_names_not_matched():
-    # lowercase, leading digit, dashes are not ENV-style names
-    assert _names("$<lower> $<1LEAD> $<has-dash>") == []
+    # Leading digits and dashes are not shell-style secret names.
+    assert _names("$<lower> $<1LEAD> $<has-dash>") == ["lower"]
 
 
 def test_none_when_absent():

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -17,7 +17,7 @@ from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
 
 
-HEAD_REVISION = "20260703_0026"
+HEAD_REVISION = "20260704_0027"
 
 
 def _index_sql(conn: sqlite3.Connection, name: str) -> str:
@@ -66,6 +66,12 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
                 "select seq, name from pragma_index_list('messages')",
             )
         }
+        vault_secret_indexes = {
+            row[1]
+            for row in conn.execute(
+                "select seq, name from pragma_index_list('vault_secrets')",
+            )
+        }
         assert "ix_messages_session_created_id" in message_indexes
         assert "ix_messages_session_type_created_id" in message_indexes
         assert "ix_messages_platform_session_created_id" in message_indexes
@@ -76,6 +82,8 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "ix_messages_inbox_user_send" in message_indexes
         assert "harness_dedupe" in _index_sql(conn, "ix_messages_inbox_activity")
         assert "harness_dedupe" in _index_sql(conn, "ix_messages_inbox_user_send")
+        assert "uq_vault_secrets_name_folded" in vault_secret_indexes
+        assert "lower(name)" in _index_sql(conn, "uq_vault_secrets_name_folded").lower()
         agent_session_indexes = {
             row[1]
             for row in conn.execute(
@@ -518,6 +526,45 @@ def test_run_migrations_expires_legacy_pending_access_cards(tmp_path: Path) -> N
     assert rows["req_legacy"][1] is not None
     assert rows["req_current"] == ("pending", None)
     assert rows["req_sign"] == ("pending", None)
+
+
+def test_run_migrations_adds_case_folded_vault_secret_name_index(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    run_migrations(db_path, revision="20260703_0026")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            insert into vault_secrets (
+                id, name, tags, kind, protection, source,
+                ciphertext, nonce, wrap_meta, public_meta, policy,
+                use_count, created_at, updated_at
+            ) values ('vlt_a', 'openAiKey', null, 'static', 'standard', 'manual',
+                'ct', 'nonce', 'wrap', null, null, 0, 'now', 'now')
+            """
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute("select version_num from alembic_version").fetchone()
+        indexes = {row[1] for row in conn.execute("select seq, name from pragma_index_list('vault_secrets')")}
+        assert version == (HEAD_REVISION,)
+        assert "uq_vault_secrets_name_folded" in indexes
+        assert "lower(name)" in _index_sql(conn, "uq_vault_secrets_name_folded").lower()
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                insert into vault_secrets (
+                    id, name, tags, kind, protection, source,
+                    ciphertext, nonce, wrap_meta, public_meta, policy,
+                    use_count, created_at, updated_at
+                ) values ('vlt_b', 'OpenAIKey', null, 'static', 'standard', 'manual',
+                    'ct', 'nonce', 'wrap', null, null, 0, 'now', 'now')
+                """
+            )
 
 
 def test_scope_agent_backfill_migrates_explicit_agent_routes(tmp_path: Path) -> None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -72,6 +72,12 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
                 "select seq, name from pragma_index_list('vault_secrets')",
             )
         }
+        vault_request_triggers = {
+            row[0]
+            for row in conn.execute(
+                "select name from sqlite_master where type = 'trigger' and tbl_name = 'vault_requests'",
+            )
+        }
         assert "ix_messages_session_created_id" in message_indexes
         assert "ix_messages_session_type_created_id" in message_indexes
         assert "ix_messages_platform_session_created_id" in message_indexes
@@ -84,6 +90,8 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "harness_dedupe" in _index_sql(conn, "ix_messages_inbox_user_send")
         assert "uq_vault_secrets_name_folded" in vault_secret_indexes
         assert "lower(name)" in _index_sql(conn, "uq_vault_secrets_name_folded").lower()
+        assert "trg_vault_requests_pending_provision_name_case_insert" in vault_request_triggers
+        assert "trg_vault_requests_pending_provision_name_case_update" in vault_request_triggers
         agent_session_indexes = {
             row[1]
             for row in conn.execute(
@@ -551,9 +559,17 @@ def test_run_migrations_adds_case_folded_vault_secret_name_index(tmp_path: Path)
     with sqlite3.connect(db_path) as conn:
         version = conn.execute("select version_num from alembic_version").fetchone()
         indexes = {row[1] for row in conn.execute("select seq, name from pragma_index_list('vault_secrets')")}
+        triggers = {
+            row[0]
+            for row in conn.execute(
+                "select name from sqlite_master where type = 'trigger' and tbl_name = 'vault_requests'"
+            )
+        }
         assert version == (HEAD_REVISION,)
         assert "uq_vault_secrets_name_folded" in indexes
         assert "lower(name)" in _index_sql(conn, "uq_vault_secrets_name_folded").lower()
+        assert "trg_vault_requests_pending_provision_name_case_insert" in triggers
+        assert "trg_vault_requests_pending_provision_name_case_update" in triggers
         with pytest.raises(sqlite3.IntegrityError):
             conn.execute(
                 """
@@ -563,6 +579,31 @@ def test_run_migrations_adds_case_folded_vault_secret_name_index(tmp_path: Path)
                     use_count, created_at, updated_at
                 ) values ('vlt_b', 'OpenAIKey', null, 'static', 'standard', 'manual',
                     'ct', 'nonce', 'wrap', null, null, 0, 'now', 'now')
+                """
+            )
+        conn.execute(
+            """
+            insert into vault_requests (
+                id, request_type, secret_name, requester, delivery, status,
+                message_id, created_at, decided_at, expires_at
+            ) values ('vrq_a', 'provision', 'openAiKey', null, '{}', 'pending', null, 'now', null, null)
+            """
+        )
+        conn.execute(
+            """
+            insert into vault_requests (
+                id, request_type, secret_name, requester, delivery, status,
+                message_id, created_at, decided_at, expires_at
+            ) values ('vrq_exact_duplicate', 'provision', 'openAiKey', null, '{}', 'pending', null, 'now', null, null)
+            """
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                insert into vault_requests (
+                    id, request_type, secret_name, requester, delivery, status,
+                    message_id, created_at, decided_at, expires_at
+                ) values ('vrq_b', 'provision', 'OpenAIKey', null, '{}', 'pending', null, 'now', null, null)
                 """
             )
 

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -476,6 +476,27 @@ def test_mixed_case_name_is_preserved_and_case_duplicate_rejected(monkeypatch):
     assert "openAiKey" in str(exc.value)
 
 
+def test_create_secret_rejects_case_only_pending_provision(monkeypatch):
+    from unittest.mock import Mock
+
+    seal = Mock(return_value=_sealed())
+    monkeypatch.setattr(api, "avault_seal_blind_box", seal)
+    with api._vault_engine().begin() as conn:
+        vault_service.create_provision_request(conn, "openAiKey")
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.create_vault_secret(
+            {
+                "name": "OpenAIKey",
+                "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+            }
+        )
+
+    assert exc.value.code == "secret_name_case_conflict"
+    assert exc.value.status == 409
+    assert "openAiKey" in str(exc.value)
+
+
 def test_invalid_name_rejected_before_avault(monkeypatch):
     from unittest.mock import Mock
 

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -476,6 +476,27 @@ def test_mixed_case_name_is_preserved_and_case_duplicate_rejected(monkeypatch):
     assert "openAiKey" in str(exc.value)
 
 
+def test_case_conflict_is_rejected_before_standard_seal(monkeypatch):
+    from unittest.mock import Mock
+
+    seal = Mock(side_effect=api.AvaultError("seal failed"))
+    monkeypatch.setattr(api, "avault_seal_blind_box", seal)
+    with api._vault_engine().begin() as conn:
+        vault_service.create_secret(conn, name="openAiKey", sealed=_sealed("existing"))
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.create_vault_secret(
+            {
+                "name": "OpenAIKey",
+                "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+            }
+        )
+
+    assert exc.value.code == "secret_name_case_conflict"
+    assert exc.value.status == 409
+    seal.assert_not_called()
+
+
 def test_create_secret_rejects_case_only_pending_provision(monkeypatch):
     from unittest.mock import Mock
 

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -358,6 +358,29 @@ def test_create_secret_with_fulfilled_provision_request_returns_secret_exists(mo
     assert exc.value.status == 409
 
 
+def test_create_secret_exact_duplicate_still_returns_secret_exists(monkeypatch):
+    from unittest.mock import Mock
+
+    seal = Mock(return_value=_sealed())
+    monkeypatch.setattr(api, "avault_seal_blind_box", seal)
+    api.create_vault_secret(
+        {
+            "name": "openAiKey",
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.create_vault_secret(
+            {
+                "name": "openAiKey",
+                "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc2", "ct": "ct2"},
+            }
+        )
+    assert exc.value.code == "secret_exists"
+    assert exc.value.status == 409
+
+
 def test_secret_exists_response_commits_stale_pending_provision_cleanup(monkeypatch):
     seal = Mock(side_effect=[_sealed("first"), _sealed("second")])
     monkeypatch.setattr(api, "avault_seal_blind_box", seal)
@@ -448,8 +471,9 @@ def test_mixed_case_name_is_preserved_and_case_duplicate_rejected(monkeypatch):
                 "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc2", "ct": "ct2"},
             }
         )
-    assert exc.value.code == "secret_exists"
+    assert exc.value.code == "secret_name_case_conflict"
     assert exc.value.status == 409
+    assert "openAiKey" in str(exc.value)
 
 
 def test_invalid_name_rejected_before_avault(monkeypatch):

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -424,13 +424,46 @@ def test_duplicate_name_conflict(monkeypatch):
     assert exc.value.status == 409
 
 
+def test_mixed_case_name_is_preserved_and_case_duplicate_rejected(monkeypatch):
+    from unittest.mock import Mock
+
+    seal = Mock(return_value=_sealed())
+    monkeypatch.setattr(api, "avault_seal_blind_box", seal)
+    created = api.create_vault_secret(
+        {
+            "name": "openAiKey",
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+    assert created["secret"]["name"] == "openAiKey"
+    seal.assert_called_once_with(
+        "openAiKey",
+        {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+    )
+
+    with pytest.raises(api.VaultApiError) as exc:
+        api.create_vault_secret(
+            {
+                "name": "OpenAIKey",
+                "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc2", "ct": "ct2"},
+            }
+        )
+    assert exc.value.code == "secret_exists"
+    assert exc.value.status == 409
+
+
 def test_invalid_name_rejected_before_avault(monkeypatch):
     from unittest.mock import Mock
 
     seal = Mock(return_value=_sealed())
     monkeypatch.setattr(api, "avault_seal_blind_box", seal)
     with pytest.raises(api.VaultApiError) as exc:
-        api.create_vault_secret({"name": "lower", "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"}})
+        api.create_vault_secret(
+            {
+                "name": "bad-name",
+                "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+            }
+        )
     assert exc.value.code == "invalid_name"
     seal.assert_not_called()
 

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -1862,6 +1862,17 @@ def test_request_rejects_spec_with_plaintext_value(capfd):
     assert payload["code"] == "invalid_spec"
 
 
+def test_request_case_conflict_uses_name_conflict_code(capfd):
+    _create_standard_secret("openAiKey")
+
+    code = cli.cmd_vault_request(_ns(name="OpenAIKey", reason="need it"))
+    payload = json.loads(capfd.readouterr().err)
+
+    assert code == 1
+    assert payload["code"] == "secret_name_case_conflict"
+    assert "openAiKey" in payload["error"]
+
+
 def test_request_for_existing_secret_returns_fulfilled(tmp_path, capfd, monkeypatch):
     _create_standard_secret("HAVE_KEY")
     assert cli.cmd_vault_request(_ns(name="HAVE_KEY", wait=30)) == 0

--- a/tests/test_vault_crypto.py
+++ b/tests/test_vault_crypto.py
@@ -28,9 +28,11 @@ def test_vault_crypto_error_kept_for_back_compat():
     ("name", "valid"),
     [
         ("OPENAI_API_KEY", True),
+        ("openAiKey", True),
+        ("_localKey", True),
         ("A", True),
         ("A1_B2", True),
-        ("lowercase", False),
+        ("lowercase", True),
         ("1LEADING_DIGIT", False),
         ("HAS-DASH", False),
         ("HAS SPACE", False),

--- a/tests/test_vault_schema.py
+++ b/tests/test_vault_schema.py
@@ -22,6 +22,8 @@ def test_vault_metadata_schema_matches_grant_id_tag_model(tmp_path):
         secret_cols = {row[1] for row in conn.execute(text("pragma table_info(vault_secrets)"))}
         assert {"name", "tags", "kind", "protection", "ciphertext", "nonce", "wrap_meta"} <= secret_cols
         assert "group_name" not in secret_cols
+        secret_indexes = {row[1] for row in conn.execute(text("select seq, name from pragma_index_list('vault_secrets')"))}
+        assert "uq_vault_secrets_name_folded" in secret_indexes
 
         grant_cols = {row[1] for row in conn.execute(text("pragma table_info(vault_grants)"))}
         assert {

--- a/tests/test_vault_schema.py
+++ b/tests/test_vault_schema.py
@@ -24,6 +24,14 @@ def test_vault_metadata_schema_matches_grant_id_tag_model(tmp_path):
         assert "group_name" not in secret_cols
         secret_indexes = {row[1] for row in conn.execute(text("select seq, name from pragma_index_list('vault_secrets')"))}
         assert "uq_vault_secrets_name_folded" in secret_indexes
+        request_triggers = {
+            row[0]
+            for row in conn.execute(
+                text("select name from sqlite_master where type = 'trigger' and tbl_name = 'vault_requests'")
+            )
+        }
+        assert "trg_vault_requests_pending_provision_name_case_insert" in request_triggers
+        assert "trg_vault_requests_pending_provision_name_case_update" in request_triggers
 
         grant_cols = {row[1] for row in conn.execute(text("pragma table_info(vault_grants)"))}
         assert {

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -125,6 +125,41 @@ def test_provision_request_rejects_case_only_duplicate_pending_request(vault):
     assert [row["secret_name"] for row in rows] == ["openAiKey"]
 
 
+def test_provision_request_case_guard_is_database_enforced(vault):
+    with vault.begin() as conn:
+        conn.execute(
+            vault_requests.insert().values(
+                id="vrq_a",
+                request_type="provision",
+                secret_name="openAiKey",
+                status="pending",
+                delivery="{}",
+                created_at="now",
+            )
+        )
+        conn.execute(
+            vault_requests.insert().values(
+                id="vrq_exact_duplicate",
+                request_type="provision",
+                secret_name="openAiKey",
+                status="pending",
+                delivery="{}",
+                created_at="now",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                vault_requests.insert().values(
+                    id="vrq_b",
+                    request_type="provision",
+                    secret_name="OpenAIKey",
+                    status="pending",
+                    delivery="{}",
+                    created_at="now",
+                )
+            )
+
+
 def test_create_secret_rejects_case_only_duplicate_pending_request(vault):
     with vault.begin() as conn:
         pending = vs.create_provision_request(conn, "openAiKey")

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -68,8 +68,9 @@ def test_secret_names_preserve_case_and_reject_case_only_duplicates(vault):
         with pytest.raises(vs.SecretNotFoundError):
             vs.get_secret_meta(conn, "OPENAIKEY")
 
-    with pytest.raises(vs.SecretExistsError):
+    with pytest.raises(vs.SecretNameCaseConflictError) as exc:
         _create(vault, name="OpenAIKey")
+    assert exc.value.existing_name == "openAiKey"
 
 
 def test_provision_request_rejects_case_only_duplicate_secret(vault):
@@ -77,10 +78,28 @@ def test_provision_request_rejects_case_only_duplicate_secret(vault):
 
     with vault.begin() as conn:
         fulfilled = vs.create_provision_request(conn, "OpenAIKey")
-        with pytest.raises(vs.SecretExistsError):
+        with pytest.raises(vs.SecretNameCaseConflictError) as exc:
             vs.create_provision_request(conn, "openAIKey")
 
     assert fulfilled["status"] == "fulfilled"
+    assert exc.value.existing_name == "OpenAIKey"
+
+
+def test_provision_request_rejects_case_only_duplicate_pending_request(vault):
+    with vault.begin() as conn:
+        pending = vs.create_provision_request(conn, "openAiKey")
+        with pytest.raises(vs.SecretNameCaseConflictError) as exc:
+            vs.create_provision_request(conn, "OpenAIKey")
+
+        rows = (
+            conn.execute(select(vault_requests).where(vault_requests.c.request_type == "provision"))
+            .mappings()
+            .all()
+        )
+
+    assert pending["status"] == "pending"
+    assert exc.value.existing_name == "openAiKey"
+    assert [row["secret_name"] for row in rows] == ["openAiKey"]
 
 
 def test_skill_links_are_stored_as_skill_tags(vault):

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -102,6 +102,25 @@ def test_provision_request_rejects_case_only_duplicate_pending_request(vault):
     assert [row["secret_name"] for row in rows] == ["openAiKey"]
 
 
+def test_create_secret_rejects_case_only_duplicate_pending_request(vault):
+    with vault.begin() as conn:
+        pending = vs.create_provision_request(conn, "openAiKey")
+        with pytest.raises(vs.SecretNameCaseConflictError) as exc:
+            vs.create_secret(conn, name="OpenAIKey", sealed=_sealed("case"))
+
+        secrets = conn.execute(select(vault_secrets.c.name)).scalars().all()
+        requests = (
+            conn.execute(select(vault_requests.c.secret_name, vault_requests.c.status))
+            .mappings()
+            .all()
+        )
+
+    assert pending["status"] == "pending"
+    assert exc.value.existing_name == "openAiKey"
+    assert secrets == []
+    assert [dict(row) for row in requests] == [{"secret_name": "openAiKey", "status": "pending"}]
+
+
 def test_skill_links_are_stored_as_skill_tags(vault):
     _create(vault, name="GH_PAT", tags=["github"])
 

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from storage import vault_service as vs
 from storage.db import create_sqlite_engine
@@ -71,6 +72,28 @@ def test_secret_names_preserve_case_and_reject_case_only_duplicates(vault):
     with pytest.raises(vs.SecretNameCaseConflictError) as exc:
         _create(vault, name="OpenAIKey")
     assert exc.value.existing_name == "openAiKey"
+
+
+def test_secret_name_case_uniqueness_is_enforced_by_database(vault):
+    _create(vault, name="openAiKey")
+
+    with vault.begin() as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                vault_secrets.insert().values(
+                    id="vlt_case_race",
+                    name="OpenAIKey",
+                    kind="static",
+                    protection="standard",
+                    source="manual",
+                    ciphertext="ct",
+                    nonce="nonce",
+                    wrap_meta="wrap",
+                    use_count=0,
+                    created_at="now",
+                    updated_at="now",
+                )
+            )
 
 
 def test_provision_request_rejects_case_only_duplicate_secret(vault):

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -59,6 +59,30 @@ def test_secret_metadata_is_global_name_plus_tags(vault):
         assert vs.list_secrets(conn, tag="prod")[0]["name"] == "OPENAI_API_KEY"
 
 
+def test_secret_names_preserve_case_and_reject_case_only_duplicates(vault):
+    meta = _create(vault, name="openAiKey", description="key")
+
+    assert meta["name"] == "openAiKey"
+    with vault.connect() as conn:
+        assert vs.get_secret_meta(conn, "openAiKey")["name"] == "openAiKey"
+        with pytest.raises(vs.SecretNotFoundError):
+            vs.get_secret_meta(conn, "OPENAIKEY")
+
+    with pytest.raises(vs.SecretExistsError):
+        _create(vault, name="OpenAIKey")
+
+
+def test_provision_request_rejects_case_only_duplicate_secret(vault):
+    _create(vault, name="OpenAIKey")
+
+    with vault.begin() as conn:
+        fulfilled = vs.create_provision_request(conn, "OpenAIKey")
+        with pytest.raises(vs.SecretExistsError):
+            vs.create_provision_request(conn, "openAIKey")
+
+    assert fulfilled["status"] == "fulfilled"
+
+
 def test_skill_links_are_stored_as_skill_tags(vault):
     _create(vault, name="GH_PAT", tags=["github"])
 

--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -36,13 +36,13 @@ import { cn, copyTextToClipboard } from '@/lib/utils';
 // leave it off for authored markdown (agent replies) where wrapped lines must
 // not sprout stray hard breaks.
 
-// Vault dynamic-ask: an agent reply may contain `$<OPENAI_API_KEY>`. When interactive,
+// Vault dynamic-ask: an agent reply may contain `$<openAiKey>`. When interactive,
 // we rewrite each marker (outside code) to an `avibe-secret:NAME` link that the `a` handler
 // renders as an inline SecretRequestCard. Fenced/inline code spans AND indented (≥4-space / tab)
 // code lines are left verbatim so a marker shown in any code example never becomes a real
 // input card.
 const SECRET_LINK_SCHEME = 'avibe-secret';
-const SECRET_REQUEST_RE = /\$<([A-Z][A-Z0-9_]*)>/g;
+const SECRET_REQUEST_RE = /\$<([A-Za-z_][A-Za-z0-9_]*)>/g;
 const CODE_SPAN_RE = /```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`/g;
 const INDENTED_CODE_LINE_RE = /^(?: {4}|\t)/;
 

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -459,6 +459,10 @@ export const VaultSecretForm: React.FC<{
           handleExistingSecret();
           return;
         }
+        if (created.code === 'secret_name_case_conflict') {
+          setError(created.message || t('vaults.dialog.errors.secretNameCaseConflict'));
+          return;
+        }
         if (created.code === 'vault_already_initialized') {
           // Another tab established the vault first — drop the rejected local VMK and
           // reload the server's wrap_meta so the user unlocks it instead of splitting keys.
@@ -486,6 +490,8 @@ export const VaultSecretForm: React.FC<{
         setError(t('vaults.dialog.errors.invalidPublicKey'));
       } else if (err instanceof ApiError && err.code === 'secret_exists') {
         handleExistingSecret();
+      } else if (err instanceof ApiError && err.code === 'secret_name_case_conflict') {
+        setError(err.message || t('vaults.dialog.errors.secretNameCaseConflict'));
       } else {
         setError(err instanceof Error ? err.message : String(err));
       }

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -235,7 +235,7 @@ export const VaultSecretForm: React.FC<{
   }, [requestSpec]);
 
   const p2Ready = useMemo(() => avaultP2Ready(avaultDep), [avaultDep]);
-  const secretName = (fixedName ?? name).trim().toUpperCase();
+  const secretName = (fixedName ?? name).trim();
   const protectedCreateReady = protectedVault.status === 'unlocked';
   const isKeypair = kind === 'keypair';
   const isProvision = Boolean(fixedName);

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2290,7 +2290,7 @@
       "kindStaticHelp": "A token, password, or any text value.",
       "kindKeypair": "Signing key",
       "kindKeypairHelp": "A signing key generated in your browser.",
-      "nameHint": "Uppercase A–Z 0–9 _ · globally unique",
+      "nameHint": "Letters, numbers, underscore · case preserved",
       "signingKeyHelp": "A new secp256k1 signing key is created in your browser. The private key is sealed in your browser — standard keys are signed by avault locally, protected keys are signed in your browser — and only the public key is stored in the clear.",
       "signingGenerate": "Generate",
       "signingImport": "Import",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2290,7 +2290,7 @@
       "kindStaticHelp": "A token, password, or any text value.",
       "kindKeypair": "Signing key",
       "kindKeypairHelp": "A signing key generated in your browser.",
-      "nameHint": "Letters, numbers, underscore · case preserved",
+      "nameHint": "Start with a letter or underscore; then use letters, numbers, or underscore · case preserved",
       "signingKeyHelp": "A new secp256k1 signing key is created in your browser. The private key is sealed in your browser — standard keys are signed by avault locally, protected keys are signed in your browser — and only the public key is stored in the clear.",
       "signingGenerate": "Generate",
       "signingImport": "Import",
@@ -2343,7 +2343,8 @@
         "fileEmpty": "Choose a non-empty file.",
         "fileTooLarge": "Choose a file up to {{size}}.",
         "fileReadFailed": "Couldn't read that file.",
-        "secretExists": "A secret with this name already exists."
+        "secretExists": "A secret with this name already exists.",
+        "secretNameCaseConflict": "A secret already uses this name with different letter casing."
       }
     },
     "requests": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2289,7 +2289,7 @@
       "kindStaticHelp": "令牌、密码,或任意文本值。",
       "kindKeypair": "签名密钥",
       "kindKeypairHelp": "在你浏览器里生成的签名私钥。",
-      "nameHint": "字母、数字、下划线 · 保留大小写",
+      "nameHint": "首字符必须是字母或下划线；后续可用字母、数字、下划线 · 保留大小写",
       "signingKeyHelp": "会在你的浏览器里新生成一把 secp256k1 签名密钥。私钥在浏览器中封存——标准密钥由本机 avault 签名,保护层密钥在浏览器中签名——只有公钥明文保存。",
       "signingGenerate": "生成",
       "signingImport": "导入",
@@ -2342,7 +2342,8 @@
         "fileEmpty": "请选择非空文件。",
         "fileTooLarge": "请选择不超过 {{size}} 的文件。",
         "fileReadFailed": "读取文件失败。",
-        "secretExists": "同名密钥已存在。"
+        "secretExists": "同名密钥已存在。",
+        "secretNameCaseConflict": "已有密钥使用了仅大小写不同的名称。"
       }
     },
     "requests": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2289,7 +2289,7 @@
       "kindStaticHelp": "令牌、密码,或任意文本值。",
       "kindKeypair": "签名密钥",
       "kindKeypairHelp": "在你浏览器里生成的签名私钥。",
-      "nameHint": "大写 A–Z 0–9 _ · 全局唯一",
+      "nameHint": "字母、数字、下划线 · 保留大小写",
       "signingKeyHelp": "会在你的浏览器里新生成一把 secp256k1 签名密钥。私钥在浏览器中封存——标准密钥由本机 avault 签名,保护层密钥在浏览器中签名——只有公钥明文保存。",
       "signingGenerate": "生成",
       "signingImport": "导入",

--- a/ui/src/lib/vaultCrypto.test.ts
+++ b/ui/src/lib/vaultCrypto.test.ts
@@ -297,11 +297,11 @@ describe('vaultCrypto blind boxes', () => {
 
   it('enforces the daemon vault secret-name syntax before producing AAD', async () => {
     expect(() => standardCreateBlindBoxContext('OPENAI_API_KEY')).not.toThrow();
+    expect(() => standardCreateBlindBoxContext('openAi_key')).not.toThrow();
     expect(() => standardCreateBlindBoxContext(' OPENAI_API_KEY ')).toThrow(/secret name/);
-    expect(() => standardCreateBlindBoxContext('openai_key')).toThrow(/secret name/);
     expect(() => standardCreateBlindBoxContext('1OPENAI_KEY')).toThrow(/secret name/);
     await expect(
-      protectedDekReleaseBlindBoxContext('openai_key', {
+      protectedDekReleaseBlindBoxContext('1OPENAI_KEY', {
         kind: 'agent-deliver',
         scopeType: 'session',
         scopeRef: 'sess-1',

--- a/ui/src/lib/vaultCrypto.ts
+++ b/ui/src/lib/vaultCrypto.ts
@@ -18,7 +18,7 @@ const NONCE_BYTES = 12;
 const ARGON2_VERSION = 19;
 const PASSKEY_PRF_SALT_BYTES = 32;
 const PASSKEY_HKDF_INFO = 'avault:protected-vmk:kek-passkey:v1';
-const SECRET_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const SECRET_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const DEFAULT_SCRYPT = {
   n: 2 ** 15,
   r: 8,
@@ -951,7 +951,7 @@ export function importSigningKey(privateKey: BytesLike | string): SigningKeyMate
 
 function validateSecretName(name: string): string {
   if (typeof name !== 'string' || !SECRET_NAME_PATTERN.test(name)) {
-    throw new Error('vault secret name must match ^[A-Z][A-Z0-9_]*$');
+    throw new Error('vault secret name must match ^[A-Za-z_][A-Za-z0-9_]*$');
   }
   return name;
 }

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1518,6 +1518,12 @@ def create_vault_secret(payload: dict) -> dict:
             )
     except vault_service.InvalidSecretNameError as exc:
         raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name") from exc
+    except vault_service.SecretNameCaseConflictError as exc:
+        raise VaultApiError(
+            f"secret name '{name}' conflicts with existing secret '{exc.existing_name}'",
+            code="secret_name_case_conflict",
+            status=409,
+        ) from exc
     except vault_service.SecretExistsError as exc:
         fulfilled_count = 0
         try:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1481,6 +1481,36 @@ def create_vault_secret(payload: dict) -> dict:
     signer_kind = payload.get("signer_kind")
     if signer_kind is not None:
         signer_kind = str(signer_kind)
+    provision_request_id = str(payload.get("provision_request_id") or "") or None
+    engine = _vault_engine()
+    try:
+        with engine.begin() as conn:
+            vault_service.preflight_secret_create(
+                conn,
+                name=name,
+                provision_request_id=provision_request_id,
+            )
+    except vault_service.InvalidSecretNameError as exc:
+        raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name") from exc
+    except vault_service.SecretNameCaseConflictError as exc:
+        raise VaultApiError(
+            f"secret name '{name}' conflicts with existing secret '{exc.existing_name}'",
+            code="secret_name_case_conflict",
+            status=409,
+        ) from exc
+    except vault_service.SecretExistsError as exc:
+        fulfilled_count = 0
+        try:
+            with engine.begin() as conn:
+                fulfilled_count = vault_service.fulfill_pending_provision_requests_for_secret(conn, name)
+        except Exception:
+            logger.warning("failed to settle pending provision requests for existing secret %s", name, exc_info=True)
+        if fulfilled_count > 0:
+            _publish_vaults_updated(scope="secret", secret_name=name, request_status="fulfilled")
+        raise VaultApiError(f"secret '{name}' already exists", code="secret_exists", status=409) from exc
+    except vault_service.VaultServiceError as exc:
+        raise VaultApiError(str(exc), code="vault_error") from exc
+
     if protection == "standard":
         blind_box = payload.get("blind_box")
         if isinstance(blind_box, dict):
@@ -1499,7 +1529,6 @@ def create_vault_secret(payload: dict) -> dict:
         sealed = _sealed_from_payload(payload.get("sealed") or payload.get("envelope") or payload)
     else:
         raise VaultApiError("invalid protection tier", code="invalid_protection")
-    engine = _vault_engine()
     try:
         with engine.begin() as conn:
             meta = vault_service.create_secret(
@@ -1514,7 +1543,7 @@ def create_vault_secret(payload: dict) -> dict:
                 policy=policy,
                 public_meta=public_meta,
                 establishing_vmk=establishing_vmk,
-                provision_request_id=str(payload.get("provision_request_id") or "") or None,
+                provision_request_id=provision_request_id,
             )
     except vault_service.InvalidSecretNameError as exc:
         raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name") from exc

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1465,7 +1465,7 @@ def create_vault_secret(payload: dict) -> dict:
     _reject_plaintext_value_fields(payload)
     name = str(payload.get("name") or "").strip()
     if not vault_crypto.is_valid_secret_name(name):
-        raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name")
+        raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name")
     tags = [str(tag) for tag in payload.get("tags", []) if isinstance(tag, str)] if isinstance(payload.get("tags"), list) else []
     policy = payload.get("policy") if isinstance(payload.get("policy"), dict) else None
     public_meta = payload.get("public_meta") if isinstance(payload.get("public_meta"), dict) else None
@@ -1517,7 +1517,7 @@ def create_vault_secret(payload: dict) -> dict:
                 provision_request_id=str(payload.get("provision_request_id") or "") or None,
             )
     except vault_service.InvalidSecretNameError as exc:
-        raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name") from exc
+        raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name") from exc
     except vault_service.SecretExistsError as exc:
         fulfilled_count = 0
         try:
@@ -1581,7 +1581,7 @@ def get_vault_provision_request_by_name(name: str) -> dict:
 
     requested_name = str(name or "").strip()
     if not vault_crypto.is_valid_secret_name(requested_name):
-        raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name")
+        raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name")
     engine = _vault_engine()
     with engine.begin() as conn:
         request, ambiguous = vault_service.resolve_pending_provision_request_by_name(conn, requested_name)
@@ -1720,7 +1720,7 @@ def request_vault_access(payload: dict) -> dict:
     if not name and source_selector is None:
         raise VaultApiError("name or source_selector is required", code="invalid_request", status=409)
     if name and not vault_crypto.is_valid_secret_name(name):
-        raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name")
+        raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name")
     purpose = str(payload.get("purpose") or "run")
     engine = _vault_engine()
     try:
@@ -1768,7 +1768,7 @@ def request_vault_sign(payload: dict) -> dict:
     if scheme not in vault_service.SUPPORTED_SIGNATURE_SCHEMES:
         raise VaultApiError(f"unsupported signature scheme: {scheme}", code="invalid_request", status=409)
     if not vault_crypto.is_valid_secret_name(name):
-        raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name")
+        raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name")
     engine = _vault_engine()
     try:
         with engine.begin() as conn:
@@ -2617,7 +2617,7 @@ def vault_sign(payload: dict) -> dict:
     if scheme not in vault_service.SUPPORTED_SIGNATURE_SCHEMES:
         raise VaultApiError(f"unsupported signature scheme: {scheme}", code="invalid_request", status=409)
     if not vault_crypto.is_valid_secret_name(name):
-        raise VaultApiError("invalid secret name (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name")
+        raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name")
     engine = _vault_engine()
     protected_response: dict | None = None
     protected_event: dict | None = None

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -6035,6 +6035,9 @@ def cmd_vault_request(args):
     except TaskCliError as exc:
         _print_task_error(exc)
         return 1
+    except vault_service.SecretNameCaseConflictError as exc:
+        _print_task_error(TaskCliError(str(exc), code="secret_name_case_conflict", help_command=help_command))
+        return 1
     except vault_service.VaultServiceError as exc:
         _print_task_error(TaskCliError(str(exc), code="invalid_spec", help_command=help_command))
         return 1

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4952,7 +4952,7 @@ def cmd_vault_access(args):
     name = getattr(args, "name", "")
     try:
         if not vault_crypto.is_valid_secret_name(name):
-            raise TaskCliError(f"invalid secret name: {name!r} (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name", help_command=help_command)
+            raise TaskCliError(f"invalid secret name: {name!r} (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name", help_command=help_command)
         engine = _open_vault_engine()
         with engine.begin() as conn:
             vault_service.get_secret_meta(conn, name)
@@ -5978,7 +5978,7 @@ def cmd_vault_request(args):
     try:
         name = args.name
         if not vault_crypto.is_valid_secret_name(name):
-            raise TaskCliError(f"invalid secret name: {name!r} (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name", help_command=help_command)
+            raise TaskCliError(f"invalid secret name: {name!r} (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name", help_command=help_command)
         spec = _load_vault_request_spec(args, help_command=help_command)
         engine = _open_vault_engine()
         with engine.begin() as conn:
@@ -6050,7 +6050,7 @@ def cmd_vault_sign(args):
     name = getattr(args, "name", "")
     try:
         if not vault_crypto.is_valid_secret_name(name):
-            raise TaskCliError(f"invalid secret name: {name!r} (use ^[A-Z][A-Z0-9_]*$)", code="invalid_name", help_command=help_command)
+            raise TaskCliError(f"invalid secret name: {name!r} (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name", help_command=help_command)
         digest = api._sign_digest_from_payload(getattr(args, "digest", None))
         scheme = getattr(args, "scheme", None) or "ecdsa-secp256k1-recoverable"
         engine = _open_vault_engine()


### PR DESCRIPTION
## Summary
- preserve user-entered Vault secret name casing across API, CLI, UI, and dynamic `$<name>` request parsing
- allow shell-style names matching `^[A-Za-z_][A-Za-z0-9_]*$`
- reject case-only duplicate secret names so exact lookup stays unambiguous
- enforce case-folded secret uniqueness atomically in SQLite with a `lower(name)` unique index
- enforce pending provision request case conflicts atomically with SQLite triggers while preserving exact-name sibling asks
- return deterministic `secret_name_case_conflict` errors before avault sealing or broad CLI invalid-spec handling
- update UI hints, docs, and focused tests for the new contract

## Evidence
- `python3 -m pytest tests/test_vault_crypto.py tests/test_reply_enhancer_secret_requests.py tests/test_vault_service.py::test_secret_names_preserve_case_and_reject_case_only_duplicates tests/test_vault_service.py::test_provision_request_rejects_case_only_duplicate_secret tests/test_vault_api.py::test_mixed_case_name_is_preserved_and_case_duplicate_rejected tests/test_vault_api.py::test_invalid_name_rejected_before_avault`
- `python3 -m pytest tests/test_vault_service.py::test_provision_request_case_guard_is_database_enforced tests/test_vault_api.py::test_case_conflict_is_rejected_before_standard_seal tests/test_vault_cli.py::test_request_case_conflict_uses_name_conflict_code tests/test_vault_schema.py::test_vault_metadata_schema_matches_grant_id_tag_model tests/test_sqlite_state_migration.py::test_run_migrations_adds_case_folded_vault_secret_name_index`
- `python3 -m pytest tests/test_vault_service.py tests/test_vault_api.py tests/test_vault_cli.py tests/test_vault_schema.py`
- `python3 -m pytest tests/test_sqlite_state_migration.py`
- `python3 -m ruff check storage/models.py storage/vault_service.py storage/alembic/versions/20260704_0027_vault_secret_name_case_index.py vibe/api.py vibe/cli.py tests/test_sqlite_state_migration.py tests/test_vault_schema.py tests/test_vault_service.py tests/test_vault_api.py tests/test_vault_cli.py`
- `cd ui && npm run test:crypto`
- `cd ui && npm run build`
- `git diff --check`
