### PR TITLE
refactor(vault): passkey-only protected vault backend

### DIFF
--- a/docs/plans/vault-protected-delete-authz.md
+++ b/docs/plans/vault-protected-delete-authz.md
@@ -1,0 +1,405 @@
+# Protected Vault secret deletion authorization
+
+Status: design plan only, no implementation.
+Owner: Vaults workstream.
+Date: 2026-07-07.
+
+This revises the earlier #818 design for the pre-launch product decision:
+protected-tier vaults are Passkey (WebAuthn-PRF) only. There is no password
+factor, no password-derived signing key, and no legacy password-only migration
+path to preserve.
+
+## Background verified from current code
+
+Protected-tier secret values are still client-side custody. The browser unwraps
+the VMK with a WebAuthn-PRF passkey copy, seals protected envelopes, signs
+protected keypair requests, and releases protected DEKs as blind boxes. The
+daemon stores names, metadata, ciphertext, nonce, and opaque `wrap_meta`; it does
+not verify passkeys today and does not hold the VMK.
+
+The current delete paths are uneven:
+
+- `vibe vault rm` checks metadata first and refuses protected secrets with
+  `protected_delete_forbidden`.
+- The Vaults page has a client-side destructive confirmation dialog, including
+  stronger warnings for signing keys.
+- `DELETE /api/vault/secrets/<name>` still calls `api.delete_vault_secret(name)`
+  directly.
+- `api.delete_vault_secret` calls `vault_service.delete_secret`, expires related
+  requests/grants, deletes the row, and publishes updates.
+- `vault_service.delete_secret` does not re-authorize protected rows.
+
+That means same-origin and CSRF only protect the HTTP route. A same-machine agent
+or script can obtain both and delete a protected row through HTTP even though the
+CLI and UI button path look gated.
+
+## Product goal
+
+Deleting a protected secret must require a fresh user authorization that the
+daemon can verify before it mutates storage. The proof must be operation-scoped,
+must name the exact protected secret being deleted, and must not require the
+daemon to store protected values, DEKs, VMKs, passkey PRF outputs, or plaintext.
+
+Non-goals for the first implementation:
+
+- changing standard-tier deletion behavior;
+- making the daemon decrypt protected secret values;
+- adding a general account login system;
+- solving same-origin XSS or a fully compromised browser profile;
+- building all future destructive-operation policy in the first PR.
+
+## Threat model
+
+Blocked:
+
+- Local agent via CLI: already blocked by `vibe vault rm`; the service guard
+  should also make future CLI regressions fail closed.
+- Local agent via HTTP: cannot delete a protected secret unless it can complete a
+  server-issued WebAuthn challenge for that exact delete operation.
+- Remote caller: still needs the existing setup auth, same-origin/CSRF checks,
+  and a valid protected-operation proof. A stolen CSRF token alone is not enough.
+- Replay caller: cannot reuse a previous proof because challenges are short-lived,
+  single-use, and bound to `{operation, secret_id/name, updated_at}`.
+
+Not fully blocked:
+
+- The real user intentionally authorizing deletion.
+- Malware that can drive the user's browser and satisfy the OS/passkey ceremony.
+- Attackers that can arbitrarily edit the local SQLite database or patch the
+  running daemon. This feature is an API-layer authorization boundary, not a
+  host compromise boundary.
+
+The daemon verifies exactly one proof type: a WebAuthn `get()` assertion with
+user verification, checked against a daemon-stored credential public key.
+
+## Compared approaches
+
+### 1. Server-verifiable WebAuthn assertion
+
+Add a server-side protected authorization factor registry. Passkey setup uses a
+daemon-issued WebAuthn registration challenge and stores the credential public
+key, credential id, RP id, algorithm, and signature counter. Protected delete
+uses a new daemon challenge; the browser calls `navigator.credentials.get()`
+with `userVerification: "required"` and submits the assertion to the daemon.
+The daemon verifies `clientDataJSON.challenge`, origin/RP id, authenticator
+data flags, signature, credential id, and counter before deleting.
+
+Pros:
+
+- strongest match for passkey user presence;
+- no VMK, plaintext, or PRF output reaches Python;
+- same-machine scripts cannot forge assertions without the authenticator and
+  user verification;
+- cleanly reuses WebAuthn's replay protection and per-credential public key
+  model.
+
+Cons:
+
+- current PRF passkey setup did not persist the credential public key, so the new
+  setup flow must register the authorization public key when the protected vault
+  is established;
+- needs a WebAuthn verification implementation and registration challenge flow;
+- requires a valid WebAuthn context, which means localhost or HTTPS tunnel RP
+  origins; raw-IP access such as `127.0.0.1` cannot complete WebAuthn.
+
+### 2. Delete-request plus approval flow
+
+Model protected delete as a new `vault_requests` type, for example
+`request_type="delete"`. A local or remote caller creates a pending delete
+request. The user approves it in the browser, and approval completes the delete.
+
+Pros:
+
+- fits the existing human-in-the-loop Vaults request UX;
+- good audit trail and good remote/async story;
+- can later support "agent requested deletion, user approved from inbox".
+
+Cons:
+
+- by itself, it is not an authorization primitive. If approval only means "the
+  UI posted approve", a same-machine agent can post that too.
+- adding a durable pending destructive state is more machinery than direct UI
+  delete needs.
+- it still needs a daemon-verifiable WebAuthn proof at approval time.
+
+This is useful as an outer workflow, not as the root security boundary.
+
+### 3. Short-lived browser/session delete token
+
+After the browser completes a server-verified passkey challenge, mint a
+short-lived daemon token that can authorize one protected delete.
+
+Pros:
+
+- can reduce repeated passkey prompts for tightly grouped future operations;
+- can be layered over the same server-verified challenge primitive.
+
+Cons:
+
+- if minted from the current UI-only unlock, it does not close the HTTP bypass;
+- if stolen from browser storage, it becomes a bearer delete capability;
+- "vault was unlocked earlier" is weaker than fresh presence for deletion.
+
+This should not be the first fix. A short grace token could be layered later only
+after the token is minted from a server-verified WebAuthn proof and is restricted
+to one operation.
+
+## Recommendation
+
+Implement a reusable protected-operation authorization service, and use it first
+for protected secret deletion. Keep the first product surface as direct delete
+from the Vaults page, not a new request queue item. The route and service should
+fail closed for protected rows unless a fresh operation-scoped WebAuthn assertion
+verifies.
+
+Recommended shape:
+
+1. Store server-verifiable WebAuthn authorization factors for the protected vault.
+2. Issue short-lived delete challenges from the daemon.
+3. Verify a WebAuthn assertion with user verification.
+4. Consume the challenge and delete the protected row in one transaction.
+5. Keep `vault_requests` available for a later "agent asks user to delete"
+   workflow, but do not make it the security primitive.
+
+This is the smallest design that closes the agent-via-HTTP hole without moving
+protected values into the daemon.
+
+## Schema and storage
+
+Add `vault_auth_factors`:
+
+- `id`: stable factor id, e.g. `vaf_*`.
+- `kind`: `webauthn`.
+- `label`: user-visible device/factor label, optional.
+- `rp_id`: WebAuthn RP id.
+- `credential_id`: base64url/raw credential id.
+- `public_key`: COSE/JWK or normalized public-key bytes.
+- `alg`: WebAuthn COSE alg.
+- `sign_count`: last accepted WebAuthn counter.
+- `transports`: JSON array, optional.
+- `created_at`, `updated_at`, `last_used_at`, `disabled_at`.
+
+Add `vault_operation_challenges`:
+
+- `id`: challenge id, e.g. `vop_*`.
+- `operation`: initially `delete_secret`.
+- `secret_name`, `secret_id`, `secret_updated_at`: binds proof to the row that
+  existed when the challenge was issued.
+- `challenge_hash`: hash of the random challenge bytes; never store only a
+  reusable bearer token.
+- `expires_at`, `consumed_at`.
+- `factor_id`: set when consumed.
+- `created_at`.
+
+Setup:
+
+- Create both tables.
+- New protected-vault setup registers a real WebAuthn authorization factor.
+- Do not backfill fake factors.
+- Standard secrets remain deletable.
+- Protected secrets without a registered auth factor return
+  `protected_authz_setup_required` for protected delete.
+
+Custody boundary:
+
+- The daemon stores public verification material and challenges only.
+- It does not store protected plaintext, DEKs, VMKs, passkey PRF outputs, or raw
+  private authenticator material.
+- `wrap_meta` remains the browser/crypto custody object, not the server
+  authorization verifier.
+
+## Passkey factor flow
+
+Setup should stop using a purely browser-random passkey creation challenge for
+the authorization factor. The browser asks the daemon for registration options:
+
+`POST /api/vault/authz/factors/webauthn/options`
+
+The daemon returns a registration challenge with:
+
+- RP name/id derived from the current UI origin;
+- `userVerification: "required"`;
+- resident-key settings matching the current protected vault UX;
+- allowed algorithms, initially ES256 and RS256 only if the verifier supports
+  them;
+- a challenge id with a short expiry.
+
+The browser calls `navigator.credentials.create()` with the PRF extension still
+enabled for VMK wrapping. It then submits the attestation response:
+
+`POST /api/vault/authz/factors/webauthn`
+
+The daemon verifies registration and stores the credential public key. The
+browser continues storing the PRF `credential_id` and `prf_salt` inside
+`wrap_meta` for VMK unlock. The public key is only for daemon authorization.
+
+Delete proof:
+
+1. Browser calls `POST /api/vault/secrets/<name>/delete-challenge`.
+2. Daemon checks the secret exists and is protected, creates a challenge, and
+   returns WebAuthn request options for registered passkey factors.
+3. Browser calls `navigator.credentials.get()` with `userVerification:
+   "required"`.
+4. Browser submits the assertion with the delete request.
+5. Daemon verifies and consumes the challenge before deleting.
+
+This assertion is separate from the WebAuthn PRF assertion used to unwrap the
+VMK. Delete does not need the VMK.
+
+## API changes
+
+Challenge issue:
+
+`POST /api/vault/secrets/<name>/delete-challenge`
+
+Returns one of:
+
+- `{ok: true, challenge_id, expires_at, operation, secret_name, webauthn}`
+- `{ok: false, code: "secret_not_found"}`
+- `{ok: false, code: "not_protected"}` if a protected challenge was requested
+  for a standard row.
+- `{ok: false, code: "protected_authz_setup_required"}` if no usable WebAuthn
+  factor is registered.
+
+Delete:
+
+Keep `DELETE /api/vault/secrets/<name>` as the canonical route. For protected
+rows, require a JSON body:
+
+```json
+{
+  "authz": {
+    "challenge_id": "vop_...",
+    "factor_id": "vaf_...",
+    "kind": "webauthn",
+    "assertion": {
+      "id": "...",
+      "rawId": "...",
+      "type": "public-key",
+      "response": {
+        "clientDataJSON": "...",
+        "authenticatorData": "...",
+        "signature": "...",
+        "userHandle": "..."
+      }
+    }
+  }
+}
+```
+
+Route behavior:
+
+- Standard row: existing delete behavior remains.
+- Protected row without `authz`: return `409 protected_auth_required`.
+- Protected row with invalid/expired/replayed proof: return `409
+  invalid_protected_authz`.
+- Protected row with valid proof: consume challenge, delete row, expire related
+  grants/requests, publish `vaults.updated`.
+
+Service boundary:
+
+- Change `vault_service.delete_secret` so protected rows require a verified
+  protected-operation authorization context, not just API-route checks.
+- The API layer can parse and verify WebAuthn payloads, but the final storage
+  mutation should still fail closed if the service is called without a verified
+  context.
+- The CLI can continue refusing protected delete, but future code paths inherit
+  the service-level guard.
+
+## UI changes
+
+Build on the existing delete dialog instead of adding a separate approval queue.
+
+For standard secrets:
+
+- No UX change.
+
+For protected secrets:
+
+1. User opens the existing delete dialog.
+2. Dialog shows the existing destructive copy and a passkey authorization step.
+3. On confirm, the UI requests a delete challenge.
+4. The browser prompts WebAuthn user verification.
+5. Submit the assertion with the delete request.
+6. Show existing success/error toasts and refresh.
+
+The dialog should not unlock or expose the VMK just to delete a row. Passkey
+delete authorization is a normal WebAuthn assertion. The current protected
+unlock panel remains for create, sign, and protected-access approval flows.
+
+If the daemon returns `protected_authz_setup_required`, the UI should open a
+short "Enable protected delete authorization" setup flow and make clear that
+deletion is blocked until at least one server-verifiable WebAuthn factor exists.
+
+## WebAuthn context consequence
+
+Protected vaults require a WebAuthn-capable origin. The supported contexts are
+localhost and HTTPS tunnel origins with a stable RP id. Raw-IP access such as
+`127.0.0.1` cannot complete WebAuthn ceremonies, so it cannot create, unlock, or
+delete protected-vault entries. This is accepted for the passkey-only product.
+
+## Scope boundary
+
+The first implementation should enforce this only for protected secret deletion.
+The underlying authorization service should be named generically enough to cover
+future protected destructive operations:
+
+- removing the last protected auth factor;
+- rotating/replacing the protected vault root metadata;
+- deleting protected keypairs;
+- possibly protected secret metadata changes that affect delivery policy.
+
+Do not gate standard metadata edits, standard deletion, request denial, or grant
+revocation with this new proof in the first phase.
+
+## Phased todo
+
+### Phase 0: design acceptance
+
+- Decide WebAuthn verification dependency: implement minimal verification with
+  `cryptography`/CBOR parsing, or add a focused WebAuthn/FIDO2 dependency.
+- Decide the challenge payload, canonicalization, expiry, replay rules, and row
+  binding fields.
+- Confirm RP id/origin derivation for localhost and HTTPS tunnel access.
+
+### Phase 1: daemon primitives
+
+- Add WebAuthn auth factor and operation challenge tables plus migrations.
+- Add WebAuthn factor registration APIs.
+- Add challenge issue and assertion verification helpers.
+- Add audit events for challenge issued, factor registered, delete authorized,
+  and delete denied.
+- Add focused tests for challenge expiry, replay, secret mismatch, stale row
+  version, invalid assertions, and no-factor fail-closed behavior.
+
+### Phase 2: protected delete enforcement
+
+- Change `api.delete_vault_secret` to accept an optional `authz` payload.
+- Change the HTTP route to pass JSON body through for DELETE.
+- Change `vault_service.delete_secret` to refuse protected rows without a
+  verified authorization context.
+- Keep CLI protected deletion refused.
+- Add API/service tests proving direct protected delete without proof fails even
+  when origin/CSRF would otherwise pass.
+
+### Phase 3: UI integration
+
+- Extend the Vaults delete dialog with protected passkey challenge handling.
+- Add WebAuthn assertion helpers.
+- Add i18n strings for protected auth required, setup required, expired
+  challenge, invalid proof, and unavailable WebAuthn context.
+- Add focused UI tests for passkey options and setup-required error handling.
+
+### Phase 4: setup UX
+
+- Register WebAuthn auth factors during new protected vault setup.
+- Add a Vault settings or inline setup panel for missing protected auth factors.
+- Add telemetry/audit-only counters for how many protected rows are blocked by
+  missing auth factors, without exposing secret values.
+
+### Phase 5: follow-up scope
+
+- Revisit whether protected auth should also guard destructive protected factor
+  management and protected metadata policy changes.
+- Consider an optional `vault_requests` delete workflow for remote/agent-initiated
+  deletion requests, using the same WebAuthn verifier at approval time.

--- a/storage/vault_protected.py
+++ b/storage/vault_protected.py
@@ -1,43 +1,30 @@
-"""Protected-tier envelope — canonical wire-format reference (design: vaults.md §7.1).
+"""Protected-tier envelope reference.
 
 A **Vault Master Key (VMK)** is the protected-tier root. The VMK is wrapped
-*independently* by one or more factors (password now; WebAuthn-PRF passkey copies are
-added browser-side later, with the same copy shape) so any single factor can unwrap it
-and losing one factor — while another remains — doesn't lose the vault. Each protected
-secret's data key (DEK) is wrapped by the VMK.
+by one or more WebAuthn-PRF passkey copies in browser-owned ``wrap_meta``. There
+is no password factor and no daemon-side VMK unwrap path. Each protected secret's
+data key (DEK) is wrapped by the VMK.
 
-    VMK  --wrapped by--> KEK_password = KDF(password, salt)     (0..N copies)
+    VMK  --wrapped by--> KEK_passkey = HKDF(WebAuthn PRF output, salt)  (1..N copies)
     secret: value --AES-256-GCM(DEK)--> ciphertext;  DEK --AES-256-GCM(VMK)--> wrapped
 
-**IMPORTANT — production decryption is BROWSER-SIDE (§8.4):** the vault password never
-reaches the daemon. This module is the *canonical format definition + test vectors* the
-browser implementation mirrors. Its ``unwrap``/``open`` path exists for tests and
-offline tooling and must NOT be wired into a daemon-side resolve. The daemon only ever
-stores the opaque ``wrap_meta`` + ciphertext the browser produces.
-
-KDF note: this reference uses Scrypt (zero-dep, ships in ``cryptography``); each wrap
-copy records its ``kdf`` + params, so an Argon2id variant is just another ``kdf`` value
-(the protected-tier KDF is still open Q7). The ``kind`` field distinguishes
-``password`` copies from future ``passkey`` copies.
+**IMPORTANT — production decryption is BROWSER-SIDE:** passkey PRF output, the
+VMK, and plaintext never reach the daemon. This module keeps only the DEK/VMK
+envelope reference used by tests and offline tooling. The daemon stores the
+opaque ``wrap_meta`` + ciphertext the browser produces.
 """
 
 from __future__ import annotations
 
 import base64
-import json
 import os
 from dataclasses import dataclass
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 
-WRAP_META_VERSION = 1
 _KEY_BYTES = 32
 _NONCE_BYTES = 12
-_SCRYPT_N = 2**15
-_SCRYPT_R = 8
-_SCRYPT_P = 1
 
 
 class ProtectedFormatError(Exception):
@@ -64,75 +51,6 @@ def _unb64(text: str) -> bytes:
 
 def new_vmk() -> bytes:
     return os.urandom(_KEY_BYTES)
-
-
-def _kek_password(password: str, salt: bytes, *, n: int = _SCRYPT_N, r: int = _SCRYPT_R, p: int = _SCRYPT_P) -> bytes:
-    return Scrypt(salt=salt, length=_KEY_BYTES, n=n, r=r, p=p).derive(password.encode("utf-8"))
-
-
-def _validate_scrypt_params(n: int, r: int, p: int) -> None:
-    """Bound copy-controlled KDF params so a hostile/corrupt wrap_meta can't OOM or hang
-    the unwrap before authentication fails. N is a power of two ≤ 2^17 (~256 MB at r=8)."""
-    if not (isinstance(n, int) and n >= 2 and (n & (n - 1)) == 0 and n <= 2**17):
-        raise ProtectedFormatError(f"scrypt N out of bounds: {n!r}")
-    if not (isinstance(r, int) and 1 <= r <= 16):
-        raise ProtectedFormatError(f"scrypt r out of bounds: {r!r}")
-    if not (isinstance(p, int) and 1 <= p <= 16):
-        raise ProtectedFormatError(f"scrypt p out of bounds: {p!r}")
-
-
-def _password_copy(vmk: bytes, password: str) -> dict:
-    salt = os.urandom(16)
-    nonce = os.urandom(_NONCE_BYTES)
-    kek = _kek_password(password, salt)
-    wrapped = AESGCM(kek).encrypt(nonce, vmk, None)
-    return {
-        "kind": "password",
-        "kdf": "scrypt",
-        "n": _SCRYPT_N,
-        "r": _SCRYPT_R,
-        "p": _SCRYPT_P,
-        "salt": _b64(salt),
-        "nonce": _b64(nonce),
-        "wrapped": _b64(wrapped),
-    }
-
-
-def build_wrap_meta(vmk: bytes, passwords: list[str]) -> str:
-    """Build a ``wrap_meta`` JSON wrapping ``vmk`` under each password (one copy each)."""
-    if not passwords:
-        raise ProtectedFormatError("at least one factor (password) is required")
-    copies = [_password_copy(vmk, pw) for pw in passwords]
-    return json.dumps({"v": WRAP_META_VERSION, "copies": copies})
-
-
-def add_password_copy(wrap_meta: str, vmk: bytes, password: str) -> str:
-    """Append a new password wrap copy of the same VMK (e.g. a second device / rotation)."""
-    meta = json.loads(wrap_meta)
-    meta.setdefault("copies", []).append(_password_copy(vmk, password))
-    return json.dumps(meta)
-
-
-def unwrap_vmk(wrap_meta: str, password: str) -> bytes:
-    """Recover the VMK by trying the password against each ``password`` copy.
-
-    Reference/test path only — production unwrap is browser-side (§8.4).
-    """
-    try:
-        meta = json.loads(wrap_meta)
-    except (TypeError, ValueError) as exc:
-        raise ProtectedFormatError("wrap_meta is not valid JSON") from exc
-    for copy in meta.get("copies", []):
-        if copy.get("kind") != "password" or copy.get("kdf") != "scrypt":
-            continue
-        try:
-            n, r, p = int(copy["n"]), int(copy["r"]), int(copy["p"])
-            _validate_scrypt_params(n, r, p)  # bound before deriving; skip a copy with hostile params
-            kek = _kek_password(password, _unb64(copy["salt"]), n=n, r=r, p=p)
-            return AESGCM(kek).decrypt(_unb64(copy["nonce"]), _unb64(copy["wrapped"]), None)
-        except (InvalidTag, KeyError, ValueError, TypeError, ProtectedFormatError):
-            continue
-    raise ProtectedFormatError("no password copy could be unwrapped (wrong password?)")
 
 
 def seal_protected(value: bytes, vmk: bytes) -> ProtectedSealed:

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -802,11 +802,26 @@ def test_create_protected_stores_browser_envelope_without_avault(monkeypatch):
 
     seal = Mock(return_value=_sealed("should-not-use"))
     monkeypatch.setattr(api, "avault_seal_blind_box", seal)
+    passkey_wrap_meta = {
+        "v": 1,
+        "copies": [
+            {
+                "kind": "passkey",
+                "credential_id": "cred-1",
+                "kdf": "webauthn-prf-hkdf-sha256",
+                "prf_salt": "salt",
+                "nonce": "copy-nonce",
+                "wrapped": "wrapped-vmk",
+            }
+        ],
+        "wrapped_dek": "dek",
+        "dek_nonce": "dek-nonce",
+    }
     created = api.create_vault_secret(
         {
             "name": "PROTECTED_KEY",
             "protection": "protected",
-            "sealed": {"ciphertext": "browser-ct", "nonce": "browser-n", "wrap_meta": {"v": 1, "wrapped_dek": "dek"}},
+            "sealed": {"ciphertext": "browser-ct", "nonce": "browser-n", "wrap_meta": passkey_wrap_meta},
             "public_meta": {"factor_hint": "passkey-first"},
         }
     )
@@ -815,7 +830,7 @@ def test_create_protected_stores_browser_envelope_without_avault(monkeypatch):
     with api._vault_engine().connect() as conn:
         row = conn.execute(select(vault_secrets).where(vault_secrets.c.name == "PROTECTED_KEY")).mappings().one()
     assert row["ciphertext"] == "browser-ct"
-    assert json.loads(row["wrap_meta"]) == {"v": 1, "wrapped_dek": "dek"}
+    assert json.loads(row["wrap_meta"]) == passkey_wrap_meta
 
 
 def test_protected_create_establishing_vmk_rejects_second_init(monkeypatch):

--- a/tests/test_vault_protected_format.py
+++ b/tests/test_vault_protected_format.py
@@ -1,4 +1,4 @@
-"""Protected-tier envelope format reference (P1, vaults.md §7.1). Pure crypto, no I/O."""
+"""Protected-tier envelope reference. Pure crypto, no I/O."""
 
 from __future__ import annotations
 
@@ -8,53 +8,19 @@ from storage import vault_protected as vp
 from storage.vault_protected import ProtectedFormatError
 
 
-def test_password_unwraps_vmk_and_secret_round_trips():
+def test_vmk_opens_protected_secret_round_trip():
     vmk = vp.new_vmk()
-    wrap_meta = vp.build_wrap_meta(vmk, ["correct horse battery staple"])
     sealed = vp.seal_protected(b"the protected value", vmk)
 
-    # Recover the VMK from the password, then open the secret.
-    recovered = vp.unwrap_vmk(wrap_meta, "correct horse battery staple")
-    assert recovered == vmk
-    assert vp.open_protected(sealed, recovered) == b"the protected value"
-
-
-def test_wrong_password_cannot_unwrap():
-    vmk = vp.new_vmk()
-    wrap_meta = vp.build_wrap_meta(vmk, ["right"])
-    with pytest.raises(ProtectedFormatError):
-        vp.unwrap_vmk(wrap_meta, "wrong")
-
-
-def test_multi_factor_either_password_unwraps_same_vmk():
-    vmk = vp.new_vmk()
-    wrap_meta = vp.build_wrap_meta(vmk, ["laptop-pass", "phone-pass"])
-    assert vp.unwrap_vmk(wrap_meta, "laptop-pass") == vmk
-    assert vp.unwrap_vmk(wrap_meta, "phone-pass") == vmk
-
-
-def test_add_copy_is_a_rotation_not_a_reencrypt():
-    # Adding a password copy wraps the SAME vmk — existing secrets stay valid (only the
-    # tiny wrap_meta changes, never the ciphertext). This is the cheap-rekey property.
-    vmk = vp.new_vmk()
-    sealed = vp.seal_protected(b"v", vmk)
-    wrap_meta = vp.build_wrap_meta(vmk, ["old-pass"])
-    wrap_meta = vp.add_password_copy(wrap_meta, vmk, "new-pass")
-    assert vp.unwrap_vmk(wrap_meta, "old-pass") == vmk
-    assert vp.unwrap_vmk(wrap_meta, "new-pass") == vmk
-    assert vp.open_protected(sealed, vp.unwrap_vmk(wrap_meta, "new-pass")) == b"v"
+    assert vp.open_protected(sealed, vmk) == b"the protected value"
 
 
 def test_open_with_wrong_vmk_fails():
     vmk = vp.new_vmk()
     sealed = vp.seal_protected(b"v", vmk)
+
     with pytest.raises(ProtectedFormatError):
         vp.open_protected(sealed, vp.new_vmk())
-
-
-def test_build_requires_a_factor():
-    with pytest.raises(ProtectedFormatError):
-        vp.build_wrap_meta(vp.new_vmk(), [])
 
 
 def test_each_seal_is_unique():


### PR DESCRIPTION
## Summary
- Remove server-side password-factor crypto from `storage/vault_protected.py`, including password KEK derivation, password wrap copies, and server-side password VMK unwrap helpers.
- Keep protected `wrap_meta` opaque at the daemon boundary and pin passkey-shaped `wrap_meta` storage coverage.
- Add a passkey-only revision of the protected delete authorization design from #818.

## Evidence layers
- Unit: `PYTHONPATH=$(pwd) /Users/cyh/vibe-remote-project/avibe/.venv/bin/python -m pytest tests/ -k vault -q`
- Lint: `/Library/Frameworks/Python.framework/Versions/3.13/bin/ruff check storage/vault_protected.py tests/test_vault_protected_format.py tests/test_vault_api.py`
- Contract/scenario: not changed; this PR only removes backend password scaffolding and revises the design doc.
- Residual manual checks: frontend password-factor removal is handled separately.

## Notes
- PR #818 is still open; this branch carries the passkey-only design revision so the backend cleanup can merge independently.
