### PR TITLE
fix(vault): make protected establishment atomic

### DIFF
--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -49,6 +49,7 @@ logger = logging.getLogger(__name__)
 
 SKILL_TAG_PREFIX = "skill:"
 VAULT_SETTINGS_META_KEY = "vault_settings"
+PROTECTED_VAULT_ESTABLISHMENT_LOCK_META_KEY = "vault_protected_establishment_lock"
 DEFAULT_UNLOCK_WINDOW_SECONDS = 600
 UNLOCK_WINDOW_OPTIONS_SECONDS = (300, 600, 1800)
 GRANT_DURATION_ONE_TIME = "one-time"
@@ -2042,10 +2043,25 @@ def create_secret(
     )
 
     if establishing_vmk and protection == "protected":
-        # Atomic single-init guard: this runs inside the write transaction (SQLite
-        # serialises writers), so two concurrent first-time setups cannot both pass —
-        # the loser is rejected instead of splitting the vault key history with a
-        # second VMK. The browser then reloads and unlocks the established vault.
+        # A deferred SQLite transaction does not take the writer lock for the
+        # existence check below. This metadata upsert is establishment's first
+        # write, so concurrent initializers serialize before checking. The row is
+        # only a mutex; protected-secret existence remains the source of truth.
+        lock_updated_at = _now()
+        lock_stmt = sqlite_insert(state_meta).values(
+            key=PROTECTED_VAULT_ESTABLISHMENT_LOCK_META_KEY,
+            value_json="{}",
+            updated_at=lock_updated_at,
+        )
+        conn.execute(
+            lock_stmt.on_conflict_do_update(
+                index_elements=[state_meta.c.key],
+                set_={
+                    "value_json": lock_stmt.excluded.value_json,
+                    "updated_at": lock_stmt.excluded.updated_at,
+                },
+            )
+        )
         if (
             conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.protection == "protected").limit(1)).first()
             is not None

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -2057,6 +2057,11 @@ def create_secret(
                 },
             )
         )
+        if (
+            conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.protection == "protected").limit(1)).first()
+            is not None
+        ):
+            raise VaultAlreadyInitializedError("a protected vault already exists; unlock it instead of re-initializing")
 
     provision_row, _existing_secret = _preflight_secret_create_name(
         conn,
@@ -2065,11 +2070,6 @@ def create_secret(
     )
 
     if establishing_protected_vault:
-        if (
-            conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.protection == "protected").limit(1)).first()
-            is not None
-        ):
-            raise VaultAlreadyInitializedError("a protected vault already exists; unlock it instead of re-initializing")
         if not isinstance(authz_factor_registration, dict):
             raise ProtectedAuthzSetupRequiredError("protected vault establishment requires a passkey authorization factor")
 

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -2036,17 +2036,12 @@ def create_secret(
         raise VaultServiceError(f"invalid vault secret kind: {kind!r}")
     if kind != "keypair" and signer_kind is not None:
         raise VaultServiceError("signer_kind is only valid for keypair secrets")
-    provision_row, _existing_secret = _preflight_secret_create_name(
-        conn,
-        name=name,
-        provision_request_id=provision_request_id,
-    )
-
-    if establishing_vmk and protection == "protected":
-        # A deferred SQLite transaction does not take the writer lock for the
-        # existence check below. This metadata upsert is establishment's first
-        # write, so concurrent initializers serialize before checking. The row is
-        # only a mutex; protected-secret existence remains the source of truth.
+    establishing_protected_vault = establishing_vmk and protection == "protected"
+    if establishing_protected_vault:
+        # This must be the transaction's first database access: a deferred SQLite
+        # transaction cannot safely promote an older read snapshot after another
+        # initializer commits. The row is only a mutex; protected-secret existence
+        # remains the source of truth.
         lock_updated_at = _now()
         lock_stmt = sqlite_insert(state_meta).values(
             key=PROTECTED_VAULT_ESTABLISHMENT_LOCK_META_KEY,
@@ -2062,6 +2057,14 @@ def create_secret(
                 },
             )
         )
+
+    provision_row, _existing_secret = _preflight_secret_create_name(
+        conn,
+        name=name,
+        provision_request_id=provision_request_id,
+    )
+
+    if establishing_protected_vault:
         if (
             conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.protection == "protected").limit(1)).first()
             is not None

--- a/tests/test_vault_api.py
+++ b/tests/test_vault_api.py
@@ -1622,7 +1622,8 @@ def test_create_vault_reveal_context_rejects_protected_keypair(monkeypatch):
     assert exc.value.code == "keypair_not_value_deliverable"
 
 
-def test_protected_create_establishing_vmk_rejects_second_init(monkeypatch):
+@pytest.mark.parametrize("second_name", ["FIRST_PROTECTED", "SECOND_PROTECTED"])
+def test_protected_create_establishing_vmk_rejects_second_init(monkeypatch, second_name):
     _establish_protected_secret_with_factor("FIRST_PROTECTED")
     with api._vault_engine().connect() as conn:
         assert vault_service.get_secret_meta(conn, "FIRST_PROTECTED")["protection"] == "protected"
@@ -1632,7 +1633,7 @@ def test_protected_create_establishing_vmk_rejects_second_init(monkeypatch):
     with pytest.raises(api.VaultApiError) as exc:
         api.create_vault_secret(
             {
-                "name": "SECOND_PROTECTED",
+                "name": second_name,
                 "protection": "protected",
                 "sealed": {"ciphertext": "ct2", "nonce": "n2", "wrap_meta": {"v": 1, "copies": [], "wrapped_dek": "d2"}},
                 "establishing_vmk": True,

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -426,7 +426,7 @@ def test_protected_vault_establishment_is_atomic_under_concurrency(vault, monkey
             with vault.begin() as conn:
                 return vs.create_secret(
                     conn,
-                    name=f"CONCURRENT_PROTECTED_{index}",
+                    name="CONCURRENT_PROTECTED",
                     sealed=_sealed(f"concurrent-{index}"),
                     protection="protected",
                     establishing_vmk=True,

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -391,6 +391,8 @@ def test_protected_vault_establishment_is_atomic_under_concurrency(vault, monkey
     pre_guard_barrier = threading.Barrier(2)
     post_guard_barrier = threading.Barrier(2)
     lock_seen = threading.Event()
+    database_access_before_lock = threading.Event()
+    thread_state = threading.local()
 
     def is_init_lock(statement: str, parameters) -> bool:
         return statement.lstrip().upper().startswith("INSERT INTO STATE_META") and init_lock_key in parameters
@@ -401,12 +403,16 @@ def test_protected_vault_establishment_is_atomic_under_concurrency(vault, monkey
 
     def synchronize_before_guard(_conn, _cursor, statement, parameters, _context, _executemany):
         if is_init_lock(statement, parameters):
+            thread_state.init_lock_seen = True
             lock_seen.set()
             lock_barrier.wait(timeout=5)
-        elif not lock_seen.is_set() and is_protected_guard(statement):
-            # On the unfixed implementation, force both deferred transactions
-            # through the empty-vault read before either reaches its first write.
-            pre_guard_barrier.wait(timeout=5)
+        else:
+            if not getattr(thread_state, "init_lock_seen", False):
+                database_access_before_lock.set()
+            if not lock_seen.is_set() and is_protected_guard(statement):
+                # On the unfixed implementation, force both deferred transactions
+                # through the empty-vault read before either reaches its first write.
+                pre_guard_barrier.wait(timeout=5)
 
     def synchronize_after_guard(_conn, _cursor, statement, _parameters, _context, _executemany):
         if not lock_seen.is_set() and is_protected_guard(statement):
@@ -441,6 +447,7 @@ def test_protected_vault_establishment_is_atomic_under_concurrency(vault, monkey
     assert len(successes) == 1
     assert len(failures) == 1
     assert isinstance(failures[0], vs.VaultAlreadyInitializedError)
+    assert not database_access_before_lock.is_set()
 
     with vault.connect() as conn:
         protected_names = list(

--- a/tests/test_vault_service.py
+++ b/tests/test_vault_service.py
@@ -8,7 +8,7 @@ import threading
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import event, select
 from sqlalchemy.exc import IntegrityError
 
 from storage import vault_service as vs, vault_webauthn
@@ -381,6 +381,75 @@ def test_save_vault_settings_first_write_is_atomic_under_concurrency(vault):
 
     assert len(rows) == 1
     assert {result["last_grant_ttl"] for result in results}.issubset({300, 900})
+
+
+def test_protected_vault_establishment_is_atomic_under_concurrency(vault, monkeypatch):
+    init_lock_key = vs.PROTECTED_VAULT_ESTABLISHMENT_LOCK_META_KEY
+    monkeypatch.setattr(vs, "register_webauthn_factor", lambda *_args, **_kwargs: None)
+
+    lock_barrier = threading.Barrier(2)
+    pre_guard_barrier = threading.Barrier(2)
+    post_guard_barrier = threading.Barrier(2)
+    lock_seen = threading.Event()
+
+    def is_init_lock(statement: str, parameters) -> bool:
+        return statement.lstrip().upper().startswith("INSERT INTO STATE_META") and init_lock_key in parameters
+
+    def is_protected_guard(statement: str) -> bool:
+        normalized = " ".join(statement.upper().split())
+        return "FROM VAULT_SECRETS" in normalized and "WHERE VAULT_SECRETS.PROTECTION =" in normalized
+
+    def synchronize_before_guard(_conn, _cursor, statement, parameters, _context, _executemany):
+        if is_init_lock(statement, parameters):
+            lock_seen.set()
+            lock_barrier.wait(timeout=5)
+        elif not lock_seen.is_set() and is_protected_guard(statement):
+            # On the unfixed implementation, force both deferred transactions
+            # through the empty-vault read before either reaches its first write.
+            pre_guard_barrier.wait(timeout=5)
+
+    def synchronize_after_guard(_conn, _cursor, statement, _parameters, _context, _executemany):
+        if not lock_seen.is_set() and is_protected_guard(statement):
+            post_guard_barrier.wait(timeout=5)
+
+    event.listen(vault, "before_cursor_execute", synchronize_before_guard)
+    event.listen(vault, "after_cursor_execute", synchronize_after_guard)
+
+    def establish(index: int):
+        try:
+            with vault.begin() as conn:
+                return vs.create_secret(
+                    conn,
+                    name=f"CONCURRENT_PROTECTED_{index}",
+                    sealed=_sealed(f"concurrent-{index}"),
+                    protection="protected",
+                    establishing_vmk=True,
+                    authz_factor_registration={},
+                )
+        except vs.VaultServiceError as exc:
+            return exc
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(establish, range(2)))
+    finally:
+        event.remove(vault, "before_cursor_execute", synchronize_before_guard)
+        event.remove(vault, "after_cursor_execute", synchronize_after_guard)
+
+    successes = [result for result in results if isinstance(result, dict)]
+    failures = [result for result in results if isinstance(result, vs.VaultServiceError)]
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert isinstance(failures[0], vs.VaultAlreadyInitializedError)
+
+    with vault.connect() as conn:
+        protected_names = list(
+            conn.execute(select(vault_secrets.c.name).where(vault_secrets.c.protection == "protected")).scalars()
+        )
+        lock_row = conn.execute(select(state_meta).where(state_meta.c.key == init_lock_key)).mappings().one()
+
+    assert protected_names == [successes[0]["name"]]
+    assert lock_row["value_json"] == "{}"
 
 
 def test_sibling_approval_requires_matching_purpose(vault):

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2336,14 +2336,18 @@ def create_vault_secret(payload: dict, *, origin: str | None = None) -> dict:
     if signer_kind is not None:
         signer_kind = str(signer_kind)
     provision_request_id = str(payload.get("provision_request_id") or "") or None
+    atomic_protected_establishment = establishing_vmk and protection == "protected"
     engine = _vault_engine()
     try:
-        with engine.begin() as conn:
-            vault_service.preflight_secret_create(
-                conn,
-                name=name,
-                provision_request_id=provision_request_id,
-            )
+        # Establishment defers preflight to create_secret's write-serialized
+        # transaction so a same-name loser receives vault_already_initialized.
+        if not atomic_protected_establishment:
+            with engine.begin() as conn:
+                vault_service.preflight_secret_create(
+                    conn,
+                    name=name,
+                    provision_request_id=provision_request_id,
+                )
     except vault_service.InvalidSecretNameError as exc:
         raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name") from exc
     except vault_service.SecretNameCaseConflictError as exc:


### PR DESCRIPTION
## Capability

Makes first-time protected Vault establishment atomic under concurrent requests.
Exactly one initializer can establish the Vault; a concurrent loser observes the
winner and receives `vault_already_initialized` before storing an envelope under
a different VMK.

Closes #697.

## Why

SQLite deferred transactions do not acquire the writer lock for the existing
protected-secret check. Two browser tabs could therefore both observe an empty
Vault before either inserted its first record. Current master happened to roll
the loser back later during vestigial WebAuthn factor registration, coupling the
single-VMK invariant to unrelated legacy behavior and returning the wrong error.

## Implementation

- Upsert a fixed, value-free `state_meta` row before any protected-establishment
  read. The write serializes concurrent establishment transactions.
- Keep protected-secret existence as the source of truth; the metadata row is
  only a mutex and contains no VMK, envelope, factor, or secret-derived data.
- Defer API name/request preflight for protected establishment to the same
  mutex-owned service transaction, so same-name and different-name losers both
  receive `vault_already_initialized`.
- Preserve ordinary protected-secret creation and fresh establishment after the
  last protected secret is deleted.
- Add deterministic service and API regressions that remove WebAuthn factor
  registration as a fallback and prove one commit plus the correct loser error.

## Evidence layers

- **Unit:** `uv run pytest tests/ -k vault -q --disable-warnings` -> 471 passed,
  4004 deselected.
- **Concurrency:** the focused race test passed 10 consecutive runs; same-name
  and different-name API collisions plus delete-last-then-reestablish pass.
- **Contract:** both collision shapes map to `409 vault_already_initialized`.
- **Lint:** `uv run ruff check storage/vault_service.py vibe/api.py
  tests/test_vault_service.py tests/test_vault_api.py`.
- **Scenario:** no cataloged scenario covers Vault establishment; no scenario ID
  changed.
- **Residual manual checks:** none. The behavior is fully exercised against
  isolated SQLite databases and does not require a browser or real credentials.

## Risk

The mutex adds one stable metadata row and advances its timestamp only during
first-establishment attempts. SQLite already serializes writers; this only moves
the write-lock boundary ahead of every read that participates in the VMK
invariant.
