### PR TITLE
feat(ui): show instance name in browser tab title

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -310,6 +310,10 @@ class UiConfig:
     setup_port: int = 5123
     open_browser: bool = True
     chat_message_font_size: int = DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX
+    # Display name appended to the browser tab title ("Avibe - <name>"). When
+    # blank the UI falls back to the machine's system hostname (surfaced as the
+    # read-only ``system_hostname`` field in the /api/config payload).
+    instance_name: str = ""
 
 
 @dataclass

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -48,6 +48,7 @@ const AppsTerminalPage = lazy(() =>
   import('./components/workbench/AppsTerminalPage').then((m) => ({ default: m.AppsTerminalPage })),
 );
 import { hasConfiguredPlatformCredentials } from './lib/platforms';
+import { applyAppTitle } from './lib/documentTitle';
 import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './components/ui/card';
 import { Button } from './components/ui/button';
@@ -281,9 +282,29 @@ const AppsRouteFallback = () => {
   return <div className="grid min-h-[40vh] place-items-center text-[12px] text-muted">{t('common.loading')}</div>;
 };
 
+// Sets the browser tab title to "Avibe - <name>" from config (configured
+// instance name, else system hostname). Config is cached in ApiContext, so this
+// mount-time fetch is deduplicated with the AuthGuard's own config read.
+const DocumentTitle = () => {
+  const { getConfig } = useApi();
+  useEffect(() => {
+    let cancelled = false;
+    getConfig()
+      .then((config) => {
+        if (!cancelled) applyAppTitle(config);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [getConfig]);
+  return null;
+};
+
 function AppRoutes() {
   return (
     <>
+    <DocumentTitle />
     <WebPushNotificationNavigator />
     <Routes>
       <Route element={<AuthGuard><AppShell /></AuthGuard>}>

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FileText, Globe2, Play, RotateCw, Server, Square } from 'lucide-react';
+import { FileText, Globe2, Play, RotateCw, Server, Square, Tag } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -10,6 +10,7 @@ import { apiFetch } from '@/lib/apiFetch';
 import { SettingsPageShell } from './SettingsPageShell';
 import { CompactField, SettingsPanel, SettingsRow } from './SettingsPrimitives';
 import { Button } from '@/components/ui/button';
+import { applyAppTitle } from '@/lib/documentTitle';
 
 // Mirrors design.pen mHUcm (VR/CM/Service): two cards.
 // svcSec1: header [16, 20] + value rows [12, 20] with bottom borders.
@@ -30,6 +31,8 @@ export const SettingsServicePage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [uiSaving, setUiSaving] = useState(false);
   const [uiMessage, setUiMessage] = useState<string | null>(null);
+  const [nameSaving, setNameSaving] = useState(false);
+  const [nameMessage, setNameMessage] = useState<string | null>(null);
 
   useEffect(() => {
     api.getConfig().then(setConfig).catch(() => {});
@@ -118,6 +121,26 @@ export const SettingsServicePage: React.FC = () => {
       setUiMessage(t('common.saveFailed'));
     } finally {
       setUiSaving(false);
+    }
+  };
+
+  // The instance name only changes the browser tab title ("Avibe - <name>"),
+  // so it saves config without restarting the UI server and applies the new
+  // title immediately for live feedback.
+  const handleSaveInstanceName = async () => {
+    if (!config) return;
+    setNameSaving(true);
+    setNameMessage(null);
+    try {
+      const instanceName = (config.ui?.instance_name || '').trim();
+      const nextUi = { ...(config.ui || {}), instance_name: instanceName };
+      await api.saveConfig({ ui: nextUi });
+      applyAppTitle({ ui: nextUi });
+      setNameMessage(t('common.saved'));
+    } catch {
+      setNameMessage(t('common.saveFailed'));
+    } finally {
+      setNameSaving(false);
     }
   };
 
@@ -244,6 +267,42 @@ export const SettingsServicePage: React.FC = () => {
               >
                 <RotateCw className={clsx('size-3.5', uiSaving && 'animate-spin')} strokeWidth={2.5} />
                 {uiSaving ? t('common.saving') : t('common.saveAndRestart')}
+              </Button>
+            </div>
+          }
+        />
+        <SettingsRow
+          title={
+            <span className="inline-flex items-center gap-2">
+              <Tag className="size-3.5 text-cyan" />
+              {t('settings.instanceNameTitle')}
+            </span>
+          }
+          description={nameMessage || t('settings.instanceNameHint')}
+          control={
+            <div className="grid grid-cols-[minmax(160px,220px)_auto] items-center gap-2">
+              <CompactField
+                aria-label={t('settings.instanceNameTitle')}
+                placeholder={config?.ui?.system_hostname || ''}
+                value={config?.ui?.instance_name || ''}
+                onChange={(event) => {
+                  const instanceName = event.target.value;
+                  setNameMessage(null);
+                  setConfig((prev: any) => ({
+                    ...(prev || {}),
+                    ui: { ...((prev && prev.ui) || {}), instance_name: instanceName },
+                  }));
+                }}
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => void handleSaveInstanceName()}
+                disabled={nameSaving}
+                className="text-[12px]"
+              >
+                {nameSaving ? t('common.saving') : t('common.save')}
               </Button>
             </div>
           }

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -133,9 +133,16 @@ export const SettingsServicePage: React.FC = () => {
     setNameMessage(null);
     try {
       const instanceName = (config.ui?.instance_name || '').trim();
-      const nextUi = { ...(config.ui || {}), instance_name: instanceName };
-      await api.saveConfig({ ui: nextUi });
-      applyAppTitle({ ui: nextUi });
+      // Persist ONLY the instance name. Spreading the shared (and possibly
+      // dirty) config.ui would also save unsaved Console server host/port
+      // edits — but without the /api/ui/reload + redirect that
+      // handleUiSaveRestart performs — so the running UI keeps the old bind
+      // while the next restart silently moves to the unsaved address. The
+      // backend deep-merges config saves, so host/port are preserved.
+      await api.saveConfig({ ui: { instance_name: instanceName } });
+      // Reflect the new title immediately. system_hostname is the read-only,
+      // server-computed fallback (unaffected by host/port edits).
+      applyAppTitle({ ui: { instance_name: instanceName, system_hostname: config.ui?.system_hostname } });
       setNameMessage(t('common.saved'));
     } catch {
       setNameMessage(t('common.saveFailed'));

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -60,7 +60,11 @@ export const SettingsServicePage: React.FC = () => {
         setup_host: config.ui?.setup_host || '127.0.0.1',
         setup_port: config.ui?.setup_port || 5123,
       };
-      await api.saveConfig({ ui: { ...(config.ui || {}), ...uiPayload } });
+      // Send ONLY host/port — not the whole config.ui. Spreading config.ui
+      // would persist any unsaved instance_name draft the user typed but
+      // didn't Save on that row. The backend deep-merges config saves, so
+      // instance_name and chat_message_font_size are preserved regardless.
+      await api.saveConfig({ ui: uiPayload });
       await apiFetch('/api/ui/reload', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -220,6 +220,8 @@
     "statusNow": "Current state",
     "consoleServerTitle": "Console server",
     "consoleServerHint": "Saving these values restarts only the Web UI server.",
+    "instanceNameTitle": "Instance name",
+    "instanceNameHint": "Shown in the browser tab title (\"Avibe - name\"). Leave blank to use the system hostname.",
     "consoleServerRedirecting": "UI server moved. Redirecting to {{origin}}...",
     "consoleServerRelocated": "UI server now listens on {{origin}}. Open this URL to continue.",
     "serviceNotesTitle": "Operational notes",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -220,6 +220,8 @@
     "statusNow": "当前状态",
     "consoleServerTitle": "控制台服务",
     "consoleServerHint": "保存这些值只会重启 Web UI 服务，不会重启主服务。",
+    "instanceNameTitle": "实例名称",
+    "instanceNameHint": "显示在浏览器标签标题中（“Avibe - 名称”）。留空则使用系统 hostname。",
     "consoleServerRedirecting": "UI 服务地址已变更，正在跳转到 {{origin}}...",
     "consoleServerRelocated": "UI 服务现在监听 {{origin}}，请打开该地址继续。",
     "serviceNotesTitle": "运维说明",

--- a/ui/src/lib/documentTitle.ts
+++ b/ui/src/lib/documentTitle.ts
@@ -1,0 +1,21 @@
+// Browser tab title: "Avibe - <name>", where <name> is the configured
+// ``ui.instance_name`` or, when blank, the machine's system hostname (both
+// served in the /api/config payload). Falls back to plain "Avibe" when neither
+// is available.
+const BASE_TITLE = 'Avibe';
+
+export function computeAppTitle(config: unknown): string {
+  const ui = (config as { ui?: Record<string, unknown> } | null | undefined)?.ui ?? {};
+  const configured = typeof ui.instance_name === 'string' ? ui.instance_name.trim() : '';
+  const hostname = typeof ui.system_hostname === 'string' ? ui.system_hostname.trim() : '';
+  const name = configured || hostname;
+  return name ? `${BASE_TITLE} - ${name}` : BASE_TITLE;
+}
+
+export function applyAppTitle(config: unknown): void {
+  try {
+    document.title = computeAppTitle(config);
+  } catch {
+    // document may be unavailable in non-DOM contexts (SSR/tests); ignore.
+  }
+}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -6,6 +6,7 @@ import os
 import platform
 import re
 import shutil
+import socket
 import ssl
 import stat
 import subprocess
@@ -920,6 +921,14 @@ def _project_secret_fields(payload: dict | None, fields: tuple[str, ...], *, inc
     return projected
 
 
+def _system_hostname() -> str:
+    """Best-effort system hostname for the browser-title fallback."""
+    try:
+        return socket.gethostname() or ""
+    except OSError:
+        return ""
+
+
 def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dict:
     from config.platform_registry import platform_descriptors
     from modules.agents.catalog import agent_backend_catalog_payload
@@ -963,7 +972,11 @@ def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dic
             _GATEWAY_SECRET_FIELDS,
             include_secrets=include_secrets,
         ),
-        "ui": config.ui.__dict__,
+        # ``system_hostname`` is a read-only, computed hint (not a stored config
+        # field): the UI uses it as the browser-title fallback when
+        # ``ui.instance_name`` is blank. It is dropped on save via
+        # ``_filter_dataclass_fields`` so it never persists.
+        "ui": {**config.ui.__dict__, "system_hostname": _system_hostname()},
         "remote_access": {
             "provider": config.remote_access.provider,
             "vibe_cloud": _vibe_cloud_payload(config, include_secrets),


### PR DESCRIPTION
## What

Append `- <name>` to the browser tab title so multiple Avibe instances are distinguishable at a glance. `<name>` is a configurable **instance name** that falls back to the machine's **system hostname** when left blank.

- Title becomes `Avibe - <instance_name || system_hostname>` (plain `Avibe` if neither resolves).
- Configurable under **高级设置 → Service** ("Instance name"), with the system hostname shown as the placeholder.

## Changes

**Backend**
- `config/v2_config.py` — add persisted `ui.instance_name` field.
- `vibe/api.py` — `config_to_payload` merges a read-only, computed `ui.system_hostname` (`socket.gethostname()`) into `/api/config`. It's dropped on save (`_filter_dataclass_fields`), so it never persists.

**Frontend**
- `ui/src/lib/documentTitle.ts` (new) — `computeAppTitle`/`applyAppTitle` helpers.
- `ui/src/App.tsx` — `<DocumentTitle />` sets the title on load (reuses the cached config fetch).
- `SettingsServicePage.tsx` — "Instance name" field; saves without restarting the UI server and updates the title live.
- `en.json` / `zh.json` — new i18n keys.

## Verification

- Python: `instance_name` round-trips; `system_hostname` is computed-only and filtered on save; hostname resolves.
- `tsc -b`: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
