### PR TITLE
feat(ui): mobile editor entry + full-page /apps/editor route

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -47,6 +47,9 @@ const AppsFileBrowserPage = lazy(() =>
 const AppsTerminalPage = lazy(() =>
   import('./components/workbench/AppsTerminalPage').then((m) => ({ default: m.AppsTerminalPage })),
 );
+const AppsEditorPage = lazy(() =>
+  import('./components/workbench/AppsEditorPage').then((m) => ({ default: m.AppsEditorPage })),
+);
 import { hasConfiguredPlatformCredentials } from './lib/platforms';
 import { applyAppTitle } from './lib/documentTitle';
 import { useTranslation } from 'react-i18next';
@@ -339,6 +342,14 @@ function AppRoutes() {
           element={
             <Suspense fallback={<AppsRouteFallback />}>
               <AppsTerminalPage />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/apps/editor"
+          element={
+            <Suspense fallback={<AppsRouteFallback />}>
+              <AppsEditorPage />
             </Suspense>
           }
         />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -34,6 +34,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { WorkbenchInboxProvider } from './context/WorkbenchInboxContext';
 import { WorkbenchProjectsProvider } from './context/WorkbenchProjectsContext';
 import { ComposerBridgeProvider } from './context/ComposerBridgeContext';
+import { NavGuardProvider } from './context/NavGuardContext';
 import { AgentationToggle } from './components/AgentationToggle';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -421,10 +422,12 @@ function App() {
             <WorkbenchInboxProvider>
               <WorkbenchProjectsProvider>
                 <ComposerBridgeProvider>
-                  <BrowserRouter>
-                    <AppRoutes />
-                  </BrowserRouter>
-                  <AgentationToggle />
+                  <NavGuardProvider>
+                    <BrowserRouter>
+                      <AppRoutes />
+                    </BrowserRouter>
+                    <AgentationToggle />
+                  </NavGuardProvider>
                 </ComposerBridgeProvider>
               </WorkbenchProjectsProvider>
             </WorkbenchInboxProvider>

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -15,6 +15,7 @@ import { WorkbenchSidebar } from './workbench/WorkbenchSidebar';
 import { AppsLauncher } from './AppsLauncher';
 import { ErrorBoundary } from './ui/error-boundary';
 import { WindowManagerProvider } from '../context/WindowManagerContext';
+import { useNavGuard } from '../context/NavGuardContext';
 import { WindowLayer } from './apps/WindowLayer';
 import { NewSessionSheet } from './workbench/NewSessionSheet';
 import { SearchPalette } from './workbench/search/SearchPalette';
@@ -112,6 +113,7 @@ const ShellNavGroup: React.FC<{ item: ShellNavItem }> = ({ item }) => {
 
 const MobileNavLink: React.FC<{ item: ShellNavItem }> = ({ item }) => {
   const location = useLocation();
+  const { confirmLeave } = useNavGuard();
   const active = item.match ? item.match(location.pathname) : location.pathname === item.to;
   const Icon = item.icon;
   const isWorkbench = item.variant === 'workbench';
@@ -147,9 +149,12 @@ const MobileNavLink: React.FC<{ item: ShellNavItem }> = ({ item }) => {
   );
 
   if (item.onClick) {
-    return <button type="button" onClick={item.onClick} className={className}>{inner}</button>;
+    const onClick = item.onClick;
+    return <button type="button" onClick={() => { if (confirmLeave()) onClick(); }} className={className}>{inner}</button>;
   }
-  return <NavLink to={item.to ?? '#'} className={className}>{inner}</NavLink>;
+  // Confirm before leaving a page that registered an unsaved-changes guard (e.g. the mobile editor);
+  // NavLink navigation bypasses `beforeunload`, so this is where in-app tab taps get intercepted.
+  return <NavLink to={item.to ?? '#'} onClick={(e) => { if (!confirmLeave()) e.preventDefault(); }} className={className}>{inner}</NavLink>;
 };
 
 type CenterButton = { label: string; icon: React.ComponentType<{ className?: string }>; to?: string; onClick?: () => void };
@@ -159,6 +164,7 @@ type CenterButton = { label: string; icon: React.ComponentType<{ className?: str
 // Workbench (jump back) — the symmetric counterpart Alex asked for, so each
 // shell can reach the other from the tab bar.
 const MobileTabBar: React.FC<{ items: ShellNavItem[]; center?: CenterButton }> = ({ items, center }) => {
+  const { confirmLeave } = useNavGuard();
   // No center FAB → a plain even row of tabs. The Control Panel uses this so
   // "Workbench" is just the first tab, which reads cleaner than an asymmetric
   // raised center button.
@@ -184,7 +190,7 @@ const MobileTabBar: React.FC<{ items: ShellNavItem[]; center?: CenterButton }> =
             <Button
               type="button"
               variant="brand"
-              onClick={center.onClick}
+              onClick={() => { if (confirmLeave()) center.onClick?.(); }}
               aria-label={center.label}
               className="size-12 -translate-y-1 rounded-full p-0 shadow-[0_8px_20px_-4px_rgba(91,255,160,0.6)]"
             >
@@ -196,7 +202,7 @@ const MobileTabBar: React.FC<{ items: ShellNavItem[]; center?: CenterButton }> =
               variant="brand"
               className="size-12 -translate-y-1 rounded-full p-0 shadow-[0_8px_20px_-4px_rgba(91,255,160,0.6)]"
             >
-              <Link to={center.to ?? '/'} aria-label={center.label}>
+              <Link to={center.to ?? '/'} onClick={(e) => { if (!confirmLeave()) e.preventDefault(); }} aria-label={center.label}>
                 <CenterIcon className="size-6" />
               </Link>
             </Button>

--- a/ui/src/components/workbench/AppsEditorPage.tsx
+++ b/ui/src/components/workbench/AppsEditorPage.tsx
@@ -1,0 +1,148 @@
+import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { CodeXml, FolderOpen } from 'lucide-react';
+
+import { Button } from '../ui/button';
+import { FileEditorPane } from './FileEditorPane';
+
+// The Editor app as a full-page route (sibling of /apps/files and /apps/terminal). On desktop it
+// mounts the same full Editor IDE the Dock window uses; on phones — where there is no window layer —
+// it renders a slim single-file editor. Design: `dnYPx` (IDE) + `w0qoC` (welcome).
+const EditorApp = lazy(() => import('./EditorApp').then((m) => ({ default: m.EditorApp })));
+
+// The desktop IDE (dnYPx) is designed dark and forces Monaco dark; below this the phone gets the
+// slim editor instead. Matches the File Browser's window-vs-page breakpoint so a tablet (≥768) gets
+// the same full IDE it gets a resizable window for.
+const DESKTOP_QUERY = '(min-width: 768px)';
+
+// A file handed to the editor when navigating in from the File Browser (mobile) or a direct link.
+// Carried in router state — like the window params `wm.openApp` passes — so absolute paths stay out
+// of the URL; a refresh (no state) just lands on the empty/welcome state.
+type LaunchFile = { path: string; filename: string; mtime: number | null };
+
+function readLaunch(state: unknown): LaunchFile | null {
+  if (!state || typeof state !== 'object') return null;
+  const s = state as Record<string, unknown>;
+  if (typeof s.path !== 'string') return null;
+  return {
+    path: s.path,
+    filename: typeof s.filename === 'string' ? s.filename : s.path.split('/').filter(Boolean).pop() || s.path,
+    mtime: typeof s.mtime === 'number' ? s.mtime : null,
+  };
+}
+
+// Live desktop/phone flag, re-evaluated on resize/rotate so crossing the breakpoint re-picks the
+// right surface (mirrors ThemeContext's system-theme media subscription).
+function useDesktop(): boolean {
+  const [desktop, setDesktop] = useState(() => window.matchMedia(DESKTOP_QUERY).matches);
+  useEffect(() => {
+    const mq = window.matchMedia(DESKTOP_QUERY);
+    const onChange = () => setDesktop(mq.matches);
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+  return desktop;
+}
+
+const PaneLoading: React.FC = () => {
+  const { t } = useTranslation();
+  return <div className="grid min-h-0 flex-1 place-items-center text-[12px] text-muted">{t('common.loading')}</div>;
+};
+
+export const AppsEditorPage: React.FC = () => {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const desktop = useDesktop();
+  // Re-read whenever the router state changes (each navigation carries a fresh state object) so
+  // opening another file while already on this route swaps the launch target.
+  const launch = useMemo(() => readLaunch(location.state), [location.state]);
+
+  return (
+    <div className="flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]">
+      <div>
+        <h1 className="text-[18px] font-semibold text-foreground">{t('apps.editor.label')}</h1>
+        <p className="text-[12px] text-muted">{t('apps.editor.tagline')}</p>
+      </div>
+      {desktop ? (
+        // Full Editor IDE, forced dark like its Dock window (data-theme re-cascades the dark token
+        // set to this subtree). No windowId: the window-only niceties (title, close guard, ⌘O/⌘N)
+        // stay inert, but open/edit/save all work full-page.
+        <div data-theme="dark" className="flex min-h-0 flex-1 overflow-hidden rounded-xl border border-border bg-surface">
+          <Suspense fallback={<PaneLoading />}>
+            <EditorApp params={launch ? { path: launch.path, filename: launch.filename, mtime: launch.mtime } : undefined} />
+          </Suspense>
+        </div>
+      ) : (
+        <MobileEditor launch={launch} />
+      )}
+    </div>
+  );
+};
+
+// Phone single-file editor: one file at a time (no activity bar / explorer). FileEditorPane already
+// renders the filename + dirty dot + Save header and the Monaco touch accessory bar; opening/switching
+// a file reuses the File Browser (the mobile file-picking surface), which owns the editable-vs-download
+// decision. The name-only launch has no live cursor/search — that richness stays on the desktop IDE.
+const MobileEditor: React.FC<{ launch: LaunchFile | null }> = ({ launch }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [file, setFile] = useState<LaunchFile | null>(launch);
+  const [dirty, setDirty] = useState(false);
+
+  // A fresh navigation from Files swaps the open file. Edits to a previous file were already
+  // discarded when the user left this page to pick another (guarded in openAnother).
+  useEffect(() => {
+    if (launch) {
+      setFile(launch);
+      setDirty(false);
+    }
+  }, [launch]);
+
+  // Open / switch a file via the File Browser. Confirm first when the current buffer is dirty, since
+  // leaving unmounts this pane and drops the unsaved edits.
+  const openAnother = () => {
+    if (dirty && !window.confirm(t('apps.editor.confirmDiscardSwitch'))) return;
+    navigate('/apps/files');
+  };
+
+  // Guard a hard unload (refresh / close / navigating out of the SPA) while there are unsaved edits.
+  // In-app tab-bar navigation can't be blocked here (BrowserRouter has no navigation blocker); the
+  // header's open button is the guarded in-app switch path.
+  useEffect(() => {
+    if (!dirty) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [dirty]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-surface">
+      {file ? (
+        <FileEditorPane
+          path={file.path}
+          filename={file.filename}
+          mtime={file.mtime}
+          onOpenFile={openAnother}
+          onDirtyChange={setDirty}
+        />
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+          <span className="grid size-12 place-items-center rounded-2xl border border-violet/50 bg-violet/[0.1]">
+            <CodeXml className="size-6 text-violet" />
+          </span>
+          <div className="flex flex-col gap-1">
+            <div className="text-[15px] font-semibold text-foreground">{t('apps.editor.empty')}</div>
+            <p className="max-w-[260px] text-[12.5px] text-muted">{t('apps.editor.emptyHint')}</p>
+          </div>
+          <Button type="button" variant="brand" size="sm" className="gap-1.5" onClick={() => navigate('/apps/files')}>
+            <FolderOpen className="size-4" /> {t('apps.editor.browseFiles')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/workbench/AppsEditorPage.tsx
+++ b/ui/src/components/workbench/AppsEditorPage.tsx
@@ -33,17 +33,26 @@ function readLaunch(state: unknown): LaunchFile | null {
   };
 }
 
-// Live desktop/phone flag, re-evaluated on resize/rotate so crossing the breakpoint re-picks the
-// right surface (mirrors ThemeContext's system-theme media subscription).
-function useDesktop(): boolean {
-  const [desktop, setDesktop] = useState(() => window.matchMedia(DESKTOP_QUERY).matches);
+// Pick the surface ONCE at mount, deliberately NOT reactive: swapping between the mobile pane and the
+// desktop IDE on a mid-edit resize/rotate would unmount whichever holds the buffer and silently drop
+// unsaved edits. A phone that rotates keeps the surface it opened with.
+function useDesktopAtMount(): boolean {
+  return useState(() => window.matchMedia(DESKTOP_QUERY).matches)[0];
+}
+
+// Warn before a hard unload (refresh / tab close / leaving the SPA) while there are unsaved edits.
+// SPA in-app navigation does NOT fire this — that's handled separately (mobile: the NavGuard on the
+// tab bar; both surfaces: the editor's own guarded controls).
+function useUnloadWarning(active: boolean): void {
   useEffect(() => {
-    const mq = window.matchMedia(DESKTOP_QUERY);
-    const onChange = () => setDesktop(mq.matches);
-    mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
-  }, []);
-  return desktop;
+    if (!active) return;
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [active]);
 }
 
 const PaneLoading: React.FC = () => {
@@ -54,7 +63,7 @@ const PaneLoading: React.FC = () => {
 export const AppsEditorPage: React.FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
-  const desktop = useDesktop();
+  const desktop = useDesktopAtMount();
   // Re-read whenever the router state changes (each navigation carries a fresh state object) so
   // opening another file while already on this route swaps the launch target.
   const launch = useMemo(() => readLaunch(location.state), [location.state]);
@@ -65,26 +74,34 @@ export const AppsEditorPage: React.FC = () => {
         <h1 className="text-[18px] font-semibold text-foreground">{t('apps.editor.label')}</h1>
         <p className="text-[12px] text-muted">{t('apps.editor.tagline')}</p>
       </div>
-      {desktop ? (
-        // Full Editor IDE, forced dark like its Dock window (data-theme re-cascades the dark token
-        // set to this subtree). No windowId: the window-only niceties (title, close guard, ⌘O/⌘N)
-        // stay inert, but open/edit/save all work full-page.
-        <div data-theme="dark" className="flex min-h-0 flex-1 overflow-hidden rounded-xl border border-border bg-surface">
-          <Suspense fallback={<PaneLoading />}>
-            <EditorApp params={launch ? { path: launch.path, filename: launch.filename, mtime: launch.mtime } : undefined} />
-          </Suspense>
-        </div>
-      ) : (
-        <MobileEditor launch={launch} />
-      )}
+      {desktop ? <DesktopEditor launch={launch} /> : <MobileEditor launch={launch} />}
+    </div>
+  );
+};
+
+// Desktop / tablet: the full Editor IDE, forced dark like its Dock window (data-theme re-cascades the
+// dark token set to this subtree). No windowId, so the window-only niceties (title, close guard,
+// ⌘O/⌘N) stay inert; open/edit/save all work full-page. `useWindowCloseGuard` is a no-op without a
+// window, so a page-level unload warning covers a dirty refresh/close here.
+const DesktopEditor: React.FC<{ launch: LaunchFile | null }> = ({ launch }) => {
+  const [dirty, setDirty] = useState(false);
+  useUnloadWarning(dirty);
+  return (
+    <div data-theme="dark" className="flex min-h-0 flex-1 overflow-hidden rounded-xl border border-border bg-surface">
+      <Suspense fallback={<PaneLoading />}>
+        <EditorApp
+          onDirtyChange={setDirty}
+          params={launch ? { path: launch.path, filename: launch.filename, mtime: launch.mtime } : undefined}
+        />
+      </Suspense>
     </div>
   );
 };
 
 // Phone single-file editor: one file at a time (no activity bar / explorer). FileEditorPane already
 // renders the filename + dirty dot + Save header and the Monaco touch accessory bar; opening/switching
-// a file reuses the File Browser (the mobile file-picking surface), which owns the editable-vs-download
-// decision. The name-only launch has no live cursor/search — that richness stays on the desktop IDE.
+// a file reuses the File Browser (the mobile file-picking surface, which owns the editable-vs-download
+// decision). The name-only launch has no live cursor/search — that richness stays on the desktop IDE.
 const MobileEditor: React.FC<{ launch: LaunchFile | null }> = ({ launch }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -108,27 +125,23 @@ const MobileEditor: React.FC<{ launch: LaunchFile | null }> = ({ launch }) => {
     navigate('/apps/files');
   };
 
-  // Guard leaving with unsaved edits. The NavGuard covers in-app mobile tab-bar navigation (whose
-  // NavLinks bypass `beforeunload`); the `beforeunload` handler covers a hard unload (refresh /
-  // close / leaving the SPA). The header's open button is separately guarded in openAnother.
+  // Guard leaving with unsaved edits: the NavGuard confirms in-app mobile tab-bar navigation (whose
+  // NavLinks bypass `beforeunload`); useUnloadWarning covers a hard unload. The header open button is
+  // separately guarded in openAnother.
   useEffect(() => {
     setGuard(dirty ? t('apps.editor.confirmDiscardSwitch') : null);
     return () => setGuard(null);
   }, [dirty, setGuard, t]);
-  useEffect(() => {
-    if (!dirty) return;
-    const onBeforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = '';
-    };
-    window.addEventListener('beforeunload', onBeforeUnload);
-    return () => window.removeEventListener('beforeunload', onBeforeUnload);
-  }, [dirty]);
+  useUnloadWarning(dirty);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-surface">
       {file ? (
+        // Key by path so switching to a different file remounts the pane and reads it fresh —
+        // FileEditorPane treats a live path change as a rename and skips the reread otherwise, which
+        // would show the previous file's buffer under the new name.
         <FileEditorPane
+          key={file.path}
           path={file.path}
           filename={file.filename}
           mtime={file.mtime}

--- a/ui/src/components/workbench/AppsEditorPage.tsx
+++ b/ui/src/components/workbench/AppsEditorPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { CodeXml, FolderOpen } from 'lucide-react';
 
 import { Button } from '../ui/button';
+import { useNavGuard } from '../../context/NavGuardContext';
 import { FileEditorPane } from './FileEditorPane';
 
 // The Editor app as a full-page route (sibling of /apps/files and /apps/terminal). On desktop it
@@ -87,6 +88,7 @@ export const AppsEditorPage: React.FC = () => {
 const MobileEditor: React.FC<{ launch: LaunchFile | null }> = ({ launch }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { setGuard } = useNavGuard();
   const [file, setFile] = useState<LaunchFile | null>(launch);
   const [dirty, setDirty] = useState(false);
 
@@ -106,9 +108,13 @@ const MobileEditor: React.FC<{ launch: LaunchFile | null }> = ({ launch }) => {
     navigate('/apps/files');
   };
 
-  // Guard a hard unload (refresh / close / navigating out of the SPA) while there are unsaved edits.
-  // In-app tab-bar navigation can't be blocked here (BrowserRouter has no navigation blocker); the
-  // header's open button is the guarded in-app switch path.
+  // Guard leaving with unsaved edits. The NavGuard covers in-app mobile tab-bar navigation (whose
+  // NavLinks bypass `beforeunload`); the `beforeunload` handler covers a hard unload (refresh /
+  // close / leaving the SPA). The header's open button is separately guarded in openAnother.
+  useEffect(() => {
+    setGuard(dirty ? t('apps.editor.confirmDiscardSwitch') : null);
+    return () => setGuard(null);
+  }, [dirty, setGuard, t]);
   useEffect(() => {
     if (!dirty) return;
     const onBeforeUnload = (e: BeforeUnloadEvent) => {

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Braces,
@@ -128,6 +129,7 @@ function relFolder(rel: string | undefined): string {
 export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: string }> = ({ windowed = false }) => {
   const { t } = useTranslation();
   const wm = useWindowManager();
+  const routerNavigate = useNavigate();
   const { projects } = useWorkbenchProjectsTree();
   const [cwd, setCwd] = useState('');
   const [listing, setListing] = useState<FsListing | null>(null);
@@ -264,9 +266,24 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
     if (query.trim()) runSearch(query);
   }, [cwd, navigate, query, runSearch]);
 
+  // Open an editable text/code file in the Editor: desktop opens a resizable Editor window; phone —
+  // which has no window layer — navigates to the full-page editor route. The launch file rides in
+  // router state, mirroring the window's `params`. Re-checks the breakpoint (like onNewFile) so it
+  // routes correctly regardless of where it's called from.
+  const openInEditor = useCallback(
+    (path: string, filename: string, mtime: number | null) => {
+      if (window.matchMedia('(min-width: 768px)').matches) {
+        wm.openApp('editor', { title: filename, params: { path, filename, mtime } });
+      } else {
+        routerNavigate('/apps/editor', { state: { path, filename, mtime } });
+      }
+    },
+    [wm, routerNavigate],
+  );
+
   // Open: dir → navigate (and leave search); image / PDF / Office / Markdown → the standalone Preview
   // window (desktop) or the in-page overlay (mobile, which has no window layer); editable text/code
-  // file (within the size cap) → Editor window; anything else → download.
+  // file (within the size cap) → Editor (desktop window / mobile route); anything else → download.
   const openItem = async (item: RowItem) => {
     if (item.entry.kind === 'dir') {
       setQuery('');
@@ -281,23 +298,20 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
       else setPreview({ path: item.full, name: item.entry.name });
       return;
     }
-    // Mobile has no editor window layer (windows are md+), so a non-previewable file just downloads.
-    if (!desktop) {
-      downloadFile(item.full);
-      return;
-    }
-    // Desktop: fetch CURRENT metadata (content-sniffs `text`) and decide by CONTENT, not just the
-    // extension — so an extensionless TEXT file opens in the editor while a binary file downloads.
+    // Fetch CURRENT metadata (content-sniffs `text`) and decide by CONTENT, not just the extension —
+    // so an extensionless TEXT file opens in the editor while a true binary downloads. downloadFile
+    // uses an anchor (not a popup), so it survives this awaited recheck without losing the tap's user
+    // activation on Safari/iOS.
     try {
       const m = await fileMeta(item.full);
       if (isEditableMeta(m)) {
-        wm.openApp('editor', { title: item.entry.name, params: { path: item.full, filename: item.entry.name, mtime: m.mtime } });
+        openInEditor(item.full, item.entry.name, m.mtime);
       } else {
         downloadFile(item.full);
       }
     } catch {
       if (isEditableFile(item.entry)) {
-        wm.openApp('editor', { title: item.entry.name, params: { path: item.full, filename: item.entry.name, mtime: item.entry.mtime } });
+        openInEditor(item.full, item.entry.name, item.entry.mtime);
       } else {
         downloadFile(item.full);
       }

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -30,7 +30,7 @@ import clsx from 'clsx';
 
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
-import { isEditableFile, isEditableMeta, previewWindowKind } from '../../lib/filePreview';
+import { isEditableFile, isEditableMeta, previewOverlayKind, previewWindowKind } from '../../lib/filePreview';
 import {
   contentUrl,
   deletePath,
@@ -291,11 +291,17 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
       return;
     }
     const desktop = window.matchMedia('(min-width: 768px)').matches;
-    if (previewWindowKind(item.entry)) {
-      // Desktop opens a real, resizable Preview window (a dedicated app); mobile has no window layer,
-      // so it falls back to the in-page overlay so the file can still be viewed.
-      if (desktop) wm.openApp('preview', { title: item.entry.name, params: { path: item.full, name: item.entry.name } });
-      else setPreview({ path: item.full, name: item.entry.name });
+    if (desktop) {
+      // Desktop: image / PDF / Office / Markdown open the dedicated, resizable Preview window.
+      if (previewWindowKind(item.entry)) {
+        wm.openApp('preview', { title: item.entry.name, params: { path: item.full, name: item.entry.name } });
+        return;
+      }
+    } else if (previewOverlayKind(item.entry)) {
+      // Mobile has no window layer: only NON-editable rich files (image / PDF / Office) open the
+      // in-page overlay. Markdown/SVG are previewable too but ALSO editable, so they fall through to
+      // the editor below (it has its own Source⇄Preview toggle) instead of a read-only overlay.
+      setPreview({ path: item.full, name: item.entry.name });
       return;
     }
     // Fetch CURRENT metadata (content-sniffs `text`) and decide by CONTENT, not just the extension —

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -590,11 +590,13 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
                             onSaveAs={(textValue) => saveAs(tab.id, textValue)}
                             reveal={reveal?.tabId === tab.id ? { line: reveal.line, column: reveal.column, endColumn: reveal.endColumn, nonce: reveal.nonce } : null}
                             reloadNonce={tab.reload}
-                            // The active tab owns preview-mode ⌘S. In a window, only while that window
-                            // is frontmost; on the full-page /apps/editor mount (no windowId, so no
-                            // window can be "focused") the page is always the foreground, so treat it
-                            // as focused — otherwise ⌘S would be dead while previewing there.
-                            saveHotkey={active === tab.id && (!windowId || wm.focusedId === windowId)}
+                            // The active tab owns preview-mode ⌘S. In a window: only while that window
+                            // is frontmost. On the full-page /apps/editor mount (no windowId): only
+                            // when NO app window is focused on top (focusedId === null) — otherwise a
+                            // floating window opened over the page would let this background editor
+                            // also swallow ⌘S. When windowless AND no window is up, the page IS the
+                            // foreground, so preview-mode ⌘S works there.
+                            saveHotkey={active === tab.id && (windowId ? wm.focusedId === windowId : wm.focusedId === null)}
                           />
                         </Suspense>
                       )}

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -273,7 +273,12 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
     if (dir) {
       setRoot(dir);
       newFile();
+      return;
     }
+    // "Open in Editor" from a project (sidebar): root the explorer at the folder with NO tab open —
+    // just the file tree + the select-a-file hint, no untitled buffer.
+    const rootDir = typeof params?.rootDir === 'string' ? params.rootDir : null;
+    if (rootDir) setRoot(rootDir);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -585,7 +585,11 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
                             onSaveAs={(textValue) => saveAs(tab.id, textValue)}
                             reveal={reveal?.tabId === tab.id ? { line: reveal.line, column: reveal.column, endColumn: reveal.endColumn, nonce: reveal.nonce } : null}
                             reloadNonce={tab.reload}
-                            saveHotkey={active === tab.id && wm.focusedId === windowId}
+                            // The active tab owns preview-mode ⌘S. In a window, only while that window
+                            // is frontmost; on the full-page /apps/editor mount (no windowId, so no
+                            // window can be "focused") the page is always the foreground, so treat it
+                            // as focused — otherwise ⌘S would be dead while previewing there.
+                            saveHotkey={active === tab.id && (!windowId || wm.focusedId === windowId)}
                           />
                         </Suspense>
                       )}

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -81,7 +81,13 @@ function languageLabel(filename: string | undefined): string | undefined {
 // fully integrated here. Files opens a file via openApp('editor', { params: { path } }). Open
 // Folder / Save use the in-window FilePicker (browsing the real filesystem), and New File opens an
 // untitled buffer that picks its location only on first save.
-export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, unknown> }> = ({ windowId, params }) => {
+export const EditorApp: React.FC<{
+  windowId?: string;
+  params?: Record<string, unknown>;
+  /** Report whether ANY open tab has unsaved edits — the full-page route uses it for an unload guard
+   *  (the window mount relies on useWindowCloseGuard instead). */
+  onDirtyChange?: (dirty: boolean) => void;
+}> = ({ windowId, params, onDirtyChange }) => {
   const { t } = useTranslation();
   const wm = useWindowManager();
   const [root, setRoot] = useState<string | null>(null);
@@ -284,6 +290,11 @@ export const EditorApp: React.FC<{ windowId?: string; params?: Record<string, un
 
   const anyDirty = Object.values(dirty).some(Boolean);
   useWindowCloseGuard(windowId, anyDirty ? t('apps.editor.confirmDiscardClose') : null);
+  // Surface aggregate dirty state to a non-window host (the full-page /apps/editor route), which has
+  // no window close guard and registers a page-level unload warning instead.
+  useEffect(() => {
+    onDirtyChange?.(anyDirty);
+  }, [anyDirty, onDirtyChange]);
 
   // Reflect the active file in the window title, so the Dock + titlebar identify which file this
   // editor window holds (important when several editor windows are open). Clears to the app title

--- a/ui/src/components/workbench/FileEditorPane.tsx
+++ b/ui/src/components/workbench/FileEditorPane.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Code2, Eye, Loader2, PanelRightOpen, Save } from 'lucide-react';
+import { Code2, Eye, FolderOpen, Loader2, PanelRightOpen, Save } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useTheme } from '../../context/ThemeContext';
@@ -86,6 +86,12 @@ export const FileEditorPane: React.FC<{
   onPopOut?: (live: { mtime: number | null }) => void;
   /** The owning window id, when this editor lives in a window — enables the unsaved-close guard. */
   windowId?: string;
+  /**
+   * When provided, the header shows an "open file" button (the mobile single-file editor's way to
+   * open/switch files — desktop uses the IDE explorer instead). No-op in `chromeless` mode, which has
+   * no header.
+   */
+  onOpenFile?: () => void;
   /** Report dirty state up (used by the Editor IDE to aggregate one close guard over its tabs). */
   onDirtyChange?: (dirty: boolean) => void;
   /**
@@ -111,7 +117,7 @@ export const FileEditorPane: React.FC<{
    * window-level ⌘S itself — scoped by this flag so only the foreground tab saves.
    */
   saveHotkey?: boolean;
-}> = ({ path, filename, mtime, readOnly = false, onPopOut, windowId, onDirtyChange, chromeless = false, onCursor, onSaveAs, reveal, reloadNonce, saveHotkey = false }) => {
+}> = ({ path, filename, mtime, readOnly = false, onPopOut, windowId, onOpenFile, onDirtyChange, chromeless = false, onCursor, onSaveAs, reveal, reloadNonce, saveHotkey = false }) => {
   const { t } = useTranslation();
   const { resolvedTheme } = useTheme();
   const [text, setText] = useState<string | null>(null);
@@ -237,6 +243,19 @@ export const FileEditorPane: React.FC<{
     <div className="flex h-full min-h-0 flex-col">
       {!chromeless && (
         <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          {onOpenFile && (
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="size-7 shrink-0 text-muted"
+              aria-label={t('apps.editor.browseFiles')}
+              title={t('apps.editor.browseFiles')}
+              onClick={onOpenFile}
+            >
+              <FolderOpen className="size-3.5" />
+            </Button>
+          )}
           <span className="flex-1 truncate font-mono text-[12px] text-foreground">{filename}</span>
           {dirty && <span className="size-1.5 shrink-0 rounded-full bg-mint" title={t('apps.fileBrowser.unsaved')} />}
           {onPopOut && (

--- a/ui/src/components/workbench/MonacoEditor.tsx
+++ b/ui/src/components/workbench/MonacoEditor.tsx
@@ -221,9 +221,11 @@ export default function MonacoEditor({ value, language, path, readOnly, dark = t
         />
       </div>
 
-      {/* Mobile accessory bar — Monaco has no touch affordances, so phones get the
-          symbol keys + select/copy helpers, the same pattern as TerminalView. */}
-      <div className="flex items-center gap-1 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 md:hidden">
+      {/* Touch accessory bar — Monaco has no touch affordances, so coarse-pointer devices get the
+          symbol keys + select/copy helpers. Keyed off pointer type rather than the md: viewport
+          breakpoint so tablets keep it and desktops (a hardware keyboard already has these keys)
+          don't — the same rule TerminalView's key bar uses (PR #796). */}
+      <div className="hidden items-center gap-1 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pointer-coarse:flex">
         {!readOnly &&
           SYMBOL_KEYS.map((key) => (
             <button key={key} type="button" onClick={() => insert(key)} className={accessoryBtn}>

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, FolderTree, Link as LinkIcon, LogOut, SlidersHorizontal, SquareTerminal } from 'lucide-react';
+import { ArrowRight, CodeXml, FolderTree, Link as LinkIcon, LogOut, SlidersHorizontal, SquareTerminal } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -96,6 +96,19 @@ export const MorePage: React.FC = () => {
           <span className="min-w-0 flex-1">
             <span className="block text-[15px] font-semibold">{t('apps.terminal.label')}</span>
             <span className="block truncate text-[11.5px] text-muted">{t('apps.terminal.desc')}</span>
+          </span>
+          <ArrowRight className="size-[18px] shrink-0 text-muted" />
+        </Link>
+        <Link
+          to="/apps/editor"
+          className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
+        >
+          <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-violet/[0.12]">
+            <CodeXml className="size-[18px] text-violet" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-[15px] font-semibold">{t('apps.editor.label')}</span>
+            <span className="block truncate text-[11.5px] text-muted">{t('apps.editor.desc')}</span>
           </span>
           <ArrowRight className="size-[18px] shrink-0 text-muted" />
         </Link>

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Bot,
   ChevronDown,
   ChevronRight,
+  CodeXml,
   Ellipsis,
   FileText,
   Folder,
@@ -29,6 +30,7 @@ import type { LucideIcon } from 'lucide-react';
 
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
+import { useWindowManager } from '../../context/WindowManagerContext';
 import { useComposerInsertTarget } from '../../context/ComposerBridgeContext';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
@@ -436,6 +438,7 @@ const ProjectRow: React.FC<{
   onArchiveSession,
 }) => {
   const { t } = useTranslation();
+  const wm = useWindowManager();
   const Chevron = expanded ? ChevronDown : ChevronRight;
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState(project.display_name);
@@ -562,6 +565,21 @@ const ProjectRow: React.FC<{
                   >
                     <FileText className="size-3 text-muted" />
                     {t('workbench.projectEditAgents')}
+                  </button>
+                )}
+                {project.folder_path && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      // Open the Editor rooted at the project folder, no file tab open (rootDir sets
+                      // the explorer root only). Desktop-only surface, so the floating window is right.
+                      wm.openApp('editor', { title: project.display_name, params: { rootDir: project.folder_path } });
+                    }}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
+                  >
+                    <CodeXml className="size-3 text-muted" />
+                    {t('workbench.projectOpenInEditor')}
                   </button>
                 )}
                 <button

--- a/ui/src/context/NavGuardContext.tsx
+++ b/ui/src/context/NavGuardContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
+import type { ReactNode } from 'react';
+
+// A lightweight "unsaved changes" guard for in-app navigation. A page with unwritten work (the mobile
+// single-file editor) registers a confirm message; navigation surfaces that can't otherwise be blocked
+// — the mobile tab bar, whose NavLinks bypass `beforeunload` — call `confirmLeave()` first and cancel
+// the navigation when the user declines. The message lives in a ref so registering it never re-renders
+// consumers, mirroring the WindowManager close-guard pattern. `confirmLeave()` is a no-op (returns
+// true) whenever no guard is set, so every other page is unaffected.
+interface NavGuardValue {
+  /** Register a confirm message while there is unsaved work, or null to clear the guard. */
+  setGuard: (message: string | null) => void;
+  /** Returns true when it's safe to leave (no guard, or the user confirmed discarding). */
+  confirmLeave: () => boolean;
+}
+
+const NavGuardContext = createContext<NavGuardValue | null>(null);
+
+export const NavGuardProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const messageRef = useRef<string | null>(null);
+
+  const setGuard = useCallback((message: string | null) => {
+    messageRef.current = message;
+  }, []);
+
+  const confirmLeave = useCallback(() => {
+    const message = messageRef.current;
+    return !message || window.confirm(message);
+  }, []);
+
+  const value = useMemo<NavGuardValue>(() => ({ setGuard, confirmLeave }), [setGuard, confirmLeave]);
+
+  return <NavGuardContext.Provider value={value}>{children}</NavGuardContext.Provider>;
+};
+
+export function useNavGuard(): NavGuardValue {
+  const ctx = useContext(NavGuardContext);
+  if (!ctx) throw new Error('useNavGuard must be used within a NavGuardProvider');
+  return ctx;
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -629,6 +629,7 @@
     "editor": {
       "label": "Editor",
       "desc": "A fast code editor for files on this machine.",
+      "tagline": "A fast code editor, in your browser.",
       "explorer": "Explorer",
       "noFolder": "No folder opened",
       "welcomeSub": "A code editor for files on this machine · VS Code engine",
@@ -649,6 +650,7 @@
       "openInWindow": "Open in editor window",
       "saveBeforePopOut": "Save before opening in a window",
       "confirmDiscardClose": "Discard unsaved changes and close this window?",
+      "confirmDiscardSwitch": "Discard unsaved changes?",
       "selectAll": "Select all",
       "copyAll": "Copy all",
       "untitled": "Untitled-{{n}}",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -846,6 +846,7 @@
     "projectRename": "Rename",
     "projectSettings": "Project settings",
     "projectEditAgents": "Edit AGENTS.md",
+    "projectOpenInEditor": "Open in Editor",
     "projectArchive": "Archive",
     "projectArchiveConfirm": "Archive project \"{{name}}\"? Session history is preserved; it just stops showing in the sidebar.",
     "projectRenamePlaceholder": "New name",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -629,6 +629,7 @@
     "editor": {
       "label": "编辑器",
       "desc": "本机文件的快速代码编辑器。",
+      "tagline": "在浏览器里编辑代码文件。",
       "explorer": "资源管理器",
       "noFolder": "未打开文件夹",
       "welcomeSub": "本机文件的代码编辑器 · VS Code 内核",
@@ -649,6 +650,7 @@
       "openInWindow": "在编辑器窗口中打开",
       "saveBeforePopOut": "请先保存，再在新窗口中打开",
       "confirmDiscardClose": "放弃未保存的更改并关闭此窗口？",
+      "confirmDiscardSwitch": "放弃未保存的更改？",
       "selectAll": "全选",
       "copyAll": "全部复制",
       "untitled": "未命名-{{n}}",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -846,6 +846,7 @@
     "projectRename": "重命名",
     "projectSettings": "设置项目",
     "projectEditAgents": "编辑 AGENTS.md",
+    "projectOpenInEditor": "用编辑器打开",
     "projectArchive": "归档",
     "projectArchiveConfirm": "确定归档项目「{{name}}」?会话历史会保留,侧栏不再显示。",
     "projectRenamePlaceholder": "新名字",


### PR DESCRIPTION
## Capability

Adds a **mobile entry point for the code Editor** (previously desktop-window-only) plus a **project "Open in Editor"** shortcut. On a phone you can now open a text/code file from the File Browser, edit it, and save; the Editor is reachable directly from the More tab; and each project row can open the Editor rooted at its folder.

## What changed

- **New `/apps/editor` full-page route** (lazy, alongside `/apps/files` and `/apps/terminal`).
  - **Desktop / tablet (≥768px):** mounts the existing full `EditorApp` IDE with the same page-header treatment as the other app routes, forced dark (`data-theme`) like its Dock window. Accepts an optional launch file via router state (`{ path, filename, mtime }`, mirroring `wm.openApp` params).
  - **Phone (<768px):** a slim single-file editor built by **reusing `FileEditorPane`** (non-chromeless: filename + dirty dot + Save header). Opening/switching a file reuses the File Browser (the mobile file-picking surface, which already owns the editable-vs-download decision) via a header folder button; empty state links to Files. No mobile IDE (no activity bar/explorer).
- **File Browser on phones** (`AppsFileBrowserPage.openItem`): editable files now **navigate to the editor route** instead of downloading, gated by the existing `isEditableMeta`/`isEditableFile` checks (incl. the 1MB text cap). Non-editable files still download; **desktop behavior unchanged** (still opens the Editor window). Factored into a shared `openInEditor` helper. `downloadFile` is anchor-based, so it survives the awaited `fileMeta` recheck without losing tap activation.
- **MorePage:** added an Editor entry alongside Files and Terminal.
- **Project sidebar menu (desktop):** added an **"Open in Editor"** item to each project's ⋯ menu, after "Edit AGENTS.md" and before Archive, gated on `project.folder_path` (same as Edit AGENTS.md), CodeXml icon. It opens the Editor floating window rooted at the project folder with no file tab — via a new `rootDir` launch param on `EditorApp` (sets the explorer root only; no untitled buffer). Desktop-only surface, so the window is correct — no mobile variant.
- **MonacoEditor accessory bar:** switched the touch symbol/select/copy bar from `md:hidden` to hidden-by-default + `pointer-coarse:flex` — the same rule TerminalView's key bar uses (PR #796), so tablets keep it and desktops with a hardware keyboard don't. This makes the previously-dead mobile accessory bar reachable.
- **EditorApp:** preview-mode ⌘S now works on the full-page mount (no `windowId`), not only inside a focused window.
- i18n: added `apps.editor.tagline`, `apps.editor.confirmDiscardSwitch`, `workbench.projectOpenInEditor` to en + zh (1:1); reused the pre-existing `empty` / `emptyHint` / `browseFiles` keys.

## Layout / scroll-lock

The phone body is `overflow:hidden`; the route follows the proven in-`<main>` pattern used by the Files/Terminal pages — `h-[calc(100dvh-7rem)] min-h-[460px] md:h-[calc(100vh-8rem)]` — so the Save button + accessory bar stay above the fold and rise above the iOS keyboard (same behavior as the Terminal key bar).

## Evidence layers

- **Unit:** none — these workbench UI components have no existing unit-test pattern in the repo; no new framework introduced.
- **Contract / scenario:** n/a — no API contract changed and no scenario catalog covers the file-browser/editor UI.
- **Build:** `cd ui && npm run build` (tsc + vite) green.
- **Review:** ran a reviewer subagent over the mobile-editor diff; no correctness bugs. Two low-severity findings applied (preview-mode ⌘S on the full-page mount; `beforeunload` guard for unsaved edits). The sidebar "Open in Editor" addition mirrors the existing "Edit AGENTS.md" item and was self-reviewed. One noted-only nit (cross-breakpoint resize discards the mobile buffer — mirrors the File Browser's own breakpoint swap).
- **Residual manual checks:**
  - Phone: Files → tap an editable file (`.ts`, `.md`, extensionless text) → lands on `/apps/editor` and loads it; edit → Save persists (dirty dot clears).
  - Phone dirty guard: the header "open file" button confirms before discarding; a hard unload prompts while dirty.
  - Phone: non-editable/binary file still downloads; image/PDF still opens the in-page preview overlay.
  - Accessory bar visible on touch (coarse pointer), hidden on desktop (fine pointer).
  - More tab → Editor entry opens the route (empty state when no file).
  - Desktop: file browser still opens the resizable Editor window (unchanged); project ⋯ → "Open in Editor" opens a window rooted at the folder with the file tree and no tab.
