### PR TITLE
feat(agents): per-Agent env overrides via metadata.env for isolated backend auth

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -187,6 +187,15 @@ class SessionHandler(BaseHandler):
             await self.cleanup_session(composite_key)
             return None
 
+        agent_env = self._vibe_agent_env_overrides(context)
+        if getattr(client, "_vibe_agent_env", {}) != agent_env:
+            logger.info(
+                "Recreating cached Claude SDK client for %s because Agent env overrides changed",
+                composite_key,
+            )
+            await self.cleanup_session(composite_key)
+            return None
+
         try:
             await self._set_claude_model_if_needed(client, current_model)
         except Exception as e:
@@ -227,6 +236,14 @@ class SessionHandler(BaseHandler):
         if getattr(client, "_vibe_caller_env", {}) != caller_env:
             logger.info(
                 "Recreating cached Claude subagent SDK client for %s because caller context env changed",
+                composite_key,
+            )
+            await self.cleanup_session(composite_key)
+            return None
+        agent_env = self._vibe_agent_env_overrides(context)
+        if getattr(client, "_vibe_agent_env", {}) != agent_env:
+            logger.info(
+                "Recreating cached Claude subagent SDK client for %s because Agent env overrides changed",
                 composite_key,
             )
             await self.cleanup_session(composite_key)
@@ -761,6 +778,36 @@ class SessionHandler(BaseHandler):
         finally:
             self._untrack_claude_session_create(composite_key, create_future)
 
+    def _vibe_agent_env_overrides(self, context: MessageContext) -> Dict[str, str]:
+        """Per-Agent env overrides declared in ``VibeAgent.metadata["env"]``.
+
+        Applied on top of the global auth composition at subprocess spawn so
+        Agents on the same backend can carry isolated authentication (e.g.
+        one OAuth Agent and one ``ANTHROPIC_API_KEY`` Agent) while sharing
+        the backend binary, settings, and skills.
+        """
+        from core.vibe_agents import (
+            resolve_agent_env_overrides,
+            vibe_agent_name_from_platform_payload,
+        )
+
+        agent_name = vibe_agent_name_from_platform_payload(
+            getattr(context, "platform_specific", None)
+        )
+        if not agent_name:
+            return {}
+        store = getattr(self.controller, "vibe_agent_store", None)
+        if store is None:
+            return {}
+        try:
+            agent = store.get(agent_name)
+        except Exception:
+            logger.warning(
+                "Agent env override lookup failed for %r", agent_name, exc_info=True
+            )
+            return {}
+        return resolve_agent_env_overrides(agent)
+
     async def _create_claude_session(
         self,
         *,
@@ -853,6 +900,16 @@ class SessionHandler(BaseHandler):
         from vibe.claude_config import build_claude_subprocess_env
 
         claude_env = build_claude_subprocess_env(getattr(self.config, "claude", None))
+        agent_env_overrides = self._vibe_agent_env_overrides(context)
+        if agent_env_overrides:
+            # Per-Agent auth/env isolation: metadata["env"] wins over the
+            # global auth composition but never over Avibe identity keys
+            # (caller context and owner marker below). Log key names only.
+            claude_env.update(agent_env_overrides)
+            logger.info(
+                "Applied Agent env override(s): %s",
+                ", ".join(sorted(agent_env_overrides)),
+            )
         claude_env.update(caller_env_for_platform_payload(getattr(context, "platform_specific", None)))
         claude_env[AVIBE_CLAUDE_PROCESS_OWNER_ENV] = AVIBE_CLAUDE_SESSION_OWNER
         if self._should_mark_claude_isolated_env():
@@ -910,6 +967,7 @@ class SessionHandler(BaseHandler):
         # Create new Claude client
         client = ClaudeSDKClient(options=options)
         setattr(client, "_vibe_caller_env", caller_env_for_platform_payload(getattr(context, "platform_specific", None)))
+        setattr(client, "_vibe_agent_env", agent_env_overrides)
 
         # Log the actual options being used
         logger.info("ClaudeAgentOptions details:")

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 from uuid import uuid4
 
 import yaml
@@ -101,6 +102,85 @@ class AgentImportCandidate:
 class AgentImportResult:
     imported: list[VibeAgent]
     skipped: list[dict[str, Any]]
+
+
+# Metadata key holding per-Agent env overrides for backend subprocesses.
+# The value is a JSON object of env-var names to string values. A value of
+# the exact form "${NAME}" is resolved from the daemon process environment
+# at spawn time, so secrets can stay out of the agents store.
+AGENT_ENV_METADATA_KEY = "env"
+
+
+def vibe_agent_name_from_platform_payload(payload: Mapping[str, Any] | None) -> Optional[str]:
+    """Return the Avibe Agent name a message/turn payload resolved to.
+
+    Message dispatch stamps ``resolved_vibe_agent`` onto the platform
+    payload once routing picks an Agent; Agent-run/session targets carry
+    ``agent_session_target.agent_name``. Both shapes are accepted so
+    per-Agent behavior applies uniformly across IM routing,
+    ``vibe agent run``, scheduled tasks, and watches.
+    """
+    if not payload:
+        return None
+    resolved = payload.get("resolved_vibe_agent")
+    if isinstance(resolved, Mapping):
+        name = str(resolved.get("name") or "").strip()
+        if name:
+            return name
+    target = payload.get("agent_session_target")
+    if isinstance(target, Mapping):
+        name = str(target.get("agent_name") or "").strip()
+        if name:
+            return name
+    return None
+
+
+def resolve_agent_env_overrides(
+    agent: Optional[VibeAgent],
+    *,
+    base_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return the env overrides ``agent.metadata["env"]`` declares.
+
+    The mapping is applied on top of the backend subprocess env at spawn
+    time. This lets multiple Agents share one backend binary and one
+    settings/skills home while running with isolated authentication —
+    e.g. a subscription (OAuth) Claude Agent next to an
+    ``ANTHROPIC_API_KEY`` Claude Agent.
+
+    Non-dict metadata, blank/non-string keys, and ``None`` values are
+    ignored. A value of the exact form ``"${NAME}"`` resolves from
+    ``base_env`` (the daemon process env by default) and is skipped with
+    a warning when unset, so a missing secret fails visibly instead of
+    injecting an empty credential.
+    """
+    if agent is None or not isinstance(agent.metadata, dict):
+        return {}
+    raw = agent.metadata.get(AGENT_ENV_METADATA_KEY)
+    if not isinstance(raw, dict):
+        return {}
+    env_source = base_env if base_env is not None else os.environ
+    overrides: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key.strip():
+            continue
+        if value is None:
+            continue
+        text = str(value)
+        if text.startswith("${") and text.endswith("}") and len(text) > 3:
+            ref = text[2:-1]
+            resolved_value = str(env_source.get(ref) or "")
+            if not resolved_value:
+                logger.warning(
+                    "Agent %r env override %s references unset ${%s}; skipping",
+                    agent.name,
+                    key,
+                    ref,
+                )
+                continue
+            text = resolved_value
+        overrides[key.strip()] = text
+    return overrides
 
 
 class VibeAgentStore:

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -825,6 +825,42 @@ When queried by `<name>`, the result includes `current` — the Agent's configur
 accept any value but warn (without rejecting) when it is not in the known set and
 point back to this command.
 
+### Per-Agent env overrides (`metadata.env`)
+
+An Agent may declare environment overrides for its backend subprocess in the
+`env` key of its metadata JSON. They are applied on top of the backend's
+global env composition every time a session process is spawned for that
+Agent, so multiple Agents on the same backend can run with isolated
+authentication while still sharing the backend binary, settings, skills, and
+permission configuration.
+
+The primary use case is running one Claude Code Agent on subscription OAuth
+and another on API-key billing side by side:
+
+```bash
+# Global Claude auth stays "oauth" (Settings → Backends → Claude).
+# This Agent alone talks to the API with its own key:
+vibe agent create cc-api --backend claude \
+  --description "Claude Code on API-key billing" \
+  --metadata '{"env": {"ANTHROPIC_API_KEY": "${CC_API_KEY}"}}'
+```
+
+- values are strings; non-string values are stringified, `null` values are ignored
+- a value of the exact form `"${NAME}"` is resolved from the Avibe daemon's
+  process environment at spawn time, so the secret itself never has to be
+  stored in the agents database; an unset reference is skipped with a warning
+  instead of injecting an empty value
+- overrides win over the global auth composition but never over
+  Avibe-managed identity variables (`AVIBE_SESSION_ID` and friends)
+- changing an Agent's `env` metadata takes effect on the next message: a
+  cached live session with different overrides is recreated automatically
+- Claude Code note: `~/.claude/settings.json`'s `env` block is applied by the
+  CLI itself at launch and wins over process env. Keep global Claude auth in
+  OAuth mode (which keeps that block free of `ANTHROPIC_*` credentials) when
+  giving individual Agents their own `ANTHROPIC_API_KEY`.
+- currently applied to the `claude` backend; `codex` / `opencode` wiring can
+  adopt the same metadata contract later
+
 ### `vibe agent run`
 
 ```bash

--- a/docs/COMMANDS_ZH.md
+++ b/docs/COMMANDS_ZH.md
@@ -801,6 +801,34 @@ vibe agent models --backend opencode --provider deepseek
 按 `<name>` 查询时，结果包含 `current`——该 Agent 配置的 `model` / `reasoning_effort` 及其是否仍然有效。
 `create` / `update` 接受任意取值，但当取值不在已知集合中时会给出警告（不拒绝），并指回本命令。
 
+### Per-Agent 环境变量覆盖（`metadata.env`）
+
+Agent 可以在 metadata JSON 的 `env` 键里声明后端子进程的环境变量覆盖。
+每次为该 Agent 拉起会话进程时，这些覆盖会叠加在后端全局环境组合之上——
+同一后端上的多个 Agent 因此可以携带互相隔离的认证，同时继续共享后端二进制、
+settings、skills 与权限配置。
+
+典型场景：一个 Claude Code Agent 走订阅 OAuth，另一个走 API-key 计费，并行运行：
+
+```bash
+# 全局 Claude 认证保持 "oauth"（Settings → Backends → Claude）。
+# 只有这个 Agent 用自己的 key 直连 API：
+vibe agent create cc-api --backend claude \
+  --description "Claude Code on API-key billing" \
+  --metadata '{"env": {"ANTHROPIC_API_KEY": "${CC_API_KEY}"}}'
+```
+
+- 值为字符串；非字符串值会被字符串化，`null` 值被忽略
+- 形如 `"${NAME}"` 的值会在拉起时从 Avibe 守护进程的环境变量解析，
+  密钥本身无需落入 agents 数据库；引用未设置时跳过并告警，而不是注入空值
+- 覆盖优先于全局认证组合，但永远不会覆盖 Avibe 管理的身份变量
+  （`AVIBE_SESSION_ID` 等）
+- 修改 Agent 的 `env` metadata 在下一条消息生效：缓存的活跃会话若覆盖不同会自动重建
+- Claude Code 注意事项：`~/.claude/settings.json` 的 `env` 块由 CLI 启动时自行应用，
+  优先级高于进程环境。给单个 Agent 配 `ANTHROPIC_API_KEY` 时，请让全局 Claude
+  认证保持 OAuth 模式（该模式会保证 settings.json 中不含 `ANTHROPIC_*` 凭证）。
+- 目前应用于 `claude` 后端；`codex` / `opencode` 后续可按同一 metadata 契约接入
+
 ### `vibe agent run`
 
 ```bash

--- a/docs/plans/agent-env-overrides.md
+++ b/docs/plans/agent-env-overrides.md
@@ -1,0 +1,64 @@
+# Per-Agent Env Overrides (`metadata.env`)
+
+## Background
+
+Claude backend authentication is a single global choice today: `agents.claude.auth_mode`
+(`oauth` | `api_key`) plus `~/.claude/settings.json` decide the credentials for every
+Claude subprocess (`vibe/claude_config.py::build_claude_subprocess_env`). Two Agents on
+the `claude` backend therefore always share one identity. Users who want a subscription
+(OAuth) instance and an API-key instance side by side — e.g. burst work on API billing
+while daily work stays on the subscription — cannot express that, even though the
+Claude CLI itself supports it (an inherited `ANTHROPIC_API_KEY` suppresses the OAuth
+credential store per process).
+
+## Goal
+
+Multiple Agents on one backend with **isolated authentication** and **shared
+everything else** (backend binary, `~/.claude` settings, skills, permission config).
+No new database schema, no new global config surface.
+
+## Solution
+
+Reuse the existing free-form Agent `metadata` JSON: an `env` object is treated as
+per-Agent env overrides for the backend subprocess.
+
+- `core/vibe_agents.py`
+  - `AGENT_ENV_METADATA_KEY = "env"`
+  - `vibe_agent_name_from_platform_payload(payload)` — resolves the acting Agent from
+    `resolved_vibe_agent` (IM routing) or `agent_session_target.agent_name`
+    (agent run / tasks / watches).
+  - `resolve_agent_env_overrides(agent, base_env=...)` — pure resolver: string
+    coercion, `None`/blank-key skipping, `"${NAME}"` indirection from the daemon env
+    (unset references are skipped with a warning, never injected as empty).
+- `core/handlers/session_handler.py`
+  - `_vibe_agent_env_overrides(context)` — payload → store lookup → resolver.
+  - `_create_claude_session` merges the overrides on top of
+    `build_claude_subprocess_env(...)`, before caller-context identity env and the
+    owner marker (identity keys stay authoritative). Key names are logged, values are
+    not.
+  - Both cached-session reuse paths compare the client's recorded `_vibe_agent_env`
+    and recreate the session when overrides changed, mirroring the existing
+    `_vibe_caller_env` invalidation contract.
+
+Ordering: `build_claude_subprocess_env` → Agent overrides → caller-context env →
+`AVIBE_CLAUDE_PROCESS_OWNER_ENV` / `IS_SANDBOX`.
+
+## Constraints and Notes
+
+- Claude Code applies the `settings.json` `env` block on top of process env at launch;
+  per-Agent `ANTHROPIC_API_KEY` therefore requires global claude auth to stay in OAuth
+  mode (which keeps that block credential-free). Documented in `docs/COMMANDS.md`.
+- Scope: wired for the `claude` backend. The resolver lives in `core/` and is
+  backend-agnostic so `codex` (`CODEX_HOME`) / `opencode` can adopt the same metadata
+  contract in a follow-up.
+- Vault integration (e.g. `${vault:NAME}` value forms) is a possible follow-up; `${NAME}`
+  daemon-env indirection covers the secret-hygiene need without new coupling.
+
+## Todo
+
+- [x] resolver + payload helpers in `core/vibe_agents.py`
+- [x] claude spawn merge + cached-session invalidation in `core/handlers/session_handler.py`
+- [x] unit tests `tests/test_agent_env_overrides.py` (17 cases)
+- [x] docs: `docs/COMMANDS.md` + `docs/COMMANDS_ZH.md`
+- [ ] follow-up: codex/opencode wiring
+- [ ] follow-up: mask `metadata.env` values in `vibe agent show` output

--- a/tests/test_agent_env_overrides.py
+++ b/tests/test_agent_env_overrides.py
@@ -1,0 +1,177 @@
+"""Unit tests for per-Agent env overrides (``VibeAgent.metadata["env"]``).
+
+Two Agents on the same claude backend must be able to run with isolated
+authentication (e.g. one OAuth via Claude Code's credential store, one
+``ANTHROPIC_API_KEY``) while sharing the backend binary, settings, and
+skills. The override surface is intentionally tiny: a plain env mapping in
+Agent metadata, resolved by ``core.vibe_agents.resolve_agent_env_overrides``
+and applied on top of ``build_claude_subprocess_env`` output at spawn time.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from core.handlers.session_handler import SessionHandler
+from core.vibe_agents import (
+    VibeAgent,
+    resolve_agent_env_overrides,
+    vibe_agent_name_from_platform_payload,
+)
+
+
+def _agent(metadata: dict | None) -> VibeAgent:
+    return VibeAgent(
+        id=str(uuid4()),
+        name="worker",
+        normalized_name="worker",
+        backend="claude",
+        metadata=metadata if metadata is not None else {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_agent_env_overrides
+# ---------------------------------------------------------------------------
+
+
+def test_no_agent_returns_empty() -> None:
+    assert resolve_agent_env_overrides(None) == {}
+
+
+def test_metadata_without_env_returns_empty() -> None:
+    assert resolve_agent_env_overrides(_agent({"builtin": True})) == {}
+
+
+def test_non_dict_env_metadata_is_ignored() -> None:
+    assert resolve_agent_env_overrides(_agent({"env": "ANTHROPIC_API_KEY=sk-x"})) == {}
+    assert resolve_agent_env_overrides(_agent({"env": ["ANTHROPIC_API_KEY"]})) == {}
+
+
+def test_literal_values_pass_through() -> None:
+    agent = _agent({"env": {"ANTHROPIC_API_KEY": "sk-ant-agent", "ANTHROPIC_BASE_URL": "https://relay.example"}})
+    assert resolve_agent_env_overrides(agent) == {
+        "ANTHROPIC_API_KEY": "sk-ant-agent",
+        "ANTHROPIC_BASE_URL": "https://relay.example",
+    }
+
+
+def test_values_are_coerced_to_strings_and_none_is_skipped() -> None:
+    agent = _agent({"env": {"CLAUDE_CODE_MAX_OUTPUT_TOKENS": 32000, "DROPPED": None}})
+    assert resolve_agent_env_overrides(agent) == {"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "32000"}
+
+
+def test_blank_and_non_string_keys_are_skipped() -> None:
+    agent = _agent({"env": {"": "x", "  ": "y", 7: "z", " PADDED ": "kept"}})
+    assert resolve_agent_env_overrides(agent) == {"PADDED": "kept"}
+
+
+def test_env_var_indirection_resolves_from_base_env() -> None:
+    agent = _agent({"env": {"ANTHROPIC_API_KEY": "${WORK_ANTHROPIC_KEY}"}})
+    out = resolve_agent_env_overrides(agent, base_env={"WORK_ANTHROPIC_KEY": "sk-ant-indirect"})
+    assert out == {"ANTHROPIC_API_KEY": "sk-ant-indirect"}
+
+
+def test_unset_env_var_indirection_is_skipped_not_empty() -> None:
+    # Injecting "" would silently break auth; a missing secret must stay
+    # visible as "no override" instead.
+    agent = _agent({"env": {"ANTHROPIC_API_KEY": "${MISSING_KEY}"}})
+    assert resolve_agent_env_overrides(agent, base_env={}) == {}
+
+
+def test_bare_dollar_brace_literal_is_kept() -> None:
+    agent = _agent({"env": {"MARKER": "${}"}})
+    assert resolve_agent_env_overrides(agent, base_env={}) == {"MARKER": "${}"}
+
+
+# ---------------------------------------------------------------------------
+# vibe_agent_name_from_platform_payload
+# ---------------------------------------------------------------------------
+
+
+def test_payload_none_returns_none() -> None:
+    assert vibe_agent_name_from_platform_payload(None) is None
+    assert vibe_agent_name_from_platform_payload({}) is None
+
+
+def test_resolved_vibe_agent_name_wins() -> None:
+    payload = {
+        "resolved_vibe_agent": {"name": "cc-api"},
+        "agent_session_target": {"agent_name": "other"},
+    }
+    assert vibe_agent_name_from_platform_payload(payload) == "cc-api"
+
+
+def test_agent_session_target_is_fallback() -> None:
+    payload = {"agent_session_target": {"agent_name": "cc-api"}}
+    assert vibe_agent_name_from_platform_payload(payload) == "cc-api"
+
+
+def test_blank_names_are_ignored() -> None:
+    payload = {
+        "resolved_vibe_agent": {"name": "  "},
+        "agent_session_target": {"agent_name": ""},
+    }
+    assert vibe_agent_name_from_platform_payload(payload) is None
+
+
+# ---------------------------------------------------------------------------
+# SessionHandler._vibe_agent_env_overrides glue
+# ---------------------------------------------------------------------------
+
+
+class _FakeStore:
+    def __init__(self, agent: VibeAgent | None):
+        self._agent = agent
+        self.requested: list[str] = []
+
+    def get(self, name: str) -> VibeAgent | None:
+        self.requested.append(name)
+        return self._agent
+
+
+def _handler_with_store(store) -> SimpleNamespace:
+    return SimpleNamespace(controller=SimpleNamespace(vibe_agent_store=store))
+
+
+def _context(payload: dict | None) -> SimpleNamespace:
+    return SimpleNamespace(platform_specific=payload)
+
+
+def test_handler_resolves_agent_env_from_payload() -> None:
+    agent = _agent({"env": {"ANTHROPIC_API_KEY": "sk-ant-agent"}})
+    store = _FakeStore(agent)
+    fake_self = _handler_with_store(store)
+    context = _context({"resolved_vibe_agent": {"name": "worker"}})
+
+    out = SessionHandler._vibe_agent_env_overrides(fake_self, context)
+
+    assert out == {"ANTHROPIC_API_KEY": "sk-ant-agent"}
+    assert store.requested == ["worker"]
+
+
+def test_handler_without_agent_in_payload_is_noop() -> None:
+    store = _FakeStore(_agent({"env": {"ANTHROPIC_API_KEY": "sk-ant-agent"}}))
+    fake_self = _handler_with_store(store)
+
+    assert SessionHandler._vibe_agent_env_overrides(fake_self, _context(None)) == {}
+    assert store.requested == []
+
+
+def test_handler_tolerates_store_lookup_failure() -> None:
+    class _BrokenStore:
+        def get(self, name: str):
+            raise RuntimeError("db locked")
+
+    fake_self = _handler_with_store(_BrokenStore())
+    context = _context({"resolved_vibe_agent": {"name": "worker"}})
+
+    assert SessionHandler._vibe_agent_env_overrides(fake_self, context) == {}
+
+
+def test_handler_without_store_is_noop() -> None:
+    fake_self = SimpleNamespace(controller=SimpleNamespace())
+    context = _context({"resolved_vibe_agent": {"name": "worker"}})
+
+    assert SessionHandler._vibe_agent_env_overrides(fake_self, context) == {}


### PR DESCRIPTION
## Capability

Multiple Agents on the same `claude` backend can now run with **isolated authentication** while sharing the backend binary, `~/.claude` settings, skills, and permission configuration. The primary use case: one Agent on subscription OAuth and another on `ANTHROPIC_API_KEY` billing, side by side.

## How

An Agent may declare env overrides in its existing free-form metadata JSON under the `env` key — no schema migration, no new global config surface:

```bash
vibe agent create cc-api --backend claude \
  --metadata '{"env": {"ANTHROPIC_API_KEY": "${CC_API_KEY}"}}'
```

- `core/vibe_agents.py`: `AGENT_ENV_METADATA_KEY`, `vibe_agent_name_from_platform_payload()` (accepts both `resolved_vibe_agent` from IM routing and `agent_session_target.agent_name` from agent run / tasks / watches), and pure `resolve_agent_env_overrides()` with `${NAME}` daemon-env indirection so secrets can stay out of the agents DB (unset references are skipped with a warning, never injected as empty).
- `core/handlers/session_handler.py`: overrides merge on top of `build_claude_subprocess_env()` at spawn — after global auth composition, **before** caller-context identity env and the owner marker, so Avibe identity keys stay authoritative. Key names are logged, values never. Both cached-session reuse paths compare the client's recorded `_vibe_agent_env` and recreate the session when overrides change, mirroring the existing `_vibe_caller_env` invalidation contract.
- Works because an inherited `ANTHROPIC_API_KEY` suppresses Claude Code's OAuth credential store per process; global claude auth staying in `oauth` mode keeps `settings.json`'s env block credential-free (that block wins over process env at CLI launch). Documented in `docs/COMMANDS.md`.

## Scope

Wired for the `claude` backend. The resolver lives in `core/` and is backend-agnostic; `codex` (`CODEX_HOME`) / `opencode` can adopt the same metadata contract as a follow-up. A second follow-up candidate: masking `metadata.env` values in `vibe agent show` output.

## Evidence

- **Unit**: new `tests/test_agent_env_overrides.py` — 17 cases (resolver value/key hygiene, `${NAME}` indirection incl. unset-skip, payload name resolution precedence, SessionHandler glue incl. store-failure tolerance) — all pass.
- **Contract/regression**: `tests/test_claude_subprocess_env.py`, `tests/test_claude_cli_path.py`, `tests/test_claude_agent_sessions.py` — 118 passed.
- **Lint**: `ruff check` clean on changed files.
- **Residual manual**: patch applied to a live install; in-session probe verification pending a service restart (will confirm on this PR).
- No scenario catalog exists for this area; plan doc added at `docs/plans/agent-env-overrides.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
