### PR TITLE
fix(vault): avoid passkey evalByCredential on iOS

### DIFF
--- a/ui/src/lib/useProtectedVault.test.ts
+++ b/ui/src/lib/useProtectedVault.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { readPasskeyPrfResult } from './useProtectedVault';
+import { bytesToBase64 } from './vaultCrypto';
+import { passkeyCreationOptions, passkeyPrfAssertionOptions, readPasskeyPrfResult } from './useProtectedVault';
 
 function passkeyCredential(first?: ArrayBuffer | ArrayBufferView | number[]): PublicKeyCredential {
   return {
@@ -13,6 +14,45 @@ function passkeyCredential(first?: ArrayBuffer | ArrayBufferView | number[]): Pu
 }
 
 describe('protected vault WebAuthn PRF result handling', () => {
+  it('creates passkeys as required resident credentials', () => {
+    const options = passkeyCreationOptions('alex-app.avibe.bot');
+
+    expect(options.rp.id).toBe('alex-app.avibe.bot');
+    expect(options.authenticatorSelection).toEqual({ residentKey: 'required', userVerification: 'required' });
+    expect(options.extensions).toEqual({ prf: {} });
+  });
+
+  it('uses simple PRF eval with allowCredentials for credential-bound unlock', () => {
+    const prfSalt = new Uint8Array(32).fill(0x11);
+    const credentialId = new Uint8Array([1, 2, 3, 4]);
+    const options = passkeyPrfAssertionOptions(
+      [{ credentialId: bytesToBase64(credentialId), prfSalt }],
+      'alex-app.avibe.bot',
+    );
+    const prf = (options.extensions as { prf: { eval: { first: ArrayBuffer }; evalByCredential?: unknown } }).prf;
+
+    expect(options.rpId).toBe('alex-app.avibe.bot');
+    expect(options.userVerification).toBe('required');
+    expect(options.allowCredentials).toHaveLength(1);
+    expect(new Uint8Array(options.allowCredentials?.[0]?.id as ArrayBuffer)).toEqual(credentialId);
+    expect(new Uint8Array(prf.eval.first)).toEqual(prfSalt);
+    expect(prf.evalByCredential).toBeUndefined();
+  });
+
+  it('rejects multiple passkey entries instead of falling back to evalByCredential', () => {
+    const prfSalt = new Uint8Array(32).fill(0x11);
+
+    expect(() =>
+      passkeyPrfAssertionOptions(
+        [
+          { credentialId: bytesToBase64(new Uint8Array([1])), prfSalt },
+          { credentialId: bytesToBase64(new Uint8Array([2])), prfSalt },
+        ],
+        'alex-app.avibe.bot',
+      ),
+    ).toThrow(/passkey-multiple-not-supported/);
+  });
+
   it('copies the PRF output before handing it to the VMK wrap chain', () => {
     const source = new Uint8Array(32).fill(0x22);
     const backing = source.buffer as ArrayBuffer;

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -84,11 +84,6 @@ function randomChallenge(): ArrayBuffer {
   return bufferSource(crypto.getRandomValues(new Uint8Array(32)));
 }
 
-/** WebAuthn `prf.evalByCredential` keys are base64url-encoded credential ids. */
-function base64ToBase64Url(b64: string): string {
-  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
 /** Strip a stored record's DEK fields back to the bare VMK wrap_meta ({v, copies, scheme?}). */
 function baseVmkWrapMeta(wrapMeta: string): string {
   const parsed = JSON.parse(wrapMeta) as Record<string, unknown>;
@@ -124,32 +119,55 @@ export function readPasskeyPrfResult(credential: PublicKeyCredential | null): Ui
   return prfOutput;
 }
 
-type PasskeyEntry = { credentialId?: string; prfSalt: Uint8Array };
+export type PasskeyEntry = { credentialId?: string; prfSalt: Uint8Array };
+
+function singlePasskeyEntry(entries: PasskeyEntry[]): PasskeyEntry {
+  if (entries.length === 0) throw new Error('passkey-not-configured');
+  if (entries.length > 1) throw new Error('passkey-multiple-not-supported');
+  return entries[0];
+}
+
+export function passkeyCreationOptions(rpId: string): PublicKeyCredentialCreationOptions {
+  return {
+    rp: { name: WEBAUTHN_RP_NAME, id: rpId },
+    user: { id: bufferSource(WEBAUTHN_USER_HANDLE), name: 'avibe-vault', displayName: WEBAUTHN_RP_NAME },
+    challenge: randomChallenge(),
+    pubKeyCredParams: [
+      { type: 'public-key', alg: -7 },
+      { type: 'public-key', alg: -257 },
+    ],
+    authenticatorSelection: { residentKey: 'required', userVerification: 'required' },
+    extensions: { prf: {} } as AuthenticationExtensionsClientInputs,
+  };
+}
+
+export function passkeyPrfAssertionOptions(entries: PasskeyEntry[], rpId: string): PublicKeyCredentialRequestOptions {
+  const entry = singlePasskeyEntry(entries);
+  const options: PublicKeyCredentialRequestOptions = {
+    challenge: randomChallenge(),
+    rpId,
+    userVerification: 'required',
+    extensions: webAuthnPrfExtensionInput(entry.prfSalt) as AuthenticationExtensionsClientInputs,
+  };
+  if (entry.credentialId) {
+    options.allowCredentials = [
+      {
+        type: 'public-key' as const,
+        id: bufferSource(base64ToBytes(entry.credentialId)),
+      },
+    ];
+  }
+  return options;
+}
 
 /**
- * Assert one of the vault's passkeys and extract its PRF output. Uses
- * `evalByCredential` so each credential is evaluated with its own stored salt, then
- * returns the salt of whichever credential actually responded.
+ * Assert the vault passkey and extract its PRF output. Keep the assertion on the
+ * simple `prf.eval` path: iOS 1Password currently fails on `evalByCredential`,
+ * while `allowCredentials + prf.eval` preserves the exact credential binding.
  */
 async function assertPasskeyPrf(entries: PasskeyEntry[]): Promise<{ prfOutput: Uint8Array; prfSalt: Uint8Array }> {
-  const withId = entries.filter((entry) => entry.credentialId);
-  const evalByCredential: Record<string, { first: ArrayBuffer }> = {};
-  for (const entry of withId) {
-    evalByCredential[base64ToBase64Url(entry.credentialId as string)] = { first: bufferSource(entry.prfSalt) };
-  }
-  const extensions = (withId.length > 0
-    ? { prf: { evalByCredential } }
-    : webAuthnPrfExtensionInput(entries[0].prfSalt)) as AuthenticationExtensionsClientInputs;
   const assertion = (await navigator.credentials.get({
-    publicKey: {
-      challenge: randomChallenge(),
-      allowCredentials: withId.map((entry) => ({
-        type: 'public-key' as const,
-        id: bufferSource(base64ToBytes(entry.credentialId as string)),
-      })),
-      userVerification: 'required',
-      extensions,
-    },
+    publicKey: passkeyPrfAssertionOptions(entries, window.location.hostname),
   })) as PublicKeyCredential | null;
   if (!assertion) throw new Error('passkey-cancelled');
   const prfOutput = readPasskeyPrfResult(assertion);
@@ -161,17 +179,7 @@ async function assertPasskeyPrf(entries: PasskeyEntry[]): Promise<{ prfOutput: U
 /** Create a resident passkey, then assert it once to extract the PRF output. */
 async function setupPasskeyFactor(prfSalt: Uint8Array): Promise<{ prfOutput: Uint8Array; credentialId: string }> {
   const created = (await navigator.credentials.create({
-    publicKey: {
-      rp: { name: WEBAUTHN_RP_NAME, id: window.location.hostname },
-      user: { id: bufferSource(WEBAUTHN_USER_HANDLE), name: 'avibe-vault', displayName: WEBAUTHN_RP_NAME },
-      challenge: randomChallenge(),
-      pubKeyCredParams: [
-        { type: 'public-key', alg: -7 },
-        { type: 'public-key', alg: -257 },
-      ],
-      authenticatorSelection: { residentKey: 'preferred', userVerification: 'required' },
-      extensions: { prf: {} } as AuthenticationExtensionsClientInputs,
-    },
+    publicKey: passkeyCreationOptions(window.location.hostname),
   })) as PublicKeyCredential | null;
   if (!created) throw new Error('passkey-cancelled');
   const credentialId = bytesToBase64(toUint8(created.rawId));


### PR DESCRIPTION
## Summary

Fix the protected Vault passkey PRF flow for iOS Safari + 1Password by avoiding the `prf.evalByCredential` request shape that triggers the 1Password blank-sheet failure.

The new path intentionally targets the pre-launch product model:

- create passkeys as required resident credentials
- assert the single stored passkey with `allowCredentials + prf.eval`
- include an explicit `rpId` on PRF assertions
- reject multiple passkey PRF copies instead of silently choosing one

This keeps the credential binding and user-verification requirements while using the request shape validated by the mobile diagnostic lab.

## Evidence

- Unit: `npx vitest run src/lib/useProtectedVault.test.ts src/lib/vaultCrypto.test.ts`
- Contract/build: `npm run build`
- Lint: `npx eslint src/lib/useProtectedVault.ts src/lib/useProtectedVault.test.ts`
- Review: read-only Codex review found the multi-passkey ambiguity; this PR now rejects multiple passkey entries explicitly
- Scenario/manual: Show Page lab cases A, B, E, F, G, and H passed on iOS Safari + 1Password; only the `evalByCredential` cases C and D failed

## Residual checks

- The passkey operation itself still needs owner-device validation after deployment because real iOS Safari + 1Password ceremonies cannot be fully automated in CI.
