### PR TITLE
fix(core): normalize terminal backend failures

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -34,7 +34,7 @@ from modules.agents.opencode.message_processor import (
 from modules.agents.opencode.utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
 from modules.im import InlineButton, InlineKeyboard, MessageContext
 from core.resource_governance import governor_from_controller
-from core.message_output import terminal_turn_output
+from core.message_output import MessageOutput, terminal_turn_output
 from vibe.i18n import t as i18n_t
 from vibe.opencode_config import remove_opencode_provider_api_key
 
@@ -874,15 +874,22 @@ class AgentAuthService:
 
         return False
 
-    async def maybe_emit_auth_recovery_message(self, context: MessageContext, backend: str, error_text: str) -> bool:
+    async def maybe_emit_auth_recovery_message(
+        self,
+        context: MessageContext,
+        backend: str,
+        error_text: str,
+        *,
+        output: MessageOutput | None = None,
+        terminal_error: str | None = None,
+    ) -> bool:
         """Emit a reset-oauth button when the backend error is auth-related.
 
-        Each backend error-emit site calls this FIRST and emits its own terminal
-        error result only when this returns ``False``. When this DOES handle the
-        error (auth-related), the recovery message is a button row (not a result),
-        so settle the turn through the outbound chokepoint here by emitting a
-        terminal ``error`` result — that turns the workbench dot red and releases
-        the SSE waiter. No-op off-workbench (the outbound resolves no session id).
+        Each backend error-emit site calls this FIRST and emits its own failure
+        path only when this returns ``False``. When this DOES handle the error,
+        the recovery message is a button row, so settle the turn separately
+        through the outbound chokepoint with a silent terminal failure. No-op
+        off-workbench (the outbound resolves no session id).
         """
         if not classify_auth_error(backend, error_text):
             return False
@@ -913,8 +920,8 @@ class AgentAuthService:
             persist_agent_message(context, "notify", durable_text)
         except Exception:
             logger.debug("auth recovery: failed to persist durable notify", exc_info=True)
-        # Settle the failed turn through the outbound status chokepoint: an empty
-        # terminal ``error`` result turns the dot red and releases the SSE waiter
+        # Settle the failed turn through the outbound status chokepoint: a silent
+        # terminal failure turns the dot red and releases the SSE waiter
         # without adding a second visible message (the recovery button above is the
         # visible one). No-op off-workbench.
         try:
@@ -923,7 +930,9 @@ class AgentAuthService:
                 "result",
                 "",
                 is_error=True,
-                output=terminal_turn_output(),
+                level="silent",
+                output=output or terminal_turn_output(),
+                terminal_error=terminal_error or error_text,
             )
         except Exception:
             logger.debug("auth recovery: failed to settle turn status", exc_info=True)

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -57,6 +57,39 @@ def _failure_identity(
     return uuid.uuid4().hex
 
 
+def backend_failure_notification_output(
+    context: Any,
+    backend: str,
+    *,
+    request: Any = None,
+    output: MessageOutput | None = None,
+    failure_id: str | None = None,
+) -> MessageOutput:
+    """Build the durable, non-settling visible half of a backend failure."""
+
+    backend_name = str(backend or "backend").strip() or "backend"
+    terminal = _terminal_output(request, output)
+    identity = _failure_identity(context, request, failure_id)
+    metadata = dict(terminal.metadata)
+    metadata.update(
+        {
+            "backend": backend_name,
+            "event": BACKEND_FAILURE_EVENT,
+            "failure_id": identity,
+        }
+    )
+    return MessageOutput(
+        completes_turn=False,
+        completes_run=False,
+        detached=terminal.detached,
+        idempotency_key=f"backend-failure:{identity}",
+        activity_id=terminal.activity_id,
+        causation_id=terminal.causation_id,
+        run_id=terminal.run_id,
+        metadata=metadata,
+    )
+
+
 async def emit_backend_failure(
     controller: Any,
     context: Any,
@@ -80,24 +113,12 @@ async def emit_backend_failure(
     error = str(diagnostic or "").strip() or f"{backend_name} backend failed"
     visible = str(display_text or "").strip() or error
     terminal = _terminal_output(request, output)
-    identity = _failure_identity(context, request, failure_id)
-    notify_metadata = dict(terminal.metadata)
-    notify_metadata.update(
-        {
-            "backend": backend_name,
-            "event": BACKEND_FAILURE_EVENT,
-            "failure_id": identity,
-        }
-    )
-    notification = MessageOutput(
-        completes_turn=False,
-        completes_run=False,
-        detached=terminal.detached,
-        idempotency_key=f"backend-failure:{identity}",
-        activity_id=terminal.activity_id,
-        causation_id=terminal.causation_id,
-        run_id=terminal.run_id,
-        metadata=notify_metadata,
+    notification = backend_failure_notification_output(
+        context,
+        backend_name,
+        request=request,
+        output=terminal,
+        failure_id=failure_id,
     )
 
     async def settle_terminal_failure() -> None:

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -1,0 +1,119 @@
+"""Shared representation for authoritative backend terminal failures."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from core.message_output import MessageOutput, terminal_output_for, terminal_turn_output
+
+
+def _terminal_output(request: Any, output: MessageOutput | None) -> MessageOutput:
+    if output is not None:
+        return output
+    if request is not None:
+        return terminal_output_for(request)
+    return terminal_turn_output()
+
+
+def _failure_identity(
+    context: Any,
+    request: Any,
+    explicit_id: str | None,
+) -> str:
+    identity = str(explicit_id or "").strip()
+    if identity:
+        return identity
+
+    for source in (getattr(request, "context", None), context):
+        payload = getattr(source, "platform_specific", None) or {}
+        for key in (
+            "task_execution_id",
+            "turn_token",
+            "agent_runtime_turn_token",
+        ):
+            identity = str(payload.get(key) or "").strip()
+            if identity:
+                return identity
+
+    if request is not None:
+        identity = str(getattr(request, "_backend_failure_id", "") or "").strip()
+        if not identity:
+            identity = uuid.uuid4().hex
+            setattr(request, "_backend_failure_id", identity)
+        return identity
+    return uuid.uuid4().hex
+
+
+async def emit_backend_failure(
+    controller: Any,
+    context: Any,
+    backend: str,
+    diagnostic: str,
+    *,
+    display_text: str | None = None,
+    request: Any = None,
+    output: MessageOutput | None = None,
+    failure_id: str | None = None,
+) -> bool:
+    """Notify once, then settle one terminal backend failure silently.
+
+    Backend adapters own structured failure recognition. This helper owns the
+    shared representation and keeps visible delivery separate from lifecycle
+    settlement. The return value is true when auth recovery supplied the visible
+    notification.
+    """
+
+    backend_name = str(backend or "backend").strip() or "backend"
+    error = str(diagnostic or "").strip() or f"{backend_name} backend failed"
+    visible = str(display_text or "").strip() or error
+    terminal = _terminal_output(request, output)
+    identity = _failure_identity(context, request, failure_id)
+    notify_metadata = dict(terminal.metadata)
+    notify_metadata.update(
+        {
+            "backend": backend_name,
+            "event": "backend_failure",
+            "failure_id": identity,
+        }
+    )
+    notification = MessageOutput(
+        completes_turn=False,
+        completes_run=False,
+        detached=terminal.detached,
+        idempotency_key=f"backend-failure:{identity}",
+        activity_id=terminal.activity_id,
+        causation_id=terminal.causation_id,
+        run_id=terminal.run_id,
+        metadata=notify_metadata,
+    )
+
+    auth_service = getattr(controller, "agent_auth_service", None)
+    maybe_recover = getattr(auth_service, "maybe_emit_auth_recovery_message", None)
+    if callable(maybe_recover) and await maybe_recover(
+        context,
+        backend_name,
+        visible,
+        output=terminal,
+        terminal_error=error,
+    ):
+        return True
+
+    try:
+        await controller.emit_agent_message(
+            context,
+            "notify",
+            visible,
+            output=notification,
+        )
+    finally:
+        await controller.emit_agent_message(
+            context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
+            output=terminal,
+            terminal_error=error,
+        )
+    return False

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -100,25 +100,7 @@ async def emit_backend_failure(
         metadata=notify_metadata,
     )
 
-    auth_service = getattr(controller, "agent_auth_service", None)
-    maybe_recover = getattr(auth_service, "maybe_emit_auth_recovery_message", None)
-    if callable(maybe_recover) and await maybe_recover(
-        context,
-        backend_name,
-        visible,
-        output=terminal,
-        terminal_error=error,
-    ):
-        return True
-
-    try:
-        await controller.emit_agent_message(
-            context,
-            "notify",
-            visible,
-            output=notification,
-        )
-    finally:
+    async def settle_terminal_failure() -> None:
         await controller.emit_agent_message(
             context,
             "result",
@@ -128,4 +110,31 @@ async def emit_backend_failure(
             output=terminal,
             terminal_error=error,
         )
+
+    auth_service = getattr(controller, "agent_auth_service", None)
+    maybe_recover = getattr(auth_service, "maybe_emit_auth_recovery_message", None)
+    if callable(maybe_recover):
+        try:
+            handled_auth = await maybe_recover(
+                context,
+                backend_name,
+                visible,
+                output=terminal,
+                terminal_error=error,
+            )
+        except Exception:
+            await settle_terminal_failure()
+            raise
+        if handled_auth:
+            return True
+
+    try:
+        await controller.emit_agent_message(
+            context,
+            "notify",
+            visible,
+            output=notification,
+        )
+    finally:
+        await settle_terminal_failure()
     return False

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -7,6 +7,18 @@ from typing import Any
 
 from core.message_output import MessageOutput, terminal_output_for, terminal_turn_output
 
+BACKEND_FAILURE_EVENT = "backend_failure"
+
+
+def is_backend_failure_notification(message_type: str | None, metadata: Any) -> bool:
+    """Whether a persisted message is the visible half of a terminal failure."""
+
+    return (
+        str(message_type or "").strip() == "notify"
+        and isinstance(metadata, dict)
+        and metadata.get("event") == BACKEND_FAILURE_EVENT
+    )
+
 
 def _terminal_output(request: Any, output: MessageOutput | None) -> MessageOutput:
     if output is not None:
@@ -73,7 +85,7 @@ async def emit_backend_failure(
     notify_metadata.update(
         {
             "backend": backend_name,
-            "event": "backend_failure",
+            "event": BACKEND_FAILURE_EVENT,
             "failure_id": identity,
         }
     )

--- a/core/controller.py
+++ b/core/controller.py
@@ -1280,6 +1280,7 @@ class Controller:
         status_label: Optional[str] = None,
         result_footer: Optional[str] = None,
         output: MessageOutput | None = None,
+        terminal_error: Optional[str] = None,
     ):
         """Backward-compatible entrypoint; delegated to message dispatcher."""
         try:
@@ -1293,6 +1294,7 @@ class Controller:
                 status_label=status_label,
                 result_footer=result_footer,
                 output=output,
+                terminal_error=terminal_error,
             )
         finally:
             manager = getattr(self, "session_turns", None)

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -995,7 +995,10 @@ class ConsolidatedMessageDispatcher:
             if run_terminal_status and self._run_has_blocking_activity(run_id):
                 defer_terminal = getattr(store, "defer_run_terminal", None)
                 if callable(defer_terminal):
-                    defer_terminal(run_id, terminal_status=run_terminal_status)
+                    defer_kwargs = {"terminal_status": run_terminal_status}
+                    if terminal_error is not None:
+                        defer_kwargs["error"] = terminal_error
+                    defer_terminal(run_id, **defer_kwargs)
                 run_terminal_status = None
             record_output = getattr(store, "record_run_output", None)
             if callable(record_output):
@@ -1351,9 +1354,8 @@ class ConsolidatedMessageDispatcher:
         - ``"normal"`` (default): delivered / persisted / streamed as usual.
         - ``"silent"``: settles the dot + releases the SSE waiter for a terminal
           ``result``, then returns WITHOUT delivering, persisting, or streaming.
-          Used for intentional, non-noteworthy lifecycle events (e.g. a user-
-          initiated stop) so the turn ends cleanly with no user-facing bubble —
-          replacing the old "fake it with empty text" trick with an explicit flag.
+          Used when lifecycle settlement must not add another visible bubble,
+          including intentional stops and failures already shown as notifications.
 
         ``status_label`` is an optional backend-computed clean tool-call label
         (claude-pipe style) used ONLY as the concise status-bubble body for the
@@ -1387,10 +1389,14 @@ class ConsolidatedMessageDispatcher:
 
         # Terminal status-bubble reason word for the done/orphan footer:
         # a clean turn is "done" (✅); a failure is "stopped" (⏹) when it was an
-        # intentional silent stop (e.g. user stop), else "failed" (⏹). Computed
-        # here where both is_error + level are known, then threaded into the
-        # compose/tidy helpers so the footer marker stays consistent.
-        terminal_reason = "done" if not is_error else ("stopped" if level == "silent" else "failed")
+        # intentional silent stop (e.g. user stop), else "failed" (⏹). An explicit
+        # diagnostic distinguishes a silent backend failure from a silent stop.
+        if not is_error:
+            terminal_reason = "done"
+        elif level == "silent" and terminal_error is None:
+            terminal_reason = "stopped"
+        else:
+            terminal_reason = "failed"
 
         # OUTBOUND status chokepoint (one of exactly two — the other is the
         # inbound AgentService.handle_message). A terminal ``result`` ends the
@@ -1525,6 +1531,7 @@ class ConsolidatedMessageDispatcher:
                         recorded_text,
                         message_id,
                         is_error=is_error,
+                        terminal_error=terminal_error,
                         output_semantics=output_semantics,
                     )
                 elif canonical_type == "result" or (context.platform_specific or {}).get("task_trigger_kind") != "agent_run":

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -983,6 +983,7 @@ class ConsolidatedMessageDispatcher:
         text: str,
         message_id: str | None,
         terminal_status: str | None,
+        terminal_error: str | None,
         output_semantics: MessageOutput,
         provenance: dict[str, Any],
     ) -> None:
@@ -1006,23 +1007,33 @@ class ConsolidatedMessageDispatcher:
                 if not output_id:
                     digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:20]
                     output_id = f"content:{digest}"
+                record_kwargs = {
+                    "output_id": output_id,
+                    "text": text,
+                    "message_id": message_id,
+                    "sequence": output_semantics.sequence,
+                    "provenance": provenance,
+                    "terminal_status": run_terminal_status,
+                }
+                if terminal_error is not None:
+                    record_kwargs["error"] = terminal_error
                 record_output(
                     run_id,
-                    output_id=output_id,
-                    text=text,
-                    message_id=message_id,
-                    sequence=output_semantics.sequence,
-                    provenance=provenance,
-                    terminal_status=run_terminal_status,
+                    **record_kwargs,
                 )
             else:
                 # Compatibility for isolated stores and older persisted-state
                 # adapters while the shared SQLite path owns the output ledger.
+                record_kwargs = {
+                    "text": text,
+                    "message_id": message_id,
+                    "terminal_status": run_terminal_status,
+                }
+                if terminal_error is not None:
+                    record_kwargs["error"] = terminal_error
                 store.record_run_message(
                     run_id,
-                    text=text,
-                    message_id=message_id,
-                    terminal_status=run_terminal_status,
+                    **record_kwargs,
                 )
 
     def _run_has_blocking_activity(self, run_id: str) -> bool:
@@ -1061,6 +1072,7 @@ class ConsolidatedMessageDispatcher:
         message_id: str | None,
         *,
         is_error: bool,
+        terminal_error: str | None = None,
         output_semantics: MessageOutput | None = None,
         log_label: str = "agent run terminal result",
     ) -> None:
@@ -1093,6 +1105,7 @@ class ConsolidatedMessageDispatcher:
                 text=text,
                 message_id=message_id,
                 terminal_status=terminal_status,
+                terminal_error=terminal_error,
                 output_semantics=semantics,
                 provenance=semantics.provenance(context),
             )
@@ -1115,6 +1128,7 @@ class ConsolidatedMessageDispatcher:
         message_id: str | None,
         *,
         is_error: bool,
+        terminal_error: str | None = None,
         output_semantics: MessageOutput | None = None,
     ) -> None:
         self._record_agent_run_terminal_result(
@@ -1122,6 +1136,7 @@ class ConsolidatedMessageDispatcher:
             text,
             message_id,
             is_error=is_error,
+            terminal_error=terminal_error,
             output_semantics=output_semantics,
             log_label="suppressed agent run terminal result",
         )
@@ -1313,6 +1328,7 @@ class ConsolidatedMessageDispatcher:
         status_label: Optional[str] = None,
         result_footer: Optional[str] = None,
         output: MessageOutput | None = None,
+        terminal_error: Optional[str] = None,
     ) -> Optional[str]:
         """Centralized dispatch for agent messages.
 
@@ -1411,6 +1427,7 @@ class ConsolidatedMessageDispatcher:
                         text,
                         None,
                         is_error=is_error,
+                        terminal_error=terminal_error,
                         output_semantics=output_semantics,
                     )
                 if mutates_turn_lifecycle:
@@ -1462,6 +1479,7 @@ class ConsolidatedMessageDispatcher:
                         duplicate_result_text,
                         None,
                         is_error=is_error,
+                        terminal_error=terminal_error,
                         output_semantics=output_semantics,
                     )
                 if mutates_turn_lifecycle:
@@ -1534,7 +1552,13 @@ class ConsolidatedMessageDispatcher:
                 # Record only once delivered (avibe always, via SSE) so a failed
                 # IM send isn't stored as if the user received it.
                 if persists_without_delivery or message_id is not None:
-                    persist_agent_message(target_context, "notify", text)
+                    persist_agent_message(
+                        target_context,
+                        "notify",
+                        text,
+                        metadata=output_metadata,
+                        native_message_id=native_output_id,
+                    )
                 # Live SSE turn stream for the web Chat page (no-op for IM/CLI).
                 await _stream_chunk(self.controller, context, text=text, message_id=message_id, kind="notify")
                 return message_id
@@ -1781,6 +1805,7 @@ class ConsolidatedMessageDispatcher:
                         persisted_result_text,
                         primary_message_id,
                         is_error=is_error,
+                        terminal_error=terminal_error,
                         output_semantics=output_semantics,
                     )
 
@@ -1836,6 +1861,7 @@ class ConsolidatedMessageDispatcher:
                         persisted_result_text,
                         primary_message_id,
                         is_error=is_error,
+                        terminal_error=terminal_error,
                         output_semantics=output_semantics,
                     )
 

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -1343,10 +1343,10 @@ class ConsolidatedMessageDispatcher:
 
         ``is_error`` marks a terminal ``result`` as a FAILED turn. It is the only
         signal the sidebar dot needs on the way out: a terminal result settles the
-        session to ``idle`` (or ``failed`` when ``is_error``). Callers that hit a
-        terminal failure emit it as ``result`` + ``is_error=True`` instead of a
-        bare ``notify`` — that routes the failure through this one outbound
-        chokepoint (dot + SSE stream release), so no caller pokes the dot directly.
+        session to ``idle`` (or ``failed`` when ``is_error``). Structured backend
+        failures use a visible ``notify`` for delivery followed by a silent
+        ``result`` with ``is_error=True`` for lifecycle settlement, keeping those
+        responsibilities independent while still passing through this chokepoint.
 
         ``level`` is the visibility grade — orthogonal to ``message_type``. The
         type says what role the message plays (and drives the dot + unread); the

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1122,12 +1122,19 @@ class TaskExecutionStore:
             error=error,
         )
 
-    def defer_run_terminal(self, run_id: str, *, terminal_status: str) -> bool:
+    def defer_run_terminal(
+        self,
+        run_id: str,
+        *,
+        terminal_status: str,
+        error: Optional[str] = None,
+    ) -> bool:
         if self._sqlite is None:
             return False
         return self._sqlite.defer_run_terminal(
             run_id,
             terminal_status=terminal_status,
+            error=error,
         )
 
     def update_callback_status(

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from config import paths
+from core.backend_failure import BACKEND_FAILURE_EVENT, is_backend_failure_notification
 from vibe.i18n import t
 
 TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
@@ -79,10 +80,13 @@ class ForkSourceState:
     has_messages_after_anchor: bool = False
     has_terminal_agent_output_after_anchor: bool = False
     has_user_turn_after_anchor: bool = False
+    anchor_is_backend_failure: bool = False
 
     @property
     def anchor_is_terminal_agent_output(self) -> bool:
-        return self.anchor_author == "agent" and self.anchor_type in TERMINAL_AGENT_OUTPUT_TYPES
+        return self.anchor_author == "agent" and (
+            self.anchor_type in TERMINAL_AGENT_OUTPUT_TYPES or self.anchor_is_backend_failure
+        )
 
 
 @dataclass(frozen=True)
@@ -388,7 +392,7 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
     if not source_session_id or not source_message_id:
         return ForkSourceState()
 
-    from sqlalchemy import select
+    from sqlalchemy import and_, func, or_, select
 
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
@@ -399,7 +403,13 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
     try:
         with engine.connect() as conn:
             anchor = conn.execute(
-                select(messages.c.created_at, messages.c.id, messages.c.author, messages.c.type)
+                select(
+                    messages.c.created_at,
+                    messages.c.id,
+                    messages.c.author,
+                    messages.c.type,
+                    messages.c.metadata_json,
+                )
                 .where(messages.c.session_id == source_session_id, messages.c.id == source_message_id)
                 .limit(1)
             ).mappings().first()
@@ -412,10 +422,17 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
                 | ((messages.c.created_at == anchor_created_at) & (messages.c.id > anchor_id))
             )
             latest_after_anchor = conn.execute(
-                select(messages.c.author, messages.c.type)
+                select(messages.c.author, messages.c.type, messages.c.metadata_json)
                 .where(
                     messages.c.session_id == source_session_id,
-                    messages.c.type.in_(["user", *list(SOURCE_PROGRESS_AGENT_OUTPUT_TYPES)]),
+                    or_(
+                        messages.c.type.in_(["user", *list(SOURCE_PROGRESS_AGENT_OUTPUT_TYPES)]),
+                        and_(
+                            messages.c.type == "notify",
+                            func.json_extract(messages.c.metadata_json, "$.event")
+                            == BACKEND_FAILURE_EVENT,
+                        ),
+                    ),
                     after_anchor,
                 )
                 .order_by(messages.c.created_at.desc(), messages.c.id.desc())
@@ -427,9 +444,18 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
             latest_after_anchor_type = (
                 str(latest_after_anchor["type"] or "").strip() if latest_after_anchor else ""
             )
+            latest_after_anchor_metadata = _load_metadata(
+                latest_after_anchor["metadata_json"] if latest_after_anchor else None
+            )
             has_terminal_agent_output_after_anchor = (
                 latest_after_anchor_author == "agent"
-                and latest_after_anchor_type in TERMINAL_AGENT_OUTPUT_TYPES
+                and (
+                    latest_after_anchor_type in TERMINAL_AGENT_OUTPUT_TYPES
+                    or is_backend_failure_notification(
+                        latest_after_anchor_type,
+                        latest_after_anchor_metadata,
+                    )
+                )
             )
             has_user_turn_after_anchor = (
                 conn.execute(
@@ -452,6 +478,10 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
                 has_messages_after_anchor=latest_after_anchor is not None,
                 has_terminal_agent_output_after_anchor=has_terminal_agent_output_after_anchor,
                 has_user_turn_after_anchor=has_user_turn_after_anchor,
+                anchor_is_backend_failure=is_backend_failure_notification(
+                    anchor["type"],
+                    _load_metadata(anchor["metadata_json"]),
+                ),
             )
     except Exception as exc:
         import logging

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -10,16 +10,35 @@ from typing import Any
 
 from sqlalchemy import or_, select
 
+from core.backend_failure import is_backend_failure_notification
 from storage import messages_service, web_push_service
 from storage.models import agent_sessions, messages
 
 logger = logging.getLogger(__name__)
 
-_NOTIFIABLE_TYPES = {"result", "error"}
+_NOTIFIABLE_TYPES = {"result", "error", "notify"}
 _UNREAD_GATED_TYPES = {"result"}
 WEB_PUSH_NOTIFICATION_DELAY_SECONDS = 3.0
 WEB_PUSH_USER_KEY_METADATA = "_web_push_user_key"
 WEB_PUSH_USER_KEYS_METADATA = "_web_push_user_keys"
+
+
+def _is_notifiable_message(message_type: Any, metadata: Any = None) -> bool:
+    normalized_type = str(message_type or "").strip()
+    return normalized_type in {"result", "error"} or is_backend_failure_notification(
+        normalized_type,
+        metadata,
+    )
+
+
+def _parse_metadata(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    try:
+        parsed = json.loads(value or "{}")
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def maybe_notify_inbox_message(message: dict[str, Any] | None, inbox_row: dict[str, Any] | None) -> None:
@@ -36,7 +55,7 @@ def maybe_notify_inbox_message(message: dict[str, Any] | None, inbox_row: dict[s
         return
     if message.get("author") != "agent":
         return
-    if message.get("type") not in _NOTIFIABLE_TYPES:
+    if not _is_notifiable_message(message.get("type"), message.get("metadata")):
         return
     if not message.get("session_id"):
         return
@@ -61,13 +80,17 @@ def _message_still_unread(conn: Any, message_id: str | None) -> bool:
     if not message_id:
         return False
     row = conn.execute(
-        select(messages.c.type, messages.c.read_at)
+        select(messages.c.type, messages.c.read_at, messages.c.metadata_json)
         .where(messages.c.id == message_id)
         .where(messages.c.platform == "avibe")
         .where(messages.c.author == "agent")
         .where(messages.c.type.in_(_NOTIFIABLE_TYPES))
     ).first()
-    return bool(row is not None and (row[0] not in _UNREAD_GATED_TYPES or row[1] is None))
+    return bool(
+        row is not None
+        and _is_notifiable_message(row[0], _parse_metadata(row[2]))
+        and (row[0] not in _UNREAD_GATED_TYPES or row[1] is None)
+    )
 
 
 def _metadata_user_keys(metadata: dict[str, Any]) -> list[str]:
@@ -96,15 +119,24 @@ def _web_push_user_keys_for_message(conn: Any, message_id: str | None) -> list[s
     if not message_id:
         return []
     agent_row = conn.execute(
-        select(messages.c.session_id, messages.c.created_at, messages.c.id)
+        select(
+            messages.c.session_id,
+            messages.c.created_at,
+            messages.c.id,
+            messages.c.type,
+            messages.c.metadata_json,
+        )
         .where(messages.c.id == message_id)
         .where(messages.c.platform == "avibe")
         .where(messages.c.author == "agent")
         .where(messages.c.type.in_(_NOTIFIABLE_TYPES))
     ).first()
-    if not agent_row or not agent_row[0]:
+    if not agent_row or not agent_row[0] or not _is_notifiable_message(
+        agent_row[3],
+        _parse_metadata(agent_row[4]),
+    ):
         return []
-    session_id, created_at, row_id = agent_row
+    session_id, created_at, row_id = agent_row[0], agent_row[1], agent_row[2]
 
     user_rows = conn.execute(
         select(messages.c.metadata_json)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -2312,6 +2312,12 @@ class ClaudeAgent(BaseAgent):
             str(getattr(message, "result", "") or "").strip(),
             cls._error_value_text(error_value),
         ]
+        error_token = cls._error_value_text(error_value).lower()
+        if not candidates[0] and error_token in {
+            "authentication_error",
+            "authentication_failed",
+        }:
+            candidates.insert(0, "OAuth authentication failed.")
         if isinstance(errors, (list, tuple)):
             candidates.extend(cls._error_value_text(item) for item in errors)
         elif errors:

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Callable, Optional
 
 from core.agent_auth_service import classify_auth_error
+from core.backend_failure import emit_backend_failure
 from core.message_output import MessageOutput, terminal_output_for, terminal_turn_output
 from core.reply_enhancer import strip_silent_blocks
 from core.session_activities import SessionActivity, activity_completion_output
@@ -54,6 +55,7 @@ class ClaudeAgent(BaseAgent):
         self._pending_assistant_message: dict[str, str] = {}
         self._native_session_ids: dict[str, str] = {}
         self._suppressed_synthetic_results: set[str] = set()
+        self._suppressed_synthetic_error_text: dict[str, str] = {}
         self._suppress_receiver_runtime_release: set[str] = set()
         # Store reaction info per runtime session for cleanup after terminal
         # result. Under the runtime turn gate there is normally one active entry;
@@ -172,38 +174,36 @@ class ClaudeAgent(BaseAgent):
             self._mark_session_idle_if_no_pending_requests(runtime_session_key)
             await self._remove_ack_reaction(request)
             error_notify = self._format_error_notify(e)
-            handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
-                context,
-                "claude",
-                error_notify,
-            )
-            if not handled:
-                await self.session_handler.handle_session_error(runtime_session_key, context, e)
-                # ``handle_session_error`` sends through the IM client, which doesn't
-                # write to ``messages``, and the web Chat renders only durable
-                # ``message.new`` rows — so persist a terminal notify or the avibe
-                # user's prompt stops with no explanation (Codex P2). The HANDLED
-                # (auth) branch instead persists the full recovery text centrally in
-                # ``maybe_emit_auth_recovery_message``.
-                try:
-                    from core.message_mirror import persist_agent_message
-
-                    persist_agent_message(context, "notify", error_notify)
-                except Exception:
-                    logger.debug("claude: failed to persist terminal error row", exc_info=True)
-            # Synchronous failure (query/setup raised), no async receiver result
-            # coming: settle the turn through the OUTBOUND status chokepoint. An
-            # empty terminal error result turns the dot red AND releases the
-            # web-Chat stream waiter (the visible error was sent + persisted
-            # above), instead of waiting out the safety timeout. No-op off-workbench.
             try:
-                await self.controller.emit_agent_message(
+                handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                     context,
-                    "result",
-                    "",
-                    is_error=True,
+                    "claude",
+                    error_notify,
                     output=terminal_output_for(request),
+                    terminal_error=str(e),
                 )
+                if not handled:
+                    await self.session_handler.handle_session_error(runtime_session_key, context, e)
+                    # ``handle_session_error`` sends through the IM client, which doesn't
+                    # write to ``messages``, and the web Chat renders only durable
+                    # ``message.new`` rows. The auth branch persists its recovery text.
+                    try:
+                        from core.message_mirror import persist_agent_message
+
+                        persist_agent_message(context, "notify", error_notify)
+                    except Exception:
+                        logger.debug("claude: failed to persist terminal error row", exc_info=True)
+                    # No async receiver result is coming. Auth recovery settles its
+                    # own failure; otherwise do that here without another bubble.
+                    await self.controller.emit_agent_message(
+                        context,
+                        "result",
+                        "",
+                        is_error=True,
+                        level="silent",
+                        output=terminal_output_for(request),
+                        terminal_error=str(e),
+                    )
             finally:
                 self._release_service_runtime_turn(context)
         finally:
@@ -397,6 +397,7 @@ class ClaudeAgent(BaseAgent):
         self._pending_assistant_message.pop(composite_key, None)
         self._native_session_ids.pop(composite_key, None)
         self._suppressed_synthetic_results.discard(composite_key)
+        self._suppressed_synthetic_error_text.pop(composite_key, None)
         if not preserve_pending_request_state:
             self._pending_reactions.pop(composite_key, None)
             pending_requests = self._pending_requests.pop(composite_key, None) or []
@@ -672,7 +673,6 @@ class ClaudeAgent(BaseAgent):
                         if context_tokens:
                             self.controller.note_session_tokens(context, total=context_tokens)
 
-                        auth_failure_assistant = self._is_auth_failure_assistant_message(message)
                         assistant_text = self._extract_text_blocks(message, context)
                         if output_mode == "detached":
                             if assistant_text:
@@ -682,26 +682,15 @@ class ClaudeAgent(BaseAgent):
                             if assistant_text:
                                 self._detached_assistant_text[composite_key] = assistant_text
                             continue
-                        auth_failure_text = assistant_text or "OAuth authentication failed."
-                        if await self._handle_auth_failure_result(
-                            context,
-                            composite_key,
-                            "error" if auth_failure_assistant else "",
-                            auth_failure_text if auth_failure_assistant else assistant_text,
-                        ):
-                            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
-                            if callable(mark_session_idle):
-                                mark_session_idle(composite_key)
-                            await self._clear_pending_reactions(composite_key, context)
-                            self._last_assistant_text.pop(composite_key, None)
-                            self._pending_assistant_message.pop(composite_key, None)
-                            return
-                        if await self._handle_synthetic_api_error_message(
+                        failure_disposition = await self._handle_assistant_terminal_failure(
                             context,
                             composite_key,
                             message,
                             assistant_text,
-                        ):
+                        )
+                        if failure_disposition == "auth":
+                            return
+                        if failure_disposition:
                             continue
                         if assistant_text:
                             self._last_assistant_text[composite_key] = assistant_text
@@ -860,20 +849,16 @@ class ClaudeAgent(BaseAgent):
                             if fallback:
                                 result_text = fallback
 
-                        if await self._handle_auth_failure_result(
+                        failure_disposition = await self._handle_terminal_failure_result(
                             context,
                             composite_key,
-                            getattr(message, "subtype", "") or "",
+                            message,
                             result_text,
-                        ):
-                            self._retire_failed_auth_turn(composite_key, context)
-                            mark_session_idle = getattr(self.session_handler, "mark_session_idle", None)
-                            if callable(mark_session_idle):
-                                mark_session_idle(composite_key)
-                            await self._clear_pending_reactions(composite_key, context)
-                            self._last_assistant_text.pop(composite_key, None)
-                            self._pending_assistant_message.pop(composite_key, None)
+                        )
+                        if failure_disposition == "auth":
                             return
+                        if failure_disposition:
+                            continue
 
                         # NOTE: The pending assistant message is intentionally
                         # NOT emitted here.  ResultMessage.result already
@@ -1012,7 +997,8 @@ class ClaudeAgent(BaseAgent):
             # context BEFORE clearing the FIFO (and before either the auth-recovery or
             # the non-auth emit below), mirroring the in-loop auth-failure paths (Codex P2).
             _pending = self._pending_requests.get(composite_key) or []
-            self._adopt_pending_turn_token(context, _pending[0] if _pending else None)
+            pending_request = _pending[0] if _pending else None
+            self._adopt_pending_turn_token(context, pending_request)
             # Clean up all pending reactions for this session on error —
             # the receiver is dead and won't process any more results.
             await self._clear_pending_reactions(composite_key, context)
@@ -1021,6 +1007,8 @@ class ClaudeAgent(BaseAgent):
                 context,
                 "claude",
                 error_notify,
+                output=terminal_output_for(pending_request),
+                terminal_error=str(e),
             )
             if not handled:
                 await self.session_handler.handle_session_error(composite_key, context, e)
@@ -1046,7 +1034,9 @@ class ClaudeAgent(BaseAgent):
                     "result",
                     "",
                     is_error=True,
-                    output=terminal_turn_output(),
+                    level="silent",
+                    output=terminal_output_for(pending_request),
+                    terminal_error=str(e),
                 )
             self._release_service_runtime_turn(context)
         # NOTE: no `finally` cleanup of pending reactions here.
@@ -1059,6 +1049,7 @@ class ClaudeAgent(BaseAgent):
         # inside the loop.
         finally:
             self._suppressed_synthetic_results.discard(composite_key)
+            self._suppressed_synthetic_error_text.pop(composite_key, None)
             detached_activity = self._detached_activity_outputs.pop(composite_key, None)
             if detached_activity is not None:
                 registry = self._activity_registry()
@@ -1105,58 +1096,126 @@ class ClaudeAgent(BaseAgent):
                 "result",
                 "",
                 is_error=True,
+                level="silent",
                 output=terminal_output_for(pending_request),
+                terminal_error="Claude receiver ended without a terminal result",
             )
         finally:
             self._release_service_runtime_turn(context)
 
-    async def _handle_synthetic_api_error_message(
+    async def _handle_assistant_terminal_failure(
         self,
         context: MessageContext,
         composite_key: str,
         message,
         text: str,
+    ) -> str | None:
+        """Handle a structured AssistantMessage failure and its paired result."""
+
+        diagnostic = self._terminal_backend_failure(message, text)
+        if diagnostic is None:
+            return None
+
+        handled_auth = await self._settle_terminal_backend_failure(
+            context,
+            composite_key,
+            diagnostic,
+        )
+        if handled_auth:
+            return "auth"
+        self._suppressed_synthetic_results.add(composite_key)
+        self._suppressed_synthetic_error_text[composite_key] = diagnostic
+        return "failure"
+
+    async def _handle_terminal_failure_result(
+        self,
+        context: MessageContext,
+        composite_key: str,
+        message,
+        text: str | None,
+    ) -> str | None:
+        diagnostic = self._terminal_backend_failure(message, text)
+        if diagnostic is None:
+            return None
+        handled_auth = await self._settle_terminal_backend_failure(
+            context,
+            composite_key,
+            diagnostic,
+        )
+        return "auth" if handled_auth else "failure"
+
+    async def _settle_terminal_backend_failure(
+        self,
+        context: MessageContext,
+        composite_key: str,
+        diagnostic: str,
     ) -> bool:
-        """Settle Claude Code synthetic API errors without publishing them as chat."""
-
-        if not self._is_synthetic_api_error_message(message, text):
-            return False
-
-        pending_request = self._pop_pending_request(composite_key)
-        self._requeue_request_activity(pending_request)
+        pending_requests = self._pending_requests.get(composite_key) or []
+        pending_request = pending_requests[0] if pending_requests else None
         self._adopt_pending_turn_token(context, pending_request)
         logger.warning(
-            "Claude malformed tool-use synthetic API error for session %s suppressed from user-visible transcript: %s",
+            "Claude terminal backend failure for session %s: %s",
             composite_key,
-            text or "<empty>",
+            diagnostic,
         )
-        await self.controller.emit_agent_message(
+        handled_auth = await emit_backend_failure(
+            self.controller,
             context,
-            "result",
-            "",
-            is_error=True,
-            output=terminal_output_for(pending_request),
+            self.name,
+            diagnostic,
+            display_text=f"❌ Claude error: {diagnostic}",
+            request=pending_request,
         )
-        if pending_request is not None:
-            await self._remove_ack_reaction(pending_request)
+        if handled_auth:
+            self._retire_failed_auth_turn(composite_key, context)
+            await self._cleanup_runtime_session(
+                composite_key,
+                current_receiver_task=asyncio.current_task(),
+                preserve_pending_request_state=True,
+            )
+            if pending_request is not None:
+                await self._remove_ack_reaction(pending_request)
+            self._discard_pending_reaction(composite_key)
+            await self._clear_pending_reactions(composite_key, context)
+            self._mark_session_idle_if_no_pending_requests(composite_key)
+            return True
+
+        popped_request = self._pop_pending_request(composite_key)
+        self._requeue_request_activity(popped_request)
+        if popped_request is not None:
+            await self._remove_ack_reaction(popped_request)
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)
-        self._suppressed_synthetic_results.add(composite_key)
         self._discard_pending_reaction(composite_key)
         self._mark_session_idle_if_no_pending_requests(composite_key)
-        return True
+        return False
 
     def _consume_suppressed_synthetic_result(self, composite_key: str, message, text: Optional[str]) -> bool:
         if composite_key not in self._suppressed_synthetic_results:
             return False
 
-        if not self._is_malformed_tool_call_retry_failure_result(message, text):
+        expected = " ".join(
+            self._suppressed_synthetic_error_text.get(composite_key, "").lower().split()
+        )
+        actual = " ".join((text or "").lower().split())
+        same_failure_text = bool(
+            expected
+            and actual
+            and (expected in actual or actual in expected)
+        )
+        if (
+            self._terminal_backend_failure(message, text) is None
+            and not same_failure_text
+            and not self._is_malformed_tool_call_retry_failure_result(message, text)
+        ):
             self._suppressed_synthetic_results.discard(composite_key)
+            self._suppressed_synthetic_error_text.pop(composite_key, None)
             return False
 
         self._suppressed_synthetic_results.discard(composite_key)
+        self._suppressed_synthetic_error_text.pop(composite_key, None)
         logger.warning(
-            "Claude paired malformed tool-use synthetic ResultMessage for session %s suppressed: %s",
+            "Claude paired terminal ResultMessage for session %s suppressed: %s",
             composite_key,
             text or "<empty>",
         )
@@ -1848,16 +1907,11 @@ class ClaudeAgent(BaseAgent):
             return "activity"
         if composite_key in self._detached_unsolicited_outputs:
             return "detached"
-        # A malformed-tool-use synthetic API error pops the turn's real pending
-        # request and arms ``_suppressed_synthetic_results`` for the PAIRED
-        # ResultMessage, which the result branch then skips (``continue``) with NO
-        # terminal emit. That paired result reaches this hook with an empty FIFO +
-        # free gate, so opening an agent-initiated turn for it would leak the gate /
-        # pending request / active flag until EOF — and the NEXT user message for
-        # this Claude session would block behind the leaked gate (Codex P1). Skip
-        # while a suppressed synthetic result is pending; the set is cleared by
-        # ``_consume_suppressed_synthetic_result`` / cleanup, so real later turns
-        # open normally.
+        # A structured AssistantMessage failure pops the turn's real pending
+        # request and arms ``_suppressed_synthetic_results`` for its paired
+        # ResultMessage. Opening an agent-initiated turn for that duplicate frame
+        # would leak the gate and block the next user message. The marker is cleared
+        # when the paired result is consumed or the receiver exits.
         if composite_key in self._suppressed_synthetic_results:
             return None
         registry = self._activity_registry()
@@ -2205,12 +2259,15 @@ class ClaudeAgent(BaseAgent):
         # active-turn guard would otherwise treat the stale token as a superseded
         # turn and skip the failed-status write for 2nd-or-later Claude auth failures.
         pending = self._pending_requests.get(composite_key) or []
-        self._adopt_pending_turn_token(context, pending[0] if pending else None)
+        pending_request = pending[0] if pending else None
+        self._adopt_pending_turn_token(context, pending_request)
 
         handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
             context,
             "claude",
             f"❌ Claude error: {text}",
+            output=terminal_output_for(pending_request),
+            terminal_error=text,
         )
         if handled:
             await self._cleanup_runtime_session(
@@ -2220,9 +2277,49 @@ class ClaudeAgent(BaseAgent):
             )
         return handled
 
-    def _is_auth_failure_assistant_message(self, message) -> bool:
-        error_kind = (getattr(message, "error", "") or "").strip().lower()
-        return error_kind == "authentication_failed"
+    @staticmethod
+    def _error_value_text(value) -> str:
+        if isinstance(value, dict):
+            for key in ("message", "error", "type", "name"):
+                text = str(value.get(key) or "").strip()
+                if text:
+                    return text
+            return str(value).strip()
+        return str(value or "").strip()
+
+    @classmethod
+    def _terminal_backend_failure(cls, message, text: Optional[str]) -> str | None:
+        """Extract only structured terminal failure evidence from Claude frames."""
+
+        subtype = str(getattr(message, "subtype", "") or "").strip().lower()
+        error_value = getattr(message, "error", None)
+        errors = getattr(message, "errors", None)
+        api_status = getattr(message, "api_error_status", None)
+        structured_failure = bool(
+            getattr(message, "is_error", False)
+            or error_value
+            or bool(errors)
+            or api_status
+            or subtype == "failed"
+            or subtype.startswith("error")
+            or cls._is_synthetic_api_error_message(message, text)
+        )
+        if not structured_failure:
+            return None
+
+        candidates = [
+            str(text or "").strip(),
+            str(getattr(message, "result", "") or "").strip(),
+            cls._error_value_text(error_value),
+        ]
+        if isinstance(errors, (list, tuple)):
+            candidates.extend(cls._error_value_text(item) for item in errors)
+        elif errors:
+            candidates.append(cls._error_value_text(errors))
+        if api_status:
+            candidates.append(f"API error status {api_status}")
+        candidates.append(subtype)
+        return next((candidate for candidate in candidates if candidate), "Claude backend failed")
 
     @staticmethod
     def _is_synthetic_api_error_message(message, text: Optional[str] = None) -> bool:

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -5,7 +5,7 @@ import uuid
 from typing import Callable, Optional
 
 from core.agent_auth_service import classify_auth_error
-from core.backend_failure import emit_backend_failure
+from core.backend_failure import backend_failure_notification_output, emit_backend_failure
 from core.message_output import MessageOutput, terminal_output_for, terminal_turn_output
 from core.reply_enhancer import strip_silent_blocks
 from core.session_activities import SessionActivity, activity_completion_output
@@ -190,7 +190,19 @@ class ClaudeAgent(BaseAgent):
                     try:
                         from core.message_mirror import persist_agent_message
 
-                        persist_agent_message(context, "notify", error_notify)
+                        notification = backend_failure_notification_output(
+                            context,
+                            "claude",
+                            request=request,
+                            output=terminal_output_for(request),
+                        )
+                        persist_agent_message(
+                            context,
+                            "notify",
+                            error_notify,
+                            metadata=notification.metadata,
+                            native_message_id=notification.idempotency_key,
+                        )
                     except Exception:
                         logger.debug("claude: failed to persist terminal error row", exc_info=True)
                     # No async receiver result is coming. Auth recovery settles its
@@ -1019,7 +1031,19 @@ class ClaudeAgent(BaseAgent):
                 try:
                     from core.message_mirror import persist_agent_message
 
-                    persist_agent_message(context, "notify", error_notify)
+                    notification = backend_failure_notification_output(
+                        context,
+                        "claude",
+                        request=pending_request,
+                        output=terminal_output_for(pending_request),
+                    )
+                    persist_agent_message(
+                        context,
+                        "notify",
+                        error_notify,
+                        metadata=notification.metadata,
+                        native_message_id=notification.idempotency_key,
+                    )
                 except Exception:
                     logger.debug("claude: failed to persist terminal receiver-error row", exc_info=True)
                 # A dead receiver is terminal. The HANDLED (auth) branch already

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -16,6 +16,7 @@ from config.v2_config import (
     DEFAULT_CODEX_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER,
 )
 from core.avibe_cloud import avibe_cloud_url_available
+from core.backend_failure import emit_backend_failure
 from core.caller_context import caller_env_for_platform_payload
 from core.message_output import terminal_output_for
 from core.services.session_fork import fork_source_state, pending_native_fork
@@ -130,26 +131,26 @@ class CodexAgent(BaseAgent):
         try:
             transport = await self._get_or_create_transport(request.working_path)
         except FileNotFoundError:
-            # Terminal failure → emit as a RESULT (error): the outbound chokepoint
-            # turns the dot red and releases the SSE waiter (no separate latch).
-            await self.controller.emit_agent_message(
+            await emit_backend_failure(
+                self.controller,
                 request.context,
-                "result",
-                "❌ Codex CLI not found. Please install it or set CODEX_CLI_PATH.",
-                is_error=True,
-                output=terminal_output_for(request),
+                self.name,
+                "Codex CLI not found",
+                display_text="❌ Codex CLI not found. Please install it or set CODEX_CLI_PATH.",
+                request=request,
             )
             await self._remove_ack_reaction(request)
             self._event_handler._release_stream_turn(request.context)
             return
         except Exception as e:
             logger.error("Failed to start Codex transport: %s", e, exc_info=True)
-            await self.controller.emit_agent_message(
+            await emit_backend_failure(
+                self.controller,
                 request.context,
-                "result",
-                f"❌ Failed to start Codex CLI: {e}",
-                is_error=True,
-                output=terminal_output_for(request),
+                self.name,
+                str(e),
+                display_text=f"❌ Failed to start Codex CLI: {e}",
+                request=request,
             )
             await self._remove_ack_reaction(request)
             self._event_handler._release_stream_turn(request.context)
@@ -187,12 +188,13 @@ class CodexAgent(BaseAgent):
                         if self._is_recoverable_transport_error(e):
                             raise
                         logger.warning("Failed to interrupt turn %s: %s", active_turn, e)
-                        await self.controller.emit_agent_message(
+                        await emit_backend_failure(
+                            self.controller,
                             request.context,
-                            "result",
-                            f"❌ Failed to interrupt previous Codex turn: {e}",
-                            is_error=True,
-                            output=terminal_output_for(request),
+                            self.name,
+                            str(e),
+                            display_text=f"❌ Failed to interrupt previous Codex turn: {e}",
+                            request=request,
                         )
                         await self._remove_ack_reaction(request)
                         self._event_handler._release_stream_turn(request.context)
@@ -233,24 +235,14 @@ class CodexAgent(BaseAgent):
                 self._turn_registry.clear_pending_turn_start(request.base_session_id, request)
                 logger.error("Error in Codex handle_message: %s", e, exc_info=True)
                 error_text = f"❌ Codex error: {e}"
-                handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+                await emit_backend_failure(
+                    self.controller,
                     request.context,
-                    "codex",
-                    error_text,
+                    self.name,
+                    str(e),
+                    display_text=error_text,
+                    request=request,
                 )
-                if not handled:
-                    # Terminal failure → RESULT (error): the outbound chokepoint
-                    # turns the dot red. The auth-recovery branch (handled) emits
-                    # its own terminal error result inside
-                    # ``maybe_emit_auth_recovery_message``, so both paths settle
-                    # the dot via the same outbound — no separate latch.
-                    await self.controller.emit_agent_message(
-                        request.context,
-                        "result",
-                        error_text,
-                        is_error=True,
-                        output=terminal_output_for(request),
-                    )
                 await self._remove_ack_reaction(request)
                 # The turn never started (all retries failed) — release the
                 # web-Chat working/Stop state instead of leaving it until the

--- a/modules/agents/codex/event_handler.py
+++ b/modules/agents/codex/event_handler.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from vibe.i18n import t as i18n_t
-from core.message_output import terminal_output_for
+from core.backend_failure import emit_backend_failure
 
 if TYPE_CHECKING:
     from modules.agents.base import AgentRequest
@@ -160,26 +160,15 @@ class CodexEventHandler:
 
             if should_emit_terminal_error and not already_notified:
                 message = f"❌ Codex turn failed: {error_msg}"
-                handled = await self._agent.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+                await emit_backend_failure(
+                    self._agent.controller,
                     tracked_request.context,
                     "codex",
-                    message,
+                    error_msg or "Unknown error",
+                    display_text=message,
+                    request=tracked_request,
+                    failure_id=turn_id,
                 )
-                if not handled:
-                    # Terminal failure → RESULT (error): the outbound status
-                    # chokepoint turns the dot red. The auth-recovery branch
-                    # settles it via its own terminal error result.
-                    await self._agent.controller.emit_agent_message(
-                        tracked_request.context,
-                        "result",
-                        message,
-                        is_error=True,
-                        output=terminal_output_for(tracked_request),
-                    )
-                # handled == True persists the durable recovery notify centrally in
-                # ``maybe_emit_auth_recovery_message`` (the auth service is the single
-                # home for the reset-prompt text); the not-handled branch persists via
-                # ``emit_agent_message`` above.
                 error_was_user_visible = True
             else:
                 logger.info("Suppressing inactive Codex turn failure for %s: %s", turn_id, error_msg)
@@ -344,42 +333,29 @@ class CodexEventHandler:
                 and not turn_state.terminal_error_notified
             ):
                 text = f"❌ Codex turn failed: {message}"
-                handled = await self._agent.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+                await emit_backend_failure(
+                    self._agent.controller,
                     request.context,
                     "codex",
-                    text,
+                    message,
+                    display_text=text,
+                    request=request,
+                    failure_id=turn_id,
                 )
-                if not handled:
-                    # Terminal failure → error RESULT so the outbound chokepoint
-                    # turns the dot red (the later completed handler suppresses a
-                    # second message once terminal_error_notified is set).
-                    await self._agent.controller.emit_agent_message(
-                        request.context,
-                        "result",
-                        text,
-                        is_error=True,
-                        output=terminal_output_for(request),
-                    )
                 turn_state.terminal_error_notified = True
             else:
                 logger.info("Logging inactive Codex turn error for %s: %s", turn_id, message)
             return
 
         text = f"❌ Codex error: {message}"
-        handled = await self._agent.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+        await emit_backend_failure(
+            self._agent.controller,
             request.context,
             "codex",
-            text,
+            message,
+            display_text=text,
+            request=request,
         )
-        if not handled:
-            # No-turnId terminal error → error RESULT so the dot turns red.
-            await self._agent.controller.emit_agent_message(
-                request.context,
-                "result",
-                text,
-                is_error=True,
-                output=terminal_output_for(request),
-            )
 
     def _extract_error_message(self, error: Any) -> str:
         if isinstance(error, dict):

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -14,6 +14,7 @@ import time
 from typing import Dict, Optional
 
 from core.avibe_cloud import avibe_cloud_url_available
+from core.backend_failure import emit_backend_failure
 from core.message_output import terminal_output_for
 from core.resource_governance import governor_from_controller
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
@@ -197,14 +198,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             await server.ensure_running()
         except Exception as e:
             logger.error(f"Failed to start OpenCode server: {e}", exc_info=True)
-            # Terminal failure → emit as a RESULT (error): the outbound chokepoint
-            # turns the dot red and releases the SSE waiter. No separate latch.
-            await self.controller.emit_agent_message(
+            await emit_backend_failure(
+                self.controller,
                 request.context,
-                "result",
-                f"Failed to start OpenCode server: {e}",
-                is_error=True,
-                output=terminal_output_for(request),
+                self.name,
+                str(e),
+                display_text=f"Failed to start OpenCode server: {e}",
+                request=request,
             )
             await self._remove_ack_reaction(request)
             return
@@ -218,12 +218,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             # The previous session is gone server-side — surface it as a terminal
             # ERROR result (outbound chokepoint turns the dot red), don't silently
             # fork a fresh session and lose context.
-            await self.controller.emit_agent_message(
+            await emit_backend_failure(
+                self.controller,
                 request.context,
-                "result",
-                f"❌ {e}",
-                is_error=True,
-                output=terminal_output_for(request),
+                self.name,
+                str(e),
+                display_text=f"❌ {e}",
+                request=request,
             )
             await self._remove_ack_reaction(request)
             return
@@ -235,26 +236,24 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             # (which settles the dot itself); otherwise emit the error result here.
             logger.error(f"OpenCode session acquisition failed: {e}", exc_info=True)
             message = f"OpenCode error: {type(e).__name__}: {e}".strip()
-            handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
-                request.context, "opencode", message
+            await emit_backend_failure(
+                self.controller,
+                request.context,
+                self.name,
+                str(e),
+                display_text=message,
+                request=request,
             )
-            if not handled:
-                await self.controller.emit_agent_message(
-                    request.context,
-                    "result",
-                    message,
-                    is_error=True,
-                    output=terminal_output_for(request),
-                )
             await self._remove_ack_reaction(request)
             return
         if not session_id:
-            await self.controller.emit_agent_message(
+            await emit_backend_failure(
+                self.controller,
                 request.context,
-                "result",
+                self.name,
                 "Failed to obtain OpenCode session ID",
-                is_error=True,
-                output=terminal_output_for(request),
+                display_text="Failed to obtain OpenCode session ID",
+                request=request,
             )
             await self._remove_ack_reaction(request)
             return
@@ -470,25 +469,14 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 self.sessions.remove_active_poll(session_id)
 
             message = f"OpenCode request failed: {error_text}"
-            handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+            await emit_backend_failure(
+                self.controller,
                 request.context,
-                "opencode",
-                message,
+                self.name,
+                error_text,
+                display_text=message,
+                request=request,
             )
-            if not handled:
-                # Terminal failure → error RESULT so the outbound chokepoint turns
-                # the dot red (auth-classified errors settle via the recovery path).
-                await self.controller.emit_agent_message(
-                    request.context,
-                    "result",
-                    message,
-                    is_error=True,
-                    output=terminal_output_for(request),
-                )
-            # handled == True persists the durable recovery notify centrally in
-            # ``maybe_emit_auth_recovery_message`` (which also latches the turn
-            # failure for the workbench dot — auth AND non-auth); the not-handled
-            # branch persists via ``emit_agent_message`` above.
         finally:
             if run_registered:
                 await server.mark_run_inactive(session_id)

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -8,6 +8,7 @@ import time
 from typing import Any, Dict, Optional
 
 from config.v2_config import DEFAULT_OPENCODE_ERROR_RETRY_LIMIT
+from core.backend_failure import emit_backend_failure
 from core.message_context import build_context_session_key
 from core.message_output import terminal_output_for, terminal_turn_output
 from modules.agents.base import AgentRequest
@@ -85,86 +86,6 @@ class OpenCodePollLoop:
 
     def _build_restored_context(self, poll_info):
         return self._build_restored_handle(poll_info).context
-
-    def _empty_terminal_message_text(
-        self,
-        *,
-        model_dict: Optional[Dict[str, str]],
-        reasoning_effort: Optional[str],
-        detail: Optional[str] = None,
-    ) -> str:
-        provider_id = (model_dict or {}).get("providerID") or self._t("common.default")
-        model_id = (model_dict or {}).get("modelID") or self._t("common.default")
-        variant = reasoning_effort or self._t("common.default")
-        if detail:
-            return self._t(
-                "error.opencodeProviderRuntimeError",
-                provider=provider_id,
-                model=model_id,
-                variant=variant,
-                detail=detail,
-            )
-        return self._t(
-            "error.opencodeEmptyResponse",
-            provider=provider_id,
-            model=model_id,
-            variant=variant,
-        )
-
-    async def _empty_terminal_message_detail(
-        self,
-        server: OpenCodeServerManager,
-        session_id: str,
-        model_dict: Optional[Dict[str, str]] = None,
-        *,
-        since: Optional[float] = None,
-    ) -> Optional[str]:
-        try:
-            detail = await server.get_recent_session_error(session_id, since=since)
-            if detail:
-                return detail
-            provider_id = (model_dict or {}).get("providerID")
-            model_id = (model_dict or {}).get("modelID")
-            if provider_id and model_id:
-                return await server.get_provider_api_diagnostic(provider_id, model_id)
-        except Exception as err:
-            logger.debug("Failed to inspect OpenCode logs for %s: %s", session_id, err)
-        return None
-
-    async def _emit_empty_terminal_failure(
-        self,
-        *,
-        context,
-        server: OpenCodeServerManager,
-        session_id: str,
-        model_dict: Optional[Dict[str, str]],
-        reasoning_effort: Optional[str],
-        prompt_started_at: Optional[float] = None,
-    ) -> None:
-        detail = await self._empty_terminal_message_detail(
-            server,
-            session_id,
-            model_dict=model_dict,
-            since=prompt_started_at,
-        )
-        message = self._empty_terminal_message_text(
-            model_dict=model_dict,
-            reasoning_effort=reasoning_effort,
-            detail=detail,
-        )
-        await self._agent.controller.emit_agent_message(
-            context,
-            "notify",
-            message,
-        )
-        await self._agent.controller.emit_agent_message(
-            context,
-            "result",
-            message,
-            is_error=True,
-            level="silent",
-            output=terminal_turn_output(),
-        )
 
     def _build_restored_ack_request(self, poll_info) -> AgentRequest:
         handle = self._build_restored_handle(poll_info)
@@ -251,8 +172,6 @@ class OpenCodePollLoop:
         emitted_assistant_messages: set[str] = set()
         poll_interval_seconds = 2.0
         final_text: Optional[str] = None
-        get_started_at = getattr(server, "get_last_prompt_started_at", None)
-        prompt_started_at = get_started_at(session_id) if callable(get_started_at) else None
 
         error_retry_count = 0
         error_retry_limit = getattr(
@@ -409,23 +328,17 @@ class OpenCodePollLoop:
                                     retry_err,
                                 )
 
-                        message = f"OpenCode error: {error_name} - {error_msg[:500]}"
-                        handled = await self._agent.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+                        diagnostic = f"{error_name} - {error_msg[:500]}".strip(" -")
+                        message = f"OpenCode error: {diagnostic}"
+                        await emit_backend_failure(
+                            self._agent.controller,
                             request.context,
                             "opencode",
-                            message,
+                            diagnostic,
+                            display_text=message,
+                            request=request,
+                            failure_id=str(last_id or ""),
                         )
-                        if not handled:
-                            # Retry exhausted on a message error → terminal FAILURE.
-                            # Emit an ERROR result so the outbound chokepoint turns the
-                            # dot red (a bare notify never settles agent_status) (Codex P2).
-                            await self._agent.controller.emit_agent_message(
-                                request.context,
-                                "result",
-                                message,
-                                is_error=True,
-                                output=terminal_output_for(request),
-                            )
                         # Terminal: stop polling AND signal the caller NOT to emit the
                         # "(No response from OpenCode)" warning result — that warning is
                         # idle and would reset the dot we (or the auth-recovery path)
@@ -459,15 +372,7 @@ class OpenCodePollLoop:
                                 (model_dict or {}).get("modelID"),
                                 reasoning_effort,
                             )
-                            await self._emit_empty_terminal_failure(
-                                context=request.context,
-                                server=server,
-                                session_id=session_id,
-                                model_dict=model_dict,
-                                reasoning_effort=reasoning_effort,
-                                prompt_started_at=prompt_started_at,
-                            )
-                            return None, False
+                            break
                         break
 
             await asyncio.sleep(poll_interval_seconds)
@@ -478,7 +383,8 @@ class OpenCodePollLoop:
         """Continue a poll loop that was interrupted by restart."""
 
         session_id = poll_info.opencode_session_id
-        context = self._build_restored_context(poll_info)
+        restored_request = self._build_restored_ack_request(poll_info)
+        context = restored_request.context
 
         await self._agent.controller.emit_agent_message(
             context,
@@ -492,10 +398,6 @@ class OpenCodePollLoop:
         emitted_assistant_messages = set(poll_info.emitted_assistant_messages)
         poll_interval_seconds = 2.0
         final_text: Optional[str] = None
-        get_started_at = getattr(server, "get_last_prompt_started_at", None)
-        prompt_started_at = getattr(poll_info, "prompt_started_at", None) or (
-            get_started_at(session_id) if callable(get_started_at) else None
-        )
 
         error_retry_count = 0
         error_retry_limit = getattr(
@@ -619,23 +521,15 @@ class OpenCodePollLoop:
                                 error_retry_count += 1
                                 if error_retry_count > error_retry_limit:
                                     message = f"OpenCode error: {error_text}"
-                                    handled = await self._agent.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+                                    await emit_backend_failure(
+                                        self._agent.controller,
                                         context,
                                         "opencode",
-                                        message,
+                                        error_text,
+                                        display_text=message,
+                                        request=restored_request,
+                                        failure_id=str(last_info.get("id") or ""),
                                     )
-                                    if not handled:
-                                        # Terminal failure (retry exhausted) on the
-                                        # restored poll path → ERROR result so the dot
-                                        # turns red, not a notify that leaves it
-                                        # running until the safety timeout (Codex P2).
-                                        await self._agent.controller.emit_agent_message(
-                                            context,
-                                            "result",
-                                            message,
-                                            is_error=True,
-                                            output=terminal_turn_output(),
-                                        )
                                     self._agent.sessions.remove_active_poll(session_id)
                                     await self.remove_restored_ack(poll_info)
                                     return
@@ -662,17 +556,7 @@ class OpenCodePollLoop:
                                         "Restored OpenCode session %s completed without text/error",
                                         session_id,
                                     )
-                                    await self._emit_empty_terminal_failure(
-                                        context=context,
-                                        server=server,
-                                        session_id=session_id,
-                                        model_dict=getattr(poll_info, "model_dict", None),
-                                        reasoning_effort=getattr(poll_info, "reasoning_effort", None),
-                                        prompt_started_at=prompt_started_at,
-                                    )
-                                    self._agent.sessions.remove_active_poll(session_id)
-                                    await self.remove_restored_ack(poll_info)
-                                    return
+                                    break
                                 break
 
                 await asyncio.sleep(poll_interval_seconds)
@@ -717,18 +601,12 @@ class OpenCodePollLoop:
             await self.remove_restored_ack(poll_info)
 
             message = f"Restored OpenCode session failed: {error_text}"
-            handled = await self._agent.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+            await emit_backend_failure(
+                self._agent.controller,
                 context,
                 "opencode",
-                message,
+                error_text,
+                display_text=message,
+                request=restored_request,
+                failure_id=session_id,
             )
-            if not handled:
-                # Terminal failure → error RESULT so the outbound chokepoint turns
-                # the dot red (auth-classified errors settle via the recovery path).
-                await self._agent.controller.emit_agent_message(
-                    context,
-                    "result",
-                    message,
-                    is_error=True,
-                    output=terminal_turn_output(),
-                )

--- a/storage/background.py
+++ b/storage/background.py
@@ -1199,6 +1199,7 @@ class SQLiteBackgroundTaskStore:
         text: str,
         message_id: str | None = None,
         terminal_status: Optional[str] = None,
+        error: Optional[str] = None,
         updated_at: Optional[str] = None,
     ) -> None:
         now = updated_at or _utc_now_iso()
@@ -1224,6 +1225,8 @@ class SQLiteBackgroundTaskStore:
             if terminal_status:
                 values["status"] = normalize_run_status(terminal_status)
                 values["completed_at"] = now
+                if error is not None:
+                    values["error"] = str(error)
             result = conn.execute(
                 update(agent_runs)
                 .where(agent_runs.c.id == run_id)
@@ -1245,6 +1248,7 @@ class SQLiteBackgroundTaskStore:
         sequence: int | None = None,
         provenance: Optional[dict[str, Any]] = None,
         terminal_status: Optional[str] = None,
+        error: Optional[str] = None,
         updated_at: Optional[str] = None,
     ) -> dict[str, Any]:
         """Append one idempotent Run output and optionally settle the Run once."""
@@ -1325,6 +1329,13 @@ class SQLiteBackgroundTaskStore:
                     .values(**values)
                 )
             if effective_terminal_status:
+                terminal_values: dict[str, Any] = {
+                    "status": normalize_run_status(effective_terminal_status),
+                    "completed_at": now,
+                    "updated_at": now,
+                }
+                if error is not None:
+                    terminal_values["error"] = str(error)
                 transition = conn.execute(
                     update(agent_runs)
                     .where(agent_runs.c.id == run_id)
@@ -1334,11 +1345,7 @@ class SQLiteBackgroundTaskStore:
                             + _status_query_values("running")
                         )
                     )
-                    .values(
-                        status=normalize_run_status(effective_terminal_status),
-                        completed_at=now,
-                        updated_at=now,
-                    )
+                    .values(**terminal_values)
                 )
                 terminal_transition = bool(transition.rowcount)
 

--- a/storage/background.py
+++ b/storage/background.py
@@ -1277,11 +1277,15 @@ class SQLiteBackgroundTaskStore:
                 result_payload = {}
             payload_changed = False
             effective_terminal_status = terminal_status
+            effective_terminal_error = error
             if terminal_status and "deferred_terminal_status" in result_payload:
                 effective_terminal_status = _stronger_terminal_status(
                     result_payload.pop("deferred_terminal_status", None),
                     terminal_status,
                 )
+                deferred_error = result_payload.pop("deferred_terminal_error", None)
+                if deferred_error is not None:
+                    effective_terminal_error = str(deferred_error)
                 payload_changed = True
             raw_outputs = result_payload.get("outputs")
             outputs = [dict(item) for item in raw_outputs if isinstance(item, dict)] if isinstance(raw_outputs, list) else []
@@ -1334,8 +1338,8 @@ class SQLiteBackgroundTaskStore:
                     "completed_at": now,
                     "updated_at": now,
                 }
-                if error is not None:
-                    terminal_values["error"] = str(error)
+                if effective_terminal_error is not None:
+                    terminal_values["error"] = str(effective_terminal_error)
                 transition = conn.execute(
                     update(agent_runs)
                     .where(agent_runs.c.id == run_id)
@@ -1370,9 +1374,10 @@ class SQLiteBackgroundTaskStore:
         run_id: str,
         *,
         terminal_status: str,
+        error: Optional[str] = None,
         updated_at: Optional[str] = None,
     ) -> bool:
-        """Remember a terminal intent while an owned Activity still blocks it."""
+        """Remember a terminal intent and diagnostic while an Activity blocks it."""
 
         now = updated_at or _utc_now_iso()
         row_to_publish = None
@@ -1393,9 +1398,17 @@ class SQLiteBackgroundTaskStore:
                 result_payload.get("deferred_terminal_status"),
                 terminal_status,
             )
-            if result_payload.get("deferred_terminal_status") == normalized:
+            status_changed = result_payload.get("deferred_terminal_status") != normalized
+            error_text = str(error) if error is not None else None
+            error_changed = bool(
+                error_text is not None
+                and not result_payload.get("deferred_terminal_error")
+            )
+            if not status_changed and not error_changed:
                 return False
             result_payload["deferred_terminal_status"] = normalized
+            if error_changed:
+                result_payload["deferred_terminal_error"] = error_text
             conn.execute(
                 update(agent_runs)
                 .where(agent_runs.c.id == run_id)
@@ -1438,6 +1451,7 @@ class SQLiteBackgroundTaskStore:
             if not deferred_status:
                 return False
             result_payload.pop("deferred_terminal_status", None)
+            deferred_error = result_payload.pop("deferred_terminal_error", None)
             status = (
                 _stronger_terminal_status(deferred_status, terminal_status)
                 if terminal_status
@@ -1449,8 +1463,9 @@ class SQLiteBackgroundTaskStore:
                 "updated_at": now,
                 "result_payload_json": _json_dumps(result_payload),
             }
-            if error is not None:
-                values["error"] = error
+            effective_error = deferred_error if deferred_error is not None else error
+            if effective_error is not None:
+                values["error"] = str(effective_error)
             transition = conn.execute(
                 update(agent_runs)
                 .where(agent_runs.c.id == run_id)

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -219,7 +219,9 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
             "result",
             "",
             is_error=True,
+            level="silent",
             output=ANY,
+            terminal_error="❌ Codex error: 401 Unauthorized",
         )
 
     async def test_maybe_emit_auth_recovery_message_defers_non_auth_error_to_caller(self):

--- a/tests/test_backend_failure.py
+++ b/tests/test_backend_failure.py
@@ -119,6 +119,14 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
             "backend-failure:turn-1",
         )
         self.assertEqual(
+            notify_call.kwargs["output"].metadata,
+            {
+                "backend": "codex",
+                "event": "backend_failure",
+                "failure_id": "turn-1",
+            },
+        )
+        self.assertEqual(
             terminal_call,
             call(
                 request.context,

--- a/tests/test_backend_failure.py
+++ b/tests/test_backend_failure.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, call
+
+from core.backend_failure import emit_backend_failure
+from modules.agents.base import AgentRequest
+from modules.im import MessageContext
+
+
+def _request() -> AgentRequest:
+    context = MessageContext(
+        user_id="U1",
+        channel_id="C1",
+        platform="avibe",
+        platform_specific={"turn_token": "turn-1"},
+    )
+    return AgentRequest(
+        context=context,
+        message="work",
+        working_path="/tmp/work",
+        base_session_id="session-1",
+        composite_session_id="session-1:/tmp/work",
+        session_key="avibe::project::p1",
+    )
+
+
+class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_auth_recovery_owns_the_only_terminal_settlement(self) -> None:
+        request = _request()
+        controller = SimpleNamespace(
+            agent_auth_service=SimpleNamespace(
+                maybe_emit_auth_recovery_message=AsyncMock(return_value=True)
+            ),
+            emit_agent_message=AsyncMock(),
+        )
+
+        handled_auth = await emit_backend_failure(
+            controller,
+            request.context,
+            "claude",
+            "401 Unauthorized",
+            request=request,
+        )
+
+        self.assertTrue(handled_auth)
+        controller.emit_agent_message.assert_not_awaited()
+
+    async def test_separates_notify_from_terminal_settlement(self) -> None:
+        request = _request()
+        controller = SimpleNamespace(
+            agent_auth_service=SimpleNamespace(
+                maybe_emit_auth_recovery_message=AsyncMock(return_value=False)
+            ),
+            emit_agent_message=AsyncMock(),
+        )
+
+        handled_auth = await emit_backend_failure(
+            controller,
+            request.context,
+            "codex",
+            "provider unavailable",
+            display_text="Codex failed: provider unavailable",
+            request=request,
+        )
+
+        self.assertFalse(handled_auth)
+        auth_call = controller.agent_auth_service.maybe_emit_auth_recovery_message.await_args
+        self.assertEqual(
+            auth_call.args,
+            (request.context, "codex", "Codex failed: provider unavailable"),
+        )
+        self.assertEqual(auth_call.kwargs["terminal_error"], "provider unavailable")
+        terminal_output = auth_call.kwargs["output"]
+        notify_call, terminal_call = controller.emit_agent_message.await_args_list
+        self.assertEqual(
+            notify_call,
+            call(
+                request.context,
+                "notify",
+                "Codex failed: provider unavailable",
+                output=ANY,
+            ),
+        )
+        self.assertFalse(notify_call.kwargs["output"].settles_run)
+        self.assertEqual(
+            notify_call.kwargs["output"].idempotency_key,
+            "backend-failure:turn-1",
+        )
+        self.assertEqual(
+            terminal_call,
+            call(
+                request.context,
+                "result",
+                "",
+                is_error=True,
+                level="silent",
+                output=terminal_output,
+                terminal_error="provider unavailable",
+            ),
+        )
+
+    async def test_identity_is_stable_for_duplicate_terminal_events(self) -> None:
+        request = _request()
+        controller = SimpleNamespace(
+            agent_auth_service=SimpleNamespace(
+                maybe_emit_auth_recovery_message=AsyncMock(return_value=False)
+            ),
+            emit_agent_message=AsyncMock(),
+        )
+
+        await emit_backend_failure(controller, request.context, "claude", "server error", request=request)
+        await emit_backend_failure(controller, request.context, "claude", "server error", request=request)
+
+        notify_outputs = [
+            item.kwargs["output"]
+            for item in controller.emit_agent_message.await_args_list
+            if item.args[1] == "notify"
+        ]
+        self.assertEqual(
+            [output.idempotency_key for output in notify_outputs],
+            ["backend-failure:turn-1", "backend-failure:turn-1"],
+        )
+
+    async def test_settles_lifecycle_when_notify_raises(self) -> None:
+        request = _request()
+        terminal_calls = []
+
+        async def emit(_context, message_type, _text, **kwargs):
+            if message_type == "notify":
+                raise RuntimeError("delivery unavailable")
+            terminal_calls.append(kwargs)
+
+        controller = SimpleNamespace(
+            agent_auth_service=SimpleNamespace(
+                maybe_emit_auth_recovery_message=AsyncMock(return_value=False)
+            ),
+            emit_agent_message=emit,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "delivery unavailable"):
+            await emit_backend_failure(
+                controller,
+                request.context,
+                "opencode",
+                "transport failed",
+                request=request,
+            )
+
+        self.assertEqual(
+            terminal_calls,
+            [
+                {
+                    "is_error": True,
+                    "level": "silent",
+                    "output": request.output,
+                    "terminal_error": "transport failed",
+                }
+            ],
+        )

--- a/tests/test_backend_failure.py
+++ b/tests/test_backend_failure.py
@@ -47,6 +47,36 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(handled_auth)
         controller.emit_agent_message.assert_not_awaited()
 
+    async def test_settles_lifecycle_when_auth_recovery_delivery_raises(self) -> None:
+        request = _request()
+        controller = SimpleNamespace(
+            agent_auth_service=SimpleNamespace(
+                maybe_emit_auth_recovery_message=AsyncMock(
+                    side_effect=RuntimeError("button delivery unavailable")
+                )
+            ),
+            emit_agent_message=AsyncMock(),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "button delivery unavailable"):
+            await emit_backend_failure(
+                controller,
+                request.context,
+                "codex",
+                "401 Unauthorized",
+                request=request,
+            )
+
+        controller.emit_agent_message.assert_awaited_once_with(
+            request.context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
+            output=request.output,
+            terminal_error="401 Unauthorized",
+        )
+
     async def test_separates_notify_from_terminal_settlement(self) -> None:
         request = _request()
         controller = SimpleNamespace(

--- a/tests/test_claude_agent_initiated_turn.py
+++ b/tests/test_claude_agent_initiated_turn.py
@@ -209,7 +209,7 @@ def _build_agent(*, running_calls=None, mark_idle_calls=None, active_calls=None)
     agent._maybe_capture_session_id = lambda *a, **k: None
     agent._consume_suppressed_synthetic_result = lambda *a, **k: False
     agent._handle_auth_failure_result = AsyncMock(return_value=False)
-    agent._handle_synthetic_api_error_message = AsyncMock(return_value=False)
+    agent._handle_assistant_terminal_failure = AsyncMock(return_value=False)
     agent._reserved_native_session_id = lambda *a, **k: None
     agent._adopt_pending_turn_token = lambda *a, **k: None
     agent._get_formatter = lambda context: None

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -101,6 +101,16 @@ class _StubController:
 
 
 class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
+    def assert_backend_failure_emitted(self, emitter, context, display_text, diagnostic):
+        self.assertEqual(emitter.await_count, 2)
+        notify_call, terminal_call = emitter.await_args_list
+        self.assertEqual(notify_call.args[:3], (context, "notify", display_text))
+        self.assertFalse(notify_call.kwargs["output"].settles_run)
+        self.assertEqual(terminal_call.args[:3], (context, "result", ""))
+        self.assertTrue(terminal_call.kwargs["is_error"])
+        self.assertEqual(terminal_call.kwargs["level"], "silent")
+        self.assertEqual(terminal_call.kwargs["terminal_error"], diagnostic)
+
     async def test_handle_message_serializes_queries_for_same_runtime_session(self):
         controller = _StubController()
         runtime_key = "wechat_o9:/tmp/work"
@@ -348,7 +358,15 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(queries, [("first", runtime_key)])
         self.assertEqual(mark_active_calls, [runtime_key])
         self.assertIn(runtime_key, mark_idle_calls)
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        controller.emit_agent_message.assert_awaited_once_with(
+            context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
+            output=ANY,
+            terminal_error="Claude receiver ended without a terminal result",
+        )
         agent._remove_ack_reaction.assert_awaited_once_with(request)
         self.assertNotIn(runtime_key, agent._pending_requests)
         self.assertNotIn(runtime_key, controller.claude_sessions)
@@ -1219,7 +1237,15 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             await agent._receive_messages(_FailingClient(), "session-1", "/tmp/work", context)
 
         agent.session_handler.handle_session_error.assert_awaited_once()
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        controller.emit_agent_message.assert_awaited_once_with(
+            context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
+            output=ANY,
+            terminal_error="Connection lost",
+        )
         persist.assert_called_once()
         self.assertEqual(persist.call_args.args[1], "notify")
         self.assertEqual(persist.call_args.args[2], "❌ Claude error: Connection lost")
@@ -1253,11 +1279,22 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             await agent._receive_messages(_FailingClient(), "session-1", "/tmp/work", context)
 
         agent.session_handler.handle_session_error.assert_awaited_once()
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        terminal_error = "Failed to decode JSON: JSON message exceeded maximum buffer size of 1048576 bytes"
+        controller.emit_agent_message.assert_awaited_once_with(
+            context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
+            output=ANY,
+            terminal_error=terminal_error,
+        )
         controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once_with(
             context,
             "claude",
             "❌ Connection to Claude was lost. Please try your message again.",
+            output=ANY,
+            terminal_error=terminal_error,
         )
         persist.assert_called_once_with(
             context,
@@ -1678,7 +1715,15 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         await asyncio.wait_for(receiver_task, timeout=1)
 
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        controller.emit_agent_message.assert_awaited_once_with(
+            context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
+            output=ANY,
+            terminal_error="Claude receiver ended without a terminal result",
+        )
         self.assertFalse(service._turn_gates[composite_key].lock.locked())
         self.assertNotIn(composite_key, controller.claude_sessions)
         self.assertNotIn(composite_key, agent._pending_requests)
@@ -1852,7 +1897,15 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         await asyncio.wait_for(receiver_task, timeout=1)
 
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        controller.emit_agent_message.assert_awaited_once_with(
+            context,
+            "result",
+            "",
+            is_error=True,
+            level="silent",
+            output=ANY,
+            terminal_error="Claude receiver ended without a terminal result",
+        )
         self.assertEqual(context.platform_specific["turn_token"], "current-turn")
         self.assertEqual(context.platform_specific["agent_runtime_turn_token"], "current-runtime")
         self.assertFalse(service._turn_gates[composite_key].lock.locked())
@@ -1993,7 +2046,12 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
 
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        self.assert_backend_failure_emitted(
+            controller.emit_agent_message,
+            context,
+            f"❌ Claude error: {error_text}",
+            error_text,
+        )
         agent.emit_result_message.assert_not_awaited()
         agent._remove_ack_reaction.assert_awaited_once_with(pending_request)
         self.assertEqual(context.platform_specific["turn_token"], "T1")
@@ -2048,7 +2106,12 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
 
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        self.assert_backend_failure_emitted(
+            controller.emit_agent_message,
+            context,
+            f"❌ Claude error: {error_text}",
+            error_text,
+        )
         agent.emit_result_message.assert_not_awaited()
         self.assertEqual(agent._pending_requests[composite_key], [next_request])
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
@@ -2106,7 +2169,13 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
 
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        diagnostic = "The model's tool call could not be parsed (retry also failed)."
+        self.assert_backend_failure_emitted(
+            controller.emit_agent_message,
+            context,
+            f"❌ Claude error: {diagnostic}",
+            diagnostic,
+        )
         agent.emit_result_message.assert_not_awaited()
         self.assertEqual(agent._pending_requests[composite_key], [next_request])
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
@@ -2178,7 +2247,13 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         client.ready.set()
         await receiver_task
 
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        diagnostic = "The model's tool call could not be parsed (retry also failed)."
+        self.assert_backend_failure_emitted(
+            controller.emit_agent_message,
+            context,
+            f"❌ Claude error: {diagnostic}",
+            diagnostic,
+        )
         agent.emit_result_message.assert_not_awaited()
         self.assertEqual(agent._pending_requests[composite_key], [followup_request])
         self.assertEqual(agent._pending_reactions[composite_key], [("m2", ":eyes:")])
@@ -2251,7 +2326,13 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         client.ready.set()
         await receiver_task
 
-        controller.emit_agent_message.assert_awaited_once_with(context, "result", "", is_error=True, output=ANY)
+        diagnostic = "The model's tool call could not be parsed (retry also failed)."
+        self.assert_backend_failure_emitted(
+            controller.emit_agent_message,
+            context,
+            f"❌ Claude error: {diagnostic}",
+            diagnostic,
+        )
         agent.emit_result_message.assert_awaited_once_with(
             context,
             "next turn result",
@@ -2339,13 +2420,13 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn(composite_key, agent._pending_requests)
 
-    async def test_non_malformed_synthetic_api_error_remains_visible(self):
+    async def test_synthetic_server_error_notifies_and_suppresses_paired_result(self):
         controller = _StubController()
         controller._get_session_key = lambda context: "avibe::project::p1"
         controller.emit_agent_message = AsyncMock()
         agent = ClaudeAgent(controller)
         agent.emit_result_message = AsyncMock()
-        error_text = "Claude API rate_limit: retry later."
+        error_text = "API Error: 503 provider unavailable"
         agent._extract_text_blocks = lambda message, context: error_text
         context = SimpleNamespace(
             user_id="U1",
@@ -2364,7 +2445,8 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
                 "content": [],
                 "isApiErrorMessage": True,
                 "model": "<synthetic>",
-                "error": "rate_limit",
+                "error": "server_error",
+                "api_error_status": 503,
             },
         )()
         result_message = type(
@@ -2383,16 +2465,97 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
 
-        controller.emit_agent_message.assert_not_awaited()
+        controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once_with(
+            context,
+            "claude",
+            f"❌ Claude error: {error_text}",
+            output=ANY,
+            terminal_error=error_text,
+        )
+        self.assertEqual(controller.emit_agent_message.await_count, 2)
+        notify_call, terminal_call = controller.emit_agent_message.await_args_list
+        self.assertEqual(notify_call.args[:3], (context, "notify", f"❌ Claude error: {error_text}"))
+        self.assertFalse(notify_call.kwargs["output"].settles_run)
+        self.assertEqual(terminal_call.args[:3], (context, "result", ""))
+        self.assertTrue(terminal_call.kwargs["is_error"])
+        self.assertEqual(terminal_call.kwargs["level"], "silent")
+        self.assertEqual(terminal_call.kwargs["terminal_error"], error_text)
+        agent.emit_result_message.assert_not_awaited()
+        self.assertNotIn(composite_key, agent._pending_requests)
+
+    async def test_result_is_error_fails_without_error_subtype(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent.emit_result_message = AsyncMock()
+        context = SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={})
+        composite_key = "session-1:/tmp/work"
+        pending_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        agent._pending_requests[composite_key] = [pending_request]
+        result_message = type(
+            "ResultMessage",
+            (),
+            {
+                "subtype": "success",
+                "is_error": True,
+                "result": "provider rejected the request",
+                "duration_ms": 1,
+            },
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield result_message
+
+                return _iterate()
+
+        await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
+        self.assertEqual(controller.emit_agent_message.await_count, 2)
+        agent.emit_result_message.assert_not_awaited()
+        terminal_call = controller.emit_agent_message.await_args_list[1]
+        self.assertEqual(terminal_call.kwargs["terminal_error"], "provider rejected the request")
+
+    async def test_success_result_with_error_words_remains_agent_output(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "avibe::project::p1"
+        controller.emit_agent_message = AsyncMock()
+        agent = ClaudeAgent(controller)
+        agent.emit_result_message = AsyncMock()
+        context = SimpleNamespace(user_id="U1", channel_id="C1", platform_specific={})
+        composite_key = "session-1:/tmp/work"
+        pending_request = SimpleNamespace(context=SimpleNamespace(platform_specific={"turn_token": "T1"}))
+        agent._pending_requests[composite_key] = [pending_request]
+        result_message = type(
+            "ResultMessage",
+            (),
+            {
+                "subtype": "success",
+                "is_error": False,
+                "result": "The test failed with an error; I fixed it.",
+                "duration_ms": 1,
+            },
+        )()
+
+        class _Client:
+            def receive_messages(self):
+                async def _iterate():
+                    yield result_message
+
+                return _iterate()
+
+        await agent._receive_messages(_Client(), "session-1", "/tmp/work", context, composite_key=composite_key)
+
         agent.emit_result_message.assert_awaited_once_with(
             context,
-            error_text,
-            subtype="error",
+            "The test failed with an error; I fixed it.",
+            subtype="success",
             duration_ms=1,
             parse_mode="markdown",
             request=pending_request,
         )
-        self.assertNotIn(composite_key, agent._pending_requests)
 
     async def test_assistant_auth_error_without_is_api_error_flag_still_triggers_recovery(self):
         """Scenario: AUTH-SETUP-902"""

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -836,12 +836,21 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         agent._pending_requests[runtime_key] = [queued_request]
         agent._pending_reactions[runtime_key] = [("m2", ":eyes:")]
 
-        await agent.handle_message(request)
+        with patch("core.message_mirror.persist_agent_message") as persist:
+            await agent.handle_message(request)
 
         self.assertEqual(mark_idle_calls, [])
         self.assertEqual(agent._pending_requests[runtime_key], [queued_request])
         self.assertEqual(agent._pending_reactions[runtime_key], [("m2", ":eyes:")])
         agent._remove_ack_reaction.assert_awaited_once_with(request)
+        persist.assert_called_once()
+        self.assertEqual(persist.call_args.args[1:], ("notify", "❌ Claude error: boom"))
+        self.assertEqual(persist.call_args.kwargs["metadata"]["backend"], "claude")
+        self.assertEqual(persist.call_args.kwargs["metadata"]["event"], "backend_failure")
+        self.assertTrue(persist.call_args.kwargs["metadata"]["failure_id"])
+        self.assertTrue(
+            persist.call_args.kwargs["native_message_id"].startswith("backend-failure:")
+        )
 
     async def test_clear_sessions_cancels_receiver_tasks_for_cleared_session(self):
         controller = _StubController()
@@ -1249,6 +1258,12 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         persist.assert_called_once()
         self.assertEqual(persist.call_args.args[1], "notify")
         self.assertEqual(persist.call_args.args[2], "❌ Claude error: Connection lost")
+        self.assertEqual(persist.call_args.kwargs["metadata"]["backend"], "claude")
+        self.assertEqual(persist.call_args.kwargs["metadata"]["event"], "backend_failure")
+        self.assertTrue(persist.call_args.kwargs["metadata"]["failure_id"])
+        self.assertTrue(
+            persist.call_args.kwargs["native_message_id"].startswith("backend-failure:")
+        )
 
     async def test_receiver_buffer_error_persists_connection_lost_notify(self):
         controller = _StubController()
@@ -1296,10 +1311,20 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             output=ANY,
             terminal_error=terminal_error,
         )
-        persist.assert_called_once_with(
-            context,
-            "notify",
-            "❌ Connection to Claude was lost. Please try your message again.",
+        persist.assert_called_once()
+        self.assertEqual(
+            persist.call_args.args,
+            (
+                context,
+                "notify",
+                "❌ Connection to Claude was lost. Please try your message again.",
+            ),
+        )
+        self.assertEqual(persist.call_args.kwargs["metadata"]["backend"], "claude")
+        self.assertEqual(persist.call_args.kwargs["metadata"]["event"], "backend_failure")
+        self.assertTrue(persist.call_args.kwargs["metadata"]["failure_id"])
+        self.assertTrue(
+            persist.call_args.kwargs["native_message_id"].startswith("backend-failure:")
         )
 
     async def test_result_auth_error_prefers_oauth_recovery_message(self):

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1999,7 +1999,13 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         await agent._receive_messages(_Client(), "session-1", "/tmp/work", context)
 
-        controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
+        controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once_with(
+            context,
+            "claude",
+            "❌ Claude error: OAuth authentication failed.",
+            output=ANY,
+            terminal_error="OAuth authentication failed.",
+        )
         agent._remove_ack_reaction.assert_awaited_once_with(pending_request)
         self.assertNotIn(composite_key, controller.receiver_tasks)
         self.assertNotIn(composite_key, controller.claude_sessions)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -904,15 +904,20 @@ class CodexAgentHandleMessageTests(unittest.IsolatedAsyncioTestCase):
 
         agent._event_handler.clear_pending.assert_not_called()
         agent._remove_ack_reaction.assert_awaited_once_with(request)
-        # The failed interrupt is a terminal failure → emitted as an ERROR result
-        # (the outbound status chokepoint turns the dot red), not a bare notify.
-        agent.controller.emit_agent_message.assert_awaited_once_with(
-            request.context,
-            "result",
-            "❌ Failed to interrupt previous Codex turn: interrupt failed",
-            is_error=True,
-            output=ANY,
+        self.assertEqual(agent.controller.emit_agent_message.await_count, 2)
+        notify_call, terminal_call = agent.controller.emit_agent_message.await_args_list
+        self.assertEqual(
+            notify_call.args[:3],
+            (
+                request.context,
+                "notify",
+                "❌ Failed to interrupt previous Codex turn: interrupt failed",
+            ),
         )
+        self.assertEqual(terminal_call.args[:3], (request.context, "result", ""))
+        self.assertTrue(terminal_call.kwargs["is_error"])
+        self.assertEqual(terminal_call.kwargs["level"], "silent")
+        self.assertEqual(terminal_call.kwargs["terminal_error"], "interrupt failed")
 
     async def test_handle_message_recovers_from_broken_transport_once(self):
         agent = object.__new__(CodexAgent)

--- a/tests/test_codex_event_handler.py
+++ b/tests/test_codex_event_handler.py
@@ -179,14 +179,19 @@ class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
             request.context,
             "codex",
             "❌ Codex turn failed: unexpected status 401 Unauthorized:",
-        )
-        agent.controller.emit_agent_message.assert_awaited_once_with(
-            request.context,
-            "result",
-            "❌ Codex turn failed: unexpected status 401 Unauthorized:",
-            is_error=True,
             output=ANY,
+            terminal_error="unexpected status 401 Unauthorized:",
         )
+        self.assertEqual(agent.controller.emit_agent_message.await_count, 2)
+        notify_call, terminal_call = agent.controller.emit_agent_message.await_args_list
+        self.assertEqual(
+            notify_call.args[:3],
+            (request.context, "notify", "❌ Codex turn failed: unexpected status 401 Unauthorized:"),
+        )
+        self.assertEqual(terminal_call.args[:3], (request.context, "result", ""))
+        self.assertTrue(terminal_call.kwargs["is_error"])
+        self.assertEqual(terminal_call.kwargs["level"], "silent")
+        self.assertEqual(terminal_call.kwargs["terminal_error"], "unexpected status 401 Unauthorized:")
 
         await handler._on_turn_completed(
             {
@@ -199,7 +204,7 @@ class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
             request,
         )
 
-        assert agent.controller.emit_agent_message.await_count == 1
+        assert agent.controller.emit_agent_message.await_count == 2
         agent._remove_ack_reaction.assert_awaited_once_with(request)
 
     async def test_turn_failure_falls_back_to_completion_error_when_no_error_notification_arrives(self):
@@ -223,16 +228,17 @@ class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
             request.context,
             "codex",
             "❌ Codex turn failed: fallback message",
-        )
-        # Terminal failure → error RESULT (the outbound status chokepoint turns
-        # the dot red), not a bare notify.
-        agent.controller.emit_agent_message.assert_awaited_once_with(
-            request.context,
-            "result",
-            "❌ Codex turn failed: fallback message",
-            is_error=True,
             output=ANY,
+            terminal_error="fallback message",
         )
+        self.assertEqual(agent.controller.emit_agent_message.await_count, 2)
+        notify_call, terminal_call = agent.controller.emit_agent_message.await_args_list
+        self.assertEqual(
+            notify_call.args[:3],
+            (request.context, "notify", "❌ Codex turn failed: fallback message"),
+        )
+        self.assertEqual(terminal_call.args[:3], (request.context, "result", ""))
+        self.assertEqual(terminal_call.kwargs["terminal_error"], "fallback message")
         agent._remove_ack_reaction.assert_awaited_once_with(request)
 
     async def test_unknown_turn_error_is_logged_without_emitting(self):

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -312,6 +312,7 @@ class MessageDispatcherResultFallbackTests(unittest.IsolatedAsyncioTestCase):
             "already delivered",
             None,
             is_error=False,
+            terminal_error=None,
             output_semantics=output,
         )
         dispatcher._collapse_status_bubble.assert_awaited_once()

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -772,6 +772,26 @@ class MessageDispatcherStatusChokepointTests(unittest.IsolatedAsyncioTestCase):
             await dispatcher.emit_agent_message(_avibe_ctx(), "result", "", is_error=True)
         self.assertEqual(controller.status_calls, [("ses-1", "failed")])
 
+    async def test_silent_backend_failure_collapses_status_as_failed(self):
+        controller = _AvibeStatusController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        dispatcher._collapse_status_bubble = mock.AsyncMock()
+        context = _avibe_ctx()
+        with mock.patch("core.message_dispatcher.persist_agent_message"):
+            await dispatcher.emit_agent_message(
+                context,
+                "result",
+                "",
+                is_error=True,
+                level="silent",
+                terminal_error="provider unavailable",
+            )
+        dispatcher._collapse_status_bubble.assert_awaited_once_with(
+            context,
+            controller.im_client,
+            reason="failed",
+        )
+
     async def test_notify_does_not_settle_dot(self):
         controller = _AvibeStatusController()
         dispatcher = ConsolidatedMessageDispatcher(controller)

--- a/tests/test_message_dispatcher_scheduled.py
+++ b/tests/test_message_dispatcher_scheduled.py
@@ -194,6 +194,105 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(message_id)
         self.assertEqual(calls, [("run-empty", "", "succeeded")])
 
+    async def test_terminal_failure_records_explicit_run_error_without_result_text(self):
+        controller = _StubController()
+        controller.agent_service = SimpleNamespace(
+            activities=SimpleNamespace(has_blocking_run_activity=lambda _run_id: False),
+            emit_matches_runtime_turn=lambda _context: True,
+            release_runtime_turn=lambda _context: None,
+        )
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-failed",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def get_run(self, run_id):
+                return {"status": "running"}
+
+            def record_run_output(self, run_id, **kwargs):
+                calls.append((run_id, kwargs))
+
+            def close(self):
+                pass
+
+        with patch.object(
+            message_dispatcher_module,
+            "SQLiteBackgroundTaskStore",
+            return_value=_Store(),
+        ):
+            await dispatcher.emit_agent_message(
+                context,
+                "result",
+                "",
+                is_error=True,
+                level="silent",
+                output=MessageOutput(completes_turn=True, completes_run=True),
+                terminal_error="provider unavailable",
+            )
+
+        self.assertEqual(len(calls), 1)
+        run_id, payload = calls[0]
+        self.assertEqual(run_id, "run-failed")
+        self.assertEqual(payload["text"], "")
+        self.assertEqual(payload["terminal_status"], "failed")
+        self.assertEqual(payload["error"], "provider unavailable")
+
+    async def test_notify_output_uses_stable_persistence_identity(self):
+        controller = _StubController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+        )
+        persisted_ids = set()
+        persisted = []
+
+        def exists(_context, native_message_id):
+            return native_message_id in persisted_ids
+
+        def persist(_context, message_type, text, **kwargs):
+            native_message_id = kwargs["native_message_id"]
+            persisted_ids.add(native_message_id)
+            persisted.append((message_type, text, kwargs))
+            return {"id": "row-1"}
+
+        output = MessageOutput(
+            idempotency_key="backend-failure:turn-1",
+            metadata={"backend": "codex", "event": "backend_failure"},
+        )
+        with (
+            patch.object(message_dispatcher_module, "agent_message_exists", side_effect=exists),
+            patch.object(message_dispatcher_module, "persist_agent_message", side_effect=persist),
+        ):
+            first = await dispatcher.emit_agent_message(
+                context,
+                "notify",
+                "Codex failed",
+                output=output,
+            )
+            second = await dispatcher.emit_agent_message(
+                context,
+                "notify",
+                "Codex failed",
+                output=output,
+            )
+
+        self.assertEqual(first, "bot-msg-1")
+        self.assertTrue(str(second).startswith("agent-output:codex:"))
+        self.assertEqual(controller.im_client.sent, [("C123", None, "Codex failed")])
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0][0:2], ("notify", "Codex failed"))
+        self.assertEqual(persisted[0][2]["metadata"]["event"], "backend_failure")
+
     async def test_activity_run_settlement_waits_for_successful_delivery(self):
         controller = _StubController()
         controller.im_client = _FailingIMClient()

--- a/tests/test_message_dispatcher_scheduled.py
+++ b/tests/test_message_dispatcher_scheduled.py
@@ -245,6 +245,61 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["terminal_status"], "failed")
         self.assertEqual(payload["error"], "provider unavailable")
 
+    async def test_blocking_activity_defers_terminal_error_with_status(self):
+        controller = _StubController()
+        controller.agent_service = SimpleNamespace(
+            activities=SimpleNamespace(has_blocking_run_activity=lambda _run_id: True),
+            emit_matches_runtime_turn=lambda _context: True,
+            release_runtime_turn=lambda _context: None,
+        )
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-failed",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def get_run(self, run_id):
+                return {"status": "running"}
+
+            def defer_run_terminal(self, run_id, **kwargs):
+                calls.append(("defer", run_id, kwargs))
+
+            def record_run_output(self, run_id, **kwargs):
+                calls.append(("output", run_id, kwargs))
+
+            def close(self):
+                pass
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            await dispatcher.emit_agent_message(
+                context,
+                "result",
+                "",
+                is_error=True,
+                level="silent",
+                output=MessageOutput(completes_turn=True, completes_run=True),
+                terminal_error="provider unavailable",
+            )
+
+        self.assertEqual(
+            calls[0],
+            (
+                "defer",
+                "run-failed",
+                {"terminal_status": "failed", "error": "provider unavailable"},
+            ),
+        )
+        self.assertEqual(calls[1][0:2], ("output", "run-failed"))
+        self.assertIsNone(calls[1][2]["terminal_status"])
+        self.assertEqual(calls[1][2]["error"], "provider unavailable")
+
     async def test_notify_output_uses_stable_persistence_identity(self):
         controller = _StubController()
         dispatcher = ConsolidatedMessageDispatcher(controller)
@@ -651,6 +706,46 @@ class MessageDispatcherScheduledTests(unittest.IsolatedAsyncioTestCase):
                 ("close",),
             ],
         )
+
+    async def test_suppressed_agent_run_failure_records_diagnostic(self):
+        controller = _StubController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C123",
+            platform="slack",
+            platform_specific={
+                "suppress_delivery": True,
+                "task_trigger_kind": "agent_run",
+                "task_execution_id": "run-agent",
+            },
+        )
+        calls = []
+
+        class _Store:
+            def get_run(self, run_id):
+                return {"status": "running"}
+
+            def record_run_output(self, run_id, **kwargs):
+                calls.append((run_id, kwargs))
+
+            def close(self):
+                pass
+
+        with patch.object(message_dispatcher_module, "SQLiteBackgroundTaskStore", return_value=_Store()):
+            message_id = await dispatcher.emit_agent_message(
+                context,
+                "result",
+                "private failure",
+                is_error=True,
+                terminal_error="provider unavailable",
+            )
+
+        self.assertEqual(message_id, "suppressed:run-agent")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "run-agent")
+        self.assertEqual(calls[0][1]["terminal_status"], "failed")
+        self.assertEqual(calls[0][1]["error"], "provider unavailable")
 
     async def test_suppressed_coalesced_agent_run_result_marks_each_run_terminal(self):
         controller = _StubController()

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1312,17 +1312,19 @@ def test_opencode_poll_aborts_disabled_question_toolcall():
     assert emitted[0][1] == "translated:error.opencodeQuestionToolDisabled"
 
 
-def test_opencode_poll_emits_error_result_on_retry_exhaustion():
+def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
     # A completed assistant message carrying an error, with retries exhausted
     # (error_retry_limit=0) and the auth-recovery path declining (non-auth error),
-    # is a terminal FAILURE. It must (a) emit an ERROR result so the dot turns red
-    # and (b) return should_emit=False so the caller does NOT then emit the idle
-    # "(No response from OpenCode)" warning that would reset the dot to idle (Codex P2).
+    # is a terminal FAILURE. It emits one visible notification plus one silent
+    # failed settlement, then suppresses the idle "(No response from OpenCode)"
+    # result that would overwrite the terminal state.
     emitted = []
 
     class _AuthSvc:
-        async def maybe_emit_auth_recovery_message(self, context, backend, message):
-            return False  # non-auth error → caller emits the terminal result itself
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
 
     class _Formatter:
         def format_toolcall(self, *args, **kwargs):
@@ -1344,8 +1346,9 @@ def test_opencode_poll_emits_error_result_on_retry_exhaustion():
             is_error=False,
             level="normal",
             output=None,
+            terminal_error=None,
         ):
-            emitted.append((message_type, is_error))
+            emitted.append((message_type, text, is_error, level, terminal_error))
 
     class _Agent:
         opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
@@ -1401,11 +1404,12 @@ def test_opencode_poll_emits_error_result_on_retry_exhaustion():
     # should_emit False → caller skips the idle "(No response)" warning that would
     # otherwise reset the dot we just turned red.
     assert should_emit is False
-    assert ("result", True) in emitted
-    assert not any(mtype == "notify" for mtype, _ in emitted)
+    assert [item[0] for item in emitted] == ["notify", "result"]
+    assert emitted[0][1] == "OpenCode error: ProviderError - rate limited"
+    assert emitted[1][1:] == ("", True, "silent", "ProviderError - rate limited")
 
 
-def test_opencode_poll_emits_notify_and_silent_error_result_on_empty_terminal_message():
+def test_opencode_poll_keeps_explicit_empty_completion_on_success_path():
     emitted = []
 
     class _AuthSvc:
@@ -1515,27 +1519,15 @@ def test_opencode_poll_emits_notify_and_silent_error_result_on_empty_terminal_me
     )
 
     assert final_text is None
-    assert should_emit is False
-    assert emitted == [
-        (
-            "notify",
-            "provider:glm/glm-5.2/(Default):AI_APICallError (ECONNRESET) while calling https://relay.example/messages",
-            False,
-            "normal",
-        ),
-        (
-            "result",
-            "provider:glm/glm-5.2/(Default):AI_APICallError (ECONNRESET) while calling https://relay.example/messages",
-            True,
-            "silent",
-        ),
-    ]
+    assert should_emit is True
+    assert emitted == []
 
 
-def test_opencode_restored_poll_preserves_model_details_for_empty_terminal_probe():
+def test_opencode_restored_poll_keeps_empty_completion_successful():
     emitted = []
     removed = []
     diagnostics = []
+    results = []
 
     class _AuthSvc:
         async def maybe_emit_auth_recovery_message(self, context, backend, message):
@@ -1632,8 +1624,8 @@ def test_opencode_restored_poll_preserves_model_details_for_empty_terminal_probe
         def _extract_response_text(self, message):
             return ""
 
-        async def emit_result_message(self, *args, **kwargs):
-            raise AssertionError("empty terminal path should emit failure directly")
+        async def emit_result_message(self, context, text, **kwargs):
+            results.append((text, kwargs))
 
         async def _remove_ack_reaction(self, request):
             return None
@@ -1655,7 +1647,7 @@ def test_opencode_restored_poll_preserves_model_details_for_empty_terminal_probe
     loop = OpenCodePollLoop(_Agent())
     asyncio.run(loop.run_restored_poll_loop(poll))
 
-    assert diagnostics == [("glm", "glm-5.2")]
+    assert diagnostics == []
     assert removed == ["oc-session"]
     assert emitted == [
         (
@@ -1664,19 +1656,11 @@ def test_opencode_restored_poll_preserves_model_details_for_empty_terminal_probe
             False,
             "normal",
         ),
-        (
-            "notify",
-            "provider:glm/glm-5.2/high:Provider API returned HTTP 503: No available accounts",
-            False,
-            "normal",
-        ),
-        (
-            "result",
-            "provider:glm/glm-5.2/high:Provider API returned HTTP 503: No available accounts",
-            True,
-            "silent",
-        ),
     ]
+    assert len(results) == 1
+    assert results[0][0] == "(No response from OpenCode)"
+    assert results[0][1]["subtype"] == "warning"
+    assert isinstance(results[0][1]["started_at"], float)
 
 
 def test_processing_indicator_handle_is_source_of_truth_for_backend_cleanup():

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -2200,6 +2200,65 @@ def test_duplicate_terminal_output_does_not_append_result_text_again(
     assert "deferred_terminal_status" not in terminal["result_payload"]
 
 
+def test_failed_run_records_error_and_enqueues_one_terminal_callback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    caller_session_id = _make_avibe_session(monkeypatch, tmp_path)
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="target-session",
+        message="delegated work",
+        agent_name="codex",
+        callback_session_id=caller_session_id,
+    )
+    service = ScheduledTaskService(
+        controller=_avibe_controller_double(
+            gate=SimpleNamespace(submit_scheduled=lambda *_args, **_kwargs: None, in_flight={}),
+            handle_scheduled_message=lambda *_args, **_kwargs: None,
+        ),
+        store=ScheduledTaskStore(tmp_path / "scheduled_tasks.json"),
+        request_store=request_store,
+    )
+    assert request_store.claim(request.id) is not None
+    sqlite_store = request_store._sqlite
+    assert sqlite_store is not None
+
+    first = sqlite_store.record_run_output(
+        request.id,
+        output_id="terminal",
+        text="",
+        terminal_status="failed",
+        error="provider unavailable",
+    )
+    duplicate = sqlite_store.record_run_output(
+        request.id,
+        output_id="terminal",
+        text="",
+        terminal_status="failed",
+        error="provider unavailable",
+    )
+    asyncio.run(service._drain_callbacks())
+    asyncio.run(service._drain_callbacks())
+
+    original = request_store.get_run(request.id)
+    assert original is not None
+    assert first["terminal_transition"] is True
+    assert duplicate["terminal_transition"] is False
+    assert original["status"] == "failed"
+    assert original["error"] == "provider unavailable"
+    assert not original["result_text"]
+    assert original["callback_status"] == "sent"
+    callback_runs = [
+        run
+        for run in request_store.list_runs()
+        if run.get("source_kind") == "callback" and run.get("parent_run_id") == request.id
+    ]
+    assert [run["message"] for run in callback_runs] == ["Error: provider unavailable"]
+    assert callback_runs[0]["source_actor"] == f"{request.id}:terminal:failed"
+
+
 @pytest.mark.parametrize(
     ("activity_status", "expected_run_status"),
     [

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -2259,6 +2259,46 @@ def test_failed_run_records_error_and_enqueues_one_terminal_callback(
     assert callback_runs[0]["source_actor"] == f"{request.id}:terminal:failed"
 
 
+def test_deferred_failure_preserves_error_through_later_output(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    request_store = TaskExecutionStore()
+    request = request_store.enqueue_agent_run(
+        session_id="target-session",
+        message="delegated work",
+        agent_name="claude",
+    )
+    assert request_store.claim(request.id) is not None
+    sqlite_store = request_store._sqlite
+    assert sqlite_store is not None
+
+    assert sqlite_store.defer_run_terminal(
+        request.id,
+        terminal_status="failed",
+        error="provider unavailable",
+    ) is True
+    running = request_store.get_run(request.id)
+    assert running is not None
+    assert running["result_payload"]["deferred_terminal_error"] == "provider unavailable"
+
+    terminal = sqlite_store.record_run_output(
+        request.id,
+        output_id="activity-output",
+        text="background output",
+        terminal_status="succeeded",
+    )
+
+    settled = request_store.get_run(request.id)
+    assert settled is not None
+    assert terminal["terminal_transition"] is True
+    assert settled["status"] == "failed"
+    assert settled["error"] == "provider unavailable"
+    assert "deferred_terminal_status" not in settled["result_payload"]
+    assert "deferred_terminal_error" not in settled["result_payload"]
+
+
 @pytest.mark.parametrize(
     ("activity_status", "expected_run_status"),
     [

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -1128,6 +1128,85 @@ def test_fork_source_state_ignores_notify_as_terminal_output(
         engine.dispose()
 
 
+def test_fork_source_state_treats_backend_failure_notify_anchor_as_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            notify = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="notify",
+                text="Codex backend failed",
+                metadata={"event": "backend_failure", "failure_id": "failure_1"},
+            )
+
+        fork = {"source_session_id": source_id, "source_message_id": notify["id"]}
+        state = fork_source_state(fork)
+
+        assert state.anchor_is_terminal_agent_output is True
+        assert state.has_messages_after_anchor is False
+        assert fork_anchor_is_terminal_agent_output(fork) is True
+    finally:
+        engine.dispose()
+
+
+def test_fork_source_state_treats_backend_failure_notify_after_anchor_as_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from config import paths
+    from storage.importer import ensure_sqlite_state
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    db_path = paths.get_sqlite_state_path()
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(select(agent_sessions).where(agent_sessions.c.id == source_id)).mappings().one()
+            user = messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="user",
+                message_type="user",
+                text="Do the task",
+            )
+            messages_service.append(
+                conn,
+                scope_id=row["scope_id"],
+                session_id=source_id,
+                platform="avibe",
+                author="agent",
+                message_type="notify",
+                text="Codex backend failed",
+                metadata={"event": "backend_failure", "failure_id": "failure_1"},
+            )
+
+        state = fork_source_state({"source_session_id": source_id, "source_message_id": user["id"]})
+
+        assert state.latest_after_anchor_author == "agent"
+        assert state.latest_after_anchor_type == "notify"
+        assert state.has_messages_after_anchor is True
+        assert state.has_terminal_agent_output_after_anchor is True
+    finally:
+        engine.dispose()
+
+
 def test_fork_source_state_ignores_operational_rows_after_anchor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -54,6 +54,35 @@ def test_maybe_notify_inbox_message_schedules_agent_result(monkeypatch):
     ]
 
 
+def test_maybe_notify_inbox_message_schedules_backend_failure_notify(monkeypatch):
+    calls = []
+
+    class _Thread:
+        def __init__(self, *, target, args, daemon):
+            assert daemon is True
+            self.args = args
+
+        def start(self):
+            calls.append(self.args[0])
+
+    monkeypatch.setattr(web_push_notifications.threading, "Thread", _Thread)
+
+    web_push_notifications.maybe_notify_inbox_message(
+        {
+            "id": "msg_failure",
+            "platform": "avibe",
+            "author": "agent",
+            "type": "notify",
+            "session_id": "ses_1",
+            "text": "Codex backend failed",
+            "metadata": {"event": "backend_failure", "failure_id": "failure_1"},
+        },
+        {"title": "Build fix"},
+    )
+
+    assert [call["message_id"] for call in calls] == ["msg_failure"]
+
+
 def test_maybe_notify_inbox_message_skips_non_notifiable(monkeypatch):
     calls = []
     monkeypatch.setattr(
@@ -89,6 +118,70 @@ def test_maybe_notify_inbox_message_skips_non_notifiable(monkeypatch):
     )
 
     assert calls == []
+
+
+def test_backend_failure_notify_passes_durable_web_push_gates(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    now = "2026-07-11T00:00:00Z"
+    with engine.begin() as conn:
+        scope_id = upsert_scope(conn, platform="avibe", scope_type="project", native_id="proj_failure", now=now)
+        conn.execute(
+            agent_sessions.insert().values(
+                id="ses_failure",
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="ses_failure",
+                native_session_id="",
+                title="Failure",
+                status="active",
+                metadata_json="{}",
+                created_at=now,
+                updated_at=now,
+                last_active_at=now,
+            )
+        )
+        messages_service.append(
+            conn,
+            scope_id=scope_id,
+            session_id="ses_failure",
+            platform="avibe",
+            author="user",
+            source="user",
+            metadata={"_web_push_user_key": "remote:user-a"},
+            message_type="user",
+            text="Please finish",
+        )
+        failure = messages_service.append(
+            conn,
+            scope_id=scope_id,
+            session_id="ses_failure",
+            platform="avibe",
+            author="agent",
+            source="agent",
+            metadata={"event": "backend_failure", "failure_id": "failure_1"},
+            message_type="notify",
+            text="Codex backend failed",
+        )
+        ordinary_notify = messages_service.append(
+            conn,
+            scope_id=scope_id,
+            session_id="ses_failure",
+            platform="avibe",
+            author="agent",
+            source="agent",
+            message_type="notify",
+            text="Still working",
+        )
+
+    with engine.connect() as conn:
+        assert web_push_notifications._message_still_unread(conn, failure["id"]) is True
+        assert web_push_notifications._web_push_user_keys_for_message(conn, failure["id"]) == ["remote:user-a"]
+        assert web_push_notifications._message_still_unread(conn, ordinary_notify["id"]) is False
+        assert web_push_notifications._web_push_user_keys_for_message(conn, ordinary_notify["id"]) == []
+    engine.dispose()
 
 
 def test_send_to_enabled_subscriptions_waits_then_sends_to_owner_devices(monkeypatch, tmp_path):

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -11,6 +11,7 @@ import { useRegisterComposerTarget, type ComposerInsertTarget } from '../../cont
 import type { SessionRuntimeState, VaultRequest, VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
+import { isNotifyMessageType } from '../../lib/chatMessageTypes';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
@@ -2432,9 +2433,9 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
   // Each branch composes this onto its own ``justify-*`` so alignment is kept.
   const rowClass = (extra: string) => clsx('flex w-full', extra, highlighted && 'msg-highlight');
 
-  // A notify row is a turn-terminal marker (agent run that failed/stopped
-  // without a result) — a compact status pill, not an answer.
-  const isNotify = message.type === 'notify';
+  // Runtime notifications and legacy error rows are compact status pills,
+  // not Agent-authored answers.
+  const isNotify = isNotifyMessageType(message.type);
   const isAgent = !isNotify && message.author === 'agent';
   const isSystem = !isNotify && message.author === 'system';
   // A harness-origin row is a user-role prompt the human didn't type (scheduled

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -11,7 +11,7 @@ import { useRegisterComposerTarget, type ComposerInsertTarget } from '../../cont
 import type { SessionRuntimeState, VaultRequest, VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
-import { isNotifyMessageType } from '../../lib/chatMessageTypes';
+import { isNotifyMessageType, isTerminalAgentMessage } from '../../lib/chatMessageTypes';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
@@ -2032,12 +2032,13 @@ const Transcript: React.FC<TranscriptProps> = ({
   // The reply arrives atomically as a persisted ``result`` row (no streaming
   // card), so the thinking bubble shows for the whole gap between send and
   // reply. Hide it the moment the last row is a fresh agent terminal — a
-  // successful ``result`` OR a failed ``error`` both end the turn.
-  const lastIsAgentResult =
-    messages.length > 0 &&
-    messages[messages.length - 1].author === 'agent' &&
-    (messages[messages.length - 1].type === 'result' || messages[messages.length - 1].type === 'error');
-  const showThinking = working && !lastIsAgentResult;
+  // successful ``result``, a legacy ``error``, or a structured backend-failure
+  // ``notify`` all end the visible response. ``working`` itself still settles
+  // only from turn.end or the authoritative turn-state poll, so a late row from
+  // an older Turn cannot clear Stop for a newer one.
+  const lastIsAgentTerminal =
+    messages.length > 0 && isTerminalAgentMessage(messages[messages.length - 1]);
+  const showThinking = working && !lastIsAgentTerminal;
   const empty = messages.length === 0 && !working;
 
   // Capture the topmost (partly) visible row as the restore anchor. Viewport-

--- a/ui/src/lib/chatMessageTypes.test.ts
+++ b/ui/src/lib/chatMessageTypes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNotifyMessageType } from './chatMessageTypes';
+
+describe('isNotifyMessageType', () => {
+  it('renders current and legacy failure rows as notifications', () => {
+    expect(isNotifyMessageType('notify')).toBe(true);
+    expect(isNotifyMessageType('error')).toBe(true);
+  });
+
+  it('keeps agent results out of the notification treatment', () => {
+    expect(isNotifyMessageType('result')).toBe(false);
+    expect(isNotifyMessageType('assistant')).toBe(false);
+  });
+});

--- a/ui/src/lib/chatMessageTypes.test.ts
+++ b/ui/src/lib/chatMessageTypes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isNotifyMessageType } from './chatMessageTypes';
+import { isNotifyMessageType, isTerminalAgentMessage } from './chatMessageTypes';
 
 describe('isNotifyMessageType', () => {
   it('renders current and legacy failure rows as notifications', () => {
@@ -11,5 +11,31 @@ describe('isNotifyMessageType', () => {
   it('keeps agent results out of the notification treatment', () => {
     expect(isNotifyMessageType('result')).toBe(false);
     expect(isNotifyMessageType('assistant')).toBe(false);
+  });
+});
+
+describe('isTerminalAgentMessage', () => {
+  it('recognizes results, legacy errors, and structured backend failures', () => {
+    expect(isTerminalAgentMessage({ author: 'agent', type: 'result' })).toBe(true);
+    expect(isTerminalAgentMessage({ author: 'agent', type: 'error' })).toBe(true);
+    expect(
+      isTerminalAgentMessage({
+        author: 'agent',
+        type: 'notify',
+        metadata: { event: 'backend_failure' },
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps ordinary notifications and user rows nonterminal', () => {
+    expect(isTerminalAgentMessage({ author: 'agent', type: 'notify' })).toBe(false);
+    expect(
+      isTerminalAgentMessage({
+        author: 'agent',
+        type: 'notify',
+        metadata: { event: 'activity_completed' },
+      }),
+    ).toBe(false);
+    expect(isTerminalAgentMessage({ author: 'user', type: 'result' })).toBe(false);
   });
 });

--- a/ui/src/lib/chatMessageTypes.ts
+++ b/ui/src/lib/chatMessageTypes.ts
@@ -1,0 +1,2 @@
+export const isNotifyMessageType = (type: string): boolean =>
+  type === 'notify' || type === 'error';

--- a/ui/src/lib/chatMessageTypes.ts
+++ b/ui/src/lib/chatMessageTypes.ts
@@ -1,2 +1,14 @@
 export const isNotifyMessageType = (type: string): boolean =>
   type === 'notify' || type === 'error';
+
+type TerminalMessageCandidate = {
+  author: string;
+  type: string;
+  metadata?: Record<string, unknown> | null;
+};
+
+export const isTerminalAgentMessage = (message: TerminalMessageCandidate): boolean =>
+  message.author === 'agent' &&
+  (message.type === 'result' ||
+    message.type === 'error' ||
+    (message.type === 'notify' && message.metadata?.event === 'backend_failure'));


### PR DESCRIPTION
## Summary

- map authoritative terminal failure signals from Claude, Codex, and OpenCode into one shared backend-failure path
- separate the visible `notify` from the silent `is_error=True` lifecycle settlement
- persist the underlying diagnostic in `agent_runs.error` and keep Run completion/callback emission idempotent
- preserve auth recovery, backend retry policy, successful empty output, Stop/Cancel behavior, and normal Agent text
- render existing persisted `type=error` rows with the compact notification treatment

Closes #844

## Capability and scope

This PR implements the #844 terminal backend failure contract. A structured terminal failure produces one durable user notification, one silent failed settlement, a failed correlated Agent Run with an explicit error, and one failure callback when configured.

The adapters continue to own only structured signal recognition. No arbitrary response-text classification was added. Retryable Codex/OpenCode events remain non-terminal, and successful empty OpenCode completions remain on the existing success path.

Scenario IDs: none. #844 does not currently map to a scenario-catalog entry.

## Evidence

- Unit and contract: 531 focused Python tests across the shared helper, auth recovery, Claude sessions, Codex events/agent, OpenCode live/restored polls, dispatcher, Run persistence, duplicate terminal transitions, callbacks, Workbench Web Push, and Session fork boundaries
- UI compatibility: 4 Vitest cases for current `notify`, legacy `error`, and structured backend-failure terminal rows
- Static/build: Ruff passed for every changed Python file; `npm run build` passed
- Scenario coverage: existing successful one-result, retryable-error, empty-success, and cross-backend runtime regressions remain green

## Residual manual checks

- No live provider outage or real IM delivery failure was injected locally; GitHub CI remains the broad gate.
