### PR TITLE
Vaults: unify add/approve dialogs (shared components)

### DIFF
--- a/docs/plans/vault-chat-requests.md
+++ b/docs/plans/vault-chat-requests.md
@@ -1,0 +1,114 @@
+# Vault requests in chat — cards, unified dialogs, auto-resume
+
+## Background
+
+A vault request that needs the human — **provision** (fill a not-yet-stored secret),
+**access** (approve an agent using a protected secret), **sign** (approve a signature) —
+currently surfaces to the user in two thin ways:
+
+- **Vaults page** (`VaultsPage` → `PendingRequestsSection`): lists pending requests and
+  opens the approval / provide dialog. Since #765 this is **SSE-driven** (`vaults.updated`
+  event via `connectWorkbenchEvents`; the 5s poll is only a fallback when the event bridge
+  is down).
+- **`$<NAME>` inline card** (`markdown.tsx` → `SecretRequestCard`): if an **agent reply**
+  literally contains the marker `$<UPPER_NAME>` (regex `\$<([A-Z][A-Z0-9_]*)>`, outside code,
+  gated on `secretRequests={isAgent}`), it renders an inline "provide" card. `reply_enhancer`
+  only *parses* the marker — nothing *instructs or injects* it, and it is **provision-only**.
+  In practice it rarely fires (the model isn't told to emit it), and access/sign have no chat
+  card at all.
+
+Agent-side, a request either **blocks** the turn (`--wait`, model idles until timeout) or
+returns and the agent must **poll/re-run** (`vibe vault await`) — i.e. hand-roll its own wait.
+
+Two dialogs also drifted visually: the `$<NAME>` card and the Vaults "Add secret" dialog both
+wrap the same `VaultSecretForm`, but with **different headers** (custom cyan-key header vs a
+plain `DialogHeader` title), so they read as two different things.
+
+## Goal
+
+1. Push an **interactive card into the chat** when a request is created — not just the Vaults
+   page — matching Avibe's IM-first "colleague" model.
+2. **Unify the dialogs** so every entry point opens the *same* add/provide dialog and the
+   *same* approval dialog (reuse + visual consistency).
+3. Make the agent flow **friendly**: the agent doesn't block or hand-roll a watch — request
+   resolution **auto-resumes** its session via the *same* callback entry Agent Run uses.
+
+## Constraints
+
+- **Browser-only crypto.** Filling / approving / signing needs browser-side sealing, DEK
+  release, and browser-signs-protected. So the actionable dialog runs in the **web** UI only.
+  On pure IM (Slack/Discord/…), the card degrades to a **notification + deep link** to the web
+  approval — never an inline approve.
+- Preserve the cardinal invariant: only public material (signature / avault-bound DEK blind
+  box) ever reaches the daemon.
+
+## Design
+
+### Interaction model (user's refinement)
+
+- **Provision (add-secret)** → **card A only** (inline, in the timeline). No strong reminder —
+  the user may choose not to add it.
+- **Approval (access / sign)** → **card A** inline, **plus a conditional floating bar B**:
+  when a pending approval card is **not in the viewport** (scrolled past, above *or* below),
+  float B above the composer. When the request **expires**, the A card collapses to an
+  "expired" state and B auto-dismisses. Multiple pending → B shows a count.
+- **Click B** → open the approval dialog directly (fastest path); with several pending, act on
+  the oldest.
+- Visibility is tracked with an `IntersectionObserver` on the inline A card(s); B is derived
+  from "any unresolved approval whose card is off-screen".
+
+### Dialog unification
+
+Two shared components under `ui/src/components/ui/`, one consistent header style (icon tile +
+title + subtitle, design.pen `F4N19`/`vyed5`):
+
+1. **`VaultSecretDialog`** — Dialog wrapping `VaultSecretForm` (create *and* provide modes).
+   Callers: Vaults "Add", Vaults pending-provision (`PendingRequestsSection`), the `$<NAME>`
+   chat card (`SecretRequestCard`), and the new chat provision card.
+2. **`VaultApprovalDialog`** — Dialog wrapping `VaultApprovalCard`. Callers: Vaults "Review",
+   the new chat approval card, and the floating bar B.
+
+`SecretRequestCard` and `VaultsPage`'s inline `AddSecretDialog` / review `Dialog` collapse into
+these two.
+
+### Chat cards
+
+- A small `VaultRequestCard` (Form A) rendered in the chat transcript, keyed by request
+  `session_id` == current session, fed by the existing `vaults.updated` SSE (fetch pending for
+  the session on the event; no new backend event needed for v1). Variants: access (gold lock),
+  sign (violet pen + scheme-relevant address via `SigningAddressList`), provision (accent key).
+  Resolved → collapses to a quiet "✓ approved / ✕ denied / ⏱ expired" line.
+- `VaultFloatingApproval` (Form B): sticky bar above the composer, approval-only, shown when an
+  unresolved approval card is off-screen; auto-hidden on expiry.
+
+### Auto-resume (callback) — unified entry
+
+On request resolution (approved / provided / denied / expired), the daemon enqueues a **callback
+turn** to the request's `session_id` through the **same** path Agent Run / watch / scheduled
+tasks use: a `session_turns` spec with `callback_session_id` + `source_kind="callback"`
+(`core/session_turns.py`). The agent's turn ends when it makes the request; it is woken with the
+outcome. No agent-side `--wait` block and no hand-rolled watch. A `--no-callback`-style opt-out
+mirrors Agent Run.
+
+## Phases
+
+- **P1 — Dialog unification** (frontend, no behavior change): extract `VaultSecretDialog` +
+  `VaultApprovalDialog`; rewire Vaults page + `SecretRequestCard`. Shippable on its own.
+- **P2 — Chat cards (Form A)**: `VaultRequestCard` in the transcript, SSE-driven, session-scoped,
+  opening the P1 dialogs; access/sign/provision variants + resolved states.
+- **P3 — Floating bar (Form B)**: approval-only, off-viewport via IntersectionObserver,
+  expiry auto-dismiss.
+- **P4 — Auto-resume callback** (backend): enqueue a callback turn on resolution via the
+  session_turns callback entry; opt-out flag; agent-facing CLI copy updated to stop telling the
+  agent to poll/visit the Vaults page.
+- **P5 — IM degrade**: request notification + deep link on IM platforms.
+
+## Evidence plan
+
+- Unit: dialog components render both modes; `VaultRequestCard` state machine (pending →
+  resolved/expired); callback-turn enqueue on resolution (backend test alongside existing
+  `tests/test_vault_*`).
+- Contract: request resolution emits exactly one callback turn to the right session; no
+  duplicate on re-resolve.
+- Manual: web chat card → dialog → approve → agent auto-resumes; scroll → B floats → expiry
+  dismisses; IM deep-link.

--- a/ui/src/components/ui/secret-request-card.tsx
+++ b/ui/src/components/ui/secret-request-card.tsx
@@ -2,22 +2,20 @@ import { useEffect, useState } from 'react';
 import { CheckCircle2, KeyRound, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { badgeVariants } from './badge';
-import { Dialog, DialogContent, DialogTitle } from './dialog';
-import { VaultSecretForm } from './vault-secret-form';
-import { useApi, type VaultRequest, type VaultRequestSpec } from '@/context/ApiContext';
+import { VaultSecretDialog } from './vault-secret-dialog';
+import { useApi, type VaultRequest } from '@/context/ApiContext';
 import { cn } from '@/lib/utils';
 
 /**
- * Inline rendering of a `$<NAME>` dynamic-ask marker in an agent message. The agent
- * asked for a secret; this card is self-contained so it can live inline inside the
- * markdown renderer. Browser-side sealing is required before the UI can submit values.
+ * Inline rendering of a `$<NAME>` dynamic-ask marker in an agent message. The badge
+ * opens the shared {@link VaultSecretDialog} (same dialog as the Vaults "Add" flow), so
+ * the provide experience is identical everywhere. Browser-side sealing happens in the form.
  */
 export const SecretRequestCard: React.FC<{ name: string; requestId?: string }> = ({ name, requestId }) => {
   const { t } = useTranslation();
   const api = useApi();
   const [open, setOpen] = useState(false);
   const [fulfilled, setFulfilled] = useState(false);
-  const [requestSpec, setRequestSpec] = useState<VaultRequestSpec | null>(null);
   const [resolvedRequest, setResolvedRequest] = useState<VaultRequest | null>(null);
   const [requestLoaded, setRequestLoaded] = useState(false);
   const [requestAmbiguous, setRequestAmbiguous] = useState(false);
@@ -34,13 +32,11 @@ export const SecretRequestCard: React.FC<{ name: string; requestId?: string }> =
       .then((res) => {
         if (!alive) return;
         setResolvedRequest(res.request ?? null);
-        setRequestSpec(((res.request?.card as { spec?: VaultRequestSpec } | null)?.spec ?? null) as VaultRequestSpec | null);
         setRequestAmbiguous(!requestId && Boolean('ambiguous' in res && res.ambiguous));
       })
       .catch(() => {
         if (!alive) return;
         setResolvedRequest(null);
-        setRequestSpec(null);
         setRequestAmbiguous(false);
       })
       .finally(() => {
@@ -59,11 +55,6 @@ export const SecretRequestCard: React.FC<{ name: string; requestId?: string }> =
       </span>
     );
   }
-  const requestCard = (resolvedRequest?.card ?? null) as { default_protection?: unknown } | null;
-  const defaultProtection =
-    requestCard?.default_protection === 'standard' || requestCard?.default_protection === 'protected'
-      ? requestCard.default_protection
-      : undefined;
 
   return (
     <>
@@ -75,48 +66,28 @@ export const SecretRequestCard: React.FC<{ name: string; requestId?: string }> =
         <KeyRound className="mr-1 inline size-3" />
         {name} — {t('vaults.request.provide')}
       </button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent>
-          {/* Accessible name for the Radix dialog — the visible title below is styled per
-              design.pen `F4N19`, so keep a screen-reader-only DialogTitle for a11y. */}
-          <DialogTitle className="sr-only">{t('vaults.request.title')}</DialogTitle>
-          {/* Header — design.pen `F4N19` (SecureInputCard): cyan key + ask copy. */}
-          <div className="flex items-start gap-3 pr-6">
-            <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/15 text-accent">
-              <KeyRound className="size-5" />
-            </span>
-            <div className="flex flex-col gap-0.5">
-              <span className="text-[15px] font-semibold text-foreground">{t('vaults.request.title')}</span>
-              <span className="text-xs text-muted-foreground">{t('vaults.request.help')}</span>
-            </div>
-          </div>
-          {requestLoaded ? (
-            requestAmbiguous ? (
-              <div className="rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-muted">
-                {t('vaults.request.ambiguousProvision')}
-              </div>
-            ) : (
-              <VaultSecretForm
-                fixedName={name}
-                provisionRequestId={resolvedRequest?.id ?? requestId ?? null}
-                requestSpec={requestSpec}
-                defaultProtection={defaultProtection}
-                onCancel={() => setOpen(false)}
-                onCreated={() => {
-                  setFulfilled(true);
-                  setOpen(false);
-                }}
-                treatExistingAsFulfilled
-              />
-            )
-          ) : (
+      <VaultSecretDialog
+        open={open}
+        onOpenChange={setOpen}
+        name={name}
+        request={resolvedRequest}
+        notice={
+          !requestLoaded ? (
             <div className="flex items-center gap-2 rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-muted">
               <Loader2 className="size-4 animate-spin" />
               {t('common.loading')}
             </div>
-          )}
-        </DialogContent>
-      </Dialog>
+          ) : requestAmbiguous ? (
+            <div className="rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-muted">
+              {t('vaults.request.ambiguousProvision')}
+            </div>
+          ) : undefined
+        }
+        onCreated={() => {
+          setFulfilled(true);
+          setOpen(false);
+        }}
+      />
     </>
   );
 };

--- a/ui/src/components/ui/vault-approval-dialog.tsx
+++ b/ui/src/components/ui/vault-approval-dialog.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from 'react-i18next';
+
+import type { VaultRequest } from '@/context/ApiContext';
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+import { VaultApprovalCard, type ApprovalOutcome } from './vault-approval-card';
+
+/**
+ * The single approval dialog: {@link VaultApprovalCard} in a modal. Reused by the
+ * Vaults "Review" action, the chat approval card, and the floating approval bar.
+ *
+ * The card already renders its own header ("Agent wants to use / sign …"), so this
+ * wrapper adds only a screen-reader title — no second visible heading.
+ */
+export const VaultApprovalDialog: React.FC<{
+  /** The request under review; the dialog is open iff this is non-null. */
+  request: VaultRequest | null;
+  onResolved: (outcome: ApprovalOutcome) => void;
+  onClose: () => void;
+}> = ({ request, onResolved, onClose }) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog
+      open={request != null}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogTitle className="sr-only">{t('vaults.requests.reviewTitle')}</DialogTitle>
+        {request != null ? (
+          <VaultApprovalCard key={request.id} request={request} onResolved={onResolved} onCancel={onClose} />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/ui/src/components/ui/vault-secret-dialog.tsx
+++ b/ui/src/components/ui/vault-secret-dialog.tsx
@@ -1,0 +1,66 @@
+import { KeyRound } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { VaultRequest, VaultRequestSpec } from '@/context/ApiContext';
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+import { VaultSecretForm } from './vault-secret-form';
+
+/**
+ * The single add/provide-secret dialog: a consistent branded header (design.pen
+ * `F4N19`/`vyed5`) over {@link VaultSecretForm}. Reused by every entry point — the
+ * Vaults "Add" button, a Vaults pending-provision row, the `$<NAME>` chat card, and
+ * the chat provision card — so they are visually and behaviorally identical.
+ *
+ * Create mode (no name/request) vs provide mode (a `$<NAME>` ask or a pending
+ * provision request) only differ in the header copy and the seeded form fields.
+ */
+export const VaultSecretDialog: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Explicit fixed name (e.g. a `$<NAME>` chat ask) when there may be no request object yet. */
+  name?: string;
+  /** A pending provision request; spec / default protection / id are derived from it. */
+  request?: VaultRequest | null;
+  /** Rendered in place of the form (loading / ambiguous-provision notices from callers). */
+  notice?: React.ReactNode;
+  onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
+}> = ({ open, onOpenChange, name, request, notice, onCreated }) => {
+  const { t } = useTranslation();
+  const card = (request?.card ?? null) as { default_protection?: unknown; spec?: VaultRequestSpec } | null;
+  const requestSpec = (card?.spec ?? null) as VaultRequestSpec | null;
+  const defaultProtection =
+    card?.default_protection === 'standard' || card?.default_protection === 'protected' ? card.default_protection : undefined;
+  const fixedName = name ?? request?.secret_name ?? undefined;
+  const isProvide = Boolean(fixedName);
+  const title = isProvide ? t('vaults.request.title') : t('vaults.dialog.title');
+  const subtitle = isProvide ? t('vaults.request.help') : t('vaults.dialog.subtitle');
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {/* Accessible name; the visible heading is the branded header below. */}
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <div className="flex items-start gap-3 pr-6">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/15 text-accent">
+            <KeyRound className="size-5" />
+          </span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[15px] font-semibold text-foreground">{title}</span>
+            <span className="text-xs text-muted-foreground">{subtitle}</span>
+          </div>
+        </div>
+        {notice ?? (
+          <VaultSecretForm
+            fixedName={fixedName}
+            provisionRequestId={request?.id ?? null}
+            requestSpec={requestSpec}
+            defaultProtection={defaultProtection}
+            onCancel={() => onOpenChange(false)}
+            onCreated={onCreated}
+            treatExistingAsFulfilled={isProvide}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -6,57 +6,18 @@ import { CapabilityTabs } from './CapabilityTabs';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
 import { cn } from '../../lib/utils';
 import { partitionTags } from '../../lib/vaultTags';
-import { useApi, type VaultAuditEvent, type VaultGrant, type VaultRequest, type VaultRequestSpec, type VaultSecret } from '../../context/ApiContext';
+import { useApi, type VaultAuditEvent, type VaultGrant, type VaultRequest, type VaultSecret } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
-import { VaultApprovalCard, type ApprovalOutcome } from '../ui/vault-approval-card';
-import { VaultSecretForm } from '../ui/vault-secret-form';
+import type { ApprovalOutcome } from '../ui/vault-approval-card';
 import { SigningAddressList } from '../ui/signing-address-list';
+import { VaultApprovalDialog } from '../ui/vault-approval-dialog';
+import { VaultSecretDialog } from '../ui/vault-secret-dialog';
 
 const PENDING_REQUEST_POLL_INTERVAL_MS = 5000;
 const PENDING_REQUEST_EXPIRY_GRACE_MS = 100;
 const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
-
-const AddSecretDialog: React.FC<{
-  onClose: () => void;
-  onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
-  request?: VaultRequest | null;
-}> = ({ onClose, onCreated, request }) => {
-  const { t } = useTranslation();
-  const requestCard = (request?.card ?? null) as { default_protection?: unknown; spec?: VaultRequestSpec } | null;
-  const requestSpec = (requestCard?.spec ?? null) as VaultRequestSpec | null;
-  const defaultProtection =
-    requestCard?.default_protection === 'standard' || requestCard?.default_protection === 'protected'
-      ? requestCard.default_protection
-      : undefined;
-  const fixedName = request?.secret_name ?? undefined;
-
-  return (
-    <Dialog
-      open
-      onOpenChange={(o) => {
-        if (!o) onClose();
-      }}
-    >
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{request ? t('vaults.request.title') : t('vaults.dialog.title')}</DialogTitle>
-        </DialogHeader>
-        <VaultSecretForm
-          fixedName={fixedName}
-          provisionRequestId={request?.id ?? null}
-          requestSpec={requestSpec}
-          defaultProtection={defaultProtection}
-          onCancel={onClose}
-          onCreated={onCreated}
-          treatExistingAsFulfilled={Boolean(request)}
-        />
-      </DialogContent>
-    </Dialog>
-  );
-};
 
 /** All allowed proxy-fetch hosts on a secret (for the `proxy · <host> +N` badge). */
 const proxyHosts = (s: VaultSecret): string[] => {
@@ -426,25 +387,14 @@ const PendingRequestsSection: React.FC<{ onResolved: () => void }> = ({ onResolv
           }}
         />
       ))}
-      <Dialog
-        open={reviewing != null}
-        onOpenChange={(o) => {
-          if (!o) setReviewing(null);
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('vaults.requests.reviewTitle')}</DialogTitle>
-          </DialogHeader>
-          {reviewing != null ? (
-            <VaultApprovalCard key={reviewing.id} request={reviewing} onResolved={handleOutcome} onCancel={() => setReviewing(null)} />
-          ) : null}
-        </DialogContent>
-      </Dialog>
+      <VaultApprovalDialog request={reviewing} onResolved={handleOutcome} onClose={() => setReviewing(null)} />
       {provisioning != null ? (
-        <AddSecretDialog
+        <VaultSecretDialog
+          open
+          onOpenChange={(o) => {
+            if (!o) setProvisioning(null);
+          }}
           request={provisioning}
-          onClose={() => setProvisioning(null)}
           onCreated={(name, reason) => {
             setProvisioning(null);
             if (reason !== 'already_exists') {
@@ -772,17 +722,18 @@ export const VaultsPage: React.FC = () => {
           )}
         </div>
       )}
-      {adding && (
-        <AddSecretDialog
-          onClose={() => setAdding(false)}
-          onCreated={(name, reason) => {
-            if (reason === 'already_exists') return;
-            setAdding(false);
-            showToast(t('vaults.created', { name }), 'success');
-            refresh();
-          }}
-        />
-      )}
+      <VaultSecretDialog
+        open={adding}
+        onOpenChange={(o) => {
+          if (!o) setAdding(false);
+        }}
+        onCreated={(name, reason) => {
+          if (reason === 'already_exists') return;
+          setAdding(false);
+          showToast(t('vaults.created', { name }), 'success');
+          refresh();
+        }}
+      />
     </div>
   );
 };

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2271,6 +2271,7 @@
     },
     "dialog": {
       "title": "Add a secret",
+      "subtitle": "Stored encrypted; the value never reaches the chat or the model.",
       "name": "Name",
       "value": "Value",
       "valuePlaceholder": "Paste the secret value",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2270,6 +2270,7 @@
     },
     "dialog": {
       "title": "添加密钥",
+      "subtitle": "加密存储;值不会进入聊天或模型。",
       "name": "名称",
       "value": "值",
       "valuePlaceholder": "粘贴密钥值",


### PR DESCRIPTION
## What & why

**P1** of `docs/plans/vault-chat-requests.md` — unify the vault dialogs, a prerequisite for
the upcoming in-chat request cards and directly the "统一弹窗" ask: the `$<NAME>` chat card and
the Vaults "Add" dialog both wrapped `VaultSecretForm` but with **different headers**, so they
read as two different dialogs.

## Changes (no behavior change)

- **`VaultSecretDialog`** — one branded header (icon + title + subtitle, create *and* provide
  modes) over `VaultSecretForm`, with a `notice` slot for loading / ambiguous-provision states.
  Reused by: Vaults "Add", Vaults pending-provision row, and the `$<NAME>` `SecretRequestCard`.
- **`VaultApprovalDialog`** — wraps `VaultApprovalCard` (which owns its own header), so the
  Vaults "Review" path no longer renders a redundant second title.
- Removed `VaultsPage`'s local `AddSecretDialog` and the inline review `Dialog`; both call the
  shared components now. `SecretRequestCard` rewritten to open `VaultSecretDialog`.
- Added `vaults.dialog.subtitle` (en + zh) for the create-mode header.

Result: every entry point opens the *same* add/provide dialog and the *same* approval dialog —
one interaction to learn, one place to maintain.

## Evidence

- **Unit/build**: UI CI gate `npm run build` (tsc + vite) green.
- **Contract**: no API/schema change; behavior parity verified across all three provide/add
  call sites and the review path (create vs provide header + `treatExistingAsFulfilled`).
- **Scenario**: none (no catalog for this surface).
- **Residual manual**: dialog headers now consistent; approval dialog no longer double-titled.

## Follow-up (same plan, later PRs)

P2 in-chat request cards (Form A), P3 conditional floating approval bar (Form B), P4 auto-resume
via the Agent-Run callback entry, P5 IM notify + deep link. See the plan doc.
