### PR TITLE
docs(agents): sync review-loop rules to lane standard and current vault contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,13 +179,30 @@ Source-of-truth rule:
 
 ### Review Loop for PRs
 
-- before opening a PR, run the reviewer subagent and fix significant issues first
-- PR descriptions must name the changed capability and list the affected scenario IDs when a scenario catalog exists
-- PR descriptions must state which evidence layers were updated: unit, contract, scenario, and residual manual checks
-- after opening a PR, use the `background-watch-hook` skill to keep a review-fix loop running until Codex review passes
-- use the skill's bundled `wait_pr.py` / `wait_action.py` for PR review and CI watches; do not hand-roll PR waiters
-- by default, create the review watch immediately after the PR is opened; do not wait for the user to remind you unless they explicitly say not to keep a watch
-- keep expensive full-suite gates on GitHub CI by default, then require those CI checks to pass before merge
+- the full implementation-lane standard lives at
+  `~/vibe-remote-project/.agents/skills/pr-delivery-loop/SKILL.md` (roles and
+  authority, contracts, Codex-bot review-loop discipline, close-out); follow
+  it for every PR
+- open PRs non-draft; draft PRs do not trigger the Codex bot review
+- the GitHub Codex bot is the review gate: after every push confirm a review
+  of the new head starts, comment `@codex review` if none appears, and treat a
+  trigger as accepted only once the bot reacts 👀 to that comment
+- a bot pass is a plain issue comment naming the reviewed commit; close-out
+  requires zero unresolved review threads on the current head, not just a
+  0-finding latest review
+- after opening a PR, use the `background-watch-hook` skill to keep a
+  review-fix loop running until the review passes; use its bundled
+  `wait_pr.py` / `wait_action.py`, never hand-rolled waiters, and create the
+  watch immediately without waiting to be reminded
+- PR descriptions must name the changed capability, list affected scenario IDs
+  when a catalog exists, and state which evidence layers were updated: unit,
+  contract, scenario, and residual manual checks
+- do not merge on your own initiative: the orchestrator (or the user) does the
+  final review and merge; an explicit merge instruction from them is carried
+  out directly after a mechanical `mergeStateStatus == CLEAN` check, never by
+  spawning another agent to re-review
+- keep expensive full-suite gates on GitHub CI by default, then require those
+  CI checks to pass before merge
 
 ### Pre-Push Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,10 +179,11 @@ Source-of-truth rule:
 
 ### Review Loop for PRs
 
-- the full implementation-lane standard lives at
-  `~/vibe-remote-project/.agents/skills/pr-delivery-loop/SKILL.md` (roles and
-  authority, contracts, Codex-bot review-loop discipline, close-out); follow
-  it for every PR
+- the rules in this section are the self-sufficient baseline for every PR; a
+  fuller implementation-lane standard (roles and authority, contracts,
+  close-out details) lives in the multi-repo workspace at
+  `~/vibe-remote-project/.agents/skills/pr-delivery-loop/SKILL.md` — follow it
+  whenever that workspace file is available in your environment
 - open PRs non-draft; draft PRs do not trigger the Codex bot review
 - the GitHub Codex bot is the review gate: after every push confirm a review
   of the new head starts, comment `@codex review` if none appears, and treat a

--- a/docs/plans/vault-sandbox-protocol-v2.md
+++ b/docs/plans/vault-sandbox-protocol-v2.md
@@ -333,11 +333,27 @@ engine supports it), no pending `ui.show` unacknowledged. Confirm buttons are
 dead for the first ~500 ms after render (anti-timing-redress) and may use
 hold-to-confirm for release/reveal. Otherwise fail closed with
 `sandbox_not_visible` (parent responds by expanding the modal and retrying).
-This was designed in v1 and never built; in v2 it is a blocker for shipping
-R2-without-passkey. Note the shape of the residual: an XSS with **no user
+Note the shape of the residual: an XSS with **no user
 present** can complete nothing (every R2/R3 needs a real gesture inside the
 sandbox document); the residual is exclusively "user present and redressed",
 bounded by these checks and by Strict mode.
+
+**Parent surface attestation is advisory telemetry, not an enforced gate.**
+While an embedded confirm is up, the parent measures the sandbox iframe
+element (rect, own IntersectionObserver reading, computed opacity and
+pointer-events) and streams it as per-request `surface` plus `confirm.surface`
+events refreshed every ~10 s (wire shape frozen by the parent's
+`buildVaultConfirmSurface` unit test and the sandbox's
+`parseParentConfirmSurface`). The sandbox records it and logs anomalies but
+never fails a ceremony on it, for two reasons. First, it is self-reported by
+the very party the sandbox distrusts: a compromised parent fabricates a
+perfect reading, so enforcing it adds nothing against the adversary it
+targets (overlay redress requires a compromised parent, which lies). Second,
+honest parents fail it persistently: IntersectionObserver v2 `trackVisibility`
+reports occlusion whenever any ancestor carries a transform, filter, opacity
+transition, or animation — ordinary modal CSS. Enforcement therefore only
+taxes legitimate users. The browser-truth self-checks above remain the
+enforced gate.
 
 ## 7. Flow redesigns
 
@@ -529,6 +545,21 @@ Implementation split (Alex): frontend UI/UX & product-experience work →
 Claude; daemon/backend & cryptography-sensitive work (incl. the sandbox) →
 Codex. Orchestrated from the design session; each implementation agent owns
 its PR review loop; the orchestrator reviews and merges last.
+
+## 12. Frozen contract — signed context verification & approvalNonce
+
+1. The daemon signature covers the **entire** context object exactly as
+   transmitted, including the `release` block. The sandbox verifies against
+   the received record losslessly — no field allowlist, no re-serialization
+   that could drop or reorder content (`parseSignedOperationContext` returns
+   the raw record; `signedOperationContextMessage` re-canonicalizes it whole).
+2. `release.approvalNonce` is **produced by the daemon** (random) and consumed
+   by the sandbox as-is when sealing the blind box. The sandbox never derives
+   its own nonce.
+3. Canonical JSON on both sides: UTF-8, keys sorted, compact separators
+   (`","`/`":"`), non-ASCII characters **unescaped** (Python
+   `ensure_ascii=False` ≡ JS `JSON.stringify`). Cross-boundary tests must
+   include non-ASCII payloads.
 
 ## 13. Contract-audit edge — operation identity TTL vs binding expiry (2026-07-10)
 


### PR DESCRIPTION
## What changed

- `AGENTS.md` Review Loop section now matches the current process: the GitHub Codex bot is the sole review gate (the pre-PR reviewer-subagent step no longer exists), 👀-trigger rule, pass-comment shape, zero-unresolved-threads close-out, and merge authority (orchestrator/user merges; an explicit merge instruction is executed directly after a mechanical `mergeStateStatus == CLEAN` check, never by spawning another agent to re-review).
- `docs/plans/vault-sandbox-protocol-v2.md`: §6.6 records that parent surface attestation is advisory telemetry, not an enforced gate (self-reported by the distrusted party; IObserver v2 `trackVisibility` false-positives on ordinary modal CSS), with the browser-truth sandbox self-checks remaining enforced; restores §12 frozen contract (lossless signed-context verification, daemon-owned `approvalNonce`, canonical JSON with non-ASCII unescaped).

## Evidence layers

Docs-only: no code paths changed; no scenario IDs affected. Contract text cross-checked against merged implementations (#851, sandbox #10/#11, #855, #857).