### PR TITLE
fix(claude): surface safety fallback notifications

### DIFF
--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -1351,7 +1351,7 @@ class ClaudeAgent(BaseAgent):
             return
 
         direction = str(data.get("direction") or "").strip().lower()
-        if direction != "retry":
+        if direction and direction != "retry":
             logger.info(
                 "Ignoring legacy Claude refusal fallback direction %r for %s",
                 direction,
@@ -1359,18 +1359,16 @@ class ClaudeAgent(BaseAgent):
             )
             return
 
-        # The refusal event retracts the primary model's partial response before
-        # Claude retries on the fallback model. Avibe buffers the latest assistant
-        # text until the next assistant/result frame, so discard that buffer now
-        # instead of emitting a response Claude explicitly withdrew.
-        self._pending_assistant_message.pop(composite_key, None)
-        self._last_assistant_text.pop(composite_key, None)
-
+        # Claude Code can write this marker after the fallback assistant row. Do
+        # not infer retraction order from the marker alone: the result path may
+        # still need that assistant text when ResultMessage.result is empty.
         pending_requests = self._pending_requests.get(composite_key) or []
         self._adopt_pending_turn_token(context, pending_requests[0] if pending_requests else None)
 
-        original_model = " ".join(str(data.get("original_model") or "").split())[:160]
-        fallback_model = " ".join(str(data.get("fallback_model") or "").split())[:160]
+        original_value = data.get("original_model") or data.get("originalModel") or ""
+        fallback_value = data.get("fallback_model") or data.get("fallbackModel") or ""
+        original_model = " ".join(str(original_value).split())[:160]
+        fallback_model = " ".join(str(fallback_value).split())[:160]
         provider_content = str(data.get("content") or "").strip()
 
         text = ""

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -559,16 +559,21 @@ class ClaudeAgent(BaseAgent):
                     message_type = self._detect_message_type(message)
                     formatter = self._get_formatter(context)
                     is_model_refusal_fallback = self._is_model_refusal_fallback_message(message)
+                    model_refusal_fallback_notice = (
+                        self._parse_model_refusal_fallback_notice(message)
+                        if is_model_refusal_fallback
+                        else None
+                    )
 
                     # Unsolicited backend output (a background-task completion or
                     # a ScheduleWakeup re-invoked the agent inside this SDK
                     # process) reaches this long-lived receiver with no Avibe turn
                     # open. Open an agent-initiated turn so the reply is persisted
                     # + delivered + notified instead of dropped by the outbound
-                    # active-turn guard. A refusal-fallback system frame is the one
-                    # user-facing system exception: it precedes the replacement
-                    # assistant response and must open the same turn first.
-                    if message_type in ("assistant", "result") or is_model_refusal_fallback:
+                    # active-turn guard. An actionable refusal-fallback frame is
+                    # the one user-facing system exception: it belongs to the
+                    # replacement run and must use that run's turn.
+                    if message_type in ("assistant", "result") or model_refusal_fallback_notice is not None:
                         await self._maybe_begin_agent_initiated_turn(
                             context,
                             composite_key,
@@ -703,10 +708,19 @@ class ClaudeAgent(BaseAgent):
                     # current SDK's generic SystemMessage class. A future SDK may
                     # promote this event to a dedicated typed message.
                     if is_model_refusal_fallback:
+                        if model_refusal_fallback_notice is None:
+                            logger.debug("Ignoring non-actionable Claude refusal fallback for %s", composite_key)
+                            continue
+                        if not self._has_pending_requests(composite_key):
+                            logger.info(
+                                "Dropping Claude refusal fallback for %s without an active turn",
+                                composite_key,
+                            )
+                            continue
                         await self._handle_model_refusal_fallback(
                             context,
                             composite_key,
-                            message,
+                            model_refusal_fallback_notice,
                         )
                         continue
 
@@ -1338,38 +1352,39 @@ class ClaudeAgent(BaseAgent):
     def _is_model_refusal_fallback_message(message) -> bool:
         return (getattr(message, "subtype", "") or "").strip().lower() == "model_refusal_fallback"
 
-    async def _handle_model_refusal_fallback(
-        self,
-        context: MessageContext,
-        composite_key: str,
-        message,
-    ) -> None:
-        """Surface Claude's structured safety fallback without ending the turn."""
+    @staticmethod
+    def _parse_model_refusal_fallback_notice(message) -> Optional[tuple[str, str, str]]:
         data = getattr(message, "data", None)
         if not isinstance(data, dict):
-            logger.warning("Claude refusal fallback for %s had no structured payload", composite_key)
-            return
+            return None
 
         direction = str(data.get("direction") or "").strip().lower()
         if direction and direction != "retry":
-            logger.info(
-                "Ignoring legacy Claude refusal fallback direction %r for %s",
-                direction,
-                composite_key,
-            )
-            return
-
-        # Claude Code can write this marker after the fallback assistant row. Do
-        # not infer retraction order from the marker alone: the result path may
-        # still need that assistant text when ResultMessage.result is empty.
-        pending_requests = self._pending_requests.get(composite_key) or []
-        self._adopt_pending_turn_token(context, pending_requests[0] if pending_requests else None)
+            return None
 
         original_value = data.get("original_model") or data.get("originalModel") or ""
         fallback_value = data.get("fallback_model") or data.get("fallbackModel") or ""
         original_model = " ".join(str(original_value).split())[:160]
         fallback_model = " ".join(str(fallback_value).split())[:160]
         provider_content = str(data.get("content") or "").strip()
+        if not provider_content and not (original_model and fallback_model):
+            return None
+        return original_model, fallback_model, provider_content
+
+    async def _handle_model_refusal_fallback(
+        self,
+        context: MessageContext,
+        composite_key: str,
+        notice: tuple[str, str, str],
+    ) -> None:
+        """Surface Claude's structured safety fallback without ending the turn."""
+        # Claude Code can write this marker after the fallback assistant row. Do
+        # not infer retraction order from the marker alone: the result path may
+        # still need that assistant text when ResultMessage.result is empty.
+        pending_requests = self._pending_requests.get(composite_key) or []
+        self._adopt_pending_turn_token(context, pending_requests[0] if pending_requests else None)
+
+        original_model, fallback_model, provider_content = notice
 
         text = ""
         translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -558,15 +558,17 @@ class ClaudeAgent(BaseAgent):
 
                     message_type = self._detect_message_type(message)
                     formatter = self._get_formatter(context)
+                    is_model_refusal_fallback = self._is_model_refusal_fallback_message(message)
 
                     # Unsolicited backend output (a background-task completion or
                     # a ScheduleWakeup re-invoked the agent inside this SDK
                     # process) reaches this long-lived receiver with no Avibe turn
                     # open. Open an agent-initiated turn so the reply is persisted
                     # + delivered + notified instead of dropped by the outbound
-                    # active-turn guard. Content messages only — system/user
-                    # frames never carry a user-facing reply.
-                    if message_type in ("assistant", "result"):
+                    # active-turn guard. A refusal-fallback system frame is the one
+                    # user-facing system exception: it precedes the replacement
+                    # assistant response and must open the same turn first.
+                    if message_type in ("assistant", "result") or is_model_refusal_fallback:
                         await self._maybe_begin_agent_initiated_turn(
                             context,
                             composite_key,
@@ -695,6 +697,17 @@ class ClaudeAgent(BaseAgent):
                         #         base_session_id,
                         #     )
 
+                        continue
+
+                    # Match the structured subtype instead of relying only on the
+                    # current SDK's generic SystemMessage class. A future SDK may
+                    # promote this event to a dedicated typed message.
+                    if is_model_refusal_fallback:
+                        await self._handle_model_refusal_fallback(
+                            context,
+                            composite_key,
+                            message,
+                        )
                         continue
 
                     if message_type == "system":
@@ -1320,6 +1333,72 @@ class ClaudeAgent(BaseAgent):
                 if text:
                     parts.append(self._get_formatter(context).escape_special_chars(text))
         return "\n\n".join(parts).strip()
+
+    @staticmethod
+    def _is_model_refusal_fallback_message(message) -> bool:
+        return (getattr(message, "subtype", "") or "").strip().lower() == "model_refusal_fallback"
+
+    async def _handle_model_refusal_fallback(
+        self,
+        context: MessageContext,
+        composite_key: str,
+        message,
+    ) -> None:
+        """Surface Claude's structured safety fallback without ending the turn."""
+        data = getattr(message, "data", None)
+        if not isinstance(data, dict):
+            logger.warning("Claude refusal fallback for %s had no structured payload", composite_key)
+            return
+
+        direction = str(data.get("direction") or "").strip().lower()
+        if direction != "retry":
+            logger.info(
+                "Ignoring legacy Claude refusal fallback direction %r for %s",
+                direction,
+                composite_key,
+            )
+            return
+
+        # The refusal event retracts the primary model's partial response before
+        # Claude retries on the fallback model. Avibe buffers the latest assistant
+        # text until the next assistant/result frame, so discard that buffer now
+        # instead of emitting a response Claude explicitly withdrew.
+        self._pending_assistant_message.pop(composite_key, None)
+        self._last_assistant_text.pop(composite_key, None)
+
+        pending_requests = self._pending_requests.get(composite_key) or []
+        self._adopt_pending_turn_token(context, pending_requests[0] if pending_requests else None)
+
+        original_model = " ".join(str(data.get("original_model") or "").split())[:160]
+        fallback_model = " ".join(str(data.get("fallback_model") or "").split())[:160]
+        provider_content = str(data.get("content") or "").strip()
+
+        text = ""
+        translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)
+        if callable(translator) and original_model and fallback_model:
+            text = translator(
+                "status.claudeRefusalFallback",
+                originalModel=original_model,
+                fallbackModel=fallback_model,
+            )
+        if not text:
+            text = provider_content
+        if not text:
+            logger.warning("Claude refusal fallback for %s had no displayable content", composite_key)
+            return
+
+        logger.info(
+            "Claude safety fallback for session %s: %s -> %s",
+            composite_key,
+            original_model or "<unknown>",
+            fallback_model or "<unknown>",
+        )
+        await self.controller.emit_agent_message(
+            context,
+            "notify",
+            text,
+            parse_mode="markdown",
+        )
 
     async def _handle_auth_failure_result(
         self,

--- a/tests/test_claude_agent_initiated_turn.py
+++ b/tests/test_claude_agent_initiated_turn.py
@@ -70,6 +70,23 @@ def _one_result_client():
     return _Client()
 
 
+def _fallback_client(data):
+    class ModelRefusalFallbackMessage:
+        subtype = "model_refusal_fallback"
+
+        def __init__(self):
+            self.data = data
+
+    class _Client:
+        def receive_messages(self):
+            async def _iterate():
+                yield ModelRefusalFallbackMessage()
+
+            return _iterate()
+
+    return _Client()
+
+
 def _build_agent(*, running_calls=None, mark_idle_calls=None, active_calls=None):
     mark_idle_calls = mark_idle_calls if mark_idle_calls is not None else []
     controller = SimpleNamespace(
@@ -217,6 +234,79 @@ class BeginAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
 
 
 class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
+    async def test_non_actionable_fallback_does_not_open_agent_initiated_turn(self):
+        active_calls: list[str] = []
+        agent, service = _build_agent(active_calls=active_calls)
+        composite_key = "session-fallback:/tmp/work"
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform="avibe",
+            platform_specific={
+                "agent_runtime_turn_key": composite_key,
+                "agent_runtime_turn_token": "OLD",
+                "agent_session_id": "sess-fallback",
+            },
+        )
+
+        await agent._receive_messages(
+            _fallback_client(
+                {
+                    "direction": "declined",
+                    "original_model": "claude-fable-5",
+                    "fallback_model": "claude-opus-4-8",
+                }
+            ),
+            "session-fallback",
+            "/tmp/work",
+            context,
+            composite_key=composite_key,
+        )
+
+        gate = service._get_turn_gate(composite_key)
+        self.assertFalse(gate.lock.locked())
+        self.assertEqual(gate.token, "")
+        self.assertFalse(agent._has_pending_requests(composite_key))
+        self.assertEqual(active_calls, [])
+        agent.controller.emit_agent_message.assert_not_awaited()
+
+    async def test_fallback_notice_is_dropped_when_agent_initiated_turn_is_contended(self):
+        agent, service = _build_agent()
+        composite_key = "session-fallback:/tmp/work"
+        gate = service._get_turn_gate(composite_key)
+        await gate.lock.acquire()
+        gate.token = "USER-TURN"
+        gate.backend = "claude"
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform="avibe",
+            platform_specific={
+                "agent_runtime_turn_key": composite_key,
+                "agent_runtime_turn_token": "OLD",
+                "agent_session_id": "sess-fallback",
+            },
+        )
+        try:
+            await agent._receive_messages(
+                _fallback_client(
+                    {
+                        "originalModel": "claude-fable-5",
+                        "fallbackModel": "claude-opus-4-8",
+                    }
+                ),
+                "session-fallback",
+                "/tmp/work",
+                context,
+                composite_key=composite_key,
+            )
+        finally:
+            gate.lock.release()
+
+        self.assertEqual(gate.token, "USER-TURN")
+        self.assertFalse(agent._has_pending_requests(composite_key))
+        agent.controller.emit_agent_message.assert_not_awaited()
+
     async def test_unsolicited_reply_is_delivered_not_dropped(self):
         running_calls: list = []
         mark_idle_calls: list[str] = []

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from modules.agents.base import BaseAgent
 from modules.agents.claude_agent import ClaudeAgent
 from modules.agents.service import AgentService
+from modules.claude_sdk_compat import AssistantMessage, TextBlock
 
 
 class _StubSessions:
@@ -1362,15 +1363,19 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._native_session_ids[composite_key], "session-sdk")
         controller.emit_agent_message.assert_not_awaited()
 
-    async def test_receive_refusal_fallback_emits_notify_and_discards_retracted_text(self):
+    async def test_receive_legacy_refusal_fallback_notifies_without_dropping_replacement_text(self):
         controller = _StubController()
         controller._get_session_key = lambda _context: "avibe::project::p1"
+        controller.im_client.formatter = SimpleNamespace(
+            escape_special_chars=lambda text: text,
+            format_assistant_message=lambda parts: "\n\n".join(parts),
+        )
         controller.session_handler = SimpleNamespace(
             capture_session_id=lambda *_args, **_kwargs: None,
             mark_session_idle=lambda _key: None,
             _t=lambda key, **kwargs: (
                 (
-                    "Claude's safeguards flagged this message. "
+                    "Claude's safety checks triggered for this request. "
                     f"It switched from {kwargs['originalModel']} to {kwargs['fallbackModel']} and retried. "
                     f"This session will continue on {kwargs['fallbackModel']}."
                 )
@@ -1398,8 +1403,6 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         pending_request = SimpleNamespace(context=pending_context)
         composite_key = "session-1:/tmp/work"
         agent._pending_requests[composite_key] = [pending_request]
-        agent._pending_assistant_message[composite_key] = "retracted partial response"
-        agent._last_assistant_text[composite_key] = "retracted partial response"
 
         emitted = []
 
@@ -1414,29 +1417,32 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             )
 
         controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        replacement_message = AssistantMessage(
+            content=[TextBlock(text="replacement answer")],
+            model="claude-opus-4-8",
+        )
         fallback_message = type(
             "ModelRefusalFallbackMessage",
             (),
             {
                 "subtype": "model_refusal_fallback",
                 "data": {
-                    "direction": "retry",
                     "trigger": "refusal",
-                    "original_model": "claude-fable-5",
-                    "fallback_model": "claude-opus-4-8",
-                    "content": "provider fallback notice",
+                    "originalModel": "claude-fable-5[1m]",
+                    "fallbackModel": "claude-opus-4-8",
                 },
             },
         )()
         result_message = type(
             "ResultMessage",
             (),
-            {"subtype": "success", "result": "replacement answer", "duration_ms": 1},
+            {"subtype": "success", "result": None, "duration_ms": 1},
         )()
 
         class _Client:
             def receive_messages(self):
                 async def _iterate():
+                    yield replacement_message
                     yield fallback_message
                     yield result_message
 
@@ -1455,7 +1461,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             [
                 (
                     "notify",
-                    "Claude's safeguards flagged this message. It switched from claude-fable-5 "
+                    "Claude's safety checks triggered for this request. It switched from claude-fable-5[1m] "
                     "to claude-opus-4-8 and retried. This session will continue on "
                     "claude-opus-4-8.",
                     {"parse_mode": "markdown"},

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from modules.agents.base import BaseAgent
 from modules.agents.claude_agent import ClaudeAgent
 from modules.agents.service import AgentService
-from modules.claude_sdk_compat import AssistantMessage, TextBlock
+from modules.claude_sdk_compat import TextBlock
 
 
 class _StubSessions:
@@ -1417,10 +1417,18 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             )
 
         controller.emit_agent_message = AsyncMock(side_effect=_emit)
-        replacement_message = AssistantMessage(
-            content=[TextBlock(text="replacement answer")],
-            model="claude-opus-4-8",
-        )
+        replacement_block = TextBlock.__new__(TextBlock)
+        replacement_block.text = "replacement answer"
+        replacement_message = type(
+            "AssistantMessage",
+            (),
+            {
+                "content": [replacement_block],
+                "model": "claude-opus-4-8",
+                "usage": None,
+                "error": None,
+            },
+        )()
         fallback_message = type(
             "ModelRefusalFallbackMessage",
             (),

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1362,6 +1362,122 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(agent._native_session_ids[composite_key], "session-sdk")
         controller.emit_agent_message.assert_not_awaited()
 
+    async def test_receive_refusal_fallback_emits_notify_and_discards_retracted_text(self):
+        controller = _StubController()
+        controller._get_session_key = lambda _context: "avibe::project::p1"
+        controller.session_handler = SimpleNamespace(
+            capture_session_id=lambda *_args, **_kwargs: None,
+            mark_session_idle=lambda _key: None,
+            _t=lambda key, **kwargs: (
+                (
+                    "Claude's safeguards flagged this message. "
+                    f"It switched from {kwargs['originalModel']} to {kwargs['fallbackModel']} and retried. "
+                    f"This session will continue on {kwargs['fallbackModel']}."
+                )
+                if key == "status.claudeRefusalFallback"
+                else key
+            ),
+        )
+        agent = ClaudeAgent(controller)
+        agent.emit_result_message = AsyncMock()
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform_specific={
+                "turn_token": "stale-turn",
+                "agent_runtime_turn_token": "stale-runtime",
+            },
+        )
+        pending_context = SimpleNamespace(
+            platform_specific={
+                "turn_token": "current-turn",
+                "agent_runtime_turn_key": "session-1:/tmp/work",
+                "agent_runtime_turn_token": "current-runtime",
+            }
+        )
+        pending_request = SimpleNamespace(context=pending_context)
+        composite_key = "session-1:/tmp/work"
+        agent._pending_requests[composite_key] = [pending_request]
+        agent._pending_assistant_message[composite_key] = "retracted partial response"
+        agent._last_assistant_text[composite_key] = "retracted partial response"
+
+        emitted = []
+
+        async def _emit(message_context, message_type, text, **kwargs):
+            emitted.append(
+                (
+                    message_type,
+                    text,
+                    kwargs,
+                    dict(message_context.platform_specific),
+                )
+            )
+
+        controller.emit_agent_message = AsyncMock(side_effect=_emit)
+        fallback_message = type(
+            "ModelRefusalFallbackMessage",
+            (),
+            {
+                "subtype": "model_refusal_fallback",
+                "data": {
+                    "direction": "retry",
+                    "trigger": "refusal",
+                    "original_model": "claude-fable-5",
+                    "fallback_model": "claude-opus-4-8",
+                    "content": "provider fallback notice",
+                },
+            },
+        )()
+        result_message = type(
+            "ResultMessage",
+            (),
+            {"subtype": "success", "result": "replacement answer", "duration_ms": 1},
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield fallback_message
+                    yield result_message
+
+                return _iterate()
+
+        await agent._receive_messages(
+            _Client(),
+            "session-1",
+            "/tmp/work",
+            context,
+            composite_key=composite_key,
+        )
+
+        self.assertEqual(
+            emitted,
+            [
+                (
+                    "notify",
+                    "Claude's safeguards flagged this message. It switched from claude-fable-5 "
+                    "to claude-opus-4-8 and retried. This session will continue on "
+                    "claude-opus-4-8.",
+                    {"parse_mode": "markdown"},
+                    {
+                        "turn_token": "current-turn",
+                        "agent_runtime_turn_key": composite_key,
+                        "agent_runtime_turn_token": "current-runtime",
+                    },
+                )
+            ],
+        )
+        self.assertNotIn(composite_key, agent._pending_assistant_message)
+        self.assertNotIn(composite_key, agent._last_assistant_text)
+        agent.emit_result_message.assert_awaited_once_with(
+            context,
+            "replacement answer",
+            subtype="success",
+            duration_ms=1,
+            parse_mode="markdown",
+            request=pending_request,
+        )
+
     async def test_init_message_binds_native_session_to_existing_agent_session(self):
         controller = _StubController()
         binds = []

--- a/tests/test_claude_sdk_compat.py
+++ b/tests/test_claude_sdk_compat.py
@@ -52,6 +52,30 @@ def test_receive_messages_skips_unknown_types_returning_none():
     assert messages == []
 
 
+@requires_claude_sdk
+def test_receive_messages_preserves_model_refusal_fallback_payload():
+    payload = {
+        "type": "system",
+        "subtype": "model_refusal_fallback",
+        "trigger": "refusal",
+        "direction": "retry",
+        "original_model": "claude-fable-5",
+        "fallback_model": "claude-opus-4-8",
+        "request_id": "req_test",
+        "api_refusal_category": "cyber",
+        "content": "Fable 5 safeguards flagged this message. Switched to Opus 4.8.",
+        "uuid": "msg_test",
+        "session_id": "session_test",
+    }
+
+    messages = asyncio.run(_collect_messages([payload]))
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], compat.SystemMessage)
+    assert messages[0].subtype == "model_refusal_fallback"
+    assert messages[0].data == payload
+
+
 def test_missing_sdk_permission_allow_fallback_is_non_throwing(monkeypatch):
     original_import = builtins.__import__
 

--- a/tests/test_claude_sdk_compat.py
+++ b/tests/test_claude_sdk_compat.py
@@ -53,21 +53,41 @@ def test_receive_messages_skips_unknown_types_returning_none():
 
 
 @requires_claude_sdk
-def test_receive_messages_preserves_model_refusal_fallback_payload():
-    payload = {
-        "type": "system",
-        "subtype": "model_refusal_fallback",
-        "trigger": "refusal",
-        "direction": "retry",
-        "original_model": "claude-fable-5",
-        "fallback_model": "claude-opus-4-8",
-        "request_id": "req_test",
-        "api_refusal_category": "cyber",
-        "content": "Fable 5 safeguards flagged this message. Switched to Opus 4.8.",
-        "uuid": "msg_test",
-        "session_id": "session_test",
-    }
-
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            {
+                "type": "system",
+                "subtype": "model_refusal_fallback",
+                "trigger": "refusal",
+                "direction": "retry",
+                "original_model": "claude-fable-5",
+                "fallback_model": "claude-opus-4-8",
+                "request_id": "req_test",
+                "api_refusal_category": "cyber",
+                "content": "Fable 5 safeguards flagged this request. Switched to Opus 4.8.",
+                "uuid": "msg_test",
+                "session_id": "session_test",
+            },
+            id="sdk",
+        ),
+        pytest.param(
+            {
+                "type": "system",
+                "subtype": "model_refusal_fallback",
+                "level": "warning",
+                "trigger": "refusal",
+                "originalModel": "claude-fable-5[1m]",
+                "fallbackModel": "claude-opus-4-8",
+                "apiRefusalCategory": None,
+                "apiRefusalExplanation": None,
+            },
+            id="legacy-transcript",
+        ),
+    ],
+)
+def test_receive_messages_preserves_model_refusal_fallback_payload(payload):
     messages = asyncio.run(_collect_messages([payload]))
 
     assert len(messages) == 1

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -4,6 +4,7 @@
     "done": "done",
     "stopped": "stopped",
     "failed": "failed",
+    "claudeRefusalFallback": "Claude's safeguards flagged this message. It switched from {originalModel} to {fallbackModel} and retried. This session will continue on {fallbackModel}.",
     "steps": "{count} st",
     "tokens": "{count} tok"
   },

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -4,7 +4,7 @@
     "done": "done",
     "stopped": "stopped",
     "failed": "failed",
-    "claudeRefusalFallback": "Claude's safeguards flagged this message. It switched from {originalModel} to {fallbackModel} and retried. This session will continue on {fallbackModel}.",
+    "claudeRefusalFallback": "Claude's safety checks triggered for this request. It switched from {originalModel} to {fallbackModel} and retried. This session will continue on {fallbackModel}.",
     "steps": "{count} st",
     "tokens": "{count} tok"
   },

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -4,6 +4,7 @@
     "done": "完成",
     "stopped": "已终止",
     "failed": "失败",
+    "claudeRefusalFallback": "Claude 的安全机制标记了这条消息，已从 {originalModel} 切换到 {fallbackModel} 并重试。本会话后续将继续使用 {fallbackModel}。",
     "steps": "{count} 步",
     "tokens": "{count} tok"
   },

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -4,7 +4,7 @@
     "done": "完成",
     "stopped": "已终止",
     "failed": "失败",
-    "claudeRefusalFallback": "Claude 的安全机制标记了这条消息，已从 {originalModel} 切换到 {fallbackModel} 并重试。本会话后续将继续使用 {fallbackModel}。",
+    "claudeRefusalFallback": "本次请求触发了 Claude 的安全检查，已从 {originalModel} 切换到 {fallbackModel} 并重试。本会话后续将继续使用 {fallbackModel}。",
     "steps": "{count} 步",
     "tokens": "{count} tok"
   },


### PR DESCRIPTION
## Summary

- consume Claude Agent SDK's structured `system/model_refusal_fallback` retry event
- emit a localized, non-terminal Notify Message through Avibe's shared dispatcher, covering both IM and Web
- accept both current snake_case SDK fields and legacy camelCase transcript fields
- preserve replacement assistant text when Claude writes the fallback marker after the Opus response
- validate the event before opening an unsolicited turn and suppress stale notices when the runtime gate is contended
- preserve the active turn token so the notice and replacement result stay attached to the correct turn

## Scenario coverage

- Scenario IDs: none; the current scenario catalog has no Claude runtime fallback scenario

## Evidence

- Unit: current and legacy payload parsing, long-lived receiver ordering, active-turn gating, and no-SDK compatibility
- Contract: current SDK preserves the snake_case fallback payload on `SystemMessage.data`; Avibe emits the existing canonical `notify` type
- Scenario: existing shared dispatcher, message mirror, and transcript tests cover Notify delivery and persistence for IM/Web
- Residual manual check: Claude's safety classifier is non-deterministic, so a live Fable 5 refusal was not forced in automated tests

## Verification

- `144 passed` across Claude receiver/session, dispatcher, mirror, and transcript suites
- no-SDK receiver regression passed with `claude_agent_sdk` imports blocked at process startup
- Ruff `0.4.9` passed on all changed Python files
- English and Chinese translation JSON loaded and interpolated successfully
