### PR TITLE
feat(ui): add Browse All Groups button to Lark group settings

### DIFF
--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -495,6 +495,11 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
         recordRefreshMeta(platform, result);
         if (result.ok) {
           setChannels(result.channels || []);
+          // Feishu's bot token can only ever list chats the bot already belongs
+          // to — there is no member-vs-all-workspace distinction like Slack, so
+          // "Browse All Groups" is simply a full re-discovery of the bot's
+          // groups. Deliberately do NOT flip browseAll here: the "showing all
+          // workspace groups" badge would be misleading for Lark.
           if (result.refreshing) scheduleRefreshFollowup(platform, isAll);
         }
       } else if (platform === 'telegram') {
@@ -1394,7 +1399,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
           {/* Browse all + Can't find hint — per-platform tabs only */}
           {pageTab !== 'all' && (
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-0.5">
-              {!['lark', 'telegram'].includes(pageTab) && (
+              {!['telegram'].includes(pageTab) && (
                 <Button
                   type="button"
                   variant="secondary"
@@ -1757,7 +1762,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             >
               <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> {t('channelList.refreshList')}
             </Button>
-            {!browseAll && !['lark', 'telegram'].includes(platform) && (
+            {!browseAll && !['telegram'].includes(platform) && (
               <Button
                 type="button"
                 variant="secondary"


### PR DESCRIPTION
## Capability

Enable the Group Settings **"Browse All Groups"** control on the **Lark/Feishu** tab. Previously this button was rendered only for Slack and Discord (Lark and Telegram were excluded). Users configuring the bot on Lark now get the same prominent discovery entry point to (re)load the group chats the bot belongs to.

## What changed

Frontend only — `ui/src/components/steps/ChannelList.tsx`:
- Removed `'lark'` from the two exclusion arrays gating the button (tab hint-row + toolbar); Telegram stays excluded.
- The Lark `loadChannels` branch performs a forced full re-discovery via the existing `api.larkChats(..., force=true)` → `/api/lark/chats` path.

## Lark semantics (intentional)

Feishu's bot token can only ever list chats the bot **already belongs to** (`im/v1/chats`); there is no member-vs-all-workspace distinction like Slack's `conversations_list`. So for Lark, "Browse All Groups" is a full re-discovery of the bot's groups. It deliberately does **not** flip the `browseAll` state, because the reused "showing all workspace groups" badge would be misleading for Lark. Net effect: it's a more prominent discovery CTA that issues the same request as "Refresh List".

## Backend

No backend change — Lark discovery (`vibe/api.py` `lark_list_chats` / `lark_list_chats_live`, `core/chat_discovery.py`) already supported this path.

## Evidence layers

- **Unit / contract**: none added — no backend or API-contract change; existing Lark discovery path unchanged.
- **Build**: `cd ui && npm run build` passes (tsc typecheck + vite, clean).
- **Manual**: verified locally on a Lark-configured instance — the button appears on the Lark tab and refreshes the discovered bot groups.
- **Scenario**: no scenario-catalog entry applies to this UI-only affordance.

## Follow-up (out of scope)

`browseAll` is a single boolean shared across all platform tabs (not scoped per platform). Switching tabs after enabling browse-all on one platform can leak the badge/initial-load mode to another. Pre-existing; worth scoping per platform in a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
