### PR TITLE
feat(ui): refresh backend model catalogs dynamically

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -34,6 +34,7 @@ from core.caller_context import caller_env_for_platform_payload
 from core.resource_governance import governor_from_controller
 from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
+from vibe import backend_model_catalog
 
 from .base import BaseHandler
 
@@ -813,7 +814,11 @@ class SessionHandler(BaseHandler):
         effective_model = explicit_model or agent_model or self.config.claude.default_model
         from modules.agents.opencode.utils import normalize_claude_reasoning_effort
 
-        effective_effort = normalize_claude_reasoning_effort(effective_model, explicit_effort)
+        effective_effort = normalize_claude_reasoning_effort(
+            effective_model,
+            explicit_effort,
+            backend_model_catalog.catalog_reasoning_efforts_for_model("claude", effective_model),
+        )
 
         # Determine final system prompt: agent prompt takes precedence over config.
         # Always append avibe system prompt injection so transport

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -1,5 +1,6 @@
 """Settings and configuration handlers"""
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -479,7 +480,7 @@ class SettingsHandler(BaseHandler):
             try:
                 from vibe.api import codex_agents as get_codex_agents, codex_models as get_codex_models
 
-                models_result = get_codex_models()
+                models_result = await asyncio.to_thread(get_codex_models)
                 if models_result.get("ok"):
                     codex_models = models_result.get("models", [])
                 cwd = self.controller.get_cwd(context)

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -440,7 +440,7 @@ def build_reasoning_effort_options(
 # (which derives options from live model metadata), these are static.
 # Defined here so that every IM module shares a single source of truth.
 
-_CODEX_REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+_CODEX_REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh"]
 _CLAUDE_REASONING_EFFORTS = ["low", "medium", "high"]
 _CLAUDE_1M_CONTEXT_LABEL = "[1M]"
 _CLAUDE_OPUS_ALIASES = {"opus", "opus[1m]"}

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -15,7 +15,7 @@ _REASONING_FALLBACK_OPTIONS = [
     {"value": "high", "label": "High"},
 ]
 
-_REASONING_VARIANT_ORDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+_REASONING_VARIANT_ORDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
 
 _REASONING_VARIANT_LABELS = {
     "none": "None",
@@ -25,6 +25,7 @@ _REASONING_VARIANT_LABELS = {
     "high": "High",
     "xhigh": "Extra High",
     "max": "Max",
+    "ultra": "Ultra",
 }
 
 _UTILITY_MODEL_KEYWORDS = ["embedding", "tts", "whisper", "ada", "davinci", "turbo-instruct"]
@@ -439,7 +440,7 @@ def build_reasoning_effort_options(
 # (which derives options from live model metadata), these are static.
 # Defined here so that every IM module shares a single source of truth.
 
-_CODEX_REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh"]
+_CODEX_REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
 _CLAUDE_REASONING_EFFORTS = ["low", "medium", "high"]
 _CLAUDE_1M_CONTEXT_LABEL = "[1M]"
 _CLAUDE_OPUS_ALIASES = {"opus", "opus[1m]"}
@@ -501,7 +502,7 @@ def format_claude_model_label(model: object) -> str:
     return model_id
 
 
-def build_codex_reasoning_options() -> List[Dict[str, str]]:
+def build_codex_reasoning_options(reasoning_efforts: Optional[List[str]] = None) -> List[Dict[str, str]]:
     """Return the canonical Codex reasoning-effort option list.
 
     The returned format mirrors ``build_reasoning_effort_options`` so that
@@ -509,7 +510,14 @@ def build_codex_reasoning_options() -> List[Dict[str, str]]:
     helper logic.
     """
     options: List[Dict[str, str]] = [{"value": "__default__", "label": "(Default)"}]
-    for effort in _CODEX_REASONING_EFFORTS:
+    seen: set[str] = set()
+    for effort in reasoning_efforts if reasoning_efforts is not None else _CODEX_REASONING_EFFORTS:
+        if not isinstance(effort, str):
+            continue
+        effort = effort.strip()
+        if not effort or effort in seen:
+            continue
+        seen.add(effort)
         options.append(
             {
                 "value": effort,
@@ -519,7 +527,10 @@ def build_codex_reasoning_options() -> List[Dict[str, str]]:
     return options
 
 
-def build_claude_reasoning_options(target_model: Optional[str]) -> List[Dict[str, str]]:
+def build_claude_reasoning_options(
+    target_model: Optional[str],
+    reasoning_efforts: Optional[List[str]] = None,
+) -> List[Dict[str, str]]:
     """Return the canonical Claude reasoning-effort option list for a model.
 
     Claude currently supports `low` / `medium` / `high` broadly. Newer
@@ -527,14 +538,22 @@ def build_claude_reasoning_options(target_model: Optional[str]) -> List[Dict[str
     4.7, 4.6, Sonnet 5, and Sonnet 4.6 also support `max`.
     """
 
-    efforts = list(_CLAUDE_REASONING_EFFORTS)
-    if _supports_claude_xhigh_reasoning(target_model):
-        efforts.append("xhigh")
-    if _supports_claude_max_reasoning(target_model):
-        efforts.append("max")
+    efforts = list(reasoning_efforts) if reasoning_efforts is not None else list(_CLAUDE_REASONING_EFFORTS)
+    if reasoning_efforts is None:
+        if _supports_claude_xhigh_reasoning(target_model):
+            efforts.append("xhigh")
+        if _supports_claude_max_reasoning(target_model):
+            efforts.append("max")
 
     options: List[Dict[str, str]] = [{"value": "__default__", "label": "(Default)"}]
+    seen: set[str] = set()
     for effort in efforts:
+        if not isinstance(effort, str):
+            continue
+        effort = effort.strip()
+        if not effort or effort in seen:
+            continue
+        seen.add(effort)
         options.append(
             {
                 "value": effort,

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -563,10 +563,14 @@ def build_claude_reasoning_options(
     return options
 
 
-def normalize_claude_reasoning_effort(target_model: Optional[str], effort: Optional[str]) -> Optional[str]:
+def normalize_claude_reasoning_effort(
+    target_model: Optional[str],
+    effort: Optional[str],
+    reasoning_efforts: Optional[List[str]] = None,
+) -> Optional[str]:
     """Return a Claude effort only when it is valid for the target model."""
 
     if not effort:
         return None
-    allowed = {item["value"] for item in build_claude_reasoning_options(target_model)}
+    allowed = {item["value"] for item in build_claude_reasoning_options(target_model, reasoning_efforts)}
     return effort if effort in allowed else None

--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -86,3 +86,19 @@ def test_failed_refresh_with_stale_catalog_uses_failure_ttl():
     }
 
     assert backend_model_catalog._remote_cache_stale(payload) is True
+
+
+def test_remote_catalog_refresh_pending_tracks_in_flight_and_token_changes(monkeypatch):
+    backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
+    backend_model_catalog._REMOTE_MEMORY_CACHE.update({"fetched_at": 10.0, "catalog": {}})
+    monkeypatch.setattr(backend_model_catalog, "_REMOTE_REFRESH_IN_FLIGHT", False)
+
+    token = backend_model_catalog.remote_catalog_token()
+
+    assert backend_model_catalog.remote_catalog_refresh_pending(token) is False
+    monkeypatch.setattr(backend_model_catalog, "_REMOTE_REFRESH_IN_FLIGHT", True)
+    assert backend_model_catalog.remote_catalog_refresh_pending(token) is True
+    monkeypatch.setattr(backend_model_catalog, "_REMOTE_REFRESH_IN_FLIGHT", False)
+    backend_model_catalog._REMOTE_MEMORY_CACHE["fetched_at"] = 11.0
+    assert backend_model_catalog.remote_catalog_refresh_pending(token) is True
+    backend_model_catalog._REMOTE_MEMORY_CACHE.clear()

--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -73,6 +73,9 @@ def test_refresh_remote_catalog_persists_state_cache(monkeypatch, tmp_path):
     assert cached_payload["catalog"]["backends"]["claude"]["models"][0]["id"] == "claude-fable-6"
     assert cached_payload["error"] is None
     backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
+    reloaded = backend_model_catalog.load_cached_remote_catalog(schedule_refresh=False)
+    assert backend_model_catalog.backend_model_entries("claude", reloaded)[0]["id"] == "claude-fable-6"
+    backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
 
 
 def test_failed_refresh_with_stale_catalog_uses_failure_ttl():

--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -1,6 +1,8 @@
 import json
 import time
 
+import pytest
+
 from vibe import backend_model_catalog
 
 
@@ -76,6 +78,51 @@ def test_refresh_remote_catalog_persists_state_cache(monkeypatch, tmp_path):
     reloaded = backend_model_catalog.load_cached_remote_catalog(schedule_refresh=False)
     assert backend_model_catalog.backend_model_entries("claude", reloaded)[0]["id"] == "claude-fable-6"
     backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
+
+
+def test_malformed_remote_catalog_preserves_last_good_cache(monkeypatch, tmp_path):
+    previous_catalog = {
+        "schema_version": 1,
+        "backends": {"claude": {"models": [{"id": "claude-fable-6"}]}},
+    }
+    monkeypatch.setattr(backend_model_catalog.paths, "get_state_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        backend_model_catalog.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse({"schema_version": 2, "models": []}),
+    )
+    monkeypatch.setattr(backend_model_catalog.time, "time", lambda: 200.0)
+    backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
+    backend_model_catalog._write_cached_remote_payload(
+        {"fetched_at": 100.0, "catalog": previous_catalog, "error": None}
+    )
+    monkeypatch.setattr(backend_model_catalog, "_REMOTE_REFRESH_IN_FLIGHT", True)
+
+    backend_model_catalog._refresh_remote_catalog_worker()
+
+    cached_payload = json.loads((tmp_path / "backend_model_catalog.json").read_text(encoding="utf-8"))
+    assert cached_payload["catalog"] == previous_catalog
+    assert cached_payload["failed_at"] == 200.0
+    assert "fetched_at" not in cached_payload
+    assert "Unsupported backend model catalog schema version" in cached_payload["error"]
+    assert backend_model_catalog._REMOTE_REFRESH_IN_FLIGHT is False
+    backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
+
+
+def test_fetch_remote_catalog_rejects_invalid_model_entries(monkeypatch):
+    monkeypatch.setattr(
+        backend_model_catalog.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(
+            {
+                "schema_version": 1,
+                "backends": {"codex": {"models": [{"label": "missing id"}]}},
+            }
+        ),
+    )
+
+    with pytest.raises(ValueError, match="invalid model entry"):
+        backend_model_catalog.fetch_remote_catalog("https://example.test/catalog.json")
 
 
 def test_failed_refresh_with_stale_catalog_uses_failure_ttl():

--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -1,0 +1,85 @@
+import json
+import time
+
+from vibe import backend_model_catalog
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_backend_model_entries_normalize_string_and_dict_entries():
+    catalog = {
+        "schema_version": 1,
+        "backends": {
+            "codex": {
+                "models": [
+                    "gpt-custom",
+                    {
+                        "slug": "gpt-5.6-sol",
+                        "display_name": "GPT-5.6-Sol",
+                        "supported_reasoning_levels": [{"effort": "low"}, {"effort": "ultra"}],
+                    },
+                ]
+            }
+        },
+    }
+
+    entries = backend_model_catalog.backend_model_entries("codex", catalog)
+
+    assert entries == [
+        {"id": "gpt-custom"},
+        {
+            "id": "gpt-5.6-sol",
+            "label": "GPT-5.6-Sol",
+            "reasoning_efforts": ["low", "ultra"],
+        },
+    ]
+
+
+def test_refresh_remote_catalog_persists_state_cache(monkeypatch, tmp_path):
+    payload = {
+        "schema_version": 1,
+        "backends": {
+            "claude": {
+                "models": [
+                    {"id": "claude-fable-6", "reasoning_efforts": ["low", "max"]},
+                ]
+            }
+        },
+    }
+    monkeypatch.setattr(backend_model_catalog.paths, "get_state_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        backend_model_catalog.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(payload),
+    )
+    backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
+
+    catalog = backend_model_catalog.refresh_remote_catalog_now("https://example.test/catalog.json")
+
+    assert backend_model_catalog.backend_model_entries("claude", catalog)[0]["id"] == "claude-fable-6"
+    cached_payload = json.loads((tmp_path / "backend_model_catalog.json").read_text(encoding="utf-8"))
+    assert cached_payload["catalog"]["backends"]["claude"]["models"][0]["id"] == "claude-fable-6"
+    assert cached_payload["error"] is None
+    backend_model_catalog._REMOTE_MEMORY_CACHE.clear()
+
+
+def test_failed_refresh_with_stale_catalog_uses_failure_ttl():
+    payload = {
+        "fetched_at": time.time() - backend_model_catalog.REMOTE_CATALOG_TTL_SECONDS + 60,
+        "failed_at": time.time() - backend_model_catalog.REMOTE_CATALOG_FAILURE_TTL_SECONDS - 1,
+        "catalog": {"backends": {"codex": {"models": ["gpt-5.6-sol"]}}},
+    }
+
+    assert backend_model_catalog._remote_cache_stale(payload) is True

--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -49,6 +49,17 @@ def test_backend_model_entries_normalize_string_and_dict_entries():
     ]
 
 
+def test_bundled_codex_56_efforts_include_ultra():
+    catalog = backend_model_catalog.load_bundled_catalog()
+    entries = {
+        backend_model_catalog.model_id(entry): backend_model_catalog.reasoning_efforts(entry)
+        for entry in backend_model_catalog.backend_model_entries("codex", catalog)
+    }
+
+    assert "ultra" in entries["gpt-5.6-sol"]
+    assert "ultra" in entries["gpt-5.6-terra"]
+
+
 def test_refresh_remote_catalog_persists_state_cache(monkeypatch, tmp_path):
     payload = {
         "schema_version": 1,

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -161,6 +161,42 @@ def test_session_handler_passes_configured_claude_cli_path(monkeypatch, tmp_path
     assert getattr(client, "_vibe_runtime_session_key") == f"slack_C123:{tmp_path}"
 
 
+def test_session_handler_preserves_catalog_provided_claude_effort(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            captured["connected"] = True
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(
+        session_handler_module.backend_model_catalog,
+        "catalog_reasoning_efforts_for_model",
+        lambda backend, model: ["low", "medium", "ultra"]
+        if (backend, model) == ("claude", "claude-fable-6")
+        else None,
+    )
+
+    handler = SessionHandler(_Controller(tmp_path))
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    asyncio.run(
+        handler.get_or_create_claude_session(
+            context,
+            subagent_model="claude-fable-6",
+            subagent_reasoning_effort="ultra",
+        )
+    )
+
+    assert captured["connected"] is True
+    assert captured["options"].extra_args == {"model": "claude-fable-6"}
+    assert captured["options"].effort == "ultra"
+
+
 def test_session_handler_moves_claude_process_into_agent_cgroup(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[int, str]] = []
 

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -497,6 +497,25 @@ def test_gather_routing_modal_data_prefetches_all_backends_when_requested() -> N
     ]
 
 
+def test_gather_routing_modal_data_runs_codex_model_probe_in_worker_thread() -> None:
+    handler, server = _make_routing_handler()
+    context = MessageContext(user_id="U1", channel_id="D0APS47LPU2", platform="slack")
+    models_result = {"ok": True, "models": ["gpt-5.4"]}
+
+    with patch("vibe.api.codex_models") as codex_models, patch(
+        "vibe.api.codex_agents", return_value={"ok": True, "agents": []}
+    ), patch(
+        "core.handlers.settings_handler.asyncio.to_thread",
+        new=AsyncMock(return_value=models_result),
+    ) as to_thread:
+        data = asyncio.run(handler._gather_routing_modal_data(context, selected_backend="codex"))
+
+    to_thread.assert_awaited_once_with(codex_models)
+    codex_models.assert_not_called()
+    assert data.codex_models == ["gpt-5.4"]
+    assert server.calls == []
+
+
 def test_gather_routing_modal_data_hides_disabled_backends() -> None:
     handler, server = _make_routing_handler()
     handler.config.claude.enabled = False

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2117,7 +2117,8 @@ def test_codex_models_prefers_live_catalog_and_model_reasoning(monkeypatch, tmp_
                     {"effort": "ultra"},
                 ],
             },
-            {"slug": "hidden-live-model", "visibility": "hide", "priority": 0},
+            {"slug": "gpt-5.6-luna", "visibility": "hide", "priority": 0},
+            {"slug": "hidden-live-model", "visibility": "hide", "priority": 3},
         ]
     }
 
@@ -2167,9 +2168,10 @@ def test_codex_models_prefers_live_catalog_and_model_reasoning(monkeypatch, tmp_
     assert result["models"][:4] == [
         "gpt-5.6-sol",
         "gpt-5.6-terra",
-        "gpt-5.6-luna",
         "gpt-5.5",
+        "gpt-5.4",
     ]
+    assert "gpt-5.6-luna" not in result["models"]
     assert "hidden-live-model" not in result["models"]
     assert "codex-auto-review" not in result["models"]
     assert "stale-codex-model" in result["models"]
@@ -2300,6 +2302,7 @@ def test_codex_models_bundled_catalog_uses_model_supported_reasoning(monkeypatch
         "high",
         "xhigh",
         "max",
+        "ultra",
     ]
     assert [o["value"] for o in result["reasoning_options"]["gpt-5.5"]] == [
         "__default__",

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1946,11 +1946,28 @@ def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(api.backend_model_catalog, "load_cached_remote_catalog", lambda **kwargs: {})
     monkeypatch.setattr(api.backend_model_catalog, "load_bundled_catalog", lambda: {})
-    monkeypatch.setattr(api, "infer_bundle_path_from_cli", lambda cli_path: None)
+    configured_claude_path = "/custom/bin/claude-beta"
+    resolved_claude_path = "/usr/local/bin/claude-beta"
+    v2_config = SimpleNamespace(
+        agents=SimpleNamespace(claude=SimpleNamespace(cli_path=configured_claude_path))
+    )
+    scanned_cli_paths = []
+    monkeypatch.setattr(api.V2Config, "load", staticmethod(lambda: v2_config))
+    monkeypatch.setattr(
+        api,
+        "resolve_cli_path",
+        lambda binary: resolved_claude_path if binary == configured_claude_path else None,
+    )
+    monkeypatch.setattr(
+        api,
+        "infer_bundle_path_from_cli",
+        lambda cli_path: scanned_cli_paths.append(cli_path) or None,
+    )
 
     result = api.claude_models()
 
     assert result["ok"] is True
+    assert scanned_cli_paths == [resolved_claude_path]
     assert result["models"][:4] == [
         "claude-opus-4-6",
         "claude-sonnet-4-6",
@@ -1982,6 +1999,8 @@ def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
 def test_claude_models_merges_remote_catalog_with_dynamic_reasoning(monkeypatch, tmp_path):
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
     monkeypatch.setattr(api, "load_catalog_models", lambda: ["claude-opus-4-6"])
+    monkeypatch.setattr(api, "_configured_claude_cli_path", lambda: "claude")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda binary: None)
     monkeypatch.setattr(api, "infer_bundle_path_from_cli", lambda cli_path: None)
     monkeypatch.setattr(api.backend_model_catalog, "remote_catalog_token", lambda: (1.0, None))
     monkeypatch.setattr(

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1994,7 +1994,12 @@ def test_claude_models_merges_remote_catalog_with_dynamic_reasoning(monkeypatch,
                             "id": "claude-fable-6",
                             "label": "Claude Fable 6",
                             "reasoning_efforts": ["low", "medium", "ultra"],
-                        }
+                        },
+                        {
+                            "id": "claude-fable-6-20260710",
+                            "label": "Internal dated model",
+                            "reasoning_efforts": ["low"],
+                        },
                     ]
                 }
             }
@@ -2022,6 +2027,7 @@ def test_claude_models_merges_remote_catalog_with_dynamic_reasoning(monkeypatch,
 
     assert result["ok"] is True
     assert result["models"][:2] == ["claude-fable-6", "claude-opus-4-6"]
+    assert "claude-fable-6-20260710" not in result["models"]
     assert result["model_labels"]["claude-fable-6"] == "Claude Fable 6"
     assert [item["value"] for item in result["reasoning_options"]["claude-fable-6"]] == [
         "__default__",
@@ -2236,11 +2242,35 @@ def test_codex_models_includes_static_reasoning(monkeypatch, tmp_path):
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
     result = api.codex_models()
     assert result["ok"] is True
-    expected = ["__default__", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+    expected = ["__default__", "minimal", "low", "medium", "high", "xhigh"]
     # static set, surfaced under the default "" key and per-model
     assert [o["value"] for o in result["reasoning_options"][""]] == expected
     first_model = result["models"][0]
     assert [o["value"] for o in result["reasoning_options"][first_model]] == expected
+
+
+def test_codex_models_bundled_catalog_uses_model_supported_reasoning(monkeypatch, tmp_path):
+    _disable_live_codex_catalog(monkeypatch)
+    monkeypatch.setattr(api.backend_model_catalog, "load_cached_remote_catalog", lambda **kwargs: {})
+    monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
+
+    result = api.codex_models()
+
+    assert [o["value"] for o in result["reasoning_options"]["gpt-5.6-sol"]] == [
+        "__default__",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert [o["value"] for o in result["reasoning_options"]["gpt-5.5"]] == [
+        "__default__",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
 
 
 def test_agent_model_options_claude_strips_default_and_marks_default(monkeypatch):

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1119,6 +1119,33 @@ def test_normalize_backend_routing_payload_prefers_canonical_claude_overrides() 
     assert result["claude_reasoning_effort"] is None
 
 
+def test_normalize_backend_routing_payload_accepts_remote_claude_effort(monkeypatch) -> None:
+    monkeypatch.setattr(
+        api.backend_model_catalog,
+        "load_cached_remote_catalog",
+        lambda **kwargs: {
+            "backends": {
+                "claude": {
+                    "models": [
+                        {"id": "claude-future", "reasoning_efforts": ["low", "ultra"]},
+                    ]
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(api.backend_model_catalog, "load_bundled_catalog", lambda: {})
+
+    result = api._normalize_backend_routing_payload(
+        {
+            "agent_name": "claude",
+            "model": "claude-future",
+            "reasoning_effort": "ultra",
+        }
+    )
+
+    assert result["reasoning_effort"] == "ultra"
+
+
 def test_normalize_backend_routing_payload_prefers_canonical_over_round_trip_aliases() -> None:
     result = api._normalize_backend_routing_payload(
         {
@@ -1973,7 +2000,23 @@ def test_claude_models_merges_remote_catalog_with_dynamic_reasoning(monkeypatch,
             }
         },
     )
-    monkeypatch.setattr(api.backend_model_catalog, "load_bundled_catalog", lambda: {})
+    monkeypatch.setattr(
+        api.backend_model_catalog,
+        "load_bundled_catalog",
+        lambda: {
+            "backends": {
+                "claude": {
+                    "models": [
+                        {
+                            "id": "claude-fable-6",
+                            "label": "Stale bundled label",
+                            "reasoning_efforts": ["low", "medium"],
+                        }
+                    ]
+                }
+            }
+        },
+    )
 
     result = api.claude_models()
 
@@ -2053,6 +2096,23 @@ def test_codex_models_prefers_live_catalog_and_model_reasoning(monkeypatch, tmp_
 
     api._CODEX_LIVE_MODEL_CATALOG_CACHE.clear()
     monkeypatch.setattr(api.backend_model_catalog, "load_cached_remote_catalog", lambda **kwargs: {})
+    monkeypatch.setattr(
+        api.backend_model_catalog,
+        "load_bundled_catalog",
+        lambda: {
+            "backends": {
+                "codex": {
+                    "models": [
+                        {
+                            "id": "gpt-5.6-sol",
+                            "label": "Stale bundled label",
+                            "reasoning_efforts": ["low"],
+                        }
+                    ]
+                }
+            }
+        },
+    )
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
     monkeypatch.setattr(api, "resolve_cli_path", lambda binary: "/usr/local/bin/codex" if binary == "codex" else binary)
     monkeypatch.setattr(api.subprocess, "run", fake_run)

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1917,6 +1917,9 @@ def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
             "claude-opus-4-5",
         ],
     )
+    monkeypatch.setattr(api.backend_model_catalog, "load_cached_remote_catalog", lambda **kwargs: {})
+    monkeypatch.setattr(api.backend_model_catalog, "load_bundled_catalog", lambda: {})
+    monkeypatch.setattr(api, "infer_bundle_path_from_cli", lambda cli_path: None)
 
     result = api.claude_models()
 
@@ -1949,6 +1952,136 @@ def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
     ]
 
 
+def test_claude_models_merges_remote_catalog_with_dynamic_reasoning(monkeypatch, tmp_path):
+    monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(api, "load_catalog_models", lambda: ["claude-opus-4-6"])
+    monkeypatch.setattr(api, "infer_bundle_path_from_cli", lambda cli_path: None)
+    monkeypatch.setattr(
+        api.backend_model_catalog,
+        "load_cached_remote_catalog",
+        lambda **kwargs: {
+            "backends": {
+                "claude": {
+                    "models": [
+                        {
+                            "id": "claude-fable-6",
+                            "label": "Claude Fable 6",
+                            "reasoning_efforts": ["low", "medium", "ultra"],
+                        }
+                    ]
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(api.backend_model_catalog, "load_bundled_catalog", lambda: {})
+
+    result = api.claude_models()
+
+    assert result["ok"] is True
+    assert result["models"][:2] == ["claude-fable-6", "claude-opus-4-6"]
+    assert result["model_labels"]["claude-fable-6"] == "Claude Fable 6"
+    assert [item["value"] for item in result["reasoning_options"]["claude-fable-6"]] == [
+        "__default__",
+        "low",
+        "medium",
+        "ultra",
+    ]
+
+
+def _disable_remote_backend_catalog(monkeypatch):
+    monkeypatch.setattr(api.backend_model_catalog, "load_cached_remote_catalog", lambda **kwargs: {})
+    monkeypatch.setattr(api.backend_model_catalog, "load_bundled_catalog", lambda: {})
+
+
+def _disable_live_codex_catalog(monkeypatch):
+    api._CODEX_LIVE_MODEL_CATALOG_CACHE.clear()
+    monkeypatch.setattr(api, "resolve_cli_path", lambda binary: None if binary == "codex" else binary)
+
+
+def test_codex_models_prefers_live_catalog_and_model_reasoning(monkeypatch, tmp_path):
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir(parents=True, exist_ok=True)
+    (codex_dir / "models_cache.json").write_text(
+        json.dumps(
+            {
+                "models": [
+                    {"slug": "stale-codex-model", "visibility": "list", "priority": 1},
+                    {"slug": "codex-auto-review", "visibility": "hide", "priority": 2},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    live_catalog = {
+        "models": [
+            {
+                "slug": "gpt-5.6-terra",
+                "display_name": "GPT-5.6-Terra",
+                "visibility": "list",
+                "priority": 2,
+                "supported_reasoning_levels": [
+                    {"effort": "low"},
+                    {"effort": "medium"},
+                    {"effort": "high"},
+                    {"effort": "xhigh"},
+                    {"effort": "max"},
+                    {"effort": "ultra"},
+                ],
+            },
+            {
+                "slug": "gpt-5.6-sol",
+                "display_name": "GPT-5.6-Sol",
+                "visibility": "list",
+                "priority": 1,
+                "supported_reasoning_levels": [
+                    {"effort": "low"},
+                    {"effort": "medium"},
+                    {"effort": "high"},
+                    {"effort": "xhigh"},
+                    {"effort": "max"},
+                    {"effort": "ultra"},
+                ],
+            },
+            {"slug": "hidden-live-model", "visibility": "hide", "priority": 0},
+        ]
+    }
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["/usr/local/bin/codex", "debug", "models"]
+        assert kwargs["timeout"] == api._CODEX_LIVE_MODEL_CATALOG_TIMEOUT_SECONDS
+        return api.subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(live_catalog), stderr="")
+
+    api._CODEX_LIVE_MODEL_CATALOG_CACHE.clear()
+    monkeypatch.setattr(api.backend_model_catalog, "load_cached_remote_catalog", lambda **kwargs: {})
+    monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(api, "resolve_cli_path", lambda binary: "/usr/local/bin/codex" if binary == "codex" else binary)
+    monkeypatch.setattr(api.subprocess, "run", fake_run)
+
+    result = api.codex_models()
+
+    assert result["ok"] is True
+    assert result["live"] is True
+    assert result["models"][:4] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+    ]
+    assert "hidden-live-model" not in result["models"]
+    assert "codex-auto-review" not in result["models"]
+    assert "stale-codex-model" in result["models"]
+    assert result["model_labels"]["gpt-5.6-sol"] == "GPT-5.6-Sol"
+    assert [o["value"] for o in result["reasoning_options"]["gpt-5.6-sol"]] == [
+        "__default__",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    ]
+
+
 def test_codex_models_prefers_cli_cache_and_filters_hidden_models(monkeypatch, tmp_path):
     codex_dir = tmp_path / ".codex"
     codex_dir.mkdir(parents=True, exist_ok=True)
@@ -1977,12 +2110,18 @@ def test_codex_models_prefers_cli_cache_and_filters_hidden_models(monkeypatch, t
         encoding="utf-8",
     )
 
+    _disable_live_codex_catalog(monkeypatch)
+    _disable_remote_backend_catalog(monkeypatch)
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
 
     result = api.codex_models()
 
     assert result["ok"] is True
-    assert result["models"][:4] == [
+    assert result["live"] is False
+    assert result["models"][:7] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -2009,12 +2148,22 @@ def test_codex_models_falls_back_when_cli_cache_missing(monkeypatch, tmp_path):
         encoding="utf-8",
     )
 
+    _disable_live_codex_catalog(monkeypatch)
+    _disable_remote_backend_catalog(monkeypatch)
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
 
     result = api.codex_models()
 
     assert result["ok"] is True
-    assert result["models"][:4] == ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]
+    assert result["models"][:7] == [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+    ]
     assert "custom-codex-model" in result["models"]
     assert "legacy-codex" in result["models"]
     assert "gpt-5.1-codex-max" in result["models"]
@@ -2022,10 +2171,12 @@ def test_codex_models_falls_back_when_cli_cache_missing(monkeypatch, tmp_path):
 
 
 def test_codex_models_includes_static_reasoning(monkeypatch, tmp_path):
+    _disable_live_codex_catalog(monkeypatch)
+    _disable_remote_backend_catalog(monkeypatch)
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
     result = api.codex_models()
     assert result["ok"] is True
-    expected = ["__default__", "minimal", "low", "medium", "high", "xhigh"]
+    expected = ["__default__", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
     # static set, surfaced under the default "" key and per-model
     assert [o["value"] for o in result["reasoning_options"][""]] == expected
     first_model = result["models"][0]

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1983,6 +1983,12 @@ def test_claude_models_merges_remote_catalog_with_dynamic_reasoning(monkeypatch,
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
     monkeypatch.setattr(api, "load_catalog_models", lambda: ["claude-opus-4-6"])
     monkeypatch.setattr(api, "infer_bundle_path_from_cli", lambda cli_path: None)
+    monkeypatch.setattr(api.backend_model_catalog, "remote_catalog_token", lambda: (1.0, None))
+    monkeypatch.setattr(
+        api.backend_model_catalog,
+        "remote_catalog_refresh_pending",
+        lambda token: token == (1.0, None),
+    )
     monkeypatch.setattr(
         api.backend_model_catalog,
         "load_cached_remote_catalog",
@@ -2029,6 +2035,7 @@ def test_claude_models_merges_remote_catalog_with_dynamic_reasoning(monkeypatch,
     assert result["models"][:2] == ["claude-fable-6", "claude-opus-4-6"]
     assert "claude-fable-6-20260710" not in result["models"]
     assert result["model_labels"]["claude-fable-6"] == "Claude Fable 6"
+    assert result["catalog_refresh_pending"] is True
     assert [item["value"] for item in result["reasoning_options"]["claude-fable-6"]] == [
         "__default__",
         "low",
@@ -2095,8 +2102,11 @@ def test_codex_models_prefers_live_catalog_and_model_reasoning(monkeypatch, tmp_
         ]
     }
 
+    configured_codex_path = "/custom/bin/codex-wrapper"
+    resolved_codex_path = "/usr/local/bin/codex"
+
     def fake_run(cmd, **kwargs):
-        assert cmd == ["/usr/local/bin/codex", "debug", "models"]
+        assert cmd == [resolved_codex_path, "debug", "models"]
         assert kwargs["timeout"] == api._CODEX_LIVE_MODEL_CATALOG_TIMEOUT_SECONDS
         return api.subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(live_catalog), stderr="")
 
@@ -2120,7 +2130,15 @@ def test_codex_models_prefers_live_catalog_and_model_reasoning(monkeypatch, tmp_
         },
     )
     monkeypatch.setattr(api.Path, "home", lambda: tmp_path)
-    monkeypatch.setattr(api, "resolve_cli_path", lambda binary: "/usr/local/bin/codex" if binary == "codex" else binary)
+    v2_config = SimpleNamespace(
+        agents=SimpleNamespace(codex=SimpleNamespace(cli_path=configured_codex_path))
+    )
+    monkeypatch.setattr(api.V2Config, "load", staticmethod(lambda: v2_config))
+    monkeypatch.setattr(
+        api,
+        "resolve_cli_path",
+        lambda binary: resolved_codex_path if binary == configured_codex_path else None,
+    )
     monkeypatch.setattr(api.subprocess, "run", fake_run)
 
     result = api.codex_models()

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -418,7 +418,9 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
                 disabled={patching}
                 onClick={() => void applyPatch({ reasoning_effort: opt })}
               >
-                <span className="flex-1 capitalize">{t(`chat.picker.effortOptions.${opt}`)}</span>
+                <span className="flex-1 capitalize">
+                  {t(`chat.picker.effortOptions.${opt}`, { defaultValue: opt })}
+                </span>
               </RouteItem>
             ))}
           </RouteColumn>

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { useApi } from '../../context/ApiContext';
 import type { VibeAgentBrief } from '../../context/ApiContext';
 import { loadBackendModelsWithRefresh, modelOptionLabel } from '../../lib/backendModels';
-import { resolveEffortOptions } from '../../lib/effortOptions';
+import { isEffortSupported, resolveEffortOptions } from '../../lib/effortOptions';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -402,9 +402,8 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
                     // Switching to a model whose effort set no longer includes
                     // the current effort: clear it in the same patch so the displayed
                     // route matches what dispatches.
-                    if (currentEffort) {
-                      const opts = backendReasoning[model];
-                      if (opts && !opts.some((o) => o.value === currentEffort)) patch.reasoning_effort = null;
+                    if (!isEffortSupported(backend, model, currentEffort, backendReasoning)) {
+                      patch.reasoning_effort = null;
                     }
                     void applyPatch(patch);
                   }}

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -83,10 +83,10 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   const [open, setOpen] = useState(false);
   const [modelsByBackend, setModelsByBackend] = useState<Record<string, string[]>>({});
   const [modelLabelsByBackend, setModelLabelsByBackend] = useState<Record<string, Record<string, string>>>({});
-  // Claude reasoning efforts are MODEL-specific (newer Opus/Sonnet add xhigh/max),
-  // so the backend returns them keyed by model. Cached so the effort column offers
-  // exactly the efforts the selected model supports.
-  const [claudeReasoning, setClaudeReasoning] = useState<Record<string, { value: string; label: string }[]>>({});
+  // Some backends expose model-specific reasoning efforts. Cache the active
+  // backend's map so the effort column offers exactly what the selected model
+  // supports.
+  const [reasoningByBackend, setReasoningByBackend] = useState<Record<string, Record<string, { value: string; label: string }[]>>>({});
   const [loadingModels, setLoadingModels] = useState(false);
   const [patching, setPatching] = useState(false);
   // Free-text filter for the model column — long backends (OpenCode) list dozens.
@@ -189,7 +189,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
       try {
         const { models, modelLabels, reasoningOptions } = await fetchBackendModels(api, backend);
         if (!cancelled) {
-          if (reasoningOptions) setClaudeReasoning(reasoningOptions);
+          setReasoningByBackend((prev) => ({ ...prev, [backend]: reasoningOptions ?? {} }));
           setModelsByBackend((prev) => ({ ...prev, [backend]: models }));
           setModelLabelsByBackend((prev) => ({ ...prev, [backend]: modelLabels ?? {} }));
         }
@@ -211,6 +211,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
 
   const models = modelsByBackend[backend] ?? [];
   const modelLabels = modelLabelsByBackend[backend] ?? {};
+  const backendReasoning = reasoningByBackend[backend] ?? {};
   // Show the search field only when the list is long enough to warrant it, so
   // claude/codex (a handful of models) stay uncluttered.
   const showModelSearch = models.length > 8;
@@ -223,8 +224,8 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
       )
     : models;
   const effortOptions = useMemo(
-    () => resolveEffortOptions(backend, currentModel, claudeReasoning),
-    [backend, currentModel, claudeReasoning],
+    () => resolveEffortOptions(backend, currentModel, backendReasoning),
+    [backend, currentModel, backendReasoning],
   );
 
   return (
@@ -387,11 +388,11 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
                   disabled={patching}
                   onClick={() => {
                     const patch: AgentRoutePatch = { model };
-                    // Switching to a Claude model whose effort set no longer includes
+                    // Switching to a model whose effort set no longer includes
                     // the current effort: clear it in the same patch so the displayed
                     // route matches what dispatches.
-                    if (backend === 'claude' && currentEffort) {
-                      const opts = claudeReasoning[model];
+                    if (currentEffort) {
+                      const opts = backendReasoning[model];
                       if (opts && !opts.some((o) => o.value === currentEffort)) patch.reasoning_effort = null;
                     }
                     void applyPatch(patch);
@@ -408,7 +409,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
             )}
           </RouteColumn>
 
-          {/* Column 3 — Effort (Claude: model-specific; others: backend superset) */}
+          {/* Column 3 — Effort (uses per-model catalog entries when available) */}
           <RouteColumn title={t('chat.picker.effort')}>
             {effortOptions.map((opt) => (
               <RouteItem

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Bot, ChevronDown, Loader2, Plus, Search, Sparkles } from 'lucide-react';
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
 import type { VibeAgentBrief } from '../../context/ApiContext';
-import { fetchBackendModels, modelOptionLabel } from '../../lib/backendModels';
+import { loadBackendModelsWithRefresh, modelOptionLabel } from '../../lib/backendModels';
 import { resolveEffortOptions } from '../../lib/effortOptions';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { Button } from '../ui/button';
@@ -91,6 +91,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   // backend's map so the effort column offers exactly what the selected model
   // supports.
   const [reasoningByBackend, setReasoningByBackend] = useState<Record<string, Record<string, ReasoningOption[]>>>({});
+  const loadedModelBackendsRef = useRef<Set<string>>(new Set());
   const [loadingModels, setLoadingModels] = useState(false);
   const [patching, setPatching] = useState(false);
   // Free-text filter for the model column — long backends (OpenCode) list dozens.
@@ -156,6 +157,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
 
   useEffect(() => {
     const clearOpenCodeModels = () => {
+      loadedModelBackendsRef.current.delete('opencode');
       setModelsByBackend((prev) => {
         if (!prev.opencode) return prev;
         const next = { ...prev };
@@ -186,27 +188,32 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   // Fetch the active backend's model list the first time the menu opens for it;
   // cached per backend so toggling agents doesn't refetch.
   useEffect(() => {
-    if (!open || !backend || modelsByBackend[backend]) return;
-    let cancelled = false;
+    const loadedBackends = loadedModelBackendsRef.current;
+    if (!open || !backend || loadedBackends.has(backend)) return;
+    loadedBackends.add(backend);
+    let reloadOnNextOpen = true;
     setLoadingModels(true);
-    (async () => {
-      try {
-        const { models, modelLabels, reasoningOptions } = await fetchBackendModels(api, backend);
-        if (!cancelled) {
-          setReasoningByBackend((prev) => ({ ...prev, [backend]: reasoningOptions ?? {} }));
-          setModelsByBackend((prev) => ({ ...prev, [backend]: models }));
-          setModelLabelsByBackend((prev) => ({ ...prev, [backend]: modelLabels ?? {} }));
-        }
-      } catch {
-        if (!cancelled) setModelsByBackend((prev) => ({ ...prev, [backend]: [] }));
-      } finally {
-        if (!cancelled) setLoadingModels(false);
-      }
-    })();
+    const cancel = loadBackendModelsWithRefresh(
+      api,
+      backend,
+      ({ models, modelLabels, reasoningOptions, catalogRefreshPending }) => {
+        reloadOnNextOpen = Boolean(catalogRefreshPending);
+        setReasoningByBackend((prev) => ({ ...prev, [backend]: reasoningOptions ?? {} }));
+        setModelsByBackend((prev) => ({ ...prev, [backend]: models }));
+        setModelLabelsByBackend((prev) => ({ ...prev, [backend]: modelLabels ?? {} }));
+        setLoadingModels(false);
+      },
+      () => {
+        loadedBackends.delete(backend);
+        setModelsByBackend((prev) => ({ ...prev, [backend]: [] }));
+        setLoadingModels(false);
+      },
+    );
     return () => {
-      cancelled = true;
+      cancel();
+      if (reloadOnNextOpen) loadedBackends.delete(backend);
     };
-  }, [open, backend, api, modelsByBackend]);
+  }, [open, backend, api]);
 
   // Start each open (and every backend switch) from the full, unfiltered list.
   useEffect(() => {

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -55,6 +55,10 @@ interface AgentRoutePickerProps {
   onNavigateAway?: () => void;
 }
 
+type ReasoningOption = { value: string; label: string };
+
+const EMPTY_REASONING_OPTIONS: Record<string, ReasoningOption[]> = {};
+
 // design.pen Q5xIZa — one cyan-ringed trigger showing `[backend] agent · model ·
 // effort` that opens a three-column cascading menu (Agent → Model → Effort).
 // Picking an agent seeds model/effort from its defaults; the model column is
@@ -86,7 +90,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   // Some backends expose model-specific reasoning efforts. Cache the active
   // backend's map so the effort column offers exactly what the selected model
   // supports.
-  const [reasoningByBackend, setReasoningByBackend] = useState<Record<string, Record<string, { value: string; label: string }[]>>>({});
+  const [reasoningByBackend, setReasoningByBackend] = useState<Record<string, Record<string, ReasoningOption[]>>>({});
   const [loadingModels, setLoadingModels] = useState(false);
   const [patching, setPatching] = useState(false);
   // Free-text filter for the model column — long backends (OpenCode) list dozens.
@@ -211,7 +215,7 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
 
   const models = modelsByBackend[backend] ?? [];
   const modelLabels = modelLabelsByBackend[backend] ?? {};
-  const backendReasoning = reasoningByBackend[backend] ?? {};
+  const backendReasoning = reasoningByBackend[backend] ?? EMPTY_REASONING_OPTIONS;
   // Show the search field only when the list is long enough to warrant it, so
   // claude/codex (a handful of models) stay uncluttered.
   const showModelSearch = models.length > 8;

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -37,7 +37,7 @@ import { Textarea } from '../ui/textarea';
 import { EditorDialog } from '../ui/editor-dialog';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { estimateTokens } from '../../lib/tokenEstimate';
-import { fetchBackendModels, modelOptionLabel } from '../../lib/backendModels';
+import { loadBackendModelsWithRefresh, modelOptionLabel } from '../../lib/backendModels';
 import { resolveEffortOptions } from '../../lib/effortOptions';
 import { WorkbenchPageHeader } from './WorkbenchPageHeader';
 import { CapabilityTabs } from './CapabilityTabs';
@@ -687,22 +687,15 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
   // suggestions. Keeps `allowCustomValue` so users can type a model the
   // backend doesn't know about yet (e.g. a freshly-released preview).
   useEffect(() => {
-    let cancelled = false;
-    async function loadModels() {
-      try {
-        const { models, modelLabels, reasoningOptions: opts } = await fetchBackendModels(api, agent.backend);
-        if (!cancelled) {
-          setModelOptions(models.map((m) => ({ value: m, label: modelOptionLabel(m, modelLabels) })));
-          setReasoningOptions(opts ?? {});
-        }
-      } catch {
-        if (!cancelled) setModelOptions([]);
-      }
-    }
-    loadModels();
-    return () => {
-      cancelled = true;
-    };
+    return loadBackendModelsWithRefresh(
+      api,
+      agent.backend,
+      ({ models, modelLabels, reasoningOptions: opts }) => {
+        setModelOptions(models.map((m) => ({ value: m, label: modelOptionLabel(m, modelLabels) })));
+        setReasoningOptions(opts ?? {});
+      },
+      () => setModelOptions([]),
+    );
   }, [agent.backend, api]);
 
   const systemPromptTokens = estimateTokens(systemPrompt);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -669,9 +669,20 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
   const [systemPrompt, setSystemPrompt] = useState(agent.system_prompt ?? '');
   const [systemPromptOpen, setSystemPromptOpen] = useState(false);
   const [editorOpen, setEditorOpen] = useState(false);
-  const [modelOptions, setModelOptions] = useState<ComboboxOption[]>([]);
-  const [reasoningOptions, setReasoningOptions] = useState<Record<string, { value: string; label: string }[]>>({});
+  const [modelCatalogs, setModelCatalogs] = useState<
+    Record<
+      string,
+      {
+        modelOptions: ComboboxOption[];
+        reasoningOptions: Record<string, { value: string; label: string }[]>;
+      }
+    >
+  >({});
   const [running, setRunning] = useState(false);
+
+  const activeModelCatalog = modelCatalogs[agent.backend];
+  const modelOptions = activeModelCatalog?.modelOptions ?? [];
+  const reasoningOptions = activeModelCatalog?.reasoningOptions ?? {};
 
   useEffect(() => {
     setName(agent.name);
@@ -691,10 +702,20 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
       api,
       agent.backend,
       ({ models, modelLabels, reasoningOptions: opts }) => {
-        setModelOptions(models.map((m) => ({ value: m, label: modelOptionLabel(m, modelLabels) })));
-        setReasoningOptions(opts ?? {});
+        setModelCatalogs((current) => ({
+          ...current,
+          [agent.backend]: {
+            modelOptions: models.map((m) => ({ value: m, label: modelOptionLabel(m, modelLabels) })),
+            reasoningOptions: opts ?? {},
+          },
+        }));
       },
-      () => setModelOptions([]),
+      () => {
+        setModelCatalogs((current) => ({
+          ...current,
+          [agent.backend]: { modelOptions: [], reasoningOptions: {} },
+        }));
+      },
     );
   }, [agent.backend, api]);
 

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
 import type { VibeAgentFull } from '../../context/ApiContext';
-import { fetchBackendModels, modelOptionLabel } from '../../lib/backendModels';
+import { loadBackendModelsWithRefresh, modelOptionLabel } from '../../lib/backendModels';
 import { resolveEffortOptions } from '../../lib/effortOptions';
 import { estimateTokens } from '../../lib/tokenEstimate';
 import { Combobox } from '../ui/combobox';
@@ -77,26 +77,22 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
   // freshly-released model IDs can still be typed in.
   useEffect(() => {
     if (!open) return;
-    let cancelled = false;
-    async function loadModels() {
-      try {
-        const { models, modelLabels, reasoningOptions: opts } = await fetchBackendModels(api, backend);
-        if (!cancelled) {
-          setModelOptions(models.map((m) => ({ value: m, label: modelOptionLabel(m, modelLabels) })));
-          setReasoningOptions(opts ?? {});
-          // Clear model when the backend changes if the previous choice
-          // isn't in the new catalog — avoids silently mismatched pairs.
-          if (model && !models.includes(model)) setModel('');
+    return loadBackendModelsWithRefresh(
+      api,
+      backend,
+      ({ models, modelLabels, reasoningOptions: opts, catalogRefreshPending }) => {
+        setModelOptions(models.map((m) => ({ value: m, label: modelOptionLabel(m, modelLabels) })));
+        setReasoningOptions(opts ?? {});
+        // Do not clear a newly released model while the remote catalog is
+        // still refreshing; the follow-up snapshot may contain it.
+        if (!catalogRefreshPending) {
+          setModel((currentModel) =>
+            currentModel && !models.includes(currentModel) ? '' : currentModel,
+          );
         }
-      } catch {
-        if (!cancelled) setModelOptions([]);
-      }
-    }
-    loadModels();
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+      },
+      () => setModelOptions([]),
+    );
   }, [backend, open, api]);
 
   const modelComboboxOptions = useMemo(() => modelOptions, [modelOptions]);

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -194,7 +194,14 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
                 <button
                   key={opt.key}
                   type="button"
-                  onClick={() => setBackend(opt.key)}
+                  onClick={() => {
+                    if (backend === opt.key) return;
+                    setBackend(opt.key);
+                    setModel('');
+                    setEffort('medium');
+                    setModelOptions([]);
+                    setReasoningOptions({});
+                  }}
                   className={clsx(
                     'flex flex-col items-center justify-center gap-1.5 rounded-lg border-2 px-3 py-3.5 transition',
                     active ? `${cc.border} ${cc.bg}` : 'border-border-strong bg-surface-2 hover:bg-foreground/[0.04]',

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -452,13 +452,14 @@ export type ApiContextType = {
   opencodeSetupPermission: () => Promise<{ ok: boolean; message: string; config_path: string }>;
   opencodePermissionStatus: () => Promise<{ ok: boolean; permission_allowed: boolean; config_path: string }>;
   claudeAgents: (cwd?: string) => Promise<{ ok: boolean; agents?: { id: string; name: string; path: string; source?: string }[]; error?: string }>;
-  claudeModels: () => Promise<{ ok: boolean; models?: string[]; reasoning_options?: Record<string, { value: string; label: string }[]>; model_labels?: Record<string, string>; error?: string }>;
+  claudeModels: () => Promise<{ ok: boolean; models?: string[]; reasoning_options?: Record<string, { value: string; label: string }[]>; model_labels?: Record<string, string>; catalog_refresh_pending?: boolean; error?: string }>;
   codexAgents: (cwd?: string) => Promise<{ ok: boolean; agents?: { id: string; name: string; path: string; source?: string; description?: string }[]; error?: string }>;
   codexModels: () => Promise<{
     ok: boolean;
     models?: string[];
     reasoning_options?: Record<string, { value: string; label: string }[]>;
     model_labels?: Record<string, string>;
+    catalog_refresh_pending?: boolean;
     error?: string;
   }>;
   getLogs: (lines?: number, source?: string) => Promise<{ logs: LogEntry[]; total: number; source: string; sources: LogSource[] }>;

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -395,7 +395,13 @@ export type ApiContextType = {
   claudeAgents: (cwd?: string) => Promise<{ ok: boolean; agents?: { id: string; name: string; path: string; source?: string }[]; error?: string }>;
   claudeModels: () => Promise<{ ok: boolean; models?: string[]; reasoning_options?: Record<string, { value: string; label: string }[]>; model_labels?: Record<string, string>; error?: string }>;
   codexAgents: (cwd?: string) => Promise<{ ok: boolean; agents?: { id: string; name: string; path: string; source?: string; description?: string }[]; error?: string }>;
-  codexModels: () => Promise<{ ok: boolean; models?: string[]; error?: string }>;
+  codexModels: () => Promise<{
+    ok: boolean;
+    models?: string[];
+    reasoning_options?: Record<string, { value: string; label: string }[]>;
+    model_labels?: Record<string, string>;
+    error?: string;
+  }>;
   getLogs: (lines?: number, source?: string) => Promise<{ logs: LogEntry[]; total: number; source: string; sources: LogSource[] }>;
   getVersion: () => Promise<VersionInfo>;
   doUpgrade: () => Promise<UpgradeResult>;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2180,7 +2180,8 @@
         "medium": "Medium",
         "high": "High",
         "xhigh": "Extra High",
-        "max": "Max"
+        "max": "Max",
+        "ultra": "Ultra"
       }
     },
     "compose": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2180,7 +2180,8 @@
         "medium": "中",
         "high": "高",
         "xhigh": "极高",
-        "max": "最高"
+        "max": "最高",
+        "ultra": "Ultra"
       }
     },
     "compose": {

--- a/ui/src/lib/backendModels.test.ts
+++ b/ui/src/lib/backendModels.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ApiContextType } from '../context/ApiContext';
+import { loadBackendModelsWithRefresh } from './backendModels';
+
+describe('loadBackendModelsWithRefresh', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('delivers the cached snapshot and silently refetches after a catalog refresh', async () => {
+    vi.useFakeTimers();
+    const claudeModels = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        models: ['claude-old'],
+        catalog_refresh_pending: true,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        models: ['claude-old', 'claude-new'],
+        catalog_refresh_pending: false,
+      });
+    const api = { claudeModels } as unknown as ApiContextType;
+    const snapshots: string[][] = [];
+
+    const cancel = loadBackendModelsWithRefresh(api, 'claude', (result) => {
+      snapshots.push(result.models);
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(snapshots).toEqual([['claude-old']]);
+
+    await vi.advanceTimersByTimeAsync(3_500);
+    expect(snapshots).toEqual([['claude-old'], ['claude-old', 'claude-new']]);
+    expect(claudeModels).toHaveBeenCalledTimes(2);
+
+    cancel();
+  });
+});

--- a/ui/src/lib/backendModels.ts
+++ b/ui/src/lib/backendModels.ts
@@ -7,7 +7,12 @@ export interface BackendModels {
   modelLabels?: Record<string, string>;
   /** Per-model reasoning-effort option sets; undefined when a backend has none. */
   reasoningOptions?: Record<string, { value: string; label: string }[]>;
+  /** True when the backend catalog changed, or is still refreshing, after this snapshot was read. */
+  catalogRefreshPending?: boolean;
 }
+
+const CATALOG_REFRESH_RETRY_DELAY_MS = 3_500;
+const CATALOG_REFRESH_MAX_RETRIES = 2;
 
 export function modelOptionLabel(model: string, labels?: Record<string, string>): string {
   return labels?.[model] || model;
@@ -36,6 +41,7 @@ export async function fetchBackendModels(
       models: res.ok && res.models ? res.models : [],
       modelLabels: res.model_labels,
       reasoningOptions: res.reasoning_options,
+      catalogRefreshPending: res.catalog_refresh_pending,
     };
   }
   if (backend === 'codex') {
@@ -44,6 +50,7 @@ export async function fetchBackendModels(
       models: res.ok && res.models ? res.models : [],
       modelLabels: res.model_labels,
       reasoningOptions: res.reasoning_options,
+      catalogRefreshPending: res.catalog_refresh_pending,
     };
   }
   if (backend === 'opencode') {
@@ -54,4 +61,35 @@ export async function fetchBackendModels(
     return { models };
   }
   return { models: [] };
+}
+
+export function loadBackendModelsWithRefresh(
+  api: ApiContextType,
+  backend: string,
+  onResult: (result: BackendModels) => void,
+  onInitialError?: () => void,
+): () => void {
+  let cancelled = false;
+  let delivered = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const load = async (retriesRemaining: number) => {
+    try {
+      const result = await fetchBackendModels(api, backend);
+      if (cancelled) return;
+      delivered = true;
+      onResult(result);
+      if (result.catalogRefreshPending && retriesRemaining > 0) {
+        timer = setTimeout(() => void load(retriesRemaining - 1), CATALOG_REFRESH_RETRY_DELAY_MS);
+      }
+    } catch {
+      if (!cancelled && !delivered) onInitialError?.();
+    }
+  };
+
+  void load(CATALOG_REFRESH_MAX_RETRIES);
+  return () => {
+    cancelled = true;
+    if (timer !== undefined) clearTimeout(timer);
+  };
 }

--- a/ui/src/lib/backendModels.ts
+++ b/ui/src/lib/backendModels.ts
@@ -5,7 +5,7 @@ export interface BackendModels {
   models: string[];
   /** Optional display labels keyed by model identifier; values remain raw ids. */
   modelLabels?: Record<string, string>;
-  /** Per-model reasoning-effort option sets (Claude only); undefined elsewhere. */
+  /** Per-model reasoning-effort option sets; undefined when a backend has none. */
   reasoningOptions?: Record<string, { value: string; label: string }[]>;
 }
 
@@ -40,7 +40,11 @@ export async function fetchBackendModels(
   }
   if (backend === 'codex') {
     const res = await api.codexModels();
-    return { models: res.ok && res.models ? res.models : [] };
+    return {
+      models: res.ok && res.models ? res.models : [],
+      modelLabels: res.model_labels,
+      reasoningOptions: res.reasoning_options,
+    };
   }
   if (backend === 'opencode') {
     const res = await api.getOpencodeProviders();

--- a/ui/src/lib/effortOptions.test.ts
+++ b/ui/src/lib/effortOptions.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEffortSupported, resolveEffortOptions } from './effortOptions';
+
+describe('effort options', () => {
+  it('uses backend fallbacks when the selected model has no catalog entry', () => {
+    const reasoningOptions = {
+      'gpt-5.6-sol': [
+        { value: '__default__', label: 'Default' },
+        { value: 'max', label: 'Max' },
+      ],
+    };
+
+    expect(resolveEffortOptions('codex', 'gpt-fallback', reasoningOptions)).toEqual([
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ]);
+    expect(isEffortSupported('codex', 'gpt-fallback', 'max', reasoningOptions)).toBe(false);
+  });
+
+  it('accepts catalog-only efforts for models that explicitly provide them', () => {
+    const reasoningOptions = {
+      'claude-fable-6': [
+        { value: '__default__', label: 'Default' },
+        { value: 'ultra', label: 'Ultra' },
+      ],
+    };
+
+    expect(isEffortSupported('claude', 'claude-fable-6', 'ultra', reasoningOptions)).toBe(true);
+  });
+});

--- a/ui/src/lib/effortOptions.ts
+++ b/ui/src/lib/effortOptions.ts
@@ -1,12 +1,12 @@
 // Single source of truth for reasoning-effort options, shared by ChatPage, the
 // Agents detail panel, and the New Agent dialog. Mirrors the backend lists in
-// modules/agents/opencode/utils.py: Codex is minimal..ultra, Claude is
+// modules/agents/opencode/utils.py: Codex falls back to minimal..xhigh, Claude is
 // low/medium/high (+ xhigh/max on models that support it), OpenCode uses the
-// broad superset.
+// broad superset. Codex/Claude model catalogs override these fallbacks.
 export const EFFORT_BY_BACKEND: Record<string, string[]> = {
   claude: ['low', 'medium', 'high'],
-  codex: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
-  opencode: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+  codex: ['minimal', 'low', 'medium', 'high', 'xhigh'],
+  opencode: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
 };
 
 const DEFAULT_EFFORTS = ['low', 'medium', 'high'];

--- a/ui/src/lib/effortOptions.ts
+++ b/ui/src/lib/effortOptions.ts
@@ -39,3 +39,12 @@ export function resolveEffortOptions(
   }
   return effortOptionsFor(backend);
 }
+
+export function isEffortSupported(
+  backend: string,
+  model: string | null | undefined,
+  effort: string | null | undefined,
+  reasoningOptions: Record<string, { value: string; label: string }[]> | undefined,
+): boolean {
+  return !effort || resolveEffortOptions(backend, model, reasoningOptions).includes(effort);
+}

--- a/ui/src/lib/effortOptions.ts
+++ b/ui/src/lib/effortOptions.ts
@@ -1,32 +1,31 @@
 // Single source of truth for reasoning-effort options, shared by ChatPage, the
 // Agents detail panel, and the New Agent dialog. Mirrors the backend lists in
-// modules/agents/opencode/utils.py: Codex is minimal..xhigh, Claude is
+// modules/agents/opencode/utils.py: Codex is minimal..ultra, Claude is
 // low/medium/high (+ xhigh/max on models that support it), OpenCode uses the
 // broad superset.
 export const EFFORT_BY_BACKEND: Record<string, string[]> = {
   claude: ['low', 'medium', 'high'],
-  codex: ['minimal', 'low', 'medium', 'high', 'xhigh'],
-  opencode: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+  codex: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+  opencode: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
 };
 
 const DEFAULT_EFFORTS = ['low', 'medium', 'high'];
 
 export const effortOptionsFor = (backend: string): string[] => EFFORT_BY_BACKEND[backend] ?? DEFAULT_EFFORTS;
 
-// Backends whose model catalog actually ships per-model reasoning options.
-// Today only Claude — Codex/OpenCode return a flat list, so a stale options map
-// left over from a previous backend (e.g. ChatPage's claudeReasoning cache,
-// which isn't cleared on backend switch) must NOT leak into their effort set.
-const PER_MODEL_EFFORT_BACKENDS = new Set(['claude']);
+// Backends whose model catalog ships per-model reasoning options. A stale
+// options map left over from a previous backend must NOT leak into other
+// backends' effort set.
+const PER_MODEL_EFFORT_BACKENDS = new Set(['claude', 'codex']);
 
 // Resolve the selectable effort values for a backend + model. Only backends that
-// publish per-model reasoning options (Claude) consult ``reasoningOptions``; the
-// rest always use their backend superset, so a stale map can't leak. A known
+// publish per-model reasoning options consult ``reasoningOptions``; the rest
+// always use their backend superset, so a stale map can't leak. A known
 // model uses its own set (Opus exposes xhigh/max, Haiku doesn't); an inherited
 // (empty) or unknown/custom model uses the catalog's "" default set. We do NOT
-// union across all models: the backend re-derives the effective model and runs
-// normalize_claude_reasoning_effort, so a broader UI list would just surface
-// efforts the backend silently drops (a false affordance). ``reasoningOptions``
+// union across all models: backend adapters validate or pass through efforts
+// against their effective model, so a broader UI list would just surface false
+// affordances. ``reasoningOptions``
 // may be {} before the catalog loads — that yields the backend fallback.
 export function resolveEffortOptions(
   backend: string,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3994,8 +3994,25 @@ def _normalize_backend_routing_payload(routing_payload: dict) -> dict:
         routing.reasoning_effort = normalize_claude_reasoning_effort(
             routing.model,
             routing.reasoning_effort,
+            _catalog_reasoning_efforts_for_model("claude", routing.model),
         )
     return _routing_to_dict(routing)
+
+
+def _catalog_reasoning_efforts_for_model(backend: str, model: Optional[str]) -> Optional[list[str]]:
+    if not model:
+        return None
+    for catalog in (
+        backend_model_catalog.load_cached_remote_catalog(schedule_refresh=False),
+        backend_model_catalog.load_bundled_catalog(),
+    ):
+        for entry in backend_model_catalog.backend_model_entries(backend, catalog):
+            if backend_model_catalog.model_id(entry) != model:
+                continue
+            efforts = backend_model_catalog.reasoning_efforts(entry)
+            if efforts:
+                return efforts
+    return None
 
 
 def _backend_for_routing_agent(agent_name: Optional[str]) -> Optional[str]:
@@ -5354,10 +5371,10 @@ def claude_models() -> dict:
                 continue
             label = backend_model_catalog.model_label(entry)
             if label:
-                model_labels[model] = label
+                model_labels.setdefault(model, label)
             efforts = backend_model_catalog.reasoning_efforts(entry)
             if efforts:
-                reasoning_efforts[model] = efforts
+                reasoning_efforts.setdefault(model, efforts)
 
     options: list[str] = []
     seen: set[str] = set()
@@ -10565,6 +10582,7 @@ def _append_codex_catalog_models(
     seen: set[str],
     model_labels: dict[str, str],
     reasoning_efforts: dict[str, list[str]],
+    overwrite_metadata: bool = False,
 ) -> None:
     for item in _sorted_codex_catalog_items(data):
         model_id = _append_unique_model(options, seen, item.get("slug") or item.get("id"))
@@ -10572,10 +10590,12 @@ def _append_codex_catalog_models(
             continue
         display_name = item.get("display_name") or item.get("label")
         if isinstance(display_name, str) and display_name.strip():
-            model_labels[model_id] = display_name.strip()
+            if overwrite_metadata or model_id not in model_labels:
+                model_labels[model_id] = display_name.strip()
         efforts = _codex_reasoning_efforts_from_catalog_item(item)
         if efforts:
-            reasoning_efforts[model_id] = efforts
+            if overwrite_metadata or model_id not in reasoning_efforts:
+                reasoning_efforts[model_id] = efforts
 
 
 def _read_codex_live_model_catalog() -> tuple[object | None, str | None]:
@@ -10697,6 +10717,7 @@ def codex_models() -> dict:
             seen=seen,
             model_labels=model_labels,
             reasoning_efforts=reasoning_efforts,
+            overwrite_metadata=True,
         )
 
     for model in _CODEX_BUILT_IN_MODEL_OPTIONS:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -59,6 +59,7 @@ from vibe.claude_model_catalog import (
     DEFAULT_CLAUDE_MODEL_ALIASES,
     infer_bundle_path_from_cli,
     infer_models_from_bundle,
+    is_public_catalog_model,
     load_catalog_models,
 )
 from vibe.i18n import t as backend_t
@@ -5366,7 +5367,10 @@ def claude_models() -> dict:
 
     def _append_catalog_entries(catalog: dict) -> None:
         for entry in backend_model_catalog.backend_model_entries("claude", catalog):
-            model = _append_unique_model(options, seen, backend_model_catalog.model_id(entry))
+            catalog_model = backend_model_catalog.model_id(entry)
+            if not catalog_model or not is_public_catalog_model(catalog_model):
+                continue
+            model = _append_unique_model(options, seen, catalog_model)
             if not model:
                 continue
             label = backend_model_catalog.model_label(entry)

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5385,6 +5385,7 @@ def claude_models() -> dict:
     model_labels: dict[str, str] = {}
     reasoning_efforts: dict[str, list[str]] = {}
 
+    remote_refresh_token = backend_model_catalog.remote_catalog_token()
     _append_catalog_entries(backend_model_catalog.load_cached_remote_catalog())
     _append_catalog_entries(backend_model_catalog.load_bundled_catalog())
 
@@ -5432,6 +5433,7 @@ def claude_models() -> dict:
         "models": options,
         "reasoning_options": reasoning_options,
         "model_labels": model_labels,
+        "catalog_refresh_pending": backend_model_catalog.remote_catalog_refresh_pending(remote_refresh_token),
     }
 
 
@@ -10602,11 +10604,24 @@ def _append_codex_catalog_models(
                 reasoning_efforts[model_id] = efforts
 
 
+def _configured_codex_cli_path() -> str:
+    try:
+        config = V2Config.load()
+        backend_cfg = getattr(getattr(config, "agents", None), "codex", None)
+        return str(getattr(backend_cfg, "cli_path", "") or "codex")
+    except Exception:
+        logger.debug("Failed to load configured Codex CLI path", exc_info=True)
+        return "codex"
+
+
 def _read_codex_live_model_catalog() -> tuple[object | None, str | None]:
     now = time.time()
+    configured_path = _configured_codex_cli_path()
+    codex_path = resolve_cli_path(configured_path)
+    cache_key = codex_path or configured_path
     with _CODEX_LIVE_MODEL_CATALOG_LOCK:
         cached_at = _CODEX_LIVE_MODEL_CATALOG_CACHE.get("cached_at")
-        if isinstance(cached_at, (int, float)):
+        if isinstance(cached_at, (int, float)) and _CODEX_LIVE_MODEL_CATALOG_CACHE.get("cli_path") == cache_key:
             ttl = (
                 _CODEX_LIVE_MODEL_CATALOG_TTL_SECONDS
                 if _CODEX_LIVE_MODEL_CATALOG_CACHE.get("data") is not None
@@ -10615,9 +10630,8 @@ def _read_codex_live_model_catalog() -> tuple[object | None, str | None]:
             if now - cached_at < ttl:
                 return _CODEX_LIVE_MODEL_CATALOG_CACHE.get("data"), _CODEX_LIVE_MODEL_CATALOG_CACHE.get("error")
 
-    codex_path = resolve_cli_path("codex")
     if not codex_path:
-        error = "codex CLI not found"
+        error = f"codex CLI not found: {configured_path}"
         data = None
     else:
         try:
@@ -10655,7 +10669,9 @@ def _read_codex_live_model_catalog() -> tuple[object | None, str | None]:
         logger.debug("Failed to read live Codex model catalog: %s", error)
     with _CODEX_LIVE_MODEL_CATALOG_LOCK:
         _CODEX_LIVE_MODEL_CATALOG_CACHE.clear()
-        _CODEX_LIVE_MODEL_CATALOG_CACHE.update({"cached_at": now, "data": data, "error": error})
+        _CODEX_LIVE_MODEL_CATALOG_CACHE.update(
+            {"cached_at": now, "cli_path": cache_key, "data": data, "error": error}
+        )
     return data, error
 
 
@@ -10688,6 +10704,7 @@ def codex_models() -> dict:
             "model_labels": model_labels,
             "live": live_catalog_error is None,
             "source": "github backend model catalog + codex debug models + built-in fallbacks",
+            "catalog_refresh_pending": backend_model_catalog.remote_catalog_refresh_pending(remote_refresh_token),
         }
         if live_catalog_error:
             result["notes"] = [live_catalog_error]
@@ -10701,6 +10718,7 @@ def codex_models() -> dict:
     models_cache_path = codex_home / "models_cache.json"
     config_path = codex_home / "config.toml"
 
+    remote_refresh_token = backend_model_catalog.remote_catalog_token()
     for catalog in (
         backend_model_catalog.load_cached_remote_catalog(),
         backend_model_catalog.load_bundled_catalog(),

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -54,7 +54,13 @@ from vibe.upgrade import (
     should_skip_show_runtime_prepare,
 )
 from vibe.restart_supervisor import schedule_restart
-from vibe.claude_model_catalog import DEFAULT_CLAUDE_MODEL_ALIASES, load_catalog_models
+from vibe import backend_model_catalog
+from vibe.claude_model_catalog import (
+    DEFAULT_CLAUDE_MODEL_ALIASES,
+    infer_bundle_path_from_cli,
+    infer_models_from_bundle,
+    load_catalog_models,
+)
 from vibe.i18n import t as backend_t
 from modules.agents.catalog import (
     agent_backend_catalog_payload,
@@ -80,6 +86,11 @@ logger = logging.getLogger(__name__)
 # Cache per cwd: { cwd: { "data": ..., "updated_at": ... } }
 _OPENCODE_OPTIONS_CACHE: dict[str, dict] = {}
 _OPENCODE_OPTIONS_TTL_SECONDS = 30.0
+_CODEX_LIVE_MODEL_CATALOG_CACHE: dict[str, Any] = {}
+_CODEX_LIVE_MODEL_CATALOG_LOCK = threading.Lock()
+_CODEX_LIVE_MODEL_CATALOG_TTL_SECONDS = 300.0
+_CODEX_LIVE_MODEL_CATALOG_FAILURE_TTL_SECONDS = 60.0
+_CODEX_LIVE_MODEL_CATALOG_TIMEOUT_SECONDS = 5.0
 
 
 _PLATFORM_SECRET_FIELDS: dict[str, tuple[str, ...]] = {
@@ -4717,52 +4728,70 @@ def claude_models() -> dict:
 
     Claude Code does not expose a stable `list models` CLI subcommand.
     We merge suggestions from:
-    - The repository-owned Claude model catalog
+    - The GitHub-hosted backend model catalog, refreshed in the background
+    - The package-bundled backend/Claude model catalogs
+    - Locally installed Claude Code bundle hints
     - ~/.claude/settings.json model/env values
     """
 
-    def _append_unique(options: list[str], seen: set[str], value: object) -> None:
-        if not isinstance(value, str):
-            return
-        model = value.strip()
-        if not model or model in seen:
-            return
-        seen.add(model)
-        options.append(model)
+    def _append_catalog_entries(catalog: dict) -> None:
+        for entry in backend_model_catalog.backend_model_entries("claude", catalog):
+            model = _append_unique_model(options, seen, backend_model_catalog.model_id(entry))
+            if not model:
+                continue
+            label = backend_model_catalog.model_label(entry)
+            if label:
+                model_labels[model] = label
+            efforts = backend_model_catalog.reasoning_efforts(entry)
+            if efforts:
+                reasoning_efforts[model] = efforts
 
     options: list[str] = []
     seen: set[str] = set()
+    model_labels: dict[str, str] = {}
+    reasoning_efforts: dict[str, list[str]] = {}
+
+    _append_catalog_entries(backend_model_catalog.load_cached_remote_catalog())
+    _append_catalog_entries(backend_model_catalog.load_bundled_catalog())
 
     for model in load_catalog_models():
-        _append_unique(options, seen, model)
+        _append_unique_model(options, seen, model)
+
+    try:
+        bundle_path = infer_bundle_path_from_cli(resolve_cli_path("claude"))
+        if bundle_path is not None:
+            for model in infer_models_from_bundle(bundle_path):
+                _append_unique_model(options, seen, model)
+    except Exception as exc:
+        logger.debug("Failed to infer Claude models from local bundle: %s", exc, exc_info=True)
 
     for model in DEFAULT_CLAUDE_MODEL_ALIASES:
-        _append_unique(options, seen, model)
+        _append_unique_model(options, seen, model)
 
     settings_path = Path.home() / ".claude" / "settings.json"
     try:
         if settings_path.exists() and settings_path.is_file():
             data = json.loads(settings_path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
-                _append_unique(options, seen, data.get("model"))
+                _append_unique_model(options, seen, data.get("model"))
                 env = data.get("env")
                 if isinstance(env, dict):
                     for key in (
                         "ANTHROPIC_MODEL",
                         "ANTHROPIC_SMALL_FAST_MODEL",
                     ):
-                        _append_unique(options, seen, env.get(key))
+                        _append_unique_model(options, seen, env.get(key))
     except Exception as exc:
         logger.warning("Failed to read Claude settings.json: %s", exc, exc_info=True)
 
     from modules.agents.opencode.utils import build_claude_reasoning_options, format_claude_model_label
 
     reasoning_options = {"": build_claude_reasoning_options(None)}
-    model_labels = {}
     for model in options:
-        reasoning_options[model] = build_claude_reasoning_options(model)
+        efforts = reasoning_efforts.get(model)
+        reasoning_options[model] = build_claude_reasoning_options(model, efforts)
         label = format_claude_model_label(model)
-        if label != model:
+        if model not in model_labels and label != model:
             model_labels[model] = label
     return {
         "ok": True,
@@ -4959,9 +4988,9 @@ def agent_model_options(
             "backend": "codex",
             "default_model": default_model,
             "models": _flat_catalog_models(data, default_model),
-            "source": "codex built-in list + ~/.codex caches",
-            "live": False,
-            "notes": ["Codex CLI has no stable list-models command; this is a best-effort merged list."],
+            "source": data.get("source") or "codex built-in list + ~/.codex caches",
+            "live": bool(data.get("live")),
+            "notes": data.get("notes") or None,
         }
     else:
         result = _opencode_model_options(provider=provider, cwd=cwd, config=config)
@@ -9833,80 +9862,243 @@ def set_opencode_default_provider(payload: dict) -> dict:
     return {"ok": True, "default_provider": provider_id}
 
 
+_CODEX_BUILT_IN_MODEL_OPTIONS: list[str] = [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+    "gpt-5.2-codex",
+    "gpt-5.2",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
+    "gpt-5.1",
+    "gpt-5",
+]
+
+_HIDDEN_CODEX_MODEL_VISIBILITIES = {"hide", "hidden"}
+
+
+def _append_unique_model(options: list[str], seen: set[str], value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    model = value.strip()
+    if not model:
+        return None
+    if model not in seen:
+        seen.add(model)
+        options.append(model)
+    return model
+
+
+def _codex_model_visible(item: dict) -> bool:
+    visibility = item.get("visibility")
+    if not isinstance(visibility, str):
+        return True
+    return visibility.strip().lower() not in _HIDDEN_CODEX_MODEL_VISIBILITIES
+
+
+def _codex_reasoning_efforts_from_catalog_item(item: dict) -> list[str]:
+    raw_levels = item.get("reasoning_efforts") or item.get("supported_reasoning_levels")
+    if not isinstance(raw_levels, list):
+        return []
+    efforts: list[str] = []
+    seen: set[str] = set()
+    for level in raw_levels:
+        if isinstance(level, dict):
+            effort = level.get("effort")
+        else:
+            effort = level
+        if not isinstance(effort, str):
+            continue
+        effort = effort.strip()
+        if not effort or effort in seen:
+            continue
+        seen.add(effort)
+        efforts.append(effort)
+    return efforts
+
+
+def _sorted_codex_catalog_items(data: object) -> list[dict]:
+    if isinstance(data, dict):
+        raw_models = data.get("models")
+    else:
+        raw_models = data
+    if not isinstance(raw_models, list):
+        return []
+
+    visible_models: list[tuple[int, int, dict]] = []
+    for index, item in enumerate(raw_models):
+        if not isinstance(item, dict) or not _codex_model_visible(item):
+            continue
+        slug = item.get("slug") or item.get("id")
+        if not isinstance(slug, str) or not slug.strip():
+            continue
+        priority = item.get("priority")
+        if not isinstance(priority, int):
+            priority = 10**9
+        visible_models.append((priority, index, item))
+    return [item for _, _, item in sorted(visible_models, key=lambda entry: (entry[0], entry[1]))]
+
+
+def _append_codex_catalog_models(
+    data: object,
+    *,
+    options: list[str],
+    seen: set[str],
+    model_labels: dict[str, str],
+    reasoning_efforts: dict[str, list[str]],
+) -> None:
+    for item in _sorted_codex_catalog_items(data):
+        model_id = _append_unique_model(options, seen, item.get("slug") or item.get("id"))
+        if not model_id:
+            continue
+        display_name = item.get("display_name") or item.get("label")
+        if isinstance(display_name, str) and display_name.strip():
+            model_labels[model_id] = display_name.strip()
+        efforts = _codex_reasoning_efforts_from_catalog_item(item)
+        if efforts:
+            reasoning_efforts[model_id] = efforts
+
+
+def _read_codex_live_model_catalog() -> tuple[object | None, str | None]:
+    now = time.time()
+    with _CODEX_LIVE_MODEL_CATALOG_LOCK:
+        cached_at = _CODEX_LIVE_MODEL_CATALOG_CACHE.get("cached_at")
+        if isinstance(cached_at, (int, float)):
+            ttl = (
+                _CODEX_LIVE_MODEL_CATALOG_TTL_SECONDS
+                if _CODEX_LIVE_MODEL_CATALOG_CACHE.get("data") is not None
+                else _CODEX_LIVE_MODEL_CATALOG_FAILURE_TTL_SECONDS
+            )
+            if now - cached_at < ttl:
+                return _CODEX_LIVE_MODEL_CATALOG_CACHE.get("data"), _CODEX_LIVE_MODEL_CATALOG_CACHE.get("error")
+
+    codex_path = resolve_cli_path("codex")
+    if not codex_path:
+        error = "codex CLI not found"
+        data = None
+    else:
+        try:
+            result = subprocess.run(
+                [codex_path, "debug", "models"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=_CODEX_LIVE_MODEL_CATALOG_TIMEOUT_SECONDS,
+                env=_command_env_for(codex_path if os.path.isabs(codex_path) else None),
+                **isolated_subprocess_kwargs(),
+            )
+            if result.returncode != 0:
+                stderr = (result.stderr or "").strip()
+                error = f"codex debug models failed with exit code {result.returncode}"
+                if stderr:
+                    error = f"{error}: {stderr.splitlines()[-1]}"
+                data = None
+            else:
+                parsed = json.loads(result.stdout or "{}")
+                if isinstance(parsed, dict) and isinstance(parsed.get("models"), list):
+                    data = {"models": parsed["models"]}
+                else:
+                    data = parsed
+                error = None
+        except subprocess.TimeoutExpired:
+            error = "codex debug models timed out"
+            data = None
+        except (FileNotFoundError, OSError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
+            error = f"codex debug models unavailable: {exc}"
+            data = None
+
+    if error:
+        logger.debug("Failed to read live Codex model catalog: %s", error)
+    with _CODEX_LIVE_MODEL_CATALOG_LOCK:
+        _CODEX_LIVE_MODEL_CATALOG_CACHE.clear()
+        _CODEX_LIVE_MODEL_CATALOG_CACHE.update({"cached_at": now, "data": data, "error": error})
+    return data, error
+
+
 def codex_models() -> dict:
     """Best-effort merged list of Codex model options.
 
-    Codex CLI does not expose a stable `list models` command.
-    We merge suggestions from:
-    - Built-in known model ids
-    - ~/.codex/models_cache.json (maintained by Codex CLI)
-    - ~/.codex/config.toml (user-selected model and migration hints)
+    Prefer the current Codex CLI model catalog, then merge fallback suggestions
+    from built-in known model ids, ~/.codex/models_cache.json, and
+    ~/.codex/config.toml (user-selected model and migration hints).
     """
 
-    def _append_unique(options: list[str], seen: set[str], value: object) -> None:
-        if not isinstance(value, str):
-            return
-        model = value.strip()
-        if not model or model in seen:
-            return
-        seen.add(model)
-        options.append(model)
-
-    def _result(model_options: list[str]) -> dict:
-        # Codex reasoning-effort levels are static (model-independent). Surface
-        # them per-model so the shape matches claude_models(), letting a single
-        # caller (agent_model_options / the UI) treat both backends uniformly.
+    def _result(
+        model_options: list[str],
+        *,
+        model_labels: dict[str, str],
+        reasoning_efforts: dict[str, list[str]],
+        live_catalog_error: str | None,
+    ) -> dict:
         from modules.agents.opencode.utils import build_codex_reasoning_options
 
-        codex_reasoning = build_codex_reasoning_options()
-        reasoning_options = {"": codex_reasoning}
+        default_reasoning = build_codex_reasoning_options()
+        reasoning_options = {"": default_reasoning}
         for model_id in model_options:
-            reasoning_options[model_id] = codex_reasoning
-        return {"ok": True, "models": model_options, "reasoning_options": reasoning_options}
-
-    built_in_options: list[str] = [
-        "gpt-5.5",
-        "gpt-5.4",
-        "gpt-5.4-mini",
-        "gpt-5.4-nano",
-        "gpt-5.3-codex",
-        "gpt-5.3-codex-spark",
-        "gpt-5.2-codex",
-        "gpt-5.2",
-        "gpt-5.1-codex-max",
-        "gpt-5.1-codex-mini",
-        "gpt-5.1",
-        "gpt-5",
-    ]
+            efforts = reasoning_efforts.get(model_id)
+            reasoning_options[model_id] = build_codex_reasoning_options(efforts) if efforts else default_reasoning
+        result = {
+            "ok": True,
+            "models": model_options,
+            "reasoning_options": reasoning_options,
+            "model_labels": model_labels,
+            "live": live_catalog_error is None,
+            "source": "github backend model catalog + codex debug models + built-in fallbacks",
+        }
+        if live_catalog_error:
+            result["notes"] = [live_catalog_error]
+        return result
 
     options: list[str] = []
     seen: set[str] = set()
+    model_labels: dict[str, str] = {}
+    reasoning_efforts: dict[str, list[str]] = {}
     codex_home = Path.home() / ".codex"
     models_cache_path = codex_home / "models_cache.json"
     config_path = codex_home / "config.toml"
 
-    for model in built_in_options:
-        _append_unique(options, seen, model)
+    for catalog in (
+        backend_model_catalog.load_cached_remote_catalog(),
+        backend_model_catalog.load_bundled_catalog(),
+    ):
+        _append_codex_catalog_models(
+            {"models": backend_model_catalog.backend_model_entries("codex", catalog)},
+            options=options,
+            seen=seen,
+            model_labels=model_labels,
+            reasoning_efforts=reasoning_efforts,
+        )
+
+    live_catalog, live_catalog_error = _read_codex_live_model_catalog()
+    if live_catalog is not None:
+        _append_codex_catalog_models(
+            live_catalog,
+            options=options,
+            seen=seen,
+            model_labels=model_labels,
+            reasoning_efforts=reasoning_efforts,
+        )
+
+    for model in _CODEX_BUILT_IN_MODEL_OPTIONS:
+        _append_unique_model(options, seen, model)
 
     try:
         if models_cache_path.exists() and models_cache_path.is_file():
             cache_data = json.loads(models_cache_path.read_text(encoding="utf-8"))
-            models = cache_data.get("models")
-            if isinstance(models, list):
-                visible_models: list[tuple[int, int, str]] = []
-                for index, item in enumerate(models):
-                    if not isinstance(item, dict):
-                        continue
-                    slug = item.get("slug")
-                    if not isinstance(slug, str) or not slug.strip():
-                        continue
-                    priority = item.get("priority")
-                    if not isinstance(priority, int):
-                        priority = 10**9
-                    visible_models.append((priority, index, slug.strip()))
-
-                for _, _, slug in sorted(visible_models):
-                    _append_unique(options, seen, slug)
+            _append_codex_catalog_models(
+                cache_data,
+                options=options,
+                seen=seen,
+                model_labels=model_labels,
+                reasoning_efforts=reasoning_efforts,
+            )
     except Exception as exc:
         logger.warning("Failed to read Codex models_cache.json: %s", exc, exc_info=True)
 
@@ -9918,22 +10110,32 @@ def codex_models() -> dict:
                 tomllib = None
 
             if tomllib is None:
-                return _result(options)
+                return _result(
+                    options,
+                    model_labels=model_labels,
+                    reasoning_efforts=reasoning_efforts,
+                    live_catalog_error=live_catalog_error,
+                )
 
             data = tomllib.loads(config_path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
-                _append_unique(options, seen, data.get("model"))
+                _append_unique_model(options, seen, data.get("model"))
                 notice = data.get("notice")
                 if isinstance(notice, dict):
                     migrations = notice.get("model_migrations")
                     if isinstance(migrations, dict):
                         for k, v in migrations.items():
-                            _append_unique(options, seen, k)
-                            _append_unique(options, seen, v)
+                            _append_unique_model(options, seen, k)
+                            _append_unique_model(options, seen, v)
     except Exception as exc:
         logger.warning("Failed to read Codex config.toml: %s", exc, exc_info=True)
 
-    return _result(options)
+    return _result(
+        options,
+        model_labels=model_labels,
+        reasoning_efforts=reasoning_efforts,
+        live_catalog_error=live_catalog_error,
+    )
 
 
 def _lark_api_base(domain: str = "feishu") -> str:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -3995,25 +3995,9 @@ def _normalize_backend_routing_payload(routing_payload: dict) -> dict:
         routing.reasoning_effort = normalize_claude_reasoning_effort(
             routing.model,
             routing.reasoning_effort,
-            _catalog_reasoning_efforts_for_model("claude", routing.model),
+            backend_model_catalog.catalog_reasoning_efforts_for_model("claude", routing.model),
         )
     return _routing_to_dict(routing)
-
-
-def _catalog_reasoning_efforts_for_model(backend: str, model: Optional[str]) -> Optional[list[str]]:
-    if not model:
-        return None
-    for catalog in (
-        backend_model_catalog.load_cached_remote_catalog(schedule_refresh=False),
-        backend_model_catalog.load_bundled_catalog(),
-    ):
-        for entry in backend_model_catalog.backend_model_entries(backend, catalog):
-            if backend_model_catalog.model_id(entry) != model:
-                continue
-            efforts = backend_model_catalog.reasoning_efforts(entry)
-            if efforts:
-                return efforts
-    return None
 
 
 def _backend_for_routing_agent(agent_name: Optional[str]) -> Optional[str]:
@@ -5354,6 +5338,14 @@ def codex_agents(cwd: Optional[str] = None) -> dict:
         return {"ok": False, "error": str(e)}
 
 
+def _configured_claude_cli_path() -> str:
+    try:
+        return str(V2Config.load().agents.claude.cli_path or "claude")
+    except Exception:
+        logger.debug("Failed to load configured Claude CLI path", exc_info=True)
+        return "claude"
+
+
 def claude_models() -> dict:
     """Best-effort merged list of Claude Code model options.
 
@@ -5393,7 +5385,8 @@ def claude_models() -> dict:
         _append_unique_model(options, seen, model)
 
     try:
-        bundle_path = infer_bundle_path_from_cli(resolve_cli_path("claude"))
+        configured_claude_path = _configured_claude_cli_path()
+        bundle_path = infer_bundle_path_from_cli(resolve_cli_path(configured_claude_path) or configured_claude_path)
         if bundle_path is not None:
             for model in infer_models_from_bundle(bundle_path):
                 _append_unique_model(options, seen, model)

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10574,6 +10574,20 @@ def _sorted_codex_catalog_items(data: object) -> list[dict]:
     return [item for _, _, item in sorted(visible_models, key=lambda entry: (entry[0], entry[1]))]
 
 
+def _hidden_codex_catalog_model_ids(data: object) -> set[str]:
+    raw_models = data.get("models") if isinstance(data, dict) else data
+    if not isinstance(raw_models, list):
+        return set()
+    hidden: set[str] = set()
+    for item in raw_models:
+        if not isinstance(item, dict) or _codex_model_visible(item):
+            continue
+        model_id = item.get("slug") or item.get("id")
+        if isinstance(model_id, str) and model_id.strip():
+            hidden.add(model_id.strip())
+    return hidden
+
+
 def _append_codex_catalog_models(
     data: object,
     *,
@@ -10726,6 +10740,13 @@ def codex_models() -> dict:
 
     live_catalog, live_catalog_error = _read_codex_live_model_catalog()
     if live_catalog is not None:
+        hidden_live_models = _hidden_codex_catalog_model_ids(live_catalog)
+        if hidden_live_models:
+            options[:] = [model for model in options if model not in hidden_live_models]
+            seen.update(hidden_live_models)
+            for model in hidden_live_models:
+                model_labels.pop(model, None)
+                reasoning_efforts.pop(model, None)
         _append_codex_catalog_models(
             live_catalog,
             options=options,

--- a/vibe/backend_model_catalog.py
+++ b/vibe/backend_model_catalog.py
@@ -87,7 +87,7 @@ def fetch_remote_catalog(url: str | None = None) -> dict[str, Any]:
     request_url = (url or os.environ.get(REMOTE_CATALOG_URL_ENV) or DEFAULT_REMOTE_CATALOG_URL).strip()
     req = urllib.request.Request(request_url, headers={"User-Agent": REMOTE_CATALOG_USER_AGENT})
     with urllib.request.urlopen(req, timeout=REMOTE_CATALOG_TIMEOUT_SECONDS) as response:  # noqa: S310 - public catalog
-        return _normalize_catalog(json.loads(response.read().decode("utf-8")))
+        return _normalize_catalog(json.loads(response.read().decode("utf-8")), strict=True)
 
 
 def backend_model_entries(backend: str, catalog: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -122,6 +122,22 @@ def model_label(entry: dict[str, Any]) -> str | None:
 def reasoning_efforts(entry: dict[str, Any]) -> list[str]:
     values = entry.get("reasoning_efforts")
     return _dedupe_str_values(values) if isinstance(values, list) else []
+
+
+def catalog_reasoning_efforts_for_model(backend: str, model: str | None) -> list[str] | None:
+    if not model:
+        return None
+    for catalog in (
+        load_cached_remote_catalog(schedule_refresh=False),
+        load_bundled_catalog(),
+    ):
+        for entry in backend_model_entries(backend, catalog):
+            if model_id(entry) != model:
+                continue
+            efforts = reasoning_efforts(entry)
+            if efforts:
+                return efforts
+    return None
 
 
 def _cached_remote_payload() -> dict[str, Any]:
@@ -181,12 +197,17 @@ def _read_cached_remote_payload(path: Path) -> dict[str, Any]:
         return {}
 
     normalized: dict[str, Any] = {}
+    catalog_valid = False
     raw_catalog = payload.get("catalog")
     if isinstance(raw_catalog, dict):
-        normalized["catalog"] = _normalize_catalog(raw_catalog)
+        try:
+            normalized["catalog"] = _normalize_catalog(raw_catalog, strict=True)
+            catalog_valid = True
+        except ValueError:
+            pass
     for key in ("fetched_at", "failed_at"):
         value = payload.get(key)
-        if isinstance(value, (int, float)):
+        if isinstance(value, (int, float)) and (key != "fetched_at" or catalog_valid):
             normalized[key] = value
     error = payload.get("error")
     if isinstance(error, str) or error is None:
@@ -212,22 +233,42 @@ def _write_cached_remote_payload(payload: dict[str, Any]) -> None:
         _REMOTE_MEMORY_CACHE.update(payload)
 
 
-def _normalize_catalog(payload: object) -> dict[str, Any]:
+def _normalize_catalog(payload: object, *, strict: bool = False) -> dict[str, Any]:
     if not isinstance(payload, dict):
+        if strict:
+            raise ValueError("Backend model catalog must be an object")
         return {}
+    schema_version = payload.get("schema_version")
+    if strict and schema_version != 1:
+        raise ValueError(f"Unsupported backend model catalog schema version: {schema_version!r}")
     backends = payload.get("backends")
     if not isinstance(backends, dict):
+        if strict:
+            raise ValueError("Backend model catalog must contain a backends object")
         return {}
     normalized_backends: dict[str, Any] = {}
     for backend, raw_backend in backends.items():
         if not isinstance(backend, str) or not isinstance(raw_backend, dict):
+            if strict:
+                raise ValueError("Backend model catalog contains an invalid backend entry")
+            continue
+        backend_key = backend.strip().lower()
+        if not backend_key:
+            if strict:
+                raise ValueError("Backend model catalog contains an empty backend name")
             continue
         models = raw_backend.get("models")
         if not isinstance(models, list):
+            if strict:
+                raise ValueError(f"Backend model catalog models must be a list: {backend_key}")
             continue
         entries = [_normalize_model_entry(item) for item in models]
-        normalized_backends[backend.strip().lower()] = {"models": [entry for entry in entries if entry]}
-    return {"schema_version": payload.get("schema_version") or 1, "backends": normalized_backends}
+        if strict and any(not entry for entry in entries):
+            raise ValueError(f"Backend model catalog contains an invalid model entry: {backend_key}")
+        normalized_backends[backend_key] = {"models": [entry for entry in entries if entry]}
+    if strict and not normalized_backends:
+        raise ValueError("Backend model catalog must contain at least one backend")
+    return {"schema_version": schema_version or 1, "backends": normalized_backends}
 
 
 def _normalize_model_entry(item: object) -> dict[str, Any]:

--- a/vibe/backend_model_catalog.py
+++ b/vibe/backend_model_catalog.py
@@ -47,6 +47,22 @@ def load_cached_remote_catalog(*, schedule_refresh: bool = True) -> dict[str, An
     return catalog if isinstance(catalog, dict) else {}
 
 
+def remote_catalog_token() -> tuple[float | None, float | None]:
+    payload = _cached_remote_payload()
+    fetched_at = payload.get("fetched_at")
+    failed_at = payload.get("failed_at")
+    return (
+        float(fetched_at) if isinstance(fetched_at, (int, float)) else None,
+        float(failed_at) if isinstance(failed_at, (int, float)) else None,
+    )
+
+
+def remote_catalog_refresh_pending(since: tuple[float | None, float | None]) -> bool:
+    with _REMOTE_LOCK:
+        refresh_in_flight = _REMOTE_REFRESH_IN_FLIGHT
+    return refresh_in_flight or remote_catalog_token() != since
+
+
 def schedule_remote_catalog_refresh() -> bool:
     global _REMOTE_REFRESH_IN_FLIGHT
 

--- a/vibe/backend_model_catalog.py
+++ b/vibe/backend_model_catalog.py
@@ -113,7 +113,7 @@ def _cached_remote_payload() -> dict[str, Any]:
         if _REMOTE_MEMORY_CACHE:
             return dict(_REMOTE_MEMORY_CACHE)
 
-    payload = _read_catalog(get_cached_catalog_path()) or {}
+    payload = _read_cached_remote_payload(get_cached_catalog_path())
     if isinstance(payload, dict):
         with _REMOTE_LOCK:
             _REMOTE_MEMORY_CACHE.clear()
@@ -154,6 +154,28 @@ def _read_catalog(path: Path) -> dict[str, Any] | None:
     except Exception:
         return None
     return _normalize_catalog(payload)
+
+
+def _read_cached_remote_payload(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, UnicodeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+
+    normalized: dict[str, Any] = {}
+    raw_catalog = payload.get("catalog")
+    if isinstance(raw_catalog, dict):
+        normalized["catalog"] = _normalize_catalog(raw_catalog)
+    for key in ("fetched_at", "failed_at"):
+        value = payload.get(key)
+        if isinstance(value, (int, float)):
+            normalized[key] = value
+    error = payload.get("error")
+    if isinstance(error, str) or error is None:
+        normalized["error"] = error
+    return normalized
 
 
 def _write_cached_remote_payload(payload: dict[str, Any]) -> None:

--- a/vibe/backend_model_catalog.py
+++ b/vibe/backend_model_catalog.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import time
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable
+
+from config import paths
+
+
+REMOTE_CATALOG_URL_ENV = "AVIBE_BACKEND_MODEL_CATALOG_URL"
+DEFAULT_REMOTE_CATALOG_URL = (
+    "https://raw.githubusercontent.com/avibe-bot/avibe/master/vibe/data/backend_models.json"
+)
+REMOTE_CATALOG_TTL_SECONDS = 6 * 60 * 60
+REMOTE_CATALOG_FAILURE_TTL_SECONDS = 10 * 60
+REMOTE_CATALOG_TIMEOUT_SECONDS = 3.0
+REMOTE_CATALOG_USER_AGENT = "avibe/backend-model-catalog"
+
+_REMOTE_LOCK = threading.Lock()
+_REMOTE_REFRESH_IN_FLIGHT = False
+_REMOTE_MEMORY_CACHE: dict[str, Any] = {}
+
+
+def get_bundled_catalog_path(repo_root: Path | None = None) -> Path:
+    base_dir = repo_root if repo_root is not None else Path(__file__).resolve().parent
+    return base_dir / "data" / "backend_models.json"
+
+
+def get_cached_catalog_path() -> Path:
+    return paths.get_state_dir() / "backend_model_catalog.json"
+
+
+def load_bundled_catalog(path: Path | None = None) -> dict[str, Any]:
+    return _read_catalog(path or get_bundled_catalog_path()) or {}
+
+
+def load_cached_remote_catalog(*, schedule_refresh: bool = True) -> dict[str, Any]:
+    cached = _cached_remote_payload()
+    if schedule_refresh and _remote_cache_stale(cached):
+        schedule_remote_catalog_refresh()
+    catalog = cached.get("catalog")
+    return catalog if isinstance(catalog, dict) else {}
+
+
+def schedule_remote_catalog_refresh() -> bool:
+    global _REMOTE_REFRESH_IN_FLIGHT
+
+    with _REMOTE_LOCK:
+        if _REMOTE_REFRESH_IN_FLIGHT:
+            return False
+        _REMOTE_REFRESH_IN_FLIGHT = True
+
+    thread = threading.Thread(target=_refresh_remote_catalog_worker, name="avibe-model-catalog-refresh", daemon=True)
+    thread.start()
+    return True
+
+
+def refresh_remote_catalog_now(url: str | None = None) -> dict[str, Any]:
+    catalog = fetch_remote_catalog(url=url)
+    payload = {"fetched_at": time.time(), "catalog": catalog, "error": None}
+    _write_cached_remote_payload(payload)
+    return catalog
+
+
+def fetch_remote_catalog(url: str | None = None) -> dict[str, Any]:
+    request_url = (url or os.environ.get(REMOTE_CATALOG_URL_ENV) or DEFAULT_REMOTE_CATALOG_URL).strip()
+    req = urllib.request.Request(request_url, headers={"User-Agent": REMOTE_CATALOG_USER_AGENT})
+    with urllib.request.urlopen(req, timeout=REMOTE_CATALOG_TIMEOUT_SECONDS) as response:  # noqa: S310 - public catalog
+        return _normalize_catalog(json.loads(response.read().decode("utf-8")))
+
+
+def backend_model_entries(backend: str, catalog: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(catalog, dict):
+        return []
+    backend_key = (backend or "").strip().lower()
+    backends = catalog.get("backends")
+    raw_backend = backends.get(backend_key) if isinstance(backends, dict) else catalog.get(backend_key)
+    if not isinstance(raw_backend, dict):
+        return []
+    raw_models = raw_backend.get("models")
+    if not isinstance(raw_models, list):
+        return []
+    entries: list[dict[str, Any]] = []
+    for item in raw_models:
+        entry = _normalize_model_entry(item)
+        if entry:
+            entries.append(entry)
+    return entries
+
+
+def model_id(entry: dict[str, Any]) -> str | None:
+    value = entry.get("id")
+    return value if isinstance(value, str) and value else None
+
+
+def model_label(entry: dict[str, Any]) -> str | None:
+    value = entry.get("label")
+    return value if isinstance(value, str) and value else None
+
+
+def reasoning_efforts(entry: dict[str, Any]) -> list[str]:
+    values = entry.get("reasoning_efforts")
+    return _dedupe_str_values(values) if isinstance(values, list) else []
+
+
+def _cached_remote_payload() -> dict[str, Any]:
+    with _REMOTE_LOCK:
+        if _REMOTE_MEMORY_CACHE:
+            return dict(_REMOTE_MEMORY_CACHE)
+
+    payload = _read_catalog(get_cached_catalog_path()) or {}
+    if isinstance(payload, dict):
+        with _REMOTE_LOCK:
+            _REMOTE_MEMORY_CACHE.clear()
+            _REMOTE_MEMORY_CACHE.update(payload)
+        return payload
+    return {}
+
+
+def _remote_cache_stale(payload: dict[str, Any]) -> bool:
+    fetched_at = payload.get("fetched_at")
+    failed_at = payload.get("failed_at")
+    if isinstance(failed_at, (int, float)) and (
+        not isinstance(fetched_at, (int, float)) or float(failed_at) >= float(fetched_at)
+    ):
+        return time.time() - float(failed_at) >= REMOTE_CATALOG_FAILURE_TTL_SECONDS
+    if not isinstance(fetched_at, (int, float)):
+        return True
+    return time.time() - float(fetched_at) >= REMOTE_CATALOG_TTL_SECONDS
+
+
+def _refresh_remote_catalog_worker() -> None:
+    global _REMOTE_REFRESH_IN_FLIGHT
+    try:
+        refresh_remote_catalog_now()
+    except Exception as exc:
+        payload = {"failed_at": time.time(), "catalog": _cached_remote_payload().get("catalog"), "error": str(exc)}
+        _write_cached_remote_payload(payload)
+    finally:
+        with _REMOTE_LOCK:
+            _REMOTE_REFRESH_IN_FLIGHT = False
+
+
+def _read_catalog(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+    return _normalize_catalog(payload)
+
+
+def _write_cached_remote_payload(payload: dict[str, Any]) -> None:
+    cache_path = get_cached_catalog_path()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{cache_path.name}.", suffix=".tmp", dir=str(cache_path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        Path(tmp_name).replace(cache_path)
+    finally:
+        tmp_path = Path(tmp_name)
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+    with _REMOTE_LOCK:
+        _REMOTE_MEMORY_CACHE.clear()
+        _REMOTE_MEMORY_CACHE.update(payload)
+
+
+def _normalize_catalog(payload: object) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    backends = payload.get("backends")
+    if not isinstance(backends, dict):
+        return {}
+    normalized_backends: dict[str, Any] = {}
+    for backend, raw_backend in backends.items():
+        if not isinstance(backend, str) or not isinstance(raw_backend, dict):
+            continue
+        models = raw_backend.get("models")
+        if not isinstance(models, list):
+            continue
+        entries = [_normalize_model_entry(item) for item in models]
+        normalized_backends[backend.strip().lower()] = {"models": [entry for entry in entries if entry]}
+    return {"schema_version": payload.get("schema_version") or 1, "backends": normalized_backends}
+
+
+def _normalize_model_entry(item: object) -> dict[str, Any]:
+    if isinstance(item, str):
+        model = item.strip()
+        return {"id": model} if model else {}
+    if not isinstance(item, dict):
+        return {}
+    raw_id = item.get("id") or item.get("slug") or item.get("model") or item.get("value")
+    if not isinstance(raw_id, str) or not raw_id.strip():
+        return {}
+    entry: dict[str, Any] = {"id": raw_id.strip()}
+    raw_label = item.get("label") or item.get("display_name") or item.get("name")
+    if isinstance(raw_label, str) and raw_label.strip():
+        entry["label"] = raw_label.strip()
+    raw_priority = item.get("priority")
+    if isinstance(raw_priority, int):
+        entry["priority"] = raw_priority
+    raw_visibility = item.get("visibility")
+    if isinstance(raw_visibility, str) and raw_visibility.strip():
+        entry["visibility"] = raw_visibility.strip()
+    efforts = _coerce_reasoning_efforts(item.get("reasoning_efforts") or item.get("supported_reasoning_levels"))
+    if efforts:
+        entry["reasoning_efforts"] = efforts
+    return entry
+
+
+def _coerce_reasoning_efforts(values: object) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    efforts: list[str] = []
+    for value in values:
+        if isinstance(value, dict):
+            efforts.append(value.get("effort"))
+        else:
+            efforts.append(value)
+    return _dedupe_str_values(efforts)
+
+
+def _dedupe_str_values(values: Iterable[object]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        candidate = value.strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        normalized.append(candidate)
+    return normalized

--- a/vibe/claude_model_catalog.py
+++ b/vibe/claude_model_catalog.py
@@ -74,13 +74,13 @@ def infer_models_from_bundle(bundle_path: Path) -> list[str]:
     with bundle_path.open("rb") as handle, mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mapped:
         for match in _CLAUDE_MODEL_PATTERN.finditer(mapped):
             model = match.group(0).decode("utf-8")
-            if _is_public_catalog_model(model):
+            if is_public_catalog_model(model):
                 matches.add(model)
     return sort_catalog_models(matches)
 
 
 def sort_catalog_models(models: Iterable[str]) -> list[str]:
-    normalized = [model for model in _dedupe_str_values(models) if _is_public_catalog_model(model)]
+    normalized = [model for model in _dedupe_str_values(models) if is_public_catalog_model(model)]
 
     def sort_key(model: str) -> tuple[int, tuple[int, ...], str]:
         parts = model.split("-")
@@ -119,7 +119,7 @@ def _dedupe_str_values(values: Iterable[str]) -> list[str]:
     return normalized
 
 
-def _is_public_catalog_model(model: str) -> bool:
+def is_public_catalog_model(model: str) -> bool:
     parts = model.split("-")
     if len(parts) >= 4 and parts[-1].isdigit() and len(parts[-1]) == 8:
         major = _int_or_none(parts[2])
@@ -129,6 +129,9 @@ def _is_public_catalog_model(model: str) -> bool:
         if major is not None and minor is not None and (major, minor) >= (4, 6):
             return False
     return True
+
+
+_is_public_catalog_model = is_public_catalog_model
 
 
 def _int_or_none(value: str) -> int | None:

--- a/vibe/data/backend_models.json
+++ b/vibe/data/backend_models.json
@@ -83,13 +83,13 @@
           "id": "gpt-5.6-sol",
           "label": "GPT-5.6-Sol",
           "priority": 1,
-          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
         },
         {
           "id": "gpt-5.6-terra",
           "label": "GPT-5.6-Terra",
           "priority": 2,
-          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
         },
         {
           "id": "gpt-5.6-luna",
@@ -101,25 +101,25 @@
           "id": "gpt-5.5",
           "label": "GPT-5.5",
           "priority": 7,
-          "reasoning_efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh"]
         },
         {
           "id": "gpt-5.4",
           "label": "GPT-5.4",
           "priority": 16,
-          "reasoning_efforts": ["minimal", "low", "medium", "high", "xhigh"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh"]
         },
         {
           "id": "gpt-5.4-mini",
           "label": "GPT-5.4-Mini",
           "priority": 23,
-          "reasoning_efforts": ["minimal", "low", "medium", "high"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh"]
         },
         {
           "id": "gpt-5.2",
           "label": "GPT-5.2",
           "priority": 29,
-          "reasoning_efforts": ["minimal", "low", "medium", "high", "xhigh"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh"]
         }
       ]
     }

--- a/vibe/data/backend_models.json
+++ b/vibe/data/backend_models.json
@@ -83,13 +83,13 @@
           "id": "gpt-5.6-sol",
           "label": "GPT-5.6-Sol",
           "priority": 1,
-          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
         },
         {
           "id": "gpt-5.6-terra",
           "label": "GPT-5.6-Terra",
           "priority": 2,
-          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
         },
         {
           "id": "gpt-5.6-luna",

--- a/vibe/data/backend_models.json
+++ b/vibe/data/backend_models.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": 1,
+  "backends": {
+    "claude": {
+      "models": [
+        {
+          "id": "claude-fable-5",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "claude-opus-4-8",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "claude-opus-4-7",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "claude-opus-4-6",
+          "reasoning_efforts": ["low", "medium", "high", "max"]
+        },
+        {
+          "id": "claude-sonnet-5",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "claude-sonnet-4-6",
+          "reasoning_efforts": ["low", "medium", "high", "max"]
+        },
+        {
+          "id": "claude-haiku-4-5",
+          "reasoning_efforts": ["low", "medium", "high"]
+        },
+        {
+          "id": "claude-opus-4-5",
+          "reasoning_efforts": ["low", "medium", "high"]
+        },
+        {
+          "id": "claude-sonnet-4-5",
+          "reasoning_efforts": ["low", "medium", "high"]
+        },
+        {
+          "id": "claude-opus-4",
+          "reasoning_efforts": ["low", "medium", "high"]
+        },
+        {
+          "id": "claude-sonnet-4",
+          "reasoning_efforts": ["low", "medium", "high"]
+        },
+        {
+          "id": "claude-haiku-4",
+          "reasoning_efforts": ["low", "medium", "high"]
+        },
+        {
+          "id": "opus",
+          "label": "opus [1M]",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "sonnet",
+          "label": "sonnet [1M]",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "haiku",
+          "reasoning_efforts": ["low", "medium", "high"]
+        },
+        {
+          "id": "opus[1m]",
+          "label": "opus[1m] [1M]",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "sonnet[1m]",
+          "label": "sonnet[1m] [1M]",
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        }
+      ]
+    },
+    "codex": {
+      "models": [
+        {
+          "id": "gpt-5.6-sol",
+          "label": "GPT-5.6-Sol",
+          "priority": 1,
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+        },
+        {
+          "id": "gpt-5.6-terra",
+          "label": "GPT-5.6-Terra",
+          "priority": 2,
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+        },
+        {
+          "id": "gpt-5.6-luna",
+          "label": "GPT-5.6-Luna",
+          "priority": 3,
+          "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "gpt-5.5",
+          "label": "GPT-5.5",
+          "priority": 7,
+          "reasoning_efforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
+        },
+        {
+          "id": "gpt-5.4",
+          "label": "GPT-5.4",
+          "priority": 16,
+          "reasoning_efforts": ["minimal", "low", "medium", "high", "xhigh"]
+        },
+        {
+          "id": "gpt-5.4-mini",
+          "label": "GPT-5.4-Mini",
+          "priority": 23,
+          "reasoning_efforts": ["minimal", "low", "medium", "high"]
+        },
+        {
+          "id": "gpt-5.2",
+          "label": "GPT-5.2",
+          "priority": 29,
+          "reasoning_efforts": ["minimal", "low", "medium", "high", "xhigh"]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- refresh the Codex and Claude Code model catalogs asynchronously from the Avibe GitHub repository
- merge remote entries with bundled catalogs, installed CLI catalogs, and user-configured model values
- expose per-model reasoning efforts to the Web UI so newly published effort levels do not require a frontend release
- persist the remote catalog with bounded success/failure refresh intervals and keep bundled fallbacks for offline use

## Scenarios

No scenario catalog IDs apply to the backend model picker.

## Evidence

- Unit: remote catalog normalization, persistence/reload, failure TTL, source precedence, and dynamic Claude effort validation
- Contract: Claude/Codex API model responses include model labels and per-model reasoning options consumed by the shared route picker
- Scenario: focused routing/settings and Slack/Feishu regressions pass; UI production build passes
- Residual manual: packaged-wheel probe confirms the catalog JSON is included and the API returns GPT-5.6 models plus model-specific effort options through `max`

## Dependencies

None.

## Known By Design

- Remote refresh is non-blocking. A cold first request uses persisted/bundled data while the background refresh completes; refreshed entries appear on the next model-list request or page reload.
- Successful catalogs refresh every 6 hours. Failed refreshes keep the last good catalog and retry after 10 minutes.
