### PR TITLE
fix(ui): show terminal accessory key bar only on touch devices

### DIFF
--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -283,9 +283,11 @@ export const TerminalView: React.FC<{
       )}
 
       {status !== 'disabled' && (
-        // The accessory key bar shows on desktop too (design iwYIX): quick esc/tab/ctrl/arrows
-        // without leaving the window. On phones it's essential (soft keyboards lack these keys).
-        <div className="flex gap-1 overflow-x-auto border-t border-border bg-surface px-2 py-1.5">
+        // Accessory key bar for touch devices only — soft keyboards lack esc/tab/ctrl/arrows.
+        // Hidden when the primary pointer is fine (desktop, incl. touchscreen laptops): a
+        // hardware keyboard already has these keys and the bar just costs a row. Keyed off
+        // pointer type rather than the md: viewport breakpoint so tablets keep it.
+        <div className="hidden gap-1 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pointer-coarse:flex">
           {KEYS.map((k) => (
             <button
               key={k.labelKey}


### PR DESCRIPTION
## Capability

The Terminal accessory key bar (Esc / Tab / Ctrl / arrows / ^C / |) at the bottom of every terminal now renders **only on touch-primary devices** (phones, tablets without a hardware pointer). Desktop no longer shows it — a hardware keyboard already has these keys, and the bar cost a row of terminal height (user feedback on the workbench chat page).

## Implementation

One-line class change in `TerminalView.tsx`: the bar wrapper goes from `flex …` to `hidden … pointer-coarse:flex`.

Why `pointer-coarse:` instead of the `md:` viewport breakpoint used elsewhere:

- The bar's reason to exist is "the soft keyboard lacks these keys", which tracks pointer capability, not viewport width.
- iPad (≥ md viewport, touch-primary) keeps the bar; iPad + Magic Keyboard/trackpad reports a fine primary pointer, so the bar auto-hides exactly when a hardware keyboard is attached.
- Touchscreen laptops report a fine primary pointer and count as desktop (hidden).
- Prior art in-repo: `ChatPage.tsx` already uses `pointer-coarse:` for the timestamp reveal.

Note: the Monaco editor's mobile accessory bar uses `md:hidden` for the same concept; unifying it on `pointer-coarse:` is a candidate follow-up, left out of this fix to keep the diff minimal. Design frame `iwYIX` still shows the bar on the desktop terminal; the design file needs a matching touch-up.

## Evidence

- Scenario catalog: none applicable (pure presentation change, no scenario IDs).
- Unit/contract: none added — no logic changed; the sticky-Ctrl handler is unreachable while the bar is hidden and stays inert.
- Build: `npm run build` green in the worktree; verified the emitted CSS contains `@media (pointer:coarse){.pointer-coarse\:flex{display:flex}}` and that `hidden` + the variant land in the same utilities layer with later-wins ordering (compiled through the project's Tailwind 4.1.18 pipeline).
- Reviewer subagent: passed (layout, state, and consumer blast-radius checked; `TerminalTabs` is the only consumer and makes no assumption about the bar).
- Residual manual check: eyeball the terminal window on desktop (no bar) and a phone (bar present) after merge.
