### PR TITLE
Fix protected Vault sign approval payload

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -2145,6 +2145,7 @@ def complete_sign_request(
     scheme: str,
     signature: dict[str, Any],
     requester: Any = None,
+    browser_signed: bool = False,
 ) -> dict[str, Any]:
     row_dict = _load_request_for_transition(
         conn,
@@ -2175,7 +2176,7 @@ def complete_sign_request(
         conn,
         name,
         requester=requester,
-        delivery={"scheme": scheme, "digest": digest, "browser_signed": bool(signature.get("browser_signed"))},
+        delivery={"scheme": scheme, "digest": digest, "browser_signed": bool(browser_signed)},
         request_id=request_id,
     )
     updated = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().one()

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -16,7 +16,7 @@ import pytest
 from sqlalchemy import select
 
 from storage import vault_service
-from storage.models import vault_requests, vault_secrets
+from storage.models import vault_audit, vault_requests, vault_secrets
 from storage.vault_crypto import Sealed
 from vibe import api
 
@@ -1297,6 +1297,11 @@ def test_agent_sign_request_approved_via_avault_sign(monkeypatch):
     assert completed["request"]["delivery"]["signature"] == {"signature": "ab" * 64, "recovery_id": 1}
     assert api.get_vault_request(requested["request"]["id"])["result"]["signature"] == {"signature": "ab" * 64, "recovery_id": 1}
     sign.assert_called_once_with(_sealed("key"), "00" * 32, "ecdsa-secp256k1-recoverable", name="ETH_KEY")
+    with api._vault_engine().connect() as conn:
+        audit_row = conn.execute(
+            select(vault_audit.c.delivery).where(vault_audit.c.request_id == requested["request"]["id"], vault_audit.c.event == "signed")
+        ).scalar_one()
+    assert json.loads(audit_row)["browser_signed"] is False
 
 
 def test_agent_sign_claims_request_before_avault_sign(monkeypatch):
@@ -2731,6 +2736,11 @@ def test_protected_sign_completion_requires_matching_request(monkeypatch):
     )
     assert result["ok"] is True
     assert result["request"]["status"] == "approved"
+    with api._vault_engine().connect() as conn:
+        audit_row = conn.execute(
+            select(vault_audit.c.delivery).where(vault_audit.c.request_id == request_id, vault_audit.c.event == "signed")
+        ).scalar_one()
+    assert json.loads(audit_row)["browser_signed"] is True
 
 
 def test_protected_sign_completion_rejects_malformed_browser_signature(monkeypatch):
@@ -2790,7 +2800,7 @@ def test_protected_sign_completion_rejects_signature_extra_fields(monkeypatch):
                 "digest": digest,
                 "scheme": "ecdsa-secp256k1-recoverable",
                 "request_id": pending["request"]["id"],
-                "signature": {**signature, "private_key": "raw", "dek": "raw"},
+                "signature": {**signature, "browser_signed": True, "private_key": "raw", "dek": "raw"},
             }
         )
 

--- a/ui/src/components/ui/vault-approval-card.tsx
+++ b/ui/src/components/ui/vault-approval-card.tsx
@@ -266,7 +266,7 @@ export const VaultApprovalCard: React.FC<{
         const material = card?.secret_unlock_material;
         if (!material) throw new Error(t('vaults.approval.errors.missingMaterial'));
         const sig = await vault.signProtectedRequest(material, digest, scheme as SignatureScheme);
-        const signature: Record<string, unknown> = { signature: sig.signature, browser_signed: true };
+        const signature: Record<string, unknown> = { signature: sig.signature };
         if (sig.recovery_id != null) signature.recovery_id = sig.recovery_id;
         failIfNotOk(await api.signVaultDigest({ name, request_id: request.id, digest, scheme, signature }));
       } else {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2734,6 +2734,7 @@ def vault_sign(payload: dict) -> dict:
                         scheme=scheme,
                         signature=signature,
                         requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
+                        browser_signed=True,
                     )
                     protected_event = {
                         "scope": "request",


### PR DESCRIPTION
## Summary
- stop sending the UI-only `browser_signed` marker inside protected signature payloads
- keep protected signature completion strict: only `signature` and `recovery_id` are accepted from the browser
- preserve audit intent by marking protected browser signing through an internal service parameter instead of trusting request payload metadata

## Why
Regression testing found protected signing approval failing with `signature payload contains unsupported fields: browser_signed`. The browser was correctly producing a public signature, but then mixed a UI/audit marker into the public signature object. The backend rejected it by design before completing the sign request.

## Evidence
- Unit: `python3 -m pytest tests/test_vault_api.py -q -k 'protected_sign or agent_sign_request_approved'` -> 10 passed
- Unit: `python3 -m pytest tests/test_vault_api.py tests/test_vault_cli.py -q` -> 198 passed
- Lint: `python3 -m ruff check vibe/api.py storage/vault_service.py tests/test_vault_api.py` -> passed
- UI: `npm run build` -> passed
- UI: `npx eslint src/components/ui/vault-approval-card.tsx` -> passed

## Notes
Existing protected sign requests that already failed can be retried after updating the regression environment. No migration is needed because the fix changes only the approval payload and audit marker path.
