### PR TITLE
fix(doctor): preserve empty home during repair

### DIFF
--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -730,6 +730,7 @@ def test_current_cli_install_family_resolves_cached_launcher_symlink(monkeypatch
 
 def test_repair_duplicate_service_processes_stops_only_extra_process(monkeypatch):
     stopped = []
+    paths.ensure_data_dirs()
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1234)
     monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
@@ -746,6 +747,7 @@ def test_repair_duplicate_service_processes_stops_only_extra_process(monkeypatch
 def test_repair_stale_install_runtime_stops_only_legacy_extra_process(monkeypatch):
     stopped = []
     refreshed = []
+    paths.ensure_data_dirs()
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
@@ -772,6 +774,7 @@ def test_repair_stale_install_runtime_stops_only_legacy_extra_process(monkeypatc
 def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monkeypatch):
     stopped = []
     statuses = []
+    paths.ensure_data_dirs()
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
@@ -797,6 +800,7 @@ def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monk
 def test_repair_stale_install_runtime_restarts_after_lockless_legacy_stopped(monkeypatch):
     stopped = []
     statuses = []
+    paths.ensure_data_dirs()
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: None)
@@ -822,6 +826,7 @@ def test_repair_stale_install_runtime_restarts_after_lockless_legacy_stopped(mon
 def test_repair_stale_install_runtime_reports_failed_when_restart_fails(monkeypatch):
     stopped = []
     refreshed = []
+    paths.ensure_data_dirs()
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
@@ -853,6 +858,45 @@ def test_repair_home_migration_skips_empty_home_without_initializing(monkeypatch
     result = cli._repair_home_migration()
 
     assert result["status"] == "skipped"
+    assert not (home / ".avibe").exists()
+    assert not (home / ".vibe_remote").exists()
+
+
+def test_repair_doctor_targets_skips_empty_home_without_post_doctor(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.delenv("AVIBE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(cli, "_doctor", lambda: (_ for _ in ()).throw(AssertionError("skipped repair must not run doctor")))
+
+    result = cli._repair_doctor_targets(["home-migration"], dry_run=False)
+
+    assert result["ok"] is True
+    assert result["results"][0]["status"] == "skipped"
+    assert "doctor" not in result
+    assert not (home / ".avibe").exists()
+    assert not (home / ".vibe_remote").exists()
+
+
+def test_repair_all_targets_skips_empty_home_without_initializing(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    monkeypatch.delenv("AVIBE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setenv("HOME", str(home))
+
+    def fail_probe(*args, **kwargs):
+        raise AssertionError("empty-home repair must not probe runtime state")
+
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", fail_probe)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", fail_probe)
+    monkeypatch.setattr(cli, "_current_cli_install_family", fail_probe)
+    monkeypatch.setattr(cli, "_doctor", fail_probe)
+
+    result = cli._repair_doctor_targets([], dry_run=False)
+
+    assert result["ok"] is True
+    assert {item["status"] for item in result["results"]} == {"skipped"}
+    assert "doctor" not in result
     assert not (home / ".avibe").exists()
     assert not (home / ".vibe_remote").exists()
 
@@ -929,6 +973,27 @@ def test_doctor_repair_dry_run_does_not_probe_runtime(monkeypatch):
 
     assert result["ok"] is True
     assert result["results"][0]["status"] == "planned"
+
+
+def test_doctor_repair_refreshes_diagnostics_after_repair(monkeypatch):
+    paths.ensure_data_dirs()
+    restart_path = runtime.get_restart_status_path()
+    runtime.write_json(restart_path, {"state": "running", "supervisor_pid": 4242})
+    old_timestamp = time.time() - 120
+    os.utime(restart_path, (old_timestamp, old_timestamp))
+    monkeypatch.setattr(cli.runtime, "pid_alive", lambda pid: False)
+    refreshed = []
+    doctor_calls = []
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: refreshed.append(True))
+    monkeypatch.setattr(cli, "_doctor", lambda: doctor_calls.append(True) or {"ok": True, "groups": []})
+
+    result = cli._repair_doctor_targets(["stale-restart-state"], dry_run=False)
+
+    assert result["ok"] is True
+    assert result["results"][0]["status"] == "repaired"
+    assert refreshed == [True]
+    assert doctor_calls == [True]
+    assert result["doctor"] == {"ok": True, "groups": []}
 
 
 def test_restart_parser_accepts_delay_seconds():

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -7858,6 +7858,11 @@ def _start_service_after_repair(target: str, success_message: str, failure_messa
     )
 
 
+def _runtime_home_exists_for_repair() -> bool:
+    runtime_home = paths.get_vibe_remote_dir()
+    return runtime_home.is_dir()
+
+
 def _repair_home_migration(*, dry_run: bool = False) -> dict:
     target = "home-migration"
     if os.environ.get(paths.AVIBE_HOME_ENV):
@@ -7937,6 +7942,8 @@ def _repair_duplicate_service_processes(*, dry_run: bool = False) -> dict:
     target = "duplicate-service-processes"
     if runtime.service_instance_lock_attached_to_process():
         return _doctor_repair_result(target, "failed", "Run this repair from the CLI, not from inside the service process.")
+    if not _runtime_home_exists_for_repair():
+        return _doctor_repair_result(target, "skipped", "No runtime home exists yet; no service process state needs repair.")
 
     owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
     extra_pids = runtime.extra_service_process_pids(owner_pid=owner_pid)
@@ -7982,6 +7989,8 @@ def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
     target = "stale-install-runtime"
     if runtime.service_instance_lock_attached_to_process():
         return _doctor_repair_result(target, "failed", "Run this repair from the CLI, not from inside the service process.")
+    if not _runtime_home_exists_for_repair():
+        return _doctor_repair_result(target, "skipped", "No runtime home exists yet; no service process state needs repair.")
 
     current_family = _current_cli_install_family()
     owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
@@ -8086,7 +8095,7 @@ def _repair_doctor_targets(targets: list[str], *, dry_run: bool = False) -> dict
         "dry_run": dry_run,
         "results": results,
     }
-    if not dry_run:
+    if not dry_run and any(result["status"] != "skipped" for result in results):
         payload["doctor"] = _doctor()
     return payload
 


### PR DESCRIPTION
## Summary

Fixes the empty-HOME semantics for doctor repair commands. When no Avibe runtime home exists yet, `vibe doctor repair home-migration --yes` now remains a true no-op instead of reporting a skipped migration and then initializing `~/.avibe` during the post-repair doctor refresh.

The same guard applies to full `vibe doctor repair --yes`: runtime process repair targets now skip before probing lock/process state when there is no runtime home to repair.

## Root cause

`_repair_doctor_targets()` always refreshed the full doctor payload after non-dry-run repairs. The full doctor path includes runtime lifecycle probes, and those probes call into runtime lock helpers that initialize the data directory. That contradicted the home-migration repair result for a fresh empty HOME.

## Validation

- `python3 -m pytest tests/test_vibe_cli.py tests/test_runtime_service_lock.py tests/test_upgrade_flow.py tests/test_ui_server_logs.py -q`
- `python3 -m ruff check vibe/cli.py tests/test_vibe_cli.py`
- Real CLI smoke checks with isolated empty HOME for both targeted and full repair commands; both exited 0 and left the HOME directory empty.
