### PR TITLE
fix(vault): show request session titles as chat links

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -31,6 +31,8 @@ from sqlalchemy.exc import IntegrityError
 
 from storage import vault_crypto, vault_webauthn
 from storage.models import (
+    agent_sessions,
+    scopes,
     vault_audit,
     vault_auth_factors,
     vault_grants,
@@ -873,6 +875,47 @@ def _hydrate_card_unlock_material(conn: Connection, row: dict[str, Any], card: d
     return card
 
 
+def _request_session_summary(conn: Connection, session_id: str | None) -> dict[str, Any] | None:
+    """Resolve the request's originating session into UI-facing display metadata."""
+    if not session_id:
+        return None
+    row = conn.execute(
+        select(
+            agent_sessions.c.id,
+            agent_sessions.c.title,
+            scopes.c.platform,
+            scopes.c.scope_type,
+            scopes.c.native_id,
+            scopes.c.display_name,
+        )
+        .select_from(agent_sessions.join(scopes, scopes.c.id == agent_sessions.c.scope_id, isouter=True))
+        .where(agent_sessions.c.id == session_id)
+        .limit(1)
+    ).mappings().first()
+    if row is None:
+        return {
+            "id": session_id,
+            "title": None,
+            "label": session_id,
+            "platform": None,
+            "scope_kind": None,
+            "is_workbench": False,
+        }
+    platform = str(row["platform"] or "").strip()
+    scope_kind = str(row["scope_type"] or "").strip()
+    is_workbench = platform == "avibe" or scope_kind == "project"
+    title = row["title"]
+    label = title if is_workbench else (row["display_name"] or row["native_id"] or title or session_id)
+    return {
+        "id": row["id"],
+        "title": title,
+        "label": label,
+        "platform": platform or None,
+        "scope_kind": scope_kind or None,
+        "is_workbench": is_workbench,
+    }
+
+
 def _request_row_payload(
     row: dict[str, Any],
     *,
@@ -890,7 +933,7 @@ def _request_row_payload(
         and isinstance(card, dict)
     ):
         card = _hydrate_card_unlock_material(conn, row, card)
-    return {
+    payload = {
         "id": row["id"],
         "request_type": row["request_type"],
         "secret_name": row.get("secret_name"),
@@ -903,6 +946,9 @@ def _request_row_payload(
         "expires_at": row.get("expires_at"),
         "card": card if isinstance(card, dict) else None,
     }
+    if policy.audience == REQUEST_AUDIENCE_UI and conn is not None:
+        payload["session"] = _request_session_summary(conn, _request_session_id(row))
+    return payload
 
 
 def _request_json_payloads(row: dict[str, Any]) -> tuple[Any, Any]:
@@ -2642,7 +2688,7 @@ def _secure_input_card(
         "request_id": request_id,
         "secret_name": name,
         # Carry the requesting session so surfaces can scope the card to its chat
-        # (mirrors approval_card); the Vaults page ignores it.
+        # (mirrors approval_card); UI reads resolve it into a display/link summary.
         "session_id": session_id,
         "reason": reason,
         "protection_options": ["standard", "protected"],

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -19,7 +19,7 @@ import pytest
 from sqlalchemy import select
 
 from storage import vault_service
-from storage.models import vault_audit, vault_auth_factors, vault_requests, vault_secrets
+from storage.models import agent_sessions, scopes, vault_audit, vault_auth_factors, vault_requests, vault_secrets
 from storage.vault_crypto import Sealed
 from tests.vault_webauthn_helpers import WebAuthnTestCredential
 from vibe import api
@@ -27,6 +27,50 @@ from vibe import api
 
 def _sealed(suffix: str = "1") -> Sealed:
     return Sealed(ciphertext=f"ct-{suffix}", nonce=f"n-{suffix}", wrap_meta=f"wm-{suffix}")
+
+
+def _insert_workbench_session(conn, *, session_id: str, title: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    scope_id = f"scope_{session_id}"
+    conn.execute(
+        scopes.insert().values(
+            id=scope_id,
+            platform="avibe",
+            scope_type="project",
+            native_id=f"project_{session_id}",
+            parent_scope_id=None,
+            display_name="Vault Project",
+            native_type=None,
+            is_private=1,
+            supports_threads=1,
+            metadata_json="{}",
+            first_seen_at=now,
+            last_seen_at=now,
+            updated_at=now,
+        )
+    )
+    conn.execute(
+        agent_sessions.insert().values(
+            id=session_id,
+            scope_id=scope_id,
+            agent_id=None,
+            agent_name="codex",
+            agent_backend="codex",
+            agent_variant="codex",
+            model=None,
+            reasoning_effort=None,
+            session_anchor=session_id,
+            workdir="/tmp/work",
+            native_session_id="native-1",
+            title=title,
+            status="active",
+            agent_status="idle",
+            metadata_json="{}",
+            created_at=now,
+            updated_at=now,
+            last_active_at=now,
+        )
+    )
 
 
 def _grant_from_request(conn, request: dict, *, session_id: str | None = None, cache_ready: bool = True) -> dict:
@@ -594,6 +638,29 @@ def test_provision_request_card_carries_session_id():
     assert req["card"]["session_id"] == "ses_abc123"
     result = api.get_vault_provision_request_by_name("DEPLOY_TOKEN")
     assert (result["request"]["card"] or {}).get("session_id") == "ses_abc123"
+
+
+def test_vault_request_ui_payload_resolves_workbench_session_summary():
+    with api._vault_engine().begin() as conn:
+        _insert_workbench_session(conn, session_id="ses_vault_title", title="Deploy checklist")
+        req = vault_service.create_provision_request(
+            conn,
+            "DEPLOY_TOKEN",
+            requester={"source": "agent-cli", "session_id": "ses_vault_title"},
+        )
+
+    listed = api.get_vault_requests(session="ses_vault_title")
+
+    assert listed["requests"][0]["session"] == {
+        "id": "ses_vault_title",
+        "title": "Deploy checklist",
+        "label": "Deploy checklist",
+        "platform": "avibe",
+        "scope_kind": "project",
+        "is_workbench": True,
+    }
+    agent_payload = api.get_vault_request(req["id"], audience=vault_service.REQUEST_AUDIENCE_AGENT)
+    assert "session" not in agent_payload["request"]
 
 
 def test_list_requests_scopes_by_session():

--- a/ui/src/components/ui/vault-approval-card.tsx
+++ b/ui/src/components/ui/vault-approval-card.tsx
@@ -12,6 +12,7 @@ import { Badge } from './badge';
 import { Button } from './button';
 import { Switch } from './switch';
 import { VaultProtectedUnlock } from './vault-protected-unlock';
+import { VaultRequestSessionLink, vaultRequestSessionDisplay } from './vault-request-session-link';
 
 /**
  * The fixed protected grant the daemon attaches to an access request's card. In the
@@ -107,6 +108,7 @@ export const VaultApprovalCard: React.FC<{
   // `grant_options[].unlock_material` are present for protected requests. No fetch or
   // loading state is needed here — the single-request GET is agent-audience (value-free).
   const card = (request.card ?? null) as ApprovalCard | null;
+  const requestSession = vaultRequestSessionDisplay(request);
   const delivery = (request.delivery ?? {}) as {
     digest?: string;
     scheme?: string;
@@ -356,9 +358,9 @@ export const VaultApprovalCard: React.FC<{
             <SigningAddressList addresses={schemeAddresses} />
           </DetailRow>
         ) : null}
-        {card.session_id ? (
+        {requestSession ? (
           <DetailRow label={t('vaults.approval.session')}>
-            <span className="truncate text-[13px] text-foreground">{card.session_id}</span>
+            <VaultRequestSessionLink session={requestSession} className="text-foreground" textClassName="text-[13px]" />
           </DetailRow>
         ) : null}
         {!isSign && card.command ? (

--- a/ui/src/components/ui/vault-request-session-link.tsx
+++ b/ui/src/components/ui/vault-request-session-link.tsx
@@ -1,0 +1,54 @@
+import { Link } from 'react-router-dom';
+
+import type { VaultRequest } from '@/context/ApiContext';
+import { cn } from '@/lib/utils';
+
+export type VaultRequestSessionDisplay = {
+  id: string;
+  label: string;
+  isWorkbench: boolean;
+  isIdFallback: boolean;
+};
+
+export function vaultRequestSessionDisplay(request: VaultRequest): VaultRequestSessionDisplay | null {
+  const card = (request.card ?? {}) as { session_id?: unknown };
+  const cardSessionId = typeof card.session_id === 'string' && card.session_id.trim() ? card.session_id.trim() : null;
+  const session = request.session ?? null;
+  const id = session?.id?.trim() || cardSessionId;
+  if (!id) return null;
+  const title = session?.title?.trim();
+  const sessionLabel = session?.label?.trim();
+  const label = title || sessionLabel || id;
+  return {
+    id,
+    label,
+    isWorkbench: Boolean(session?.is_workbench),
+    isIdFallback: label === id && !title && (!sessionLabel || sessionLabel === id),
+  };
+}
+
+export const VaultRequestSessionLink: React.FC<{
+  session: VaultRequestSessionDisplay;
+  className?: string;
+  textClassName?: string;
+}> = ({ session, className, textClassName }) => {
+  const label = (
+    <span className={cn('min-w-0 truncate', session.isIdFallback && 'font-mono', textClassName)}>
+      {session.label}
+    </span>
+  );
+  if (!session.isWorkbench) {
+    return <span className={cn('min-w-0 truncate', className)}>{label}</span>;
+  }
+  return (
+    <Link
+      to={`/chat/${encodeURIComponent(session.id)}`}
+      className={cn(
+        'min-w-0 truncate font-medium text-foreground transition-colors hover:text-cyan hover:underline',
+        className,
+      )}
+    >
+      {label}
+    </Link>
+  );
+};

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -18,6 +18,7 @@ import { useToast } from '../../context/ToastContext';
 import type { ApprovalOutcome } from '../ui/vault-approval-card';
 import { SigningAddressList } from '../ui/signing-address-list';
 import { VaultApprovalDialog } from '../ui/vault-approval-dialog';
+import { VaultRequestSessionLink, vaultRequestSessionDisplay } from '../ui/vault-request-session-link';
 import { VaultSecretDialog } from '../ui/vault-secret-dialog';
 
 const PENDING_REQUEST_POLL_INTERVAL_MS = 5000;
@@ -247,6 +248,7 @@ const RequestRow: React.FC<{ request: VaultRequest; onReview: (request: VaultReq
   const isProvision = type === 'provision';
   const isProtected = card.protection === 'protected';
   const Icon = isSign || card.kind === 'keypair' ? Wallet : KeyRound;
+  const session = vaultRequestSessionDisplay(r);
   return (
     <div className="flex items-center gap-3.5 rounded-xl border border-gold/40 bg-gold/[0.06] px-4 py-3">
       <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-gold/10 text-gold">
@@ -260,13 +262,13 @@ const RequestRow: React.FC<{ request: VaultRequest; onReview: (request: VaultReq
           </Badge>
           {isProtected ? <Badge variant="warning">{t('vaults.protected')}</Badge> : null}
         </div>
-        <span className="flex items-center gap-1.5 text-xs text-muted">
+        <span className="flex min-w-0 items-center gap-1.5 text-xs text-muted">
           <Clock className="size-3" />
           {isProvision ? t('vaults.requests.waitingForValue') : t('vaults.requests.waiting')}
-          {card.session_id ? (
+          {session ? (
             <>
               <span aria-hidden>·</span>
-              <span className="truncate font-mono">{card.session_id}</span>
+              <VaultRequestSessionLink session={session} />
             </>
           ) : null}
         </span>

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -64,6 +64,16 @@ export type VaultRequest = {
   decided_at: string | null;
   expires_at: string | null;
   card?: Record<string, unknown> | null;
+  session?: VaultRequestSession | null;
+};
+
+export type VaultRequestSession = {
+  id: string;
+  title: string | null;
+  label: string | null;
+  platform: string | null;
+  scope_kind: string | null;
+  is_workbench: boolean;
 };
 
 export type VaultRequestSpec = {


### PR DESCRIPTION
## Summary
- resolve Vault request originating sessions into UI-only display metadata
- show the session title/label instead of the raw session id on pending Vault rows
- link Workbench-originated Vault requests directly to their chat from the Vaults page and approval detail

## Scenario IDs
- None: Vault request session-linking is not covered by an existing scenario catalog.

## Evidence
- Unit: `uv run pytest tests/test_vault_api.py::test_vault_request_ui_payload_resolves_workbench_session_summary tests/test_vault_api.py::test_provision_request_card_carries_session_id -q`
- Contract: `uv run pytest tests/test_vault_rest.py::test_rest_requests_and_grants_routes tests/test_vault_api.py::test_vault_request_ui_payload_resolves_workbench_session_summary tests/test_vault_api.py::test_provision_request_card_carries_session_id -q`
- UI build: `cd ui && npm run build`
- Lint: `uv run ruff check storage/vault_service.py tests/test_vault_api.py`
- Residual manual checks: not run locally; visual behavior is covered by TypeScript build plus the shared link component path.

## Notes
- Attempted a pre-PR read-only reviewer run, but it did not return in time and was canceled cleanly before opening this PR.
