### PR TITLE
fix(runtime): align musl Git build with Alpine

### DIFF
--- a/.github/workflows/build-git.yml
+++ b/.github/workflows/build-git.yml
@@ -465,12 +465,13 @@ jobs:
           docker run --rm --platform "$TARGET_PLATFORM" \
             -e GIT_VERSION -e TARGET_ARCH \
             -v "$PWD:/work" -w "/work/git-$GIT_VERSION" alpine:3.22 sh -euxc '
-              apk add --no-cache build-base file zlib-dev zlib-static
+              # Keep the musl recipe aligned with Alpine aports/main/git.
+              apk add --no-cache build-base file linux-headers zlib-dev zlib-static
               make -j"$(getconf _NPROCESSORS_ONLN)" git \
                 NO_CURL=YesPlease NO_EXPAT=YesPlease NO_GETTEXT=YesPlease \
                 NO_PERL=YesPlease NO_PYTHON=YesPlease NO_TCLTK=YesPlease \
                 NO_OPENSSL=YesPlease NO_ICONV=YesPlease NO_REGEX=NeedsStartEnd \
-                NO_RUST=YesPlease \
+                NO_RUST=YesPlease NO_SYS_POLL_H=1 \
                 SKIP_DASHED_BUILT_INS=YesPlease RUNTIME_PREFIX=YesPlease \
                 template_dir= gitexecdir=bin \
                 CFLAGS=-Os LDFLAGS=-static


### PR DESCRIPTION
## Capability

- Align the static Linux Git build with Alpine's continuously exercised musl recipe by installing `linux-headers` and setting `NO_SYS_POLL_H=1` for both Linux matrix legs.
- Keep Git's Linux fsmonitor build path enabled instead of hiding it with an override. This stays closer to Alpine and makes future Git upgrades compile the same Linux-specific surface.
- Leave both macOS jobs unchanged; they passed both publication attempts.

## Root Cause And Choice

[Publication run 29153793192](https://github.com/avibe-bot/avibe/actions/runs/29153793192) proves the prior `REG_STARTEND` correction worked: both musl builds progressed into reftable and then failed compiling `compat/fsmonitor/fsm-path-utils-linux.c` because `/usr/include/linux/magic.h` was absent.

This PR installs `linux-headers` rather than clearing `FSMONITOR_OS_SETTINGS`. Alpine's canonical [aports/main/git APKBUILD](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/git/APKBUILD) retains Linux fsmonitor and its musl-specific make settings. The current APKBUILD does not declare `linux-headers` directly, so our deliberately sparse Alpine container declares it explicitly instead of relying on a broader package-builder environment.

## Alpine Recipe Diff

| Flag or group | Alpine APKBUILD | Avibe runtime | Reason for difference |
| --- | --- | --- | --- |
| `NO_GETTEXT` | `YesPlease` | `YesPlease` | Aligned. |
| `NO_REGEX` | `YesPlease` | `NeedsStartEnd` | Both select Git's bundled POSIX regex; Avibe preserves the value named by Git's diagnostic. |
| `NO_SYS_POLL_H` | `1` | `1` | Aligned for musl headers. |
| iconv | `ICONV_OMITS_BOM=Yes` | `NO_ICONV=YesPlease` | The local-only cut removes iconv entirely. |
| PCRE2 | `USE_LIBPCRE2=YesPlease` | omitted | Optional `grep -P` support is outside the retained runtime commands, avoiding another static dependency. |
| Python/Tcl/Tk | disabled for Alpine's bootstrap build | `NO_PYTHON`, `NO_TCLTK` | Aligned with the minimal build. |
| network/crypto | full curl, expat, and OpenSSL support | `NO_CURL`, `NO_EXPAT`, `NO_OPENSSL` | The runtime must not provide remote transports. |
| Perl/Rust | enabled when available | `NO_PERL`, `NO_RUST` | Excluded language/helper surfaces are unnecessary for local checkpointing. |
| install/layout | `INSTALL_SYMLINKS=1` | `SKIP_DASHED_BUILT_INS`, `RUNTIME_PREFIX`, empty templates, `gitexecdir=bin` | Avibe ships one relocatable multicall binary, not a system package layout. |
| compiler/link | Alpine toolchain flags plus LTO | `CFLAGS=-Os`, `LDFLAGS=-static` | Avibe requires a small static musl artifact. |
| test/tooling | `NO_SVN_TESTS`, `PYTHON_PATH` | omitted | The workflow builds only `git`; Perl/SVN/docs are excluded and the artifact smoke is inline. |

Dependencies follow the same cut: retain `file` and `zlib-dev`, add explicit `linux-headers`, add `zlib-static` for the static artifact, and omit Alpine's curl/expat/OpenSSL/PCRE2/Perl/doc dependencies because their corresponding capabilities are disabled.

## Evidence

- **Unit:** not applicable; this is a workflow-only build-recipe correction.
- **Contract:** `actionlint` v1.7.12 and `git diff --check` pass.
- **Build:** Alpine 3.22 package contents confirm `linux-headers` provides `/usr/include/linux/magic.h`. A Git 2.55.0 Makefile dry-run confirms bundled regex and `NO_SYS_POLL_H` are active while the Linux fsmonitor settings remain enabled.
- **Scenario:** no catalog scenario IDs apply. The workflow retains static-link verification and the full local-operation/helper-isolation/remote-rejection smoke on both Linux architectures.

## Residual Manual Check

- This lane does not run or publish `build-git.yml`. After merge, rerun it with `git-runtime-v2.55.0-1` and verify both Linux builds, both unchanged macOS builds, manifest generation, and release publication.

Depends on #871 and #874, both merged.
