### PR TITLE
feat(show-pages): align Show Page scaffold + prompt with built-in Tailwind

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -944,7 +944,9 @@ export default function App() {
 
 
 def _default_styles_css() -> str:
-    return """:root {
+    return """@import "tailwindcss";
+
+:root {
   color-scheme: light;
 }
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -93,6 +93,7 @@ Guidance:
 - The standard structure is `index.html`, `src/main.tsx`, `src/App.tsx`, `src/styles.css`, and optional `api/*.ts`; treat `index.html` and `src/main.tsx` as the runtime-owned app shell.
 - Hot reload is available while `/show/<session-id>/` is open. Users will see page changes live. Prefer component-level changes that preserve React state.
 - Built-in UI imports include shadcn-style aliases such as `@/components/ui/button`, `@/components/ui/card`, `@/components/ui/badge`, `@/components/ui/dialog`, `@/components/ui/input`, `@/components/ui/progress`, plus `@avibe/show-ui/theme` for theme presets and CSS variables.
+- Tailwind CSS v4 utility classes are built in and work in any `className`. `src/styles.css` is the CSS entry and must keep `@import "tailwindcss";` at the top; theme through the `@avibe/show-ui/theme` CSS variables.
 - Prefer the built-in UI primitives over hand-rolled controls. They include Show Page motion for changed text, numbers, badges, cards, and progress without extra animation calls.
 - Optional server handlers live under `api/` and run only when requested. Export functions named like HTTP methods, for example `export async function GET(request) { return Response.json({ ok: true }) }`.
 - Design for user understanding, not just for moving text onto a webpage. Choose the visual form that best helps the user inspect, compare, confirm, and continue the discussion.

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -310,6 +310,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("`vibe show path --session-id sesk8m4q2p7x`", prompt)
         self.assertIn("Make the page work reasonably on mobile", prompt)
         self.assertIn("managed React/Vite apps", prompt)
+        self.assertIn("Tailwind CSS v4 utility classes are built in", prompt)
+        self.assertIn('must keep `@import "tailwindcss";` at the top', prompt)
         self.assertNotIn("Ready to visualize", prompt)
         self.assertIn("@/components/ui/progress", prompt)
         self.assertNotIn("Excalidraw-style static SVG/PNG diagrams", prompt)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -259,6 +259,8 @@ def test_private_show_page_materializes_workspace_before_runtime_proxy(monkeypat
     assert response.status_code == 200
     assert b"Runtime Page" in response.content
     assert (page_dir / "src" / "App.tsx").exists()
+    styles_css = (page_dir / "src" / "styles.css").read_text(encoding="utf-8")
+    assert styles_css.startswith('@import "tailwindcss";'), styles_css[:60]
     assert manager.calls[0][1] == "/sessions/ses123/app/"
 
 


### PR DESCRIPTION
## Capability

Align the avibe-side Show Page scaffold and the agent-facing Show Pages prompt with **Tailwind v4 now being a built-in of the Show Runtime** (counterpart PR **avibe-bot/vibe-show-runtime#24**). Show Page workspaces are managed React/Vite apps; coding models assume a shadcn-style React/Vite environment ships Tailwind, so this makes the scaffold and guidance match that reality instead of leaving utility classes silently unstyled.

## Changes

- **`core/show_pages.py` `_default_styles_css()`** — the scaffolded `src/styles.css` now leads with `@import "tailwindcss";` (the CSS entry contract; identical to the runtime's own template so the two scaffolds stay in sync).
- **`core/system_prompt_injection.py` `_SHOW_PAGES_PROMPT`** — adds one styling bullet: Tailwind CSS v4 utility classes work in any `className`; `src/styles.css` must keep `@import "tailwindcss";` at the top; theme via the `@avibe/show-ui/theme` CSS variables. The existing `@/components/ui/*` "prefer the built-in primitives" guidance is unchanged. Factual, no history/warning tone.

## Evidence layers

- **Unit:** `tests/test_ui_show_pages.py::test_private_show_page_materializes_workspace_before_runtime_proxy` now asserts the materialized `src/styles.css` leads with `@import "tailwindcss";`. `tests/test_reply_enhancer_platform.py` asserts the new prompt guidance (`Tailwind CSS v4 utility classes are built in`, `must keep \`@import "tailwindcss";\` at the top`). Both full files pass (108 + 30).
- **Contract / scenario:** no scenario catalog applies to this scaffold/prompt change; runtime-level serving/build behavior is covered by the counterpart runtime PR's smoke assertions.
- **Residual manual checks:** `ruff check` clean on all four changed files. UI untouched.

## Merge ordering

The counterpart runtime PR **avibe-bot/vibe-show-runtime#24 must merge first**. A tagged avibe release resolves the Show Runtime `main` at tag time, so both must be on their default branches before the next avibe tag. The runtime PR also self-migrates pre-existing `styles.css` files on warm, so pages created between the two merges still get utilities regardless of order.
