### PR TITLE
fix(vault): approve protected requests in one passkey ceremony

### DIFF
--- a/ui/src/components/ui/vault-approval-card.tsx
+++ b/ui/src/components/ui/vault-approval-card.tsx
@@ -11,7 +11,6 @@ import { cn, copyTextToClipboard } from '@/lib/utils';
 import { Badge } from './badge';
 import { Button } from './button';
 import { Switch } from './switch';
-import { VaultProtectedUnlock } from './vault-protected-unlock';
 import { VaultRequestSessionLink, vaultRequestSessionDisplay } from './vault-request-session-link';
 
 /**
@@ -173,16 +172,15 @@ export const VaultApprovalCard: React.FC<{
   const schemeAddresses = useMemo(() => addressesForScheme(delivery.scheme, signAddresses), [delivery.scheme, signAddresses]);
   const hasSchemeAddress = Object.values(schemeAddresses).some(Boolean);
 
-  // A request needs the browser VMK unlocked when it touches protected key material:
-  // a protected sign, or an access whose fixed set includes protected members.
-  const needsUnlock = isSign ? isProtected : protectedNames.length > 0;
-  const unlocked = vault.status === 'unlocked';
+  // A request needs the sandbox protected-approval ceremony when it touches protected
+  // key material: a protected sign, or an access whose fixed set includes protected members.
+  const needsProtectedApproval = isSign ? isProtected : protectedNames.length > 0;
 
   useEffect(() => {
-    if (needsUnlock) void vault.refresh();
-    // vault.refresh is stable (useCallback); only re-check when unlock becomes required.
+    if (needsProtectedApproval) void vault.refresh();
+    // vault.refresh is stable (useCallback); only re-check when protected handling becomes required.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [needsUnlock]);
+  }, [needsProtectedApproval]);
 
   const finish = useCallback(
     (run: () => Promise<void>) => {
@@ -303,7 +301,7 @@ export const VaultApprovalCard: React.FC<{
     );
   }
 
-  const approveDisabled = busy || (needsUnlock && !unlocked) || (!isSign && !option);
+  const approveDisabled = busy || (!isSign && !option);
 
   return (
     <div className="flex min-w-0 flex-col gap-4">
@@ -450,10 +448,9 @@ export const VaultApprovalCard: React.FC<{
         </div>
       ) : null}
 
-      {/* Protected gating: show the browser-unlock panel while locked (it carries its own
-          factor note); once unlocked, show only the design's mint operation note. */}
-      {needsUnlock && !unlocked ? <VaultProtectedUnlock vault={vault} /> : null}
-      {needsUnlock && unlocked ? (
+      {/* Protected approval: the sandbox performs any required passkey ceremony as part
+          of the approval operation, so this card only shows the design's operation note. */}
+      {needsProtectedApproval ? (
         <span className="flex items-start gap-2 rounded-lg bg-mint-soft px-3 py-2.5 text-[11.5px] text-foreground">
           <ShieldCheck className="mt-0.5 size-[15px] shrink-0 text-mint" />
           {isSign ? t('vaults.approval.signNote') : t('vaults.approval.accessNote')}

--- a/ui/src/lib/useProtectedVault.ts
+++ b/ui/src/lib/useProtectedVault.ts
@@ -175,6 +175,19 @@ function commitUnlocked(
   armVaultAutoLock(expiresAt);
 }
 
+function commitLocked(wrapMeta: string): void {
+  if (vaultAutoLockTimer) {
+    clearTimeout(vaultAutoLockTimer);
+    vaultAutoLockTimer = null;
+  }
+  vaultLockExpiresAt = null;
+  sessionVault.wrapMeta = baseVmkWrapMeta(wrapMeta);
+  sessionVault.status = 'locked';
+  sessionVault.freshSetup = false;
+  sessionVault.authzFactorRegistration = null;
+  notifyVaultLockChange();
+}
+
 export function webauthnAvailable(): boolean {
   return typeof window !== 'undefined' && typeof crypto !== 'undefined' && Boolean(crypto.subtle);
 }
@@ -324,26 +337,46 @@ export function useProtectedVault() {
     sessionVault.authzFactorRegistration = null;
   }, []);
 
+  const syncProtectedOperationStatus = useCallback(async (wrapMeta: string) => {
+    const sandbox = await getVaultSandboxClient();
+    const baseWrapMeta = baseVmkWrapMeta(wrapMeta);
+    const sandboxStatus = await sandbox.status(baseWrapMeta);
+    if (sandboxStatus.state === 'unlocked') {
+      commitUnlocked(baseWrapMeta, false, sandboxStatus.expiresAt);
+      setStatus('unlocked');
+      setError(null);
+      return;
+    }
+    commitLocked(wrapMeta);
+    setStatus('locked');
+  }, []);
+
   const signProtectedRequest = useCallback(
     async (
       material: ProtectedUnlockMaterial,
       signingContext: VaultSandboxSigningContext,
       scheme: SignatureScheme,
     ): Promise<SignatureResult> => {
-      if (!enforceAutoLock()) throw new Error('vault-locked');
-      armVaultAutoLock();
-      return (await getVaultSandboxClient()).sign({ material, scheme, signingContext });
+      const sandbox = await getVaultSandboxClient();
+      try {
+        return await sandbox.sign({ material, scheme, signingContext });
+      } finally {
+        void syncProtectedOperationStatus(material.envelope.wrap_meta).catch(() => undefined);
+      }
     },
-    [],
+    [syncProtectedOperationStatus],
   );
 
   const releaseProtectedDelivery = useCallback(
     async (material: ProtectedUnlockMaterial, agentBinding: DaemonAgentBinding): Promise<BlindBox> => {
-      if (!enforceAutoLock()) throw new Error('vault-locked');
-      armVaultAutoLock();
-      return (await getVaultSandboxClient()).releaseDEK({ material, agentBinding });
+      const sandbox = await getVaultSandboxClient();
+      try {
+        return await sandbox.releaseDEK({ material, agentBinding });
+      } finally {
+        void syncProtectedOperationStatus(material.envelope.wrap_meta).catch(() => undefined);
+      }
     },
-    [],
+    [syncProtectedOperationStatus],
   );
 
   const lock = useCallback(() => {


### PR DESCRIPTION
## Summary

Fix protected release/sign approval so the approval button starts the sandbox ceremony directly instead of requiring a separate pre-unlock step in the parent card.

Capability: protected release/sign approval.

## Root cause

The sandbox approval flow now unlocks the VMK and performs the protected sign or DEK release inside the approval operation. The parent approval card still rendered `VaultProtectedUnlock` first and disabled approval until that pre-unlock completed, so a locked protected request could ask for a passkey before approval and then ask again during the protected operation.

## Changes

- Removed the approval-card pre-unlock gate for protected access and sign requests.
- Kept the protected operation note visible for protected requests without depending on parent unlock state.
- Allowed protected sign/release hook calls to reach the sandbox while the parent thinks the VMK is locked, then best-effort syncs the parent lock indicator after the sandbox operation.

## Evidence

- UI build: `cd ui && npm run build`
- Regression re-test: pending after merge/deploy, to confirm the real passkey ceremony end to end.
