### PR TITLE
feat(feishu): concise progress status bubble + 8s heartbeat default

### DIFF
--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -217,6 +217,15 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
         formatter_class="FeishuFormatter",
         credential_fields=("app_id", "app_secret"),
         runtime_reconcile_fields=("app_id", "app_secret", "domain", "proxy_url"),
+        # NOTE: Feishu/Lark DOES support message deletion via the API
+        # (``im.v1.message.delete``), but recalling a bot message leaves a visible
+        # "此消息已撤回" ("this message was recalled") tombstone in the chat/thread —
+        # there is no silent-delete and no API flag to suppress it. So
+        # ``supports_message_deletion`` is deliberately left False: retiring the
+        # concise status bubble by recall would look worse than the bubble it
+        # removes. Instead the dispatcher collapses the bubble via an in-place edit
+        # (``✅ done · <time> · <tok>``), which leaves no tombstone, and the result
+        # is still delivered as a fresh (pushing) message. Do NOT set this True.
         capabilities=PlatformCapabilities(
             supports_channels=True,
             supports_threads=True,

--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -223,6 +223,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_buttons=True,
             supports_quick_replies=True,
             supports_message_editing=True,
+            supports_message_deletion=True,
             markdown_upload_returns_message_id=True,
             quick_reply_single_column=True,
             supports_reaction_indicator=True,

--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -227,6 +227,7 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             quick_reply_single_column=True,
             supports_reaction_indicator=True,
             preferred_processing_indicator="reaction",
+            supports_status_bubble=True,
         ),
     ),
     "wechat": PlatformDescriptor(

--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -223,7 +223,6 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_buttons=True,
             supports_quick_replies=True,
             supports_message_editing=True,
-            supports_message_deletion=True,
             markdown_upload_returns_message_id=True,
             quick_reply_single_column=True,
             supports_reaction_indicator=True,

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -436,7 +436,7 @@ class V2Config:
     #   "off" (default) no process bubble, "concise" one self-updating bubble,
     #   "verbose" legacy append/split process log.
     agent_progress_style: str = DEFAULT_AGENT_PROGRESS_STYLE
-    agent_status_heartbeat_ms: int = 15000  # status-bubble elapsed-timer heartbeat
+    agent_status_heartbeat_ms: int = 8000  # status-bubble elapsed-timer heartbeat
     agent_status_no_output_ms: int = 180000  # "no output for N min" hint threshold
     # True once the user has finished the setup wizard. This is the explicit
     # gate for ``setup_state().needs_setup`` — it replaces the old heuristic
@@ -655,7 +655,7 @@ class V2Config:
 
         # Cap to sane upper bounds so a fat-fingered value can't silence the
         # heartbeat (heartbeat ≤ 1h, no-output hint ≤ 24h); out-of-range → default.
-        agent_status_heartbeat_ms = _positive_int(payload.get("agent_status_heartbeat_ms"), 15000, 3_600_000)
+        agent_status_heartbeat_ms = _positive_int(payload.get("agent_status_heartbeat_ms"), 8000, 3_600_000)
         agent_status_no_output_ms = _positive_int(payload.get("agent_status_no_output_ms"), 180000, 86_400_000)
 
         # ``setup_completed`` is the explicit setup gate. Read the stored value

--- a/core/controller.py
+++ b/core/controller.py
@@ -949,8 +949,8 @@ class Controller:
 
     def get_heartbeat_interval_ms_for_context(self, context: MessageContext) -> int:
         _refresh_status_bubble_config(self)
-        value = getattr(self.config, "agent_status_heartbeat_ms", 15000)
-        return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else 15000
+        value = getattr(self.config, "agent_status_heartbeat_ms", 8000)
+        return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else 8000
 
     def get_no_output_hint_after_ms_for_context(self, context: MessageContext) -> int:
         _refresh_status_bubble_config(self)

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -637,17 +637,20 @@ class ConsolidatedMessageDispatcher:
         backend_dead: bool = False,
         hourglass: str = "⏳",
         steps: int = 0,
+        force_duration: bool = False,
     ) -> str:
         elapsed = self._format_elapsed(elapsed_s)
         token_field = self._token_field(context)
         if done:
             # Terminal footer: a reason word with a marker (✅ clean "done", ⏹
-            # "stopped"/"failed"). Elapsed time is appended only when show_duration
-            # is on (matches result-message duration gating); the session token
-            # total is kept so the final bubble still reports usage.
+            # "stopped"/"failed") · elapsed · tokens. Elapsed time is appended when
+            # show_duration is on OR force_duration is set: the collapsed status
+            # bubble always summarises its own run time (that's the whole point of
+            # the residual marker), while the result-message footer keeps the
+            # show_duration gating so it doesn't double-surface the duration.
             marker = "✅" if reason == "done" else "⏹"
             footer = f"{marker} {self._t('status.' + reason)}"
-            if self._show_duration():
+            if force_duration or self._show_duration():
                 footer += f" · {elapsed}"
             if token_field:
                 footer += f" · {token_field}"
@@ -877,7 +880,11 @@ class ConsolidatedMessageDispatcher:
         if not bubble_id:
             return
         elapsed_s = self._now() - self._status_started_at.get(key, self._now())
-        marker = self._status_footer_text(context, elapsed_s=elapsed_s, done=True, reason=reason)
+        # The collapsed bubble is the turn's residual summary line, so always show
+        # the run time here (✅ done · 1m30s · 240k tok) regardless of show_duration.
+        marker = self._status_footer_text(
+            context, elapsed_s=elapsed_s, done=True, reason=reason, force_duration=True
+        )
         target_context = self._get_target_context(context)
         try:
             # Render the marker as the footer (empty body → footer-only bubble) so

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -533,8 +533,8 @@ class ConsolidatedMessageDispatcher:
                 if value and value > 0:
                     return float(value) / 1000.0
             except Exception:
-                logger.debug("get_heartbeat_interval_ms_for_context failed; default 15s", exc_info=True)
-        return 15.0
+                logger.debug("get_heartbeat_interval_ms_for_context failed; default 8s", exc_info=True)
+        return 8.0
 
     def _no_output_hint_after_s(self, context: MessageContext) -> float:
         getter = getattr(self.controller, "get_no_output_hint_after_ms_for_context", None)

--- a/docs/plans/agent-progress-status-bubble.md
+++ b/docs/plans/agent-progress-status-bubble.md
@@ -125,7 +125,7 @@
 可调：`heartbeat_interval_ms`(默认 30000)、`no_output_hint_after_ms`(默认 180000，即 3min 触发"已 N 分钟无输出"提示)、`show_step_count`(默认关，先不显示步数保持最简)。状态条正文固定显示"当前动作"（已拍，见 §11）；footer 保留 ⏳ 沙漏。
 
 > **后续更新（2026-07）**：
-> - **飞书/Lark 也支持 concise 状态条**，见 [feishu-concise-progress.md](./feishu-concise-progress.md)。飞书卡片 schema 2.0 无 `note` 组件，footer 用 notation 字号 + 内联 `<font color='grey'>` 渲染；并借 `im.v1.message.delete` 撤回能力实现「收尾只留一条结果消息」，与 Slack/Discord 对齐。当前支持 concise 的平台为 **Slack / Discord / Lark**。
+> - **飞书/Lark 也支持 concise 状态条**，见 [feishu-concise-progress.md](./feishu-concise-progress.md)。飞书卡片 schema 2.0 无 `note` 组件，footer 用 notation 字号 + 内联 `<font color='grey'>` 渲染。收尾**不走撤回**（飞书撤回会留「此消息已撤回」墓碑），而是把气泡 `edit` 塌缩成 `✅ done · 耗时 · tok` 小标记；结果仍单独新发以保留推送。当前支持 concise 的平台为 **Slack / Discord / Lark**。
 > - **心跳间隔默认已改为 8s**（`agent_status_heartbeat_ms`，实现值此前为 15000，本节 30000 为更早的规划值）。全局生效，非按平台。
 
 ## 10. 实现顺序（最小切片）

--- a/docs/plans/agent-progress-status-bubble.md
+++ b/docs/plans/agent-progress-status-bubble.md
@@ -124,6 +124,10 @@
 频道级 `progress_style`：`concise`（**Slack/Discord 首版直接默认**，见 §11 分叉2）/ `off`（仅 typing + 结果）。
 可调：`heartbeat_interval_ms`(默认 30000)、`no_output_hint_after_ms`(默认 180000，即 3min 触发"已 N 分钟无输出"提示)、`show_step_count`(默认关，先不显示步数保持最简)。状态条正文固定显示"当前动作"（已拍，见 §11）；footer 保留 ⏳ 沙漏。
 
+> **后续更新（2026-07）**：
+> - **飞书/Lark 也支持 concise 状态条**，见 [feishu-concise-progress.md](./feishu-concise-progress.md)。飞书卡片 schema 2.0 无 `note` 组件，footer 用 notation 字号 + 内联 `<font color='grey'>` 渲染；并借 `im.v1.message.delete` 撤回能力实现「收尾只留一条结果消息」，与 Slack/Discord 对齐。当前支持 concise 的平台为 **Slack / Discord / Lark**。
+> - **心跳间隔默认已改为 8s**（`agent_status_heartbeat_ms`，实现值此前为 15000，本节 30000 为更早的规划值）。全局生效，非按平台。
+
 ## 10. 实现顺序（最小切片）
 
 > P0 **先不带计时**（计时随 P1 心跳落地）——状态条 P0 阶段是静态动作标签（Nit N3）。

--- a/docs/plans/feishu-concise-progress.md
+++ b/docs/plans/feishu-concise-progress.md
@@ -112,21 +112,30 @@ Footer text is composed in core (`_compose_status_message`) from existing
 i18n-safe pieces; no new user-facing strings in the Feishu adapter. Verify the
 `note` content carries no hardcoded English added in the adapter.
 
-## Single-message finalize (implemented)
+## Turn-end: collapse, do NOT recall (keeps push, no tombstone)
 
-Feishu can recall its own messages (`im.v1.message.delete`, verified live), so
-this closes the "two persistent messages" gap:
+Feishu message *recall* (`im.v1.message.delete`) works, but it leaves a visible
+"此消息已撤回" tombstone in the thread — worse than the bubble it removes. And a
+card *edit* fires no push, while the result must push. So on Feishu:
 
-- lark declares `supports_message_deletion=True`.
-- `FeishuBot.delete_message` overrides the base no-op to call `adelete`.
-- At turn end `_retire_status_bubble` (`message_dispatcher.py:891-911`) deletes
-  the status bubble; only the fresh final-answer message remains, and being a
-  new message it fires a push notification — matching Slack/Discord.
-- `delete_message` returns `False` on any failure, so the dispatcher falls back
-  to collapsing the bubble to a terminal marker (never left as "running").
+- lark does NOT declare `supports_message_deletion` (recall would tombstone).
+- The result is delivered as a fresh, **pushing** message (unchanged).
+- `_retire_status_bubble` (`message_dispatcher.py:891-911`) falls through to
+  `_collapse_status_bubble`, which EDITS the bubble in place to a terminal
+  marker (no recall → no tombstone).
+- The collapsed marker always shows the run time: `✅ done · 1:30 · 240k tok`
+  (`_status_footer_text(..., force_duration=True)`), independent of the
+  `show_duration` config, because the residual bubble IS the turn's run summary.
+  The result-message footer keeps `show_duration` gating so it doesn't
+  double-surface the duration.
+
+Net turn-end state on Feishu: a small grey `✅ done · <time> · <tok>` marker
+(the former bubble, edited in place) + the pushing answer message. No tombstone.
 
 ## Out of scope / follow-up
 
+- True single-message finalize (bubble edited into the full answer) would drop
+  the residual marker but also the final push; deferred since push is wanted.
 - Per-channel progress style override (core already notes it can layer later).
 
 ## Risks / breakage surface

--- a/docs/plans/feishu-concise-progress.md
+++ b/docs/plans/feishu-concise-progress.md
@@ -112,25 +112,21 @@ Footer text is composed in core (`_compose_status_message`) from existing
 i18n-safe pieces; no new user-facing strings in the Feishu adapter. Verify the
 `note` content carries no hardcoded English added in the adapter.
 
-## Expected v1 behavior difference (document, do not "fix")
+## Single-message finalize (implemented)
 
-Because Feishu does not declare `supports_message_deletion`,
-`_retire_status_bubble` (`message_dispatcher.py:891-911`) cannot delete the
-bubble. So at turn end Feishu shows **two persistent messages**: the collapsed
-status bubble (footer-only terminal marker `✅ done` / `⏹ stopped|failed`) AND
-the separate final-result message. Slack/Discord end with just the one final
-message (bubble deleted). This is intentional for v1 — testers should not file
-it as a bug. The bubble still self-updates in place during the turn (the
-concise value); only the terminal cleanup differs.
+Feishu can recall its own messages (`im.v1.message.delete`, verified live), so
+this closes the "two persistent messages" gap:
+
+- lark declares `supports_message_deletion=True`.
+- `FeishuBot.delete_message` overrides the base no-op to call `adelete`.
+- At turn end `_retire_status_bubble` (`message_dispatcher.py:891-911`) deletes
+  the status bubble; only the fresh final-answer message remains, and being a
+  new message it fires a push notification — matching Slack/Discord.
+- `delete_message` returns `False` on any failure, so the dispatcher falls back
+  to collapsing the bubble to a terminal marker (never left as "running").
 
 ## Out of scope / follow-up
 
-- **Push notification / single-message finalize parity:** achieving the
-  Slack/Discord "one final message" end state needs `delete_message` support on
-  Feishu (+ `supports_message_deletion`). Separate follow-up. Do NOT flip
-  `supports_message_deletion` in this change (leaving it false is safe:
-  `delete_message` defaults to a no-op, so a mistaken flip fails-soft, but keep
-  it off).
 - Per-channel progress style override (core already notes it can layer later).
 
 ## Risks / breakage surface

--- a/docs/plans/feishu-concise-progress.md
+++ b/docs/plans/feishu-concise-progress.md
@@ -1,0 +1,176 @@
+# Feishu/Lark: Concise Progress Mode Support
+
+## Background
+
+Avibe models mid-turn agent "progress" (thinking / tool calls / status) as a
+single tri-state setting `agent_progress_style` = `concise | verbose | off`
+(`config/v2_config.py:77, 435-438`).
+
+- `off` — no process bubble (default).
+- `concise` — ONE self-updating status bubble: short body line (`🔧 <action>`)
+  plus a de-emphasized liveness footer (elapsed / step count), edited in place,
+  finally rewritten into the answer.
+- `verbose` — legacy append/split process log.
+
+The concise machinery in the shared core is already fully platform-agnostic:
+- `core/controller.py:919-948` resolves style + `uses_concise_status_bubble`.
+- `core/message_dispatcher.py:340-370` `_concise_progress_style` gates on the
+  per-platform capability `supports_status_bubble`; non-capable platforms are
+  hard-capped to `verbose`.
+- `_render_concise_status` (`:372-473`) + `begin_status_bubble` (`:475-521`)
+  create/edit the bubble, passing `subtext=footer` to
+  `im_client.edit_message` / `send_message`.
+
+**Gap:** only Slack and Discord set `supports_status_bubble=True` AND render the
+`subtext` footer. Feishu/Lark advertises neither, so it always falls back to
+`verbose`.
+
+Current Feishu state:
+- `config/platform_registry.py:220-230` lark descriptor has no
+  `supports_status_bubble` (→ False).
+- `modules/im/feishu.py` `send_message` (:367-425), `_reply_message` (:427-461),
+  `edit_message` (:634-689) accept `subtext` but **ignore** it.
+- `_build_card_json` (:463-532) renders only the body markdown element (card
+  schema 2.0), no footer element.
+
+## Goal
+
+Let a user who selects `agent_progress_style = concise` get the single
+self-updating status bubble on Feishu/Lark, matching Slack/Discord semantics.
+No core dispatcher changes — close the gap purely in the Feishu adapter + the
+one capability flag.
+
+## Reference: how Slack/Discord render the footer
+
+- Slack: renders `subtext` as a native context block (small grey text)
+  (`modules/im/slack.py:762-766`).
+- Discord: appends `-# subtext` small text, handles footer-only empty body
+  (`modules/im/discord.py:474-497`).
+- Contract doc: `modules/im/base.py:325-348`.
+
+Feishu card schema 2.0 has a `note` element that renders small grey secondary
+text — the direct analog.
+
+## Changes
+
+### 1. Enable the capability
+`config/platform_registry.py` lark descriptor: add
+`supports_status_bubble=True`.
+
+### 2. Render the footer in the card
+`modules/im/feishu.py` `_build_card_json`: add a `subtext: Optional[str] = None`
+parameter. When non-empty, append a `note` element after the body:
+
+```python
+if subtext:
+    elements.append({
+        "tag": "note",
+        "elements": [{"tag": "plain_text", "content": subtext}],
+    })
+```
+
+Buttons (if any) stay after/around per existing layout; footer note goes last.
+
+### 3. Handle footer-only (empty body) bubble
+`begin_status_bubble` posts an empty body + footer. Feishu `send_message`
+currently raises on empty text (`if not text: raise ValueError`).
+- Relax the guard: allow empty `text` when `subtext` is non-empty.
+- In `_build_card_json`, only add the body markdown element when `text` is
+  non-empty, so a footer-only card renders the note alone (no empty markdown
+  element). Preserve existing behavior when both empty (still reject upstream).
+
+### 4. Thread `subtext` through all send/edit paths
+- `send_message` (:367): pass `subtext` into `_build_card_json`; on the
+  thread-reply branch, pass `subtext` into `_reply_message`. While here, clean
+  up the pre-built-then-discarded `body_builder`/`request` (:389-401) so the
+  subtext-aware build isn't shadowed by a stale non-subtext build on the
+  thread-reply branch.
+- `_reply_message` (:427): add `subtext` param, forward to `_build_card_json`.
+- `edit_message` (:634): pass `subtext` into `_build_card_json` (both the
+  text-present and keyboard-only branches). No guard relaxation needed here —
+  it already treats `text=""` as "build empty-text card", so the terminal
+  collapse path (`message_dispatcher.py:887`, `edit_message(text="",
+  subtext=marker)`) works once `_build_card_json` skips the empty body element.
+
+### 4b. Thread `subtext` through the buttoned result path (FUNCTIONAL BLOCKER)
+`core/message_dispatcher.py:1823-1854` (`_send_result_inline`) and
+`_send_split_result_messages` (:1856-1908) call `send_message_with_buttons(...,
+subtext=...)` whenever the final result has quick-reply buttons AND a done
+footer (concise turns almost always have one, since `begin_status_bubble` runs
+at turn start). Feishu's `send_message_with_buttons` (:534) has no `subtext`
+param → raises `TypeError`, which the caller's try/except swallows by falling
+back to plain `send_message` — silently DROPPING the quick-reply buttons.
+Slack (`slack.py:1532-1540`) and Discord (`discord.py:529-537`) both accept it.
+
+Fix: add `subtext: Optional[str] = None` to `send_message_with_buttons`, thread
+it into the single `_build_card_json(text, button_rows)` call (:564), and apply
+the same empty-text guard relaxation as `send_message`. `_reply_message_with_card`
+needs no change (card JSON is built once before the thread/non-thread branch).
+
+### 5. i18n / display text
+Footer text is composed in core (`_compose_status_message`) from existing
+i18n-safe pieces; no new user-facing strings in the Feishu adapter. Verify the
+`note` content carries no hardcoded English added in the adapter.
+
+## Expected v1 behavior difference (document, do not "fix")
+
+Because Feishu does not declare `supports_message_deletion`,
+`_retire_status_bubble` (`message_dispatcher.py:891-911`) cannot delete the
+bubble. So at turn end Feishu shows **two persistent messages**: the collapsed
+status bubble (footer-only terminal marker `✅ done` / `⏹ stopped|failed`) AND
+the separate final-result message. Slack/Discord end with just the one final
+message (bubble deleted). This is intentional for v1 — testers should not file
+it as a bug. The bubble still self-updates in place during the turn (the
+concise value); only the terminal cleanup differs.
+
+## Out of scope / follow-up
+
+- **Push notification / single-message finalize parity:** achieving the
+  Slack/Discord "one final message" end state needs `delete_message` support on
+  Feishu (+ `supports_message_deletion`). Separate follow-up. Do NOT flip
+  `supports_message_deletion` in this change (leaving it false is safe:
+  `delete_message` defaults to a no-op, so a mistaken flip fails-soft, but keep
+  it off).
+- Per-channel progress style override (core already notes it can layer later).
+
+## Risks / breakage surface
+
+- Card schema 2.0 `note` element must be valid for both `acreate` and `apatch`
+  (edit) requests, and inside `reply_in_thread` cards.
+- Empty-body guard relaxation must not let a truly empty (no text, no subtext)
+  card through.
+- Non-concise platforms and Feishu `verbose`/`off` paths must be untouched:
+  when `subtext` is None (the normal non-concise send/edit), `_build_card_json`
+  output is byte-for-byte identical to today.
+- The thread-reply path (`_reply_message`) previously dropped buttons; only add
+  `subtext`, do not change button behavior.
+
+## Early de-risk (before full plumbing)
+
+Feishu card schema 2.0 `note` element validity is the central design bet.
+Before wiring all the Python paths, do ONE raw smoke call (`im/v1/messages`
+create, msg_type `interactive`, schema 2.0 card with a single `note` element)
+against a real chat to confirm the API accepts it. Card content schema is
+identical across create/apatch/reply, so one create check covers all three
+call sites. Fail fast here rather than during the Incus pass.
+
+## Test / verification plan
+
+- Unit: extend Feishu adapter tests (stub lark client) to assert
+  `_build_card_json` includes the `note` element iff `subtext` is set, and that
+  `subtext=None` produces the current card exactly; assert footer-only
+  (empty text + subtext) builds a valid single-note card.
+- Contract: assert `send_message`/`edit_message`/`send_message_with_buttons`
+  forward `subtext` into the card content sent to the stubbed client.
+- Buttons + concise: assert that concise mode + quick-reply buttons on the final
+  result renders BOTH the buttons and the footer note (mirror the Discord case
+  `tests/test_status_bubble_footer_render.py:89`
+  `test_buttons_subtext_composes_footer_into_content`).
+- Capability: assert `_concise_progress_style` returns `concise` for lark once
+  the flag is set (dispatcher-level test if a pattern exists).
+- Regression (Incus, Lark): with `agent_progress_style=concise`, verify the
+  bubble lifecycle — turn-start footer-only bubble → in-place update on tool
+  calls → terminal collapse to a footer-only marker (`✅ done`) PLUS a separate
+  final-answer message (two messages; the bubble is NOT rewritten into the
+  answer, see "Expected v1 behavior difference"); also verify in-thread.
+- Lint: `ruff check` on changed Python files before push.

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -483,7 +483,12 @@ class FeishuBot(BaseIMClient):
         With ``subtext=None`` the card is byte-for-byte identical to before.
         """
         elements: list = []
-        if text:
+        # Keep the body markdown element for every legacy (subtext=None) call so
+        # a bare ``text=""`` (e.g. the settings-toggle keyboard-only edit) stays
+        # byte-for-byte identical. Only the footer-only concise bubble
+        # (text empty AND subtext set) drops the empty body so the note stands
+        # alone.
+        if text or subtext is None:
             elements.append({"tag": "markdown", "content": text})
         if buttons:
             for row in buttons:

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -374,11 +374,12 @@ class FeishuBot(BaseIMClient):
     ) -> str:
         """Send a text message to Feishu.
 
-        ``subtext`` (concise status-bubble footer) is part of the BaseIMClient
-        contract; Feishu has no native footer styling, so it is accepted and
-        ignored (no behavior change)."""
+        ``subtext`` (concise status-bubble footer) is rendered as a trailing
+        ``note`` element in the card (see ``_build_card_json``). When ``text`` is
+        empty but ``subtext`` is set (footer-only turn-start bubble) the send is
+        allowed and the note renders alone."""
         self._ensure_client()
-        if not text:
+        if not text and not subtext:
             raise ValueError("Feishu send_message requires non-empty text")
 
         from lark_oapi.api.im.v1 import (
@@ -386,27 +387,28 @@ class FeishuBot(BaseIMClient):
             CreateMessageRequestBody,
         )
 
-        body_builder = (
-            CreateMessageRequestBody.builder()
-            .receive_id(context.channel_id)
-            .msg_type("interactive")
-            .content(self._build_card_json(text))
-        )
-
-        # Thread reply
+        # Thread reply: the reply API path builds its own card, so avoid
+        # constructing an unused (and non-subtext-aware) request here.
         root_id = context.thread_id or reply_to
         if root_id:
-            body_builder = body_builder.uuid(f"{root_id}-{int(time.time() * 1000)}")
-
-        request = CreateMessageRequest.builder().receive_id_type("chat_id").request_body(body_builder.build()).build()
-
-        # If replying in thread, use reply API
-        if root_id:
-            message_id = await self._reply_message(root_id, text)
+            message_id = await self._reply_message(root_id, text, subtext=subtext)
             if self.settings_manager:
                 if self.sessions:
                     self.sessions.mark_thread_active(context.user_id, context.channel_id, root_id)
             return message_id
+
+        request = (
+            CreateMessageRequest.builder()
+            .receive_id_type("chat_id")
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(context.channel_id)
+                .msg_type("interactive")
+                .content(self._build_card_json(text, subtext=subtext))
+                .build()
+            )
+            .build()
+        )
 
         response = await self._lark_client.im.v1.message.acreate(request)
         if not response.success():
@@ -424,12 +426,13 @@ class FeishuBot(BaseIMClient):
                 self.sessions.mark_thread_active(context.user_id, context.channel_id, thread)
         return message_id
 
-    async def _reply_message(self, parent_id: str, text: str) -> str:
+    async def _reply_message(self, parent_id: str, text: str, subtext: Optional[str] = None) -> str:
         """Reply to an existing message as a topic (reply_in_thread).
 
         Using ``reply_in_thread=True`` keeps replies collapsed inside
         a topic, similar to Slack threads, instead of flooding the
-        main channel timeline.
+        main channel timeline. ``subtext`` renders the concise status-bubble
+        footer as a trailing ``note`` element.
         """
         self._ensure_client()
         from lark_oapi.api.im.v1 import (
@@ -443,7 +446,7 @@ class FeishuBot(BaseIMClient):
             .request_body(
                 ReplyMessageRequestBody.builder()
                 .msg_type("interactive")
-                .content(self._build_card_json(text))
+                .content(self._build_card_json(text, subtext=subtext))
                 .reply_in_thread(True)
                 .build()
             )
@@ -464,14 +467,24 @@ class FeishuBot(BaseIMClient):
         self,
         text: str,
         buttons: Optional[List[List[dict]]] = None,
+        subtext: Optional[str] = None,
     ) -> str:
         """Build interactive card JSON (v2) for a message with optional buttons.
 
         Uses JSON 2.0 card schema so that button callbacks are delivered via
         the ``card.action.trigger`` event, which supports WebSocket long
         connections.
+
+        ``subtext`` is the concise status-bubble footer (BaseIMClient contract).
+        When present it is rendered as a trailing ``note`` element — Feishu's
+        small de-emphasized secondary text, the analog of Slack's context block
+        / Discord's ``-#``. When ``text`` is empty (footer-only turn-start
+        bubble) the body markdown element is omitted so the note renders alone.
+        With ``subtext=None`` the card is byte-for-byte identical to before.
         """
-        elements: list = [{"tag": "markdown", "content": text}]
+        elements: list = []
+        if text:
+            elements.append({"tag": "markdown", "content": text})
         if buttons:
             for row in buttons:
                 if len(row) == 1:
@@ -522,6 +535,14 @@ class FeishuBot(BaseIMClient):
                         }
                     )
 
+        if subtext:
+            elements.append(
+                {
+                    "tag": "note",
+                    "elements": [{"tag": "plain_text", "content": subtext}],
+                }
+            )
+
         card = {
             "schema": "2.0",
             "body": {
@@ -537,10 +558,15 @@ class FeishuBot(BaseIMClient):
         text: str,
         keyboard: InlineKeyboard,
         parse_mode: Optional[str] = None,
+        subtext: Optional[str] = None,
     ) -> str:
-        """Send a message with interactive card buttons."""
+        """Send a message with interactive card buttons.
+
+        ``subtext`` renders the concise status-bubble footer as a trailing
+        ``note`` element; the concise result path passes it alongside quick-reply
+        buttons, so it must be accepted here (parity with Slack/Discord)."""
         self._ensure_client()
-        if not text:
+        if not text and not subtext:
             raise ValueError("Feishu send_message_with_buttons requires non-empty text")
 
         from lark_oapi.api.im.v1 import (
@@ -561,7 +587,7 @@ class FeishuBot(BaseIMClient):
                 )
             button_rows.append(btn_row)
 
-        card_json = self._build_card_json(text, button_rows)
+        card_json = self._build_card_json(text, button_rows, subtext=subtext)
 
         # Thread reply
         root_id = context.thread_id
@@ -642,8 +668,10 @@ class FeishuBot(BaseIMClient):
     ) -> bool:
         """Edit an existing Feishu message.
 
-        ``subtext`` is accepted for the BaseIMClient contract and ignored:
-        Feishu has no native de-emphasized footer styling (no behavior change)."""
+        ``subtext`` renders the concise status-bubble footer as a trailing
+        ``note`` element (see ``_build_card_json``). The status bubble edits its
+        body in place on each tool call and collapses to a footer-only marker at
+        turn end, so the footer must be carried through the patched card."""
         self._ensure_client()
         try:
             from lark_oapi.api.im.v1 import (
@@ -661,10 +689,10 @@ class FeishuBot(BaseIMClient):
                     button_rows.append(btn_row)
 
             if text is not None:
-                card_json = self._build_card_json(text, button_rows)
+                card_json = self._build_card_json(text, button_rows, subtext=subtext)
             elif keyboard is not None:
                 # Only updating buttons, need some fallback text
-                card_json = self._build_card_json("", button_rows)
+                card_json = self._build_card_json("", button_rows, subtext=subtext)
             else:
                 return True
 

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -121,6 +121,10 @@ class FeishuBot(BaseIMClient):
         self._user_info_cache: Dict[str, Dict[str, Any]] = {}
         self._dm_chat_ids: set = set()
         self._message_text_cache: Dict[str, str] = {}
+        # Concise-status footer (subtext) per message, so removing quick-reply
+        # buttons can rebuild the card WITHOUT dropping the ✅ done · time · tok
+        # footer. Parallel to the body cache above.
+        self._message_footer_cache: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle / injection
@@ -607,7 +611,7 @@ class FeishuBot(BaseIMClient):
         root_id = context.thread_id
         if root_id:
             message_id = await self._reply_message_with_card(root_id, card_json)
-            self._remember_message_text(message_id, text)
+            self._remember_message_text(message_id, text, subtext=subtext)
             if self.settings_manager:
                 if self.sessions:
                     self.sessions.mark_thread_active(context.user_id, context.channel_id, root_id)
@@ -636,7 +640,7 @@ class FeishuBot(BaseIMClient):
             raise RuntimeError(f"Feishu send card failed: {response.msg}")
 
         message_id = response.data.message_id
-        self._remember_message_text(message_id, text)
+        self._remember_message_text(message_id, text, subtext=subtext)
         if self.settings_manager and context.thread_id:
             if self.sessions:
                 self.sessions.mark_thread_active(context.user_id, context.channel_id, context.thread_id)
@@ -726,19 +730,30 @@ class FeishuBot(BaseIMClient):
                 )
                 return False
             if text is not None:
-                self._remember_message_text(message_id, text)
+                self._remember_message_text(message_id, text, subtext=subtext)
             return True
         except Exception as exc:
             logger.error("Error editing Feishu message %s: %s", message_id, exc)
             return False
 
-    def _remember_message_text(self, message_id: Optional[str], text: Optional[str]) -> None:
+    def _remember_message_text(
+        self, message_id: Optional[str], text: Optional[str], subtext: Optional[str] = None
+    ) -> None:
         if not message_id or text is None:
             return
         self._message_text_cache[message_id] = text
         while len(self._message_text_cache) > 200:
             oldest_key = next(iter(self._message_text_cache))
             self._message_text_cache.pop(oldest_key, None)
+        # Track the footer so a later button-removal edit can re-apply it. A
+        # truthy subtext sets it; an explicit empty subtext clears it (the footer
+        # was removed); ``None`` leaves any known footer untouched.
+        if subtext:
+            self._message_footer_cache[message_id] = subtext
+            while len(self._message_footer_cache) > 200:
+                self._message_footer_cache.pop(next(iter(self._message_footer_cache)), None)
+        elif subtext is not None:
+            self._message_footer_cache.pop(message_id, None)
 
     async def _fetch_message_card_content(self, message_id: str) -> Optional[Dict[str, Any]]:
         """Fetch and parse card content JSON for an existing message."""
@@ -780,9 +795,18 @@ class FeishuBot(BaseIMClient):
             return None
 
     @staticmethod
-    def _extract_text_from_card_content(card_content: Dict[str, Any]) -> Optional[str]:
-        """Extract human-visible text from card content for button removal."""
+    def _extract_text_from_card_content(
+        card_content: Dict[str, Any],
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Extract ``(body, footer)`` from card content for button removal.
+
+        The concise status footer is a notation-sized grey markdown element (see
+        ``_build_card_json``); it must NOT be folded into the body, or removing
+        quick-reply buttons would duplicate/mangle it. It is captured separately
+        (with the ``<font color='grey'>`` wrapper stripped, since ``edit_message``
+        re-wraps the subtext) so the caller can re-apply it as ``subtext``."""
         collected_texts: list[str] = []
+        footer_texts: list[str] = []
 
         def _collect(node: Any) -> None:
             if isinstance(node, list):
@@ -800,7 +824,12 @@ class FeishuBot(BaseIMClient):
             if tag == "markdown":
                 markdown_content = node.get("content")
                 if isinstance(markdown_content, str) and markdown_content.strip():
-                    collected_texts.append(markdown_content)
+                    # A notation-sized markdown element is the concise footer;
+                    # keep it out of the body and unwrap the grey font tag.
+                    if node.get("text_size") == "notation":
+                        footer_texts.append(FeishuBot._strip_grey_font(markdown_content))
+                    else:
+                        collected_texts.append(markdown_content)
 
             text_obj = node.get("text")
             if isinstance(text_obj, dict):
@@ -821,10 +850,19 @@ class FeishuBot(BaseIMClient):
 
         _collect(card_content)
 
-        if not collected_texts:
-            return None
+        body = "\n\n".join(collected_texts) if collected_texts else None
+        footer = " ".join(f for f in footer_texts if f) or None
+        return body, footer
 
-        return "\n\n".join(collected_texts)
+    @staticmethod
+    def _strip_grey_font(content: str) -> str:
+        """Unwrap a ``<font color='grey'>…</font>`` footer back to its raw text."""
+        s = content.strip()
+        prefix = "<font color='grey'>"
+        suffix = "</font>"
+        if s.startswith(prefix) and s.endswith(suffix):
+            return s[len(prefix) : -len(suffix)]
+        return s
 
     async def remove_inline_keyboard(
         self,
@@ -840,6 +878,9 @@ class FeishuBot(BaseIMClient):
         card text before updating the card without buttons.
         """
         display_text = text
+        # Preserve the concise footer (✅ done · time · tok) so removing the
+        # quick-reply buttons doesn't strip it from the result message.
+        footer = self._message_footer_cache.get(message_id)
         if display_text is None:
             display_text = self._message_text_cache.get(message_id)
         if display_text is None:
@@ -847,12 +888,16 @@ class FeishuBot(BaseIMClient):
             if card_content is None:
                 logger.debug("Skip Feishu keyboard removal: unable to fetch card content for %s", message_id)
                 return False
-            display_text = self._extract_text_from_card_content(card_content)
+            display_text, extracted_footer = self._extract_text_from_card_content(card_content)
             if display_text is None:
                 logger.debug("Skip Feishu keyboard removal: unable to extract card text for %s", message_id)
                 return False
+            if footer is None:
+                footer = extracted_footer
 
-        return await self.edit_message(context, message_id, text=display_text, keyboard=None, parse_mode=parse_mode)
+        return await self.edit_message(
+            context, message_id, text=display_text, keyboard=None, subtext=footer, parse_mode=parse_mode
+        )
 
     # ------------------------------------------------------------------
     # Callbacks

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -732,33 +732,6 @@ class FeishuBot(BaseIMClient):
             logger.error("Error editing Feishu message %s: %s", message_id, exc)
             return False
 
-    async def delete_message(self, context: MessageContext, message_id: str) -> bool:
-        """Recall a message the bot previously sent (im.v1.message.delete).
-
-        Used to retire the concise status bubble at turn end so only the final
-        answer remains (single-message finalize, matching Slack/Discord). Returns
-        ``False`` on any failure so the dispatcher falls back to collapsing the
-        bubble to a terminal marker."""
-        self._ensure_client()
-        try:
-            from lark_oapi.api.im.v1 import DeleteMessageRequest
-
-            request = DeleteMessageRequest.builder().message_id(message_id).build()
-            response = await self._lark_client.im.v1.message.adelete(request)
-            if not response.success():
-                logger.warning(
-                    "Failed to delete Feishu message %s: code=%s msg=%s",
-                    message_id,
-                    response.code,
-                    response.msg,
-                )
-                return False
-            self._message_text_cache.pop(message_id, None)
-            return True
-        except Exception as exc:
-            logger.warning("Error deleting Feishu message %s: %s", message_id, exc)
-            return False
-
     def _remember_message_text(self, message_id: Optional[str], text: Optional[str]) -> None:
         if not message_id or text is None:
             return

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -732,6 +732,33 @@ class FeishuBot(BaseIMClient):
             logger.error("Error editing Feishu message %s: %s", message_id, exc)
             return False
 
+    async def delete_message(self, context: MessageContext, message_id: str) -> bool:
+        """Recall a message the bot previously sent (im.v1.message.delete).
+
+        Used to retire the concise status bubble at turn end so only the final
+        answer remains (single-message finalize, matching Slack/Discord). Returns
+        ``False`` on any failure so the dispatcher falls back to collapsing the
+        bubble to a terminal marker."""
+        self._ensure_client()
+        try:
+            from lark_oapi.api.im.v1 import DeleteMessageRequest
+
+            request = DeleteMessageRequest.builder().message_id(message_id).build()
+            response = await self._lark_client.im.v1.message.adelete(request)
+            if not response.success():
+                logger.warning(
+                    "Failed to delete Feishu message %s: code=%s msg=%s",
+                    message_id,
+                    response.code,
+                    response.msg,
+                )
+                return False
+            self._message_text_cache.pop(message_id, None)
+            return True
+        except Exception as exc:
+            logger.warning("Error deleting Feishu message %s: %s", message_id, exc)
+            return False
+
     def _remember_message_text(self, message_id: Optional[str], text: Optional[str]) -> None:
         if not message_id or text is None:
             return

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -476,11 +476,14 @@ class FeishuBot(BaseIMClient):
         connections.
 
         ``subtext`` is the concise status-bubble footer (BaseIMClient contract).
-        When present it is rendered as a trailing ``note`` element — Feishu's
-        small de-emphasized secondary text, the analog of Slack's context block
-        / Discord's ``-#``. When ``text`` is empty (footer-only turn-start
-        bubble) the body markdown element is omitted so the note renders alone.
-        With ``subtext=None`` the card is byte-for-byte identical to before.
+        When present it is rendered as a trailing notation-sized markdown element
+        with an inline ``<font color='grey'>`` wrap — the analog of Slack's
+        context block / Discord's ``-#``. Card schema 2.0 dropped the ``note``
+        component, and its markdown component rejects a ``text_color`` property,
+        so grey must come from the inline font tag. When ``text`` is empty
+        (footer-only turn-start bubble) the body markdown element is omitted so
+        the footer renders alone. With ``subtext=None`` the card is byte-for-byte
+        identical to before.
         """
         elements: list = []
         # Keep the body markdown element for every legacy (subtext=None) call so
@@ -541,10 +544,16 @@ class FeishuBot(BaseIMClient):
                     )
 
         if subtext:
+            # Card schema 2.0 removed the ``note`` component. Its replacement is a
+            # notation-sized (smallest) markdown element; the grey de-emphasis
+            # must come from an inline ``<font color='grey'>`` tag, because the
+            # 2.0 markdown component rejects a ``text_color`` property. Both were
+            # verified against the live Feishu API.
             elements.append(
                 {
-                    "tag": "note",
-                    "elements": [{"tag": "plain_text", "content": subtext}],
+                    "tag": "markdown",
+                    "content": f"<font color='grey'>{subtext}</font>",
+                    "text_size": "notation",
                 }
             )
 

--- a/tests/test_controller_config_reload.py
+++ b/tests/test_controller_config_reload.py
@@ -163,4 +163,4 @@ def test_progress_style_getter_self_refreshes_from_disk(tmp_path, monkeypatch) -
 
     # No prior _refresh_config_from_disk call; the getter itself must pick it up.
     assert controller.get_progress_style_for_context(None) == "concise"
-    assert controller.get_heartbeat_interval_ms_for_context(None) == 15000
+    assert controller.get_heartbeat_interval_ms_for_context(None) == 8000

--- a/tests/test_feishu_status_bubble_footer.py
+++ b/tests/test_feishu_status_bubble_footer.py
@@ -69,6 +69,7 @@ def _stub_lark_client(bot: FeishuBot) -> types.SimpleNamespace:
         acreate=AsyncMock(return_value=_FakeResponse()),
         apatch=AsyncMock(return_value=_FakeResponse()),
         areply=AsyncMock(return_value=_FakeResponse()),
+        adelete=AsyncMock(return_value=_FakeResponse()),
     )
     client = types.SimpleNamespace(im=types.SimpleNamespace(v1=types.SimpleNamespace(message=message)))
     bot._lark_client = client
@@ -198,17 +199,36 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         _assert_is_footer(self, content["body"]["elements"][-1], "✅ done · 248k tok")
 
 
+    async def test_delete_message_calls_adelete(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        ok = await bot.delete_message(ctx, "om_del")
+        self.assertTrue(ok)
+        self.assertEqual(message.adelete.await_args.args[0].message_id, "om_del")
+
+    async def test_delete_message_returns_false_on_api_failure(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        message.adelete.return_value = _FakeResponse()
+        message.adelete.return_value.success = lambda: False  # type: ignore[assignment]
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        # Falsey response → dispatcher falls back to collapsing the bubble.
+        self.assertFalse(await bot.delete_message(ctx, "om_del"))
+
+
 class LarkCapabilityTests(unittest.TestCase):
     def test_lark_advertises_status_bubble(self):
         from config.platform_registry import get_platform_descriptor
 
         self.assertTrue(get_platform_descriptor("lark").capabilities.supports_status_bubble)
 
-    def test_lark_still_has_no_deletion(self):
-        # v1 keeps deletion off (two-message terminal state is intended).
+    def test_lark_advertises_deletion(self):
+        # Feishu can recall its own messages, so the concise bubble is deleted at
+        # turn end (single-message finalize, matching Slack/Discord).
         from config.platform_registry import get_platform_descriptor
 
-        self.assertFalse(get_platform_descriptor("lark").capabilities.supports_message_deletion)
+        self.assertTrue(get_platform_descriptor("lark").capabilities.supports_message_deletion)
 
 
 if __name__ == "__main__":

--- a/tests/test_feishu_status_bubble_footer.py
+++ b/tests/test_feishu_status_bubble_footer.py
@@ -91,6 +91,16 @@ class BuildCardJsonFooterTests(unittest.TestCase):
         # Explicit subtext=None is identical too.
         self.assertEqual(bot._build_card_json("hello"), bot._build_card_json("hello", subtext=None))
 
+    def test_empty_text_without_subtext_keeps_empty_body_element(self):
+        # The settings-toggle keyboard-only edit calls _build_card_json("",
+        # buttons, subtext=None); it must keep the (empty) markdown element so the
+        # card stays byte-for-byte identical to before this change.
+        bot = _make_bot()
+        buttons = [[{"text": "Toggle", "callback_data": "t"}]]
+        elements = _card_elements(bot._build_card_json("", buttons, subtext=None))
+        self.assertEqual(elements[0], {"tag": "markdown", "content": ""})
+        self.assertEqual([e["tag"] for e in elements], ["markdown", "button"])
+
     def test_footer_only_empty_body_renders_note_alone(self):
         bot = _make_bot()
         elements = _card_elements(bot._build_card_json("", subtext="⏳ working · 0s"))
@@ -137,6 +147,17 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
         with self.assertRaises(ValueError):
             await bot.send_message(ctx, "", subtext=None)
+
+    async def test_thread_reply_forwards_subtext(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark", thread_id="om_root")
+        await bot.send_message(ctx, "🔧 x", subtext="⏳ 5s")
+        # Thread reply goes through areply (reply_in_thread), not acreate.
+        message.acreate.assert_not_awaited()
+        content = json.loads(message.areply.await_args.args[0].request_body.content)
+        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
+        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "⏳ 5s")
 
     async def test_edit_message_forwards_subtext(self):
         bot = _make_bot()

--- a/tests/test_feishu_status_bubble_footer.py
+++ b/tests/test_feishu_status_bubble_footer.py
@@ -69,7 +69,6 @@ def _stub_lark_client(bot: FeishuBot) -> types.SimpleNamespace:
         acreate=AsyncMock(return_value=_FakeResponse()),
         apatch=AsyncMock(return_value=_FakeResponse()),
         areply=AsyncMock(return_value=_FakeResponse()),
-        adelete=AsyncMock(return_value=_FakeResponse()),
     )
     client = types.SimpleNamespace(im=types.SimpleNamespace(v1=types.SimpleNamespace(message=message)))
     bot._lark_client = client
@@ -199,23 +198,6 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         _assert_is_footer(self, content["body"]["elements"][-1], "✅ done · 248k tok")
 
 
-    async def test_delete_message_calls_adelete(self):
-        bot = _make_bot()
-        message = _stub_lark_client(bot)
-        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
-        ok = await bot.delete_message(ctx, "om_del")
-        self.assertTrue(ok)
-        self.assertEqual(message.adelete.await_args.args[0].message_id, "om_del")
-
-    async def test_delete_message_returns_false_on_api_failure(self):
-        bot = _make_bot()
-        message = _stub_lark_client(bot)
-        message.adelete.return_value = _FakeResponse()
-        message.adelete.return_value.success = lambda: False  # type: ignore[assignment]
-        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
-        # Falsey response → dispatcher falls back to collapsing the bubble.
-        self.assertFalse(await bot.delete_message(ctx, "om_del"))
-
 
 class LarkCapabilityTests(unittest.TestCase):
     def test_lark_advertises_status_bubble(self):
@@ -223,12 +205,13 @@ class LarkCapabilityTests(unittest.TestCase):
 
         self.assertTrue(get_platform_descriptor("lark").capabilities.supports_status_bubble)
 
-    def test_lark_advertises_deletion(self):
-        # Feishu can recall its own messages, so the concise bubble is deleted at
-        # turn end (single-message finalize, matching Slack/Discord).
+    def test_lark_does_not_advertise_deletion(self):
+        # Feishu message recall leaves a visible "此消息已撤回" tombstone, so we do
+        # NOT delete the bubble; the dispatcher collapses it to a terminal marker
+        # instead (keeps the pushing result message, no tombstone).
         from config.platform_registry import get_platform_descriptor
 
-        self.assertTrue(get_platform_descriptor("lark").capabilities.supports_message_deletion)
+        self.assertFalse(get_platform_descriptor("lark").capabilities.supports_message_deletion)
 
 
 if __name__ == "__main__":

--- a/tests/test_feishu_status_bubble_footer.py
+++ b/tests/test_feishu_status_bubble_footer.py
@@ -199,6 +199,56 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
 
 
 
+class KeyboardRemovalFooterTests(unittest.IsolatedAsyncioTestCase):
+    """Removing quick-reply buttons must keep the concise footer (P2 fix)."""
+
+    async def test_remove_inline_keyboard_reapplies_cached_footer(self):
+        bot = _make_bot()
+        _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        kb = InlineKeyboard(buttons=[[InlineButton(text="Continue", callback_data="c")]])
+        mid = await bot.send_message_with_buttons(ctx, "Final answer", kb, subtext="✅ done · 1:30 · 240k tok")
+        # The footer was cached alongside the body at send time.
+        self.assertEqual(bot._message_footer_cache.get(mid), "✅ done · 1:30 · 240k tok")
+
+        bot.edit_message = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        ok = await bot.remove_inline_keyboard(ctx, mid)
+        self.assertTrue(ok)
+        _, kwargs = bot.edit_message.await_args
+        self.assertEqual(kwargs["text"], "Final answer")
+        self.assertIsNone(kwargs["keyboard"])
+        # Footer re-applied, not dropped.
+        self.assertEqual(kwargs["subtext"], "✅ done · 1:30 · 240k tok")
+
+    async def test_remove_inline_keyboard_recovers_footer_from_card_on_cache_miss(self):
+        # Restart / cache miss: the footer is recovered from the live card and
+        # kept OUT of the body (font wrapper stripped), not folded into it.
+        bot = _make_bot()
+        _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        card = json.loads(
+            bot._build_card_json("Final answer", [[{"text": "OK", "callback_data": "ok"}]], subtext="✅ done · 5s")
+        )
+        bot._fetch_message_card_content = AsyncMock(return_value=card)  # type: ignore[method-assign]
+        bot.edit_message = AsyncMock(return_value=True)  # type: ignore[method-assign]
+        ok = await bot.remove_inline_keyboard(ctx, "om_uncached")
+        self.assertTrue(ok)
+        _, kwargs = bot.edit_message.await_args
+        self.assertEqual(kwargs["text"], "Final answer")  # footer NOT folded into body
+        self.assertEqual(kwargs["subtext"], "✅ done · 5s")  # font wrapper stripped
+
+    def test_extract_splits_body_and_footer(self):
+        bot = _make_bot()
+        card = json.loads(bot._build_card_json("Body text", subtext="✅ done · 5s"))
+        body, footer = bot._extract_text_from_card_content(card)
+        self.assertEqual(body, "Body text")
+        self.assertEqual(footer, "✅ done · 5s")
+
+    def test_strip_grey_font_unwraps_only_when_wrapped(self):
+        self.assertEqual(FeishuBot._strip_grey_font("<font color='grey'>x</font>"), "x")
+        self.assertEqual(FeishuBot._strip_grey_font("plain"), "plain")
+
+
 class LarkCapabilityTests(unittest.TestCase):
     def test_lark_advertises_status_bubble(self):
         from config.platform_registry import get_platform_descriptor

--- a/tests/test_feishu_status_bubble_footer.py
+++ b/tests/test_feishu_status_bubble_footer.py
@@ -1,0 +1,191 @@
+"""Feishu concise status-bubble footer rendering (parity with Slack/Discord).
+
+The dispatcher hands adapters ``(body, footer)`` separately via the optional
+``subtext`` parameter. Feishu renders the footer as a trailing card ``note``
+element (small de-emphasized text), the analog of Slack's context block and
+Discord's ``-#``. These tests cover:
+
+- the pure card builder (``_build_card_json``): note element iff ``subtext`` is
+  set, ``subtext=None`` is byte-identical to before, and footer-only (empty
+  body) renders the note alone;
+- the send/edit/buttons paths forward ``subtext`` into the card;
+- the empty-body guard relaxation;
+- the lark platform capability flag.
+
+The send paths use a stubbed lark client so nothing touches the network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from config.v2_config import LarkConfig
+from modules.im import MessageContext
+from modules.im.base import InlineButton, InlineKeyboard
+from modules.im.feishu import FeishuBot
+
+
+def _card_elements(card_json: str) -> list:
+    return json.loads(card_json)["body"]["elements"]
+
+
+def _make_bot() -> FeishuBot:
+    return FeishuBot(LarkConfig(app_id="app-id", app_secret="app-secret"))
+
+
+class _FakeResponse:
+    def __init__(self, message_id: str = "om_new") -> None:
+        self.data = types.SimpleNamespace(message_id=message_id, chat_id="oc_chat")
+        self.code = 0
+        self.msg = "ok"
+
+    def success(self) -> bool:
+        return True
+
+
+def _stub_lark_client(bot: FeishuBot) -> types.SimpleNamespace:
+    """Give ``bot`` a fake ``_lark_client`` capturing create/patch/reply calls."""
+    message = types.SimpleNamespace(
+        acreate=AsyncMock(return_value=_FakeResponse()),
+        apatch=AsyncMock(return_value=_FakeResponse()),
+        areply=AsyncMock(return_value=_FakeResponse()),
+    )
+    client = types.SimpleNamespace(im=types.SimpleNamespace(v1=types.SimpleNamespace(message=message)))
+    bot._lark_client = client
+    bot._ensure_client = lambda: None  # type: ignore[method-assign]
+    return message
+
+
+class BuildCardJsonFooterTests(unittest.TestCase):
+    def test_subtext_appends_note_element(self):
+        bot = _make_bot()
+        elements = _card_elements(bot._build_card_json("🔧 Read: feishu.py", subtext="⏳ 5s"))
+        # Body markdown first, footer note last.
+        self.assertEqual(elements[0], {"tag": "markdown", "content": "🔧 Read: feishu.py"})
+        self.assertEqual(
+            elements[-1],
+            {"tag": "note", "elements": [{"tag": "plain_text", "content": "⏳ 5s"}]},
+        )
+
+    def test_no_subtext_is_byte_identical_to_before(self):
+        bot = _make_bot()
+        # The pre-change output was a single markdown element and no note.
+        self.assertEqual(
+            bot._build_card_json("hello"),
+            json.dumps(
+                {
+                    "schema": "2.0",
+                    "body": {"direction": "vertical", "elements": [{"tag": "markdown", "content": "hello"}]},
+                },
+                ensure_ascii=False,
+            ),
+        )
+        # Explicit subtext=None is identical too.
+        self.assertEqual(bot._build_card_json("hello"), bot._build_card_json("hello", subtext=None))
+
+    def test_footer_only_empty_body_renders_note_alone(self):
+        bot = _make_bot()
+        elements = _card_elements(bot._build_card_json("", subtext="⏳ working · 0s"))
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "note")
+        self.assertEqual(elements[0]["elements"][0]["content"], "⏳ working · 0s")
+
+    def test_buttons_and_subtext_coexist(self):
+        bot = _make_bot()
+        buttons = [[{"text": "OK", "callback_data": "ok"}]]
+        elements = _card_elements(bot._build_card_json("Final answer", buttons, subtext="✅ done · 248k tok"))
+        tags = [e["tag"] for e in elements]
+        self.assertEqual(tags[0], "markdown")
+        self.assertIn("button", tags)
+        # Footer note is last so it stays below the buttons.
+        self.assertEqual(elements[-1]["tag"], "note")
+        self.assertEqual(elements[-1]["elements"][0]["content"], "✅ done · 248k tok")
+
+
+class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
+    async def test_send_message_forwards_subtext(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        await bot.send_message(ctx, "🔧 x", subtext="⏳ 5s")
+        content = json.loads(message.acreate.await_args.args[0].request_body.content)
+        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
+        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "⏳ 5s")
+
+    async def test_send_message_footer_only_is_allowed(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        # Empty body + subtext must NOT raise (turn-start footer-only bubble).
+        mid = await bot.send_message(ctx, "", subtext="⏳ working · 0s")
+        self.assertEqual(mid, "om_new")
+        content = json.loads(message.acreate.await_args.args[0].request_body.content)
+        self.assertEqual(len(content["body"]["elements"]), 1)
+        self.assertEqual(content["body"]["elements"][0]["tag"], "note")
+
+    async def test_send_message_empty_without_subtext_still_rejected(self):
+        bot = _make_bot()
+        _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        with self.assertRaises(ValueError):
+            await bot.send_message(ctx, "", subtext=None)
+
+    async def test_edit_message_forwards_subtext(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        ok = await bot.edit_message(ctx, "om_1", text="🔧 y", subtext="⏳ 9s")
+        self.assertTrue(ok)
+        content = json.loads(message.apatch.await_args.args[0].request_body.content)
+        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
+        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "⏳ 9s")
+
+    async def test_edit_message_collapse_marker_footer_only(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        # Terminal collapse edits body to "" and carries a marker footer.
+        ok = await bot.edit_message(ctx, "om_1", text="", subtext="✅ done")
+        self.assertTrue(ok)
+        content = json.loads(message.apatch.await_args.args[0].request_body.content)
+        self.assertEqual(len(content["body"]["elements"]), 1)
+        self.assertEqual(content["body"]["elements"][0]["elements"][0]["content"], "✅ done")
+
+    async def test_send_message_with_buttons_forwards_subtext(self):
+        bot = _make_bot()
+        message = _stub_lark_client(bot)
+        ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
+        keyboard = InlineKeyboard(buttons=[[InlineButton(text="Continue", callback_data="cont")]])
+        # Concise result path: buttons AND a done footer together.
+        await bot.send_message_with_buttons(ctx, "Final answer", keyboard, subtext="✅ done · 248k tok")
+        content = json.loads(message.acreate.await_args.args[0].request_body.content)
+        tags = [e["tag"] for e in content["body"]["elements"]]
+        # Both the buttons and the footer note survive (the regression codex flagged).
+        self.assertIn("button", tags)
+        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
+        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "✅ done · 248k tok")
+
+
+class LarkCapabilityTests(unittest.TestCase):
+    def test_lark_advertises_status_bubble(self):
+        from config.platform_registry import get_platform_descriptor
+
+        self.assertTrue(get_platform_descriptor("lark").capabilities.supports_status_bubble)
+
+    def test_lark_still_has_no_deletion(self):
+        # v1 keeps deletion off (two-message terminal state is intended).
+        from config.platform_registry import get_platform_descriptor
+
+        self.assertFalse(get_platform_descriptor("lark").capabilities.supports_message_deletion)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feishu_status_bubble_footer.py
+++ b/tests/test_feishu_status_bubble_footer.py
@@ -1,13 +1,14 @@
 """Feishu concise status-bubble footer rendering (parity with Slack/Discord).
 
 The dispatcher hands adapters ``(body, footer)`` separately via the optional
-``subtext`` parameter. Feishu renders the footer as a trailing card ``note``
-element (small de-emphasized text), the analog of Slack's context block and
-Discord's ``-#``. These tests cover:
+``subtext`` parameter. Card schema 2.0 dropped the ``note`` component, so Feishu
+renders the footer as a trailing notation-sized grey ``markdown`` element (its
+documented replacement) — the analog of Slack's context block and Discord's
+``-#``. These tests cover:
 
-- the pure card builder (``_build_card_json``): note element iff ``subtext`` is
-  set, ``subtext=None`` is byte-identical to before, and footer-only (empty
-  body) renders the note alone;
+- the pure card builder (``_build_card_json``): footer element iff ``subtext``
+  is set, ``subtext=None`` is byte-identical to before, and footer-only (empty
+  body) renders the footer alone;
 - the send/edit/buttons paths forward ``subtext`` into the card;
 - the empty-body guard relaxation;
 - the lark platform capability flag.
@@ -35,6 +36,17 @@ from modules.im.feishu import FeishuBot
 
 def _card_elements(card_json: str) -> list:
     return json.loads(card_json)["body"]["elements"]
+
+
+def _footer_element(subtext: str) -> dict:
+    # Card schema 2.0 has no ``note``; the footer is a notation-sized markdown
+    # element with an inline grey font wrap (verified valid against the live
+    # Feishu API — ``text_color`` as a property is rejected).
+    return {"tag": "markdown", "content": f"<font color='grey'>{subtext}</font>", "text_size": "notation"}
+
+
+def _assert_is_footer(test, element: dict, subtext: str) -> None:
+    test.assertEqual(element, _footer_element(subtext))
 
 
 def _make_bot() -> FeishuBot:
@@ -65,19 +77,16 @@ def _stub_lark_client(bot: FeishuBot) -> types.SimpleNamespace:
 
 
 class BuildCardJsonFooterTests(unittest.TestCase):
-    def test_subtext_appends_note_element(self):
+    def test_subtext_appends_footer_element(self):
         bot = _make_bot()
         elements = _card_elements(bot._build_card_json("🔧 Read: feishu.py", subtext="⏳ 5s"))
-        # Body markdown first, footer note last.
+        # Body markdown first, footer last.
         self.assertEqual(elements[0], {"tag": "markdown", "content": "🔧 Read: feishu.py"})
-        self.assertEqual(
-            elements[-1],
-            {"tag": "note", "elements": [{"tag": "plain_text", "content": "⏳ 5s"}]},
-        )
+        _assert_is_footer(self, elements[-1], "⏳ 5s")
 
     def test_no_subtext_is_byte_identical_to_before(self):
         bot = _make_bot()
-        # The pre-change output was a single markdown element and no note.
+        # The pre-change output was a single markdown element and no footer.
         self.assertEqual(
             bot._build_card_json("hello"),
             json.dumps(
@@ -101,12 +110,11 @@ class BuildCardJsonFooterTests(unittest.TestCase):
         self.assertEqual(elements[0], {"tag": "markdown", "content": ""})
         self.assertEqual([e["tag"] for e in elements], ["markdown", "button"])
 
-    def test_footer_only_empty_body_renders_note_alone(self):
+    def test_footer_only_empty_body_renders_footer_alone(self):
         bot = _make_bot()
         elements = _card_elements(bot._build_card_json("", subtext="⏳ working · 0s"))
         self.assertEqual(len(elements), 1)
-        self.assertEqual(elements[0]["tag"], "note")
-        self.assertEqual(elements[0]["elements"][0]["content"], "⏳ working · 0s")
+        _assert_is_footer(self, elements[0], "⏳ working · 0s")
 
     def test_buttons_and_subtext_coexist(self):
         bot = _make_bot()
@@ -115,9 +123,8 @@ class BuildCardJsonFooterTests(unittest.TestCase):
         tags = [e["tag"] for e in elements]
         self.assertEqual(tags[0], "markdown")
         self.assertIn("button", tags)
-        # Footer note is last so it stays below the buttons.
-        self.assertEqual(elements[-1]["tag"], "note")
-        self.assertEqual(elements[-1]["elements"][0]["content"], "✅ done · 248k tok")
+        # Footer is last so it stays below the buttons.
+        _assert_is_footer(self, elements[-1], "✅ done · 248k tok")
 
 
 class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
@@ -127,8 +134,7 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         ctx = MessageContext(user_id="U1", channel_id="oc_chat", platform="lark")
         await bot.send_message(ctx, "🔧 x", subtext="⏳ 5s")
         content = json.loads(message.acreate.await_args.args[0].request_body.content)
-        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
-        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "⏳ 5s")
+        _assert_is_footer(self, content["body"]["elements"][-1], "⏳ 5s")
 
     async def test_send_message_footer_only_is_allowed(self):
         bot = _make_bot()
@@ -139,7 +145,7 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mid, "om_new")
         content = json.loads(message.acreate.await_args.args[0].request_body.content)
         self.assertEqual(len(content["body"]["elements"]), 1)
-        self.assertEqual(content["body"]["elements"][0]["tag"], "note")
+        _assert_is_footer(self, content["body"]["elements"][0], "⏳ working · 0s")
 
     async def test_send_message_empty_without_subtext_still_rejected(self):
         bot = _make_bot()
@@ -156,8 +162,7 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         # Thread reply goes through areply (reply_in_thread), not acreate.
         message.acreate.assert_not_awaited()
         content = json.loads(message.areply.await_args.args[0].request_body.content)
-        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
-        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "⏳ 5s")
+        _assert_is_footer(self, content["body"]["elements"][-1], "⏳ 5s")
 
     async def test_edit_message_forwards_subtext(self):
         bot = _make_bot()
@@ -166,8 +171,7 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         ok = await bot.edit_message(ctx, "om_1", text="🔧 y", subtext="⏳ 9s")
         self.assertTrue(ok)
         content = json.loads(message.apatch.await_args.args[0].request_body.content)
-        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
-        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "⏳ 9s")
+        _assert_is_footer(self, content["body"]["elements"][-1], "⏳ 9s")
 
     async def test_edit_message_collapse_marker_footer_only(self):
         bot = _make_bot()
@@ -178,7 +182,7 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(ok)
         content = json.loads(message.apatch.await_args.args[0].request_body.content)
         self.assertEqual(len(content["body"]["elements"]), 1)
-        self.assertEqual(content["body"]["elements"][0]["elements"][0]["content"], "✅ done")
+        _assert_is_footer(self, content["body"]["elements"][0], "✅ done")
 
     async def test_send_message_with_buttons_forwards_subtext(self):
         bot = _make_bot()
@@ -189,10 +193,9 @@ class SendEditForwardsSubtextTests(unittest.IsolatedAsyncioTestCase):
         await bot.send_message_with_buttons(ctx, "Final answer", keyboard, subtext="✅ done · 248k tok")
         content = json.loads(message.acreate.await_args.args[0].request_body.content)
         tags = [e["tag"] for e in content["body"]["elements"]]
-        # Both the buttons and the footer note survive (the regression codex flagged).
+        # Both the buttons and the footer survive (the regression codex flagged).
         self.assertIn("button", tags)
-        self.assertEqual(content["body"]["elements"][-1]["tag"], "note")
-        self.assertEqual(content["body"]["elements"][-1]["elements"][0]["content"], "✅ done · 248k tok")
+        _assert_is_footer(self, content["body"]["elements"][-1], "✅ done · 248k tok")
 
 
 class LarkCapabilityTests(unittest.TestCase):

--- a/tests/test_message_dispatcher_status_bubble.py
+++ b/tests/test_message_dispatcher_status_bubble.py
@@ -399,7 +399,8 @@ class StatusBubbleResultTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn(("msg-2", "Final answer", "✅ done"), controller.im_client.sent)
         self.assertEqual(controller.im_client.deletes, ["msg-1"])  # delete attempted
         # Delete returned False → fall back to collapsing the bubble to a marker.
-        self.assertIn(("msg-1", "", "✅ done"), controller.im_client.edits)
+        # The collapsed marker always carries the run time (force_duration).
+        self.assertIn(("msg-1", "", "✅ done · 0s"), controller.im_client.edits)
 
     async def test_result_without_prior_bubble_sends_normally(self):
         controller = _StubController(platform="slack")
@@ -550,6 +551,22 @@ class StatusBubbleResultTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(controller.im_client.sent), sends_before)  # no new bubble posted
         self.assertEqual(len(controller.im_client.edits), edits_before)
 
+    async def test_collapsed_marker_shows_run_time_even_without_show_duration(self):
+        # The collapsed bubble is the turn's residual summary line, so it always
+        # reports the run time (force_duration) — here 90s → "1:30" — even though
+        # show_duration is off. The fresh RESULT footer keeps the show_duration
+        # gating, so it stays time-less.
+        controller = _StubController(platform="slack", im_client=_EditClient(delete_result=False))
+        d = _dispatcher(controller)
+        ctx = _ctx()
+        with mock.patch("core.message_dispatcher.persist_agent_message"):
+            await d.emit_agent_message(ctx, "toolcall", "🔧 `Bash` `{}`")  # bubble msg-1
+            key = d._get_consolidated_message_key(ctx)
+            d._status_started_at[key] = 910.0  # 90s before the frozen now (1000.0)
+            await d.emit_agent_message(ctx, "result", "Final answer")
+        self.assertIn(("msg-1", "", "✅ done · 1:30"), controller.im_client.edits)
+        self.assertIn(("msg-2", "Final answer", "✅ done"), controller.im_client.sent)
+
     async def test_error_result_collapse_fallback_uses_failed_marker(self):
         # C4: on an is_error turn where the bubble delete fails, the collapse
         # fallback reflects the failure outcome (⏹ failed), NOT a hardcoded ✅ done.
@@ -561,8 +578,8 @@ class StatusBubbleResultTests(unittest.IsolatedAsyncioTestCase):
             result_id = await d.emit_agent_message(ctx, "result", "Failed answer", is_error=True)
         self.assertEqual(result_id, "msg-2")  # fresh result message
         self.assertEqual(controller.im_client.deletes, ["msg-1"])  # delete attempted (failed)
-        self.assertIn(("msg-1", "", "⏹ failed"), controller.im_client.edits)  # collapse fallback
-        self.assertNotIn(("msg-1", "", "✅ done"), controller.im_client.edits)
+        self.assertIn(("msg-1", "", "⏹ failed · 0s"), controller.im_client.edits)  # collapse fallback
+        self.assertNotIn(("msg-1", "", "✅ done · 0s"), controller.im_client.edits)
 
     async def test_result_teardown_drops_lock_dict_entry(self):
         # C6: after a turn ends, the per-key consolidated lock must be dropped from
@@ -683,7 +700,7 @@ class BeginStatusBubbleTests(unittest.IsolatedAsyncioTestCase):
             result_id = await d.emit_agent_message(ctx, "result", "", is_error=True)
         self.assertIsNone(result_id)  # empty result delivers nothing
         # is_error + non-silent → "failed": ⏹ failed marker, not ✅.
-        self.assertIn(("msg-1", "", "⏹ failed"), controller.im_client.edits)
+        self.assertIn(("msg-1", "", "⏹ failed · 0s"), controller.im_client.edits)
 
     async def test_silent_result_tidies_starting_bubble(self):
         controller = _StubController(platform="slack")
@@ -693,7 +710,7 @@ class BeginStatusBubbleTests(unittest.IsolatedAsyncioTestCase):
         with mock.patch("core.message_dispatcher.persist_agent_message"):
             await d.emit_agent_message(ctx, "result", "🛑 stopped", level="silent")
         # Silent but NOT is_error → clean ✅ done marker.
-        self.assertIn(("msg-1", "", "✅ done"), controller.im_client.edits)
+        self.assertIn(("msg-1", "", "✅ done · 0s"), controller.im_client.edits)
 
     async def test_error_silent_result_tidies_starting_bubble_with_stop_marker(self):
         # A manually-stopped (silent + is_error) terminal collapses to ⏹ stopped.
@@ -703,7 +720,7 @@ class BeginStatusBubbleTests(unittest.IsolatedAsyncioTestCase):
         await d.begin_status_bubble(ctx)
         with mock.patch("core.message_dispatcher.persist_agent_message"):
             await d.emit_agent_message(ctx, "result", "", level="silent", is_error=True)
-        self.assertIn(("msg-1", "", "⏹ stopped"), controller.im_client.edits)
+        self.assertIn(("msg-1", "", "⏹ stopped · 0s"), controller.im_client.edits)
 
     async def test_error_result_posts_fresh_message_with_failed_footer(self):
         # A non-empty errored (non-silent) result is delivered as a fresh message

--- a/tests/test_message_dispatcher_status_bubble.py
+++ b/tests/test_message_dispatcher_status_bubble.py
@@ -186,9 +186,11 @@ class StatusBubbleProcessTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(controller.im_client.edits, [])
 
     async def test_non_editing_platform_uses_verbose_append(self):
-        controller = _StubController(platform="lark")
+        # wechat has no status-bubble capability (lark gained it), so it stays on
+        # the verbose append path.
+        controller = _StubController(platform="wechat")
         d = _dispatcher(controller)
-        self.assertEqual(d._concise_progress_style(_ctx("lark")), "verbose")
+        self.assertEqual(d._concise_progress_style(_ctx("wechat")), "verbose")
 
     async def test_concise_toolcall_renders_despite_hidden_toolcall(self):
         # Regression: the concise status bubble is an ephemeral status line, not
@@ -662,9 +664,10 @@ class BeginStatusBubbleTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(controller.im_client.edits, [])
 
     async def test_begin_noop_on_non_status_bubble_platform(self):
-        controller = _StubController(platform="lark")
+        # wechat lacks the status-bubble capability (lark gained it).
+        controller = _StubController(platform="wechat")
         d = _dispatcher(controller)
-        await d.begin_status_bubble(_ctx("lark"))
+        await d.begin_status_bubble(_ctx("wechat"))
         self.assertEqual(controller.im_client.sent, [])
         self.assertEqual(controller.im_client.edits, [])
 

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -53,7 +53,7 @@ class _StubIMClient:
 
 
 class _StubController:
-    def __init__(self, platform: str):
+    def __init__(self, platform: str, progress_style: str = "verbose"):
         self.config = type(
             "Config",
             (),
@@ -61,6 +61,15 @@ class _StubController:
         )()
         self.settings_manager = _StubSettingsManager()
         self.im_client = _StubIMClient()
+        # Process/assistant messages are gated by the progress style on
+        # status-bubble platforms (Slack/Discord/Lark). These content-transform
+        # tests exercise the verbose log-message delivery path, so default to
+        # "verbose" (lark's historical effective behavior before it gained the
+        # status-bubble capability).
+        self._progress_style = progress_style
+
+    def get_progress_style_for_context(self, context=None) -> str:
+        return self._progress_style
 
     @staticmethod
     def _get_settings_key(context: MessageContext) -> str:

--- a/tests/test_status_bubble_footer_render.py
+++ b/tests/test_status_bubble_footer_render.py
@@ -106,11 +106,12 @@ class DeletionCapabilityTests(unittest.TestCase):
     def test_status_bubble_platforms_advertise_deletion(self):
         from config.platform_registry import get_platform_descriptor
 
-        for platform in ("slack", "discord", "lark"):
+        for platform in ("slack", "discord"):
             caps = get_platform_descriptor(platform).capabilities
             self.assertTrue(caps.supports_message_deletion, platform)
-        # A non-deletion platform stays False (drives the collapse fallback).
-        self.assertFalse(get_platform_descriptor("wechat").capabilities.supports_message_deletion)
+        # Lark recall leaves a "此消息已撤回" tombstone, so it stays False and the
+        # dispatcher collapses its bubble to a marker instead of deleting.
+        self.assertFalse(get_platform_descriptor("lark").capabilities.supports_message_deletion)
 
     def test_compose_status_content_truncates_body_to_fit_2000_limit(self):
         # Over-limit body is truncated so the footer survives within Discord's

--- a/tests/test_status_bubble_footer_render.py
+++ b/tests/test_status_bubble_footer_render.py
@@ -106,11 +106,11 @@ class DeletionCapabilityTests(unittest.TestCase):
     def test_status_bubble_platforms_advertise_deletion(self):
         from config.platform_registry import get_platform_descriptor
 
-        for platform in ("slack", "discord"):
+        for platform in ("slack", "discord", "lark"):
             caps = get_platform_descriptor(platform).capabilities
             self.assertTrue(caps.supports_message_deletion, platform)
         # A non-deletion platform stays False (drives the collapse fallback).
-        self.assertFalse(get_platform_descriptor("lark").capabilities.supports_message_deletion)
+        self.assertFalse(get_platform_descriptor("wechat").capabilities.supports_message_deletion)
 
     def test_compose_status_content_truncates_body_to_fit_2000_limit(self):
         # Over-limit body is truncated so the footer survives within Discord's

--- a/tests/test_status_bubble_indicator.py
+++ b/tests/test_status_bubble_indicator.py
@@ -50,8 +50,9 @@ class UsesConciseStatusBubbleTests(unittest.TestCase):
         self.assertFalse(Controller.uses_concise_status_bubble(fake, _ctx("slack")))
 
     def test_non_editing_platform_false(self):
-        fake = self._fake("lark", "concise")
-        self.assertFalse(Controller.uses_concise_status_bubble(fake, _ctx("lark")))
+        # wechat has no status-bubble capability (lark gained it).
+        fake = self._fake("wechat", "concise")
+        self.assertFalse(Controller.uses_concise_status_bubble(fake, _ctx("wechat")))
 
 
 class ProcessingModeSuppressionTests(unittest.TestCase):

--- a/tests/test_status_bubble_settings.py
+++ b/tests/test_status_bubble_settings.py
@@ -29,7 +29,7 @@ class ConfigParsingTests(unittest.TestCase):
     def test_defaults(self):
         cfg = V2Config.from_payload(_payload())
         self.assertEqual(cfg.agent_progress_style, "off")
-        self.assertEqual(cfg.agent_status_heartbeat_ms, 15000)
+        self.assertEqual(cfg.agent_status_heartbeat_ms, 8000)
         self.assertEqual(cfg.agent_status_no_output_ms, 180000)
 
     def test_valid_overrides(self):
@@ -53,12 +53,12 @@ class ConfigParsingTests(unittest.TestCase):
             )
         )
         self.assertEqual(cfg.agent_progress_style, "off")
-        self.assertEqual(cfg.agent_status_heartbeat_ms, 15000)
+        self.assertEqual(cfg.agent_status_heartbeat_ms, 8000)
         self.assertEqual(cfg.agent_status_no_output_ms, 180000)
 
     def test_bool_is_not_accepted_as_int(self):
         cfg = V2Config.from_payload(_payload(agent_status_heartbeat_ms=True))
-        self.assertEqual(cfg.agent_status_heartbeat_ms, 15000)
+        self.assertEqual(cfg.agent_status_heartbeat_ms, 8000)
 
     def test_out_of_range_int_falls_back_to_default(self):
         # Above the sane cap (heartbeat 1h / no-output 24h) → default, so a
@@ -66,7 +66,7 @@ class ConfigParsingTests(unittest.TestCase):
         cfg = V2Config.from_payload(
             _payload(agent_status_heartbeat_ms=10_000_000, agent_status_no_output_ms=10**12)
         )
-        self.assertEqual(cfg.agent_status_heartbeat_ms, 15000)
+        self.assertEqual(cfg.agent_status_heartbeat_ms, 8000)
         self.assertEqual(cfg.agent_status_no_output_ms, 180000)
 
     def test_save_load_round_trip(self):
@@ -104,13 +104,13 @@ class ControllerGetterTests(unittest.TestCase):
 
     def test_interval_getters_guard_bad_value(self):
         fake = self._fake(agent_status_heartbeat_ms=0, agent_status_no_output_ms=-1)
-        self.assertEqual(Controller.get_heartbeat_interval_ms_for_context(fake, None), 15000)
+        self.assertEqual(Controller.get_heartbeat_interval_ms_for_context(fake, None), 8000)
         self.assertEqual(Controller.get_no_output_hint_after_ms_for_context(fake, None), 180000)
 
     def test_interval_getters_reject_bool(self):
         # bool is an int subclass; the getter must not treat True as 1ms.
         fake = self._fake(agent_status_heartbeat_ms=True, agent_status_no_output_ms=False)
-        self.assertEqual(Controller.get_heartbeat_interval_ms_for_context(fake, None), 15000)
+        self.assertEqual(Controller.get_heartbeat_interval_ms_for_context(fake, None), 8000)
         self.assertEqual(Controller.get_no_output_hint_after_ms_for_context(fake, None), 180000)
 
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1574,7 +1574,7 @@
     "replyEnhancementsHint": "Allow agents to add clickable quick-reply buttons at the end of result messages",
     "showPagesPrompt": "Show Page Guidance",
     "showPagesPromptHint": "Tell agents when and how to use visual Show Pages. The vibe show CLI remains available when this is off.",
-    "agentProgressStyle": "Progress display (Slack/Discord)",
+    "agentProgressStyle": "Progress display (Slack/Discord/Lark)",
     "agentProgressStyleHint": "How agent progress is shown: off, a single concise status bubble that becomes the result, or the verbose process log.",
     "agentProgressStyleConcise": "Concise",
     "agentProgressStyleVerbose": "Verbose",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1574,7 +1574,7 @@
     "replyEnhancementsHint": "允许 Agent 在结果消息末尾添加可点击的快捷回复按钮",
     "showPagesPrompt": "Show Page 引导",
     "showPagesPromptHint": "提示 Agent 何时以及如何使用可视化 Show Page。关闭后 vibe show CLI 仍然可用。",
-    "agentProgressStyle": "进度显示（Slack/Discord）",
+    "agentProgressStyle": "进度显示（Slack/Discord/飞书）",
     "agentProgressStyleHint": "Agent 进度的呈现方式：关闭 / 精简状态条(最终变成结果) / 详细过程日志。",
     "agentProgressStyleConcise": "精简",
     "agentProgressStyleVerbose": "详细",


### PR DESCRIPTION
## Capability

Bring the **concise progress status bubble** (previously Slack/Discord only) to **Feishu/Lark**, and lower the global elapsed-timer heartbeat default from 15s to 8s.

With `agent_progress_style = concise`, a Feishu turn now shows ONE self-updating card in the thread (`🔧 <action>` + a small grey `⏳ <elapsed>` footer), refreshed every 8s, that collapses at turn end to a `✅ done · <time> · <tok>` marker.

## What changed

- **Feishu concise bubble** (`config/platform_registry.py`, `modules/im/feishu.py`): lark advertises `supports_status_bubble`; the `subtext` footer is threaded through `send_message`/`_reply_message`/`edit_message`/`send_message_with_buttons`.
- **Schema-2.0 footer**: card schema 2.0 dropped the `note` component and rejects a `text_color` property (both hit live-API errors), so the footer renders as a notation-sized markdown element with an inline `<font color='grey'>` wrap. Verified against the live Feishu API.
- **Turn-end = collapse, NOT recall**: Feishu message recall works but leaves a visible `此消息已撤回` tombstone, so `supports_message_deletion` is intentionally left off (documented at the lark descriptor). The bubble collapses via in-place edit; the result still posts as a fresh, **pushing** message.
- **Collapsed marker shows run time**: `_status_footer_text(force_duration=True)` so the residual marker is `✅ done · 1:30 · 240k tok` regardless of `show_duration`; the result-message footer keeps its `show_duration` gating.
- **Heartbeat default 15s → 8s** (`config/v2_config.py`, `core/controller.py`, `core/message_dispatcher.py`): global, platform-agnostic; affects Slack/Discord/Lark.
- **Docs/UI**: progress-style label now reads `(Slack/Discord/Lark)` in en/zh; design docs updated.

## Evidence layers

- **Unit**: `tests/test_feishu_status_bubble_footer.py` (footer render, empty-body guard, thread reply, byte-parity when `subtext=None`), `tests/test_status_bubble_settings.py` (8s default), `tests/test_message_dispatcher_status_bubble.py` (collapse marker with run time), `tests/test_status_bubble_indicator.py` / `tests/test_status_bubble_footer_render.py` / `tests/test_controller_config_reload.py` (capability + fixture fixes).
- **Contract**: send/edit/buttons paths forward `subtext` into the card content sent to a stubbed lark client.
- **Live-API checks**: footer element shape and the send→(edit/recall) cycle were smoke-tested against the real Feishu API (that is how the `note`/`text_color`/tombstone issues were found).
- **Residual manual checks**: full Incus regression on Lark (bubble lifecycle: start footer → in-place tool-call updates → `✅ done` collapse + pushing answer; also in-thread) still recommended before merge.
- No scenario-catalog entry covers this flow; slow full-suite gates left to GitHub CI.

## Notes

- `ruff check` clean on all changed Python files.
- Reviewed iteratively by the codex-expert reviewer (plan + earlier commits); the collapse/heartbeat commits will be covered by the post-open Codex review watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
