### PR TITLE
feat(files): add undoable delete staging

### DIFF
--- a/core/file_browser_service.py
+++ b/core/file_browser_service.py
@@ -284,11 +284,69 @@ def _os_rename_noreplace(source: Path, target: Path) -> None:
     source.rename(target)
 
 
+def _rename_no_replace_into_dir(
+    source: Path,
+    target_parent_fd: int | None,
+    target_parent: Path,
+    target_name: str,
+) -> None:
+    if target_parent_fd is None:
+        _rename_no_replace(source, target_parent / target_name)
+        return
+
+    try:
+        _glibc_renameat2_noreplace_between(
+            _AT_FDCWD,
+            os.fsencode(source),
+            target_parent_fd,
+            os.fsencode(target_name),
+            target_name,
+        )
+        return
+    except FileExistsError as exc:
+        raise ConflictError("exists", "Destination already exists") from exc
+    except OSError as exc:
+        if exc.errno == errno.EXDEV:
+            raise
+        if exc.errno not in {errno.ENOSYS, errno.EINVAL, errno.ENOTSUP, errno.EOPNOTSUPP}:
+            raise
+    except AttributeError:
+        pass
+
+    try:
+        os.link(source, target_name, dst_dir_fd=target_parent_fd, follow_symlinks=False)
+    except FileExistsError as exc:
+        raise ConflictError("exists", "Destination already exists") from exc
+    except OSError as exc:
+        if exc.errno == errno.EXDEV:
+            raise
+    else:
+        _unlink_source_after_hard_link_at(source, target_parent_fd, target_name)
+        return
+
+    _warn_rename_noreplace_fallback()
+    try:
+        os.stat(target_name, dir_fd=target_parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        pass
+    else:
+        raise ConflictError("exists", "Destination already exists")
+    os.rename(source, target_name, dst_dir_fd=target_parent_fd)
+
+
 def _unlink_source_after_hard_link(source: Path, target: Path) -> None:
     try:
         os.unlink(source)
     except OSError:
         _remove_created_hard_link(target, source)
+        raise
+
+
+def _unlink_source_after_hard_link_at(source: Path, target_parent_fd: int, target_name: str) -> None:
+    try:
+        os.unlink(source)
+    except OSError:
+        _remove_created_hard_link_at(target_parent_fd, target_name, source)
         raise
 
 
@@ -298,6 +356,16 @@ def _remove_created_hard_link(target: Path, source: Path) -> None:
         target_stat = target.lstat()
         if (source_stat.st_dev, source_stat.st_ino) == (target_stat.st_dev, target_stat.st_ino):
             os.unlink(target)
+    except OSError:
+        logger.debug("Failed to remove rollback hard link after no-replace rename failure", exc_info=True)
+
+
+def _remove_created_hard_link_at(target_parent_fd: int, target_name: str, source: Path) -> None:
+    try:
+        source_stat = source.lstat()
+        target_stat = os.stat(target_name, dir_fd=target_parent_fd, follow_symlinks=False)
+        if (source_stat.st_dev, source_stat.st_ino) == (target_stat.st_dev, target_stat.st_ino):
+            os.unlink(target_name, dir_fd=target_parent_fd)
     except OSError:
         logger.debug("Failed to remove rollback hard link after no-replace rename failure", exc_info=True)
 
@@ -1421,6 +1489,24 @@ def _delete_undo_store_within_caps(entries: list[DeleteUndoEntry]) -> bool:
     )
 
 
+def _discard_delete_undo_stage_or_raise(stage_dir: Path, root: Path, *, target_parent: Path | None = None) -> None:
+    if not _delete_undo_remove_path(stage_dir):
+        raise FileBrowserError("fs_error", "Failed to remove delete undo staging entry", 400)
+    if target_parent is not None:
+        _fsync_dir(target_parent)
+    _fsync_dir(root)
+
+
+def _restore_staged_directory_after_not_empty(staged_entry: Path, target: Path, stage_dir: Path, root: Path) -> None:
+    try:
+        _rename_no_replace(staged_entry, target)
+    except ConflictError as exc:
+        raise FileBrowserError("fs_error", "Failed to restore non-empty directory after staging", 400) from exc
+    except OSError as exc:
+        raise FileBrowserError("fs_error", str(exc), 400) from exc
+    _discard_delete_undo_stage_or_raise(stage_dir, root, target_parent=target.parent)
+
+
 def _delete_undo_parent_matches(entry: DeleteUndoEntry) -> bool:
     try:
         parent_stat = entry.original_path.parent.lstat()
@@ -1431,6 +1517,60 @@ def _delete_undo_parent_matches(entry: DeleteUndoEntry) -> bool:
         and not stat.S_ISLNK(parent_stat.st_mode)
         and (parent_stat.st_dev, parent_stat.st_ino) == (entry.parent_dev, entry.parent_ino)
     )
+
+
+def _open_verified_delete_undo_parent(entry: DeleteUndoEntry) -> int | None:
+    if os.name != "posix":
+        if _delete_undo_parent_matches(entry):
+            return None
+        raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = -1
+    try:
+        fd = os.open(entry.original_path.parent, flags)
+        parent_stat = os.fstat(fd)
+        if (
+            not stat.S_ISDIR(parent_stat.st_mode)
+            or stat.S_ISLNK(parent_stat.st_mode)
+            or (parent_stat.st_dev, parent_stat.st_ino) != (entry.parent_dev, entry.parent_ino)
+        ):
+            raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
+        return fd
+    except FileBrowserError:
+        if fd >= 0:
+            os.close(fd)
+        raise
+    except OSError as exc:
+        if fd >= 0:
+            os.close(fd)
+        raise FileBrowserError("expired", "Undo token expired or unavailable", 410) from exc
+
+
+def _delete_undo_target_exists(parent_fd: int | None, target: Path) -> bool:
+    if parent_fd is None:
+        return _exists_no_follow(target)
+    try:
+        os.stat(target.name, dir_fd=parent_fd, follow_symlinks=False)
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise FileBrowserError("fs_error", str(exc), 400) from exc
+
+
+def _fsync_delete_undo_parent(parent_fd: int | None, parent: Path) -> None:
+    if parent_fd is None:
+        _fsync_dir(parent)
+        return
+    try:
+        os.fsync(parent_fd)
+    except OSError:
+        pass
 
 
 def _ensure_delete_undo_initialized() -> None:
@@ -1539,24 +1679,24 @@ def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursi
                 return None
             _os_rename_noreplace(target, staged_entry)
             renamed_to_stage = True
+            if current_is_dir and not recursive and _directory_empty_no_follow(staged_entry) is not True:
+                _restore_staged_directory_after_not_empty(staged_entry, target, stage_dir, root)
+                raise ConflictError("not_empty", "Directory is not empty")
             staged_size = _entry_size_no_follow(staged_entry, cap=effective_size_cap)
             if staged_size is None or staged_size > effective_size_cap:
-                _delete_undo_remove_path(stage_dir)
-                _fsync_dir(target.parent)
-                _fsync_dir(root)
+                _discard_delete_undo_stage_or_raise(stage_dir, root, target_parent=target.parent)
                 return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
             if staged_size != size:
                 metadata_payload["size"] = staged_size
                 _replace_delete_undo_metadata(metadata_path, metadata_payload)
         except OSError as exc:
             if stage_dir is not None:
-                _delete_undo_remove_path(stage_dir)
-                _fsync_dir(root)
+                _discard_delete_undo_stage_or_raise(
+                    stage_dir,
+                    root,
+                    target_parent=target.parent if renamed_to_stage else None,
+                )
             if renamed_to_stage:
-                try:
-                    _fsync_dir(target.parent)
-                except OSError:
-                    logger.debug("Failed to fsync delete parent after undo staging fallback", exc_info=True)
                 logger.debug("Delete undo staging failed after rename; treating delete as permanent: %s", exc)
                 return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
             logger.debug("Delete undo staging failed; falling back to permanent delete: %s", exc)
@@ -1570,8 +1710,7 @@ def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursi
             logger.debug("Delete undo staging cap purge failed after staging", exc_info=True)
             staged_retained = True
         if not staged_retained:
-            _delete_undo_remove_path(stage_dir)
-            _fsync_dir(root)
+            _discard_delete_undo_stage_or_raise(stage_dir, root, target_parent=target.parent)
             return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
     return {"ok": True, "undo_token": token, "undo_expires_seconds": ttl}
 
@@ -1615,31 +1754,43 @@ def undo_delete_path(token: str) -> dict[str, Any]:
         if entry is None or now - entry.deleted_at > _delete_undo_ttl_seconds():
             _delete_undo_remove_path(stage_dir)
             raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
-        if not _delete_undo_parent_matches(entry):
-            _delete_undo_remove_path(stage_dir)
-            _fsync_dir(root)
-            raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
-        if _exists_no_follow(entry.original_path):
-            raise ConflictError("exists", "Original path already exists")
-
-        def _restore() -> dict[str, Any]:
-            try:
-                _rename_no_replace(entry.entry_path, entry.original_path)
-            except ConflictError:
-                raise
-            except OSError as exc:
-                raise FileBrowserError("fs_error", str(exc), 400) from exc
-            _fsync_dir(entry.original_path.parent)
-            _fsync_dir(entry.directory)
-            try:
-                entry.metadata_path.unlink()
-                entry.directory.rmdir()
+        try:
+            parent_fd = _open_verified_delete_undo_parent(entry)
+        except FileBrowserError as exc:
+            if exc.code == "expired":
+                _delete_undo_remove_path(stage_dir)
                 _fsync_dir(root)
-            except OSError:
-                logger.debug("Failed to clean up delete undo staging directory after restore", exc_info=True)
-            return {"restored_path": str(entry.original_path)}
+            raise
+        try:
+            if _delete_undo_target_exists(parent_fd, entry.original_path):
+                raise ConflictError("exists", "Original path already exists")
 
-        return _run_mutation("delete_undo", entry.original_path, _restore)
+            def _restore() -> dict[str, Any]:
+                try:
+                    _rename_no_replace_into_dir(
+                        entry.entry_path,
+                        parent_fd,
+                        entry.original_path.parent,
+                        entry.original_path.name,
+                    )
+                except ConflictError:
+                    raise
+                except OSError as exc:
+                    raise FileBrowserError("fs_error", str(exc), 400) from exc
+                _fsync_delete_undo_parent(parent_fd, entry.original_path.parent)
+                _fsync_dir(entry.directory)
+                try:
+                    entry.metadata_path.unlink()
+                    entry.directory.rmdir()
+                    _fsync_dir(root)
+                except OSError:
+                    logger.debug("Failed to clean up delete undo staging directory after restore", exc_info=True)
+                return {"restored_path": str(entry.original_path)}
+
+            return _run_mutation("delete_undo", entry.original_path, _restore)
+        finally:
+            if parent_fd is not None:
+                os.close(parent_fd)
 
 
 # ---------------------------------------------------------------------------

--- a/core/file_browser_service.py
+++ b/core/file_browser_service.py
@@ -4,6 +4,7 @@ import ctypes
 import errno
 import fnmatch
 import hashlib
+import json
 import logging
 import mimetypes
 import os
@@ -23,6 +24,10 @@ logger = logging.getLogger(__name__)
 
 MAX_FILE_BYTES = 25 * 1024 * 1024
 MAX_LIST_ENTRIES = 5000
+DELETE_UNDO_TTL_SECONDS = 3600
+DELETE_UNDO_MAX_ENTRIES = 32
+DELETE_UNDO_ENTRY_SIZE_CAP_BYTES = 512 * 1024 * 1024
+DELETE_UNDO_TOTAL_SIZE_CAP_BYTES = 2 * 1024 * 1024 * 1024
 
 INLINE_SAFE_CONTENT_TYPES = {
     "image/png",
@@ -62,6 +67,15 @@ _WRITE_TEMP_PREFIX = ".avibe-write-"
 _UPLOAD_CHUNK_BYTES = 1024 * 1024
 _NO_REPLACE_UNSUPPORTED_ERRNOS = {errno.ENOSYS, errno.EINVAL, errno.ENOTSUP, errno.EOPNOTSUPP}
 _HARD_LINK_UNSUPPORTED_ERRNOS = {errno.EPERM, errno.EXDEV, errno.ENOTSUP, errno.EOPNOTSUPP}
+_DELETE_UNDO_DIR_NAME = "files_undo"
+_DELETE_UNDO_ENTRY_NAME = "entry"
+_DELETE_UNDO_METADATA_NAME = "metadata.json"
+_DELETE_UNDO_LOCK = threading.Lock()
+_DELETE_UNDO_INITIALIZED = False
+_DELETE_UNDO_ENTRY_SIZE_CAP_ENV = "AVIBE_FILES_UNDO_SIZE_CAP_BYTES"
+_DELETE_UNDO_TTL_ENV = "AVIBE_FILES_UNDO_TTL_SECONDS"
+_DELETE_UNDO_MAX_ENTRIES_ENV = "AVIBE_FILES_UNDO_MAX_ENTRIES"
+_DELETE_UNDO_TOTAL_SIZE_CAP_ENV = "AVIBE_FILES_UNDO_TOTAL_SIZE_CAP_BYTES"
 
 
 class FileBrowserError(Exception):
@@ -88,6 +102,17 @@ class FileContent:
     mime: str
     disposition: str
     data: bytes
+
+
+@dataclass(frozen=True)
+class DeleteUndoEntry:
+    token: str
+    directory: Path
+    entry_path: Path
+    metadata_path: Path
+    original_path: Path
+    deleted_at: float
+    size: int
 
 
 def resolve_safe_path(raw: str) -> Path:
@@ -1167,6 +1192,246 @@ def _remove_path_if_exists_best_effort(path: Path) -> None:
         logger.debug("Failed to remove move backup after preserving placed target", exc_info=True)
 
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning("Ignoring invalid integer value for %s", name)
+        return default
+
+
+def _delete_undo_ttl_seconds() -> int:
+    return _env_int(_DELETE_UNDO_TTL_ENV, DELETE_UNDO_TTL_SECONDS)
+
+
+def _delete_undo_max_entries() -> int:
+    return _env_int(_DELETE_UNDO_MAX_ENTRIES_ENV, DELETE_UNDO_MAX_ENTRIES)
+
+
+def _delete_undo_entry_size_cap_bytes() -> int:
+    return _env_int(_DELETE_UNDO_ENTRY_SIZE_CAP_ENV, DELETE_UNDO_ENTRY_SIZE_CAP_BYTES)
+
+
+def _delete_undo_total_size_cap_bytes() -> int:
+    return _env_int(_DELETE_UNDO_TOTAL_SIZE_CAP_ENV, DELETE_UNDO_TOTAL_SIZE_CAP_BYTES)
+
+
+def _delete_undo_root() -> Path:
+    from config import paths
+
+    return paths.get_runtime_dir() / _DELETE_UNDO_DIR_NAME
+
+
+def _ensure_delete_undo_root() -> Path:
+    root = _delete_undo_root()
+    root.mkdir(parents=True, exist_ok=True)
+    stat_result = root.lstat()
+    if stat.S_ISLNK(stat_result.st_mode) or not stat.S_ISDIR(stat_result.st_mode):
+        raise OSError(errno.ENOTDIR, "delete undo staging root is not a directory", str(root))
+    return root
+
+
+def _entry_size_no_follow(path: Path, *, cap: int) -> int | None:
+    total = 0
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            stat_result = current.lstat()
+        except OSError:
+            return None
+        total += max(0, stat_result.st_size)
+        if total > cap:
+            return total
+        if not stat.S_ISDIR(stat_result.st_mode):
+            continue
+        try:
+            with os.scandir(current) as iterator:
+                stack.extend(Path(entry.path) for entry in iterator)
+        except OSError:
+            return None
+    return total
+
+
+def _write_delete_undo_metadata(path: Path, payload: dict[str, Any]) -> None:
+    data = json.dumps(payload, sort_keys=True).encode("utf-8")
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    try:
+        os.write(fd, data)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _delete_undo_entry_from_dir(directory: Path) -> DeleteUndoEntry | None:
+    if not re.fullmatch(r"[0-9a-f]{32}", directory.name):
+        return None
+    if not directory.is_dir() or directory.is_symlink():
+        return None
+    metadata_path = directory / _DELETE_UNDO_METADATA_NAME
+    entry_path = directory / _DELETE_UNDO_ENTRY_NAME
+    try:
+        payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        original_path = Path(str(payload["original_path"]))
+        deleted_at = float(payload["deleted_at"])
+        size = int(payload["size"])
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not original_path.is_absolute() or "\x00" in str(original_path) or deleted_at < 0 or size < 0:
+        return None
+    if not _exists_no_follow(entry_path):
+        return None
+    return DeleteUndoEntry(
+        token=directory.name,
+        directory=directory,
+        entry_path=entry_path,
+        metadata_path=metadata_path,
+        original_path=original_path,
+        deleted_at=deleted_at,
+        size=size,
+    )
+
+
+def _purge_delete_undo_store_locked(root: Path, *, now: float | None = None) -> list[DeleteUndoEntry]:
+    current_time = time.time() if now is None else now
+    ttl = _delete_undo_ttl_seconds()
+    entries: list[DeleteUndoEntry] = []
+    try:
+        children = list(root.iterdir())
+    except FileNotFoundError:
+        return []
+    for child in children:
+        entry = _delete_undo_entry_from_dir(child)
+        if entry is None or current_time - entry.deleted_at > ttl:
+            _remove_path_if_exists_best_effort(child)
+            continue
+        entries.append(entry)
+
+    entries.sort(key=lambda item: (item.deleted_at, item.token))
+    max_entries = _delete_undo_max_entries()
+    while len(entries) > max_entries:
+        victim = entries.pop(0)
+        _remove_path_if_exists_best_effort(victim.directory)
+
+    total_cap = _delete_undo_total_size_cap_bytes()
+    total_size = sum(entry.size for entry in entries)
+    while entries and total_size > total_cap:
+        victim = entries.pop(0)
+        total_size -= victim.size
+        _remove_path_if_exists_best_effort(victim.directory)
+    return entries
+
+
+def _ensure_delete_undo_initialized() -> None:
+    global _DELETE_UNDO_INITIALIZED
+    if _DELETE_UNDO_INITIALIZED:
+        return
+    with _DELETE_UNDO_LOCK:
+        if _DELETE_UNDO_INITIALIZED:
+            return
+        try:
+            root = _ensure_delete_undo_root()
+            _purge_delete_undo_store_locked(root)
+        except OSError:
+            logger.debug("Delete undo staging initialization failed", exc_info=True)
+            return
+        _DELETE_UNDO_INITIALIZED = True
+
+
+def _purge_delete_undo_store_best_effort() -> None:
+    _ensure_delete_undo_initialized()
+    with _DELETE_UNDO_LOCK:
+        try:
+            root = _ensure_delete_undo_root()
+            _purge_delete_undo_store_locked(root)
+        except OSError:
+            logger.debug("Delete undo staging purge failed", exc_info=True)
+
+
+def _delete_permanently(target: Path, target_stat: os.stat_result, *, recursive: bool) -> dict[str, Any]:
+    try:
+        if stat.S_ISDIR(target_stat.st_mode):
+            if recursive:
+                shutil.rmtree(target)
+            else:
+                target.rmdir()
+        else:
+            target.unlink()
+        return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
+    except OSError as exc:
+        if stat.S_ISDIR(target_stat.st_mode) and not recursive and exc.errno in {errno.ENOTEMPTY, errno.EEXIST}:
+            raise ConflictError("not_empty", "Directory is not empty") from exc
+        if isinstance(exc, FileNotFoundError):
+            raise NotFoundError() from exc
+        if isinstance(exc, PermissionError):
+            raise FileBrowserError("permission_denied", "Permission denied", 403) from exc
+        raise FileBrowserError("fs_error", str(exc), 400) from exc
+
+
+def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursive: bool) -> dict[str, Any] | None:
+    if stat.S_ISDIR(target_stat.st_mode) and not recursive:
+        return None
+
+    entry_size_cap = _delete_undo_entry_size_cap_bytes()
+    total_size_cap = _delete_undo_total_size_cap_bytes()
+    effective_size_cap = min(entry_size_cap, total_size_cap)
+    if effective_size_cap <= 0:
+        return None
+    size = _entry_size_no_follow(target, cap=effective_size_cap)
+    if size is None or size > effective_size_cap:
+        return None
+
+    _ensure_delete_undo_initialized()
+    ttl = _delete_undo_ttl_seconds()
+    now = time.time()
+    token = uuid.uuid4().hex
+
+    with _DELETE_UNDO_LOCK:
+        stage_dir: Path | None = None
+        try:
+            root = _ensure_delete_undo_root()
+            _purge_delete_undo_store_locked(root, now=now)
+            stage_dir = root / token
+            stage_dir.mkdir(mode=0o700)
+            metadata_path = stage_dir / _DELETE_UNDO_METADATA_NAME
+            staged_entry = stage_dir / _DELETE_UNDO_ENTRY_NAME
+            _write_delete_undo_metadata(
+                metadata_path,
+                {
+                    "original_path": str(target),
+                    "deleted_at": now,
+                    "size": size,
+                },
+            )
+            _fsync_dir(stage_dir)
+            _os_rename_noreplace(target, staged_entry)
+        except OSError as exc:
+            if stage_dir is not None:
+                _remove_path_if_exists_best_effort(stage_dir)
+            logger.debug("Delete undo staging failed; falling back to permanent delete: %s", exc)
+            return None
+        _fsync_dir(stage_dir)
+        _fsync_dir(target.parent)
+        try:
+            entries = _purge_delete_undo_store_locked(root, now=now)
+            staged_retained = any(entry.token == token for entry in entries)
+        except OSError:
+            logger.debug("Delete undo staging cap purge failed after staging", exc_info=True)
+            staged_retained = True
+        if not staged_retained:
+            return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
+    return {"ok": True, "undo_token": token, "undo_expires_seconds": ttl}
+
+
+def _validate_delete_undo_token(token: str) -> str:
+    if not isinstance(token, str) or not re.fullmatch(r"[0-9a-f]{32}", token):
+        raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
+    return token
+
+
 def delete_path(raw_path: str, *, recursive: bool = False) -> dict[str, Any]:
     target = _resolve_existing_entry_path(raw_path)
     if target == target.parent:
@@ -1176,25 +1441,49 @@ def delete_path(raw_path: str, *, recursive: bool = False) -> dict[str, Any]:
     target_stat = _stat_existing(target, follow_symlinks=False)
 
     def _delete() -> dict[str, Any]:
-        try:
-            if stat.S_ISDIR(target_stat.st_mode):
-                if recursive:
-                    shutil.rmtree(target)
-                else:
-                    target.rmdir()
-            else:
-                target.unlink()
-            return {"ok": True}
-        except OSError as exc:
-            if stat.S_ISDIR(target_stat.st_mode) and not recursive and exc.errno in {errno.ENOTEMPTY, errno.EEXIST}:
-                raise ConflictError("not_empty", "Directory is not empty") from exc
-            if isinstance(exc, FileNotFoundError):
-                raise NotFoundError() from exc
-            if isinstance(exc, PermissionError):
-                raise FileBrowserError("permission_denied", "Permission denied", 403) from exc
-            raise FileBrowserError("fs_error", str(exc), 400) from exc
+        _purge_delete_undo_store_best_effort()
+        staged = _stage_delete_for_undo(target, target_stat, recursive=recursive)
+        if staged is not None:
+            return staged
+        return _delete_permanently(target, target_stat, recursive=recursive)
 
     return _run_mutation("delete", target, _delete, recursive=recursive)
+
+
+def undo_delete_path(token: str) -> dict[str, Any]:
+    token = _validate_delete_undo_token(token)
+    _ensure_delete_undo_initialized()
+    with _DELETE_UNDO_LOCK:
+        try:
+            root = _ensure_delete_undo_root()
+            _purge_delete_undo_store_locked(root)
+        except OSError as exc:
+            raise FileBrowserError("expired", "Undo token expired or unavailable", 410) from exc
+        stage_dir = root / token
+        entry = _delete_undo_entry_from_dir(stage_dir)
+        if entry is None:
+            _remove_path_if_exists_best_effort(stage_dir)
+            raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
+        if _exists_no_follow(entry.original_path):
+            raise ConflictError("exists", "Original path already exists")
+
+        def _restore() -> dict[str, Any]:
+            try:
+                _rename_no_replace(entry.entry_path, entry.original_path)
+            except ConflictError:
+                raise
+            except OSError as exc:
+                raise FileBrowserError("fs_error", str(exc), 400) from exc
+            _fsync_dir(entry.original_path.parent)
+            _fsync_dir(entry.directory)
+            try:
+                entry.metadata_path.unlink()
+                entry.directory.rmdir()
+            except OSError:
+                logger.debug("Failed to clean up delete undo staging directory after restore", exc_info=True)
+            return {"restored_path": str(entry.original_path)}
+
+        return _run_mutation("delete_undo", entry.original_path, _restore)
 
 
 # ---------------------------------------------------------------------------

--- a/core/file_browser_service.py
+++ b/core/file_browser_service.py
@@ -1192,6 +1192,15 @@ def _remove_path_if_exists_best_effort(path: Path) -> None:
         logger.debug("Failed to remove move backup after preserving placed target", exc_info=True)
 
 
+def _delete_undo_remove_path(path: Path) -> bool:
+    try:
+        _remove_path_if_exists(path)
+        return True
+    except OSError:
+        logger.debug("Failed to remove delete undo staging path", exc_info=True)
+        return False
+
+
 def _env_int(name: str, default: int) -> int:
     raw = os.environ.get(name)
     if raw is None or raw == "":
@@ -1256,6 +1265,28 @@ def _entry_size_no_follow(path: Path, *, cap: int) -> int | None:
     return total
 
 
+def _same_staged_entry(left: os.stat_result, right: os.stat_result) -> bool:
+    return (
+        left.st_dev,
+        left.st_ino,
+        left.st_mode,
+        left.st_size,
+    ) == (
+        right.st_dev,
+        right.st_ino,
+        right.st_mode,
+        right.st_size,
+    )
+
+
+def _delete_staging_type_matches(original: os.stat_result, current: os.stat_result, *, recursive: bool) -> bool:
+    original_is_dir = stat.S_ISDIR(original.st_mode)
+    current_is_dir = stat.S_ISDIR(current.st_mode)
+    if original_is_dir != current_is_dir:
+        return False
+    return not current_is_dir or recursive
+
+
 def _write_delete_undo_metadata(path: Path, payload: dict[str, Any]) -> None:
     data = json.dumps(payload, sort_keys=True).encode("utf-8")
     fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
@@ -1306,23 +1337,42 @@ def _purge_delete_undo_store_locked(root: Path, *, now: float | None = None) -> 
     for child in children:
         entry = _delete_undo_entry_from_dir(child)
         if entry is None or current_time - entry.deleted_at > ttl:
-            _remove_path_if_exists_best_effort(child)
-            continue
+            if _delete_undo_remove_path(child):
+                _fsync_dir(root)
+                continue
+            if entry is None:
+                continue
         entries.append(entry)
 
     entries.sort(key=lambda item: (item.deleted_at, item.token))
     max_entries = _delete_undo_max_entries()
     while len(entries) > max_entries:
-        victim = entries.pop(0)
-        _remove_path_if_exists_best_effort(victim.directory)
+        if not _evict_one_delete_undo_entry(root, entries):
+            break
 
     total_cap = _delete_undo_total_size_cap_bytes()
     total_size = sum(entry.size for entry in entries)
     while entries and total_size > total_cap:
-        victim = entries.pop(0)
-        total_size -= victim.size
-        _remove_path_if_exists_best_effort(victim.directory)
+        if not _evict_one_delete_undo_entry(root, entries):
+            break
+        total_size = sum(entry.size for entry in entries)
     return entries
+
+
+def _evict_one_delete_undo_entry(root: Path, entries: list[DeleteUndoEntry]) -> bool:
+    for index, victim in enumerate(entries):
+        if _delete_undo_remove_path(victim.directory):
+            entries.pop(index)
+            _fsync_dir(root)
+            return True
+    return False
+
+
+def _delete_undo_store_within_caps(entries: list[DeleteUndoEntry]) -> bool:
+    return (
+        len(entries) <= _delete_undo_max_entries()
+        and sum(entry.size for entry in entries) <= _delete_undo_total_size_cap_bytes()
+    )
 
 
 def _ensure_delete_undo_initialized() -> None:
@@ -1380,9 +1430,6 @@ def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursi
     effective_size_cap = min(entry_size_cap, total_size_cap)
     if effective_size_cap <= 0:
         return None
-    size = _entry_size_no_follow(target, cap=effective_size_cap)
-    if size is None or size > effective_size_cap:
-        return None
 
     _ensure_delete_undo_initialized()
     ttl = _delete_undo_ttl_seconds()
@@ -1393,9 +1440,21 @@ def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursi
         stage_dir: Path | None = None
         try:
             root = _ensure_delete_undo_root()
-            _purge_delete_undo_store_locked(root, now=now)
+            existing_entries = _purge_delete_undo_store_locked(root, now=now)
+            if not _delete_undo_store_within_caps(existing_entries):
+                return None
+            current_stat = target.lstat()
+            if not _delete_staging_type_matches(target_stat, current_stat, recursive=recursive):
+                return None
+            size = _entry_size_no_follow(target, cap=effective_size_cap)
+            if size is None or size > effective_size_cap:
+                return None
+            post_size_stat = target.lstat()
+            if not _same_staged_entry(current_stat, post_size_stat):
+                return None
             stage_dir = root / token
             stage_dir.mkdir(mode=0o700)
+            _fsync_dir(root)
             metadata_path = stage_dir / _DELETE_UNDO_METADATA_NAME
             staged_entry = stage_dir / _DELETE_UNDO_ENTRY_NAME
             _write_delete_undo_metadata(
@@ -1407,21 +1466,29 @@ def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursi
                 },
             )
             _fsync_dir(stage_dir)
+            pre_rename_stat = target.lstat()
+            if not _same_staged_entry(post_size_stat, pre_rename_stat):
+                _delete_undo_remove_path(stage_dir)
+                _fsync_dir(root)
+                return None
             _os_rename_noreplace(target, staged_entry)
         except OSError as exc:
             if stage_dir is not None:
-                _remove_path_if_exists_best_effort(stage_dir)
+                _delete_undo_remove_path(stage_dir)
+                _fsync_dir(root)
             logger.debug("Delete undo staging failed; falling back to permanent delete: %s", exc)
             return None
         _fsync_dir(stage_dir)
         _fsync_dir(target.parent)
         try:
             entries = _purge_delete_undo_store_locked(root, now=now)
-            staged_retained = any(entry.token == token for entry in entries)
+            staged_retained = any(entry.token == token for entry in entries) and _delete_undo_store_within_caps(entries)
         except OSError:
             logger.debug("Delete undo staging cap purge failed after staging", exc_info=True)
             staged_retained = True
         if not staged_retained:
+            _delete_undo_remove_path(stage_dir)
+            _fsync_dir(root)
             return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
     return {"ok": True, "undo_token": token, "undo_expires_seconds": ttl}
 
@@ -1454,15 +1521,16 @@ def undo_delete_path(token: str) -> dict[str, Any]:
     token = _validate_delete_undo_token(token)
     _ensure_delete_undo_initialized()
     with _DELETE_UNDO_LOCK:
+        now = time.time()
         try:
             root = _ensure_delete_undo_root()
-            _purge_delete_undo_store_locked(root)
+            _purge_delete_undo_store_locked(root, now=now)
         except OSError as exc:
             raise FileBrowserError("expired", "Undo token expired or unavailable", 410) from exc
         stage_dir = root / token
         entry = _delete_undo_entry_from_dir(stage_dir)
-        if entry is None:
-            _remove_path_if_exists_best_effort(stage_dir)
+        if entry is None or now - entry.deleted_at > _delete_undo_ttl_seconds():
+            _delete_undo_remove_path(stage_dir)
             raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
         if _exists_no_follow(entry.original_path):
             raise ConflictError("exists", "Original path already exists")
@@ -1479,6 +1547,7 @@ def undo_delete_path(token: str) -> dict[str, Any]:
             try:
                 entry.metadata_path.unlink()
                 entry.directory.rmdir()
+                _fsync_dir(root)
             except OSError:
                 logger.debug("Failed to clean up delete undo staging directory after restore", exc_info=True)
             return {"restored_path": str(entry.original_path)}

--- a/core/file_browser_service.py
+++ b/core/file_browser_service.py
@@ -111,6 +111,8 @@ class DeleteUndoEntry:
     entry_path: Path
     metadata_path: Path
     original_path: Path
+    parent_dev: int
+    parent_ino: int
     deleted_at: float
     size: int
 
@@ -1265,6 +1267,14 @@ def _entry_size_no_follow(path: Path, *, cap: int) -> int | None:
     return total
 
 
+def _directory_empty_no_follow(path: Path) -> bool | None:
+    try:
+        with os.scandir(path) as iterator:
+            return next(iterator, None) is None
+    except OSError:
+        return None
+
+
 def _same_staged_entry(left: os.stat_result, right: os.stat_result) -> bool:
     return (
         left.st_dev,
@@ -1279,12 +1289,12 @@ def _same_staged_entry(left: os.stat_result, right: os.stat_result) -> bool:
     )
 
 
-def _delete_staging_type_matches(original: os.stat_result, current: os.stat_result, *, recursive: bool) -> bool:
+def _delete_staging_type_matches(original: os.stat_result, current: os.stat_result) -> bool:
     original_is_dir = stat.S_ISDIR(original.st_mode)
     current_is_dir = stat.S_ISDIR(current.st_mode)
     if original_is_dir != current_is_dir:
         return False
-    return not current_is_dir or recursive
+    return True
 
 
 def _write_delete_undo_metadata(path: Path, payload: dict[str, Any]) -> None:
@@ -1297,6 +1307,20 @@ def _write_delete_undo_metadata(path: Path, payload: dict[str, Any]) -> None:
         os.close(fd)
 
 
+def _replace_delete_undo_metadata(path: Path, payload: dict[str, Any]) -> None:
+    temp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        _write_delete_undo_metadata(temp_path, payload)
+        os.replace(temp_path, path)
+        _fsync_dir(path.parent)
+    except OSError:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
 def _delete_undo_entry_from_dir(directory: Path) -> DeleteUndoEntry | None:
     if not re.fullmatch(r"[0-9a-f]{32}", directory.name):
         return None
@@ -1307,20 +1331,38 @@ def _delete_undo_entry_from_dir(directory: Path) -> DeleteUndoEntry | None:
     try:
         payload = json.loads(metadata_path.read_text(encoding="utf-8"))
         original_path = Path(str(payload["original_path"]))
+        parent_dev = int(payload["parent_dev"])
+        parent_ino = int(payload["parent_ino"])
         deleted_at = float(payload["deleted_at"])
-        size = int(payload["size"])
+        metadata_size = int(payload["size"])
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
         return None
-    if not original_path.is_absolute() or "\x00" in str(original_path) or deleted_at < 0 or size < 0:
+    if (
+        not original_path.is_absolute()
+        or "\x00" in str(original_path)
+        or deleted_at < 0
+        or metadata_size < 0
+        or parent_dev < 0
+        or parent_ino < 0
+    ):
         return None
     if not _exists_no_follow(entry_path):
         return None
+    effective_size_cap = min(_delete_undo_entry_size_cap_bytes(), _delete_undo_total_size_cap_bytes())
+    if effective_size_cap <= 0:
+        return None
+    actual_size = _entry_size_no_follow(entry_path, cap=effective_size_cap)
+    if actual_size is None:
+        return None
+    size = max(metadata_size, actual_size)
     return DeleteUndoEntry(
         token=directory.name,
         directory=directory,
         entry_path=entry_path,
         metadata_path=metadata_path,
         original_path=original_path,
+        parent_dev=parent_dev,
+        parent_ino=parent_ino,
         deleted_at=deleted_at,
         size=size,
     )
@@ -1341,6 +1383,10 @@ def _purge_delete_undo_store_locked(root: Path, *, now: float | None = None) -> 
                 _fsync_dir(root)
                 continue
             if entry is None:
+                continue
+        elif entry.size > min(_delete_undo_entry_size_cap_bytes(), _delete_undo_total_size_cap_bytes()):
+            if _delete_undo_remove_path(child):
+                _fsync_dir(root)
                 continue
         entries.append(entry)
 
@@ -1372,6 +1418,18 @@ def _delete_undo_store_within_caps(entries: list[DeleteUndoEntry]) -> bool:
     return (
         len(entries) <= _delete_undo_max_entries()
         and sum(entry.size for entry in entries) <= _delete_undo_total_size_cap_bytes()
+    )
+
+
+def _delete_undo_parent_matches(entry: DeleteUndoEntry) -> bool:
+    try:
+        parent_stat = entry.original_path.parent.lstat()
+    except OSError:
+        return False
+    return (
+        stat.S_ISDIR(parent_stat.st_mode)
+        and not stat.S_ISLNK(parent_stat.st_mode)
+        and (parent_stat.st_dev, parent_stat.st_ino) == (entry.parent_dev, entry.parent_ino)
     )
 
 
@@ -1422,9 +1480,6 @@ def _delete_permanently(target: Path, target_stat: os.stat_result, *, recursive:
 
 
 def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursive: bool) -> dict[str, Any] | None:
-    if stat.S_ISDIR(target_stat.st_mode) and not recursive:
-        return None
-
     entry_size_cap = _delete_undo_entry_size_cap_bytes()
     total_size_cap = _delete_undo_total_size_cap_bytes()
     effective_size_cap = min(entry_size_cap, total_size_cap)
@@ -1438,13 +1493,20 @@ def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursi
 
     with _DELETE_UNDO_LOCK:
         stage_dir: Path | None = None
+        renamed_to_stage = False
         try:
             root = _ensure_delete_undo_root()
             existing_entries = _purge_delete_undo_store_locked(root, now=now)
             if not _delete_undo_store_within_caps(existing_entries):
                 return None
             current_stat = target.lstat()
-            if not _delete_staging_type_matches(target_stat, current_stat, recursive=recursive):
+            if not _delete_staging_type_matches(target_stat, current_stat):
+                return None
+            current_is_dir = stat.S_ISDIR(current_stat.st_mode)
+            if current_is_dir and not recursive and _directory_empty_no_follow(target) is not True:
+                return None
+            parent_stat = target.parent.lstat()
+            if not stat.S_ISDIR(parent_stat.st_mode) or stat.S_ISLNK(parent_stat.st_mode):
                 return None
             size = _entry_size_no_follow(target, cap=effective_size_cap)
             if size is None or size > effective_size_cap:
@@ -1457,25 +1519,46 @@ def _stage_delete_for_undo(target: Path, target_stat: os.stat_result, *, recursi
             _fsync_dir(root)
             metadata_path = stage_dir / _DELETE_UNDO_METADATA_NAME
             staged_entry = stage_dir / _DELETE_UNDO_ENTRY_NAME
-            _write_delete_undo_metadata(
-                metadata_path,
-                {
-                    "original_path": str(target),
-                    "deleted_at": now,
-                    "size": size,
-                },
-            )
+            metadata_payload = {
+                "original_path": str(target),
+                "parent_dev": parent_stat.st_dev,
+                "parent_ino": parent_stat.st_ino,
+                "deleted_at": now,
+                "size": size,
+            }
+            _write_delete_undo_metadata(metadata_path, metadata_payload)
             _fsync_dir(stage_dir)
             pre_rename_stat = target.lstat()
             if not _same_staged_entry(post_size_stat, pre_rename_stat):
                 _delete_undo_remove_path(stage_dir)
                 _fsync_dir(root)
                 return None
+            if stat.S_ISDIR(pre_rename_stat.st_mode) and not recursive and _directory_empty_no_follow(target) is not True:
+                _delete_undo_remove_path(stage_dir)
+                _fsync_dir(root)
+                return None
             _os_rename_noreplace(target, staged_entry)
+            renamed_to_stage = True
+            staged_size = _entry_size_no_follow(staged_entry, cap=effective_size_cap)
+            if staged_size is None or staged_size > effective_size_cap:
+                _delete_undo_remove_path(stage_dir)
+                _fsync_dir(target.parent)
+                _fsync_dir(root)
+                return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
+            if staged_size != size:
+                metadata_payload["size"] = staged_size
+                _replace_delete_undo_metadata(metadata_path, metadata_payload)
         except OSError as exc:
             if stage_dir is not None:
                 _delete_undo_remove_path(stage_dir)
                 _fsync_dir(root)
+            if renamed_to_stage:
+                try:
+                    _fsync_dir(target.parent)
+                except OSError:
+                    logger.debug("Failed to fsync delete parent after undo staging fallback", exc_info=True)
+                logger.debug("Delete undo staging failed after rename; treating delete as permanent: %s", exc)
+                return {"ok": True, "undo_token": None, "undo_expires_seconds": None}
             logger.debug("Delete undo staging failed; falling back to permanent delete: %s", exc)
             return None
         _fsync_dir(stage_dir)
@@ -1531,6 +1614,10 @@ def undo_delete_path(token: str) -> dict[str, Any]:
         entry = _delete_undo_entry_from_dir(stage_dir)
         if entry is None or now - entry.deleted_at > _delete_undo_ttl_seconds():
             _delete_undo_remove_path(stage_dir)
+            raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
+        if not _delete_undo_parent_matches(entry):
+            _delete_undo_remove_path(stage_dir)
+            _fsync_dir(root)
             raise FileBrowserError("expired", "Undo token expired or unavailable", 410)
         if _exists_no_follow(entry.original_path):
             raise ConflictError("exists", "Original path already exists")

--- a/core/file_browser_service.py
+++ b/core/file_browser_service.py
@@ -72,6 +72,9 @@ _DELETE_UNDO_ENTRY_NAME = "entry"
 _DELETE_UNDO_METADATA_NAME = "metadata.json"
 _DELETE_UNDO_LOCK = threading.Lock()
 _DELETE_UNDO_INITIALIZED = False
+_DELETE_UNDO_EXPIRY_TIMER: threading.Timer | None = None
+_DELETE_UNDO_EXPIRY_TIMER_DEADLINE: float | None = None
+_DELETE_UNDO_EXPIRY_TIMER_ROOT: Path | None = None
 _DELETE_UNDO_ENTRY_SIZE_CAP_ENV = "AVIBE_FILES_UNDO_SIZE_CAP_BYTES"
 _DELETE_UNDO_TTL_ENV = "AVIBE_FILES_UNDO_TTL_SECONDS"
 _DELETE_UNDO_MAX_ENTRIES_ENV = "AVIBE_FILES_UNDO_MAX_ENTRIES"
@@ -1436,13 +1439,67 @@ def _delete_undo_entry_from_dir(directory: Path) -> DeleteUndoEntry | None:
     )
 
 
-def _purge_delete_undo_store_locked(root: Path, *, now: float | None = None) -> list[DeleteUndoEntry]:
+def _cancel_delete_undo_expiry_timer_locked() -> None:
+    global _DELETE_UNDO_EXPIRY_TIMER
+    global _DELETE_UNDO_EXPIRY_TIMER_DEADLINE
+    global _DELETE_UNDO_EXPIRY_TIMER_ROOT
+    if _DELETE_UNDO_EXPIRY_TIMER is not None:
+        _DELETE_UNDO_EXPIRY_TIMER.cancel()
+    _DELETE_UNDO_EXPIRY_TIMER = None
+    _DELETE_UNDO_EXPIRY_TIMER_DEADLINE = None
+    _DELETE_UNDO_EXPIRY_TIMER_ROOT = None
+
+
+def _schedule_delete_undo_expiry_locked(root: Path, entries: list[DeleteUndoEntry], *, now: float) -> None:
+    global _DELETE_UNDO_EXPIRY_TIMER
+    global _DELETE_UNDO_EXPIRY_TIMER_DEADLINE
+    global _DELETE_UNDO_EXPIRY_TIMER_ROOT
+    ttl = _delete_undo_ttl_seconds()
+    future_deadlines = [entry.deleted_at + ttl for entry in entries if entry.deleted_at + ttl > now]
+    if not future_deadlines:
+        _cancel_delete_undo_expiry_timer_locked()
+        return
+    deadline = min(future_deadlines)
+    if (
+        _DELETE_UNDO_EXPIRY_TIMER is not None
+        and _DELETE_UNDO_EXPIRY_TIMER.is_alive()
+        and _DELETE_UNDO_EXPIRY_TIMER_DEADLINE == deadline
+        and _DELETE_UNDO_EXPIRY_TIMER_ROOT == root
+    ):
+        return
+    _cancel_delete_undo_expiry_timer_locked()
+    timer = threading.Timer(max(0.0, deadline - now), _run_delete_undo_expiry_timer, args=(root,))
+    timer.daemon = True
+    _DELETE_UNDO_EXPIRY_TIMER = timer
+    _DELETE_UNDO_EXPIRY_TIMER_DEADLINE = deadline
+    _DELETE_UNDO_EXPIRY_TIMER_ROOT = root
+    timer.start()
+
+
+def _run_delete_undo_expiry_timer(root: Path) -> None:
+    with _DELETE_UNDO_LOCK:
+        try:
+            root_stat = root.lstat()
+            if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
+                _cancel_delete_undo_expiry_timer_locked()
+                return
+            _purge_delete_undo_store_locked(root)
+        except OSError:
+            _cancel_delete_undo_expiry_timer_locked()
+            logger.debug("Delete undo expiry purge failed", exc_info=True)
+
+
+def _purge_delete_undo_store_locked(
+    root: Path, *, now: float | None = None, schedule_expiry: bool = True
+) -> list[DeleteUndoEntry]:
     current_time = time.time() if now is None else now
     ttl = _delete_undo_ttl_seconds()
     entries: list[DeleteUndoEntry] = []
     try:
         children = list(root.iterdir())
     except FileNotFoundError:
+        if schedule_expiry:
+            _cancel_delete_undo_expiry_timer_locked()
         return []
     for child in children:
         entry = _delete_undo_entry_from_dir(child)
@@ -1470,6 +1527,8 @@ def _purge_delete_undo_store_locked(root: Path, *, now: float | None = None) -> 
         if not _evict_one_delete_undo_entry(root, entries):
             break
         total_size = sum(entry.size for entry in entries)
+    if schedule_expiry:
+        _schedule_delete_undo_expiry_locked(root, entries, now=current_time)
     return entries
 
 
@@ -1548,7 +1607,11 @@ def _open_verified_delete_undo_parent(entry: DeleteUndoEntry) -> int | None:
     except OSError as exc:
         if fd >= 0:
             os.close(fd)
-        raise FileBrowserError("expired", "Undo token expired or unavailable", 410) from exc
+        if exc.errno in {errno.ENOENT, errno.ENOTDIR, errno.ELOOP}:
+            raise FileBrowserError("expired", "Undo token expired or unavailable", 410) from exc
+        if exc.errno in {errno.EACCES, errno.EPERM} or isinstance(exc, PermissionError):
+            raise FileBrowserError("permission_denied", "Permission denied", 403) from exc
+        raise FileBrowserError("fs_error", str(exc), 400) from exc
 
 
 def _delete_undo_target_exists(parent_fd: int | None, target: Path) -> bool:

--- a/tests/test_file_browser_backend.py
+++ b/tests/test_file_browser_backend.py
@@ -18,7 +18,7 @@ from tests.ui_server_test_helpers import csrf_headers
 from vibe.ui_server import app
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def files_undo_runtime(tmp_path, monkeypatch):
     from config import paths
 
@@ -832,6 +832,18 @@ def test_delete_undo_restores_directory(files_undo_runtime, tmp_path):
     assert (nested / "child.txt").read_text(encoding="utf-8") == "child"
 
 
+def test_delete_undo_restores_empty_directory_without_recursive(files_undo_runtime, tmp_path):
+    folder = tmp_path / "empty"
+    folder.mkdir()
+
+    deleted = fs.delete_path(str(folder), recursive=False)
+
+    assert deleted["undo_token"]
+    assert not folder.exists()
+    assert fs.undo_delete_path(deleted["undo_token"]) == {"restored_path": str(folder)}
+    assert folder.is_dir()
+
+
 def test_delete_undo_token_expiry_purges_staging(files_undo_runtime, tmp_path, monkeypatch):
     now = 1000.0
     monkeypatch.setattr(fs.time, "time", lambda: now)
@@ -890,6 +902,27 @@ def test_delete_size_cap_falls_back_to_permanent_delete(files_undo_runtime, tmp_
 
     assert deleted == {"ok": True, "undo_token": None, "undo_expires_seconds": None}
     assert not target.exists()
+
+
+def test_delete_post_rename_growth_falls_back_to_permanent_delete(files_undo_runtime, tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_FILES_UNDO_SIZE_CAP_BYTES", "8")
+    target = tmp_path / "active.log"
+    target.write_text("1234", encoding="utf-8")
+    real_rename = fs._os_rename_noreplace
+
+    def rename_then_grow(source: Path, destination: Path) -> None:
+        real_rename(source, destination)
+        with destination.open("ab") as handle:
+            handle.write(b"567890")
+
+    monkeypatch.setattr(fs, "_os_rename_noreplace", rename_then_grow)
+
+    deleted = fs.delete_path(str(target))
+
+    assert deleted == {"ok": True, "undo_token": None, "undo_expires_seconds": None}
+    assert not target.exists()
+    undo_root = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME
+    assert not undo_root.exists() or not list(undo_root.iterdir())
 
 
 def test_delete_stale_file_replaced_by_directory_is_not_staged_or_removed(files_undo_runtime, tmp_path, monkeypatch):
@@ -998,6 +1031,23 @@ def test_delete_undo_failed_eviction_keeps_caps_enforced(files_undo_runtime, tmp
     assert first.read_text(encoding="utf-8") == "first"
 
 
+def test_delete_undo_purges_entry_that_grows_past_cap(files_undo_runtime, tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_FILES_UNDO_SIZE_CAP_BYTES", "8")
+    target = tmp_path / "growing.log"
+    target.write_text("1234", encoding="utf-8")
+
+    token = fs.delete_path(str(target))["undo_token"]
+    staged_entry = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token / fs._DELETE_UNDO_ENTRY_NAME
+    staged_entry.write_text("123456789", encoding="utf-8")
+
+    with pytest.raises(FileBrowserError) as exc:
+        fs.undo_delete_path(token)
+
+    assert exc.value.code == "expired"
+    assert not staged_entry.exists()
+    assert not target.exists()
+
+
 def test_delete_stages_symlink_entry_without_touching_target(files_undo_runtime, tmp_path):
     target = tmp_path / "target.txt"
     target.write_text("target", encoding="utf-8")
@@ -1013,6 +1063,26 @@ def test_delete_stages_symlink_entry_without_touching_target(files_undo_runtime,
     assert link.is_symlink()
     assert link.resolve() == target
     assert target.read_text(encoding="utf-8") == "target"
+
+
+def test_delete_undo_rejects_replaced_parent_symlink(files_undo_runtime, tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    target = parent / "note.txt"
+    target.write_text("deleted", encoding="utf-8")
+    other = tmp_path / "other"
+    other.mkdir()
+
+    token = fs.delete_path(str(target))["undo_token"]
+    parent.rmdir()
+    parent.symlink_to(other, target_is_directory=True)
+
+    with pytest.raises(FileBrowserError) as exc:
+        fs.undo_delete_path(token)
+
+    assert exc.value.code == "expired"
+    assert not (other / "note.txt").exists()
+    assert not (files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token).exists()
 
 
 def test_delete_undo_purges_corrupt_staging_entries(files_undo_runtime, tmp_path):
@@ -1044,6 +1114,7 @@ def test_delete_non_recursive_directory_maps_not_empty_only_for_not_empty_errno(
 def test_delete_non_recursive_directory_maps_permission_denied(tmp_path, monkeypatch):
     folder = tmp_path / "folder"
     folder.mkdir()
+    monkeypatch.setattr(fs, "_stage_delete_for_undo", lambda *args, **kwargs: None)
 
     def fail_rmdir(self: Path) -> None:
         if self == folder:
@@ -1063,6 +1134,7 @@ def test_delete_non_recursive_directory_maps_permission_denied(tmp_path, monkeyp
 def test_delete_non_recursive_directory_maps_concurrent_missing_to_not_found(tmp_path, monkeypatch):
     folder = tmp_path / "folder"
     folder.mkdir()
+    monkeypatch.setattr(fs, "_stage_delete_for_undo", lambda *args, **kwargs: None)
 
     def fail_rmdir(self: Path) -> None:
         if self == folder:
@@ -1082,6 +1154,7 @@ def test_delete_non_recursive_directory_maps_concurrent_missing_to_not_found(tmp
 def test_delete_non_recursive_directory_maps_generic_oserror_to_fs_error(tmp_path, monkeypatch):
     folder = tmp_path / "folder"
     folder.mkdir()
+    monkeypatch.setattr(fs, "_stage_delete_for_undo", lambda *args, **kwargs: None)
 
     def fail_rmdir(self: Path) -> None:
         if self == folder:

--- a/tests/test_file_browser_backend.py
+++ b/tests/test_file_browser_backend.py
@@ -24,9 +24,13 @@ def files_undo_runtime(tmp_path, monkeypatch):
 
     runtime = tmp_path / "runtime"
     monkeypatch.setattr(paths, "get_runtime_dir", lambda: runtime)
-    monkeypatch.setattr(fs, "_DELETE_UNDO_INITIALIZED", False)
+    with fs._DELETE_UNDO_LOCK:
+        fs._cancel_delete_undo_expiry_timer_locked()
+        fs._DELETE_UNDO_INITIALIZED = False
     yield runtime
-    fs._DELETE_UNDO_INITIALIZED = False
+    with fs._DELETE_UNDO_LOCK:
+        fs._cancel_delete_undo_expiry_timer_locked()
+        fs._DELETE_UNDO_INITIALIZED = False
 
 
 def test_resolve_safe_path_expands_home_and_requires_absolute(tmp_path, monkeypatch):
@@ -885,6 +889,49 @@ def test_delete_undo_token_expiry_purges_staging(files_undo_runtime, tmp_path, m
     assert not (files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token).exists()
 
 
+def test_delete_undo_expiry_timer_purges_without_later_file_request(files_undo_runtime, tmp_path, monkeypatch):
+    now = 2000.0
+    scheduled: list[object] = []
+
+    class FakeTimer:
+        def __init__(self, interval, function, args=(), kwargs=None):
+            self.interval = interval
+            self.function = function
+            self.args = args
+            self.kwargs = kwargs or {}
+            self.started = False
+            self.cancelled = False
+            scheduled.append(self)
+
+        def start(self):
+            self.started = True
+
+        def cancel(self):
+            self.cancelled = True
+
+        def is_alive(self):
+            return self.started and not self.cancelled
+
+    monkeypatch.setattr(fs.time, "time", lambda: now)
+    monkeypatch.setattr(fs, "DELETE_UNDO_TTL_SECONDS", 10)
+    monkeypatch.setattr(fs.threading, "Timer", FakeTimer)
+    target = tmp_path / "scheduled-expiry.txt"
+    target.write_text("expire me", encoding="utf-8")
+
+    token = fs.delete_path(str(target))["undo_token"]
+
+    assert scheduled
+    assert scheduled[-1].interval == 10
+    assert scheduled[-1].started is True
+    stage_dir = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token
+    assert stage_dir.exists()
+
+    now = 2011.0
+    scheduled[-1].function(*scheduled[-1].args, **scheduled[-1].kwargs)
+
+    assert not stage_dir.exists()
+
+
 def test_delete_undo_refuses_to_clobber_recreated_path(files_undo_runtime, tmp_path):
     target = tmp_path / "occupied.txt"
     target.write_text("deleted", encoding="utf-8")
@@ -1138,6 +1185,31 @@ def test_delete_undo_rejects_replaced_parent_symlink(files_undo_runtime, tmp_pat
     assert exc.value.code == "expired"
     assert not (other / "note.txt").exists()
     assert not (files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token).exists()
+
+
+def test_delete_undo_parent_open_permission_failure_preserves_token(files_undo_runtime, tmp_path):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    target = parent / "note.txt"
+    target.write_text("deleted", encoding="utf-8")
+    token = fs.delete_path(str(target))["undo_token"]
+    stage_dir = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token
+    real_open = fs.os.open
+
+    def fail_parent_open(path, flags, *args, **kwargs):
+        if Path(path) == parent:
+            raise PermissionError(errno.EACCES, "permission denied", str(path))
+        return real_open(path, flags, *args, **kwargs)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(fs.os, "open", fail_parent_open)
+        with pytest.raises(FileBrowserError) as exc:
+            fs.undo_delete_path(token)
+
+    assert exc.value.code == "permission_denied"
+    assert stage_dir.exists()
+    assert fs.undo_delete_path(token) == {"restored_path": str(target)}
+    assert target.read_text(encoding="utf-8") == "deleted"
 
 
 def test_delete_undo_restores_through_verified_parent_when_path_is_replaced(

--- a/tests/test_file_browser_backend.py
+++ b/tests/test_file_browser_backend.py
@@ -844,6 +844,30 @@ def test_delete_undo_restores_empty_directory_without_recursive(files_undo_runti
     assert folder.is_dir()
 
 
+def test_delete_non_recursive_directory_created_child_during_staging_returns_not_empty(
+    files_undo_runtime, tmp_path, monkeypatch
+):
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    real_rename = fs._os_rename_noreplace
+
+    def rename_then_populate(source: Path, destination: Path) -> None:
+        real_rename(source, destination)
+        if Path(destination).name == fs._DELETE_UNDO_ENTRY_NAME:
+            (Path(destination) / "child.txt").write_text("child", encoding="utf-8")
+
+    monkeypatch.setattr(fs, "_os_rename_noreplace", rename_then_populate)
+
+    with pytest.raises(FileBrowserError) as exc:
+        fs.delete_path(str(folder), recursive=False)
+
+    assert exc.value.code == "not_empty"
+    assert folder.is_dir()
+    assert (folder / "child.txt").read_text(encoding="utf-8") == "child"
+    undo_root = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME
+    assert not undo_root.exists() or not list(undo_root.iterdir())
+
+
 def test_delete_undo_token_expiry_purges_staging(files_undo_runtime, tmp_path, monkeypatch):
     now = 1000.0
     monkeypatch.setattr(fs.time, "time", lambda: now)
@@ -923,6 +947,37 @@ def test_delete_post_rename_growth_falls_back_to_permanent_delete(files_undo_run
     assert not target.exists()
     undo_root = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME
     assert not undo_root.exists() or not list(undo_root.iterdir())
+
+
+def test_delete_post_rename_growth_reports_cleanup_failure(files_undo_runtime, tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_FILES_UNDO_SIZE_CAP_BYTES", "8")
+    target = tmp_path / "active.log"
+    target.write_text("1234", encoding="utf-8")
+    real_rename = fs._os_rename_noreplace
+    real_remove = fs._delete_undo_remove_path
+    failed_removals: list[Path] = []
+
+    def rename_then_grow(source: Path, destination: Path) -> None:
+        real_rename(source, destination)
+        with destination.open("ab") as handle:
+            handle.write(b"567890")
+
+    def fail_stage_cleanup(path: Path) -> bool:
+        if Path(path).parent == files_undo_runtime / fs._DELETE_UNDO_DIR_NAME:
+            failed_removals.append(Path(path))
+            return False
+        return real_remove(path)
+
+    monkeypatch.setattr(fs, "_os_rename_noreplace", rename_then_grow)
+    monkeypatch.setattr(fs, "_delete_undo_remove_path", fail_stage_cleanup)
+
+    with pytest.raises(FileBrowserError) as exc:
+        fs.delete_path(str(target))
+
+    assert exc.value.code == "fs_error"
+    assert not target.exists()
+    assert failed_removals
+    assert failed_removals[0].exists()
 
 
 def test_delete_stale_file_replaced_by_directory_is_not_staged_or_removed(files_undo_runtime, tmp_path, monkeypatch):
@@ -1083,6 +1138,46 @@ def test_delete_undo_rejects_replaced_parent_symlink(files_undo_runtime, tmp_pat
     assert exc.value.code == "expired"
     assert not (other / "note.txt").exists()
     assert not (files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token).exists()
+
+
+def test_delete_undo_restores_through_verified_parent_when_path_is_replaced(
+    files_undo_runtime, tmp_path, monkeypatch
+):
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    folder = parent / "folder"
+    folder.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    detached_parent = tmp_path / "detached-parent"
+    token = fs.delete_path(str(folder), recursive=True)["undo_token"]
+    real_os_rename = os.rename
+    swapped = False
+
+    def renameat2_unavailable(*args, **kwargs):
+        raise AttributeError("renameat2 unavailable")
+
+    def replace_parent_then_rename(source, destination, *args, **kwargs):
+        nonlocal swapped
+        if not swapped and kwargs.get("dst_dir_fd") is not None and destination == folder.name:
+            swapped = True
+            real_os_rename(parent, detached_parent)
+            parent.symlink_to(other, target_is_directory=True)
+            try:
+                return real_os_rename(source, destination, *args, **kwargs)
+            finally:
+                parent.unlink()
+                real_os_rename(detached_parent, parent)
+        return real_os_rename(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(fs, "_glibc_renameat2_noreplace_between", renameat2_unavailable)
+    monkeypatch.setattr(fs.os, "rename", replace_parent_then_rename)
+
+    assert fs.undo_delete_path(token) == {"restored_path": str(folder)}
+
+    assert swapped is True
+    assert folder.is_dir()
+    assert not (other / "folder").exists()
 
 
 def test_delete_undo_purges_corrupt_staging_entries(files_undo_runtime, tmp_path):

--- a/tests/test_file_browser_backend.py
+++ b/tests/test_file_browser_backend.py
@@ -892,6 +892,51 @@ def test_delete_size_cap_falls_back_to_permanent_delete(files_undo_runtime, tmp_
     assert not target.exists()
 
 
+def test_delete_stale_file_replaced_by_directory_is_not_staged_or_removed(files_undo_runtime, tmp_path, monkeypatch):
+    target = tmp_path / "stale"
+    target.write_text("old file", encoding="utf-8")
+    real_purge = fs._purge_delete_undo_store_best_effort
+    swapped = False
+
+    def swap_file_for_directory_once() -> None:
+        nonlocal swapped
+        if not swapped:
+            target.unlink()
+            target.mkdir()
+            (target / "child.txt").write_text("new directory", encoding="utf-8")
+            swapped = True
+        real_purge()
+
+    monkeypatch.setattr(fs, "_purge_delete_undo_store_best_effort", swap_file_for_directory_once)
+
+    with pytest.raises(FileBrowserError) as exc:
+        fs.delete_path(str(target), recursive=False)
+
+    assert exc.value.code in {"fs_error", "permission_denied"}
+    assert target.is_dir()
+    assert (target / "child.txt").read_text(encoding="utf-8") == "new directory"
+    undo_root = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME
+    assert not undo_root.exists() or not list(undo_root.iterdir())
+
+
+def test_delete_staging_fsyncs_undo_root_before_returning_token(files_undo_runtime, tmp_path, monkeypatch):
+    target = tmp_path / "durable.txt"
+    target.write_text("durable", encoding="utf-8")
+    fsynced: list[Path] = []
+    real_fsync_dir = fs._fsync_dir
+
+    def capture_fsync_dir(path: Path) -> None:
+        fsynced.append(Path(path))
+        real_fsync_dir(path)
+
+    monkeypatch.setattr(fs, "_fsync_dir", capture_fsync_dir)
+
+    deleted = fs.delete_path(str(target))
+
+    assert deleted["undo_token"]
+    assert files_undo_runtime / fs._DELETE_UNDO_DIR_NAME in fsynced
+
+
 def test_delete_undo_eviction_by_count_and_total_size(files_undo_runtime, tmp_path, monkeypatch):
     now = 2000.0
     monkeypatch.setattr(fs.time, "time", lambda: now)
@@ -925,6 +970,32 @@ def test_delete_undo_eviction_by_count_and_total_size(files_undo_runtime, tmp_pa
         fs.undo_delete_path(first_token)
     assert total_exc.value.code == "expired"
     assert fs.undo_delete_path(second_token) == {"restored_path": str(second)}
+
+
+def test_delete_undo_failed_eviction_keeps_caps_enforced(files_undo_runtime, tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_FILES_UNDO_MAX_ENTRIES", "1")
+    first = tmp_path / "first.txt"
+    first.write_text("first", encoding="utf-8")
+    first_token = fs.delete_path(str(first))["undo_token"]
+    first_stage_dir = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / first_token
+    real_remove = fs._delete_undo_remove_path
+
+    def fail_first_eviction(path: Path) -> bool:
+        if Path(path) == first_stage_dir:
+            return False
+        return real_remove(path)
+
+    monkeypatch.setattr(fs, "_delete_undo_remove_path", fail_first_eviction)
+
+    second = tmp_path / "second.txt"
+    second.write_text("second", encoding="utf-8")
+    deleted_second = fs.delete_path(str(second))
+
+    assert deleted_second == {"ok": True, "undo_token": None, "undo_expires_seconds": None}
+    assert not second.exists()
+    assert first_stage_dir.exists()
+    assert fs.undo_delete_path(first_token) == {"restored_path": str(first)}
+    assert first.read_text(encoding="utf-8") == "first"
 
 
 def test_delete_stages_symlink_entry_without_touching_target(files_undo_runtime, tmp_path):

--- a/tests/test_file_browser_backend.py
+++ b/tests/test_file_browser_backend.py
@@ -18,6 +18,17 @@ from tests.ui_server_test_helpers import csrf_headers
 from vibe.ui_server import app
 
 
+@pytest.fixture
+def files_undo_runtime(tmp_path, monkeypatch):
+    from config import paths
+
+    runtime = tmp_path / "runtime"
+    monkeypatch.setattr(paths, "get_runtime_dir", lambda: runtime)
+    monkeypatch.setattr(fs, "_DELETE_UNDO_INITIALIZED", False)
+    yield runtime
+    fs._DELETE_UNDO_INITIALIZED = False
+
+
 def test_resolve_safe_path_expands_home_and_requires_absolute(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
@@ -790,6 +801,163 @@ def test_mutating_ops_mkdir_rename_move_delete(tmp_path, caplog):
     assert any("file_browser.delete" in record.message for record in caplog.records)
 
 
+def test_delete_undo_restores_file(files_undo_runtime, tmp_path, caplog):
+    caplog.set_level(logging.INFO, logger="core.file_browser_service")
+    target = tmp_path / "note.txt"
+    target.write_text("keep", encoding="utf-8")
+
+    deleted = fs.delete_path(str(target))
+
+    assert deleted["ok"] is True
+    assert isinstance(deleted["undo_token"], str)
+    assert deleted["undo_expires_seconds"] == fs.DELETE_UNDO_TTL_SECONDS
+    assert not target.exists()
+    restored = fs.undo_delete_path(deleted["undo_token"])
+    assert restored == {"restored_path": str(target)}
+    assert target.read_text(encoding="utf-8") == "keep"
+    assert any("file_browser.delete_undo" in record.message for record in caplog.records)
+
+
+def test_delete_undo_restores_directory(files_undo_runtime, tmp_path):
+    folder = tmp_path / "folder"
+    nested = folder / "nested"
+    nested.mkdir(parents=True)
+    (nested / "child.txt").write_text("child", encoding="utf-8")
+
+    deleted = fs.delete_path(str(folder), recursive=True)
+
+    assert deleted["undo_token"]
+    assert not folder.exists()
+    assert fs.undo_delete_path(deleted["undo_token"]) == {"restored_path": str(folder)}
+    assert (nested / "child.txt").read_text(encoding="utf-8") == "child"
+
+
+def test_delete_undo_token_expiry_purges_staging(files_undo_runtime, tmp_path, monkeypatch):
+    now = 1000.0
+    monkeypatch.setattr(fs.time, "time", lambda: now)
+    monkeypatch.setattr(fs, "DELETE_UNDO_TTL_SECONDS", 10)
+    target = tmp_path / "expired.txt"
+    target.write_text("old", encoding="utf-8")
+    token = fs.delete_path(str(target))["undo_token"]
+
+    now = 1011.0
+    with pytest.raises(FileBrowserError) as exc:
+        fs.undo_delete_path(token)
+
+    assert exc.value.code == "expired"
+    assert exc.value.status_code == 410
+    assert not (files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / token).exists()
+
+
+def test_delete_undo_refuses_to_clobber_recreated_path(files_undo_runtime, tmp_path):
+    target = tmp_path / "occupied.txt"
+    target.write_text("deleted", encoding="utf-8")
+    token = fs.delete_path(str(target))["undo_token"]
+    target.write_text("new", encoding="utf-8")
+
+    with pytest.raises(FileBrowserError) as exc:
+        fs.undo_delete_path(token)
+
+    assert exc.value.code == "exists"
+    assert exc.value.status_code == 409
+    assert target.read_text(encoding="utf-8") == "new"
+    target.unlink()
+    assert fs.undo_delete_path(token) == {"restored_path": str(target)}
+    assert target.read_text(encoding="utf-8") == "deleted"
+
+
+def test_delete_cross_device_staging_falls_back_to_permanent_delete(files_undo_runtime, tmp_path, monkeypatch):
+    target = tmp_path / "cross-device.txt"
+    target.write_text("delete me", encoding="utf-8")
+
+    def raise_exdev(_source: Path, _target: Path) -> None:
+        raise OSError(errno.EXDEV, "cross-device link")
+
+    monkeypatch.setattr(fs, "_os_rename_noreplace", raise_exdev)
+
+    deleted = fs.delete_path(str(target))
+
+    assert deleted == {"ok": True, "undo_token": None, "undo_expires_seconds": None}
+    assert not target.exists()
+
+
+def test_delete_size_cap_falls_back_to_permanent_delete(files_undo_runtime, tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_FILES_UNDO_SIZE_CAP_BYTES", "3")
+    target = tmp_path / "large.txt"
+    target.write_bytes(b"1234")
+
+    deleted = fs.delete_path(str(target))
+
+    assert deleted == {"ok": True, "undo_token": None, "undo_expires_seconds": None}
+    assert not target.exists()
+
+
+def test_delete_undo_eviction_by_count_and_total_size(files_undo_runtime, tmp_path, monkeypatch):
+    now = 2000.0
+    monkeypatch.setattr(fs.time, "time", lambda: now)
+    monkeypatch.setenv("AVIBE_FILES_UNDO_MAX_ENTRIES", "2")
+    tokens: list[str] = []
+    for index in range(3):
+        now = 2000.0 + index
+        target = tmp_path / f"count-{index}.txt"
+        target.write_text(str(index), encoding="utf-8")
+        tokens.append(fs.delete_path(str(target))["undo_token"])
+
+    with pytest.raises(FileBrowserError) as count_exc:
+        fs.undo_delete_path(tokens[0])
+    assert count_exc.value.code == "expired"
+    assert fs.undo_delete_path(tokens[1]) == {"restored_path": str(tmp_path / "count-1.txt")}
+    assert fs.undo_delete_path(tokens[2]) == {"restored_path": str(tmp_path / "count-2.txt")}
+
+    now_total = 3000.0
+    monkeypatch.setattr(fs.time, "time", lambda: now_total)
+    monkeypatch.setenv("AVIBE_FILES_UNDO_MAX_ENTRIES", "32")
+    monkeypatch.setenv("AVIBE_FILES_UNDO_TOTAL_SIZE_CAP_BYTES", "6")
+    first = tmp_path / "total-1.txt"
+    second = tmp_path / "total-2.txt"
+    first.write_text("1234", encoding="utf-8")
+    second.write_text("5678", encoding="utf-8")
+    first_token = fs.delete_path(str(first))["undo_token"]
+    now_total = 3001.0
+    second_token = fs.delete_path(str(second))["undo_token"]
+
+    with pytest.raises(FileBrowserError) as total_exc:
+        fs.undo_delete_path(first_token)
+    assert total_exc.value.code == "expired"
+    assert fs.undo_delete_path(second_token) == {"restored_path": str(second)}
+
+
+def test_delete_stages_symlink_entry_without_touching_target(files_undo_runtime, tmp_path):
+    target = tmp_path / "target.txt"
+    target.write_text("target", encoding="utf-8")
+    link = tmp_path / "link.txt"
+    link.symlink_to(target)
+
+    deleted = fs.delete_path(str(link))
+
+    assert deleted["undo_token"]
+    assert not link.exists()
+    assert target.read_text(encoding="utf-8") == "target"
+    assert fs.undo_delete_path(deleted["undo_token"]) == {"restored_path": str(link)}
+    assert link.is_symlink()
+    assert link.resolve() == target
+    assert target.read_text(encoding="utf-8") == "target"
+
+
+def test_delete_undo_purges_corrupt_staging_entries(files_undo_runtime, tmp_path):
+    corrupt = files_undo_runtime / fs._DELETE_UNDO_DIR_NAME / ("0" * 32)
+    corrupt.mkdir(parents=True)
+    (corrupt / fs._DELETE_UNDO_ENTRY_NAME).write_text("orphan", encoding="utf-8")
+    (corrupt / fs._DELETE_UNDO_METADATA_NAME).write_text("{not json", encoding="utf-8")
+    target = tmp_path / "fresh.txt"
+    target.write_text("fresh", encoding="utf-8")
+
+    deleted = fs.delete_path(str(target))
+
+    assert deleted["undo_token"]
+    assert not corrupt.exists()
+
+
 def test_delete_non_recursive_directory_maps_not_empty_only_for_not_empty_errno(tmp_path):
     nested = tmp_path / "nested"
     nested.mkdir()
@@ -1538,6 +1706,42 @@ def test_http_delete_and_move_string_false_flags_are_not_truthy(tmp_path):
     assert move_response.status_code == 409
     assert source.read_text(encoding="utf-8") == "source"
     assert destination.read_text(encoding="utf-8") == "destination"
+
+
+def test_http_delete_response_adds_undo_fields_without_dropping_ok(files_undo_runtime, tmp_path):
+    client = app.test_client()
+    headers = csrf_headers(client)
+    target = tmp_path / "delete-me.txt"
+    target.write_text("delete me", encoding="utf-8")
+
+    response = client.post(
+        "/api/files/delete",
+        json={"path": str(target)},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert isinstance(payload["undo_token"], str)
+    assert payload["undo_expires_seconds"] == fs.DELETE_UNDO_TTL_SECONDS
+
+    undo_response = client.post(
+        "/api/files/delete/undo",
+        json={"token": payload["undo_token"]},
+        headers=headers,
+    )
+    assert undo_response.status_code == 200
+    assert undo_response.get_json() == {"restored_path": str(target)}
+    assert target.read_text(encoding="utf-8") == "delete me"
+
+    expired = client.post(
+        "/api/files/delete/undo",
+        json={"token": payload["undo_token"]},
+        headers=headers,
+    )
+    assert expired.status_code == 410
+    assert expired.get_json()["error"]["code"] == "expired"
 
 
 def test_startup_reconcile_skips_tmux_when_env_set(monkeypatch):

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6209,6 +6209,20 @@ async def files_delete(starlette_request: FastAPIRequest):
     return await _dispatch_native_ui_request(starlette_request, handler)
 
 
+@app.post("/api/files/delete/undo", include_in_schema=False)
+async def files_delete_undo(starlette_request: FastAPIRequest):
+    async def handler():
+        from core import file_browser_service
+
+        payload = request.json or {}
+        try:
+            return jsonify(await asyncio.to_thread(file_browser_service.undo_delete_path, payload.get("token") or ""))
+        except Exception as exc:
+            return _file_browser_error_response(exc)
+
+    return await _dispatch_native_ui_request(starlette_request, handler)
+
+
 @app.get("/api/files/search", include_in_schema=False)
 async def files_search(starlette_request: FastAPIRequest):
     async def handler():


### PR DESCRIPTION
## Summary
- Add undo staging for `POST /api/files/delete`, returning `undo_token` and `undo_expires_seconds` while preserving the existing `ok` response shape.
- Add `POST /api/files/delete/undo` with no-clobber restore semantics and structured `exists` / `expired` errors.
- Bound staged deletes by TTL, entry count, total bytes, and an env-overridable per-entry size cap, with EXDEV and unavailable staging falling back to permanent delete.

## Changed capability
Undoable delete for the backend Files API.

## Scenario IDs
None. The file-browser backend route tests are colocated unit/contract tests and this area does not currently have a scenario catalog entry.

## Evidence layers
- Unit: `uv run pytest tests/test_file_browser_backend.py -q` (93 passed)
- Contract: delete response includes backward-compatible `ok` plus undo fields; undo route covers restore, occupied restore `409 exists`, expired/purged `410 expired`, EXDEV fallback, size-cap fallback, cap eviction, corrupt staging purge, and symlink entry safety.
- Scenario: no catalog-backed scenario updated for this backend-only API change.
- Residual manual checks: not run; behavior is covered by focused API/service tests. `npm ci` and `npm run build` were run once to generate `ui/dist` required by the fresh-worktree Python test build.

## Review
- Claude CLI reviewer found an audit-log gap on undo restore; fixed by routing successful restores through the existing mutation audit wrapper.
- Claude CLI re-review: NO FINDINGS.
