### PR TITLE
fix(vault): drop passkey requirement for protected deletes

### DIFF
--- a/docs/plans/vault-protected-delete-authz.md
+++ b/docs/plans/vault-protected-delete-authz.md
@@ -1,8 +1,18 @@
 # Protected Vault secret deletion authorization
 
-Status: design plan only, no implementation.
+Status: superseded by product decision on 2026-07-08. Do not implement this
+delete-authorization design.
 Owner: Vaults workstream.
 Date: 2026-07-07.
+
+Superseding rule: a passkey protects the protected secret value's
+confidentiality for unlock, use, reveal, sign, and DEK release. It does not
+protect the record's existence. Deleting a protected secret does not expose its
+value, so protected deletion is a normal user-confirmed Vaults UI delete. The
+CLI still refuses protected deletes as the agent guard, but the UI/API delete
+path must not require a WebAuthn/passkey assertion.
+
+The original plan below is retained as rejected historical context only.
 
 This revises the earlier #818 design for the pre-launch product decision:
 protected-tier vaults are Passkey (WebAuthn-PRF) only. There is no password

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -128,16 +128,6 @@ class CardHydrationPolicy:
     include_protected_unlock_material: bool
 
 
-@dataclass(frozen=True)
-class ProtectedOperationAuthz:
-    operation: str
-    secret_name: str
-    secret_id: str
-    secret_updated_at: str | None
-    challenge_id: str
-    factor_id: str
-
-
 class VaultServiceError(Exception):
     """Base class for vault data-layer errors."""
 
@@ -1835,103 +1825,6 @@ def register_webauthn_factor(
     return {"ok": True, "factor": _factor_payload(dict(row))}
 
 
-def create_delete_challenge(
-    conn: Connection,
-    name: str,
-    *,
-    rp_id: str,
-    origin: str,
-    ttl_seconds: int = DEFAULT_AUTHZ_CHALLENGE_TTL_SECONDS,
-) -> dict[str, Any]:
-    row = _require_row(conn, name)
-    if row.get("protection") != "protected":
-        raise SecretNotProtectedError(name)
-    factors = _usable_webauthn_factor_rows(conn, rp_id=rp_id)
-    if not factors:
-        raise ProtectedAuthzSetupRequiredError("protected delete requires a registered passkey authorization factor")
-    challenge, challenge_digest = _new_challenge()
-    challenge_id = _id("vop")
-    expires_at = _challenge_expiry(ttl_seconds)
-    conn.execute(
-        vault_operation_challenges.insert().values(
-            id=challenge_id,
-            operation="delete_secret",
-            secret_name=name,
-            secret_id=row.get("id"),
-            secret_updated_at=row.get("updated_at"),
-            challenge_hash=challenge_digest,
-            rp_id=rp_id,
-            origin=origin,
-            expires_at=expires_at,
-            created_at=_now(),
-        )
-    )
-    audit(
-        conn,
-        "delete-challenge-issued",
-        secret_name=name,
-        delivery={"challenge_id": challenge_id, "rp_id": rp_id},
-    )
-    allow_credentials = []
-    for factor in factors:
-        credential: dict[str, Any] = {
-            "type": "public-key",
-            "id": factor["credential_id"],
-            "factor_id": factor["id"],
-        }
-        transports = _stored_json_list(factor.get("transports"))
-        if transports:
-            credential["transports"] = transports
-        allow_credentials.append(credential)
-    return {
-        "ok": True,
-        "challenge_id": challenge_id,
-        "expires_at": expires_at,
-        "operation": "delete_secret",
-        "secret_name": name,
-        "webauthn": {
-            "challenge": challenge,
-            "rpId": rp_id,
-            "userVerification": "required",
-            "allowCredentials": allow_credentials,
-        },
-    }
-
-
-def verify_delete_secret_authz(conn: Connection, name: str, payload: dict[str, Any] | None) -> ProtectedOperationAuthz:
-    if not isinstance(payload, dict):
-        raise ProtectedAuthRequiredError("protected delete requires WebAuthn authorization")
-    row = _require_row(conn, name)
-    if row.get("protection") != "protected":
-        raise SecretNotProtectedError(name)
-    factor_id, challenge = _verify_webauthn_operation_authz(
-        conn,
-        payload,
-        operation="delete_secret",
-    )
-    challenge_id = str(payload.get("challenge_id") or "").strip()
-    if (
-        challenge.get("secret_name") != name
-        or challenge.get("secret_id") != row.get("id")
-        or challenge.get("secret_updated_at") != row.get("updated_at")
-    ):
-        raise InvalidProtectedAuthzError("protected delete challenge does not match the current secret row")
-    audit(
-        conn,
-        "delete-authorized",
-        secret_name=name,
-        delivery={"challenge_id": challenge_id, "factor_id": factor_id},
-    )
-    return ProtectedOperationAuthz(
-        operation="delete_secret",
-        secret_name=name,
-        secret_id=str(row["id"]),
-        secret_updated_at=row.get("updated_at"),
-        challenge_id=challenge_id,
-        factor_id=factor_id,
-    )
-
-
 def fulfill_pending_provision_requests_for_secret(
     conn: Connection,
     name: str,
@@ -2041,6 +1934,8 @@ def create_secret(
         raise SecretExistsError(name) from exc
     audit(conn, "created", secret_name=name)
     if establishing_vmk and protection == "protected":
+        # Vestigial after protected-delete authz was removed: the sandbox still
+        # submits this registration until the setup-time authz flow is cleaned up.
         register_webauthn_factor(
             conn,
             authz_factor_registration or {},
@@ -2378,20 +2273,6 @@ def rotate_secret(
     return _meta_payload(_require_row(conn, name))
 
 
-def _reject_missing_protected_delete_authz(row: dict[str, Any], authz: ProtectedOperationAuthz | None) -> None:
-    if row.get("protection") != "protected":
-        return
-    if authz is None:
-        raise ProtectedAuthRequiredError("protected delete requires verified authorization")
-    if (
-        authz.operation != "delete_secret"
-        or authz.secret_name != row.get("name")
-        or authz.secret_id != row.get("id")
-        or authz.secret_updated_at != row.get("updated_at")
-    ):
-        raise InvalidProtectedAuthzError("protected delete authorization does not match the current secret row")
-
-
 def _disable_webauthn_factors_if_vault_deestablished(conn: Connection) -> None:
     protected_row = conn.execute(
         select(vault_secrets.c.id).where(vault_secrets.c.protection == "protected").limit(1)
@@ -2413,14 +2294,12 @@ def delete_secret(
     conn: Connection,
     name: str,
     *,
-    protected_authz: ProtectedOperationAuthz | None = None,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
 ) -> None:
     row = conn.execute(select(vault_secrets).where(vault_secrets.c.name == name)).mappings().first()
     if row is None:
         raise SecretNotFoundError(name)
     row = dict(row)
-    _reject_missing_protected_delete_authz(row, protected_authz)
     _expire_pending_requests_for_secret(conn, name, reason="request-expired-envelope-changed")
     _expire_active_grants_for_secret(conn, name, cache=cache, reason="grant-expired-envelope-changed")
     conn.execute(vault_secrets.delete().where(vault_secrets.c.name == name))

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -114,16 +114,6 @@ def _establish_protected_secret_with_factor(
     return credential, _auth_factor_for_credential(credential)
 
 
-def _delete_authz_for_secret(credential: WebAuthnTestCredential, factor: dict, name: str, *, sign_count: int = 2) -> dict:
-    challenge = api.create_vault_delete_challenge(name, origin=credential.origin)
-    return credential.assertion_authz(
-        challenge_id=challenge["challenge_id"],
-        factor_id=factor["id"],
-        challenge_b64=challenge["webauthn"]["challenge"],
-        sign_count=sign_count,
-    )
-
-
 @pytest.fixture
 def avault_p2(monkeypatch):
     monkeypatch.setattr(api, "_require_avault_grant_delivery_surface", lambda _feature: None)
@@ -889,27 +879,25 @@ def test_delete_missing_is_404():
     assert exc.value.status == 404
 
 
-def test_delete_protected_secret_without_assertion_is_rejected(monkeypatch):
+def test_delete_protected_secret_without_assertion_deletes(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     api.create_vault_secret(
         {"name": "PROTECTED_DELETE", "protection": "protected", "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"}}
     )
 
-    with pytest.raises(api.VaultApiError) as exc:
-        api.delete_vault_secret("PROTECTED_DELETE")
+    removed = api.delete_vault_secret("PROTECTED_DELETE")
 
-    assert exc.value.code == "protected_auth_required"
-    assert exc.value.status == 409
+    assert removed == {"ok": True, "removed": True, "name": "PROTECTED_DELETE"}
     with api._vault_engine().connect() as conn:
-        assert vault_service.get_secret_meta(conn, "PROTECTED_DELETE")["protection"] == "protected"
+        with pytest.raises(vault_service.SecretNotFoundError):
+            vault_service.get_secret_meta(conn, "PROTECTED_DELETE")
 
 
-def test_delete_protected_secret_with_valid_assertion_deletes(monkeypatch):
+def test_delete_protected_secret_with_registered_factor_deletes_without_assertion(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
-    credential, factor = _establish_protected_secret_with_factor("PROTECTED_DELETE")
-    authz = _delete_authz_for_secret(credential, factor, "PROTECTED_DELETE")
+    _establish_protected_secret_with_factor("PROTECTED_DELETE")
 
-    removed = api.delete_vault_secret("PROTECTED_DELETE", authz=authz)
+    removed = api.delete_vault_secret("PROTECTED_DELETE")
 
     assert removed == {"ok": True, "removed": True, "name": "PROTECTED_DELETE"}
     with api._vault_engine().connect() as conn:
@@ -920,9 +908,8 @@ def test_delete_protected_secret_with_valid_assertion_deletes(monkeypatch):
 def test_deleting_last_protected_secret_allows_fresh_vault_establishment(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     first, first_factor = _establish_protected_secret_with_factor("FIRST_PROTECTED")
-    authz = _delete_authz_for_secret(first, first_factor, "FIRST_PROTECTED")
 
-    removed = api.delete_vault_secret("FIRST_PROTECTED", authz=authz)
+    removed = api.delete_vault_secret("FIRST_PROTECTED")
 
     assert removed["removed"] is True
     with api._vault_engine().connect() as conn:
@@ -937,7 +924,7 @@ def test_deleting_last_protected_secret_allows_fresh_vault_establishment(monkeyp
     assert second_factor["credential_id"] == second.credential_id_b64
 
 
-def test_forged_webauthn_factor_registration_cannot_authorize_delete(monkeypatch):
+def test_forged_webauthn_factor_registration_still_requires_existing_factor(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     _establish_protected_secret_with_factor("PROTECTED_DELETE")
     forged = WebAuthnTestCredential(credential_id=b"forged-agent-factor")
@@ -953,17 +940,9 @@ def test_forged_webauthn_factor_registration_cannot_authorize_delete(monkeypatch
         )
 
     assert exc.value.code == "protected_auth_required"
-    challenge = api.create_vault_delete_challenge("PROTECTED_DELETE", origin=forged.origin)
-    forged_authz = forged.assertion_authz(
-        challenge_id=challenge["challenge_id"],
-        factor_id="vaf_forged",
-        challenge_b64=challenge["webauthn"]["challenge"],
-    )
-    with pytest.raises(api.VaultApiError) as delete_exc:
-        api.delete_vault_secret("PROTECTED_DELETE", authz=forged_authz)
-    assert delete_exc.value.code == "invalid_protected_authz"
-    with api._vault_engine().connect() as conn:
-        assert vault_service.get_secret_meta(conn, "PROTECTED_DELETE")["protection"] == "protected"
+
+    removed = api.delete_vault_secret("PROTECTED_DELETE")
+    assert removed["removed"] is True
 
 
 def test_registering_second_webauthn_factor_requires_existing_factor_assertion(monkeypatch):
@@ -1019,17 +998,18 @@ def test_first_webauthn_factor_registration_only_happens_during_establishment(mo
     assert late_exc.value.code == "protected_authz_setup_required"
 
 
-def test_factorless_protected_secret_surfaces_recreate_state_for_delete_challenge(monkeypatch):
+def test_factorless_protected_secret_deletes_normally(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     api.create_vault_secret(
         {"name": "FACTORLESS", "protection": "protected", "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"}}
     )
-    credential = WebAuthnTestCredential()
 
-    with pytest.raises(api.VaultApiError) as exc:
-        api.create_vault_delete_challenge("FACTORLESS", origin=credential.origin)
+    removed = api.delete_vault_secret("FACTORLESS")
 
-    assert exc.value.code == "protected_authz_setup_required"
+    assert removed == {"ok": True, "removed": True, "name": "FACTORLESS"}
+    with api._vault_engine().connect() as conn:
+        with pytest.raises(vault_service.SecretNotFoundError):
+            vault_service.get_secret_meta(conn, "FACTORLESS")
 
 
 def test_audit_lists_events_without_values(monkeypatch):
@@ -2616,7 +2596,7 @@ def test_delete_protected_secret_releases_agent_scope(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     agent_release = Mock(return_value={"released": True})
     monkeypatch.setattr(api, "avault_agent_release", agent_release)
-    credential, factor = _establish_protected_secret_with_factor("GRANT_KEY")
+    _establish_protected_secret_with_factor("GRANT_KEY")
     with api._vault_engine().begin() as conn:
         req = vault_service.create_access_request(
             conn,
@@ -2625,9 +2605,8 @@ def test_delete_protected_secret_releases_agent_scope(monkeypatch):
             delivery={"session_id": "ses_1"},
         )
         grant = _grant_from_request(conn, req, session_id="ses_1")
-    authz = _delete_authz_for_secret(credential, factor, "GRANT_KEY")
 
-    removed = api.delete_vault_secret("GRANT_KEY", authz=authz)
+    removed = api.delete_vault_secret("GRANT_KEY")
 
     assert removed["removed"] is True
     agent_release.assert_called_once_with(grant_id=grant["id"])

--- a/tests/test_vault_rest.py
+++ b/tests/test_vault_rest.py
@@ -4,6 +4,8 @@ import json
 
 from unittest.mock import Mock
 
+import pytest
+
 from storage import vault_service
 from storage.vault_crypto import Sealed
 from tests.ui_server_test_helpers import csrf_headers
@@ -78,7 +80,7 @@ def test_rest_list_invalid_tag_returns_vault_error():
     assert response.get_json()["code"] == "invalid_request"
 
 
-def test_rest_delete_protected_without_assertion_is_rejected(monkeypatch):
+def test_rest_delete_protected_without_assertion_deletes(monkeypatch):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
     api.create_vault_secret(
         {
@@ -91,10 +93,11 @@ def test_rest_delete_protected_without_assertion_is_rejected(monkeypatch):
 
     response = client.delete("/api/vault/secrets/PROTECTED_HTTP_DELETE", headers=csrf_headers(client))
 
-    assert response.status_code == 409
-    assert response.get_json()["code"] == "protected_auth_required"
+    assert response.status_code == 200
+    assert response.get_json()["removed"] is True
     with api._vault_engine().connect() as conn:
-        assert vault_service.get_secret_meta(conn, "PROTECTED_HTTP_DELETE")["protection"] == "protected"
+        with pytest.raises(vault_service.SecretNotFoundError):
+            vault_service.get_secret_meta(conn, "PROTECTED_HTTP_DELETE")
 
 
 def test_rest_create_rejects_plaintext_value_in_mixed_payloads(monkeypatch):

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 
 from storage import vault_service as vs, vault_webauthn
 from storage.db import create_sqlite_engine
-from storage.models import metadata, vault_auth_factors, vault_grants, vault_operation_challenges, vault_requests, vault_secrets
+from storage.models import metadata, vault_auth_factors, vault_grants, vault_requests, vault_secrets
 from storage.vault_crypto import Sealed
 from tests.vault_webauthn_helpers import WebAuthnTestCredential
 
@@ -31,18 +31,6 @@ def _sealed(suffix: str = "1") -> Sealed:
 def _create(engine, **kw):
     with engine.begin() as conn:
         return vs.create_secret(conn, sealed=_sealed(kw.get("name", "x").lower()), **kw)
-
-
-def _protected_delete_authz(conn, name: str) -> vs.ProtectedOperationAuthz:
-    row = conn.execute(select(vault_secrets).where(vault_secrets.c.name == name)).mappings().one()
-    return vs.ProtectedOperationAuthz(
-        operation="delete_secret",
-        secret_name=row["name"],
-        secret_id=row["id"],
-        secret_updated_at=row["updated_at"],
-        challenge_id="test-challenge",
-        factor_id="test-factor",
-    )
 
 
 def _establish_protected_secret(conn, name: str, credential: WebAuthnTestCredential | None = None) -> tuple[WebAuthnTestCredential, dict]:
@@ -379,7 +367,7 @@ def test_secret_delete_rotate_and_classification_changes_expire_covering_grants(
         grant_b = _grant_from_request(conn, vs.create_access_request(conn, "B_KEY"))
         grant_c = _grant_from_request(conn, vs.create_access_request(conn, "C_KEY"))
         vs.rotate_secret(conn, "A_KEY", _sealed("rotated"))
-        vs.delete_secret(conn, "B_KEY", protected_authz=_protected_delete_authz(conn, "B_KEY"))
+        vs.delete_secret(conn, "B_KEY")
         vs.update_secret_classification(conn, "C_KEY", protection="standard")
         statuses = {
             row["id"]: row["status"]
@@ -389,13 +377,13 @@ def test_secret_delete_rotate_and_classification_changes_expire_covering_grants(
     assert statuses == {grant_a["id"]: "expired", grant_b["id"]: "expired", grant_c["id"]: "expired"}
 
 
-def test_protected_delete_requires_verified_authz_at_chokepoint(vault):
+def test_protected_delete_does_not_require_authz_at_chokepoint(vault):
     _create(vault, name="PROTECTED_KEY", protection="protected")
 
     with vault.begin() as conn:
-        with pytest.raises(vs.ProtectedAuthRequiredError):
-            vs.delete_secret(conn, "PROTECTED_KEY")
-        assert vs.get_secret_meta(conn, "PROTECTED_KEY")["protection"] == "protected"
+        vs.delete_secret(conn, "PROTECTED_KEY")
+        with pytest.raises(vs.SecretNotFoundError):
+            vs.get_secret_meta(conn, "PROTECTED_KEY")
 
 
 def test_standard_delete_does_not_require_authz(vault):
@@ -508,40 +496,6 @@ def test_sandbox_cross_origin_webauthn_rejects_wrong_top_origin():
             expected_origin=credential.origin,
             rp_id=credential.rp_id,
         )
-
-
-def test_delete_challenge_expiry_and_replay_are_rejected(vault):
-    credential = WebAuthnTestCredential()
-
-    with vault.begin() as conn:
-        _credential, registered = _establish_protected_secret(conn, "PROTECTED_KEY", credential)
-        expired = vs.create_delete_challenge(conn, "PROTECTED_KEY", rp_id=credential.rp_id, origin=credential.origin)
-        conn.execute(
-            vault_operation_challenges.update()
-            .where(vault_operation_challenges.c.id == expired["challenge_id"])
-            .values(expires_at=(datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat())
-        )
-        with pytest.raises(vs.InvalidProtectedAuthzError):
-            vs.verify_delete_secret_authz(
-                conn,
-                "PROTECTED_KEY",
-                credential.assertion_authz(
-                    challenge_id=expired["challenge_id"],
-                    factor_id=registered["id"],
-                    challenge_b64=expired["webauthn"]["challenge"],
-                ),
-            )
-
-        fresh = vs.create_delete_challenge(conn, "PROTECTED_KEY", rp_id=credential.rp_id, origin=credential.origin)
-        authz = credential.assertion_authz(
-            challenge_id=fresh["challenge_id"],
-            factor_id=registered["id"],
-            challenge_b64=fresh["webauthn"]["challenge"],
-            sign_count=3,
-        )
-        assert vs.verify_delete_secret_authz(conn, "PROTECTED_KEY", authz).challenge_id == fresh["challenge_id"]
-        with pytest.raises(vs.InvalidProtectedAuthzError):
-            vs.verify_delete_secret_authz(conn, "PROTECTED_KEY", authz)
 
 
 def test_webauthn_counter_regression_rejects_zero_after_nonzero_counter():

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -12,8 +12,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { VaultLockIndicator } from '../ui/vault-lock-indicator';
 import { cn } from '../../lib/utils';
 import { partitionTags } from '../../lib/vaultTags';
-import { useProtectedVault } from '../../lib/useProtectedVault';
-import { ApiError, useApi, type VaultAuditEvent, type VaultGrant, type VaultRequest, type VaultSecret } from '../../context/ApiContext';
+import { useApi, type VaultAuditEvent, type VaultGrant, type VaultRequest, type VaultSecret } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import type { ApprovalOutcome } from '../ui/vault-approval-card';
 import { SigningAddressList } from '../ui/signing-address-list';
@@ -25,15 +24,6 @@ const PENDING_REQUEST_EXPIRY_GRACE_MS = 100;
 const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
 
 const messageFromError = (err: unknown) => (err instanceof Error ? err.message : String(err));
-const deleteMessageFromError = (err: unknown, t: TFunction) => {
-  const code = err instanceof ApiError ? err.code : err instanceof Error ? err.message : String(err);
-  if (code === 'protected_authz_setup_required') return t('vaults.deleteDialog.authzSetupRequired');
-  if (code === 'invalid_protected_authz') return t('vaults.deleteDialog.authzInvalid');
-  if (code === 'protected_auth_required') return t('vaults.deleteDialog.authzRequired');
-  if (code === 'webauthn_origin_unsupported') return t('vaults.deleteDialog.authzUnavailable');
-  if (code === 'passkey-cancelled') return t('vaults.protectedUnlock.errors.cancelled');
-  return messageFromError(err);
-};
 /** All allowed proxy-fetch hosts on a secret (for the `proxy · <host> +N` badge). */
 const proxyHosts = (s: VaultSecret): string[] => {
   const hosts = (s.policy as { allowed_hosts?: string[] })?.allowed_hosts;
@@ -683,7 +673,6 @@ export const VaultsPage: React.FC = () => {
     }
   }, [api, showAudit]);
 
-  const protectedVault = useProtectedVault();
   const [deleteTarget, setDeleteTarget] = useState<VaultSecret | null>(null);
   const [editTarget, setEditTarget] = useState<VaultSecret | null>(null);
   const onDelete = (secret: VaultSecret) => setDeleteTarget(secret);
@@ -693,12 +682,11 @@ export const VaultsPage: React.FC = () => {
     if (!secret) return;
     try {
       setError(null);
-      const authz = secret.protection === 'protected' ? await protectedVault.authorizeProtectedDelete(secret.name) : undefined;
-      await api.deleteVaultSecret(secret.name, authz);
+      await api.deleteVaultSecret(secret.name);
       showToast(t('vaults.deleted', { name: secret.name }), 'success');
       refresh();
     } catch (err: unknown) {
-      setError(deleteMessageFromError(err, t));
+      setError(messageFromError(err));
     } finally {
       setDeleteTarget(null);
     }
@@ -861,7 +849,7 @@ export const VaultsPage: React.FC = () => {
         title={t('vaults.deleteDialog.title', { name: deleteTarget?.name ?? '' })}
         description={t('vaults.deleteDialog.description')}
         confirmLabel={t('common.delete')}
-        holdSeconds={deleteTarget?.kind === 'keypair' ? 5 : 0}
+        holdSeconds={deleteTarget?.kind === 'keypair' || deleteTarget?.protection === 'protected' ? 5 : 0}
         onConfirm={confirmDelete}
       >
         {deleteTarget?.kind === 'keypair' ? (
@@ -880,7 +868,7 @@ export const VaultsPage: React.FC = () => {
           <div className="flex flex-col gap-2 rounded-[10px] border border-warning/30 bg-warning/5 px-3 py-2.5 text-[12.5px] leading-snug text-foreground">
             <span className="flex items-start gap-2">
               <ShieldCheck className="mt-0.5 size-4 shrink-0 text-warning" />
-              <span>{t('vaults.deleteDialog.protectedPasskeyNote')}</span>
+              <span>{t('vaults.deleteDialog.protectedUnlockNote')}</span>
             </span>
           </div>
         ) : null}

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -180,6 +180,13 @@ export type VaultWebAuthnCredentialDescriptor = {
   transports?: AuthenticatorTransport[];
 };
 
+export type VaultWebAuthnAssertionOptions = {
+  challenge: string;
+  rpId: string;
+  userVerification: UserVerificationRequirement;
+  allowCredentials: VaultWebAuthnCredentialDescriptor[];
+};
+
 export type VaultWebAuthnRegistrationOptions = {
   ok: boolean;
   challenge_id: string;
@@ -198,7 +205,7 @@ export type VaultWebAuthnRegistrationOptions = {
   authorization?: {
     challenge_id: string;
     expires_at: string;
-    webauthn: VaultDeleteChallengeResult['webauthn'];
+    webauthn: VaultWebAuthnAssertionOptions;
   };
   code?: string;
   message?: string;
@@ -223,24 +230,6 @@ export type VaultWebAuthnRegistrationPayload = {
   credential: VaultWebAuthnSerializedCredential;
   label?: string;
   authz?: VaultWebAuthnAuthz;
-};
-
-export type VaultDeleteAuthz = VaultWebAuthnAuthz;
-
-export type VaultDeleteChallengeResult = {
-  ok: boolean;
-  challenge_id: string;
-  expires_at: string;
-  operation: 'delete_secret';
-  secret_name: string;
-  webauthn: {
-    challenge: string;
-    rpId: string;
-    userVerification: UserVerificationRequirement;
-    allowCredentials: VaultWebAuthnCredentialDescriptor[];
-  };
-  code?: string;
-  message?: string;
 };
 
 export type VaultCreatePayload = {
@@ -501,8 +490,7 @@ export type ApiContextType = {
   ) => Promise<{ ok: boolean; factor?: Record<string, unknown>; code?: string; message?: string }>;
   createVaultSecret: (payload: VaultCreatePayload, opts?: { handleError?: boolean }) => Promise<{ ok: boolean; secret?: VaultSecret; code?: string; message?: string }>;
   updateVaultSecret: (name: string, payload: VaultMetadataUpdatePayload, opts?: { handleError?: boolean }) => Promise<{ ok: boolean; secret?: VaultSecret; code?: string; message?: string }>;
-  createVaultDeleteChallenge: (name: string, opts?: { handleError?: boolean }) => Promise<VaultDeleteChallengeResult>;
-  deleteVaultSecret: (name: string, authz?: VaultDeleteAuthz) => Promise<{ ok: boolean; removed?: boolean; code?: string; message?: string }>;
+  deleteVaultSecret: (name: string) => Promise<{ ok: boolean; removed?: boolean; code?: string; message?: string }>;
   getVaultProvisionRequest: (
     name: string,
     opts?: { handleError?: boolean },
@@ -2302,10 +2290,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     registerVaultAuthzWebAuthnFactor: (payload) => postJson('/api/vault/authz/factors/webauthn', payload),
     createVaultSecret: (payload, opts) => postJson('/api/vault/secrets', payload, opts),
     updateVaultSecret: (name, payload, opts) => patchJson(`/api/vault/secrets/${encodeURIComponent(name)}`, payload, opts),
-    createVaultDeleteChallenge: (name, opts) =>
-      postJson(`/api/vault/secrets/${encodeURIComponent(name)}/delete-challenge`, {}, opts),
-    deleteVaultSecret: (name, authz) =>
-      deleteJson(`/api/vault/secrets/${encodeURIComponent(name)}`, authz ? { authz } : undefined),
+    deleteVaultSecret: (name) => deleteJson(`/api/vault/secrets/${encodeURIComponent(name)}`),
     getVaultProvisionRequest: (name, opts) =>
       getCachedJson(`/api/vault/provision-requests/${encodeURIComponent(name)}`, 1500, opts),
     getVaultProvisionRequestById: (requestId, opts) =>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2241,12 +2241,7 @@
       "description": "Agents will no longer be able to use this secret.",
       "keypairIrreversible": "This is a signing key — deleting it permanently destroys the private key. There is no backup and it cannot be recovered.",
       "keypairFunds": "If this key's address holds any funds, move them out first, or they will be lost for good.",
-      "protectedUnlockNote": "This is a protected secret — unlock the vault to confirm it's you before deleting.",
-      "protectedPasskeyNote": "This protected secret requires a fresh passkey authorization. The passkey prompt appears after you confirm.",
-      "authzSetupRequired": "Protected delete authorization is missing for this vault. Re-create the protected vault so setup can register the passkey authorization factor.",
-      "authzInvalid": "That passkey authorization expired or could not be verified. Try deleting again.",
-      "authzRequired": "Protected secrets require passkey authorization before deletion.",
-      "authzUnavailable": "Protected delete needs a passkey-capable origin. Open Vaults from localhost or your avibe.bot address."
+      "protectedUnlockNote": "This is a protected secret — deleting the record does not reveal its value, but agents will lose access immediately."
     },
     "deleted": "Deleted {{name}}",
     "created": "Saved {{name}}",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2241,12 +2241,7 @@
       "description": "Agent 将无法再使用这条密钥。",
       "keypairIrreversible": "这是一把签名密钥——删除会永久销毁私钥,没有备份,无法恢复。",
       "keypairFunds": "如果这把密钥的地址里还有资金,请先转出,否则将永久丢失。",
-      "protectedUnlockNote": "这是保护档密钥——删除前先解锁保险库,验证是你本人。",
-      "protectedPasskeyNote": "删除这条保护档密钥需要一次新的 passkey 授权。确认后会弹出 passkey 验证。",
-      "authzSetupRequired": "这个保险库缺少保护档删除授权。请重新创建保护档保险库,让 setup 流程注册 passkey 授权因子。",
-      "authzInvalid": "这次 passkey 授权已过期或无法验证。请重新删除一次。",
-      "authzRequired": "保护档密钥删除前必须完成 passkey 授权。",
-      "authzUnavailable": "保护档删除需要支持 passkey 的访问来源。请从 localhost 或你的 avibe.bot 地址打开 Vaults。"
+      "protectedUnlockNote": "这是保护档密钥——删除记录不会暴露密钥值,但 Agent 会立刻失去访问权限。"
     },
     "deleted": "已删除 {{name}}",
     "created": "已保存 {{name}}",

--- a/ui/src/lib/useProtectedVault.test.ts
+++ b/ui/src/lib/useProtectedVault.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { authorizeProtectedDeleteWithSandbox, webauthnAvailable } from './useProtectedVault';
+import { webauthnAvailable } from './useProtectedVault';
 import {
   VAULT_SANDBOX_EXPECTED_BUILD_HASH,
   VAULT_SANDBOX_IFRAME_URL,
@@ -23,45 +23,5 @@ describe('protected vault sandbox cutover', () => {
 
   it('fails closed outside a browser context', () => {
     expect(webauthnAvailable()).toBe(false);
-  });
-
-  it('authorizes protected delete without requiring unlocked VMK state', async () => {
-    const credential = {
-      id: 'cred-1',
-      rawId: 'cred-1',
-      type: 'public-key',
-      response: { clientDataJSON: 'client', authenticatorData: 'auth', signature: 'sig' },
-    };
-    const api = {
-      createVaultDeleteChallenge: vi.fn(async () => ({
-        ok: true,
-        challenge_id: 'vop_delete',
-        webauthn: {
-          challenge: 'challenge',
-          rpId: 'sandbox.avibe.bot',
-          userVerification: 'required',
-          allowCredentials: [{ type: 'public-key', id: 'cred-1', factor_id: 'vaf_delete' }],
-        },
-      })),
-    };
-    const client = {
-      deleteAuthzAssertion: vi.fn(async () => ({ challengeId: 'vop_delete', assertion: credential })),
-    };
-
-    await expect(
-      authorizeProtectedDeleteWithSandbox('PROTECTED_KEY', api, async () => client as never),
-    ).resolves.toEqual({
-      kind: 'webauthn',
-      challenge_id: 'vop_delete',
-      factor_id: 'vaf_delete',
-      assertion: credential,
-    });
-    expect(api.createVaultDeleteChallenge).toHaveBeenCalledWith('PROTECTED_KEY', { handleError: false });
-    expect(client.deleteAuthzAssertion).toHaveBeenCalledWith({
-      challengeId: 'vop_delete',
-      operation: 'delete_secret',
-      secretName: 'PROTECTED_KEY',
-      webauthn: expect.any(Object),
-    });
   });
 });

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useReducer, useState } from 'react';
 
 import {
   useApi,
-  type ApiContextType,
-  type VaultDeleteAuthz,
   type VaultWebAuthnRegistrationPayload,
   type VaultWebAuthnSerializedCredential,
 } from '@/context/ApiContext';
@@ -189,37 +187,6 @@ function registrationFromSandbox(value: unknown): VaultWebAuthnRegistrationPaylo
   return null;
 }
 
-export async function authorizeProtectedDeleteWithSandbox(
-  name: string,
-  api: Pick<ApiContextType, 'createVaultDeleteChallenge'>,
-  clientFactory = getVaultSandboxClient,
-): Promise<VaultDeleteAuthz> {
-  const challenge = await api.createVaultDeleteChallenge(name, { handleError: false });
-  if (!challenge?.ok) {
-    throw new Error(challenge?.code || challenge?.message || 'protected-delete-challenge-failed');
-  }
-  const result = await (await clientFactory()).deleteAuthzAssertion({
-    challengeId: challenge.challenge_id,
-    operation: 'delete_secret',
-    secretName: name,
-    webauthn: challenge.webauthn,
-  });
-  const assertion = result.assertion as VaultDeleteAuthz | VaultWebAuthnSerializedCredential;
-  if ('kind' in assertion && assertion.kind === 'webauthn' && assertion.factor_id) {
-    return assertion;
-  }
-  const credential = isSerializedCredential(assertion) ? assertion : assertion.assertion;
-  const rawId = credential.rawId;
-  const factor = rawId ? challenge.webauthn.allowCredentials.find((entry) => entry.id === rawId) : undefined;
-  if (!factor?.factor_id) throw new Error('protected-authz-factor-missing');
-  return {
-    kind: 'webauthn',
-    challenge_id: result.challengeId || challenge.challenge_id,
-    factor_id: factor.factor_id,
-    assertion: credential,
-  };
-}
-
 export function useProtectedVault() {
   const api = useApi();
   const [status, setStatus] = useState<ProtectedVaultStatus>(sessionVault.status);
@@ -352,13 +319,6 @@ export function useProtectedVault() {
     [],
   );
 
-  const authorizeProtectedDelete = useCallback(
-    async (name: string): Promise<VaultDeleteAuthz> => {
-      return authorizeProtectedDeleteWithSandbox(name, api);
-    },
-    [api],
-  );
-
   const lock = useCallback(() => {
     void lockVault(true);
     setStatus(vaultStatusNow());
@@ -387,7 +347,6 @@ export function useProtectedVault() {
     sealValue,
     signProtectedRequest,
     releaseProtectedDelivery,
-    authorizeProtectedDelete,
     afterCreated,
     lock,
     discardAndRefresh,

--- a/ui/src/lib/vaultSandboxClient.ts
+++ b/ui/src/lib/vaultSandboxClient.ts
@@ -1,9 +1,6 @@
 import type {
   SigningAddresses,
-  VaultDeleteAuthz,
-  VaultDeleteChallengeResult,
   VaultWebAuthnRegistrationPayload,
-  VaultWebAuthnSerializedCredential,
 } from '@/context/ApiContext';
 import type { BlindBox, ProtectedRecordEnvelope, SignatureResult, SignatureScheme } from './vaultCrypto';
 import {
@@ -28,7 +25,6 @@ const REQUIRED_OPS = [
   'unseal',
   'sign',
   'releaseDEK',
-  'deleteAuthzAssertion',
 ] as const;
 const DEFAULT_TIMEOUT_MS = 15_000;
 const INTERACTIVE_TIMEOUT_MS = 5 * 60_000;
@@ -86,11 +82,6 @@ export type VaultSandboxSealResult = {
   establishingVmk: boolean;
   publicKey?: string;
   addresses?: SigningAddresses;
-};
-
-export type VaultSandboxDeleteAssertionResult = {
-  challengeId: string;
-  assertion: VaultDeleteAuthz | VaultWebAuthnSerializedCredential;
 };
 
 export type DaemonAgentBinding = {
@@ -428,18 +419,6 @@ export class VaultSandboxClient {
     agentBinding: DaemonAgentBinding;
   }): Promise<BlindBox> {
     return this.request<BlindBox>('releaseDEK', payload, {
-      timeoutMs: INTERACTIVE_TIMEOUT_MS,
-      interactive: true,
-    });
-  }
-
-  deleteAuthzAssertion(payload: {
-    challengeId: string;
-    operation: 'delete_secret';
-    secretName: string;
-    webauthn: VaultDeleteChallengeResult['webauthn'];
-  }): Promise<VaultSandboxDeleteAssertionResult> {
-    return this.request<VaultSandboxDeleteAssertionResult>('deleteAuthzAssertion', payload, {
       timeoutMs: INTERACTIVE_TIMEOUT_MS,
       interactive: true,
     });

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1736,27 +1736,6 @@ def register_vault_authz_webauthn_factor(payload: dict, *, origin: str | None = 
     return result
 
 
-def create_vault_delete_challenge(name: str, *, origin: str | None = None) -> dict:
-    from storage import vault_service
-
-    context = _vault_webauthn_context(origin)
-    engine = _vault_engine()
-    try:
-        with engine.begin() as conn:
-            return vault_service.create_delete_challenge(
-                conn,
-                name,
-                rp_id=context.rp_id,
-                origin=context.origin,
-            )
-    except vault_service.SecretNotFoundError as exc:
-        raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
-    except vault_service.SecretNotProtectedError as exc:
-        raise VaultApiError(f"secret '{name}' is not protected", code="not_protected", status=409) from exc
-    except vault_service.ProtectedAuthzSetupRequiredError as exc:
-        raise VaultApiError(str(exc), code="protected_authz_setup_required", status=409) from exc
-
-
 def _reject_plaintext_value_fields(payload: object) -> None:
     if isinstance(payload, dict):
         if "value" in payload:
@@ -1980,30 +1959,18 @@ def update_vault_secret(name: str, payload: dict) -> dict:
     return {"ok": True, "secret": meta}
 
 
-def delete_vault_secret(name: str, authz: dict | None = None) -> dict:
+def delete_vault_secret(name: str) -> dict:
     from storage import vault_service
 
     engine = _vault_engine()
     release_scopes: list[dict[str, str]] = []
     try:
         with engine.begin() as conn:
-            meta = vault_service.get_secret_meta(conn, name)
-            protected_authz = (
-                vault_service.verify_delete_secret_authz(conn, name, authz)
-                if meta.get("protection") == "protected"
-                else None
-            )
             grant_rows = vault_service.active_grant_rows_for_secret(conn, name)
-            vault_service.delete_secret(conn, name, protected_authz=protected_authz)
+            vault_service.delete_secret(conn, name)
             release_scopes = vault_service.agent_release_scopes_after_rows(conn, grant_rows)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
-    except vault_service.ProtectedAuthRequiredError as exc:
-        raise VaultApiError(str(exc), code="protected_auth_required", status=409) from exc
-    except vault_service.ProtectedAuthzSetupRequiredError as exc:
-        raise VaultApiError(str(exc), code="protected_authz_setup_required", status=409) from exc
-    except vault_service.InvalidProtectedAuthzError as exc:
-        raise VaultApiError(str(exc), code="invalid_protected_authz", status=409) from exc
     release_vault_agent_scopes(release_scopes, reason="delete_vault_secret")
     _publish_vaults_updated(scope="secret", secret_name=name)
     return {"ok": True, "removed": True, "name": name}

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -5152,7 +5152,7 @@ def cmd_vault_rm(args):
             if meta.get("protection") == "protected":
                 raise TaskCliError(
                     f"'{args.name}' is a protected secret — delete it in the browser (Vaults), where it's "
-                    f"confirmed with your passkey. The CLI can't delete protected secrets.",
+                    f"confirmed by the signed-in user. The CLI can't delete protected secrets.",
                     code="protected_delete_forbidden",
                     help_command=help_command,
                 )

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3265,24 +3265,12 @@ def vault_secret_patch(name):
         return _vault_error_response(exc)
 
 
-@app.route("/api/vault/secrets/<name>/delete-challenge", methods=["POST"])
-def vault_secret_delete_challenge(name):
-    from vibe import api
-
-    try:
-        return jsonify(api.create_vault_delete_challenge(name, origin=_vault_sandbox_webauthn_origin()))
-    except ValueError as exc:
-        return _vault_error_response(exc)
-
-
 @app.route("/api/vault/secrets/<name>", methods=["DELETE"])
 def vault_secret_delete(name):
     from vibe import api
 
     try:
-        payload = request.json or {}
-        authz = payload.get("authz") if isinstance(payload, dict) else None
-        return jsonify(api.delete_vault_secret(name, authz=authz))
+        return jsonify(api.delete_vault_secret(name))
     except ValueError as exc:
         return _vault_error_response(exc)
 


### PR DESCRIPTION
## Summary

Protected vault secret deletion no longer requires a WebAuthn/passkey authorization. The passkey now gates value confidentiality only: unlock, use, reveal, sign, and DEK release. Deleting a protected record follows the same user-confirmed Vaults UI/API path as standard deletion, so a factorless or lost-passkey protected record is no longer permanently stuck.

## Changes

- Removed the protected-delete challenge/authz path from the daemon, UI route, and frontend delete flow.
- Kept the CLI protected-delete refusal intact as the agent guard, with copy updated to avoid saying the browser uses a passkey for delete.
- Kept destructive UI friction: protected and keypair deletes still use the ConfirmDialog hold countdown before plain delete.
- Marked the old protected-delete authz design plan as superseded by the 2026-07-08 product decision.

## Evidence Layers

- Unit: `pytest -k vault` passed, including updated service/API/REST coverage for protected deletion without assertions.
- Contract: tests now pin that factorless protected secrets delete normally, protected deletes release grant scopes, and CLI protected delete still refuses.
- Frontend/build: `cd ui && npm run build` passed.
- Scenario catalog: no Vault scenario ID changed in this PR; residual manual Incus/browser regression was not run.
