### PR TITLE
fix(ui): trust explicit public proxy origins

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -310,6 +310,7 @@ class UiConfig:
     setup_port: int = 5123
     open_browser: bool = True
     chat_message_font_size: int = DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX
+    trusted_public_origins: List[str] = field(default_factory=list)
     # Display name appended to the browser tab title ("Avibe - <name>"). When
     # blank the UI falls back to the machine's system hostname (surfaced as the
     # read-only ``system_hostname`` field in the /api/config payload).

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1928,6 +1928,100 @@ def test_terminal_websocket_accepts_setup_host_from_trusted_proxy(monkeypatch, t
 
 
 @pytest.mark.skipif(not ui_server.TERMINAL_SUPPORTED, reason="terminal requires a POSIX pty")
+def test_terminal_websocket_accepts_trusted_public_origin_from_proxy_when_remote_access_disabled(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("VIBE_UI_ENABLE_TERMINAL", "1")
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://avibe.example.com")
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+
+    accepted = False
+
+    async def fake_handle_websocket(websocket, session_id):
+        nonlocal accepted
+        accepted = True
+
+    monkeypatch.setattr(ui_server.get_terminal_service(), "handle_websocket", fake_handle_websocket)
+
+    with app.test_client().websocket_connect(
+        "/api/terminal/test",
+        headers={
+            "host": "127.0.0.1:5123",
+            "origin": "https://avibe.example.com",
+            "x-forwarded-proto": "https",
+            "x-forwarded-host": "avibe.example.com",
+            "x-forwarded-for": "203.0.113.10",
+            "x-vibe-test-remote-addr": "127.0.0.1",
+        },
+    ):
+        pass
+
+    assert accepted is True
+
+
+@pytest.mark.skipif(not ui_server.TERMINAL_SUPPORTED, reason="terminal requires a POSIX pty")
+def test_terminal_websocket_rejects_unlisted_public_origin_from_trusted_proxy(monkeypatch, tmp_path):
+    monkeypatch.setenv("VIBE_UI_ENABLE_TERMINAL", "1")
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with app.test_client().websocket_connect(
+            "/api/terminal/test",
+            headers={
+                "host": "127.0.0.1:5123",
+                "origin": "https://avibe.example.com",
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "avibe.example.com",
+                "x-forwarded-for": "203.0.113.10",
+                "x-vibe-test-remote-addr": "127.0.0.1",
+            },
+        ):
+            pass
+
+    assert exc.value.code == 1008
+
+
+@pytest.mark.skipif(not ui_server.TERMINAL_SUPPORTED, reason="terminal requires a POSIX pty")
+def test_terminal_websocket_rejects_loopback_trusted_public_origin_when_remote_access_enabled(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("VIBE_UI_ENABLE_TERMINAL", "1")
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://alex.avibe.bot")
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.public_url = "https://alex.avibe.bot"
+    config.remote_access.vibe_cloud.enabled = True
+    config.save()
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with app.test_client().websocket_connect(
+            "/api/terminal/test",
+            headers={
+                "host": "127.0.0.1:5123",
+                "origin": "https://alex.avibe.bot",
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "alex.avibe.bot",
+                "x-forwarded-for": "203.0.113.10",
+                "x-vibe-test-remote-addr": "127.0.0.1",
+            },
+        ):
+            pass
+
+    assert exc.value.code == 1008
+
+
+@pytest.mark.skipif(not ui_server.TERMINAL_SUPPORTED, reason="terminal requires a POSIX pty")
 def test_terminal_websocket_rejects_remote_same_host_different_origin(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_UI_ENABLE_TERMINAL", "1")
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
@@ -2794,6 +2888,29 @@ def test_setup_host_trusts_forwarded_host_from_explicit_trusted_proxy(monkeypatc
             "X-Forwarded-Proto": "http",
             "X-Forwarded-Host": "192.168.2.3",
             "X-Forwarded-For": "192.168.2.5",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+
+
+def test_trusted_public_origin_can_come_from_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.enabled = False
+    config.ui.trusted_public_origins = ["https://avibe.example.com"]
+    config.save()
+
+    response = app.test_client().get(
+        "/health",
+        base_url="http://127.0.0.1:5123",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+        headers={
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "avibe.example.com",
+            "X-Forwarded-For": "203.0.113.10",
         },
         follow_redirects=False,
     )

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -122,6 +122,7 @@ def test_config_post_accepts_vendor_json_content_type(monkeypatch, tmp_path):
 
 def test_config_post_rejects_untrusted_forwarded_origin(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://vibe.example")
     V2Config(
         mode="self_host",
         version="v2",
@@ -153,6 +154,146 @@ def test_config_post_rejects_untrusted_forwarded_origin(monkeypatch, tmp_path):
 
     assert response.status_code == 403
     assert response.get_json()["message"] == "Forbidden: invalid origin"
+
+
+def test_config_post_allows_trusted_public_origin_from_proxy_when_remote_access_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://avibe.example.com")
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    )
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+    headers["Origin"] = "https://avibe.example.com"
+    headers["X-Forwarded-Proto"] = "https"
+    headers["X-Forwarded-Host"] = "avibe.example.com"
+    headers["X-Forwarded-For"] = "203.0.113.10"
+
+    response = client.post(
+        "/api/config",
+        json={
+            "mode": "self_host",
+            "runtime": {"default_cwd": "/tmp/test"},
+            "agents": {
+                "default_backend": "opencode",
+                "opencode": {"enabled": True, "cli_path": "opencode"},
+                "claude": {"enabled": False, "cli_path": "claude"},
+                "codex": {"enabled": False, "cli_path": "codex"},
+            },
+        },
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["mode"] == "self_host"
+
+
+def test_config_post_rejects_unlisted_public_origin_from_trusted_proxy(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    )
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+    headers["Origin"] = "https://avibe.example.com"
+    headers["X-Forwarded-Proto"] = "https"
+    headers["X-Forwarded-Host"] = "avibe.example.com"
+    headers["X-Forwarded-For"] = "203.0.113.10"
+
+    response = client.post(
+        "/api/config",
+        json={"mode": "self_host"},
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_config_post_rejects_host_only_trusted_public_origin_entry(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "avibe.example.com")
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    )
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+    headers["Origin"] = "https://avibe.example.com"
+    headers["X-Forwarded-Proto"] = "https"
+    headers["X-Forwarded-Host"] = "avibe.example.com"
+    headers["X-Forwarded-For"] = "203.0.113.10"
+
+    response = client.post(
+        "/api/config",
+        json={"mode": "self_host"},
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_config_post_rejects_loopback_trusted_public_origin_when_remote_access_enabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://alex.avibe.bot")
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        remote_access=RemoteAccessConfig(),
+    )
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.public_url = "https://alex.avibe.bot"
+    cloud.session_secret = "session-secret"
+    config.save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+    headers["Origin"] = "https://alex.avibe.bot"
+    headers["X-Forwarded-Proto"] = "https"
+    headers["X-Forwarded-Host"] = "alex.avibe.bot"
+    headers["X-Forwarded-For"] = "203.0.113.10"
+
+    response = client.post(
+        "/api/config",
+        json={"mode": "self_host"},
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "remote_access_login_required"
 
 
 def test_config_post_allows_forwarded_origin_from_explicit_trusted_proxy(monkeypatch, tmp_path):

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -168,6 +168,7 @@ def test_config_post_allows_trusted_public_origin_from_proxy_when_remote_access_
         agents=AgentsConfig(),
     )
     config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.public_url = "https://avibe.example.com"
     config.save()
     client = app.test_client()
     headers = csrf_headers(client, "http://127.0.0.1:15131")

--- a/tests/test_ui_server_mutation_protection.py
+++ b/tests/test_ui_server_mutation_protection.py
@@ -198,9 +198,115 @@ def test_config_post_allows_trusted_public_origin_from_proxy_when_remote_access_
     assert response.get_json()["mode"] == "self_host"
 
 
+def test_config_post_allows_trusted_public_origin_during_first_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://avibe.example.com")
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+    headers["Origin"] = "https://avibe.example.com"
+    headers["X-Forwarded-Proto"] = "https"
+    headers["X-Forwarded-Host"] = "avibe.example.com"
+    headers["X-Forwarded-For"] = "203.0.113.10"
+
+    response = client.post(
+        "/api/config",
+        json={
+            "mode": "self_host",
+            "runtime": {"default_cwd": "/tmp/test"},
+            "agents": {
+                "default_backend": "opencode",
+                "opencode": {"enabled": True, "cli_path": "opencode"},
+                "claude": {"enabled": False, "cli_path": "claude"},
+                "codex": {"enabled": False, "cli_path": "codex"},
+            },
+        },
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["mode"] == "self_host"
+
+
+def test_config_post_prefers_trusted_public_origin_over_disabled_public_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://avibe.example.com:8443")
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    )
+    config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.public_url = "https://avibe.example.com"
+    config.save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+    headers["Origin"] = "https://avibe.example.com:8443"
+    headers["X-Forwarded-Proto"] = "https"
+    headers["X-Forwarded-Host"] = "avibe.example.com:8443"
+    headers["X-Forwarded-For"] = "203.0.113.10"
+
+    response = client.post(
+        "/api/config",
+        json={
+            "mode": "self_host",
+            "runtime": {"default_cwd": "/tmp/test"},
+            "agents": {
+                "default_backend": "opencode",
+                "opencode": {"enabled": True, "cli_path": "opencode"},
+                "claude": {"enabled": False, "cli_path": "claude"},
+                "codex": {"enabled": False, "cli_path": "codex"},
+            },
+        },
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["mode"] == "self_host"
+
+
 def test_config_post_rejects_unlisted_public_origin_from_trusted_proxy(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    )
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+    headers["Origin"] = "https://avibe.example.com"
+    headers["X-Forwarded-Proto"] = "https"
+    headers["X-Forwarded-Host"] = "avibe.example.com"
+    headers["X-Forwarded-For"] = "203.0.113.10"
+
+    response = client.post(
+        "/api/config",
+        json={"mode": "self_host"},
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_config_post_ignores_malformed_trusted_public_origin_entry(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://[::1")
     config = V2Config(
         mode="self_host",
         version="v2",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -18,7 +18,7 @@ from core.show_pages import (
 )
 from core.show_runtime import ShowRuntimeManager, _runtime_platform_tag, _safe_extract_tar, set_show_runtime_manager_for_tests
 from tests.test_ui_remote_access_auth import _mock_interface, _remote_peer, _save_config
-from vibe import remote_access
+from vibe import remote_access, ui_server
 from vibe.ui_server import app
 
 
@@ -2277,6 +2277,65 @@ def test_private_show_page_hmr_websocket_accepts_setup_host_local_peer(monkeypat
         set_show_runtime_manager_for_tests(None)
 
     assert manager.websocket_paths == ["/show/ses123/__vite_hmr"]
+
+
+def test_private_show_page_hmr_websocket_accepts_trusted_public_origin(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://avibe.example.com")
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    _create_show_page("ses123", "private")
+    manager = _FakeShowRuntimeManager()
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        with app.test_client().websocket_connect(
+            "/show/ses123/__vite_hmr",
+            headers={
+                "host": "127.0.0.1:5123",
+                "origin": "https://avibe.example.com",
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "avibe.example.com",
+                "x-forwarded-for": "203.0.113.10",
+                "x-vibe-test-remote-addr": "127.0.0.1",
+            },
+            subprotocols=["vite-hmr"],
+        ) as websocket:
+            websocket.receive_text()
+    except Exception as exc:
+        assert getattr(exc, "code", None) == 1011
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert manager.websocket_paths == ["/show/ses123/__vite_hmr"]
+
+
+def test_private_show_page_hmr_websocket_rejects_trusted_public_origin_mismatch(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv(ui_server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    monkeypatch.setenv(ui_server.TRUSTED_PUBLIC_ORIGINS_ENV, "https://avibe.example.com")
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    _create_show_page("ses123", "private")
+
+    try:
+        with app.test_client().websocket_connect(
+            "/show/ses123/__vite_hmr",
+            headers={
+                "host": "127.0.0.1:5123",
+                "origin": "https://evil.example.com",
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "avibe.example.com",
+                "x-forwarded-for": "203.0.113.10",
+                "x-vibe-test-remote-addr": "127.0.0.1",
+            },
+            subprotocols=["vite-hmr"],
+        ):
+            raise AssertionError("websocket should not connect")
+    except Exception as exc:
+        assert getattr(exc, "code", None) == 1008
 
 
 def test_public_show_page_hmr_websocket_uses_share_path(monkeypatch, tmp_path):

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -138,6 +138,7 @@ REMOTE_OAUTH_DEVICE_COOKIE_NAME = "__Host-vibe_oauth_device"
 REMOTE_OAUTH_DEVICE_TTL_SECONDS = 180 * 24 * 60 * 60
 MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 TRUSTED_PROXY_IPS_ENV = "VIBE_UI_TRUSTED_PROXY_IPS"
+TRUSTED_PUBLIC_ORIGINS_ENV = "VIBE_UI_TRUSTED_PUBLIC_ORIGINS"
 LOG_SOURCES = (
     ("service", "vibe_remote.log", lambda: paths.get_logs_dir() / "vibe_remote.log"),
     ("service_stdout", "service_stdout.log", lambda: paths.get_runtime_dir() / "service_stdout.log"),
@@ -354,6 +355,20 @@ def _effective_normalized_host() -> str:
     return _normalized_host(_effective_request_host())
 
 
+def _trusted_forwarded_origin_identity() -> tuple[str, str, int | None] | None:
+    trusted_forwarded_host = _trusted_forwarded_host()
+    if trusted_forwarded_host is None:
+        return None
+    forwarded_proto = request.headers.get("X-Forwarded-Proto", "").split(",")[0].strip().lower()
+    if forwarded_proto not in {"http", "https"}:
+        return None
+    return (
+        forwarded_proto,
+        _normalized_host(trusted_forwarded_host),
+        _origin_port(trusted_forwarded_host, forwarded_proto),
+    )
+
+
 def _trusted_forwarded_client_address() -> ipaddress._BaseAddress | None:
     if not _is_explicitly_trusted_proxy_peer():
         return None
@@ -415,6 +430,93 @@ def _forwarded_host_has_explicit_port(value: str) -> bool:
         return urlparse(f"//{value}").port is not None
     except ValueError:
         return False
+
+
+def _trusted_public_origin_entries(config: V2Config | None) -> list[str]:
+    values: list[str] = []
+    configured = getattr(getattr(config, "ui", None), "trusted_public_origins", None)
+    if isinstance(configured, str):
+        values.extend(configured.split(","))
+    elif isinstance(configured, (list, tuple, set)):
+        values.extend(str(value) for value in configured)
+    values.extend(os.environ.get(TRUSTED_PUBLIC_ORIGINS_ENV, "").split(","))
+    return [value.strip() for value in values if value and value.strip()]
+
+
+def _trusted_public_origin_entry_matches(
+    value: str,
+    *,
+    scheme: str,
+    host: str,
+    port: int | None,
+) -> bool:
+    parsed = urlparse(value)
+    try:
+        explicit_port = parsed.port
+    except ValueError:
+        logger.warning("Ignoring invalid %s entry: %s", TRUSTED_PUBLIC_ORIGINS_ENV, value)
+        return False
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        logger.warning("Ignoring invalid %s entry: %s", TRUSTED_PUBLIC_ORIGINS_ENV, value)
+        return False
+    entry_host = _normalized_host(parsed.hostname)
+    if entry_host != host:
+        return False
+    entry_scheme = parsed.scheme.lower()
+    return scheme == entry_scheme and port == (explicit_port or _origin_port(parsed.netloc, entry_scheme))
+
+
+def _trusted_public_origin_matches(
+    config: V2Config | None,
+    identity: tuple[str, str, int | None] | None,
+) -> bool:
+    if identity is None:
+        return False
+    scheme, host, port = identity
+    if not host:
+        return False
+    return any(
+        _trusted_public_origin_entry_matches(value, scheme=scheme, host=host, port=port)
+        for value in _trusted_public_origin_entries(config)
+    )
+
+
+def _trusted_public_origin_allowed_for_peer(
+    config: V2Config | None,
+    peer_address: ipaddress._BaseAddress | None,
+) -> bool:
+    if config is None:
+        return False
+    cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
+    if not getattr(cloud, "enabled", False):
+        return True
+    if peer_address is not None and not peer_address.is_loopback:
+        return True
+    logger.warning(
+        "Ignoring %s for loopback trusted proxy while remote access is enabled; "
+        "use a non-loopback proxy peer, disable remote access, or enforce authentication before the proxy.",
+        TRUSTED_PUBLIC_ORIGINS_ENV,
+    )
+    return False
+
+
+def _trusted_public_origin_local_request(config: V2Config | None) -> bool:
+    if not _has_trusted_forwarded_metadata():
+        return False
+    if not _trusted_public_origin_matches(config, _trusted_forwarded_origin_identity()):
+        return False
+    return _trusted_public_origin_allowed_for_peer(
+        config,
+        _request_peer_address(),
+    )
 
 
 def _is_mutation_guard_exempt() -> bool:
@@ -1126,6 +1228,8 @@ def _is_local_request(config: V2Config | None = None) -> bool:
         return False
     if _has_trusted_forwarded_metadata() and _trusted_forwarded_host() is None:
         return False
+    if _trusted_public_origin_local_request(config):
+        return True
     if not _has_trusted_forwarded_metadata() and _is_loopback_peer() and _effective_loopback_host():
         return True
     if _is_trusted_docker_loopback_request():
@@ -2182,6 +2286,9 @@ async def websocket_echo(websocket: WebSocket):
 async def show_runtime_hmr_websocket(websocket: WebSocket, session_id: str):
     from core.show_pages import ShowPageStore
 
+    if not _show_runtime_hmr_origin_allowed(websocket):
+        await websocket.close(code=1008)
+        return
     if not _show_runtime_websocket_authorized(websocket):
         await websocket.close(code=1008)
         return
@@ -2320,6 +2427,13 @@ def _show_runtime_websocket_authorized(websocket: Any) -> bool:
     return _remote_access_websocket_session_payload(websocket, config) is not None
 
 
+def _show_runtime_hmr_origin_allowed(websocket: Any) -> bool:
+    config = _load_remote_access_config()
+    if not _websocket_trusted_public_origin_local_request(websocket, config):
+        return True
+    return _websocket_origin_matches_effective_request(websocket)
+
+
 def _remote_access_websocket_session_payload(websocket: Any, config: V2Config | None) -> dict[str, Any] | None:
     if config is None or _websocket_is_local_request(websocket, config):
         return None
@@ -2384,6 +2498,22 @@ def _terminal_origin_allowed(websocket: Any) -> bool:
     )
 
 
+def _websocket_origin_matches_effective_request(websocket: Any) -> bool:
+    origin = _request_origin(websocket.headers.get("origin"))
+    if not origin:
+        return False
+    parsed_origin = urlparse(origin)
+    if _normalized_host(parsed_origin.netloc) != _websocket_normalized_host(websocket):
+        return False
+    origin_port = _origin_port(parsed_origin.netloc, parsed_origin.scheme)
+    websocket_scheme = _websocket_effective_scheme(websocket)
+    request_port = _origin_port(_websocket_effective_request_host(websocket), websocket_scheme)
+    return origin_port == request_port and _terminal_origin_scheme_matches_socket(
+        parsed_origin.scheme,
+        websocket_scheme,
+    )
+
+
 def _origin_port(netloc: str | None, scheme: str | None) -> int | None:
     if not netloc:
         return None
@@ -2413,6 +2543,8 @@ def _websocket_is_local_request(websocket: Any, config: V2Config | None = None) 
         return False
     if _websocket_has_trusted_forwarded_metadata(websocket) and _websocket_trusted_forwarded_host(websocket) is None:
         return False
+    if _websocket_trusted_public_origin_local_request(websocket, config):
+        return True
     client_host = _websocket_client_host(websocket)
     if not _websocket_has_trusted_forwarded_metadata(websocket) and client_host == "testclient":
         return _is_loopback_host(websocket.headers.get("host"))
@@ -2540,6 +2672,24 @@ def _websocket_effective_scheme(websocket: Any) -> str:
     return websocket.url.scheme
 
 
+def _websocket_trusted_forwarded_origin_identity(websocket: Any) -> tuple[str, str, int | None] | None:
+    trusted_forwarded_host = _websocket_trusted_forwarded_host(websocket)
+    if trusted_forwarded_host is None:
+        return None
+    forwarded_proto = websocket.headers.get("X-Forwarded-Proto", "").split(",")[0].strip().lower()
+    if forwarded_proto == "wss":
+        forwarded_proto = "https"
+    elif forwarded_proto == "ws":
+        forwarded_proto = "http"
+    if forwarded_proto not in {"http", "https"}:
+        return None
+    return (
+        forwarded_proto,
+        _normalized_host(trusted_forwarded_host),
+        _origin_port(trusted_forwarded_host, forwarded_proto),
+    )
+
+
 def _websocket_trusted_forwarded_client_address(websocket: Any) -> ipaddress._BaseAddress | None:
     if not _websocket_is_explicitly_trusted_proxy_peer(websocket):
         return None
@@ -2589,6 +2739,17 @@ def _websocket_is_private_peer(websocket: Any) -> bool:
 
 def _websocket_is_private_peer_address(address: ipaddress._BaseAddress | None) -> bool:
     return address is not None and _is_private_address(address)
+
+
+def _websocket_trusted_public_origin_local_request(websocket: Any, config: V2Config | None) -> bool:
+    if not _websocket_has_trusted_forwarded_metadata(websocket):
+        return False
+    if not _trusted_public_origin_matches(config, _websocket_trusted_forwarded_origin_identity(websocket)):
+        return False
+    return _trusted_public_origin_allowed_for_peer(
+        config,
+        _websocket_peer_address(websocket),
+    )
 
 
 def _websocket_peer_shares_setup_host_network(

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -291,22 +291,31 @@ def _current_origin() -> str:
     netloc = parsed.netloc
 
     config = _load_remote_access_config()
+    trusted_forwarded_origin = _trusted_forwarded_origin(default_scheme=scheme)
+    if trusted_forwarded_origin and _trusted_public_origin_local_request(config):
+        return trusted_forwarded_origin
+
     if config is not None and _is_remote_access_request(config):
         public_origin = _remote_access_public_origin(config)
         if public_origin:
             return public_origin
 
-    trusted_forwarded_host = _trusted_forwarded_host()
-    if trusted_forwarded_host is None:
+    if trusted_forwarded_origin is None:
         return f"{scheme}://{netloc}"
 
+    return trusted_forwarded_origin
+
+
+def _trusted_forwarded_origin(*, default_scheme: str | None = None) -> str | None:
+    trusted_forwarded_host = _trusted_forwarded_host()
+    if trusted_forwarded_host is None:
+        return None
     forwarded_proto = request.headers.get("X-Forwarded-Proto", "").split(",")[0].strip().lower()
-
+    if forwarded_proto not in {"http", "https"}:
+        forwarded_proto = (default_scheme or "").lower()
     if forwarded_proto in {"http", "https"}:
-        scheme = forwarded_proto
-    netloc = trusted_forwarded_host
-
-    return f"{scheme}://{netloc}"
+        return f"{forwarded_proto}://{trusted_forwarded_host}"
+    return None
 
 
 def _effective_request_host() -> str:
@@ -450,15 +459,16 @@ def _trusted_public_origin_entry_matches(
     host: str,
     port: int | None,
 ) -> bool:
-    parsed = urlparse(value)
     try:
+        parsed = urlparse(value)
         explicit_port = parsed.port
+        hostname = parsed.hostname
     except ValueError:
         logger.warning("Ignoring invalid %s entry: %s", TRUSTED_PUBLIC_ORIGINS_ENV, value)
         return False
     if (
         parsed.scheme.lower() not in {"http", "https"}
-        or not parsed.hostname
+        or not hostname
         or parsed.username
         or parsed.password
         or parsed.query
@@ -467,7 +477,7 @@ def _trusted_public_origin_entry_matches(
     ):
         logger.warning("Ignoring invalid %s entry: %s", TRUSTED_PUBLIC_ORIGINS_ENV, value)
         return False
-    entry_host = _normalized_host(parsed.hostname)
+    entry_host = _normalized_host(hostname)
     if entry_host != host:
         return False
     entry_scheme = parsed.scheme.lower()
@@ -494,7 +504,7 @@ def _trusted_public_origin_allowed_for_peer(
     peer_address: ipaddress._BaseAddress | None,
 ) -> bool:
     if config is None:
-        return False
+        return True
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     if not getattr(cloud, "enabled", False):
         return True

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2035,6 +2035,8 @@ def enforce_remote_access_cookie():
         if not local_request and not docker_probe_request:
             return jsonify({"ok": False, "error": "remote_access_host_mismatch"}), 503
         return None
+    if _trusted_public_origin_local_request(config):
+        return None
     if _remote_auth_exempt_path():
         return None
     from vibe import remote_access


### PR DESCRIPTION
## Summary

Fixes #791 by adding an explicit trusted public origin opt-in for self-managed reverse proxies with custom HTTPS domains.

This adds `VIBE_UI_TRUSTED_PUBLIC_ORIGINS` and the matching `ui.trusted_public_origins` config list. The env/config sources are merged, and entries must be explicit origins such as `https://avibe.example.com`. Host-only entries are ignored. The trust only applies when the request peer is already listed in `VIBE_UI_TRUSTED_PROXY_IPS` and the trusted forwarded host/proto matches one of the configured origins.

This restores the supported self-managed shape:

- `remote_access` disabled
- self-hosted reverse proxy peer explicitly trusted, for example `VIBE_UI_TRUSTED_PROXY_IPS=127.0.0.1`
- public HTTPS origin explicitly trusted, for example `VIBE_UI_TRUSTED_PUBLIC_ORIGINS=https://avibe.example.com`
- reverse proxy forwards `X-Forwarded-Proto`, `X-Forwarded-Host`, and client metadata

## Security Positioning

This does not add Avibe-layer authentication. It means Avibe trusts the operator-declared reverse proxy public origin; authentication or network restriction in front of that proxy, such as nginx auth, VPN, or an internal network boundary, remains the operator's responsibility. That matches the self-managed `remote_access` disabled deployment in #791.

To avoid an OIDC bypass when Avibe Cloud remote access is enabled, trusted public origin local trust is refused for loopback trusted proxy peers while `remote_access` is enabled. In that shape, operators must use a non-loopback proxy peer, disable remote access, or enforce authentication before the proxy.

## Coverage

- Capability: custom public origin trust for self-managed reverse proxies.
- Affected scenario IDs: none; this path is covered by focused unit/contract tests rather than a scenario catalog entry.
- Unit/contract evidence:
  - `uv run ruff check config/v2_config.py vibe/ui_server.py tests/test_ui_server_mutation_protection.py tests/test_ui_remote_access_auth.py tests/test_ui_show_pages.py`
  - `uv run pytest tests/test_ui_server_mutation_protection.py tests/test_ui_remote_access_auth.py tests/test_terminal_backend.py tests/test_ui_show_pages.py -q` (`315 passed`)
- Manual evidence: not run; behavior is covered by local HTTP/WebSocket regression tests.
