### PR TITLE
fix(ui): make doctor diagnostics fast by default

### DIFF
--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -77,6 +77,46 @@ def test_status_endpoint_uses_fast_runtime_status(monkeypatch):
     assert calls == [False]
 
 
+def test_doctor_post_runs_fast_diagnostics_by_default(monkeypatch):
+    from vibe import cli
+
+    calls = []
+
+    monkeypatch.setattr(
+        cli,
+        "_doctor",
+        lambda *, deep=True: calls.append(deep)
+        or {"mode": "fast", "groups": [], "summary": {"pass": 0, "warn": 0, "fail": 0}, "ok": True},
+    )
+
+    client = app.test_client()
+    response = client.post("/api/doctor", json={}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.get_json()["mode"] == "fast"
+    assert calls == [False]
+
+
+def test_doctor_post_can_run_deep_diagnostics(monkeypatch):
+    from vibe import cli
+
+    calls = []
+
+    monkeypatch.setattr(
+        cli,
+        "_doctor",
+        lambda *, deep=True: calls.append(deep)
+        or {"mode": "deep", "groups": [], "summary": {"pass": 0, "warn": 0, "fail": 0}, "ok": True},
+    )
+
+    client = app.test_client()
+    response = client.post("/api/doctor", json={"deep": True}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.get_json()["mode"] == "deep"
+    assert calls == [True]
+
+
 def test_route_path_to_fastapi_converts_named_path_converter():
     assert route_path_to_fastapi("/files/<path:file_path>") == "/files/{file_path:path}"
 

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1017,7 +1017,7 @@ def test_doctor_repair_refreshes_diagnostics_after_repair(monkeypatch):
     refreshed = []
     doctor_calls = []
     monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: refreshed.append(True))
-    monkeypatch.setattr(cli, "_doctor", lambda: doctor_calls.append(True) or {"ok": True, "groups": []})
+    monkeypatch.setattr(cli, "_doctor", lambda *, deep=False: doctor_calls.append(deep) or {"ok": True, "groups": []})
 
     result = cli._repair_doctor_targets(["stale-restart-state"], dry_run=False)
 
@@ -1049,16 +1049,18 @@ def test_doctor_parser_accepts_repair_target_and_dry_run():
 def test_doctor_parser_accepts_fast_and_deep_modes():
     parser = cli.build_parser()
 
+    default_args = parser.parse_args(["doctor"])
     fast_args = parser.parse_args(["doctor", "--fast"])
     deep_args = parser.parse_args(["doctor", "--deep"])
 
+    assert default_args.doctor_deep is False
     assert fast_args.doctor_deep is False
     assert deep_args.doctor_deep is True
 
 
-def test_cmd_doctor_passes_fast_mode_to_diagnostics(monkeypatch, capsys):
+def test_cmd_doctor_passes_default_fast_mode_to_diagnostics(monkeypatch, capsys):
     parser = cli.build_parser()
-    args = parser.parse_args(["doctor", "--fast"])
+    args = parser.parse_args(["doctor"])
     calls = []
 
     monkeypatch.setattr(
@@ -1070,6 +1072,23 @@ def test_cmd_doctor_passes_fast_mode_to_diagnostics(monkeypatch, capsys):
 
     assert cli.cmd_doctor(args) == 0
     assert calls == [False]
+    capsys.readouterr()
+
+
+def test_cmd_doctor_passes_deep_mode_to_diagnostics(monkeypatch, capsys):
+    parser = cli.build_parser()
+    args = parser.parse_args(["doctor", "--deep"])
+    calls = []
+
+    monkeypatch.setattr(
+        cli,
+        "_doctor",
+        lambda *, deep=False: calls.append(deep)
+        or {"mode": "deep", "groups": [], "summary": {"pass": 0, "warn": 0, "fail": 0}, "ok": True},
+    )
+
+    assert cli.cmd_doctor(args) == 0
+    assert calls == [True]
     capsys.readouterr()
 
 

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -665,6 +665,24 @@ def test_service_lifecycle_doctor_warns_when_extra_service_process_exists(monkey
     assert warning["repair"]["target"] == "duplicate-service-processes"
 
 
+def test_fast_service_lifecycle_doctor_skips_extra_process_scan(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    cli.paths.ensure_data_dirs()
+    cli.runtime.write_status("running", "healthy", 1234, None)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1234)
+    monkeypatch.setattr(cli.runtime, "service_lock_holder_pid", lambda: 1234)
+
+    def fail_process_scan(*args, **kwargs):
+        raise AssertionError("fast diagnostics must not scan service processes")
+
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", fail_process_scan)
+
+    items = cli._service_lifecycle_items(detect_extra_processes=False)
+
+    skipped = next(item for item in items if item.get("code") == "runtime.deep_service_process_scan_skipped")
+    assert skipped["status"] == "pass"
+
+
 def test_home_migration_doctor_warns_when_legacy_home_is_unmigrated(monkeypatch, tmp_path):
     home = tmp_path / "home"
     legacy_home = home / ".vibe_remote"
@@ -695,6 +713,20 @@ def test_service_install_doctor_warns_when_service_uses_legacy_package(monkeypat
 
     warning = next(item for item in items if item.get("code") == "runtime.stale_install_process")
     assert warning["repair"]["target"] == "stale-install-runtime"
+
+
+def test_fast_service_install_doctor_skips_extra_process_scan(monkeypatch):
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: None)
+
+    def fail_process_scan(*args, **kwargs):
+        raise AssertionError("fast diagnostics must not scan service processes")
+
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", fail_process_scan)
+
+    items = cli._service_install_family_items(detect_extra_processes=False)
+
+    assert any(item["status"] == "pass" for item in items)
 
 
 def test_tool_family_detection_resolves_uv_tool_launcher_symlink(tmp_path):
@@ -1012,6 +1044,33 @@ def test_doctor_parser_accepts_repair_target_and_dry_run():
     assert args.doctor_action == "repair"
     assert args.doctor_repair_targets == ["duplicate-service-processes"]
     assert args.dry_run is True
+
+
+def test_doctor_parser_accepts_fast_and_deep_modes():
+    parser = cli.build_parser()
+
+    fast_args = parser.parse_args(["doctor", "--fast"])
+    deep_args = parser.parse_args(["doctor", "--deep"])
+
+    assert fast_args.doctor_deep is False
+    assert deep_args.doctor_deep is True
+
+
+def test_cmd_doctor_passes_fast_mode_to_diagnostics(monkeypatch, capsys):
+    parser = cli.build_parser()
+    args = parser.parse_args(["doctor", "--fast"])
+    calls = []
+
+    monkeypatch.setattr(
+        cli,
+        "_doctor",
+        lambda *, deep=True: calls.append(deep)
+        or {"mode": "fast", "groups": [], "summary": {"pass": 0, "warn": 0, "fail": 0}, "ok": True},
+    )
+
+    assert cli.cmd_doctor(args) == 0
+    assert calls == [False]
+    capsys.readouterr()
 
 
 def test_doctor_bare_dry_run_does_not_request_repair():

--- a/ui/src/components/steps/DoctorPanel.tsx
+++ b/ui/src/components/steps/DoctorPanel.tsx
@@ -61,16 +61,17 @@ export const DoctorPanel: React.FC<DoctorPanelProps> = ({
   const { t } = useTranslation();
   const api = useApi();
   const { showToast } = useToast();
-  const [loading, setLoading] = useState(false);
+  const [loadingMode, setLoadingMode] = useState<'fast' | 'deep' | null>(null);
   const [results, setResults] = useState<any>(null);
 
-  const runDoctor = async () => {
-    setLoading(true);
+  const runDoctor = async (deep = false) => {
+    const mode = deep ? 'deep' : 'fast';
+    setLoadingMode(mode);
     try {
-      const res = await api.doctor();
+      const res = await api.doctor({ deep });
       setResults(res);
     } finally {
-      setLoading(false);
+      setLoadingMode(null);
     }
   };
 
@@ -130,8 +131,30 @@ export const DoctorPanel: React.FC<DoctorPanelProps> = ({
               {t('doctor.copyReport')}
             </Button>
           )}
-          <Button type="button" variant="brand" size="xs" onClick={runDoctor} disabled={loading}>
-            <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} strokeWidth={2.5} />
+          <Button
+            type="button"
+            variant="secondary"
+            size="xs"
+            onClick={() => void runDoctor(true)}
+            disabled={loadingMode !== null}
+          >
+            <RefreshCw
+              className={clsx('size-3.5', loadingMode === 'deep' && 'animate-spin')}
+              strokeWidth={2.5}
+            />
+            {t('doctor.runDeepChecks')}
+          </Button>
+          <Button
+            type="button"
+            variant="brand"
+            size="xs"
+            onClick={() => void runDoctor(false)}
+            disabled={loadingMode !== null}
+          >
+            <RefreshCw
+              className={clsx('size-3.5', loadingMode === 'fast' && 'animate-spin')}
+              strokeWidth={2.5}
+            />
             {t('doctor.runChecks')}
           </Button>
         </div>

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -388,7 +388,7 @@ export type ApiContextType = {
   larkTempWsStop: () => Promise<any>;
   wechatStartLogin: () => Promise<any>;
   wechatPollLogin: (sessionKey: string, verifyCode?: string) => Promise<any>;
-  doctor: () => Promise<any>;
+  doctor: (options?: { deep?: boolean }) => Promise<any>;
   opencodeOptions: (cwd: string) => Promise<any>;
   opencodeSetupPermission: () => Promise<{ ok: boolean; message: string; config_path: string }>;
   opencodePermissionStatus: () => Promise<{ ok: boolean; permission_allowed: boolean; config_path: string }>;
@@ -2098,7 +2098,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     larkTempWsStop: () => postJson('/api/lark/temp_ws/stop', {}),
     wechatStartLogin: () => postJson('/api/wechat/qr_login/start', {}),
     wechatPollLogin: (sessionKey, verifyCode) => postJson('/api/wechat/qr_login/poll', { session_key: sessionKey, verify_code: verifyCode || undefined }),
-    doctor: () => postJson('/api/doctor', {}),
+    doctor: (options = {}) => postJson('/api/doctor', options.deep ? { deep: true } : {}),
     opencodeOptions: (cwd) => postJson('/api/opencode/options', { cwd }),
     opencodeSetupPermission: () => postJson('/api/opencode/setup-permission', {}),
     opencodePermissionStatus: () => getJson('/api/opencode/permission-status'),

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1647,6 +1647,7 @@
     "title": "System Status",
     "copyReport": "Copy Report",
     "runChecks": "Run Checks",
+    "runDeepChecks": "Deep Diagnostics",
     "passed": "Passed",
     "warnings": "Warnings",
     "failed": "Failed"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1647,6 +1647,7 @@
     "title": "系统状态",
     "copyReport": "复制报告",
     "runChecks": "运行检查",
+    "runDeepChecks": "深诊断",
     "passed": "通过",
     "warnings": "警告",
     "failed": "失败"

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -7924,7 +7924,7 @@ def cmd_watch_remove(watch_id: str):
     return 0
 
 
-def _doctor(*, deep: bool = True):
+def _doctor(*, deep: bool = False):
     """Run diagnostic checks and return results in UI-compatible format.
 
     Returns:
@@ -8814,7 +8814,7 @@ def _repair_doctor_targets(targets: list[str], *, dry_run: bool = False) -> dict
         "results": results,
     }
     if not dry_run and any(result["status"] != "skipped" for result in results):
-        payload["doctor"] = _doctor()
+        payload["doctor"] = _doctor(deep=True)
     return payload
 
 
@@ -9945,7 +9945,7 @@ def cmd_doctor(args=None):
         _print_doctor_repair_result(result)
         return 0 if result.get("ok") else 1
 
-    deep = bool(getattr(args, "doctor_deep", True)) if args is not None else True
+    deep = bool(getattr(args, "doctor_deep", False)) if args is not None else False
     result = _doctor(deep=deep)
 
     # Terminal-friendly output
@@ -10367,7 +10367,7 @@ def build_parser():
         "--fast",
         dest="doctor_deep",
         action="store_false",
-        default=True,
+        default=False,
         help="Skip deep service process scans for a faster status-oriented diagnostic run.",
     )
     doctor_depth_group.add_argument(

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -616,12 +616,13 @@ def _current_cli_install_family() -> str | None:
     return None
 
 
-def _service_install_family_items() -> list[dict]:
+def _service_install_family_items(*, detect_extra_processes: bool = True) -> list[dict]:
     items: list[dict] = []
     current_family = _current_cli_install_family()
     owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
     service_pids = [pid for pid in [owner_pid] if pid]
-    service_pids.extend(runtime.extra_service_process_pids(owner_pid=owner_pid))
+    if detect_extra_processes:
+        service_pids.extend(runtime.extra_service_process_pids(owner_pid=owner_pid))
 
     stale_pids: list[int] = []
     for pid in sorted(set(service_pids)):
@@ -699,7 +700,7 @@ def _restart_state_items() -> list[dict]:
     return items
 
 
-def _service_lifecycle_items() -> list[dict]:
+def _service_lifecycle_items(*, detect_extra_processes: bool = True) -> list[dict]:
     items: list[dict] = []
     pid_path = paths.get_runtime_pid_path()
     recorded_pid: int | None = None
@@ -710,12 +711,6 @@ def _service_lifecycle_items() -> list[dict]:
 
     owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
     lock_holder_pid = runtime.service_lock_holder_pid()
-    extra_service_pids = runtime.extra_service_process_pids(owner_pid=owner_pid)
-    unverified_service_pids = runtime.extra_service_process_pids(
-        owner_pid=owner_pid,
-        include_unverified=True,
-    )
-    unverified_service_pids = [pid for pid in unverified_service_pids if pid not in set(extra_service_pids)]
     status = runtime.read_status()
     status_pid = status.get("service_pid")
 
@@ -758,26 +753,41 @@ def _service_lifecycle_items() -> list[dict]:
     else:
         _add_doctor_item(items, "pass", "Runtime status service_pid is absent")
 
-    if extra_service_pids:
-        _add_doctor_item(
-            items,
-            "warn",
-            f"Extra Avibe service process detected outside the service lock: pids={','.join(map(str, extra_service_pids))}",
-            "Run `vibe doctor repair duplicate-service-processes` to stop extra service processes.",
-            code="runtime.extra_service_process",
-            repair_target="duplicate-service-processes",
-            repair_risk="medium",
+    if detect_extra_processes:
+        extra_service_pids = runtime.extra_service_process_pids(owner_pid=owner_pid)
+        unverified_service_pids = runtime.extra_service_process_pids(
+            owner_pid=owner_pid,
+            include_unverified=True,
         )
-    elif unverified_service_pids:
-        _add_doctor_item(
-            items,
-            "warn",
-            f"Possible extra Avibe service process could not be matched to AVIBE_HOME: pids={','.join(map(str, unverified_service_pids))}",
-            "Inspect the process environment before starting another service.",
-            code="runtime.unverified_service_process",
-        )
+        unverified_service_pids = [pid for pid in unverified_service_pids if pid not in set(extra_service_pids)]
+        if extra_service_pids:
+            _add_doctor_item(
+                items,
+                "warn",
+                f"Extra Avibe service process detected outside the service lock: pids={','.join(map(str, extra_service_pids))}",
+                "Run `vibe doctor repair duplicate-service-processes` to stop extra service processes.",
+                code="runtime.extra_service_process",
+                repair_target="duplicate-service-processes",
+                repair_risk="medium",
+            )
+        elif unverified_service_pids:
+            _add_doctor_item(
+                items,
+                "warn",
+                f"Possible extra Avibe service process could not be matched to AVIBE_HOME: pids={','.join(map(str, unverified_service_pids))}",
+                "Inspect the process environment before starting another service.",
+                code="runtime.unverified_service_process",
+            )
+        else:
+            _add_doctor_item(items, "pass", "No extra Avibe service process detected")
     else:
-        _add_doctor_item(items, "pass", "No extra Avibe service process detected")
+        _add_doctor_item(
+            items,
+            "pass",
+            "Deep service process scan skipped in fast diagnostics",
+            "Run deep diagnostics to check duplicate service processes.",
+            code="runtime.deep_service_process_scan_skipped",
+        )
 
     return items
 
@@ -7914,11 +7924,12 @@ def cmd_watch_remove(watch_id: str):
     return 0
 
 
-def _doctor():
+def _doctor(*, deep: bool = True):
     """Run diagnostic checks and return results in UI-compatible format.
 
     Returns:
         {
+            "mode": "deep|fast",
             "groups": [{"name": "...", "items": [{"status": "pass|warn|fail", "message": "...", "action": "..."}]}],
             "summary": {"pass": 0, "warn": 0, "fail": 0},
             "ok": bool
@@ -8222,8 +8233,8 @@ def _doctor():
         summary["pass"] += 1
 
     for item in [
-        *_service_lifecycle_items(),
-        *_service_install_family_items(),
+        *_service_lifecycle_items(detect_extra_processes=deep),
+        *_service_install_family_items(detect_extra_processes=deep),
         *_restart_state_items(),
         *_runtime_architecture_items(),
     ]:
@@ -8245,6 +8256,7 @@ def _doctor():
     ok = summary["fail"] == 0
 
     result = {
+        "mode": "deep" if deep else "fast",
         "groups": groups,
         "summary": summary,
         "ok": ok,
@@ -9933,7 +9945,8 @@ def cmd_doctor(args=None):
         _print_doctor_repair_result(result)
         return 0 if result.get("ok") else 1
 
-    result = _doctor()
+    deep = bool(getattr(args, "doctor_deep", True)) if args is not None else True
+    result = _doctor(deep=deep)
 
     # Terminal-friendly output
     print("\n  Avibe Diagnostics")
@@ -10348,6 +10361,20 @@ def build_parser():
         nargs="*",
         choices=DOCTOR_REPAIR_TARGETS,
         help="Repair target(s). Defaults to all safe first-phase repair targets.",
+    )
+    doctor_depth_group = doctor_parser.add_mutually_exclusive_group()
+    doctor_depth_group.add_argument(
+        "--fast",
+        dest="doctor_deep",
+        action="store_false",
+        default=True,
+        help="Skip deep service process scans for a faster status-oriented diagnostic run.",
+    )
+    doctor_depth_group.add_argument(
+        "--deep",
+        dest="doctor_deep",
+        action="store_true",
+        help="Run full diagnostics, including duplicate service process scans.",
     )
     doctor_parser.add_argument("--fix", action="store_true", help="Alias for 'vibe doctor repair'.")
     doctor_parser.add_argument("--dry-run", action="store_true", help="Show repair actions without changing state.")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4472,7 +4472,9 @@ async def wechat_qr_login_poll():
 def doctor_post():
     from vibe.cli import _doctor
 
-    result = _doctor()
+    payload = request.json or {}
+    deep = _parse_explicit_bool(payload.get("deep")) or _parse_explicit_bool(request.args.get("deep"))
+    result = _doctor(deep=deep)
     return jsonify(result)
 
 


### PR DESCRIPTION
## Summary

- Make `/api/doctor` default to fast diagnostics for UI calls, skipping the expensive duplicate service process scan unless deep diagnostics are explicitly requested.
- Add a Diagnostics page "Deep Diagnostics" action and let the API accept `deep: true`.
- Default `vibe doctor` to fast diagnostics, with `vibe doctor --deep` for the full duplicate service process scan.

## Evidence

- Unit: `uv run pytest tests/test_vibe_cli.py -k "doctor or service_lifecycle or service_install"`
- Contract: `uv run pytest tests/test_ui_server_fastapi.py -k "doctor_post or status_endpoint"`
- UI build: `cd ui && npm run build`
- Lint: `uv run ruff check vibe/cli.py vibe/ui_server.py tests/test_vibe_cli.py tests/test_ui_server_fastapi.py`

## Residual Manual Checks

- Did not restart the user's local Avibe service.
