### PR TITLE
fix(vault): delegate WebAuthn to the sandbox iframe via a self allowlist

### DIFF
--- a/tests/test_vault_rest.py
+++ b/tests/test_vault_rest.py
@@ -182,21 +182,24 @@ def test_rest_agent_pubkey_route(monkeypatch):
     assert response.get_json() == {"ok": True, "public_key": "pk", "fingerprint": "fp"}
 
 
-def test_rest_security_headers_delegate_webauthn_to_sandbox_only():
+def test_rest_security_headers_delegate_webauthn_to_self_and_sandbox():
     client = app.test_client()
 
     response = client.get("/api/csrf-token")
 
     permissions = response.headers["Permissions-Policy"]
-    assert 'publickey-credentials-get=("https://sandbox.avibe.bot")' in permissions
-    assert 'publickey-credentials-create=("https://sandbox.avibe.bot")' in permissions
+    # Chrome only honors WebAuthn delegation to the cross-origin sandbox iframe when the
+    # allowlist includes `self` (an origin-only allowlist does not reach the child) — see
+    # VAULT_SANDBOX_PERMISSIONS_POLICY. Still narrowly scoped to self + the sandbox origin.
+    assert 'publickey-credentials-get=(self "https://sandbox.avibe.bot")' in permissions
+    assert 'publickey-credentials-create=(self "https://sandbox.avibe.bot")' in permissions
     assert 'clipboard-write=(self "https://sandbox.avibe.bot")' in permissions
-    assert "publickey-credentials-get=(self" not in permissions
-    assert "publickey-credentials-create=(self" not in permissions
+    assert "publickey-credentials-get=*" not in permissions
+    assert "publickey-credentials-create=*" not in permissions
     assert "frame-src 'self' https://sandbox.avibe.bot" in response.headers["Content-Security-Policy"]
 
 
-def test_spa_document_security_headers_delegate_webauthn_to_sandbox_only():
+def test_spa_document_security_headers_delegate_webauthn_to_self_and_sandbox():
     client = app.test_client()
 
     response = client.request("HEAD", "/vaults", base_url="http://127.0.0.1:5123")
@@ -204,11 +207,12 @@ def test_spa_document_security_headers_delegate_webauthn_to_sandbox_only():
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     permissions = response.headers["Permissions-Policy"]
-    assert 'publickey-credentials-get=("https://sandbox.avibe.bot")' in permissions
-    assert 'publickey-credentials-create=("https://sandbox.avibe.bot")' in permissions
+    # See the companion REST test: `self` is required for the cross-origin iframe delegation.
+    assert 'publickey-credentials-get=(self "https://sandbox.avibe.bot")' in permissions
+    assert 'publickey-credentials-create=(self "https://sandbox.avibe.bot")' in permissions
     assert 'clipboard-write=(self "https://sandbox.avibe.bot")' in permissions
-    assert "publickey-credentials-get=(self" not in permissions
-    assert "publickey-credentials-create=(self" not in permissions
+    assert "publickey-credentials-get=*" not in permissions
+    assert "publickey-credentials-create=*" not in permissions
     assert "frame-src 'self' https://sandbox.avibe.bot" in response.headers["Content-Security-Policy"]
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -125,9 +125,21 @@ TRACEBACK_EXCEPTION_PATTERN = re.compile(
 CSRF_COOKIE_NAME = "vibe_csrf_token"
 CSRF_HEADER_NAME = "X-Vibe-CSRF-Token"
 VAULT_SANDBOX_ORIGIN = "https://sandbox.avibe.bot"
+# WebAuthn is delegated to the cross-origin sandbox iframe via Permissions-Policy. Chrome only
+# honors the delegation when the allowlist includes `self`: an origin-only allowlist
+# (`("origin")`, no self) does NOT reach the cross-origin child — verified empirically against
+# the sandbox iframe's DevTools "Allowed Features". So get + create both include self.
+#
+# Accepted trade-off (product decision): with `self`, the parent origin can also invoke the
+# get/create ceremonies, so a parent-app XSS could — via a user-approved passkey prompt — derive
+# the VMK. We intentionally do NOT defend against that. The sandbox's purpose is that the VMK /
+# PRF output / private keys / plaintext are only ever handled *inside* the sandbox origin, and the
+# agent (a backend process, never in the browser) can never reach them — those guarantees hold
+# regardless of self. Forcing a top-level popup on every unlock to close a
+# browser-XSS-social-engineering gap would wreck UX for a strictly secondary threat.
 VAULT_SANDBOX_PERMISSIONS_POLICY = (
-    f'publickey-credentials-get=("{VAULT_SANDBOX_ORIGIN}"), '
-    f'publickey-credentials-create=("{VAULT_SANDBOX_ORIGIN}"), '
+    f'publickey-credentials-get=(self "{VAULT_SANDBOX_ORIGIN}"), '
+    f'publickey-credentials-create=(self "{VAULT_SANDBOX_ORIGIN}"), '
     f'clipboard-write=(self "{VAULT_SANDBOX_ORIGIN}")'
 )
 REMOTE_OAUTH_COOKIE_NAME = "__Host-vibe_remote_oauth"


### PR DESCRIPTION
## What
Add `self` to the `publickey-credentials-get` and `publickey-credentials-create` Permissions-Policy allowlists (`vibe/ui_server.py`), so passkey **create** and **get/PRF** run inside the cross-origin sandbox iframe (`sandbox.avibe.bot`).

## Why
Protected-vault setup was failing on desktop Chrome with `The 'publickey-credentials-create' feature is not enabled in this document`. Root-caused empirically (DevTools → Application → Frames → sandbox iframe → Allowed Features): with an **origin-only** allowlist (`("origin")`), publickey-credentials-* were **absent** from the iframe's allowed features; adding `self` (as `clipboard-write` already had) made them appear. Chrome only honors a Permissions-Policy delegation to a cross-origin child when the allowlist includes `self` — an origin-only allowlist does not reach the child. (This is also the form in every documented example.)

## Security trade-off (intentional, documented in-code)
With `self`, the **parent origin** can also invoke the get/create ceremonies, so a parent-app XSS could — behind a **user-approved passkey prompt** — derive the VMK. This is **out of scope by design**: the sandbox's guarantee is that the VMK / PRF output / private keys / plaintext are only ever *handled inside* the sandbox origin, and the **agent** (a backend process, never in the browser) can never reach them — unchanged by `self`. Forcing a top-level popup on every unlock to close a browser-XSS-social-engineering gap would wreck UX for a strictly secondary threat. (Product owner decision.)

## Evidence
- **Manual (regression):** diagnostic deploy confirmed `create`+self appears in the iframe's Allowed Features while `get` (origin-only) did not; with `get`+self both now delegate. Header verified live: `publickey-credentials-get=(self ...), publickey-credentials-create=(self ...)`.
- **Residual manual check:** full desktop protected-setup flow (in-page, no popup) — in progress.

## Scope
One-line policy change + explanatory comment. No behavior change beyond enabling the in-iframe ceremonies.