### PR TITLE
fix(ui): make status endpoint use fast runtime probe

### DIFF
--- a/tests/test_runtime_service_lock.py
+++ b/tests/test_runtime_service_lock.py
@@ -464,6 +464,58 @@ class RuntimeServiceLockTests(unittest.TestCase):
             self.assertEqual(payload["service_pid"], 12345)
             self.assertEqual(payload["pid"], 12345)
 
+    def test_render_status_skips_extra_process_scan_when_requested(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status_path = Path(tmpdir) / "status.json"
+            runtime.write_json(status_path, {"state": "running", "service_pid": 12345})
+
+            with patch("vibe.runtime.paths.get_runtime_status_path", return_value=status_path):
+                with patch("vibe.runtime.resolve_service_owner_pid", return_value=12345):
+                    with patch("vibe.runtime.extra_service_process_pids") as extra_service_process_pids:
+                        payload = runtime.json.loads(runtime.render_status(detect_extra_processes=False))
+
+            extra_service_process_pids.assert_not_called()
+            self.assertTrue(payload["running"])
+            self.assertEqual(payload["state"], "running")
+            self.assertEqual(payload["service_pid"], 12345)
+            self.assertEqual(payload["pid"], 12345)
+            self.assertEqual(payload["service_owner_pid"], 12345)
+            self.assertNotIn("extra_service_pids", payload)
+
+    def test_render_status_fast_path_skips_extra_process_scan_when_owner_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status_path = Path(tmpdir) / "status.json"
+            runtime.write_json(status_path, {"state": "running", "service_pid": 12345})
+
+            with patch("vibe.runtime.paths.get_runtime_status_path", return_value=status_path):
+                with patch("vibe.runtime.resolve_service_owner_pid", return_value=None):
+                    with patch("vibe.runtime.extra_service_process_pids") as extra_service_process_pids:
+                        payload = runtime.json.loads(runtime.render_status(detect_extra_processes=False))
+
+            extra_service_process_pids.assert_not_called()
+            self.assertFalse(payload["running"])
+            self.assertEqual(payload["state"], "stopped")
+            self.assertIsNone(payload["service_pid"])
+            self.assertIsNone(payload["pid"])
+            self.assertEqual(payload["service_owner_pid"], None)
+
+    def test_render_status_can_surface_extra_processes_when_owner_is_running(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            status_path = Path(tmpdir) / "status.json"
+            runtime.write_json(status_path, {"state": "running", "service_pid": 12345})
+
+            with patch("vibe.runtime.paths.get_runtime_status_path", return_value=status_path):
+                with patch("vibe.runtime.resolve_service_owner_pid", return_value=12345):
+                    with patch("vibe.runtime.extra_service_process_pids", return_value=[22222]):
+                        payload = runtime.json.loads(runtime.render_status())
+
+            self.assertTrue(payload["running"])
+            self.assertEqual(payload["state"], "running")
+            self.assertEqual(payload["service_pid"], 12345)
+            self.assertEqual(payload["service_owner_pid"], 12345)
+            self.assertEqual(payload["extra_service_pids"], [22222])
+            self.assertEqual(payload["detail"], "pid=12345; extra_service_pids=22222")
+
     def test_render_status_surfaces_lockless_service_process(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             status_path = Path(tmpdir) / "status.json"

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1,4 +1,5 @@
 import gzip
+import json
 
 import pytest
 
@@ -56,6 +57,24 @@ def test_fastapi_schema_routes_are_not_exposed():
     docs_response = client.get("/docs")
     assert b"swagger-ui" not in docs_response.content.lower()
     assert client.get("/openapi.json").status_code != 200
+
+
+def test_status_endpoint_uses_fast_runtime_status(monkeypatch):
+    from vibe import runtime
+
+    calls = []
+
+    def fake_render_status(*, detect_extra_processes=True):
+        calls.append(detect_extra_processes)
+        return json.dumps({"state": "running", "running": True, "service_pid": 12345})
+
+    monkeypatch.setattr(runtime, "render_status", fake_render_status)
+
+    response = app.test_client().get("/status")
+
+    assert response.status_code == 200
+    assert response.get_json()["service_pid"] == 12345
+    assert calls == [False]
 
 
 def test_route_path_to_fastapi_converts_named_path_converter():

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1028,10 +1028,12 @@ def _pid_mismatches_service(pid: int) -> bool:
     return not _command_looks_like_service_entry(command, cwd=cwd)
 
 
-def render_status():
+def render_status(*, detect_extra_processes: bool = True):
     status = read_status()
     owner_pid = resolve_service_owner_pid(include_starting=False)
-    extra_pids = extra_service_process_pids(owner_pid=owner_pid)
+    extra_pids: list[int] = []
+    if detect_extra_processes:
+        extra_pids = extra_service_process_pids(owner_pid=owner_pid)
     running = bool(owner_pid or extra_pids)
     if owner_pid:
         status["state"] = "running"

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2311,10 +2311,10 @@ def health():
 def status():
     from vibe import runtime
 
-    payload = json.loads(runtime.render_status())
+    payload = json.loads(runtime.render_status(detect_extra_processes=False))
     if not payload.get("running") and runtime.read_status().get("state") == "running":
         runtime.write_status("stopped", "process not running", None, payload.get("ui_pid"))
-        payload = json.loads(runtime.render_status())
+        payload = json.loads(runtime.render_status(detect_extra_processes=False))
     return jsonify(payload)
 
 


### PR DESCRIPTION
## Summary

- Make the HTTP `/status` endpoint use a fast runtime status probe that skips duplicate-service process scanning.
- Preserve the default `render_status()` behavior for CLI/deeper diagnostics so duplicate lockless service observability remains available.
- Add regression tests for the HTTP fast path and the detailed status path.

## Root Cause

`/status` reused the same detailed runtime status renderer as CLI diagnostics. That renderer calls `extra_service_process_pids()`, which performs a whole-process duplicate-service scan. On macOS this can be slow enough to make Status polling pile up and delay unrelated UI requests.

## Evidence

- Unit: `uv run pytest tests/test_runtime_service_lock.py tests/test_vibe_cli.py -k 'status or service_process or duplicate_service or repair_duplicate or service_lock'`
- Unit: `uv run pytest tests/test_ui_server_fastapi.py -k status`
- Contract: `uv run ruff check vibe/runtime.py vibe/ui_server.py tests/test_runtime_service_lock.py tests/test_ui_server_fastapi.py`
- Build: `cd ui && npm run build`
- Manual: fast-path probe with `detect_extra_processes=False` stayed under 1ms and asserted no scan for both running and missing-owner states.

Scenario IDs: N/A.

## Risk

Low. HTTP `/status` no longer reports duplicate lockless service processes directly, but CLI/default detailed status and doctor/repair paths still retain duplicate-service scanning.
