### PR TITLE
feat(ui): terminal scrollback search + clickable links

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,6 +22,8 @@
         "@shikijs/themes": "^4.2.0",
         "@uiw/react-json-view": "^2.0.0-alpha.43",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "agentation": "^3.0.2",
         "chart.js": "^4.4.0",
@@ -3032,6 +3034,18 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-search": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
+      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,6 +29,8 @@
     "@shikijs/themes": "^4.2.0",
     "@uiw/react-json-view": "^2.0.0-alpha.43",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "agentation": "^3.0.2",
     "chart.js": "^4.4.0",

--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -68,25 +68,27 @@ function buildWsUrl(sessionId: string, cwd?: string | null): string {
   return cwd ? `${base}?cwd=${encodeURIComponent(cwd)}` : base;
 }
 
-// Which modifier opens Find: ⌘ on Apple platforms, Ctrl elsewhere. The gating matters — Ctrl+F is a
-// live terminal key on macOS (readline forward-char, less/vim page-forward, the system emacs binding),
-// so hijacking Ctrl+F on every platform would eat a keystroke mac shells depend on. Windows/Linux
-// terminals don't bind Ctrl+F that way, so it's the natural Find shortcut there.
+// Apple vs. non-Apple decides the Find chord below. Detected once (navigator.platform is deprecated but
+// remains the most reliable signal, with userAgent as a fallback).
 const IS_APPLE =
   typeof navigator !== 'undefined' &&
   /Mac|iP(hone|ad|od)/i.test(navigator.platform || navigator.userAgent || '');
 
-// True when the event is the platform Find chord (⌘F / Ctrl+F) with no stray extra modifier. Shared by
-// the terminal's key handler and the search field so both agree on the platform gating.
+// The chord that opens Find: ⌘F on Apple platforms, Ctrl+Shift+F everywhere else. Plain Ctrl+F is a live
+// terminal key on BOTH macOS and Linux (readline forward-char, less/vim page-forward), so it must keep
+// reaching the PTY — hence ⌘ on Apple (a free modifier) and the Shift-qualified chord elsewhere, which is
+// exactly what native terminals bind for find (GNOME Terminal, Konsole, Windows Terminal). Shared by the
+// terminal key handler and the search field so both agree; altKey is excluded to avoid stray combos.
 const isFindHotkey = (e: {
   metaKey: boolean;
   ctrlKey: boolean;
+  shiftKey: boolean;
   altKey: boolean;
   key: string;
 }): boolean =>
-  (IS_APPLE ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey) &&
   !e.altKey &&
-  (e.key === 'f' || e.key === 'F');
+  (e.key === 'f' || e.key === 'F') &&
+  (IS_APPLE ? e.metaKey && !e.ctrlKey : e.ctrlKey && e.shiftKey && !e.metaKey);
 
 export const TerminalView: React.FC<{
   sessionId: string;
@@ -352,12 +354,16 @@ export const TerminalView: React.FC<{
 
   const closeSearch = () => {
     setSearchOpen(false);
+    setQuery(''); // drop the term so reopening starts fresh instead of showing a stale "0/0" counter
     searchRef.current?.clearDecorations();
     setMatches({ index: -1, count: 0 });
     termRef.current?.focus();
   };
 
   const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Mid-IME-composition (e.g. a CJK candidate), Enter/Escape belong to the IME — accepting or
+    // cancelling the candidate — not to search navigation. Let them through untouched.
+    if (e.nativeEvent.isComposing) return;
     if (e.key === 'Enter') {
       e.preventDefault();
       runFind(e.shiftKey ? 'prev' : 'next');

--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -139,11 +139,16 @@ export const TerminalView: React.FC<{
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
-    // Clickable URLs open in a new tab. noopener defeats reverse-tabnabbing (the addon's own typings
-    // call this out); routing through window.open means a link never navigates the app frame itself.
+    // Clickable URLs open in a new tab, but only on a modifier-click (⌘ on Apple, Ctrl elsewhere).
+    // Persistent sessions run tmux with `mouse on`, so an unmodified click is meaningful input for
+    // tmux/copy-mode and mouse-aware TUIs — gating on the modifier keeps plain clicks as terminal input
+    // and matches how VS Code / iTerm / GNOME Terminal follow terminal links. noopener defeats reverse-
+    // tabnabbing (the addon's own typings call this out); window.open never navigates the app frame.
     term.loadAddon(
-      new WebLinksAddon((_event, uri) => {
-        window.open(uri, '_blank', 'noopener');
+      new WebLinksAddon((event, uri) => {
+        if (IS_APPLE ? event.metaKey : event.ctrlKey) {
+          window.open(uri, '_blank', 'noopener');
+        }
       }),
     );
     const search = new SearchAddon();

--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -2,10 +2,13 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { SearchAddon } from '@xterm/addon-search';
+import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
-import { RotateCw } from 'lucide-react';
+import { ChevronDown, ChevronUp, RotateCw, Search, X } from 'lucide-react';
 
 import { Button } from '../ui/button';
+import { Input } from '../ui/input';
 
 // xterm.js wired to the /api/terminal/{id} WebSocket. Protocol (locked with the
 // backend): client sends raw stdin as BINARY frames and JSON control as TEXT
@@ -26,6 +29,20 @@ const TERMINAL_THEME = {
   cursor: '#e4e4e7',
   cursorAccent: TERMINAL_BG,
   selectionBackground: 'rgba(148,163,184,0.35)',
+};
+
+// Search-match highlight colors for the SearchAddon. Amber reads clearly on the dark terminal and
+// stays out of the app theme's way (the terminal is theme-locked dark). Colors must be #RRGGBB; the
+// active (current) match is brighter than the rest. Decorations rely on the terminal's proposed
+// decoration API — allowProposedApi is already enabled below. The overview-ruler colors are only
+// painted when overviewRulerWidth is set (we don't set it), but the type requires them.
+const SEARCH_DECORATIONS = {
+  matchBackground: '#664d00',
+  matchBorder: '#8a6d1a',
+  matchOverviewRuler: '#b8860b',
+  activeMatchBackground: '#b8860b',
+  activeMatchBorder: '#ffcf5c',
+  activeMatchColorOverviewRuler: '#ffcf5c',
 };
 
 // Accessory key bar for phones (their soft keyboards lack these). Each button sends the raw
@@ -51,6 +68,26 @@ function buildWsUrl(sessionId: string, cwd?: string | null): string {
   return cwd ? `${base}?cwd=${encodeURIComponent(cwd)}` : base;
 }
 
+// Which modifier opens Find: ⌘ on Apple platforms, Ctrl elsewhere. The gating matters — Ctrl+F is a
+// live terminal key on macOS (readline forward-char, less/vim page-forward, the system emacs binding),
+// so hijacking Ctrl+F on every platform would eat a keystroke mac shells depend on. Windows/Linux
+// terminals don't bind Ctrl+F that way, so it's the natural Find shortcut there.
+const IS_APPLE =
+  typeof navigator !== 'undefined' &&
+  /Mac|iP(hone|ad|od)/i.test(navigator.platform || navigator.userAgent || '');
+
+// True when the event is the platform Find chord (⌘F / Ctrl+F) with no stray extra modifier. Shared by
+// the terminal's key handler and the search field so both agree on the platform gating.
+const isFindHotkey = (e: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  key: string;
+}): boolean =>
+  (IS_APPLE ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey) &&
+  !e.altKey &&
+  (e.key === 'f' || e.key === 'F');
+
 export const TerminalView: React.FC<{
   sessionId: string;
   /** Start directory for a newly created session (from "Open Terminal Here"). Stable per tab. */
@@ -62,6 +99,8 @@ export const TerminalView: React.FC<{
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
+  const searchRef = useRef<SearchAddon | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const ctrlStickyRef = useRef(false);
   const busyRetriesRef = useRef(0);
@@ -74,6 +113,11 @@ export const TerminalView: React.FC<{
   const [status, setStatus] = useState<TerminalStatus>('connecting');
   const [exitCode, setExitCode] = useState<number | null>(null);
   const [reconnectKey, setReconnectKey] = useState(0);
+  // Scrollback search (SearchAddon). Opened with ⌘F/Ctrl+F while the terminal has focus; results
+  // carry {index,count} for the "3/12" match counter (index is -1 past the highlight threshold).
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [matches, setMatches] = useState<{ index: number; count: number }>({ index: -1, count: 0 });
 
   // Surface connection status to the parent (tab bar). The standalone status row inside the
   // body was removed — only the terminating states render an in-body overlay (below).
@@ -93,6 +137,35 @@ export const TerminalView: React.FC<{
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
+    // Clickable URLs open in a new tab. noopener defeats reverse-tabnabbing (the addon's own typings
+    // call this out); routing through window.open means a link never navigates the app frame itself.
+    term.loadAddon(
+      new WebLinksAddon((_event, uri) => {
+        window.open(uri, '_blank', 'noopener');
+      }),
+    );
+    const search = new SearchAddon();
+    term.loadAddon(search);
+    searchRef.current = search;
+    const searchResults = search.onDidChangeResults((e) =>
+      setMatches({ index: e.resultIndex, count: e.resultCount }),
+    );
+    // Intercept the Find chord only while xterm's textarea has focus (this handler runs solely for
+    // terminal key events), so the browser's own find stays available everywhere else in the app.
+    // Returning false stops xterm forwarding the key to the PTY; preventDefault stops the browser find.
+    term.attachCustomKeyEventHandler((e) => {
+      if (e.type === 'keydown' && isFindHotkey(e)) {
+        e.preventDefault();
+        setSearchOpen(true);
+        // Focus once the bar has mounted (first open) or refocus it (already open); rAF waits for commit.
+        requestAnimationFrame(() => {
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        });
+        return false;
+      }
+      return true;
+    });
     termRef.current = term;
     const settleTimers: number[] = [];
     let resizeSendTimer: number | null = null;
@@ -160,6 +233,7 @@ export const TerminalView: React.FC<{
     });
     setStatus('connecting');
     setExitCode(null);
+    setMatches({ index: -1, count: 0 }); // a reconnect rebuilds the SearchAddon; drop the stale count
     const ws = new WebSocket(buildWsUrl(sessionId, cwd));
     ws.binaryType = 'arraybuffer';
     wsRef.current = ws;
@@ -219,6 +293,7 @@ export const TerminalView: React.FC<{
       for (const id of settleTimers) window.clearTimeout(id);
       ro.disconnect();
       onData.dispose();
+      searchResults.dispose();
       // Detach handlers before closing. A closing socket's onclose can fire asynchronously
       // *after* its replacement has already reported 'ready' (reconnect / effect remount);
       // left attached, the stale onclose would mark the live terminal 'closed' or schedule a
@@ -235,6 +310,7 @@ export const TerminalView: React.FC<{
       term.dispose();
       wsRef.current = null;
       termRef.current = null;
+      searchRef.current = null;
     };
   }, [sessionId, cwd, reconnectKey]);
 
@@ -253,6 +329,51 @@ export const TerminalView: React.FC<{
     setReconnectKey((k) => k + 1);
   };
 
+  // Step between matches. Incremental (type-ahead) applies only to findNext — it grows the current
+  // selection while it still matches; explicit next/prev jump to the adjacent match.
+  const runFind = (direction: 'next' | 'prev', incremental = false) => {
+    const s = searchRef.current;
+    if (!s || !query) return;
+    if (direction === 'prev') s.findPrevious(query, { decorations: SEARCH_DECORATIONS });
+    else s.findNext(query, { decorations: SEARCH_DECORATIONS, incremental });
+  };
+
+  const onQueryChange = (value: string) => {
+    setQuery(value);
+    const s = searchRef.current;
+    if (!s) return;
+    if (!value) {
+      s.clearDecorations();
+      setMatches({ index: -1, count: 0 });
+      return;
+    }
+    s.findNext(value, { decorations: SEARCH_DECORATIONS, incremental: true });
+  };
+
+  const closeSearch = () => {
+    setSearchOpen(false);
+    searchRef.current?.clearDecorations();
+    setMatches({ index: -1, count: 0 });
+    termRef.current?.focus();
+  };
+
+  const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      runFind(e.shiftKey ? 'prev' : 'next');
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeSearch();
+    } else if (isFindHotkey(e)) {
+      // Focus is already in the field — keep the browser find bar from opening; reselect instead.
+      e.preventDefault();
+      e.currentTarget.select();
+    }
+  };
+
+  const matchLabel =
+    matches.count === 0 ? '0/0' : `${matches.index >= 0 ? matches.index + 1 : '?'}/${matches.count}`;
+
   return (
     <div className="flex h-full min-h-0 flex-col" style={{ backgroundColor: TERMINAL_BG }}>
       {status === 'disabled' ? (
@@ -262,6 +383,60 @@ export const TerminalView: React.FC<{
       ) : (
         <div className="relative min-h-0 flex-1">
           <div ref={containerRef} className="absolute inset-0 overflow-hidden p-1.5" />
+          {searchOpen && (
+            // Compact find widget pinned to the terminal's top-right, like an editor's find bar. Colors
+            // are fixed-dark (not theme tokens) because the terminal body is theme-locked dark — the
+            // same reason the touch key bar below uses fixed colors rather than the global palette.
+            <div className="absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-lg border border-zinc-700/80 bg-zinc-900/95 px-1.5 py-1 shadow-lg backdrop-blur-sm">
+              <Search className="ml-0.5 size-3.5 shrink-0 text-zinc-500" aria-hidden />
+              <Input
+                ref={searchInputRef}
+                variant="bare"
+                value={query}
+                onChange={(e) => onQueryChange(e.target.value)}
+                onKeyDown={onSearchKeyDown}
+                placeholder={t('apps.terminal.search.placeholder')}
+                aria-label={t('apps.terminal.search.ariaLabel')}
+                spellCheck={false}
+                autoComplete="off"
+                className="h-6 w-36 px-1 text-[12px] text-zinc-100 placeholder:text-zinc-500 sm:w-48"
+              />
+              {query && (
+                <span
+                  className="shrink-0 px-1 text-[11px] tabular-nums text-zinc-500"
+                  aria-live="polite"
+                >
+                  {matchLabel}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => runFind('prev')}
+                disabled={matches.count === 0}
+                aria-label={t('apps.terminal.search.prev')}
+                className="grid size-6 shrink-0 place-items-center rounded text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:opacity-40 disabled:hover:bg-transparent"
+              >
+                <ChevronUp className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => runFind('next')}
+                disabled={matches.count === 0}
+                aria-label={t('apps.terminal.search.next')}
+                className="grid size-6 shrink-0 place-items-center rounded text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:opacity-40 disabled:hover:bg-transparent"
+              >
+                <ChevronDown className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={closeSearch}
+                aria-label={t('apps.terminal.search.close')}
+                className="grid size-6 shrink-0 place-items-center rounded text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          )}
           {(status === 'closed' || status === 'error') && (
             // The "connected" status no longer occupies its own row — it lives in the tab bar.
             // Only the terminating states surface in the body, as a centred overlay that offers

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -806,7 +806,14 @@
         "interrupt": "^C",
         "pipe": "|"
       },
-      "renameHint": "Double-click to rename"
+      "renameHint": "Double-click to rename",
+      "search": {
+        "placeholder": "Search",
+        "ariaLabel": "Search terminal output",
+        "prev": "Previous match",
+        "next": "Next match",
+        "close": "Close search"
+      }
     },
     "picker": {
       "openFolderTitle": "Open Folder",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -806,7 +806,14 @@
         "interrupt": "^C",
         "pipe": "|"
       },
-      "renameHint": "双击重命名"
+      "renameHint": "双击重命名",
+      "search": {
+        "placeholder": "搜索",
+        "ariaLabel": "搜索终端输出",
+        "prev": "上一个匹配",
+        "next": "下一个匹配",
+        "close": "关闭搜索"
+      }
     },
     "picker": {
       "openFolderTitle": "打开文件夹",


### PR DESCRIPTION
## Capability

Adds two long-missing affordances to the Workbench **Terminal** (`TerminalView`):

1. **Clickable links** — a **modifier-click** on a URL in terminal output (⌘-click on Apple, Ctrl-click elsewhere) opens it in a new browser tab (`window.open(url, '_blank', 'noopener')`; `noopener` defeats reverse-tabnabbing, which the addon's own typings explicitly warn about). Powered by `@xterm/addon-web-links`. The modifier requirement is deliberate: persistent sessions run tmux with `mouse on`, so a **plain** click stays terminal input (tmux/copy-mode/TUIs) — same convention as VS Code / iTerm / GNOME Terminal.
2. **Scrollback search** — the platform Find chord opens a compact find bar pinned to the terminal's top-right: text input, live match counter (`3/12`), prev/next, and `Esc`/`×` to close. `Enter` = next, `Shift+Enter` = previous. Matches are highlighted (amber; active match brighter) via `@xterm/addon-search`.

### Find-chord scoping (why it's gated)
The chord is **⌘F on Apple platforms, Ctrl+Shift+F on Windows/Linux** — and it's intercepted **only while the terminal has focus** (via xterm's `attachCustomKeyEventHandler`), so the browser's own find stays available everywhere else in the app. The chord choice is deliberate: **plain Ctrl+F is a live terminal key on both macOS and Linux** (readline `forward-char`, `less`/`vim` page-forward), so it must keep reaching the PTY. ⌘ is a free modifier on Apple; elsewhere the Shift-qualified chord is exactly what native terminals bind for find (GNOME Terminal, Konsole, Windows Terminal).

## Search scope under tmux (stated per reality)
Persistent terminal sessions run **tmux**, a full-screen app that uses xterm's **alternate screen buffer, which has no scrollback**. So the SearchAddon searches **only the currently visible pane content**, not tmux's scrollback history (that lives in tmux copy-mode). This is still useful for locating text within a long visible pane, and it is **fully** useful for the non-tmux plain-shell fallback, where xterm's own ~1000-line scrollback applies. Searching tmux history server-side is intentionally **out of scope** for this PR.

## Dependencies / lockfile discipline
- Added `@xterm/addon-search@^0.16.0` and `@xterm/addon-web-links@^0.12.0` — the stable xterm-6 release line (published alongside `@xterm/xterm@6.0.0` and the existing `@xterm/addon-fit@0.11.0`); both are zero-dependency.
- `npm install` on macOS pruned two Linux WASM peer entries (`@emnapi/core`, `@emnapi/runtime`) from `package-lock.json` — the known PR #682 hazard. Fixed by restoring the pristine lock and **surgically inserting only the two new packages**: the lock diff is **+14 / −0**, and Linux optional-dep invariants are unchanged (`linux-x64` × 24). A clean `npm ci` installs both addons and leaves the lock untouched.

## Evidence
- **Unit / contract / scenario:** none added — `TerminalView` is a WebSocket-bound xterm component with no existing unit/scenario harness, and this change adds no shared/business logic. No scenario catalog applies to it.
- **Build (CI gate):** `cd ui && npm run build` (`tsc -b && vite build`) passes; `npm ci` validates the lockfile is self-consistent and CI-safe.
- **Residual manual checks** (to verify in the running Workbench terminal):
  - [ ] ⌘F (Apple) / Ctrl+Shift+F (Windows/Linux) opens the bar only when the terminal is focused; the same chord elsewhere still triggers the browser find.
  - [ ] Plain Ctrl+F still works as a terminal key on **both macOS and Linux** (e.g. in `vim` / `less` / readline).
  - [ ] Typing highlights matches; Enter / Shift+Enter and prev/next navigate; the counter tracks; Esc / × closes and refocuses the terminal.
  - [ ] With a CJK IME, pressing Enter to commit a candidate does **not** trigger a search; navigation resumes after the candidate commits.
  - [ ] **Modifier-click** (⌘-click on Apple, Ctrl-click elsewhere) on a URL opens it in a new tab; a **plain** click stays terminal input (does not open a tab) under tmux `mouse on`.
  - [ ] The search bar renders dark and legible in **both** light and dark app themes (the terminal body is theme-locked dark).

Frontend-only. No backend, config, or routing changes.

---

### Review round 1 (Codex) — addressed in `39ddccd4`
- **P2 Preserve Ctrl+F on Linux:** switched the non-Apple chord from `Ctrl+F` to `Ctrl+Shift+F` so plain Ctrl+F keeps reaching the PTY on Linux (same rationale as macOS).
- **P2 IME composition:** `onSearchKeyDown` now returns early on `e.nativeEvent.isComposing`, so a CJK candidate-commit Enter no longer runs a premature search.
- **P3 Stale query on close:** `closeSearch` now clears the query, so reopening the bar starts fresh instead of showing a misleading `0/0`.

### Review round 2 (Codex) — addressed in `7f31a1ba`
- **P2 Require a modifier before opening links:** the WebLinksAddon handler now opens a URL only on a modifier-click (⌘ on Apple, Ctrl elsewhere), so plain clicks stay terminal input under tmux `mouse on`.
