### PR TITLE
test(vault): cover protected sign callbacks

### DIFF
--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1387,7 +1387,15 @@ def test_agent_sign_request_accepts_protected_browser_signature(monkeypatch):
     sign.assert_not_called()
     with api._vault_engine().connect() as conn:
         meta = vault_service.get_secret_meta(conn, "PROTECTED_ETH_KEY")
+        row = conn.execute(select(vault_requests).where(vault_requests.c.id == requested["request"]["id"])).mappings().one()
     assert meta["use_count"] == 1
+    assert row["callback_status"] == "pending"
+    plan = vault_service.resolve_request_callback(dict(row))
+    assert plan is not None
+    assert plan.session_id == "ses_1"
+    assert plan.message.strip()
+    with api._vault_engine().connect() as conn:
+        assert vault_service.request_callback_ready(conn, dict(row)) is True
 
 
 def test_agent_sign_marks_claimed_request_failed_when_signature_validation_rejects(monkeypatch):

--- a/tests/test_vault_request_callbacks.py
+++ b/tests/test_vault_request_callbacks.py
@@ -31,6 +31,31 @@ def _sealed(suffix: str = "1") -> Sealed:
     return Sealed(ciphertext=f"ct-{suffix}", nonce=f"n-{suffix}", wrap_meta=f"wm-{suffix}")
 
 
+def _signing_public_meta() -> dict:
+    return {
+        "signing_public_key": {
+            "curve": "secp256k1",
+            "public_key": "02" + ("01" * 32),
+        }
+    }
+
+
+def _valid_recoverable_signature() -> dict:
+    return {"signature": "ab" * 64, "recovery_id": 0}
+
+
+def _create_protected_keypair(conn, name: str = "ETH_KEY") -> None:
+    vs.create_secret(
+        conn,
+        name=name,
+        sealed=_sealed("sign"),
+        protection="protected",
+        kind="keypair",
+        signer_kind="local",
+        public_meta=_signing_public_meta(),
+    )
+
+
 def _callback_status(conn, request_id: str):
     return conn.execute(
         select(vault_requests.c.callback_status).where(vault_requests.c.id == request_id)
@@ -111,6 +136,63 @@ def test_expiry_arms_callback(vault):
         assert _callback_status(conn, req["id"]) == "pending"
         plan = vs.resolve_request_callback(_row(conn, req["id"]))
         assert plan is not None and "expired" in plan.message.lower()
+
+
+def test_protected_browser_sign_approval_arms_callback(vault):
+    with vault.begin() as conn:
+        _create_protected_keypair(conn)
+        req = vs.create_sign_request(
+            conn,
+            "ETH_KEY",
+            digest="00" * 32,
+            scheme="ecdsa-secp256k1-recoverable",
+            requester={"session_id": "ses_sign", "source": "agent-cli"},
+            delivery={"session_id": "ses_sign", "command": "sign:ecdsa-secp256k1-recoverable"},
+        )
+
+        vs.complete_sign_request(
+            conn,
+            req["id"],
+            name="ETH_KEY",
+            digest="00" * 32,
+            scheme="ecdsa-secp256k1-recoverable",
+            signature=_valid_recoverable_signature(),
+            browser_signed=True,
+        )
+
+        row = _row(conn, req["id"])
+        assert row["callback_status"] == "pending"
+        plan = vs.resolve_request_callback(row)
+        assert plan is not None
+        assert plan.session_id == "ses_sign"
+        assert plan.message.strip()
+        assert "vault await" in plan.message
+        assert vs.request_callback_ready(conn, row) is True
+
+
+def test_failed_sign_request_arms_callback(vault):
+    with vault.begin() as conn:
+        _create_protected_keypair(conn)
+        req = vs.create_sign_request(
+            conn,
+            "ETH_KEY",
+            digest="00" * 32,
+            scheme="ecdsa-secp256k1-recoverable",
+            requester={"session_id": "ses_sign", "source": "agent-cli"},
+            delivery={"session_id": "ses_sign"},
+        )
+        vs.claim_sign_request(conn, req["id"], name="ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")
+
+        vs.fail_sign_request(conn, req["id"], reason="browser_signature_failed")
+
+        row = _row(conn, req["id"])
+        assert row["callback_status"] == "pending"
+        plan = vs.resolve_request_callback(row)
+        assert plan is not None
+        assert plan.session_id == "ses_sign"
+        assert plan.message.strip()
+        assert "signing error" in plan.message.lower()
+        assert vs.request_callback_ready(conn, row) is True
 
 
 # --- skip conditions ------------------------------------------------------------------------
@@ -418,3 +500,65 @@ def test_enqueue_session_callback_uses_callback_source(monkeypatch):
     # Nothing to send → no enqueue.
     assert st.enqueue_session_callback(_Store(), session_id="", message="x", source_actor="a") is None
     assert st.enqueue_session_callback(_Store(), session_id="ses", message="   ", source_actor="a") is None
+
+
+def test_vault_callback_sweep_enqueues_protected_sign_callback(monkeypatch, tmp_path):
+    import asyncio
+    from types import SimpleNamespace
+
+    from core import scheduled_tasks as st
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    engine = create_sqlite_engine()
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        _create_protected_keypair(conn)
+        req = vs.create_sign_request(
+            conn,
+            "ETH_KEY",
+            digest="00" * 32,
+            scheme="ecdsa-secp256k1-recoverable",
+            requester={"session_id": "ses_sign", "source": "agent-cli"},
+            delivery={"session_id": "ses_sign"},
+        )
+        vs.complete_sign_request(
+            conn,
+            req["id"],
+            name="ETH_KEY",
+            digest="00" * 32,
+            scheme="ecdsa-secp256k1-recoverable",
+            signature=_valid_recoverable_signature(),
+            browser_signed=True,
+        )
+
+    class _Key:
+        def to_key(self) -> str:
+            return "avibe::scope::ses_sign"
+
+    target = SimpleNamespace(
+        session_key=_Key(),
+        agent_name="codex",
+        agent_id="aid",
+        agent_backend="codex",
+        model=None,
+        reasoning_effort=None,
+    )
+    monkeypatch.setattr(st, "resolve_session_id_target", lambda session_id: target)
+    request_store = st.TaskExecutionStore(tmp_path / "task_requests")
+    service = st.ScheduledTaskService(
+        controller=SimpleNamespace(platform_settings_managers={}),
+        store=st.ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=request_store,
+    )
+
+    asyncio.run(service._drain_vault_callbacks())
+
+    with engine.connect() as conn:
+        assert _callback_status(conn, req["id"]) == "sent"
+    [callback_run] = request_store.list_pending()
+    assert callback_run.session_id == "ses_sign"
+    assert callback_run.session_policy == "existing"
+    assert callback_run.source_kind == "callback"
+    assert callback_run.source_actor == f"vault:{req['id']}"
+    assert callback_run.message
+    assert "vault await" in callback_run.message


### PR DESCRIPTION
## Summary

Adds the missing P4 regression coverage for protected-tier browser-signed `vibe vault sign` requests.

The investigation did not reproduce a storage/API/sweep defect in the current branch: the protected sign completion path arms `vault_requests.callback_status='pending'`, resolves a callback plan with the originating Session, passes the readiness gate, and the daemon sweep enqueues the callback run. The gap was that sign callbacks had no dedicated coverage, so the reported failure mode was unguarded.

## What changed

- Covers browser-signed protected keypair completion through `complete_sign_request(..., browser_signed=True)`.
- Covers `fail_sign_request` callback arming for signing failures.
- Covers the daemon `_drain_vault_callbacks` sweep enqueueing a protected sign callback and marking it sent.
- Extends the protected sign API test to assert the real `/api/vault/sign` completion path leaves a resolvable pending callback.

## Evidence

- Unit/contract: `PYTHONPATH=$(pwd) /Users/cyh/vibe-remote-project/avibe/.venv/bin/python -m pytest tests/test_vault_request_callbacks.py tests/test_vault_api.py -q` (`134 passed`)
- Lint: `ruff check tests/test_vault_request_callbacks.py tests/test_vault_api.py`
- Review: independent Codex review returned `NO FINDINGS`

## Scenario coverage

No scenario catalog ID applies; this is focused unit/contract coverage for the Vault request callback contract.

## Residual manual checks

None. This does not change runtime behavior; it pins the callback contract with automated tests.
