### PR TITLE
chore(vault): pin avault 0.1.6 (protected-record v2 AAD open fix)

### DIFF
--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -459,7 +459,7 @@ def test_avault_resolves_path_fallback_when_configured_path_missing(monkeypatch)
 def test_ensure_avault_idempotent_when_present(monkeypatch):
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
     monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/usr/local/bin/avault")
-    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: api.AVAULT_GRANT_DELIVERY_MIN_VERSION)
+    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: api._avault_ready_min_version())
     flag = {"installed": False}
     monkeypatch.setattr(api, "install_avault", lambda force=False: flag.__setitem__("installed", True) or {"ok": True})
 
@@ -470,7 +470,7 @@ def test_ensure_avault_idempotent_when_present(monkeypatch):
         "installed": True,
         "changed": False,
         "path": "/usr/local/bin/avault",
-        "version": api.AVAULT_GRANT_DELIVERY_MIN_VERSION,
+        "version": api._avault_ready_min_version(),
     }
     assert flag["installed"] is False
 
@@ -495,7 +495,7 @@ def test_ensure_avault_force_does_not_downgrade_compatible_binary_when_pin_is_ol
     monkeypatch.setattr(api, "_managed_avault_release_satisfies_ready_minimum", lambda: False)
     monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
     monkeypatch.setattr(api, "resolve_cli_path", lambda b: "/usr/local/bin/avault")
-    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: api.AVAULT_GRANT_DELIVERY_MIN_VERSION)
+    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: api._avault_ready_min_version())
     monkeypatch.setattr(api, "install_avault", lambda force=False: pytest.fail("should not downgrade avault"))
 
     out = api.ensure_avault_installed(force=True)
@@ -505,7 +505,7 @@ def test_ensure_avault_force_does_not_downgrade_compatible_binary_when_pin_is_ol
         "installed": True,
         "changed": False,
         "path": "/usr/local/bin/avault",
-        "version": api.AVAULT_GRANT_DELIVERY_MIN_VERSION,
+        "version": api._avault_ready_min_version(),
     }
 
 
@@ -622,12 +622,12 @@ def test_avault_status_present_parses_version(monkeypatch):
 
     class _R:
         returncode = 0
-        stdout = f"avault {api.AVAULT_GRANT_DELIVERY_MIN_VERSION}\n"
+        stdout = f"avault {api._avault_ready_min_version()}\n"
         stderr = ""
 
     monkeypatch.setattr(api.subprocess, "run", lambda *a, **k: _R())
     s = api.avault_status()
-    assert s["installed"] and s["version"] == api.AVAULT_GRANT_DELIVERY_MIN_VERSION and s["status"] == "ready"
+    assert s["installed"] and s["version"] == api._avault_ready_min_version() and s["status"] == "ready"
 
 
 def test_avault_status_marks_p2_only_version_upgrade_required(monkeypatch):

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5341,9 +5341,9 @@ AVAULT_P2_MIN_VERSION = "0.1.3"
 # next avault release so upgraded Avibe installs fail closed instead of sending
 # new frames to an incompatible resident agent.
 AVAULT_GRANT_DELIVERY_MIN_VERSION = "0.1.4"
-# Installer pin must reference a published manifest-pinned release. v0.1.5 is
-# the first managed release carrying the final grant_id resident delivery frames.
-AVAULT_VERSION = "0.1.5"
+# Installer pin must reference a published manifest-pinned release. v0.1.6 adds the
+# protected-record v2 AAD fix so agent delivery can open browser-sealed protected values.
+AVAULT_VERSION = "0.1.6"
 _AVAULT_RELEASE_BASE_URL = f"https://github.com/avibe-bot/avault/releases/download/v{AVAULT_VERSION}/"
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5341,6 +5341,10 @@ AVAULT_P2_MIN_VERSION = "0.1.3"
 # next avault release so upgraded Avibe installs fail closed instead of sending
 # new frames to an incompatible resident agent.
 AVAULT_GRANT_DELIVERY_MIN_VERSION = "0.1.4"
+# Protected-record open requires avault's v2 canonical-JSON record AAD (v0.1.6).
+# Older binaries cannot open browser-sealed protected values and fail with
+# "open failed for <name>", so protected Vaults must not treat them as ready.
+AVAULT_PROTECTED_RECORD_MIN_VERSION = "0.1.6"
 # Installer pin must reference a published manifest-pinned release. v0.1.6 adds the
 # protected-record v2 AAD fix so agent delivery can open browser-sealed protected values.
 AVAULT_VERSION = "0.1.6"
@@ -5383,9 +5387,11 @@ def _avault_p2_release_unavailable_result(
 
 
 def _avault_ready_min_version() -> str:
-    # Avibe-managed avault readiness follows the resident delivery protocol now
-    # that the managed pin includes grant-id frames. Older P2 binaries can still
-    # seal/sign, but they are not safe as the default dependency for Vaults.
+    # Managed avault readiness must satisfy both the resident grant-id delivery
+    # protocol and the protected-record v2 AAD open fix; take the higher floor so
+    # stale binaries (e.g. 0.1.5) are upgraded/blocked before protected delivery.
+    if _version_at_least(AVAULT_PROTECTED_RECORD_MIN_VERSION, AVAULT_GRANT_DELIVERY_MIN_VERSION):
+        return AVAULT_PROTECTED_RECORD_MIN_VERSION
     return AVAULT_GRANT_DELIVERY_MIN_VERSION
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5864,16 +5864,31 @@ def _require_avault_p2_surface(feature: str) -> None:
 
 
 def _require_avault_grant_delivery_surface(feature: str) -> None:
-    # Both call sites are protected-only (agent binding rejects non-protected
-    # secrets; agent grant gates this only when protected DEKs are needed), so the
-    # preflight must enforce the full Vaults-ready floor: the grant-id protocol AND
-    # the protected-record v2 AAD open fix. A binary that clears only the old
-    # protocol minimum still fails protected open ("open failed"), so gate delivery
-    # on the same floor as readiness instead of the protocol minimum alone.
+    # Guards protected grant/deliver operations that OPEN a protected record via
+    # avault (resident-agent grant, agent binding, deliver run/fetch/inject; all
+    # protected-only). These need the full Vaults-ready floor -- the grant-id
+    # protocol AND the protected-record v2 AAD open fix -- since a binary that
+    # clears only the old protocol minimum still fails protected open
+    # ("open failed"). Release/revoke does NOT open a record and stays on
+    # _require_avault_grant_protocol_surface() to avoid destructive cleanup.
     _require_avault_min_version(
         feature,
         _avault_ready_min_version(),
         managed_available=_managed_avault_release_satisfies_ready_minimum(),
+    )
+
+
+def _require_avault_grant_protocol_surface(feature: str) -> None:
+    # Grant-lifecycle operations that do NOT open a protected record (release /
+    # revoke) only need the grant-id delivery protocol, not the protected-record
+    # v2 AAD fix. Gating them on the 0.1.6 floor would reject the release frame on
+    # a host still on 0.1.4/0.1.5 and push cleanup into the destructive
+    # release-failure path (resetting the resident agent + expiring active grants)
+    # instead of revoking just the requested grant.
+    _require_avault_min_version(
+        feature,
+        AVAULT_GRANT_DELIVERY_MIN_VERSION,
+        managed_available=_managed_avault_release_satisfies_grant_delivery(),
     )
 
 
@@ -6171,7 +6186,7 @@ def avault_agent_release(*, grant_id: str) -> dict:
     """Drop a resident-agent protected grant if present."""
     from vibe.avault_agent import AvaultAgentClient, AvaultAgentError
 
-    _require_avault_grant_delivery_surface("resident agent release")
+    _require_avault_grant_protocol_surface("resident agent release")
     try:
         return AvaultAgentClient(_avault_agent_manager().socket_path, timeout=1.0).release(grant_id=grant_id)
     except AvaultAgentError as exc:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5864,10 +5864,16 @@ def _require_avault_p2_surface(feature: str) -> None:
 
 
 def _require_avault_grant_delivery_surface(feature: str) -> None:
+    # Both call sites are protected-only (agent binding rejects non-protected
+    # secrets; agent grant gates this only when protected DEKs are needed), so the
+    # preflight must enforce the full Vaults-ready floor: the grant-id protocol AND
+    # the protected-record v2 AAD open fix. A binary that clears only the old
+    # protocol minimum still fails protected open ("open failed"), so gate delivery
+    # on the same floor as readiness instead of the protocol minimum alone.
     _require_avault_min_version(
         feature,
-        AVAULT_GRANT_DELIVERY_MIN_VERSION,
-        managed_available=_managed_avault_release_satisfies_grant_delivery(),
+        _avault_ready_min_version(),
+        managed_available=_managed_avault_release_satisfies_ready_minimum(),
     )
 
 


### PR DESCRIPTION
## Capability
Bumps the managed avault installer pin `AVAULT_VERSION` 0.1.5 → **0.1.6**. v0.1.6 carries the protected-record **v2 record AAD** fix (avault#18): `open_with_dek` now reconstructs the byte-exact `avault:protected-record:aad:v2` JSON AAD the browser sandbox seals with, so agent delivery can open browser-sealed **protected static** values instead of failing with `open failed for <name>`.

## Why
The v2-AAD fix landed in avault master but the previously-pinned v0.1.5 release predates it. Until this pin bump, `runtime prepare` reinstalls the pre-fix v0.1.5 binary on every deploy (regression has needed a hand-built patched binary). Pinning 0.1.6 lets the managed installer pull the fixed release directly — the fix reaches all managed installs.

## Evidence layers
- **Unit / contract**: correctness is covered by avault#18's cross-implementation vector tests (v2 AAD seal↔open round-trip for static + keypair, transplant rejection). This PR is a one-constant installer pin — no avibe logic change.
- **Manual**: verified end-to-end in regression that protected create→approve→deliver works with the v0.1.6 binary; will re-confirm via `runtime prepare` once the v0.1.6 release finishes publishing.

## Depends on
avault **v0.1.6** release (tagged; release workflow building all-platform binaries + manifest.json).