### PR TITLE
perf(chat): ordered live insert + bounded retained transcript window

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -17,6 +17,7 @@ import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 import { formatLocalDateTime } from '../../lib/relativeTime';
 import { useFileDrop } from '../../lib/useFileDrop';
 import { quoteText } from '../../lib/quoteText';
+import { mergeById, insertMessageOrdered } from '../../lib/transcriptOrder';
 import { AgentRoutePicker } from './AgentRoutePicker';
 import { ShowPageShareControl } from './ShowPageShareControl';
 import { SelectionQuoteToolbar } from './SelectionQuoteToolbar';
@@ -59,27 +60,14 @@ const isTranscriptMessage = (msg: WorkbenchMessage): boolean =>
   msg.type === 'notify' ||
   (msg.metadata as { source?: string } | null)?.source === 'show_page';
 
-// Durable transcript order: ``created_at`` is second-resolution, so the
-// message id (a microsecond-clock prefix, see messages_service._new_message_id)
-// is the tie-break — matching the server's ``(created_at, id)`` ordering.
-const byCreatedThenId = (a: WorkbenchMessage, b: WorkbenchMessage): number => {
-  if (a.created_at !== b.created_at) return a.created_at < b.created_at ? -1 : 1;
-  if (a.id === b.id) return 0;
-  return a.id < b.id ? -1 : 1;
-};
-
-// Union two row sets, deduped by id and re-sorted into durable order. Used for
-// the initial snapshot + live merge AND every live append, so a fast agent
-// result that arrives over /api/events *before* its prompt row still lands in
-// the correct position instead of ahead of the prompt (Codex P2). Also closes
-// the load/subscribe race where a blind setMessages(snapshot) would clobber a
-// message that arrived over the stream before the REST load returned.
-const mergeById = (existing: WorkbenchMessage[], incoming: WorkbenchMessage[]): WorkbenchMessage[] => {
-  const seen = new Set(existing.map((m) => m.id));
-  const merged = [...existing, ...incoming.filter((m) => !seen.has(m.id))];
-  merged.sort(byCreatedThenId);
-  return merged;
-};
+// Bounded retained transcript window: cap how many message rows stay mounted so a
+// long streaming session (or a deep upward scroll) doesn't keep thousands of full
+// react-markdown subtrees in the DOM. The trimmed rows stay in SQLite and page
+// back in on demand (scroll up re-fetches older; the jump-to-latest button reloads
+// the live tail). Generous enough that normal chats never hit it. See the trim
+// logic in ``appendMessage`` (drop oldest while pinned) and ``loadOlderMessages``
+// (drop newest while reading history).
+const MAX_RETAINED_MESSAGES = 300;
 
 // Mirrors design.pen kxEkn — the inline header replaces the old "Session
 // settings" dialog. Title is click-to-edit; the cyan-bordered pill on the
@@ -217,11 +205,29 @@ export const ChatPage: React.FC = () => {
   const [olderCursor, setOlderCursor] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const loadingOlderRef = useRef(false);
+  // True while the loaded window does NOT reach the live tail: entered by a
+  // deep-link/search jump into a middle window, AND now by the retained-window
+  // cap when it drops the newest rows while the reader is scrolled up (see the
+  // MAX_RETAINED_MESSAGES trims). Suppresses live append/reconcile and shows the
+  // jump-to-latest button, which reloads the tail. Consumers: the SSE-append skip,
+  // reconcile skip, the send-path reloadLatest, and the inbox mark-read gate.
   const [historicalWindow, setHistoricalWindow] = useState(false);
   const historicalWindowRef = useRef(false);
   historicalWindowRef.current = historicalWindow;
   const oldestLoadedIdRef = useRef<string | null>(null);
   const newestLoadedIdRef = useRef<string | null>(null);
+  // Owned here but driven by the Transcript scroller (which reads/writes it in
+  // handleScroll / scrollToBottom): true while the viewport is following the live
+  // tail. The retained-window trim reads it to decide which end is safe to drop —
+  // dropping the oldest rows is invisible only when the reader is pinned to the
+  // bottom, far below them.
+  const followingTailRef = useRef(true);
+  // Set inside the trim updaters so the [messages] effect can finish the
+  // two-part state change against the COMMITTED transcript (robust to any racing
+  // append): re-point the older cursor after a pinned oldest-trim, and flip into
+  // the historical-window state after an upward newest-trim.
+  const trimmedOldestRef = useRef(false);
+  const trimmedNewestRef = useRef(false);
   // Deep-link jump (see deepLinkMessageId): the message id the transcript should
   // scroll to once its window is in the DOM, the id to highlight (~3s fade), and
   // the last ``msg`` value already handled so the jump effect runs once per value.
@@ -284,10 +290,32 @@ export const ChatPage: React.FC = () => {
   sessionIdRef.current = sessionId;
 
   const appendMessage = useCallback((msg: WorkbenchMessage) => {
-    // Dedupe by id (a sent user row is appended optimistically AND echoed over
-    // the stream) and keep durable (created_at, id) order so an out-of-order
-    // live event can't render a reply ahead of its prompt.
-    setMessages((prev) => (prev.some((m) => m.id === msg.id) ? prev : mergeById(prev, [msg])));
+    setMessages((prev) => {
+      // Ordered single-row insert (deduped, no full re-sort) so an out-of-order
+      // live event can't render a reply ahead of its prompt.
+      const next = insertMessageOrdered(prev, msg);
+      if (next === prev) return prev; // dup — same reference, React skips
+      if (next.length <= MAX_RETAINED_MESSAGES) return next;
+      // Over the cap — trim the end AWAY from the reader so a long streaming
+      // session can't keep thousands of rows mounted, whichever way they're
+      // looking:
+      //   • following the tail → drop the OLDEST (far above the pinned viewport,
+      //     invisible); the [messages] effect re-points the older cursor at the
+      //     new oldest (before_id is exclusive) so scroll-up pages them back.
+      //   • scrolled up reading history → drop the NEWEST (below the viewport;
+      //     the manual scroll-anchor tracks the TOP visible row, so removing tail
+      //     rows can't shift the reader) and detach the tail via the historical-
+      //     window state so the jump-to-latest button reloads it. This also bounds
+      //     the reader-parked-scrolled-up-mid-stream case (the row stays in SQLite
+      //     and returns on reload). Only reachable in 300+ row sessions, so normal
+      //     scroll-up-in-a-live-chat behavior is unchanged.
+      if (followingTailRef.current) {
+        trimmedOldestRef.current = true;
+        return next.slice(next.length - MAX_RETAINED_MESSAGES);
+      }
+      trimmedNewestRef.current = true;
+      return next.slice(0, MAX_RETAINED_MESSAGES);
+    });
   }, []);
 
   // The header's backend lock keys on ``native_session_id``, which the FIRST
@@ -317,6 +345,22 @@ export const ChatPage: React.FC = () => {
   useEffect(() => {
     oldestLoadedIdRef.current = messages[0]?.id ?? null;
     newestLoadedIdRef.current = messages[messages.length - 1]?.id ?? null;
+    // Finish a retained-window trim against the COMMITTED transcript. Both flags
+    // are only set when rows were actually dropped, so the paired state change is
+    // always valid and idempotent under a double-invoked updater.
+    if (trimmedOldestRef.current) {
+      trimmedOldestRef.current = false;
+      // Oldest rows dropped while following the tail → older rows certainly remain
+      // on the server; the paging invariant is olderCursor === messages[0].id.
+      setOlderCursor(messages[0]?.id ?? null);
+    }
+    if (trimmedNewestRef.current) {
+      trimmedNewestRef.current = false;
+      // Newest rows dropped while paging up → the live tail is no longer loaded,
+      // so behave like a historical window: the jump-to-latest button reloads the
+      // tail and live appends are (correctly) skipped until then.
+      setHistoricalWindow(true);
+    }
   }, [messages]);
 
   // Reconcile against durable storage after a window where ``message.new`` could
@@ -376,7 +420,19 @@ export const ChatPage: React.FC = () => {
       if (sessionId !== sessionIdRef.current) return true; // switched chats mid-fetch
       const older = res.messages.filter(isTranscriptMessage);
       if (older.length) {
-        setMessages((prev) => mergeById(prev, older));
+        setMessages((prev) => {
+          const merged = mergeById(prev, older);
+          // Bounded retained window: paging up only fires while scrolled to the
+          // top (not pinned), so drop the newest overflow — those rows sit far
+          // BELOW the viewport, and the manual scroll-anchor tracks the TOP
+          // visible row, so removing them can't shift the reader's position. The
+          // effect flips into the historical-window state (the live tail is gone).
+          if (merged.length > MAX_RETAINED_MESSAGES) {
+            trimmedNewestRef.current = true;
+            return merged.slice(0, MAX_RETAINED_MESSAGES);
+          }
+          return merged;
+        });
       }
       setOlderCursor(res.next_before_id ?? null);
       return true;
@@ -550,6 +606,11 @@ export const ChatPage: React.FC = () => {
     newestLoadedIdRef.current = null;
     loadingOlderRef.current = false;
     setLoadingOlder(false);
+    // Reset the retained-window state so no stale trim signal or follow flag from
+    // the previous chat leaks into the fresh one (the Transcript re-pins on open).
+    followingTailRef.current = true;
+    trimmedOldestRef.current = false;
+    trimmedNewestRef.current = false;
     // Drop any pending jump/highlight so it can't fire against the new session.
     setJumpTarget(null);
     setHighlightedId(null);
@@ -1368,6 +1429,7 @@ export const ChatPage: React.FC = () => {
           onQuickReply={handleQuickReply}
           onQuoteSelection={quoteSelectionToComposer}
           onAskInNewSession={askInNewSession}
+          followingTailRef={followingTailRef}
         />
         <QueueStrip queue={queue} onRemove={removeQueued} onRecall={recallQueued} onSendNow={sendQueueNow} />
         {/* key by session so the composer remounts per session — its draft-seeding
@@ -1749,6 +1811,10 @@ interface TranscriptProps {
   // ask in a new session seeded with the quote.
   onQuoteSelection: (text: string) => void;
   onAskInNewSession: (text: string) => void;
+  // Owned by ChatPage, driven here: true while the viewport follows the live
+  // tail. Lifted so the retained-window trim (ChatPage.appendMessage) can tell
+  // when dropping the oldest rows is safe (reader pinned to the bottom).
+  followingTailRef: React.MutableRefObject<boolean>;
 }
 
 const Transcript: React.FC<TranscriptProps> = ({
@@ -1767,6 +1833,7 @@ const Transcript: React.FC<TranscriptProps> = ({
   onQuickReply,
   onQuoteSelection,
   onAskInNewSession,
+  followingTailRef,
 }) => {
   const { t } = useTranslation();
   const forkSourceSessionId =
@@ -1795,7 +1862,9 @@ const Transcript: React.FC<TranscriptProps> = ({
   // ``true`` while the viewport is FOLLOWING the bottom (at/near it) — drives the
   // auto-follow of new content and hides the jump button. A ref, not state, so the
   // scroll handler + ResizeObserver read it without stale closures or extra renders.
-  const pinnedRef = useRef(true);
+  // Owned by ChatPage (see followingTailRef) so its retained-window trim can read
+  // the same follow state; every pinnedRef.current access below drives it.
+  const pinnedRef = followingTailRef;
   // While the user has scrolled UP to read history (not pinned), remember the
   // topmost row still in view and how far its top sits below the viewport top, so
   // any later content resize can put that exact row back where it was. This is a

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -64,9 +64,12 @@ const isTranscriptMessage = (msg: WorkbenchMessage): boolean =>
 // long streaming session (or a deep upward scroll) doesn't keep thousands of full
 // react-markdown subtrees in the DOM. The trimmed rows stay in SQLite and page
 // back in on demand (scroll up re-fetches older; the jump-to-latest button reloads
-// the live tail). Generous enough that normal chats never hit it. See the trim
-// logic in ``appendMessage`` (drop oldest while pinned) and ``loadOlderMessages``
-// (drop newest while reading history).
+// the live tail). Generous enough that normal chats never hit it. Enforced at two
+// kinds of site: while following the tail, ``appendMessage`` / ``reconcile`` drop
+// the OLDEST overflow (above the pinned viewport); while the reader is scrolled up,
+// the ingest points (``onMessageNew`` / ``reconcile``) and ``loadOlderMessages``
+// detach the live tail (historical-window) instead of growing the DOM with rows
+// below the viewport.
 const MAX_RETAINED_MESSAGES = 300;
 
 // Mirrors design.pen kxEkn — the inline header replaces the old "Session
@@ -206,11 +209,11 @@ export const ChatPage: React.FC = () => {
   const [loadingOlder, setLoadingOlder] = useState(false);
   const loadingOlderRef = useRef(false);
   // True while the loaded window does NOT reach the live tail: entered by a
-  // deep-link/search jump into a middle window, AND now by the retained-window
-  // cap when it drops the newest rows while the reader is scrolled up (see the
-  // MAX_RETAINED_MESSAGES trims). Suppresses live append/reconcile and shows the
-  // jump-to-latest button, which reloads the tail. Consumers: the SSE-append skip,
-  // reconcile skip, the send-path reloadLatest, and the inbox mark-read gate.
+  // deep-link/search jump into a middle window, AND by the retained-window cap
+  // detaching the tail while the reader is scrolled up (see MAX_RETAINED_MESSAGES).
+  // Suppresses live append/reconcile and shows the jump-to-latest button, which
+  // reloads the tail. Consumers: the SSE-append skip, reconcile skip, the
+  // send-path reloadLatest, and the inbox mark-read gate.
   const [historicalWindow, setHistoricalWindow] = useState(false);
   const historicalWindowRef = useRef(false);
   historicalWindowRef.current = historicalWindow;
@@ -222,12 +225,12 @@ export const ChatPage: React.FC = () => {
   // dropping the oldest rows is invisible only when the reader is pinned to the
   // bottom, far below them.
   const followingTailRef = useRef(true);
-  // Set inside the trim updaters so the [messages] effect can finish the
-  // two-part state change against the COMMITTED transcript (robust to any racing
-  // append): re-point the older cursor after a pinned oldest-trim, and flip into
-  // the historical-window state after an upward newest-trim.
+  // Set inside the pinned oldest-trim updater so the [messages] effect can
+  // re-point the older cursor against the COMMITTED transcript (robust to a racing
+  // append, and idempotent under a double-invoked updater). The newest-side trim
+  // detaches the tail synchronously at its ingest point, so it needs no deferred
+  // signal here.
   const trimmedOldestRef = useRef(false);
-  const trimmedNewestRef = useRef(false);
   // Deep-link jump (see deepLinkMessageId): the message id the transcript should
   // scroll to once its window is in the DOM, the id to highlight (~3s fade), and
   // the last ``msg`` value already handled so the jump effect runs once per value.
@@ -295,26 +298,18 @@ export const ChatPage: React.FC = () => {
       // live event can't render a reply ahead of its prompt.
       const next = insertMessageOrdered(prev, msg);
       if (next === prev) return prev; // dup — same reference, React skips
-      if (next.length <= MAX_RETAINED_MESSAGES) return next;
-      // Over the cap — trim the end AWAY from the reader so a long streaming
-      // session can't keep thousands of rows mounted, whichever way they're
-      // looking:
-      //   • following the tail → drop the OLDEST (far above the pinned viewport,
-      //     invisible); the [messages] effect re-points the older cursor at the
-      //     new oldest (before_id is exclusive) so scroll-up pages them back.
-      //   • scrolled up reading history → drop the NEWEST (below the viewport;
-      //     the manual scroll-anchor tracks the TOP visible row, so removing tail
-      //     rows can't shift the reader) and detach the tail via the historical-
-      //     window state so the jump-to-latest button reloads it. This also bounds
-      //     the reader-parked-scrolled-up-mid-stream case (the row stays in SQLite
-      //     and returns on reload). Only reachable in 300+ row sessions, so normal
-      //     scroll-up-in-a-live-chat behavior is unchanged.
-      if (followingTailRef.current) {
+      // Bounded retained window: while following the live tail, drop the oldest
+      // overflow (far above the pinned viewport, invisible); the [messages] effect
+      // re-points the older cursor at the new oldest (before_id is exclusive) so
+      // scroll-up pages them back exactly. The scrolled-up case is handled at the
+      // ingest points (onMessageNew / reconcile), which detach the tail instead of
+      // growing the DOM — so this path never drops a row the reader can see, and
+      // the user's own optimistically-appended sends are always kept.
+      if (followingTailRef.current && next.length > MAX_RETAINED_MESSAGES) {
         trimmedOldestRef.current = true;
         return next.slice(next.length - MAX_RETAINED_MESSAGES);
       }
-      trimmedNewestRef.current = true;
-      return next.slice(0, MAX_RETAINED_MESSAGES);
+      return next;
     });
   }, []);
 
@@ -345,21 +340,16 @@ export const ChatPage: React.FC = () => {
   useEffect(() => {
     oldestLoadedIdRef.current = messages[0]?.id ?? null;
     newestLoadedIdRef.current = messages[messages.length - 1]?.id ?? null;
-    // Finish a retained-window trim against the COMMITTED transcript. Both flags
-    // are only set when rows were actually dropped, so the paired state change is
-    // always valid and idempotent under a double-invoked updater.
+    // Finish a pinned oldest-trim against the COMMITTED transcript. The flag is
+    // only set when rows were actually dropped while following the tail, so older
+    // rows certainly remain on the server: re-point the older cursor at the new
+    // oldest (paging invariant olderCursor === messages[0].id; before_id is
+    // exclusive). Idempotent under a double-invoked updater. The newest-side trim
+    // (scrolled up) instead detaches the tail synchronously at the ingest point,
+    // so there is no deferred historical flip to reconcile here.
     if (trimmedOldestRef.current) {
       trimmedOldestRef.current = false;
-      // Oldest rows dropped while following the tail → older rows certainly remain
-      // on the server; the paging invariant is olderCursor === messages[0].id.
       setOlderCursor(messages[0]?.id ?? null);
-    }
-    if (trimmedNewestRef.current) {
-      trimmedNewestRef.current = false;
-      // Newest rows dropped while paging up → the live tail is no longer loaded,
-      // so behave like a historical window: the jump-to-latest button reloads the
-      // tail and live appends are (correctly) skipped until then.
-      setHistoricalWindow(true);
     }
   }, [messages]);
 
@@ -376,6 +366,15 @@ export const ChatPage: React.FC = () => {
   const reconcile = useCallback(async () => {
     if (!sessionId) return;
     if (historicalWindowRef.current) return;
+    // Reader scrolled up in an already-capped window: don't recover tail rows they
+    // aren't looking at into the DOM — detach the live tail so jump-to-latest
+    // reloads it. Synchronous flip (not via the [messages] effect) so the same
+    // commit gates mark-read. Bounds repeated-gap growth: once historical, this
+    // early-returns above. Mirrors the onMessageNew ingest policy.
+    if (!followingTailRef.current && messagesRef.current.length >= MAX_RETAINED_MESSAGES) {
+      setHistoricalWindow(true);
+      return;
+    }
     try {
       // tail: the RECENT window (not the oldest page), so a missed latest row in
       // a long chat is actually recovered (Codex P2).
@@ -386,7 +385,19 @@ export const ChatPage: React.FC = () => {
         const tailOldestId = fresh[0].id;
         const previousOldestId = oldestLoadedIdRef.current;
         const previousNewestId = newestLoadedIdRef.current;
-        setMessages((prev) => mergeById(prev, fresh));
+        setMessages((prev) => {
+          const merged = mergeById(prev, fresh);
+          // Following the tail: keep the window capped. A gap larger than the tail
+          // fetch, recovered here, would otherwise blow past the cap until the next
+          // live append (Codex). Drop the oldest; the [messages] effect re-points
+          // the older cursor (it overrides the cursor set below, which stays for
+          // the no-trim case).
+          if (followingTailRef.current && merged.length > MAX_RETAINED_MESSAGES) {
+            trimmedOldestRef.current = true;
+            return merged.slice(merged.length - MAX_RETAINED_MESSAGES);
+          }
+          return merged;
+        });
         if (!previousOldestId || !previousNewestId || tailOldestId > previousNewestId) {
           setOlderCursor(res.next_before_id ?? null);
         }
@@ -420,19 +431,21 @@ export const ChatPage: React.FC = () => {
       if (sessionId !== sessionIdRef.current) return true; // switched chats mid-fetch
       const older = res.messages.filter(isTranscriptMessage);
       if (older.length) {
+        // Bounded retained window: paging up only fires while scrolled to the top
+        // (not pinned), so drop the newest overflow — those rows sit far BELOW the
+        // viewport, and the manual scroll-anchor tracks the TOP visible row, so
+        // removing them can't shift the reader. Older rows are strictly before the
+        // current head (before_id is exclusive), so they never overlap and the
+        // merged length is deterministic — detach the live tail SYNCHRONOUSLY when
+        // it will exceed the cap (not via the [messages] effect) so the same commit
+        // that hides the tail also gates mark-read, keeping an unseen trimmed reply
+        // unread. jump-to-latest reloads the tail.
+        const willDetachTail = messagesRef.current.length + older.length > MAX_RETAINED_MESSAGES;
         setMessages((prev) => {
           const merged = mergeById(prev, older);
-          // Bounded retained window: paging up only fires while scrolled to the
-          // top (not pinned), so drop the newest overflow — those rows sit far
-          // BELOW the viewport, and the manual scroll-anchor tracks the TOP
-          // visible row, so removing them can't shift the reader's position. The
-          // effect flips into the historical-window state (the live tail is gone).
-          if (merged.length > MAX_RETAINED_MESSAGES) {
-            trimmedNewestRef.current = true;
-            return merged.slice(0, MAX_RETAINED_MESSAGES);
-          }
-          return merged;
+          return merged.length > MAX_RETAINED_MESSAGES ? merged.slice(0, MAX_RETAINED_MESSAGES) : merged;
         });
+        if (willDetachTail) setHistoricalWindow(true);
       }
       setOlderCursor(res.next_before_id ?? null);
       return true;
@@ -610,7 +623,6 @@ export const ChatPage: React.FC = () => {
     // the previous chat leaks into the fresh one (the Transcript re-pins on open).
     followingTailRef.current = true;
     trimmedOldestRef.current = false;
-    trimmedNewestRef.current = false;
     // Drop any pending jump/highlight so it can't fire against the new session.
     setJumpTarget(null);
     setHighlightedId(null);
@@ -646,6 +658,15 @@ export const ChatPage: React.FC = () => {
         if (msg.session_id !== sessionIdRef.current) return;
         if (!isTranscriptMessage(msg)) return;
         if (historicalWindowRef.current) return;
+        // Reader scrolled up in an already-capped window: don't grow the DOM with a
+        // live row they aren't looking at — detach the live tail so jump-to-latest
+        // reloads it. Flip synchronously (not append-then-trim) so the SAME commit
+        // gates mark-read: an unseen tail reply stays unread. The row is in SQLite
+        // and returns on reload. Only reachable in 300+ row sessions.
+        if (!followingTailRef.current && messagesRef.current.length >= MAX_RETAINED_MESSAGES) {
+          setHistoricalWindow(true);
+          return;
+        }
         appendMessage(msg);
         // Don't clear ``working`` from a result row here: with the queue, a
         // result can belong to an EARLIER turn while a newer queued turn is
@@ -1902,6 +1923,16 @@ const Transcript: React.FC<TranscriptProps> = ({
   useEffect(() => {
     reloadLatestRef.current = onReloadLatest;
   }, [onReloadLatest]);
+
+  // Whenever the loaded window stops reaching the live tail — a search deep-link
+  // window OR the retained-window cap detaching the tail while the reader is
+  // scrolled up — force the jump-to-latest control visible. handleScroll only
+  // recomputes ``showJump`` on scroll events, so a detach with no subsequent
+  // scroll (the cap dropping an incoming row) would otherwise leave the reader
+  // with no way back to the live tail until they scroll again.
+  useEffect(() => {
+    if (needsLatestReload) setShowJump(true);
+  }, [needsLatestReload]);
 
   // The reply arrives atomically as a persisted ``result`` row (no streaming
   // card), so the thinking bubble shows for the whole gap between send and

--- a/ui/src/lib/transcriptOrder.test.ts
+++ b/ui/src/lib/transcriptOrder.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkbenchMessage } from '../context/ApiContext';
+import { byCreatedThenId, mergeById, insertMessageOrdered } from './transcriptOrder';
+
+// The transcript keeps its rows in durable (created_at, id) order at all times.
+// Only id + created_at drive ordering, so fixtures fill just those; the rest is
+// cast away. ``created_at`` is second-resolution server-side, so same-second rows
+// with different ids exercise the id tie-break (the case that would otherwise let
+// a fast agent result render ahead of its prompt). Timestamps stay whole-second to
+// match the real format — mixing fractional seconds would only test a string-
+// compare artifact the server never produces.
+const t = (s: number) => `2024-01-01T00:00:${String(s).padStart(2, '0')}Z`;
+const mk = (id: string, created_at: string): WorkbenchMessage =>
+  ({ id, created_at }) as unknown as WorkbenchMessage;
+const ids = (list: WorkbenchMessage[]): string[] => list.map((m) => m.id);
+
+describe('byCreatedThenId', () => {
+  it('orders by created_at first', () => {
+    expect(byCreatedThenId(mk('b', t(1)), mk('a', t(2)))).toBe(-1);
+    expect(byCreatedThenId(mk('a', t(2)), mk('b', t(1)))).toBe(1);
+  });
+
+  it('breaks created_at ties by id', () => {
+    expect(byCreatedThenId(mk('a', t(1)), mk('b', t(1)))).toBe(-1);
+    expect(byCreatedThenId(mk('b', t(1)), mk('a', t(1)))).toBe(1);
+  });
+
+  it('returns 0 only for the same id at the same time', () => {
+    expect(byCreatedThenId(mk('a', t(1)), mk('a', t(1)))).toBe(0);
+  });
+});
+
+describe('mergeById', () => {
+  it('dedupes by id and sorts into durable order', () => {
+    const existing = [mk('p1', t(1))];
+    const incoming = [mk('p1', t(1)), mk('r1', t(2))];
+    expect(ids(mergeById(existing, incoming))).toEqual(['p1', 'r1']);
+  });
+
+  it('places an out-of-order result behind its prompt (same second, id tie-break)', () => {
+    // The result row (id ``r``) arrived over the stream BEFORE its prompt (id
+    // ``p``), both stamped the same second. Durable order must keep p before r.
+    const existing = [mk('r', t(5))];
+    expect(ids(mergeById(existing, [mk('p', t(5))]))).toEqual(['p', 'r']);
+  });
+
+  it('handles empty inputs', () => {
+    expect(mergeById([], [])).toEqual([]);
+    expect(ids(mergeById([], [mk('a', t(1))]))).toEqual(['a']);
+  });
+});
+
+describe('insertMessageOrdered', () => {
+  // Gaps between seconds leave room to insert a strictly-in-between row.
+  const base = () => [mk('a', t(1)), mk('c', t(3)), mk('e', t(5))];
+
+  it('returns [msg] for an empty transcript', () => {
+    expect(ids(insertMessageOrdered([], mk('a', t(1))))).toEqual(['a']);
+  });
+
+  it('appends (fast path) a message newer than the tail without re-sorting', () => {
+    expect(ids(insertMessageOrdered(base(), mk('z', t(7))))).toEqual(['a', 'c', 'e', 'z']);
+  });
+
+  it('returns the SAME array reference on a duplicate id (React skips the render)', () => {
+    const list = base();
+    expect(insertMessageOrdered(list, mk('c', t(3)))).toBe(list);
+  });
+
+  it('binary-inserts an out-of-order arrival at the head', () => {
+    expect(ids(insertMessageOrdered(base(), mk('0', t(0))))).toEqual(['0', 'a', 'c', 'e']);
+  });
+
+  it('binary-inserts an out-of-order arrival into the middle', () => {
+    // Stamped between ``a`` (t1) and ``c`` (t3) → lands at index 1.
+    expect(ids(insertMessageOrdered(base(), mk('b', t(2))))).toEqual(['a', 'b', 'c', 'e']);
+  });
+
+  it('respects the id tie-break when created_at matches an existing row', () => {
+    // Same second as ``c`` (t3): id ``bb`` < ``c`` sorts before it, ``cc`` > ``c`` after.
+    expect(ids(insertMessageOrdered(base(), mk('bb', t(3))))).toEqual(['a', 'bb', 'c', 'e']);
+    expect(ids(insertMessageOrdered(base(), mk('cc', t(3))))).toEqual(['a', 'c', 'cc', 'e']);
+  });
+
+  it('never mutates the input array', () => {
+    const list = base();
+    insertMessageOrdered(list, mk('0', t(0)));
+    expect(ids(list)).toEqual(['a', 'c', 'e']);
+  });
+
+  it('matches mergeById ordering for any single-row insert (equivalence)', () => {
+    const list = base();
+    for (const probe of [mk('0', t(0)), mk('b', t(2)), mk('z', t(7)), mk('cc', t(3))]) {
+      expect(ids(insertMessageOrdered(list, probe))).toEqual(ids(mergeById(list, [probe])));
+    }
+  });
+});

--- a/ui/src/lib/transcriptOrder.ts
+++ b/ui/src/lib/transcriptOrder.ts
@@ -1,0 +1,60 @@
+import type { WorkbenchMessage } from '../context/ApiContext';
+
+// Pure ordering/merge helpers for the chat transcript, kept transport-agnostic
+// (they only read ``created_at`` / ``id``) so the ordering contract can be unit
+// tested independently of the ChatPage component. The chat keeps its ``messages``
+// array sorted in durable (created_at, id) order at all times; these helpers are
+// the only things that decide where a row lands.
+
+// Durable transcript order: ``created_at`` is second-resolution, so the message
+// id (a microsecond-clock prefix, see messages_service._new_message_id) is the
+// tie-break — matching the server's ``(created_at, id)`` ordering.
+export const byCreatedThenId = (a: WorkbenchMessage, b: WorkbenchMessage): number => {
+  if (a.created_at !== b.created_at) return a.created_at < b.created_at ? -1 : 1;
+  if (a.id === b.id) return 0;
+  return a.id < b.id ? -1 : 1;
+};
+
+// Union two row sets, deduped by id and re-sorted into durable order. Used by the
+// BATCH paths (initial snapshot, reconcile, older-page load), so a fast agent
+// result that arrives over /api/events *before* its prompt row still lands in the
+// correct position instead of ahead of the prompt. Also closes the load/subscribe
+// race where a blind setMessages(snapshot) would clobber a message that arrived
+// over the stream before the REST load returned. The single-row live path uses
+// ``insertMessageOrdered`` instead — a full re-sort on every streamed
+// ``message.new`` was O(n log n) per chunk over a monotonically growing array.
+export const mergeById = (
+  existing: WorkbenchMessage[],
+  incoming: WorkbenchMessage[],
+): WorkbenchMessage[] => {
+  const seen = new Set(existing.map((m) => m.id));
+  const merged = [...existing, ...incoming.filter((m) => !seen.has(m.id))];
+  merged.sort(byCreatedThenId);
+  return merged;
+};
+
+// Insert ONE live row into the already-sorted transcript, preserving durable
+// (created_at, id) order without re-sorting the whole array. The transcript is
+// kept sorted, so the common case — a message newer than everything shown — is an
+// O(1) append; an out-of-order arrival (a fast agent result that beat its prompt
+// over the socket) binary-searches its slot and splices. Deduped by id (a sent
+// user row is echoed over the stream; a reconcile can race it), and the SAME array
+// reference is returned on a dup so React skips the re-render.
+export const insertMessageOrdered = (
+  existing: WorkbenchMessage[],
+  msg: WorkbenchMessage,
+): WorkbenchMessage[] => {
+  if (existing.some((m) => m.id === msg.id)) return existing;
+  const n = existing.length;
+  if (n === 0 || byCreatedThenId(msg, existing[n - 1]) > 0) return [...existing, msg];
+  let lo = 0;
+  let hi = n;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (byCreatedThenId(existing[mid], msg) < 0) lo = mid + 1;
+    else hi = mid;
+  }
+  const next = existing.slice();
+  next.splice(lo, 0, msg);
+  return next;
+};


### PR DESCRIPTION
## Capability

Fixes two unbounded costs in the Workbench chat transcript (`ui/src/components/workbench/ChatPage.tsx`) that degrade long / actively-streaming sessions:

1. **Per-chunk full re-sort.** Every `message.new` SSE event ran `mergeById(prev, [msg])`, which rebuilt a `Set` of all ids, spread the whole array, and `.sort()`-ed it — O(n log n) on a monotonically growing array, on the hot live-streaming path.
2. **No retained-window cap.** `messages.map(...)` renders every row as a full react-markdown subtree with no windowing; infinite scroll appended 50 older rows per gesture and never trimmed, and live streaming appended forever — so a long session kept thousands of subtrees mounted.

## Changes

- **Ordered single-row insert.** Extracted the pure ordering helpers (`byCreatedThenId`, `mergeById`, and a new `insertMessageOrdered`) into `ui/src/lib/transcriptOrder.ts`. The live path now inserts in order — O(1) append when the row is newer than the tail (the overwhelming common case), binary-search + splice when it arrives out of order — instead of re-sorting. `mergeById` (full sort) is retained for the batch paths (bootstrap / reconcile / older-page load), where a full union+sort is the right tool.
- **Bounded retained window** (`MAX_RETAINED_MESSAGES = 300`), trimming the end *away* from the reader so the scroll-anchor is never disturbed:
  - *Following the live tail* → drop the **oldest** overflow (far above the pinned viewport) and re-point the older cursor at the new oldest. `before_id` is exclusive (`storage/messages_service.py`), so scroll-up pages the trimmed rows back exactly — no gap, no dup, no loss.
  - *Scrolled up reading history* → drop the **newest** overflow (below the viewport; the manual iOS scroll-anchor tracks the top visible row, so removing tail rows can't shift the reader) and reuse the existing **historical-window** state, so the jump-to-latest button reloads the live tail. This also bounds the reader-parked-scrolled-up-mid-stream case.
  - Only reachable in **300+ row sessions**; shorter chats behave exactly as before. Trimmed rows stay in SQLite and page back on demand.
- Lifted the Transcript scroller's `pinnedRef` up to ChatPage as `followingTailRef` so the trim can tell which end is safe to drop.

## Affected scenarios

No scenario catalog covers the Workbench chat UI. Manually exercised paths:
- Live streaming while pinned (auto-follow), including past the 300-row cap.
- Scroll-up infinite history load + iOS scroll-anchor stability (no jump on trim / late image).
- Deep-link / search jump (centered window ≤101 rows, under the cap), and jump-to-latest reload.
- Out-of-order arrival (result before its prompt) still orders correctly.
- Session switch resets the window state.

## Evidence layers

- **Unit:** new `ui/src/lib/transcriptOrder.test.ts` (14 cases) — ordering, dedup/same-reference, append fast-path, binary insert at head/middle/tail, id tie-break, no input mutation, and `insertMessageOrdered` ≡ `mergeById` equivalence. `npx vitest run` green.
- **Contract:** none changed (no API/schema change; `before_id` cursor semantics relied on, not modified).
- **Scenario:** none (no catalog for this surface).
- **Build / typecheck:** `tsc -b` + `vite build` green (the UI CI gate).
- **Residual manual checks:** the affected-scenarios list above on a long/streaming session; full Incus regression not run for this UI-only change.

Pre-PR self-review (reviewer subagent) run; the one significant finding (unbounded growth when parked scrolled-up mid-stream) is fixed by the symmetric newest-trim + historical-window flip.