### PR TITLE
feat(vault): standard-tier signing is headless (protected/always-ask still approve)

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1197,6 +1197,25 @@ def _secret_agent_per_use_signable(row: dict[str, Any]) -> bool:
     )
 
 
+def sign_headless_allowed(row: dict[str, Any]) -> bool:
+    """A standard local keypair with no ``always_ask`` policy signs per-use without approval.
+
+    Mirrors the standard *access* headless fast path (``protection == "standard"`` and not
+    always_ask). Protected keys always sign in the browser under approval; a standard key
+    whose policy sets ``always_ask`` is opted back into per-use approval (the reserved toggle).
+    """
+    if row.get("kind") != "keypair" or (row.get("signer_kind") or "local") != "local":
+        return False
+    if row.get("protection") != "standard":
+        return False
+    return not _secret_always_ask(row)
+
+
+def sign_needs_approval(conn: Connection, name: str) -> bool:
+    """True when `vibe vault sign` must create a pending approval request for `name`."""
+    return not sign_headless_allowed(_require_row(conn, name))
+
+
 def _reject_unsignable_keypair(row: dict[str, Any], name: str) -> None:
     if not _secret_agent_per_use_signable(row):
         raise InvalidRequestError(f"{name} is not per-use signable")

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1299,9 +1299,69 @@ def test_agent_sign_request_approved_via_avault_sign(monkeypatch):
     sign.assert_called_once_with(_sealed("key"), "00" * 32, "ecdsa-secp256k1-recoverable", name="ETH_KEY")
     with api._vault_engine().connect() as conn:
         audit_row = conn.execute(
-            select(vault_audit.c.delivery).where(vault_audit.c.request_id == requested["request"]["id"], vault_audit.c.event == "signed")
+            select(vault_audit.c.delivery).where(
+                vault_audit.c.request_id == requested["request"]["id"],
+                vault_audit.c.event == "signed",
+            )
         ).scalar_one()
     assert json.loads(audit_row)["browser_signed"] is False
+
+
+def test_vault_sign_standard_key_without_request_signs_headlessly(monkeypatch):
+    signature = {"signature": "ab" * 64, "recovery_id": 1}
+    sign = Mock(return_value=signature)
+    monkeypatch.setattr(api, "avault_sign", sign)
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("key")))
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+
+    result = api.vault_sign({"name": "ETH_KEY", "digest": "00" * 32, "scheme": "ecdsa-secp256k1-recoverable"})
+
+    assert result == {"ok": True, "signature": signature}
+    sign.assert_called_once_with(_sealed("key"), "00" * 32, "ecdsa-secp256k1-recoverable", name="ETH_KEY")
+    assert api.get_vault_requests()["requests"] == []
+
+
+def test_vault_sign_standard_always_ask_without_request_requires_approval(monkeypatch):
+    sign = Mock(return_value={"signature": "ab" * 64, "recovery_id": 1})
+    monkeypatch.setattr(api, "avault_sign", sign)
+    monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("key")))
+    api.create_vault_secret(
+        {
+            "name": "ETH_KEY",
+            "kind": "keypair",
+            "signer_kind": "local",
+            "policy": {"always_ask": True},
+            "blind_box": {"scheme": "hpke-x25519-hkdfsha256-aes256gcm-v1", "enc": "enc", "ct": "ct"},
+        }
+    )
+
+    result = api.vault_sign(
+        {
+            "name": "ETH_KEY",
+            "digest": "00" * 32,
+            "scheme": "ecdsa-secp256k1-recoverable",
+            "requester": {"source": "test", "session_id": "ses_1"},
+        }
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == "approval_required"
+    assert result["request"]["secret_name"] == "ETH_KEY"
+    assert result["request"]["status"] == "pending"
+    assert result["request"]["card"]["protection"] == "standard"
+    assert "signature" not in result
+    sign.assert_not_called()
+    with api._vault_engine().connect() as conn:
+        [row] = list(conn.execute(vault_requests.select()).mappings())
+        assert row["id"] == result["request"]["id"]
+        assert row["callback_status"] is None
 
 
 def test_agent_sign_claims_request_before_avault_sign(monkeypatch):

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1330,8 +1330,10 @@ def test_vault_sign_standard_key_without_request_signs_headlessly(monkeypatch):
 
 def test_vault_sign_standard_always_ask_without_request_requires_approval(monkeypatch):
     sign = Mock(return_value={"signature": "ab" * 64, "recovery_id": 1})
+    notify = Mock()
     monkeypatch.setattr(api, "avault_sign", sign)
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed("key")))
+    monkeypatch.setattr(api, "_notify_vault_request_created", notify)
     api.create_vault_secret(
         {
             "name": "ETH_KEY",
@@ -1347,21 +1349,29 @@ def test_vault_sign_standard_always_ask_without_request_requires_approval(monkey
             "name": "ETH_KEY",
             "digest": "00" * 32,
             "scheme": "ecdsa-secp256k1-recoverable",
-            "requester": {"source": "test", "session_id": "ses_1"},
+            "session_id": "ses_1",
+            "skill": "wallet-sign",
         }
     )
 
     assert result["ok"] is False
     assert result["code"] == "approval_required"
-    assert result["request"]["secret_name"] == "ETH_KEY"
-    assert result["request"]["status"] == "pending"
-    assert result["request"]["card"]["protection"] == "standard"
+    request = result["request"]
+    assert request["secret_name"] == "ETH_KEY"
+    assert request["status"] == "pending"
+    assert request["requester"]["session_id"] == "ses_1"
+    assert request["requester"]["skill"] == "wallet-sign"
+    assert request["delivery"]["session_id"] == "ses_1"
+    assert request["delivery"]["skill"] == "wallet-sign"
+    assert request["card"]["protection"] == "standard"
     assert "signature" not in result
     sign.assert_not_called()
+    notify.assert_called_once_with(request)
     with api._vault_engine().connect() as conn:
         [row] = list(conn.execute(vault_requests.select()).mappings())
-        assert row["id"] == result["request"]["id"]
+        assert row["id"] == request["id"]
         assert row["callback_status"] is None
+        assert vault_service._request_session_id(dict(row)) == "ses_1"
 
 
 def test_agent_sign_claims_request_before_avault_sign(monkeypatch):

--- a/tests/test_vault_cli.py
+++ b/tests/test_vault_cli.py
@@ -305,10 +305,12 @@ def test_access_request_cli_accepts_protected_static_request(capfd):
     assert payload["request"]["card"]["protection"] == "protected"
 
 
-def test_sign_request_and_await_cli_reads_approved_signature(capfd, monkeypatch):
+def test_sign_cli_standard_key_returns_inline_signature_without_request(capfd, monkeypatch):
     from vibe import api
 
-    monkeypatch.setattr(api, "avault_sign", Mock(return_value={"signature": "ab" * 64, "recovery_id": 1}))
+    signature = {"signature": "ab" * 64, "recovery_id": 1}
+    sign = Mock(return_value=signature)
+    monkeypatch.setattr(api, "avault_sign", sign)
     with cli._open_vault_engine().begin() as conn:
         vault_service.create_secret(
             conn,
@@ -319,7 +321,42 @@ def test_sign_request_and_await_cli_reads_approved_signature(capfd, monkeypatch)
         )
 
     assert cli.cmd_vault_sign(_ns(name="ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")) == 0
-    request_id = json.loads(capfd.readouterr().out)["request_id"]
+    payload = json.loads(capfd.readouterr().out)
+
+    assert payload["kind"] == "vault_signature"
+    assert payload["name"] == "ETH_KEY"
+    assert payload["scheme"] == "ecdsa-secp256k1-recoverable"
+    assert payload["digest"] == "00" * 32
+    assert payload["signature"] == signature
+    sign.assert_called_once_with(_sealed("key"), "00" * 32, "ecdsa-secp256k1-recoverable", name="ETH_KEY")
+    with cli._open_vault_engine().connect() as conn:
+        assert list(conn.execute(vault_requests.select()).mappings()) == []
+
+
+def test_sign_request_and_await_cli_reads_approved_signature_for_always_ask_standard_key(capfd, monkeypatch):
+    from vibe import api
+
+    monkeypatch.setattr(api, "avault_sign", Mock(return_value={"signature": "ab" * 64, "recovery_id": 1}))
+    with cli._open_vault_engine().begin() as conn:
+        vault_service.create_secret(
+            conn,
+            name="ETH_KEY",
+            kind="keypair",
+            signer_kind="local",
+            sealed=_sealed("key"),
+            policy={"always_ask": True},
+        )
+
+    assert cli.cmd_vault_sign(_ns(name="ETH_KEY", digest="00" * 32, scheme="ecdsa-secp256k1-recoverable")) == 0
+    request_payload = json.loads(capfd.readouterr().out)
+    assert request_payload["kind"] == "vault_sign_request"
+    assert "signature" not in request_payload
+    request_id = request_payload["request_id"]
+    with cli._open_vault_engine().connect() as conn:
+        row = conn.execute(vault_requests.select().where(vault_requests.c.id == request_id)).mappings().one()
+        assert row["status"] == "pending"
+        assert row["callback_status"] is None
+
     api.vault_sign(
         {
             "name": "ETH_KEY",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2747,7 +2747,25 @@ def vault_sign(payload: dict) -> dict:
                 request_id = str(payload.get("request_id") or "")
                 if request_id:
                     vault_service.claim_sign_request(conn, request_id, name=name, digest=digest, scheme=scheme)
-                key_envelope = vault_service.get_key_envelope(conn, name)
+                    key_envelope = vault_service.get_key_envelope(conn, name)
+                elif vault_service.sign_needs_approval(conn, name):
+                    request = vault_service.create_sign_request(
+                        conn,
+                        name,
+                        digest=digest,
+                        scheme=scheme,
+                        requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
+                        delivery=payload.get("delivery") if isinstance(payload.get("delivery"), dict) else None,
+                    )
+                    protected_event = {
+                        "scope": "request",
+                        "request_id": request.get("id"),
+                        "request_status": request.get("status"),
+                        "secret_name": request.get("secret_name"),
+                    }
+                    protected_response = {"ok": False, "code": "approval_required", "request": request}
+                else:
+                    key_envelope = vault_service.get_key_envelope(conn, name)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
     except vault_service.RequestNotFoundError as exc:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2686,6 +2686,7 @@ def vault_sign(payload: dict) -> dict:
     engine = _vault_engine()
     protected_response: dict | None = None
     protected_event: dict | None = None
+    approval_required_request: dict | None = None
     try:
         with engine.begin() as conn:
             meta = vault_service.get_secret_meta(conn, name)
@@ -2754,9 +2755,11 @@ def vault_sign(payload: dict) -> dict:
                         name,
                         digest=digest,
                         scheme=scheme,
-                        requester=payload.get("requester") if isinstance(payload.get("requester"), dict) else None,
-                        delivery=payload.get("delivery") if isinstance(payload.get("delivery"), dict) else None,
+                        requester=_vault_requester_payload(payload),
+                        delivery=_vault_delivery_payload(payload),
+                        expires_at=_expires_at_from_ttl(payload),
                     )
+                    approval_required_request = request
                     protected_event = {
                         "scope": "request",
                         "request_id": request.get("id"),
@@ -2778,6 +2781,8 @@ def vault_sign(payload: dict) -> dict:
     if protected_response is not None:
         if protected_event is not None:
             _publish_vaults_updated(**protected_event)
+        if approval_required_request is not None:
+            _notify_vault_request_created(approval_required_request)
         return protected_response
 
     def _fail_claimed_request(reason: str) -> None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -6141,14 +6141,33 @@ def cmd_vault_sign(args):
                     code="unsupported_signer_kind",
                     help_command=help_command,
                 )
-            request = vault_service.create_sign_request(
-                conn,
-                name,
-                digest=digest,
-                scheme=scheme,
-                requester=_vault_cli_requester(args),
-                delivery=_vault_cli_delivery(args, mode="sign"),
+            needs_approval = vault_service.sign_needs_approval(conn, name)
+            if needs_approval:
+                request = vault_service.create_sign_request(
+                    conn,
+                    name,
+                    digest=digest,
+                    scheme=scheme,
+                    requester=_vault_cli_requester(args),
+                    delivery=_vault_cli_delivery(args, mode="sign"),
+                )
+        if not needs_approval:
+            result = api.vault_sign(
+                {
+                    "name": name,
+                    "digest": digest,
+                    "scheme": scheme,
+                    "requester": _vault_cli_requester(args),
+                }
             )
+            _print_cli_payload(
+                "vault_signature",
+                name=name,
+                scheme=scheme,
+                digest=digest,
+                signature=result.get("signature"),
+            )
+            return 0
         _publish_cli_vaults_updated(scope="request", request=request)
         _print_cli_payload(
             "vault_sign_request",
@@ -10236,11 +10255,12 @@ def build_parser():
 
     vault_sign_parser = vault_subparsers.add_parser(
         "sign",
-        help="Request one approved signature from a keypair secret",
+        help="Sign a digest with a keypair secret (standard signs inline; protected needs approval)",
         description=(
-            "Create a pending per-use signing request for a local keypair. "
-            "Standard keys sign via avault; protected keys sign in the browser. "
-            "'vibe vault await <request-id>' returns only the resulting public signature."
+            "Sign a 32-byte digest with a local keypair. Standard keys sign immediately via "
+            "avault and return the public signature inline. Protected keys — and standard keys "
+            "marked always-ask — instead create a pending per-use request you approve in the "
+            "browser; then 'vibe vault await <request-id>' returns the public signature."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         error_help_command="vibe vault sign --help",


### PR DESCRIPTION
## Capability

Standard-tier Vault keypair signing now returns the public signature inline from `vibe vault sign` instead of creating a browser approval request.

## Behavior

- Standard local keypairs without `policy.always_ask` sign headlessly through avault.
- Protected keypairs and standard keypairs with `policy.always_ask` still create pending browser approval requests.
- `policy.always_ask` remains the reserved force-approval toggle for standard signing.

## Evidence

- Unit tests updated: `tests/test_vault_cli.py`, `tests/test_vault_api.py`.
- Unit: `PYTHONPATH=$(pwd) /Users/cyh/vibe-remote-project/avibe/.venv/bin/python -m pytest tests/test_vault_cli.py tests/test_vault_api.py tests/test_vault_request_callbacks.py -q` -> 230 passed.
- Lint: `ruff check storage/vault_service.py vibe/api.py vibe/cli.py tests/test_vault_cli.py tests/test_vault_api.py tests/test_vault_request_callbacks.py` -> passed.
