### PR TITLE
chore(vault): gate sandbox integrity enforcement behind a flag (pre-launch iteration)

### DIFF
--- a/ui/src/lib/vaultSandboxClient.ts
+++ b/ui/src/lib/vaultSandboxClient.ts
@@ -8,6 +8,7 @@ import type {
 import type { BlindBox, ProtectedRecordEnvelope, SignatureResult, SignatureScheme } from './vaultCrypto';
 import {
   VAULT_SANDBOX_EXPECTED_BUILD_HASH,
+  VAULT_SANDBOX_INTEGRITY_ENFORCED,
   VAULT_SANDBOX_IFRAME_URL,
   VAULT_SANDBOX_IFRAME_RESOURCE_PATH,
   VAULT_SANDBOX_MANIFEST_PATH,
@@ -233,7 +234,9 @@ export class VaultSandboxClient {
   }
 
   static async create(): Promise<VaultSandboxClient> {
-    await verifyVaultSandboxIntegrity();
+    // Gated during pre-launch iteration — see VAULT_SANDBOX_INTEGRITY_ENFORCED. When off, the
+    // parent still origin-isolates the sandbox; it just doesn't fail-closed on a manifest mismatch.
+    if (VAULT_SANDBOX_INTEGRITY_ENFORCED) await verifyVaultSandboxIntegrity();
     const iframe = document.createElement('iframe');
     iframe.title = 'Avibe protected vault sandbox';
     iframe.allow = 'publickey-credentials-get; publickey-credentials-create; clipboard-write';

--- a/ui/src/lib/vaultSandboxManifest.ts
+++ b/ui/src/lib/vaultSandboxManifest.ts
@@ -2,6 +2,15 @@ export const VAULT_SANDBOX_ORIGIN = 'https://sandbox.avibe.bot';
 export const VAULT_SANDBOX_VERSION = '0.1.0';
 export const VAULT_SANDBOX_EXPECTED_BUILD_HASH = 'dev';
 
+// DEFERRED (pre-launch iteration): while sandbox.avibe.bot is still being iterated, the parent
+// does NOT fail-closed on a pinned-manifest mismatch — otherwise every sandbox deploy would
+// require re-pinning VAULT_SANDBOX_PINNED_MANIFEST before the app could load. Cross-origin
+// isolation still holds regardless (that comes from the origin split, not the pin).
+// FIRM PRE-LAUNCH GATE: set this back to `true` — with a freshly re-pinned manifest + an
+// immutable versioned iframe URL — before real users store protected secrets. Until then a
+// sandbox deploy-pipeline compromise would not be detected by the parent.
+export const VAULT_SANDBOX_INTEGRITY_ENFORCED = false;
+
 export type VaultSandboxPinnedManifest = {
   algorithm: 'sha256';
   resources: Record<string, string>;


### PR DESCRIPTION
## What
Adds `VAULT_SANDBOX_INTEGRITY_ENFORCED` (default `false`) and gates the parent's fetch-and-hash sandbox integrity check behind it (`ui/src/lib/vaultSandboxClient.ts` `VaultSandboxClient.create()`).

## Why
The protected-vault crypto sandbox at `sandbox.avibe.bot` is under active iteration (mobile setup fix, in-iframe create, value-flow rework). With the integrity check enforced, **every** sandbox deploy changes the asset hashes and mismatches the pinned `VAULT_SANDBOX_PINNED_MANIFEST`, which fails closed and disables protected vaults in the app until the parent is re-pinned + redeployed. That re-pin-per-deploy loop blocks fast iteration.

This is the deferral we agreed on: run a single mutable sandbox during pre-launch, with the parent integrity gate off, then re-enable it before launch.

## Not a change to isolation
Cross-origin isolation is **unchanged** — it comes from the origin split (VMK/PRF/keys/plaintext never cross the postMessage boundary), not from the hash pin. Turning off the pin only relaxes "is the served sandbox code exactly the pinned build", not "can the main app read protected material" (it can't, either way).

## FIRM pre-launch gate (documented at the flag)
Before real users store protected secrets: set the flag back to `true`, re-pin `VAULT_SANDBOX_PINNED_MANIFEST` to the shipping sandbox build, and move the iframe to an immutable versioned URL. Until then a sandbox deploy-pipeline compromise would not be caught by the parent.

## Evidence
- Unit/typecheck: `cd ui && npm run build` clean.
- Manual: regression env now loads the freshly-deployed `sandbox.avibe.bot` (post-①b) instead of failing closed on the stale pin.

## Scope
One flag + one guarded call site. No behavior change when the flag is later flipped back on.