### PR TITLE
fix(vault): preserve operation TTL near binding expiry

### DIFF
--- a/docs/plans/vault-sandbox-protocol-v2.md
+++ b/docs/plans/vault-sandbox-protocol-v2.md
@@ -529,3 +529,31 @@ Implementation split (Alex): frontend UI/UX & product-experience work →
 Claude; daemon/backend & cryptography-sensitive work (incl. the sandbox) →
 Codex. Orchestrated from the design session; each implementation agent owns
 its PR review loop; the orchestrator reviews and merges last.
+
+## 13. Contract-audit edge — operation identity TTL vs binding expiry (2026-07-10)
+
+The `agent-deliver` operation hash authenticates the approved operation
+identity: `agent-deliver`, secret name, and the original grant duration. It
+must not change as the binding approaches its absolute expiry. In particular,
+the daemon must relay the original `release.ttlSecs` to avault even when only a
+few seconds of binding life remain; otherwise avault recomputes a different
+operation hash and rejects the blind box.
+
+The cache lifetime is a separate clock. Avault caps each resident DEK grant to
+the earlier of `now + ttl_secs` and the blind-box approval's absolute
+`expires_at_unix`. The daemon also persists that same binding expiry on the
+grant. Therefore relaying the original duration preserves the three-way
+sandbox/daemon/avault operation identity without allowing the resident cache
+to outlive the binding.
+
+**Frozen contract:**
+
+1. Sandbox and daemon derive `operationHash` from the original approved grant
+   duration in `release.ttlSecs`.
+2. Daemon sends that same original duration as avault agent-grant `ttl_secs`;
+   it never substitutes remaining binding life into operation identity.
+3. Avault authenticates the blind box with that duration, but bounds the cache
+   by the approval's absolute `expires_at_unix`.
+4. Regression coverage must exercise a near-expiry binding: the blind box
+   opens with the original duration and the cached DEK becomes unavailable at
+   the binding's absolute expiry.

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -3394,23 +3394,41 @@ def test_create_grant_api_accepts_fingerprint_only_agent_pubkey(monkeypatch, ava
     assert agent_grant.call_args.kwargs["expected_pubkey"] == {"fingerprint": issued["agent_pubkey"]["fingerprint"]}
 
 
-def test_create_grant_api_caps_grant_and_relay_by_binding_expiry(monkeypatch, avault_p2):
+def test_create_grant_api_keeps_operation_ttl_near_binding_expiry(monkeypatch, avault_p2):
     monkeypatch.setattr(api, "avault_seal_blind_box", Mock(return_value=_sealed()))
-    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 60})
+    agent_grant = Mock(return_value={"granted": 1, "ttl_secs": 300})
     monkeypatch.setattr(api, "avault_agent_grant", agent_grant)
     api.create_vault_secret({"name": "GRANT_KEY", "protection": "protected", "sealed": {"ciphertext": "ct", "nonce": "n", "wrap_meta": "wm"}})
     requested = api.request_vault_access({"name": "GRANT_KEY", "session_id": "ses_1"})
-    issued = _issued_agent_dek_payload(requested["request"]["id"])
-    binding_expires_at = datetime.now(timezone.utc) + timedelta(seconds=60)
-    with api._vault_engine().begin() as conn:
-        row = conn.execute(select(vault_requests).where(vault_requests.c.id == requested["request"]["id"])).mappings().one()
-        delivery = json.loads(row["delivery"])
-        delivery["agent_binding_approvals"][0]["expires_at"] = api._isoformat_z(binding_expires_at)
-        conn.execute(
-            vault_requests.update()
-            .where(vault_requests.c.id == requested["request"]["id"])
-            .values(delivery=json.dumps(delivery))
-        )
+
+    issued_at = datetime.now(timezone.utc)
+
+    class BindingClock(datetime):
+        current = issued_at
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls.current.astimezone(tz) if tz is not None else cls.current.replace(tzinfo=None)
+
+    monkeypatch.setattr(api, "datetime", BindingClock)
+    binding = api.create_vault_agent_bindings_batch(
+        {"request_id": requested["request"]["id"], "grant_duration": 300}
+    )
+    release = _verified_signed_context(binding["items"][0]["context"])["release"]
+    assert release["ttlSecs"] == 300
+    assert release["operationHash"] == api._agent_deliver_operation_hash("GRANT_KEY", 300)
+
+    BindingClock.current = issued_at + timedelta(seconds=295)
+    issued = {
+        "agent_pubkey": binding["agent_pubkey"],
+        "deks": [
+            {
+                "name": binding["items"][0]["name"],
+                "dek_blindbox": _agent_dek_blindbox(),
+                "approval": binding["items"][0]["approval"],
+            }
+        ],
+    }
 
     created = api.create_vault_grant(
         {
@@ -3421,9 +3439,12 @@ def test_create_grant_api_caps_grant_and_relay_by_binding_expiry(monkeypatch, av
     )
 
     grant_expires_at = datetime.fromisoformat(created["grant"]["expires_at"]).astimezone(timezone.utc)
-    assert grant_expires_at <= binding_expires_at
-    assert 1 <= agent_grant.call_args.kwargs["ttl_secs"] <= 60
-    assert agent_grant.call_args.kwargs["ttl_secs"] < 300
+    remaining_binding_life = (grant_expires_at - BindingClock.current).total_seconds()
+    assert 0 < remaining_binding_life <= 5
+    assert agent_grant.call_args.kwargs["ttl_secs"] == 300
+    assert agent_grant.call_args.kwargs["deks"][0]["approval"]["expires_at_unix"] == release[
+        "approvalExpiresAtUnix"
+    ]
 
 
 def test_create_grant_api_rejects_expired_binding_before_claiming_request(monkeypatch, avault_p2):

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2812,14 +2812,6 @@ def _remaining_ttl_seconds(expires_at: datetime) -> int:
     return max(1, int(round(remaining)))
 
 
-def _binding_relay_ttl_seconds(expires_at: datetime, requested_ttl_seconds: int) -> int:
-    remaining = (expires_at - datetime.now(timezone.utc)).total_seconds()
-    if remaining <= 0:
-        raise VaultApiError("resident agent DEK binding context has expired", code="invalid_grant")
-    remaining_seconds = max(1, int(remaining))
-    return min(requested_ttl_seconds, remaining_seconds)
-
-
 def _grant_ttl_seconds(grant: dict) -> int:
     expires_at = _parse_iso_utc(grant.get("expires_at"))
     if expires_at is None:
@@ -3222,7 +3214,7 @@ def create_vault_grant(payload: dict) -> dict:
     protected_member_names = {str(member["name"]) for member in grantable_members if member.get("protection") == "protected"}
     needs_agent_deks = bool(protected_member_names)
     binding_grant_expires_at: str | None = None
-    binding_relay_ttl_seconds: int | None = None
+    binding_operation_ttl_seconds: int | None = None
 
     agent_deks = _resident_agent_deks_from_payload(payload, needs_agent_deks=needs_agent_deks)
     provided_names = {item["name"] for item in agent_deks}
@@ -3255,7 +3247,9 @@ def create_vault_grant(payload: dict) -> dict:
         binding_expires_at = _parse_iso_utc(binding_grant_expires_at)
         if binding_expires_at is None:
             raise VaultApiError("resident agent DEK binding context has invalid expiry", code="invalid_grant")
-        binding_relay_ttl_seconds = _binding_relay_ttl_seconds(binding_expires_at, binding_requested_ttl_seconds)
+        if binding_expires_at <= datetime.now(timezone.utc):
+            raise VaultApiError("resident agent DEK binding context has expired", code="invalid_grant")
+        binding_operation_ttl_seconds = binding_requested_ttl_seconds
     session_id = payload.get("session_id")
     inherit_request_session = payload.get("this_session_only") is not False
     if not inherit_request_session:
@@ -3296,11 +3290,15 @@ def create_vault_grant(payload: dict) -> dict:
         return {"ok": True, "grant": grant}
     agent_relayed = False
     try:
-        relay_ttl = binding_relay_ttl_seconds if binding_relay_ttl_seconds is not None else _grant_ttl_seconds(grant)
+        operation_ttl = (
+            binding_operation_ttl_seconds
+            if binding_operation_ttl_seconds is not None
+            else _grant_ttl_seconds(grant)
+        )
         agent_result = avault_agent_grant(
             grant_id=str(grant["id"]),
             purpose=str(grant.get("purpose") or purpose),
-            ttl_secs=relay_ttl,
+            ttl_secs=operation_ttl,
             deks=agent_deks,
             expected_pubkey=expected_pubkey,
         )


### PR DESCRIPTION
## Summary

- Relay the original approved binding duration to avault so its recomputed `agent-deliver` operation hash matches the sandbox-sealed blind box near binding expiry.
- Keep the daemon grant's absolute expiry pinned to the issued binding window; avault independently caps its resident DEK cache with the same approval deadline.
- Add a near-expiry regression that advances an issued 300-second binding to five seconds remaining and proves the daemon still relays `ttl_secs = 300`.
- Freeze the three-way sandbox/daemon/avault TTL contract in the protocol v2 plan.

## Cross-repo dependency

- Paired with [avault #19](https://github.com/avibe-bot/avault/pull/19), which locks the consumer contract with a real resident-agent test and exact absolute-expiry conversion.
- No wire-format change and no strict merge ordering, but both PRs are required for the complete contract guarantee before the next integrated Vaults build.

## Evidence

- Unit: `tests/test_vault_api.py` plus `tests/test_avault_agent.py` (153 passed).
- Contract: focused Vault REST grant/binding slice (4 passed) and near-expiry daemon relay regression.
- Scenario: no catalog scenario ID exists for this audit-found edge case.
- Residual manual: full browser sandbox -> daemon -> avault verification is deferred to the orchestrator integration pass; the current main path is unchanged.
- Lint/build: Ruff on changed Python files; UI production build used to bootstrap the fresh worktree.

## Known by design

- The avault grant response reports the original approved operation duration, not remaining binding life. Absolute approval expiry is the separate resident-cache deadline.
- Avibe requires avault grant-delivery version `0.1.4` or newer before this path runs. That initial grant-delivery release already capped the shared resident grant by approval `expires_at_unix`; avault #19 only makes the Unix-to-monotonic conversion exact below one second.
- A multi-DEK avault grant has one shared `GrantEntry.expires_at`, computed as the minimum of the requested duration and every DEK approval expiry. Legacy per-secret bindings with slightly different deadlines therefore expire together at the earliest binding deadline.
