### PR TITLE
feat(vault): in-product delete confirmation dialog (5s hold + fund/irreversible warnings for signing keys)

### DIFF
--- a/ui/src/components/ui/confirm-dialog.tsx
+++ b/ui/src/components/ui/confirm-dialog.tsx
@@ -45,20 +45,28 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
 }) => {
   const { t } = useTranslation();
   const [remaining, setRemaining] = React.useState(0);
+  const [counting, setCounting] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
 
   // Restart the hold countdown each time the dialog opens and tick it down to zero.
   React.useEffect(() => {
     if (!open || holdSeconds <= 0) {
+      setCounting(false);
       setRemaining(0);
       return;
     }
     setRemaining(holdSeconds);
+    setCounting(true);
     const id = setInterval(() => setRemaining((n) => Math.max(0, n - 1)), 1000);
     return () => clearInterval(id);
   }, [open, holdSeconds]);
 
-  const locked = remaining > 0;
+  // Lock from the very first render when a hold is required — before the effect above runs
+  // (`counting` still false) — so the destructive button can't be clicked/keyboard-activated in
+  // the frame before the countdown starts. Once counting, the remaining seconds govern.
+  const locked = open && holdSeconds > 0 && (!counting || remaining > 0);
+  // On that first pre-effect frame show the full hold instead of a spurious "(0)".
+  const displayRemaining = counting ? remaining : holdSeconds;
   const confirmText = confirmLabel ?? t('common.confirm');
 
   const handleConfirm = async () => {
@@ -95,7 +103,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
             disabled={locked || busy}
           >
             {busy ? <Loader2 className="size-4 animate-spin" /> : null}
-            {locked ? `${confirmText} (${remaining})` : confirmText}
+            {locked ? `${confirmText} (${displayRemaining})` : confirmText}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/ui/src/components/ui/confirm-dialog.tsx
+++ b/ui/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from './button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './dialog';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Extra content shown between the description and the footer — e.g. risk warnings. */
+  children?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Style the confirm button as a destructive (red) action. */
+  destructive?: boolean;
+  /**
+   * Seconds the confirm button stays disabled after the dialog opens (0 = clickable immediately).
+   * The countdown restarts every time the dialog opens — a deliberate speed bump before an
+   * irreversible action.
+   */
+  holdSeconds?: number;
+  /** Runs on confirm; while it's pending a spinner shows and the dialog can't be dismissed. */
+  onConfirm: () => void | Promise<void>;
+}
+
+/**
+ * Confirmation modal built on the app Dialog — the in-product replacement for `window.confirm`.
+ * Supports a destructive style and an optional "hold" countdown that forces the user to pause
+ * before confirming something they can't undo.
+ */
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  confirmLabel,
+  cancelLabel,
+  destructive = false,
+  holdSeconds = 0,
+  onConfirm,
+}) => {
+  const { t } = useTranslation();
+  const [remaining, setRemaining] = React.useState(0);
+  const [busy, setBusy] = React.useState(false);
+
+  // Restart the hold countdown each time the dialog opens and tick it down to zero.
+  React.useEffect(() => {
+    if (!open || holdSeconds <= 0) {
+      setRemaining(0);
+      return;
+    }
+    setRemaining(holdSeconds);
+    const id = setInterval(() => setRemaining((n) => Math.max(0, n - 1)), 1000);
+    return () => clearInterval(id);
+  }, [open, holdSeconds]);
+
+  const locked = remaining > 0;
+  const confirmText = confirmLabel ?? t('common.confirm');
+
+  const handleConfirm = async () => {
+    if (locked || busy) return;
+    setBusy(true);
+    try {
+      await onConfirm();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Don't let an outside-click/Esc dismiss mid-delete.
+        if (!busy) onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+        {children}
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            {cancelLabel ?? t('common.cancel')}
+          </Button>
+          <Button
+            variant={destructive ? 'destructive' : 'default'}
+            onClick={handleConfirm}
+            disabled={locked || busy}
+          >
+            {busy ? <Loader2 className="size-4 animate-spin" /> : null}
+            {locked ? `${confirmText} (${remaining})` : confirmText}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Clock, Globe, History, Inbox, KeyRound, Link2, Loader2, Plus, Puzzle, RefreshCw, ShieldCheck, Tag, Trash2, Wallet, X } from 'lucide-react';
+import { AlertTriangle, Clock, Globe, History, Inbox, KeyRound, Link2, Loader2, Plus, Puzzle, RefreshCw, ShieldCheck, Tag, Trash2, Wallet, X } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { CapabilityTabs } from './CapabilityTabs';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
+import { ConfirmDialog } from '../ui/confirm-dialog';
 import { cn } from '../../lib/utils';
 import { partitionTags } from '../../lib/vaultTags';
 import { useApi, type VaultAuditEvent, type VaultGrant, type VaultRequest, type VaultSecret } from '../../context/ApiContext';
@@ -27,7 +28,7 @@ const proxyHosts = (s: VaultSecret): string[] => {
   return Array.isArray(hosts) ? hosts : [];
 };
 
-const SecretRow: React.FC<{ secret: VaultSecret; onDelete: (name: string) => void }> = ({ secret: s, onDelete }) => {
+const SecretRow: React.FC<{ secret: VaultSecret; onDelete: (secret: VaultSecret) => void }> = ({ secret: s, onDelete }) => {
   const { t } = useTranslation();
   const isKeypair = s.kind === 'keypair';
   const isProtected = s.protection === 'protected';
@@ -81,7 +82,7 @@ const SecretRow: React.FC<{ secret: VaultSecret; onDelete: (name: string) => voi
         {isKeypair && s.signing_addresses ? <SigningAddressList addresses={s.signing_addresses} className="mt-1" /> : null}
       </div>
       <div className="ml-auto">
-        <Button variant="ghost" size="icon" onClick={() => onDelete(s.name)} aria-label={t('vaults.delete')}>
+        <Button variant="ghost" size="icon" onClick={() => onDelete(s)} aria-label={t('vaults.delete')}>
           <Trash2 className="size-4" />
         </Button>
       </div>
@@ -639,14 +640,19 @@ export const VaultsPage: React.FC = () => {
     }
   }, [api, showAudit]);
 
-  const onDelete = async (name: string) => {
-    if (!window.confirm(t('vaults.deleteConfirm', { name }))) return;
+  const [deleteTarget, setDeleteTarget] = useState<VaultSecret | null>(null);
+  const onDelete = (secret: VaultSecret) => setDeleteTarget(secret);
+  const confirmDelete = async () => {
+    const secret = deleteTarget;
+    if (!secret) return;
     try {
-      await api.deleteVaultSecret(name);
-      showToast(t('vaults.deleted', { name }), 'success');
+      await api.deleteVaultSecret(secret.name);
+      showToast(t('vaults.deleted', { name: secret.name }), 'success');
       refresh();
     } catch (err: unknown) {
       setError(messageFromError(err));
+    } finally {
+      setDeleteTarget(null);
     }
   };
 
@@ -783,6 +789,31 @@ export const VaultsPage: React.FC = () => {
           refresh();
         }}
       />
+      <ConfirmDialog
+        open={deleteTarget != null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        destructive
+        title={t('vaults.deleteDialog.title', { name: deleteTarget?.name ?? '' })}
+        description={t('vaults.deleteDialog.description')}
+        confirmLabel={t('common.delete')}
+        holdSeconds={deleteTarget?.kind === 'keypair' ? 5 : 0}
+        onConfirm={confirmDelete}
+      >
+        {deleteTarget?.kind === 'keypair' ? (
+          <div className="flex flex-col gap-2 rounded-[10px] border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-[12.5px] leading-snug text-foreground">
+            <span className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+              <span>{t('vaults.deleteDialog.keypairIrreversible')}</span>
+            </span>
+            <span className="flex items-start gap-2">
+              <Wallet className="mt-0.5 size-4 shrink-0 text-destructive" />
+              <span>{t('vaults.deleteDialog.keypairFunds')}</span>
+            </span>
+          </div>
+        ) : null}
+      </ConfirmDialog>
     </div>
   );
 };

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -31,6 +31,7 @@
     "edit": "Edit",
     "configure": "Configure",
     "cancel": "Cancel",
+    "confirm": "Confirm",
     "clear": "Clear",
     "retry": "Retry",
     "loading": "Loading...",
@@ -2235,7 +2236,12 @@
       }
     },
     "delete": "Delete",
-    "deleteConfirm": "Delete secret \"{{name}}\"? Agents will no longer be able to use it.",
+    "deleteDialog": {
+      "title": "Delete \"{{name}}\"?",
+      "description": "Agents will no longer be able to use this secret.",
+      "keypairIrreversible": "This is a signing key — deleting it permanently destroys the private key. There is no backup and it cannot be recovered.",
+      "keypairFunds": "If this key's address holds any funds, move them out first, or they will be lost for good."
+    },
     "deleted": "Deleted {{name}}",
     "created": "Saved {{name}}",
     "protectedUnlock": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -31,6 +31,7 @@
     "edit": "编辑",
     "configure": "配置",
     "cancel": "取消",
+    "confirm": "确定",
     "clear": "清除",
     "retry": "重试",
     "loading": "加载中...",
@@ -2234,7 +2235,12 @@
       }
     },
     "delete": "删除",
-    "deleteConfirm": "删除密钥「{{name}}」？Agent 将无法再使用它。",
+    "deleteDialog": {
+      "title": "删除「{{name}}」？",
+      "description": "Agent 将无法再使用这条密钥。",
+      "keypairIrreversible": "这是一把签名密钥——删除会永久销毁私钥,没有备份,无法恢复。",
+      "keypairFunds": "如果这把密钥的地址里还有资金,请先转出,否则将永久丢失。"
+    },
     "deleted": "已删除 {{name}}",
     "created": "已保存 {{name}}",
     "protectedUnlock": {


### PR DESCRIPTION
## Capability
Replaces the native `window.confirm` on Vault secret delete with an in-product dialog, and adds extra guard rails when deleting a **signing key (keypair)**.

## What changed
- **New reusable primitive** `ui/src/components/ui/confirm-dialog.tsx` — `ConfirmDialog` built on the app `Dialog`: title/description/children, confirm+cancel, `destructive` style, async `onConfirm` (spinner + can't dismiss mid-action), and an optional **`holdSeconds` countdown** that keeps the confirm button disabled (shows `Delete (5)…`) until it elapses, restarting each time the dialog opens. The app had ~15 `window.confirm` sites and no reusable confirm — this is the proper-home reusable unit; the Vault delete is its first adopter.
- **Vault delete** (`VaultsPage`) now opens `ConfirmDialog` instead of `window.confirm`.
  - **Signing keys**: 5-second hold on the confirm button + two warnings — the private key is destroyed permanently and cannot be recovered, and any funds at its address must be moved out first.
  - **Static secrets**: plain confirm, no countdown.
- i18n (en + zh): `common.confirm`, `vaults.deleteDialog.*` (title/description/keypair warnings); removed the now-unused `vaults.deleteConfirm`.

## Scope
Only the secret **delete** flow (per request). Grant-revoke still uses `window.confirm` — left as a follow-up. No backend changes.

## Evidence
- Build: `npm run build` green (TypeScript clean).
- Manual/regression: to verify live in the local Incus regression env after merge — delete a static secret (plain confirm), delete a signing key (5s countdown + warnings), and confirm the button unlocks only after the countdown.