### PR TITLE
fix(lark): adaptive multi-column quick-reply buttons

### DIFF
--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, fields
 from importlib import import_module
-from typing import Any
+from typing import Any, Optional
 
 
 @dataclass(frozen=True)
@@ -20,6 +20,12 @@ class PlatformCapabilities:
     supports_message_deletion: bool = False
     markdown_upload_returns_message_id: bool = False
     quick_reply_single_column: bool = False
+    # Max quick-reply buttons packed into one row before wrapping to the next.
+    # ``None`` means unlimited (all buttons on a single row). Ignored when
+    # ``quick_reply_single_column`` is set. Keeps wide-screen rows from
+    # overflowing and truncating button labels on platforms whose native
+    # wrapping (e.g. Lark's flow column_set) only kicks in on narrow screens.
+    quick_reply_max_per_row: Optional[int] = None
     supports_typing_indicator: bool = False
     typing_indicator_requires_clear: bool = False
     typing_indicator_best_effort: bool = False
@@ -225,8 +231,12 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
             # Lark cards lay quick replies out in a flow column_set that wraps to
-            # the next line when a row is full, so keep them multi-column.
+            # the next line when a row is full, so keep them multi-column. Cap at
+            # 3 per row: Lark's flow wrapping only triggers on narrow screens, so
+            # on wide desktop a longer row would compress and truncate labels. 3
+            # fits comfortably in the desktop card for typical (2-4) short labels.
             quick_reply_single_column=False,
+            quick_reply_max_per_row=3,
             supports_reaction_indicator=True,
             preferred_processing_indicator="reaction",
         ),

--- a/config/platform_registry.py
+++ b/config/platform_registry.py
@@ -224,7 +224,9 @@ PLATFORM_REGISTRY: dict[str, PlatformDescriptor] = {
             supports_quick_replies=True,
             supports_message_editing=True,
             markdown_upload_returns_message_id=True,
-            quick_reply_single_column=True,
+            # Lark cards lay quick replies out in a flow column_set that wraps to
+            # the next line when a row is full, so keep them multi-column.
+            quick_reply_single_column=False,
             supports_reaction_indicator=True,
             preferred_processing_indicator="reaction",
         ),

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -1817,7 +1817,14 @@ class ConsolidatedMessageDispatcher:
             callback = f"quick_reply:{btn.text}"
             row.append(InlineButton(text=btn.text, callback_data=callback))
 
-        rows = [[button] for button in row] if self._capabilities(context).quick_reply_single_column else [row]
+        caps = self._capabilities(context)
+        if caps.quick_reply_single_column:
+            rows = [[button] for button in row]
+        elif caps.quick_reply_max_per_row and caps.quick_reply_max_per_row > 0:
+            per_row = caps.quick_reply_max_per_row
+            rows = [row[i : i + per_row] for i in range(0, len(row), per_row)]
+        else:
+            rows = [row]
         return InlineKeyboard(buttons=rows)
 
     async def _send_result_inline(

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -473,8 +473,13 @@ class FeishuBot(BaseIMClient):
         """
         elements: list = [{"tag": "markdown", "content": text}]
         if buttons:
+            # Full-width ``fill`` only when the whole keyboard is a lone button.
+            # A single-button row that is merely the remainder of a chunked
+            # layout (e.g. 4 buttons -> 3 + 1) must stay in the flow column_set,
+            # otherwise it renders full width and clashes with the row above it.
+            single_button_card = len(buttons) == 1 and len(buttons[0]) == 1
             for row in buttons:
-                if len(row) == 1:
+                if len(row) == 1 and single_button_card:
                     btn = row[0]
                     behaviors_value: dict = {"key": btn["callback_data"]}
                     if btn.get("thread_id"):

--- a/modules/im/feishu.py
+++ b/modules/im/feishu.py
@@ -499,8 +499,9 @@ class FeishuBot(BaseIMClient):
                         columns.append(
                             {
                                 "tag": "column",
-                                "width": "weighted",
-                                "weight": 1,
+                                # ``auto`` sizes each column to its button so the
+                                # ``flow`` column_set can wrap to the next line.
+                                "width": "auto",
                                 "elements": [
                                     {
                                         "tag": "button",
@@ -516,7 +517,9 @@ class FeishuBot(BaseIMClient):
                     elements.append(
                         {
                             "tag": "column_set",
-                            "flex_mode": "none",
+                            # ``flow`` wraps columns to the next line when a row is
+                            # full, so quick replies stay readable on narrow screens.
+                            "flex_mode": "flow",
                             "background_style": "default",
                             "columns": columns,
                         }

--- a/tests/test_feishu_post_messages.py
+++ b/tests/test_feishu_post_messages.py
@@ -257,6 +257,31 @@ class FeishuCardLayoutTests(unittest.TestCase):
         self.assertEqual(button["tag"], "button")
         self.assertEqual(button["width"], "fill")
 
+    def test_chunked_remainder_single_button_stays_in_flow_column_set(self):
+        # 4 buttons chunk to rows of [3, 1]; the trailing lone button must render
+        # as a flow column_set (auto width, left-aligned), not a full-width
+        # ``fill`` button that would clash with the row of three above it.
+        bot = self._make_bot()
+        card = json.loads(
+            bot._build_card_json(
+                "pick",
+                [
+                    [
+                        {"text": "A", "callback_data": "quick_reply:A"},
+                        {"text": "B", "callback_data": "quick_reply:B"},
+                        {"text": "C", "callback_data": "quick_reply:C"},
+                    ],
+                    [{"text": "D", "callback_data": "quick_reply:D"}],
+                ],
+            )
+        )
+
+        rows = card["body"]["elements"][1:]
+        self.assertEqual([e["tag"] for e in rows], ["column_set", "column_set"])
+        self.assertEqual(len(rows[1]["columns"]), 1)
+        self.assertEqual(rows[1]["columns"][0]["width"], "auto")
+        self.assertEqual(rows[1]["flex_mode"], "flow")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_feishu_post_messages.py
+++ b/tests/test_feishu_post_messages.py
@@ -218,5 +218,45 @@ class FeishuPostMessageTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(bot.on_message_callback.await_args.args[1], "scheduled follow-up context")
 
 
+class FeishuCardLayoutTests(unittest.TestCase):
+    def _make_bot(self) -> FeishuBot:
+        return FeishuBot(LarkConfig(app_id="app-id", app_secret="app-secret"))
+
+    def test_multi_button_row_uses_flow_column_set(self):
+        bot = self._make_bot()
+        card = json.loads(
+            bot._build_card_json(
+                "pick one",
+                [
+                    [
+                        {"text": "A", "callback_data": "quick_reply:A"},
+                        {"text": "B", "callback_data": "quick_reply:B"},
+                    ]
+                ],
+            )
+        )
+
+        column_set = card["body"]["elements"][1]
+        self.assertEqual(column_set["tag"], "column_set")
+        # ``flow`` lets a full row wrap to the next line on narrow screens, and
+        # ``auto`` widths size each column to its button so wrapping works.
+        self.assertEqual(column_set["flex_mode"], "flow")
+        self.assertEqual([c["width"] for c in column_set["columns"]], ["auto", "auto"])
+        self.assertNotIn("weight", column_set["columns"][0])
+
+    def test_single_button_row_fills_width(self):
+        bot = self._make_bot()
+        card = json.loads(
+            bot._build_card_json(
+                "confirm",
+                [[{"text": "OK", "callback_data": "quick_reply:OK"}]],
+            )
+        )
+
+        button = card["body"]["elements"][1]
+        self.assertEqual(button["tag"], "button")
+        self.assertEqual(button["width"], "fill")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_message_dispatcher_platform_limits.py
+++ b/tests/test_message_dispatcher_platform_limits.py
@@ -164,5 +164,31 @@ class MessageDispatcherPlatformLimitTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(all(len(chunk.encode("utf-8")) <= 1900 for chunk in chunks))
 
 
+class _Btn:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class QuickReplyKeyboardLayoutTests(unittest.TestCase):
+    def _rows(self, platform: str, count: int):
+        dispatcher = ConsolidatedMessageDispatcher(_StubController(platform))
+        context = MessageContext(user_id="u", channel_id="c", platform=platform)
+        buttons = [_Btn(f"b{i}") for i in range(count)]
+        keyboard = dispatcher._build_quick_reply_keyboard(context, buttons)
+        return [[b.text for b in row] for row in keyboard.buttons]
+
+    def test_lark_chunks_three_per_row(self):
+        # Lark caps at 3/row so wide-screen rows don't compress + truncate.
+        self.assertEqual(self._rows("lark", 5), [["b0", "b1", "b2"], ["b3", "b4"]])
+        self.assertEqual(self._rows("lark", 3), [["b0", "b1", "b2"]])
+
+    def test_telegram_stays_single_column(self):
+        self.assertEqual(self._rows("telegram", 3), [["b0"], ["b1"], ["b2"]])
+
+    def test_slack_keeps_single_row(self):
+        # No per-row cap and not single-column: all buttons stay on one row.
+        self.assertEqual(self._rows("slack", 3), [["b0", "b1", "b2"]])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -525,7 +525,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             [("C1", "Done.", "markdown")],
         )
 
-    async def test_lark_quick_reply_buttons_use_vertical_layout(self):
+    async def test_lark_quick_reply_buttons_use_horizontal_layout(self):
         controller = _StubController("lark")
         dispatcher = ConsolidatedMessageDispatcher(controller)
         context = MessageContext(user_id="U1", channel_id="C1", platform="lark")
@@ -538,7 +538,9 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(controller.im_client.sent_button_messages), 1)
         keyboard = controller.im_client.sent_button_messages[0][3]
-        self.assertEqual([[button.text for button in row] for row in keyboard.buttons], [["继续"], ["提交PR"]])
+        # Lark quick replies are now multi-column (cap 3/row), so two buttons
+        # share a single row instead of stacking vertically.
+        self.assertEqual([[button.text for button in row] for row in keyboard.buttons], [["继续", "提交PR"]])
 
     async def test_markdown_link_style_quick_reply_dispatches_label_callbacks(self):
         controller = _StubController("slack")


### PR DESCRIPTION
## What

Fix Lark/Feishu quick-reply button layout so buttons lay out multi-column and adapt across desktop and mobile, instead of being forced one-per-row.

Before: Lark forced every quick-reply button onto its own row (`quick_reply_single_column=True`).

After:
- Lark quick replies render multi-column in a card `column_set` with `flex_mode: "flow"` (auto-wraps to the next line on narrow/mobile screens) and per-column `width: "auto"` (was `weighted`/`weight:1`, which caused proportional compression).
- Rows are capped at **3 buttons per row** via a new `quick_reply_max_per_row` capability. Lark's `flow` only wraps on narrow screens, so on wide desktop an uncapped row would compress and truncate labels; 3/row fits the desktop card comfortably for the typical 2–4 short labels.
- A single-button row that is merely a chunked remainder (e.g. 4 buttons → 3 + 1) stays inside the flow `column_set` instead of rendering as a full-width `fill` button that clashed with the row above.

## Affected capability

Quick-reply buttons on **Lark/Feishu** only. Other platforms are unaffected:
- Telegram keeps `quick_reply_single_column=True` (checked first).
- Slack/Discord: `quick_reply_max_per_row` defaults to `None` → single row (unchanged).
- WeChat: `supports_quick_replies=False`.

## Evidence

- **Unit**: `tests/test_feishu_post_messages.py` — flow column_set + auto width for multi-button rows, lone-button full-width shortcut, and chunked-remainder button staying in the flow column_set. `tests/test_message_dispatcher_platform_limits.py` — per-row chunking for Lark (3/row), Telegram single-column, Slack single-row.
- **Manual**: verified live on Lark desktop + mobile — desktop shows up to 3 content-sized buttons per row without truncation; mobile wraps within a row via `flow`.
- **Residual manual checks**: extreme case of 3 very long (~12-char) labels in one row can still compress on desktop (Lark `flow` does not wrap on wide screens); acceptable for typical usage. A width-budget packer would be the fully-robust follow-up if needed.

## Review

Reviewed with the codex-expert reviewer before opening; the chunked-remainder edge case it surfaced is fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
