### PR TITLE
feat(vault): protected static value in the add-secret form + lightweight sandbox modal

### DIFF
--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -398,11 +398,16 @@ export const VaultSecretForm: React.FC<{
   useEffect(() => {
     if (protection !== 'protected') return;
     if (kind === 'keypair') clearStaticValue();
+    // Protected static values are typed text only (byte-safe UTF-8 handed to the sandbox);
+    // file uploads (possibly binary) aren't supported for protected secrets, so force text
+    // source and drop any file the user had selected while standard.
+    setStaticSource('text');
+    clearSelectedFile();
     applySigningKey(null);
     setImportHex('');
     setSigningError(null);
     setSigningAddresses(null);
-  }, [protection, kind, clearStaticValue, applySigningKey]);
+  }, [protection, kind, clearStaticValue, clearSelectedFile, applySigningKey]);
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -511,16 +516,11 @@ export const VaultSecretForm: React.FC<{
       let protectedPublicMeta: Record<string, unknown> | undefined;
       if (protection === 'protected') {
         if (!isKeypair) {
-          if (staticSource === 'file' && selectedFile) {
-            try {
-              fileBytesToWipe = new Uint8Array(await selectedFile.arrayBuffer());
-            } catch (err) {
-              throw new Error(t('vaults.dialog.errors.fileReadFailed'), { cause: err });
-            }
-            staticValueRef.current = new TextDecoder().decode(fileBytesToWipe);
-          } else {
-            staticValueRef.current = value;
-          }
+          // Protected static values are typed text only — the source toggle is hidden for
+          // protected and reset to text (see the value field + the protection effect). No
+          // file/binary path here on purpose: TextDecoder would corrupt non-UTF-8 bytes, so a
+          // file secret can't round-trip through the string-based parent-value contract.
+          staticValueRef.current = value;
         }
         // Static protected values are entered in this form and handed to the sandbox once;
         // keypairs still generate/import inside the sandbox and return only public metadata.
@@ -624,18 +624,23 @@ export const VaultSecretForm: React.FC<{
 
   const valueField = (
     <div className="flex flex-col gap-2">
-      <div className="self-start">
-        <SegmentedRadio<StaticSecretSource>
-          value={staticSource}
-          onChange={switchStaticSource}
-          disabled={submitting}
-          ariaLabel={t('vaults.dialog.valueSource')}
-          options={[
-            { id: 'text', label: t('vaults.dialog.valueSourceText') },
-            { id: 'file', label: t('vaults.dialog.valueSourceFile') },
-          ]}
-        />
-      </div>
+      {/* Protected static values are typed and handed to the sandbox as text (byte-safe UTF-8).
+          File uploads (which may be binary) aren't supported for protected secrets yet, so the
+          text/file switch only shows for standard secrets. */}
+      {protection !== 'protected' && (
+        <div className="self-start">
+          <SegmentedRadio<StaticSecretSource>
+            value={staticSource}
+            onChange={switchStaticSource}
+            disabled={submitting}
+            ariaLabel={t('vaults.dialog.valueSource')}
+            options={[
+              { id: 'text', label: t('vaults.dialog.valueSourceText') },
+              { id: 'file', label: t('vaults.dialog.valueSourceFile') },
+            ]}
+          />
+        </div>
+      )}
       {staticSource === 'text' ? (
         <div className="flex items-start gap-2">
           {showValue ? (

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import {
   Asterisk,
@@ -137,6 +137,11 @@ export const VaultSecretForm: React.FC<{
   const api = useApi();
   const [name, setName] = useState(fixedName ?? '');
   const [value, setValue] = useState('');
+  const staticValueRef = useRef('');
+  const setStaticValue = useCallback((next: string) => {
+    staticValueRef.current = next;
+    setValue(next);
+  }, []);
   const [staticSource, setStaticSource] = useState<StaticSecretSource>('text');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [kind, setKind] = useState<VaultKind>(requestSpec?.kind ?? 'static');
@@ -288,13 +293,13 @@ export const VaultSecretForm: React.FC<{
 
   // Replace the in-memory signing key, zeroing the previous private key so raw
   // key material never lingers longer than needed.
-  const applySigningKey = (next: SigningKeyMaterial | null) => {
+  const applySigningKey = useCallback((next: SigningKeyMaterial | null) => {
     if (signingKeyRef.current && signingKeyRef.current !== next) {
       signingKeyRef.current.privateKey.fill(0);
     }
     signingKeyRef.current = next;
     setSigningKey(next);
-  };
+  }, []);
 
   // Zero any held private key when the form unmounts.
   useEffect(
@@ -332,25 +337,31 @@ export const VaultSecretForm: React.FC<{
   }, [signingKey, api]);
 
   const staticValueReady = staticSource === 'file' ? selectedFile != null && selectedFile.size > 0 : Boolean(value);
-  const valueReady = protection === 'protected' ? true : isKeypair ? signingKey != null : staticValueReady;
+  const valueReady = isKeypair ? protection === 'protected' || signingKey != null : staticValueReady;
   const canSubmit = isEdit
     ? !submitting
     : Boolean(secretName && valueReady) &&
       !submitting &&
       ((protection === 'standard' && p2Ready) || (protection === 'protected' && protectedCreateReady));
 
+  const clearSelectedFile = useCallback(() => {
+    setSelectedFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, []);
+
+  const clearStaticValue = useCallback(() => {
+    staticValueRef.current = '';
+    setValue('');
+    clearSelectedFile();
+  }, [clearSelectedFile]);
+
   const handleExistingSecret = () => {
     if (treatExistingAsFulfilled) {
-      setValue('');
+      clearStaticValue();
       onCreated(secretName, 'already_exists');
       return;
     }
     setError(t('vaults.dialog.errors.secretExists'));
-  };
-
-  const clearSelectedFile = () => {
-    setSelectedFile(null);
-    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   const chooseFile = (file: File | null) => {
@@ -370,7 +381,7 @@ export const VaultSecretForm: React.FC<{
     }
     setError(null);
     setSelectedFile(file);
-    setValue('');
+    setStaticValue('');
   };
 
   const switchStaticSource = (next: StaticSecretSource) => {
@@ -378,7 +389,7 @@ export const VaultSecretForm: React.FC<{
     setStaticSource(next);
     setError(null);
     if (next === 'file') {
-      setValue('');
+      setStaticValue('');
     } else {
       clearSelectedFile();
     }
@@ -386,13 +397,12 @@ export const VaultSecretForm: React.FC<{
 
   useEffect(() => {
     if (protection !== 'protected') return;
-    setValue('');
-    clearSelectedFile();
+    if (kind === 'keypair') clearStaticValue();
     applySigningKey(null);
     setImportHex('');
     setSigningError(null);
     setSigningAddresses(null);
-  }, [protection]);
+  }, [protection, kind, clearStaticValue, applySigningKey]);
 
   const onSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -500,9 +510,25 @@ export const VaultSecretForm: React.FC<{
       let authzFactorRegistration: Awaited<ReturnType<typeof protectedVault.sealValue>>['authzFactorRegistration'];
       let protectedPublicMeta: Record<string, unknown> | undefined;
       if (protection === 'protected') {
-        // The sandbox owns protected plaintext/key entry and returns only an opaque envelope
-        // plus public key metadata for keypairs.
-        const sealed = await protectedVault.sealValue(secretName, kind);
+        if (!isKeypair) {
+          if (staticSource === 'file' && selectedFile) {
+            try {
+              fileBytesToWipe = new Uint8Array(await selectedFile.arrayBuffer());
+            } catch (err) {
+              throw new Error(t('vaults.dialog.errors.fileReadFailed'), { cause: err });
+            }
+            staticValueRef.current = new TextDecoder().decode(fileBytesToWipe);
+          } else {
+            staticValueRef.current = value;
+          }
+        }
+        // Static protected values are entered in this form and handed to the sandbox once;
+        // keypairs still generate/import inside the sandbox and return only public metadata.
+        const sealed = await protectedVault.sealValue(
+          secretName,
+          kind,
+          isKeypair ? undefined : { valueRef: staticValueRef, clear: clearStaticValue },
+        );
         cryptoFields = { sealed: sealed.envelope };
         establishingVmk = sealed.establishingVmk;
         authzFactorRegistration = sealed.authzFactorRegistration;
@@ -568,7 +594,7 @@ export const VaultSecretForm: React.FC<{
         throw new Error(created.message || created.code || t('vaults.request.saveFailed'));
       }
       if (protection === 'protected') protectedVault.afterCreated();
-      setValue('');
+      clearStaticValue();
       setStaticSource('text');
       clearSelectedFile();
       applySigningKey(null);
@@ -615,7 +641,7 @@ export const VaultSecretForm: React.FC<{
           {showValue ? (
             <Textarea
               value={value}
-              onChange={(event) => setValue(event.target.value)}
+              onChange={(event) => setStaticValue(event.target.value)}
               placeholder={t('vaults.dialog.valuePlaceholder')}
               autoFocus={isProvision}
               required
@@ -627,7 +653,7 @@ export const VaultSecretForm: React.FC<{
             <Input
               type="password"
               value={value}
-              onChange={(event) => setValue(event.target.value)}
+              onChange={(event) => setStaticValue(event.target.value)}
               placeholder={t('vaults.dialog.valuePlaceholder')}
               autoFocus={isProvision}
               required
@@ -937,7 +963,7 @@ export const VaultSecretForm: React.FC<{
           <Badge variant="secondary" className="bg-surface">{t('vaults.request.notSetYet')}</Badge>
         </div>
 
-        {protection !== 'protected' && (
+        {!isKeypair && (
           <label className="flex flex-col gap-1.5">
             <span className={FIELD_LABEL}>{t('vaults.dialog.value')}</span>
             {valueField}
@@ -994,8 +1020,7 @@ export const VaultSecretForm: React.FC<{
               setImportHex('');
               setSigningError(null);
             } else {
-              setValue('');
-              clearSelectedFile();
+              clearStaticValue();
             }
           }}
           disabled={submitting}
@@ -1015,7 +1040,7 @@ export const VaultSecretForm: React.FC<{
       </label>
 
       {/* Value (static) or signing-key builder (keypair) */}
-      {!isKeypair && protection !== 'protected' && (
+      {!isKeypair && (
         <label className="flex flex-col gap-1.5">
           <span className={FIELD_LABEL}>{t('vaults.dialog.value')}</span>
           {valueField}

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -23,6 +23,11 @@ export type ProtectedUnlockMaterial = {
   envelope: ProtectedRecordEnvelope;
 };
 
+type ParentStaticSealValue = {
+  valueRef: { current: string };
+  clear: () => void;
+};
+
 export type ProtectedVaultStatus = 'checking' | 'needs-setup' | 'locked' | 'unlocked' | 'error';
 
 const VAULT_AUTO_LOCK_MS = 10 * 60 * 1000;
@@ -267,6 +272,7 @@ export function useProtectedVault() {
     async (
       name: string,
       kind: 'static' | 'keypair' = 'static',
+      parentStaticValue?: ParentStaticSealValue,
     ): Promise<
       VaultSandboxSealResult & {
         authzFactorRegistration?: VaultWebAuthnRegistrationPayload;
@@ -276,12 +282,31 @@ export function useProtectedVault() {
       const wrapMeta = sessionVault.wrapMeta;
       if (!wrapMeta) throw new Error('vault-locked');
       armVaultAutoLock();
-      const sealed = await (await getVaultSandboxClient()).seal({
-        name,
-        kind,
-        inputMode: 'sandbox-entry',
-        wrapMeta,
-      });
+      let sealed: VaultSandboxSealResult;
+      if (kind === 'static') {
+        if (!parentStaticValue) throw new Error('protected-static-value-required');
+        try {
+          const sandbox = await getVaultSandboxClient();
+          sealed = await sandbox.seal({
+            name,
+            kind: 'static',
+            inputMode: 'parent-value',
+            value: parentStaticValue.valueRef.current,
+            wrapMeta,
+          });
+        } finally {
+          parentStaticValue.valueRef.current = '';
+          parentStaticValue.clear();
+        }
+      } else {
+        const sandbox = await getVaultSandboxClient();
+        sealed = await sandbox.seal({
+          name,
+          kind,
+          inputMode: 'sandbox-entry',
+          wrapMeta,
+        });
+      }
       return {
         ...sealed,
         authzFactorRegistration: sessionVault.freshSetup
@@ -363,12 +388,16 @@ export function useVaultLock(): { unlocked: boolean; remainingMs: number; lockNo
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (!unlocked) return;
-    setNow(Date.now());
-    const id = setInterval(() => {
+    const updateNow = () => {
       enforceAutoLock();
       setNow(Date.now());
-    }, 1000);
-    return () => clearInterval(id);
+    };
+    const immediate = window.setTimeout(updateNow, 0);
+    const id = setInterval(updateNow, 1000);
+    return () => {
+      window.clearTimeout(immediate);
+      clearInterval(id);
+    };
   }, [unlocked]);
 
   const expiresAt = vaultUnlockExpiresAt();

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -285,19 +285,21 @@ export function useProtectedVault() {
       let sealed: VaultSandboxSealResult;
       if (kind === 'static') {
         if (!parentStaticValue) throw new Error('protected-static-value-required');
-        try {
-          const sandbox = await getVaultSandboxClient();
-          sealed = await sandbox.seal({
-            name,
-            kind: 'static',
-            inputMode: 'parent-value',
-            value: parentStaticValue.valueRef.current,
-            wrapMeta,
-          });
-        } finally {
-          parentStaticValue.valueRef.current = '';
-          parentStaticValue.clear();
-        }
+        const sandbox = await getVaultSandboxClient();
+        // Hand the plaintext to the sandbox, then drop the parent-held copy IMMEDIATELY.
+        // `seal()` captures `value` into the request payload synchronously here, so we can
+        // clear the persistent ref + revealed field right away rather than leaving the
+        // plaintext in parent memory for the whole interactive ceremony (up to a 5-min timeout).
+        const sealing = sandbox.seal({
+          name,
+          kind: 'static',
+          inputMode: 'parent-value',
+          value: parentStaticValue.valueRef.current,
+          wrapMeta,
+        });
+        parentStaticValue.valueRef.current = '';
+        parentStaticValue.clear();
+        sealed = await sealing;
       } else {
         const sandbox = await getVaultSandboxClient();
         sealed = await sandbox.seal({

--- a/ui/src/lib/vaultSandboxClient.ts
+++ b/ui/src/lib/vaultSandboxClient.ts
@@ -214,6 +214,7 @@ function parseTerminalMessage(data: unknown): TerminalMessage | null {
 
 export class VaultSandboxClient {
   private iframe: HTMLIFrameElement;
+  private backdrop: HTMLDivElement | null = null;
   private pending = new Map<string, PendingRequest>();
   private readyPromise: Promise<ReadyMessage>;
   private interactiveDepth = 0;
@@ -233,14 +234,19 @@ export class VaultSandboxClient {
     iframe.allow = 'publickey-credentials-get; publickey-credentials-create; clipboard-write';
     iframe.referrerPolicy = 'no-referrer';
     iframe.style.position = 'fixed';
-    iframe.style.inset = '0';
+    iframe.style.top = '50%';
+    iframe.style.left = '50%';
+    iframe.style.transform = 'translate(-50%, -50%)';
     iframe.style.border = '0';
     iframe.style.background = 'transparent';
     iframe.style.zIndex = '2147483647';
     iframe.style.colorScheme = 'normal';
+    iframe.style.borderRadius = '16px';
+    iframe.style.overflow = 'hidden';
+    iframe.style.boxShadow = 'none';
     // At rest the sandbox is a headless RPC worker: keep it in the DOM (so
     // postMessage works) but 0-sized + hidden so it never covers the app. It
-    // only expands to a full-screen overlay while an interactive ceremony is
+    // only expands to a centered modal while an interactive ceremony is
     // active — see setInteractive().
     iframe.style.width = '0';
     iframe.style.height = '0';
@@ -260,16 +266,37 @@ export class VaultSandboxClient {
     return target;
   }
 
+  private ensureBackdrop(): HTMLDivElement {
+    if (this.backdrop?.isConnected) return this.backdrop;
+    const backdrop = document.createElement('div');
+    backdrop.setAttribute('aria-hidden', 'true');
+    backdrop.style.position = 'fixed';
+    backdrop.style.inset = '0';
+    backdrop.style.background = 'rgba(0, 0, 0, 0.5)';
+    backdrop.style.zIndex = '2147483646';
+    backdrop.style.pointerEvents = 'auto';
+    document.body.insertBefore(backdrop, this.iframe);
+    this.backdrop = backdrop;
+    return backdrop;
+  }
+
   private setInteractive(active: boolean): void {
     this.interactiveDepth += active ? 1 : -1;
     this.interactiveDepth = Math.max(0, this.interactiveDepth);
     const interactive = this.interactiveDepth > 0;
-    // Expand to a full-screen overlay only while a ceremony is active; otherwise
-    // collapse to a hidden 0-size worker so the sandbox never covers the app.
-    this.iframe.style.width = interactive ? '100vw' : '0';
-    this.iframe.style.height = interactive ? '100vh' : '0';
+    if (interactive) {
+      this.ensureBackdrop();
+    } else {
+      this.backdrop?.remove();
+      this.backdrop = null;
+    }
+    // Expand to a lightweight centered modal only while a ceremony is active;
+    // otherwise collapse to a hidden 0-size worker so the sandbox never covers the app.
+    this.iframe.style.width = interactive ? 'min(440px, 92vw)' : '0';
+    this.iframe.style.height = interactive ? 'min(640px, 88vh)' : '0';
     this.iframe.style.visibility = interactive ? 'visible' : 'hidden';
     this.iframe.style.pointerEvents = interactive ? 'auto' : 'none';
+    this.iframe.style.boxShadow = interactive ? '0 24px 80px rgba(15, 23, 42, 0.38)' : 'none';
   }
 
   private waitForReady(): Promise<ReadyMessage> {
@@ -384,7 +411,8 @@ export class VaultSandboxClient {
   seal(payload: {
     name: string;
     kind: 'static' | 'keypair';
-    inputMode: 'sandbox-entry';
+    inputMode: 'sandbox-entry' | 'parent-value';
+    value?: string;
     wrapMeta?: string | null;
   }): Promise<VaultSandboxSealResult> {
     return this.request<VaultSandboxSealResult>('seal', payload, {


### PR DESCRIPTION
## Summary

- Show the static value field for protected static secrets in the parent add-secret/provide forms.
- Send protected static seals to the sandbox with `inputMode: 'parent-value'` and clear the parent-held value after the seal request.
- Keep protected keypairs on the sandbox-entry path and replace the full-screen sandbox iframe with a centered modal + backdrop.

## Evidence

- Unit: `npx vitest run src/lib/useProtectedVault.test.ts src/lib/vaultCrypto.test.ts`
- Contract/build: `npm run build`
- Lint: `npx eslint src/lib/useProtectedVault.ts src/lib/vaultSandboxClient.ts src/components/ui/vault-secret-form.tsx`
- Scenario: no existing vault UI test asserted the old hidden-value behavior.

## Residual manual checks

- Browser passkey/sandbox ceremony with the companion sandbox PR deployed so the new `parent-value` contract is available.
