### PR TITLE
Fix protected Vault record envelope AAD

### DIFF
--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -89,7 +89,7 @@ function base64ToBase64Url(b64: string): string {
   return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
-/** Strip a stored record's DEK fields back to the bare VMK wrap_meta ({v, copies}). */
+/** Strip a stored record's DEK fields back to the bare VMK wrap_meta ({v, copies, scheme?}). */
 function baseVmkWrapMeta(wrapMeta: string): string {
   const parsed = JSON.parse(wrapMeta) as Record<string, unknown>;
   delete parsed.dek_nonce;

--- a/ui/src/lib/vaultCrypto.test.ts
+++ b/ui/src/lib/vaultCrypto.test.ts
@@ -393,6 +393,7 @@ describe('vaultCrypto protected hierarchy', () => {
     const released = await releaseProtectedDek(sealed, vmk, avaultPublicKey, recordContext, context);
 
     expect(dek).toHaveLength(32);
+    expect(protectedRecordAadHex(recordContext)).toBe('4f50454e41495f4150495f4b45596d616368696e652d61657367636d2d763101');
     expect(protectedRecordAadHex(recordContext)).not.toBe(protectedRecordAadHex({ name: 'OTHER_SIGNING_KEY' }));
     expect(released.scheme).toBe(BLIND_BOX_SCHEME);
     expect(base64ToBytes(released.enc)).toHaveLength(32);
@@ -514,6 +515,7 @@ describe('protected record storage composition', () => {
     const sealed = await sealProtected(new TextEncoder().encode('sk-secret-value'), vmk, context);
 
     const envelope = packProtectedRecord(sealed, wrapMeta);
+    expect(JSON.parse(envelope.wrap_meta).scheme).toBe(WRAP_SCHEME);
     const restored = unpackProtectedRecord(envelope);
     const vmkAgain = await unwrapVmk(restored.vmkWrapMeta, 'vault-password');
     const opened = await openProtected(restored.sealed, vmkAgain, context);

--- a/ui/src/lib/vaultCrypto.ts
+++ b/ui/src/lib/vaultCrypto.ts
@@ -699,11 +699,13 @@ export function passkeyPrfSaltEntries(wrapMeta: string | WrapMeta): PasskeyPrfSa
 }
 
 function protectedRecordAad(context: ProtectedRecordContext): Uint8Array {
-  const out: number[] = [];
-  pushLengthPrefixed(out, utf8(validateSecretName(context.name)));
-  pushLengthPrefixed(out, utf8(context.scheme ?? WRAP_SCHEME));
-  pushLengthPrefixed(out, new Uint8Array([context.version ?? WRAP_META_VERSION]));
-  return new Uint8Array(out);
+  const name = utf8(validateSecretName(context.name));
+  const scheme = utf8(context.scheme ?? WRAP_SCHEME);
+  const out = new Uint8Array(name.length + scheme.length + 1);
+  out.set(name, 0);
+  out.set(scheme, name.length);
+  out[name.length + scheme.length] = context.version ?? WRAP_META_VERSION;
+  return out;
 }
 
 export function protectedRecordAadHex(context: ProtectedRecordContext): string {
@@ -1284,10 +1286,13 @@ export function packProtectedRecord(sealed: ProtectedSealed, vmkWrapMeta: string
   if ('dek_nonce' in meta || 'wrapped_dek' in meta) {
     throw new Error('vmk wrap_meta must not already carry a wrapped DEK');
   }
+  if ('scheme' in meta && meta.scheme !== WRAP_SCHEME) {
+    throw new Error('protected wrap_meta has unsupported scheme');
+  }
   return {
     ciphertext: sealed.ciphertext,
     nonce: sealed.nonce,
-    wrap_meta: JSON.stringify({ ...meta, dek_nonce: sealed.dek_nonce, wrapped_dek: sealed.wrapped_dek }),
+    wrap_meta: JSON.stringify({ ...meta, scheme: WRAP_SCHEME, dek_nonce: sealed.dek_nonce, wrapped_dek: sealed.wrapped_dek }),
   };
 }
 


### PR DESCRIPTION
## What

Fix protected Vault secret envelopes created by the browser so resident avault can open them after approval.

## Why

Regression showed this flow:

1. `vibe vault run` for a protected static secret asks for approval.
2. The user approves and the grant becomes active with `delivery_ready: true`.
3. Retrying the same run fails in resident avault with `open failed for <name>`.

Approval was succeeding because the DEK blind box opened correctly. The actual failure was later: the protected value envelope was encrypted with a browser-only length-prefixed record AAD, and its stored `wrap_meta` did not carry the avault envelope `scheme`. avault expects the final envelope contract: `name || "machine-aesgcm-v1" || 0x01`, with `scheme` present in `wrap_meta`.

## Fix

- Use avault's final protected value AAD format in `vaultCrypto`.
- Persist `scheme: "machine-aesgcm-v1"` in protected record `wrap_meta`.
- Add tests pinning the exact protected record AAD bytes and `wrap_meta.scheme`.

Existing protected secrets created with the old browser format need to be recreated or rotated; Vaults has not launched, so this follows the final contract rather than adding compatibility fallback.

## Validation

- `npm run test:crypto` in `ui/`: 24 passed
- `npm run build` in `ui/`: passed
- `npx eslint src/lib/vaultCrypto.ts src/lib/vaultCrypto.test.ts src/lib/useProtectedVault.ts`: passed

Note: full `npm run lint` is currently blocked by pre-existing unrelated lint failures across the UI tree.
