### PR TITLE
fix(watch): fail closed when working directory disappears

### DIFF
--- a/core/watches.py
+++ b/core/watches.py
@@ -109,6 +109,20 @@ class ManagedWatch:
         )
 
 
+def _missing_watch_cwd_error(watch: ManagedWatch) -> Optional[str]:
+    if not watch.cwd or Path(watch.cwd).is_dir():
+        return None
+    return f"watch working directory no longer exists or is not a directory: {watch.cwd}"
+
+
+def _watch_spawn_cwd(watch: ManagedWatch) -> str:
+    if watch.cwd:
+        return watch.cwd
+    stable_cwd = paths.get_vibe_remote_dir()
+    stable_cwd.mkdir(parents=True, exist_ok=True)
+    return str(stable_cwd)
+
+
 class ManagedWatchStore:
     def __init__(self, path: Optional[Path] = None):
         self.path = path or paths.get_watches_path()
@@ -634,11 +648,19 @@ class ManagedWatchService:
 
             if not self._watch_store_call(watch.id, "mark_cycle_start", lambda: self.store.mark_cycle_start(watch.id)):
                 return
+            cwd_error = _missing_watch_cwd_error(watch)
+            if cwd_error:
+                self._stop_watch_for_missing_cwd(watch, error_text=cwd_error)
+                return
             try:
                 result = await self._run_cycle(watch, timeout_seconds=cycle_timeout)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                cwd_error = _missing_watch_cwd_error(watch)
+                if cwd_error:
+                    self._stop_watch_for_missing_cwd(watch, error_text=cwd_error)
+                    return
                 result = _CycleResult(
                     exit_code=1,
                     stdout="",
@@ -722,10 +744,11 @@ class ManagedWatchService:
             return
 
     async def _run_cycle(self, watch: ManagedWatch, *, timeout_seconds: float) -> _CycleResult:
+        spawn_cwd = _watch_spawn_cwd(watch)
         if watch.shell_command:
             process = await asyncio.create_subprocess_shell(
                 watch.shell_command,
-                cwd=watch.cwd or None,
+                cwd=spawn_cwd,
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -734,7 +757,7 @@ class ManagedWatchService:
         else:
             process = await asyncio.create_subprocess_exec(
                 *watch.command,
-                cwd=watch.cwd or None,
+                cwd=spawn_cwd,
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -807,6 +830,26 @@ class ManagedWatchService:
                 f"Error: {error_text}"
             )
         self._enqueue_hook(watch, prefix=watch.message or watch.prefix, body=body)
+
+    def _stop_watch_for_missing_cwd(self, watch: ManagedWatch, *, error_text: str) -> None:
+        if not self._watch_store_call(
+            watch.id,
+            "mark_cycle_result",
+            lambda: self.store.mark_cycle_result(
+                watch.id,
+                exit_code=1,
+                error=error_text,
+                disable=True,
+            ),
+        ):
+            return
+        watch_label = watch.name or watch.id
+        body = (
+            f"Watch '{watch_label}' stopped because its working directory is no longer available.\n"
+            f"Working directory: {watch.cwd}\n"
+            "Update or recreate the watch with a valid cwd before monitoring continues."
+        )
+        self._enqueue_hook(watch, body=body)
 
 
 def _build_prompt(prefix: Optional[str], body: Optional[str]) -> str:

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -12,6 +12,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from config import paths
 from core.scheduled_tasks import TaskExecutionStore
 from core.watches import ManagedWatchService, ManagedWatchStore, WatchRuntimeStateStore, _CycleResult
 from storage.background import SQLiteBackgroundTaskStore
@@ -121,6 +122,7 @@ def test_managed_watch_exec_detaches_waiter_stdin(tmp_path: Path, monkeypatch) -
     assert captured["kwargs"]["stdin"] == asyncio.subprocess.DEVNULL
     assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
     assert captured["kwargs"]["stderr"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["cwd"] == str(paths.get_vibe_remote_dir())
 
 
 def test_managed_watch_shell_detaches_waiter_stdin(tmp_path: Path, monkeypatch) -> None:
@@ -162,6 +164,46 @@ def test_managed_watch_shell_detaches_waiter_stdin(tmp_path: Path, monkeypatch) 
     assert captured["kwargs"]["stdin"] == asyncio.subprocess.DEVNULL
     assert captured["kwargs"]["stdout"] == asyncio.subprocess.PIPE
     assert captured["kwargs"]["stderr"] == asyncio.subprocess.PIPE
+    assert captured["kwargs"]["cwd"] == str(paths.get_vibe_remote_dir())
+
+
+def test_managed_watch_legacy_none_cwd_survives_deleted_process_cwd(tmp_path: Path) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=TaskExecutionStore(tmp_path / "task_requests"),
+        runtime_store=runtime_store,
+    )
+    watch = store.add_watch(
+        name="Legacy watch",
+        session_key="slack::channel::C123",
+        command=[sys.executable, "-c", "import os; print(os.getcwd())"],
+        shell_command=None,
+        prefix=None,
+        cwd=None,
+        mode="once",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=30,
+        post_to=None,
+        deliver_key=None,
+    )
+    deleted_cwd = tmp_path / "deleted-service-cwd"
+    deleted_cwd.mkdir()
+    original_cwd = Path.cwd()
+
+    os.chdir(deleted_cwd)
+    deleted_cwd.rmdir()
+    try:
+        result = asyncio.run(service._run_cycle(watch, timeout_seconds=5))
+    finally:
+        os.chdir(original_cwd)
+
+    assert result.exit_code == 0
+    assert result.stdout == str(paths.get_vibe_remote_dir())
 
 
 def test_managed_watch_store_uses_sqlite_when_path_is_default(tmp_path: Path, monkeypatch) -> None:
@@ -631,6 +673,136 @@ def test_managed_watch_service_turns_spawn_error_into_failed_cycle(tmp_path: Pat
     assert len(pending) == 1
     assert "stopped because the waiter exited with code 1" in pending[0].prompt
     assert "fix the waiter or its dependencies" in pending[0].prompt
+
+
+@pytest.mark.parametrize("use_shell", [False, True], ids=["exec", "shell"])
+def test_managed_watch_service_stops_and_notifies_when_cwd_was_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    use_shell: bool,
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    removed_cwd = tmp_path / "removed-worktree"
+    removed_cwd.mkdir()
+    removed_cwd.rmdir()
+    watch = store.add_watch(
+        name="PR review",
+        session_key="",
+        session_id="ses-linked",
+        command=[] if use_shell else [sys.executable, "-c", "raise AssertionError('must not run')"],
+        shell_command="exit 99" if use_shell else None,
+        prefix=None,
+        message="PR review activity detected.",
+        cwd=str(removed_cwd),
+        mode="forever",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=0.01,
+        post_to=None,
+        deliver_key=None,
+    )
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=request_store,
+        runtime_store=runtime_store,
+    )
+    run_cycle_called = False
+
+    async def unexpected_run_cycle(*_args, **_kwargs):
+        nonlocal run_cycle_called
+        run_cycle_called = True
+        raise AssertionError("waiter must not spawn when its cwd is missing")
+
+    monkeypatch.setattr(service, "_run_cycle", unexpected_run_cycle)
+    service._running = True
+    asyncio.run(service._run_watch(watch.id))
+
+    saved = store.get_watch(watch.id)
+    pending = request_store.list_pending()
+    assert run_cycle_called is False
+    assert saved is not None
+    assert saved.enabled is False
+    assert saved.last_exit_code == 1
+    assert saved.last_error == (f"watch working directory no longer exists or is not a directory: {removed_cwd}")
+    assert len(pending) == 1
+    assert pending[0].session_id == "ses-linked"
+    assert pending[0].task_id == watch.id
+    assert pending[0].source_kind == "watch"
+    assert pending[0].prompt == (
+        "Watch 'PR review' stopped because its working directory is no longer available.\n"
+        f"Working directory: {removed_cwd}\n"
+        "Update or recreate the watch with a valid cwd before monitoring continues."
+    )
+
+
+def test_missing_watch_cwd_does_not_stop_other_watches(tmp_path: Path) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    removed_cwd = tmp_path / "removed-worktree"
+    broken = store.add_watch(
+        name="Broken watch",
+        session_key="slack::channel::C123",
+        command=[sys.executable, "-c", "raise AssertionError('must not run')"],
+        shell_command=None,
+        prefix=None,
+        cwd=str(removed_cwd),
+        mode="once",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=30,
+        post_to=None,
+        deliver_key=None,
+    )
+    healthy = store.add_watch(
+        name="Healthy watch",
+        session_key="slack::channel::C123",
+        command=[sys.executable, "-c", "print('healthy completed')"],
+        shell_command=None,
+        prefix="Healthy watch event.",
+        cwd=str(tmp_path),
+        mode="once",
+        timeout_seconds=5,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=30,
+        post_to=None,
+        deliver_key=None,
+    )
+    service = ManagedWatchService(
+        controller=SimpleNamespace(),
+        store=store,
+        request_store=request_store,
+        runtime_store=runtime_store,
+    )
+
+    async def _run() -> None:
+        service.start()
+        for _ in range(100):
+            broken_saved = store.get_watch(broken.id)
+            healthy_saved = store.get_watch(healthy.id)
+            if broken_saved and healthy_saved and not broken_saved.enabled and not healthy_saved.enabled:
+                break
+            await asyncio.sleep(0.02)
+        await service.stop()
+
+    asyncio.run(_run())
+
+    broken_saved = store.get_watch(broken.id)
+    healthy_saved = store.get_watch(healthy.id)
+    prompts = [request.prompt for request in request_store.list_pending()]
+    assert broken_saved is not None
+    assert broken_saved.last_error and str(removed_cwd) in broken_saved.last_error
+    assert healthy_saved is not None
+    assert healthy_saved.last_error is None
+    assert healthy_saved.last_event_at is not None
+    assert any("working directory is no longer available" in (prompt or "") for prompt in prompts)
+    assert any("healthy completed" in (prompt or "") for prompt in prompts)
 
 
 def test_managed_watch_service_forever_retries_only_allowed_exit_code(tmp_path: Path) -> None:


### PR DESCRIPTION
## Capability

Fail closed when a Harness watch loses its saved working directory, while
keeping the failure isolated to that watch and notifying its linked Agent
Session.

Closes #715.

## Why

Watch cwd is part of the waiter command's execution contract. A worktree can be
removed after a watch is persisted; running that command from `$HOME` or another
repository would change the meaning of relative paths. The correct boundary is
to stop the affected watch, report the missing context, and leave every other
watch running.

Legacy definitions with `cwd = null` had a separate problem: their waiters
inherited the long-running service process cwd, which can itself become invalid
after an upgrade or worktree cleanup.

## Implementation

- Preflight each saved watch cwd before starting a waiter cycle.
- Disable a watch whose cwd is no longer a directory and record a cwd-specific
  error.
- Enqueue exactly one dedicated failure message to the linked Session, without
  prepending the watch's normal success/event instruction.
- Recheck cwd after spawn exceptions to cover deletion between preflight and
  process creation.
- Run legacy `cwd = null` waiters from Avibe Home instead of inheriting the
  service process cwd.
- Preserve fail isolation: a broken watch cannot stop a healthy sibling watch.

## Evidence layers

- **Unit:** `uv run pytest tests/test_watches.py tests/test_cli_watch_command.py
  tests/test_scheduled_tasks.py -q` -> 147 passed.
- **Contract:** exec and shell watch definitions both disable before spawn,
  persist the missing-cwd error, and enqueue one Session-linked watch request.
- **Runtime regression:** a real child process starts from Avibe Home after its
  parent service cwd is deleted; a healthy sibling watch completes beside a
  missing-cwd watch.
- **Lint:** `uv run ruff check core/watches.py tests/test_watches.py`.
- **Scenario:** no cataloged scenario covers Harness watch process cwd; no
  scenario ID changed.
- **Residual manual checks:** no live service restart was performed because the
  deleted-cwd process boundary is exercised with a real subprocess in pytest.

## Risk

Only watches whose saved cwd is already unusable change behavior. They now stop
with an explicit error before spawning. Existing valid-cwd watches keep their
stored execution context; legacy null-cwd watches gain a stable Avibe-owned
context.
