### PR TITLE
fix(runtime): enable bundled regex for musl Git

### DIFF
--- a/.github/workflows/build-git.yml
+++ b/.github/workflows/build-git.yml
@@ -469,7 +469,8 @@ jobs:
               make -j"$(getconf _NPROCESSORS_ONLN)" git \
                 NO_CURL=YesPlease NO_EXPAT=YesPlease NO_GETTEXT=YesPlease \
                 NO_PERL=YesPlease NO_PYTHON=YesPlease NO_TCLTK=YesPlease \
-                NO_OPENSSL=YesPlease NO_ICONV=YesPlease NO_RUST=YesPlease \
+                NO_OPENSSL=YesPlease NO_ICONV=YesPlease NO_REGEX=NeedsStartEnd \
+                NO_RUST=YesPlease \
                 SKIP_DASHED_BUILT_INS=YesPlease RUNTIME_PREFIX=YesPlease \
                 template_dir= gitexecdir=bin \
                 CFLAGS=-Os LDFLAGS=-static


### PR DESCRIPTION
## Capability

- Build the static Linux Git runtime with `NO_REGEX=NeedsStartEnd`, selecting Git's bundled regex implementation when Alpine/musl does not provide `REG_STARTEND`.
- Apply the flag to both Linux matrix legs through their shared make invocation; macOS builds remain unchanged.

## Root Cause

[Runtime publication run 29153091938](https://github.com/avibe-bot/avibe/actions/runs/29153091938) failed identically on linux-x64 and linux-arm64 at `git-compat-util.h`: Git 2.55.0 requires `REG_STARTEND` or its bundled regex compatibility implementation. Both macOS jobs passed, and the manifest/release job correctly skipped without publishing partial assets.

## Evidence

- **Unit:** not applicable; this is a workflow-only compiler flag correction.
- **Contract:** `actionlint` v1.7.12 and `git diff --check` pass.
- **Build:** Git 2.55.0's Makefile dry-run confirms `NO_REGEX=NeedsStartEnd` adds `compat/regex/regex.o` and the compatibility include path.
- **Scenario:** no catalog scenario IDs apply. The workflow retains its full local-operation, helper-isolation, static-link, and remote-command rejection smoke on both Linux architectures.

## Known By Design

- The musl scan found no additional required flag for this minimal build. `NO_ICONV=YesPlease`, static zlib, and the existing disabled optional dependencies already cover the relevant link surface. Alpine's package also sets `NO_SYS_POLL_H`, but that selects between available poll headers and is not required for this build, so it is intentionally not added here.
- This depends on the Git runtime capability merged in #871.
- This lane does not run or publish the release workflow. After merge, the orchestrator will rerun `build-git.yml` with the unchanged `git-runtime-v2.55.0-1` tag and verify both Linux artifacts plus the finalized manifest/release.

## Residual Manual Check

- Rerun the real four-platform publication workflow after merge and confirm all four artifact jobs, manifest generation, and release publication succeed.
