### PR TITLE
fix(vaults): keep protected-tier pick from reverting; collapse Advanced by default

### DIFF
--- a/ui/src/components/ui/vault-protected-unlock.tsx
+++ b/ui/src/components/ui/vault-protected-unlock.tsx
@@ -114,6 +114,18 @@ export const VaultProtectedUnlock: React.FC<{ vault: Vault; secretName?: string;
           </div>
         </div>
 
+        {/* Ack sits ABOVE the button: the natural order is read-the-risk → check → the
+            (now-enabled) Add-Passkey button right below it. The button gates on `ackLoss`. */}
+        {canUsePasskey && (
+          <div className="flex flex-col gap-2 rounded-xl border border-warning/40 bg-warning/10 p-3">
+            <span className="text-[11.5px] leading-snug text-warning">{t('vaults.protectedUnlock.passkeyUnrecoverableWarning')}</span>
+            <label className="flex items-start gap-2 text-[11.5px] leading-snug text-muted-foreground">
+              <input type="checkbox" checked={ackLoss} onChange={(e) => setAckLoss(e.target.checked)} className="mt-0.5 shrink-0" />
+              <span>{t('vaults.protectedUnlock.passkeyAck')}</span>
+            </label>
+          </div>
+        )}
+
         {canUsePasskey ? (
           <div className="flex flex-col items-center gap-2.5 rounded-xl border-[1.5px] border-mint bg-mint-soft p-4">
             <Badge variant="success" className="border-transparent bg-mint uppercase tracking-wide text-background">
@@ -129,16 +141,6 @@ export const VaultProtectedUnlock: React.FC<{ vault: Vault; secretName?: string;
         ) : (
           <div className="rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs leading-snug text-warning">
             {t('vaults.protectedUnlock.unlockUnavailableHere')}
-          </div>
-        )}
-
-        {canUsePasskey && (
-          <div className="flex flex-col gap-2 rounded-xl border border-warning/40 bg-warning/10 p-3">
-            <span className="text-[11.5px] leading-snug text-warning">{t('vaults.protectedUnlock.passkeyUnrecoverableWarning')}</span>
-            <label className="flex items-start gap-2 text-[11.5px] leading-snug text-muted-foreground">
-              <input type="checkbox" checked={ackLoss} onChange={(e) => setAckLoss(e.target.checked)} className="mt-0.5 shrink-0" />
-              <span>{t('vaults.protectedUnlock.passkeyAck')}</span>
-            </label>
           </div>
         )}
 

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -160,9 +160,10 @@ export const VaultSecretForm: React.FC<{
   const [allowHosts, setAllowHosts] = useState<string[]>(requestSpec?.policy?.allowed_hosts ?? []);
   const [fetchAuthMode, setFetchAuthMode] = useState<FetchAuthMode>(requestSpec?.policy?.auth?.type ?? 'bearer');
   const [fetchAuthName, setFetchAuthName] = useState(requestSpec?.policy?.auth?.name ?? '');
-  // Advanced now holds only proxy policy (allowed hosts + fetch auth), so it auto-opens
-  // for a spec that carries policy; description and tags moved out into the main body.
-  const [advancedOpen, setAdvancedOpen] = useState(Boolean(requestSpec?.policy));
+  // Advanced holds only proxy policy (allowed hosts + fetch auth). It stays collapsed by
+  // default — even when an agent's request prefills hosts — so the form isn't cluttered;
+  // a dot on the toggle marks prefilled policy and the user can expand to review it.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [tagsPending, setTagsPending] = useState(false);
   const [hostsPending, setHostsPending] = useState(false);
   const [protection, setProtection] = useState<VaultProtection>(requestSpec?.protection ?? defaultProtection);
@@ -233,8 +234,18 @@ export const VaultSecretForm: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [protection]);
 
+  // Seed editable fields from an agent's request spec ONCE per distinct request. The chat
+  // page rebuilds the request object on every poll/re-render, so keying this on the
+  // requestSpec *identity* re-ran it mid-edit and clobbered the user's choices — most
+  // visibly reverting a manual "Protected" pick to the spec's default while the sandbox
+  // iframe was still loading. Key on the stable request id so re-renders never overwrite
+  // what the user has since changed; a genuinely new request still re-seeds.
+  const seededSpecRef = useRef<string | null>(null);
   useEffect(() => {
     if (!requestSpec) return;
+    const seedKey = provisionRequestId ?? '__spec__';
+    if (seededSpecRef.current === seedKey) return;
+    seededSpecRef.current = seedKey;
     if (requestSpec.kind) setKind(requestSpec.kind);
     if (requestSpec.protection) setProtection(requestSpec.protection);
     if (requestSpec.description) setDescription(requestSpec.description);
@@ -244,9 +255,7 @@ export const VaultSecretForm: React.FC<{
     if (requestSpec.policy?.allowed_hosts) setAllowHosts(requestSpec.policy.allowed_hosts);
     if (requestSpec.policy?.auth?.type) setFetchAuthMode(requestSpec.policy.auth.type);
     if (requestSpec.policy?.auth?.name) setFetchAuthName(requestSpec.policy.auth.name);
-    // Only proxy policy lives under Advanced now, so open it only for a policy-bearing spec.
-    if (requestSpec.policy) setAdvancedOpen(true);
-  }, [requestSpec]);
+  }, [requestSpec, provisionRequestId]);
 
   // Edit mode: seed editable metadata from the existing secret. Name / kind / protection are
   // shown read-only (not seeded into editable controls); the value is never loaded; always_ask
@@ -824,8 +833,8 @@ export const VaultSecretForm: React.FC<{
   );
 
   // Advanced — collapsible proxy policy (allowed hosts + fetch auth). Shared by BOTH modes so the
-  // provide ($NAME) dialog hides/reveals these exactly like the create dialog; auto-opens for a
-  // spec that carries policy (see `advancedOpen` init) so an agent's prefilled hosts stay visible.
+  // provide ($NAME) dialog hides/reveals these exactly like the create dialog. Collapsed by default
+  // (even when a spec prefills hosts); the toggle shows a dot so prefilled policy isn't missed.
   const advancedSection = (
     <div className="flex flex-col overflow-hidden rounded-[10px] bg-surface-2">
       <button
@@ -948,7 +957,7 @@ export const VaultSecretForm: React.FC<{
         {tagsField}
 
         {/* Protection tier + Advanced proxy policy — identical to create mode (allowed hosts for a
-            brokered-fetch secret live under Advanced, which auto-opens when a spec prefilled them). */}
+            brokered-fetch secret live under Advanced, collapsed by default with a dot when prefilled). */}
         {protectionCards}
 
         {advancedSection}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2281,8 +2281,8 @@
       "unlockPasskeyCaption": "Face ID · Touch ID · security key",
       "factorNote": "Your passkey proof never leaves the browser — the machine alone can't decrypt this",
       "cancel": "Cancel",
-      "passkeyUnrecoverableWarning": "If you lose this passkey — or open this vault from a different site/address than where you set it up — these protected secrets can't be recovered. There is no recovery fallback.",
-      "passkeyAck": "I understand: if I lose this passkey or open this vault from a different site, these secrets can't be recovered.",
+      "passkeyUnrecoverableWarning": "This passkey is the only key. Lose it and the protected secrets can't be recovered — there is no backup.",
+      "passkeyAck": "I understand: if I lose this passkey, these secrets can't be recovered.",
       "unlockUnavailableHere": "Protected vaults need a passkey. Open Vaults from localhost or your avibe.bot address; raw IP addresses like 127.0.0.1 can't use WebAuthn.",
       "errors": {
         "prfUnavailable": "This passkey/browser doesn't support the PRF extension needed for encryption. Try a platform passkey (Touch ID / Windows Hello).",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2281,8 +2281,8 @@
       "unlockPasskeyCaption": "Face ID · Touch ID · 安全密钥",
       "factorNote": "你的 passkey 证明绝不会离开浏览器——单凭这台机器无法解密",
       "cancel": "取消",
-      "passkeyUnrecoverableWarning": "一旦丢失此 passkey、或从与设置时不同的站点/地址打开此保险库,这些保护层密钥将无法恢复(没有恢复兜底)。",
-      "passkeyAck": "我明白:丢失此 passkey、或从其他站点打开此保险库后,这些密钥将无法恢复。",
+      "passkeyUnrecoverableWarning": "这个 passkey 就是唯一的钥匙,丢了它,保护档里的密钥就再也找不回来了(没有备用恢复方式)。",
+      "passkeyAck": "我明白:一旦丢失 passkey,这些密钥无法找回。",
       "unlockUnavailableHere": "保护层保险库需要 passkey。请从 localhost 或你的 avibe.bot 地址打开 Vaults；127.0.0.1 这类原始 IP 无法使用 WebAuthn。",
       "errors": {
         "prfUnavailable": "这个 passkey/浏览器不支持加密所需的 PRF 扩展。请改用平台 passkey(Touch ID / Windows Hello)。",


### PR DESCRIPTION
## What
Two fixes to the vault secret form (`ui/src/components/ui/vault-secret-form.tsx`), both surfaced from user testing on the `/vaults` + chat provision flow.

### 1. Protected tier silently reverting to Standard (correctness / security)
Selecting **Protected** on the chat provision card, then waiting for the protected-vault sandbox iframe to load, could **silently revert the tier back to Standard** once the spinner finished. Result: the user stores a *Standard* secret while believing they chose *Protected* — a silent downgrade of the protection they asked for.

**Root cause:** the form re-seeded editable fields from the agent request spec on every `requestSpec` **identity** change (the `[requestSpec]` effect ran `setProtection(requestSpec.protection)`). The chat page rebuilds the request card object on each poll/re-render, so a re-render *mid-edit* (e.g. while the iframe loads) re-ran the seed and clobbered the user's manual pick with the spec's `standard` default. A props→state re-sync anti-pattern.

**Fix:** seed once per **distinct** request, keyed on the stable provision request id (a ref guard), instead of on object identity. Parent re-renders no longer overwrite what the user has since changed; a genuinely new request still re-seeds. This protects **all** seeded fields (protection, kind, tags, hosts, auth), not just the tier.

### 2. Advanced options auto-expanding for agent requests (clutter)
For an agent-requested secret carrying a proxy policy, the **Advanced** section auto-expanded, which the user found cluttered. It now stays **collapsed by default** — the toggle already renders a dot when it holds prefilled hosts/auth, so nothing is hidden, just decluttered.

## Evidence
- **Unit / typecheck:** `cd ui && npm run build` clean.
- **Residual manual check (regression):** re-run the reported flow — pick Protected on a chat provision card, let the sandbox iframe finish loading, confirm the tier **stays** Protected; confirm Advanced is collapsed by default with a dot when the request prefilled hosts. (No React component-test infra in this repo — vitest suite is logic-only — so this path is verified by build + manual regression.)

## Scope
Frontend only; one file. No backend, protocol, or crypto changes.