### PR TITLE
fix(ui): default instance name to remote access slug

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -312,8 +312,9 @@ class UiConfig:
     chat_message_font_size: int = DEFAULT_CHAT_MESSAGE_FONT_SIZE_PX
     trusted_public_origins: List[str] = field(default_factory=list)
     # Display name appended to the browser tab title ("Avibe - <name>"). When
-    # blank the UI falls back to the machine's system hostname (surfaced as the
-    # read-only ``system_hostname`` field in the /api/config payload).
+    # blank the UI falls back to the read-only ``default_instance_name`` field
+    # in the /api/config payload (remote-access tunnel name when available,
+    # otherwise the machine's system hostname).
     instance_name: str = ""
 
 

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -206,6 +206,52 @@ def test_config_load_defaults_missing_audio_asr_to_enabled():
     assert created.audio_asr.enabled_configured is False
 
 
+def test_config_payload_defaults_instance_name_to_remote_access_slug(monkeypatch):
+    monkeypatch.setattr(api, "_system_hostname", lambda: "macbook")
+    config = V2Config.from_payload(_full_config_payload())
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.public_url = "https://alex-app.avibe.bot"
+
+    payload = api.config_to_payload(config)
+
+    assert payload["ui"]["instance_name"] == ""
+    assert payload["ui"]["default_instance_name"] == "alex"
+    assert payload["ui"]["system_hostname"] == "macbook"
+
+
+def test_config_payload_default_instance_name_falls_back_to_hostname(monkeypatch):
+    monkeypatch.setattr(api, "_system_hostname", lambda: "macbook")
+    config = V2Config.from_payload(_full_config_payload())
+    config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.public_url = "https://alex-app.avibe.bot"
+
+    payload = api.config_to_payload(config)
+
+    assert payload["ui"]["default_instance_name"] == "macbook"
+
+
+def test_config_payload_default_instance_name_ignores_invalid_remote_url(monkeypatch):
+    monkeypatch.setattr(api, "_system_hostname", lambda: "macbook")
+    config = V2Config.from_payload(_full_config_payload())
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.public_url = "http://alex-app.avibe.bot"
+
+    payload = api.config_to_payload(config)
+
+    assert payload["ui"]["default_instance_name"] == "macbook"
+
+
+def test_config_payload_default_instance_name_ignores_malformed_remote_url(monkeypatch):
+    monkeypatch.setattr(api, "_system_hostname", lambda: "macbook")
+    config = V2Config.from_payload(_full_config_payload())
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.public_url = "https://["
+
+    payload = api.config_to_payload(config)
+
+    assert payload["ui"]["default_instance_name"] == "macbook"
+
+
 def test_save_config_preserves_show_pages_prompt_toggle(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -137,6 +137,7 @@ export const SettingsServicePage: React.FC = () => {
     setNameMessage(null);
     try {
       const instanceName = (config.ui?.instance_name || '').trim();
+      const defaultInstanceName = (config.ui?.default_instance_name || config.ui?.system_hostname || '').trim();
       // Persist ONLY the instance name. Spreading the shared (and possibly
       // dirty) config.ui would also save unsaved Console server host/port
       // edits — but without the /api/ui/reload + redirect that
@@ -144,9 +145,15 @@ export const SettingsServicePage: React.FC = () => {
       // while the next restart silently moves to the unsaved address. The
       // backend deep-merges config saves, so host/port are preserved.
       await api.saveConfig({ ui: { instance_name: instanceName } });
-      // Reflect the new title immediately. system_hostname is the read-only,
-      // server-computed fallback (unaffected by host/port edits).
-      applyAppTitle({ ui: { instance_name: instanceName, system_hostname: config.ui?.system_hostname } });
+      // Reflect the new title immediately. default_instance_name is the
+      // read-only, server-computed fallback (unaffected by host/port edits).
+      applyAppTitle({
+        ui: {
+          instance_name: instanceName,
+          default_instance_name: defaultInstanceName,
+          system_hostname: config.ui?.system_hostname,
+        },
+      });
       setNameMessage(t('common.saved'));
     } catch {
       setNameMessage(t('common.saveFailed'));
@@ -154,6 +161,8 @@ export const SettingsServicePage: React.FC = () => {
       setNameSaving(false);
     }
   };
+
+  const defaultInstanceName = (config?.ui?.default_instance_name || config?.ui?.system_hostname || '').trim();
 
   return (
     <SettingsPageShell
@@ -294,7 +303,7 @@ export const SettingsServicePage: React.FC = () => {
             <div className="grid grid-cols-[minmax(160px,220px)_auto] items-center gap-2">
               <CompactField
                 aria-label={t('settings.instanceNameTitle')}
-                placeholder={config?.ui?.system_hostname || ''}
+                placeholder={defaultInstanceName}
                 value={config?.ui?.instance_name || ''}
                 onChange={(event) => {
                   const instanceName = event.target.value;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -222,7 +222,7 @@
     "consoleServerTitle": "Console server",
     "consoleServerHint": "Saving these values restarts only the Web UI server.",
     "instanceNameTitle": "Instance name",
-    "instanceNameHint": "Shown in the browser tab title (\"Avibe - name\"). Leave blank to use the system hostname.",
+    "instanceNameHint": "Shown in the browser tab title (\"Avibe - name\"). Leave blank to use the remote-access name when paired, otherwise the system hostname.",
     "consoleServerRedirecting": "UI server moved. Redirecting to {{origin}}...",
     "consoleServerRelocated": "UI server now listens on {{origin}}. Open this URL to continue.",
     "serviceNotesTitle": "Operational notes",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -222,7 +222,7 @@
     "consoleServerTitle": "控制台服务",
     "consoleServerHint": "保存这些值只会重启 Web UI 服务，不会重启主服务。",
     "instanceNameTitle": "实例名称",
-    "instanceNameHint": "显示在浏览器标签标题中（“Avibe - 名称”）。留空则使用系统 hostname。",
+    "instanceNameHint": "显示在浏览器标签标题中（“Avibe - 名称”）。留空则优先使用远程访问名称，否则使用系统 hostname。",
     "consoleServerRedirecting": "UI 服务地址已变更，正在跳转到 {{origin}}...",
     "consoleServerRelocated": "UI 服务现在监听 {{origin}}，请打开该地址继续。",
     "serviceNotesTitle": "运维说明",

--- a/ui/src/lib/documentTitle.test.ts
+++ b/ui/src/lib/documentTitle.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeAppTitle } from './documentTitle';
+
+describe('computeAppTitle', () => {
+  it('prefers the configured instance name', () => {
+    expect(
+      computeAppTitle({
+        ui: {
+          instance_name: 'Desk',
+          default_instance_name: 'alex',
+          system_hostname: 'macbook',
+        },
+      }),
+    ).toBe('Avibe - Desk');
+  });
+
+  it('uses the server-computed default when instance_name is blank', () => {
+    expect(
+      computeAppTitle({
+        ui: {
+          instance_name: '',
+          default_instance_name: 'alex',
+          system_hostname: 'macbook',
+        },
+      }),
+    ).toBe('Avibe - alex');
+  });
+
+  it('falls back to system_hostname for older config payloads', () => {
+    expect(
+      computeAppTitle({
+        ui: {
+          instance_name: '',
+          system_hostname: 'macbook',
+        },
+      }),
+    ).toBe('Avibe - macbook');
+  });
+});

--- a/ui/src/lib/documentTitle.ts
+++ b/ui/src/lib/documentTitle.ts
@@ -1,14 +1,15 @@
 // Browser tab title: "Avibe - <name>", where <name> is the configured
-// ``ui.instance_name`` or, when blank, the machine's system hostname (both
-// served in the /api/config payload). Falls back to plain "Avibe" when neither
-// is available.
+// ``ui.instance_name`` or, when blank, the server-computed default instance
+// name. Older servers may only provide system_hostname. Falls back to plain
+// "Avibe" when neither is available.
 const BASE_TITLE = 'Avibe';
 
 export function computeAppTitle(config: unknown): string {
   const ui = (config as { ui?: Record<string, unknown> } | null | undefined)?.ui ?? {};
   const configured = typeof ui.instance_name === 'string' ? ui.instance_name.trim() : '';
+  const defaultName = typeof ui.default_instance_name === 'string' ? ui.default_instance_name.trim() : '';
   const hostname = typeof ui.system_hostname === 'string' ? ui.system_hostname.trim() : '';
-  const name = configured || hostname;
+  const name = configured || defaultName || hostname;
   return name ? `${BASE_TITLE} - ${name}` : BASE_TITLE;
 }
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -932,10 +932,38 @@ def _system_hostname() -> str:
         return ""
 
 
+def _remote_access_instance_name(config: V2Config) -> str:
+    cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
+    if not cloud or not getattr(cloud, "enabled", False):
+        return ""
+    public_url = (getattr(cloud, "public_url", "") or "").strip()
+    if not public_url:
+        return ""
+    try:
+        parsed = urllib.parse.urlsplit(public_url)
+    except ValueError:
+        return ""
+    if parsed.scheme.lower() != "https" or parsed.username or parsed.password:
+        return ""
+    hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+    labels = hostname.split(".")
+    if len(labels) < 3 or labels[-2:] != ["avibe", "bot"]:
+        return ""
+    slug = labels[0]
+    if slug.endswith("-app"):
+        slug = slug[:-4]
+    return slug.strip("-")
+
+
+def _default_instance_name(config: V2Config, *, system_hostname: str) -> str:
+    return _remote_access_instance_name(config) or system_hostname
+
+
 def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dict:
     from config.platform_registry import platform_descriptors
     from modules.agents.catalog import agent_backend_catalog_payload
 
+    system_hostname = _system_hostname()
     platform_payload = {}
     for descriptor in platform_descriptors():
         descriptor_config = descriptor.get_config(config)
@@ -975,11 +1003,16 @@ def config_to_payload(config: V2Config, *, include_secrets: bool = False) -> dic
             _GATEWAY_SECRET_FIELDS,
             include_secrets=include_secrets,
         ),
-        # ``system_hostname`` is a read-only, computed hint (not a stored config
-        # field): the UI uses it as the browser-title fallback when
-        # ``ui.instance_name`` is blank. It is dropped on save via
-        # ``_filter_dataclass_fields`` so it never persists.
-        "ui": {**config.ui.__dict__, "system_hostname": _system_hostname()},
+        # ``system_hostname`` and ``default_instance_name`` are read-only,
+        # computed hints (not stored config fields): the UI uses the default as
+        # the browser-title fallback when ``ui.instance_name`` is blank. They
+        # are dropped on save via ``_filter_dataclass_fields`` so they never
+        # persist.
+        "ui": {
+            **config.ui.__dict__,
+            "system_hostname": system_hostname,
+            "default_instance_name": _default_instance_name(config, system_hostname=system_hostname),
+        },
         "remote_access": {
             "provider": config.remote_access.provider,
             "vibe_cloud": _vibe_cloud_payload(config, include_secrets),


### PR DESCRIPTION
## Summary

Default the browser-title instance name to the paired remote-access slug when remote access is enabled. For example, `https://alex-app.avibe.bot` now yields `Avibe - alex` when the user has not set an explicit instance name.

Manual instance names still take precedence, and invalid or disabled remote-access config falls back to the system hostname.

## Capability

- Instance name browser-title fallback
- Settings Service instance-name placeholder and help text

## Scenario IDs

- N/A: no scenario catalog entry covers instance-name browser-title fallback.

## Evidence

- Unit: `uv run pytest tests/test_api_save_config_merge.py -k "instance_name or audio_asr"`
- Contract: `/api/config` now exposes read-only `ui.default_instance_name` and fail-closed parsing for malformed remote URLs
- Scenario: N/A
- Residual manual checks: `npm run build`, `npx vitest run src/lib/documentTitle.test.ts`, `uv run ruff check vibe/api.py config/v2_config.py tests/test_api_save_config_merge.py`

## Review

- Ran reviewer subagent before opening the PR; it found malformed `public_url` could raise during `/api/config`. This PR includes the fail-closed fix and regression test.
