### PR TITLE
Pass locale and theme to the vault sandbox

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -31,6 +31,7 @@ import { StatusProvider } from './context/StatusContext';
 import { ApiProvider, useApi, ApiError } from './context/ApiContext';
 import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
+import { VaultSandboxAppearanceBridge } from './components/VaultSandboxAppearanceBridge';
 import { WorkbenchInboxProvider } from './context/WorkbenchInboxContext';
 import { WorkbenchProjectsProvider } from './context/WorkbenchProjectsContext';
 import { ComposerBridgeProvider } from './context/ComposerBridgeContext';
@@ -416,6 +417,7 @@ function App() {
     // data-theme on <html>, so the fallback still picks up the theme even from out here.
     <ErrorBoundary variant="page">
     <ThemeProvider>
+      <VaultSandboxAppearanceBridge />
       <StatusProvider>
         <ToastProvider>
           <ApiProvider>

--- a/ui/src/components/VaultSandboxAppearanceBridge.tsx
+++ b/ui/src/components/VaultSandboxAppearanceBridge.tsx
@@ -1,0 +1,25 @@
+import { useLayoutEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../context/ThemeContext';
+import { getActiveVaultSandboxClient } from '../lib/vaultSandboxClient';
+import {
+  normalizeVaultSandboxLocale,
+  setVaultSandboxAppearance,
+  type VaultSandboxAppearance,
+} from '../lib/vaultSandboxAppearance';
+
+export function VaultSandboxAppearanceBridge() {
+  const { resolvedTheme } = useTheme();
+  const { i18n } = useTranslation();
+
+  useLayoutEffect(() => {
+    const appearance: VaultSandboxAppearance = {
+      locale: normalizeVaultSandboxLocale(i18n.language),
+      theme: resolvedTheme,
+    };
+    setVaultSandboxAppearance(appearance);
+    getActiveVaultSandboxClient()?.setAppearance(appearance);
+  }, [i18n.language, resolvedTheme]);
+
+  return null;
+}

--- a/ui/src/lib/vaultSandboxAppearance.ts
+++ b/ui/src/lib/vaultSandboxAppearance.ts
@@ -1,0 +1,33 @@
+export type VaultSandboxLocale = 'en' | 'zh';
+export type VaultSandboxTheme = 'light' | 'dark';
+export type VaultSandboxAppearance = {
+  locale: VaultSandboxLocale;
+  theme: VaultSandboxTheme;
+};
+
+const DEFAULT_APPEARANCE: VaultSandboxAppearance = { locale: 'en', theme: 'dark' };
+
+let currentAppearance = DEFAULT_APPEARANCE;
+const listeners = new Set<(appearance: VaultSandboxAppearance) => void>();
+
+export function normalizeVaultSandboxLocale(language: string | undefined | null): VaultSandboxLocale {
+  return language?.toLowerCase().startsWith('zh') ? 'zh' : 'en';
+}
+
+export function getVaultSandboxAppearance(): VaultSandboxAppearance {
+  return currentAppearance;
+}
+
+export function setVaultSandboxAppearance(appearance: VaultSandboxAppearance): boolean {
+  if (appearance.locale === currentAppearance.locale && appearance.theme === currentAppearance.theme) {
+    return false;
+  }
+  currentAppearance = appearance;
+  listeners.forEach((listener) => listener(currentAppearance));
+  return true;
+}
+
+export function subscribeVaultSandboxAppearance(listener: (appearance: VaultSandboxAppearance) => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/ui/src/lib/vaultSandboxClient.ts
+++ b/ui/src/lib/vaultSandboxClient.ts
@@ -13,6 +13,7 @@ import {
   VAULT_SANDBOX_PINNED_MANIFEST,
   VAULT_SANDBOX_REQUIRED_RESOURCE_PATHS,
 } from './vaultSandboxManifest';
+import { getVaultSandboxAppearance, type VaultSandboxAppearance } from './vaultSandboxAppearance';
 
 const CHANNEL = 'avibe.vault.crypto';
 const VERSION = 1;
@@ -30,6 +31,7 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const INTERACTIVE_TIMEOUT_MS = 5 * 60_000;
 
 type VaultSandboxOp = (typeof REQUIRED_OPS)[number] | 'handshake';
+type ParentOnlySandboxOp = 'set-appearance';
 type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
@@ -113,6 +115,7 @@ export class VaultSandboxError extends Error {
 
 let integrityPromise: Promise<void> | null = null;
 let singleton: Promise<VaultSandboxClient> | null = null;
+let activeClient: VaultSandboxClient | null = null;
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value != null && !Array.isArray(value);
@@ -218,6 +221,7 @@ export class VaultSandboxClient {
   private pending = new Map<string, PendingRequest>();
   private readyPromise: Promise<ReadyMessage>;
   private interactiveDepth = 0;
+  private handshaken = false;
 
   private constructor(iframe: HTMLIFrameElement) {
     this.iframe = iframe;
@@ -257,6 +261,7 @@ export class VaultSandboxClient {
     iframe.src = VAULT_SANDBOX_IFRAME_URL;
     document.body.appendChild(iframe);
     await client.handshake();
+    activeClient = client;
     return client;
   }
 
@@ -349,9 +354,31 @@ export class VaultSandboxClient {
         parentOrigin: window.location.origin,
         nonce: randomId(),
         expectedBuildHash: VAULT_SANDBOX_EXPECTED_BUILD_HASH,
+        appearance: getVaultSandboxAppearance(),
       },
       { timeoutMs: DEFAULT_TIMEOUT_MS },
     );
+    this.handshaken = true;
+    this.setAppearance(getVaultSandboxAppearance());
+  }
+
+  setAppearance(appearance: VaultSandboxAppearance): void {
+    if (!this.handshaken) return;
+    try {
+      this.target.postMessage(
+        {
+          channel: CHANNEL,
+          version: VERSION,
+          id: randomId(),
+          op: 'set-appearance' satisfies ParentOnlySandboxOp,
+          payload: appearance,
+        },
+        VAULT_SANDBOX_ORIGIN,
+      );
+    } catch {
+      // The iframe may be mid-navigation or already removed; the next real
+      // sandbox request will surface availability errors if the client is stale.
+    }
   }
 
   private async request<T>(
@@ -463,8 +490,13 @@ export async function getVaultSandboxClient(): Promise<VaultSandboxClient> {
   if (!singleton) {
     singleton = VaultSandboxClient.create().catch((err) => {
       singleton = null;
+      activeClient = null;
       throw err;
     });
   }
   return singleton;
+}
+
+export function getActiveVaultSandboxClient(): VaultSandboxClient | null {
+  return activeClient;
 }


### PR DESCRIPTION
## Capability

- Publishes Avibe's resolved locale and theme through a small Vault Sandbox appearance store.
- Includes the current appearance in the sandbox handshake and pushes live `set-appearance` updates to an already-created sandbox iframe.
- Does not create the iframe just to update appearance, and remains compatible with older sandboxes that ignore the new message.

## Evidence

- Unit: no dedicated unit suite exists for this UI bridge; read-only pre-PR reviewer returned NO FINDINGS.
- Contract/build: `cd ui && npm run build` passes.
- Scenario: reasoned zh+dark open path and en+light live toggle path through the existing sandbox client.
- Residual manual: no deploy or review watch was started; `sandbox.avibe.bot` and regression deploys are owned post-merge by the maintainer.
