### PR TITLE
feat(runtime): integrate published vendored git

### DIFF
--- a/core/git_binary.py
+++ b/core/git_binary.py
@@ -8,6 +8,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from core.git_runtime import get_git_runtime_manager
+
 
 @dataclass(frozen=True)
 class ResolvedGit:
@@ -16,8 +18,8 @@ class ResolvedGit:
 
 
 def _resolve_vendored() -> ResolvedGit | None:
-    # TODO(#867): resolve the managed minimal Git bundle once it ships.
-    return None
+    path = get_git_runtime_manager().resolve_git_path()
+    return ResolvedGit(path=path, source="vendored") if path is not None else None
 
 
 def _macos_command_line_tools_available() -> bool:

--- a/core/git_binary.py
+++ b/core/git_binary.py
@@ -8,8 +8,6 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from core.git_runtime import get_git_runtime_manager
-
 
 @dataclass(frozen=True)
 class ResolvedGit:
@@ -18,6 +16,8 @@ class ResolvedGit:
 
 
 def _resolve_vendored() -> ResolvedGit | None:
+    from core.git_runtime import get_git_runtime_manager
+
     path = get_git_runtime_manager().resolve_git_path()
     return ResolvedGit(path=path, source="vendored") if path is not None else None
 

--- a/core/git_runtime.py
+++ b/core/git_runtime.py
@@ -6,7 +6,7 @@ import platform
 import shutil
 import subprocess
 import sys
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 from typing import Any
 
@@ -199,6 +199,72 @@ def resolve_system_git_path(*, env: Mapping[str, str] | None = None) -> Path | N
         if proc.returncode != 0 or not (proc.stdout or "").strip():
             return None
     return candidate_path
+
+
+def prepend_vendored_git_to_path(
+    env: MutableMapping[str, str],
+    *,
+    base_env: Mapping[str, str],
+    working_dir: Path | str | None,
+    manager: GitRuntimeManager | None = None,
+) -> bool:
+    """Prepend verified Git when the effective Agent PATH has no safe Git.
+
+    PATH composition is explicit: a ``PATH`` key in ``env`` wins even when its
+    value is empty. Only an absent key falls back to the required ``base_env``;
+    this helper never reads ``os.environ`` implicitly. A relative, empty, or
+    workspace-owned PATH entry before system Git is not trusted as system Git,
+    so the hardened vendored binary takes precedence over that mutable prefix.
+    """
+
+    current_path = env["PATH"] if "PATH" in env else base_env.get("PATH", "")
+    if _agent_path_has_system_git(current_path, working_dir=working_dir):
+        return False
+    vendored = (manager or get_git_runtime_manager()).resolve_git_path()
+    if vendored is None:
+        return False
+    bin_dir = str(vendored.parent)
+    env["PATH"] = bin_dir if not current_path else f"{bin_dir}{os.pathsep}{current_path}"
+    return True
+
+
+def _agent_path_has_system_git(
+    search_path: str,
+    *,
+    working_dir: Path | str | None,
+) -> bool:
+    workspace = _resolved_path(Path(working_dir)) if working_dir is not None else None
+    if workspace is not None and workspace.parent == workspace:
+        workspace = None
+    for raw_entry in search_path.split(os.pathsep):
+        entry = Path(raw_entry)
+        if not raw_entry or not entry.is_absolute():
+            return False
+        resolved_entry = _resolved_path(entry)
+        if workspace is not None and _path_is_within(resolved_entry, workspace):
+            return False
+        candidate = resolve_system_git_path(env={"PATH": raw_entry})
+        if candidate is None:
+            continue
+        if workspace is not None and _path_is_within(_resolved_path(candidate), workspace):
+            return False
+        return True
+    return False
+
+
+def _resolved_path(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except (OSError, RuntimeError):
+        return path.absolute()
+
+
+def _path_is_within(path: Path, directory: Path) -> bool:
+    try:
+        path.relative_to(directory)
+    except ValueError:
+        return False
+    return True
 
 
 def _probe_git_version(binary: Path | None) -> str | None:

--- a/core/git_runtime.py
+++ b/core/git_runtime.py
@@ -233,23 +233,36 @@ def _agent_path_has_system_git(
     *,
     working_dir: Path | str | None,
 ) -> bool:
-    workspace = _resolved_path(Path(working_dir)) if working_dir is not None else None
-    if workspace is not None and workspace.parent == workspace:
-        workspace = None
+    lexical_workspace = _absolute_path(Path(working_dir)) if working_dir is not None else None
+    resolved_workspace = _resolved_path(lexical_workspace) if lexical_workspace is not None else None
+    if lexical_workspace is not None and lexical_workspace.parent == lexical_workspace:
+        lexical_workspace = None
+    if resolved_workspace is not None and resolved_workspace.parent == resolved_workspace:
+        resolved_workspace = None
     for raw_entry in search_path.split(os.pathsep):
         entry = Path(raw_entry)
         if not raw_entry or not entry.is_absolute():
             return False
+        lexical_entry = _absolute_path(entry)
+        if lexical_workspace is not None and _path_is_within(lexical_entry, lexical_workspace):
+            return False
         resolved_entry = _resolved_path(entry)
-        if workspace is not None and _path_is_within(resolved_entry, workspace):
+        if resolved_workspace is not None and _path_is_within(resolved_entry, resolved_workspace):
             return False
         candidate = resolve_system_git_path(env={"PATH": raw_entry})
         if candidate is None:
             continue
-        if workspace is not None and _path_is_within(_resolved_path(candidate), workspace):
+        if resolved_workspace is not None and _path_is_within(
+            _resolved_path(candidate),
+            resolved_workspace,
+        ):
             return False
         return True
     return False
+
+
+def _absolute_path(path: Path) -> Path:
+    return Path(os.path.abspath(path))
 
 
 def _resolved_path(path: Path) -> Path:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -31,6 +31,7 @@ from config.v2_config import (
 )
 from core.avibe_cloud import avibe_cloud_url_available
 from core.caller_context import caller_env_for_platform_payload
+from core.git_runtime import prepend_vendored_git_to_path
 from core.resource_governance import governor_from_controller
 from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
@@ -854,6 +855,11 @@ class SessionHandler(BaseHandler):
 
         claude_env = build_claude_subprocess_env(getattr(self.config, "claude", None))
         claude_env.update(caller_env_for_platform_payload(getattr(context, "platform_specific", None)))
+        prepend_vendored_git_to_path(
+            claude_env,
+            base_env=os.environ,
+            working_dir=working_path,
+        )
         claude_env[AVIBE_CLAUDE_PROCESS_OWNER_ENV] = AVIBE_CLAUDE_SESSION_OWNER
         if self._should_mark_claude_isolated_env():
             claude_env["IS_SANDBOX"] = "1"

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -146,6 +146,18 @@ class SessionHandler(BaseHandler):
         await set_model(desired_model)
         setattr(client, "_vibe_current_model", desired_model)
 
+    @staticmethod
+    def _claude_git_path_state(working_path: str) -> str:
+        from core.git_runtime import prepend_vendored_git_to_path
+
+        env: dict[str, str] = {}
+        prepend_vendored_git_to_path(
+            env,
+            base_env=os.environ,
+            working_dir=working_path,
+        )
+        return env["PATH"] if "PATH" in env else os.environ.get("PATH", "")
+
     async def _reuse_cached_claude_session_if_available(
         self,
         *,
@@ -182,6 +194,14 @@ class SessionHandler(BaseHandler):
         if getattr(client, "_vibe_caller_env", {}) != caller_env:
             logger.info(
                 "Recreating cached Claude SDK client for %s because caller context env changed",
+                composite_key,
+            )
+            await self.cleanup_session(composite_key)
+            return None
+        git_path_state = self._claude_git_path_state(working_path)
+        if getattr(client, "_vibe_git_path_state", None) != git_path_state:
+            logger.info(
+                "Recreating cached Claude SDK client for %s because Git PATH changed",
                 composite_key,
             )
             await self.cleanup_session(composite_key)
@@ -227,6 +247,14 @@ class SessionHandler(BaseHandler):
         if getattr(client, "_vibe_caller_env", {}) != caller_env:
             logger.info(
                 "Recreating cached Claude subagent SDK client for %s because caller context env changed",
+                composite_key,
+            )
+            await self.cleanup_session(composite_key)
+            return None
+        git_path_state = self._claude_git_path_state(working_path)
+        if getattr(client, "_vibe_git_path_state", None) != git_path_state:
+            logger.info(
+                "Recreating cached Claude subagent SDK client for %s because Git PATH changed",
                 composite_key,
             )
             await self.cleanup_session(composite_key)
@@ -860,6 +888,7 @@ class SessionHandler(BaseHandler):
             base_env=os.environ,
             working_dir=working_path,
         )
+        git_path_state = claude_env["PATH"] if "PATH" in claude_env else os.environ.get("PATH", "")
         claude_env[AVIBE_CLAUDE_PROCESS_OWNER_ENV] = AVIBE_CLAUDE_SESSION_OWNER
         if self._should_mark_claude_isolated_env():
             claude_env["IS_SANDBOX"] = "1"
@@ -916,6 +945,7 @@ class SessionHandler(BaseHandler):
         # Create new Claude client
         client = ClaudeSDKClient(options=options)
         setattr(client, "_vibe_caller_env", caller_env_for_platform_payload(getattr(context, "platform_specific", None)))
+        setattr(client, "_vibe_git_path_state", git_path_state)
 
         # Log the actual options being used
         logger.info("ClaudeAgentOptions details:")

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -31,7 +31,6 @@ from config.v2_config import (
 )
 from core.avibe_cloud import avibe_cloud_url_available
 from core.caller_context import caller_env_for_platform_payload
-from core.git_runtime import prepend_vendored_git_to_path
 from core.resource_governance import governor_from_controller
 from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
@@ -852,6 +851,7 @@ class SessionHandler(BaseHandler):
         # control-channel client (``agent_auth_service``) cannot drift
         # away from this site's auth_mode handling.
         from vibe.claude_config import build_claude_subprocess_env
+        from core.git_runtime import prepend_vendored_git_to_path
 
         claude_env = build_claude_subprocess_env(getattr(self.config, "claude", None))
         claude_env.update(caller_env_for_platform_payload(getattr(context, "platform_specific", None)))

--- a/docs/plans/git-runtime.md
+++ b/docs/plans/git-runtime.md
@@ -19,13 +19,16 @@ must not be executed before `xcode-select -p` confirms the tools are installed.
 - Resolve an installed binary against the immutable binary hash in the active
   manifest without network access or execution. Status classifies system Git
   paths without executing PATH-selected binaries and reports both the platform
-  resolution (vendored first) and planned Agent resolution (system first).
+  resolution (vendored first) and Agent resolution (system first).
 - Support `VIBE_GIT_MANIFEST_PATH`, `VIBE_GIT_MANIFEST_URL`, and
   `VIBE_GIT_OFFLINE` for development, out-of-band updates, and offline use.
-- Keep Agent PATH injection out of this PR. The current caller-context object
-  is provenance, not the backend's final environment, and probing an untrusted
-  target PATH would execute workspace-controlled tools. The orchestrator-owned
-  post-#864 integration will define and wire the backend environment contract.
+- Agent child environments preserve an effective system Git and prepend the
+  verified runtime only when none is available. PATH composition respects an
+  explicit key, including an empty value, and uses the service environment only
+  where each backend passes it as an explicit fallback. Relative, empty, and
+  workspace-owned prefixes are not trusted ahead of system Git. Claude injects
+  at SDK client creation, Codex at its per-thread shell policy, and OpenCode at
+  its per-session `shell.env` binding.
 
 ## Build Boundary
 
@@ -42,13 +45,12 @@ stay deterministic. The workflow exercises `init`, `add`, `commit`, `status`,
 `log`, `diff`, `restore`, and `gc`; proves hostile helper markers do not run;
 and proves that `push` is rejected.
 
-## Publication Gate
+## Publication
 
-The packaged manifest remains `release_state: pending` with zero placeholders
-until the orchestrator runs the workflow with tag `git-runtime-v2.55.0-1`.
-Pending manifests never download or install. The published workflow artifact
-must replace `vibe/git_runtime_manifest.json` so real archive sizes plus archive
-and binary SHA-256 digests ship in the final integration commit.
+The four-platform workflow completed in run `29165285903`. Release
+`git-runtime-v2.55.0-1` contains the four archives and checksum files, and the
+packaged manifest carries the published release URLs, sizes, archive hashes,
+and final-binary hashes.
 
 Offline resolution deliberately fails closed across manifest version changes:
 an install is reusable only when it matches the active trusted manifest. Avibe
@@ -59,7 +61,5 @@ multi-version manifest schema can be added later if real usage justifies it.
 
 - Migrate tmux and Show Runtime to the common managed-runtime core in a separate
   change after this interface has production evidence.
-- Wire `core/git_binary.py` to `GitRuntimeManager` in the orchestrator-owned
-  post-merge integration for #669.
-- Define and wire safe Agent PATH fallback after #864 at the concrete backend
-  child-environment seam.
+- Verify vendored resolution and Show Page checkpointing end to end on a
+  gitless Incus machine as part of #669's integration pass.

--- a/docs/plans/git-runtime.md
+++ b/docs/plans/git-runtime.md
@@ -28,7 +28,8 @@ must not be executed before `xcode-select -p` confirms the tools are installed.
   where each backend passes it as an explicit fallback. Relative, empty, and
   workspace-owned prefixes are not trusted ahead of system Git. Claude injects
   at SDK client creation, Codex at its per-thread shell policy, and OpenCode at
-  its per-session `shell.env` binding.
+  its per-session `shell.env` binding. Cached clients, thread policies, and
+  binding rows refresh or clear when the effective Git PATH changes.
 
 ## Build Boundary
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -17,6 +17,7 @@ from config.v2_config import (
 )
 from core.avibe_cloud import avibe_cloud_url_available
 from core.caller_context import caller_env_for_platform_payload
+from core.git_runtime import prepend_vendored_git_to_path
 from core.message_output import terminal_output_for
 from core.services.session_fork import fork_source_state, pending_native_fork
 from core.system_prompt_injection import (
@@ -782,14 +783,19 @@ class CodexAgent(BaseAgent):
 
     def _inject_caller_env_config(self, params: Dict[str, Any], request: AgentRequest) -> None:
         env = self._caller_env_for_request(request)
-        if not env:
-            return
-        env_script_path = self._caller_env_script_path(request)
-        env = {**env, "BASH_ENV": str(env_script_path)}
         config = dict(params.get("config") or {})
         shell_policy = dict(config.get("shell_environment_policy") or {})
         set_env = dict(shell_policy.get("set") or {})
-        set_env.update(env)
+        if env:
+            env_script_path = self._caller_env_script_path(request)
+            set_env.update({**env, "BASH_ENV": str(env_script_path)})
+        git_path_changed = prepend_vendored_git_to_path(
+            set_env,
+            base_env=os.environ,
+            working_dir=getattr(request, "working_path", None),
+        )
+        if not env and not git_path_changed:
+            return
         shell_policy["set"] = set_env
         config["shell_environment_policy"] = shell_policy
         params["config"] = config

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -91,6 +91,8 @@ class CodexAgent(BaseAgent):
         self._thread_developer_instructions: Dict[str, tuple[str, str]] = {}
         # base_session_id → (thread_id, AVIBE_* caller env)
         self._thread_caller_env_configs: Dict[str, tuple[str, dict[str, str]]] = {}
+        # base_session_id → (thread_id, effective Git PATH)
+        self._thread_git_path_configs: Dict[str, tuple[str, str]] = {}
         self._fork_correction_pending_base_sessions: set[str] = set()
 
     # ------------------------------------------------------------------
@@ -780,7 +782,7 @@ class CodexAgent(BaseAgent):
         tmp_path.replace(script_path)
         return script_path
 
-    def _inject_caller_env_config(self, params: Dict[str, Any], request: AgentRequest) -> None:
+    def _inject_caller_env_config(self, params: Dict[str, Any], request: AgentRequest) -> str:
         from core.git_runtime import prepend_vendored_git_to_path
 
         env = self._caller_env_for_request(request)
@@ -790,16 +792,28 @@ class CodexAgent(BaseAgent):
         if env:
             env_script_path = self._caller_env_script_path(request)
             set_env.update({**env, "BASH_ENV": str(env_script_path)})
-        git_path_changed = prepend_vendored_git_to_path(
+        prepend_vendored_git_to_path(
             set_env,
             base_env=os.environ,
             working_dir=getattr(request, "working_path", None),
         )
-        if not env and not git_path_changed:
-            return
+        git_path_state = set_env["PATH"] if "PATH" in set_env else os.environ.get("PATH", "")
+        set_env["PATH"] = git_path_state
         shell_policy["set"] = set_env
         config["shell_environment_policy"] = shell_policy
         params["config"] = config
+        return git_path_state
+
+    def _git_path_state_for_request(self, request: AgentRequest) -> str:
+        from core.git_runtime import prepend_vendored_git_to_path
+
+        env: dict[str, str] = {}
+        prepend_vendored_git_to_path(
+            env,
+            base_env=os.environ,
+            working_dir=getattr(request, "working_path", None),
+        )
+        return env["PATH"] if "PATH" in env else os.environ.get("PATH", "")
 
     async def _start_thread(
         self,
@@ -816,7 +830,7 @@ class CodexAgent(BaseAgent):
         developer_instructions = self._build_thread_developer_instructions(request)
         if developer_instructions:
             params["developerInstructions"] = developer_instructions
-        self._inject_caller_env_config(params, request)
+        git_path_state = self._inject_caller_env_config(params, request)
 
         resp = await transport.send_request("thread/start", params)
         # thread/start returns Thread directly OR may nest under "thread"
@@ -837,6 +851,7 @@ class CodexAgent(BaseAgent):
             thread_id,
             self._caller_env_for_request(request),
         )
+        self._remember_thread_git_path_config(request.base_session_id, thread_id, git_path_state)
         return thread_id
 
     async def _fork_thread(
@@ -860,7 +875,7 @@ class CodexAgent(BaseAgent):
             params["developerInstructions"] = developer_instructions
         if effective_model:
             params["model"] = effective_model
-        self._inject_caller_env_config(params, request)
+        git_path_state = self._inject_caller_env_config(params, request)
 
         self._mark_fork_correction_pending(request.base_session_id)
         try:
@@ -887,6 +902,7 @@ class CodexAgent(BaseAgent):
             thread_id,
             self._caller_env_for_request(request),
         )
+        self._remember_thread_git_path_config(request.base_session_id, thread_id, git_path_state)
         logger.info("Forked Codex thread %s from %s for session %s", thread_id, source_thread_id, request.base_session_id)
         return thread_id
 
@@ -1020,7 +1036,7 @@ class CodexAgent(BaseAgent):
                     "threadId": persisted,
                     "developerInstructions": self._build_thread_developer_instructions(request),
                 }
-                self._inject_caller_env_config(resume_params, request)
+                git_path_state = self._inject_caller_env_config(resume_params, request)
                 model_provider = await self._resolve_resume_model_provider_override(transport, request, persisted)
                 if model_provider:
                     resume_params["modelProvider"] = model_provider
@@ -1060,6 +1076,16 @@ class CodexAgent(BaseAgent):
                 request.base_session_id,
                 thread_id,
                 resume_params.get("developerInstructions"),
+            )
+            self._remember_thread_caller_env_config(
+                request.base_session_id,
+                thread_id,
+                self._caller_env_for_request(request),
+            )
+            self._remember_thread_git_path_config(
+                request.base_session_id,
+                thread_id,
+                git_path_state,
             )
             logger.info("Resumed Codex thread %s for session %s", thread_id, request.base_session_id)
             return thread_id
@@ -1219,19 +1245,24 @@ class CodexAgent(BaseAgent):
         self.ensure_agent_session_id(request)
         caller_env = self._caller_env_for_request(request)
         developer_instructions = self._build_thread_developer_instructions(request)
-        if not developer_instructions and not caller_env:
-            return
+        git_path_state = self._git_path_state_for_request(request)
 
         if not hasattr(self, "_thread_developer_instructions"):
             self._thread_developer_instructions = {}
         if not hasattr(self, "_thread_caller_env_configs"):
             self._thread_caller_env_configs = {}
+        if not hasattr(self, "_thread_git_path_configs"):
+            self._thread_git_path_configs = {}
 
         cached = self._thread_developer_instructions.get(request.base_session_id)
         cached_caller_env = self._thread_caller_env_configs.get(request.base_session_id)
+        cached_git_path = self._thread_git_path_configs.get(request.base_session_id)
+        git_path_changed = cached_git_path != (thread_id, git_path_state)
+        if not developer_instructions and not caller_env and not git_path_changed:
+            return
         if cached == (thread_id, developer_instructions) and (
             not caller_env or cached_caller_env == (thread_id, caller_env)
-        ):
+        ) and not git_path_changed:
             return
 
         resume_params: Dict[str, Any] = {
@@ -1239,8 +1270,8 @@ class CodexAgent(BaseAgent):
         }
         if cached != (thread_id, developer_instructions):
             resume_params["developerInstructions"] = developer_instructions
-        if caller_env:
-            self._inject_caller_env_config(resume_params, request)
+        if caller_env or git_path_changed:
+            git_path_state = self._inject_caller_env_config(resume_params, request)
         model_provider = await self._resolve_resume_model_provider_override(transport, request, thread_id)
         if model_provider:
             resume_params["modelProvider"] = model_provider
@@ -1255,6 +1286,7 @@ class CodexAgent(BaseAgent):
             developer_instructions,
         )
         self._remember_thread_caller_env_config(request.base_session_id, thread_id, caller_env)
+        self._remember_thread_git_path_config(request.base_session_id, thread_id, git_path_state)
 
     def _remember_thread_developer_instructions(
         self,
@@ -1280,11 +1312,23 @@ class CodexAgent(BaseAgent):
             self._thread_caller_env_configs = {}
         self._thread_caller_env_configs[base_session_id] = (thread_id, dict(caller_env))
 
+    def _remember_thread_git_path_config(
+        self,
+        base_session_id: str,
+        thread_id: str,
+        git_path_state: str,
+    ) -> None:
+        if not hasattr(self, "_thread_git_path_configs"):
+            self._thread_git_path_configs = {}
+        self._thread_git_path_configs[base_session_id] = (thread_id, git_path_state)
+
     def _clear_thread_developer_instructions(self, base_session_id: str) -> None:
         if hasattr(self, "_thread_developer_instructions"):
             self._thread_developer_instructions.pop(base_session_id, None)
         if hasattr(self, "_thread_caller_env_configs"):
             self._thread_caller_env_configs.pop(base_session_id, None)
+        if hasattr(self, "_thread_git_path_configs"):
+            self._thread_git_path_configs.pop(base_session_id, None)
 
     def _fork_correction_pending_sessions(self) -> set[str]:
         if not hasattr(self, "_fork_correction_pending_base_sessions"):

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -91,8 +91,8 @@ class CodexAgent(BaseAgent):
         self._thread_developer_instructions: Dict[str, tuple[str, str]] = {}
         # base_session_id → (thread_id, AVIBE_* caller env)
         self._thread_caller_env_configs: Dict[str, tuple[str, dict[str, str]]] = {}
-        # base_session_id → (thread_id, effective Git PATH)
-        self._thread_git_path_configs: Dict[str, tuple[str, str]] = {}
+        # base_session_id → (thread_id, effective Git PATH, PATH override persisted)
+        self._thread_git_path_configs: Dict[str, tuple[str, str, bool]] = {}
         self._fork_correction_pending_base_sessions: set[str] = set()
 
     # ------------------------------------------------------------------
@@ -782,27 +782,38 @@ class CodexAgent(BaseAgent):
         tmp_path.replace(script_path)
         return script_path
 
-    def _inject_caller_env_config(self, params: Dict[str, Any], request: AgentRequest) -> str:
+    def _inject_caller_env_config(
+        self,
+        params: Dict[str, Any],
+        request: AgentRequest,
+        *,
+        force_path: bool = False,
+    ) -> tuple[str, bool]:
         from core.git_runtime import prepend_vendored_git_to_path
 
         env = self._caller_env_for_request(request)
         config = dict(params.get("config") or {})
         shell_policy = dict(config.get("shell_environment_policy") or {})
         set_env = dict(shell_policy.get("set") or {})
+        had_path = "PATH" in set_env
         if env:
             env_script_path = self._caller_env_script_path(request)
             set_env.update({**env, "BASH_ENV": str(env_script_path)})
-        prepend_vendored_git_to_path(
+        git_path_changed = prepend_vendored_git_to_path(
             set_env,
             base_env=os.environ,
             working_dir=getattr(request, "working_path", None),
         )
         git_path_state = set_env["PATH"] if "PATH" in set_env else os.environ.get("PATH", "")
-        set_env["PATH"] = git_path_state
+        path_managed = had_path or git_path_changed or force_path
+        if force_path:
+            set_env["PATH"] = git_path_state
+        if not env and not path_managed:
+            return git_path_state, False
         shell_policy["set"] = set_env
         config["shell_environment_policy"] = shell_policy
         params["config"] = config
-        return git_path_state
+        return git_path_state, path_managed
 
     def _git_path_state_for_request(self, request: AgentRequest) -> str:
         from core.git_runtime import prepend_vendored_git_to_path
@@ -830,7 +841,7 @@ class CodexAgent(BaseAgent):
         developer_instructions = self._build_thread_developer_instructions(request)
         if developer_instructions:
             params["developerInstructions"] = developer_instructions
-        git_path_state = self._inject_caller_env_config(params, request)
+        git_path_state, git_path_managed = self._inject_caller_env_config(params, request)
 
         resp = await transport.send_request("thread/start", params)
         # thread/start returns Thread directly OR may nest under "thread"
@@ -851,7 +862,12 @@ class CodexAgent(BaseAgent):
             thread_id,
             self._caller_env_for_request(request),
         )
-        self._remember_thread_git_path_config(request.base_session_id, thread_id, git_path_state)
+        self._remember_thread_git_path_config(
+            request.base_session_id,
+            thread_id,
+            git_path_state,
+            git_path_managed,
+        )
         return thread_id
 
     async def _fork_thread(
@@ -875,7 +891,7 @@ class CodexAgent(BaseAgent):
             params["developerInstructions"] = developer_instructions
         if effective_model:
             params["model"] = effective_model
-        git_path_state = self._inject_caller_env_config(params, request)
+        git_path_state, git_path_managed = self._inject_caller_env_config(params, request)
 
         self._mark_fork_correction_pending(request.base_session_id)
         try:
@@ -902,7 +918,12 @@ class CodexAgent(BaseAgent):
             thread_id,
             self._caller_env_for_request(request),
         )
-        self._remember_thread_git_path_config(request.base_session_id, thread_id, git_path_state)
+        self._remember_thread_git_path_config(
+            request.base_session_id,
+            thread_id,
+            git_path_state,
+            git_path_managed,
+        )
         logger.info("Forked Codex thread %s from %s for session %s", thread_id, source_thread_id, request.base_session_id)
         return thread_id
 
@@ -1036,7 +1057,10 @@ class CodexAgent(BaseAgent):
                     "threadId": persisted,
                     "developerInstructions": self._build_thread_developer_instructions(request),
                 }
-                git_path_state = self._inject_caller_env_config(resume_params, request)
+                git_path_state, git_path_managed = self._inject_caller_env_config(
+                    resume_params,
+                    request,
+                )
                 model_provider = await self._resolve_resume_model_provider_override(transport, request, persisted)
                 if model_provider:
                     resume_params["modelProvider"] = model_provider
@@ -1086,6 +1110,7 @@ class CodexAgent(BaseAgent):
                 request.base_session_id,
                 thread_id,
                 git_path_state,
+                git_path_managed,
             )
             logger.info("Resumed Codex thread %s for session %s", thread_id, request.base_session_id)
             return thread_id
@@ -1257,7 +1282,15 @@ class CodexAgent(BaseAgent):
         cached = self._thread_developer_instructions.get(request.base_session_id)
         cached_caller_env = self._thread_caller_env_configs.get(request.base_session_id)
         cached_git_path = self._thread_git_path_configs.get(request.base_session_id)
-        git_path_changed = cached_git_path != (thread_id, git_path_state)
+        git_path_changed = cached_git_path is None or cached_git_path[:2] != (
+            thread_id,
+            git_path_state,
+        )
+        git_path_managed = bool(
+            cached_git_path
+            and cached_git_path[0] == thread_id
+            and cached_git_path[2]
+        )
         if not developer_instructions and not caller_env and not git_path_changed:
             return
         if cached == (thread_id, developer_instructions) and (
@@ -1271,7 +1304,11 @@ class CodexAgent(BaseAgent):
         if cached != (thread_id, developer_instructions):
             resume_params["developerInstructions"] = developer_instructions
         if caller_env or git_path_changed:
-            git_path_state = self._inject_caller_env_config(resume_params, request)
+            git_path_state, git_path_managed = self._inject_caller_env_config(
+                resume_params,
+                request,
+                force_path=git_path_managed,
+            )
         model_provider = await self._resolve_resume_model_provider_override(transport, request, thread_id)
         if model_provider:
             resume_params["modelProvider"] = model_provider
@@ -1286,7 +1323,12 @@ class CodexAgent(BaseAgent):
             developer_instructions,
         )
         self._remember_thread_caller_env_config(request.base_session_id, thread_id, caller_env)
-        self._remember_thread_git_path_config(request.base_session_id, thread_id, git_path_state)
+        self._remember_thread_git_path_config(
+            request.base_session_id,
+            thread_id,
+            git_path_state,
+            git_path_managed,
+        )
 
     def _remember_thread_developer_instructions(
         self,
@@ -1317,10 +1359,15 @@ class CodexAgent(BaseAgent):
         base_session_id: str,
         thread_id: str,
         git_path_state: str,
+        path_managed: bool,
     ) -> None:
         if not hasattr(self, "_thread_git_path_configs"):
             self._thread_git_path_configs = {}
-        self._thread_git_path_configs[base_session_id] = (thread_id, git_path_state)
+        self._thread_git_path_configs[base_session_id] = (
+            thread_id,
+            git_path_state,
+            path_managed,
+        )
 
     def _clear_thread_developer_instructions(self, base_session_id: str) -> None:
         if hasattr(self, "_thread_developer_instructions"):

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -17,7 +17,6 @@ from config.v2_config import (
 )
 from core.avibe_cloud import avibe_cloud_url_available
 from core.caller_context import caller_env_for_platform_payload
-from core.git_runtime import prepend_vendored_git_to_path
 from core.message_output import terminal_output_for
 from core.services.session_fork import fork_source_state, pending_native_fork
 from core.system_prompt_injection import (
@@ -782,6 +781,8 @@ class CodexAgent(BaseAgent):
         return script_path
 
     def _inject_caller_env_config(self, params: Dict[str, Any], request: AgentRequest) -> None:
+        from core.git_runtime import prepend_vendored_git_to_path
+
         env = self._caller_env_for_request(request)
         config = dict(params.get("config") or {})
         shell_policy = dict(config.get("shell_environment_policy") or {})

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from typing import Dict, Optional
 
@@ -359,7 +360,12 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 system_prompt_injection = f"{request.vibe_agent_system_prompt}\n\n{system_prompt_injection}"
 
             try:
-                bind_caller_context_session(session_id, request.context.platform_specific or {})
+                bind_caller_context_session(
+                    session_id,
+                    request.context.platform_specific or {},
+                    base_env=os.environ,
+                    working_dir=request.working_path,
+                )
             except Exception:
                 logger.warning("Failed to bind OpenCode caller context for session %s", session_id, exc_info=True)
 

--- a/modules/agents/opencode/caller_context.py
+++ b/modules/agents/opencode/caller_context.py
@@ -17,6 +17,7 @@ from typing import Any, Mapping
 
 from config import paths
 from core.caller_context import caller_context_from_platform_payload
+from core.git_runtime import prepend_vendored_git_to_path
 
 PLUGIN_FILENAME = "avibe-caller-context.js"
 BINDINGS_FILENAME = "opencode_caller_context.json"
@@ -134,13 +135,21 @@ def bind_session(
     opencode_session_id: str,
     platform_payload: Mapping[str, object] | None,
     *,
+    base_env: Mapping[str, str],
+    working_dir: Path | str | None,
     ttl_hours: int = BINDING_TTL_HOURS,
 ) -> bool:
     session_id = str(opencode_session_id or "").strip()
     if not session_id:
         return False
     caller = caller_context_from_platform_payload(platform_payload)
-    if caller is None:
+    env = caller.to_env() if caller is not None else {}
+    prepend_vendored_git_to_path(
+        env,
+        base_env=base_env,
+        working_dir=working_dir,
+    )
+    if not env:
         return False
 
     path = binding_path()
@@ -149,12 +158,14 @@ def bind_session(
     expires_at = now + timedelta(hours=max(1, int(ttl_hours)))
     data = _load_bindings(path)
     sessions = _prune_sessions(data.get("sessions", {}), now)
-    sessions[session_id] = {
-        "env": caller.to_env(),
-        "caller_context": caller.to_metadata(),
+    entry = {
+        "env": env,
         "updated_at": now.isoformat(),
         "expires_at": expires_at.isoformat(),
     }
+    if caller is not None:
+        entry["caller_context"] = caller.to_metadata()
+    sessions[session_id] = entry
     data["sessions"] = sessions
     tmp_path = path.with_suffix(path.suffix + ".tmp")
     tmp_path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")

--- a/modules/agents/opencode/caller_context.py
+++ b/modules/agents/opencode/caller_context.py
@@ -17,7 +17,6 @@ from typing import Any, Mapping
 
 from config import paths
 from core.caller_context import caller_context_from_platform_payload
-from core.git_runtime import prepend_vendored_git_to_path
 
 PLUGIN_FILENAME = "avibe-caller-context.js"
 BINDINGS_FILENAME = "opencode_caller_context.json"
@@ -139,6 +138,8 @@ def bind_session(
     working_dir: Path | str | None,
     ttl_hours: int = BINDING_TTL_HOURS,
 ) -> bool:
+    from core.git_runtime import prepend_vendored_git_to_path
+
     session_id = str(opencode_session_id or "").strip()
     if not session_id:
         return False

--- a/modules/agents/opencode/caller_context.py
+++ b/modules/agents/opencode/caller_context.py
@@ -130,6 +130,13 @@ def _prune_sessions(sessions: dict[str, Any], now: datetime) -> dict[str, Any]:
     return pruned
 
 
+def _write_bindings(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
 def bind_session(
     opencode_session_id: str,
     platform_payload: Mapping[str, object] | None,
@@ -150,12 +157,20 @@ def bind_session(
         base_env=base_env,
         working_dir=working_dir,
     )
+    path = binding_path()
+    now = _utc_now()
     if not env:
+        if not path.is_file():
+            return False
+        data = _load_bindings(path)
+        existing_sessions = data.get("sessions", {})
+        sessions = _prune_sessions(existing_sessions, now)
+        sessions.pop(session_id, None)
+        if sessions != existing_sessions:
+            data["sessions"] = sessions
+            _write_bindings(path, data)
         return False
 
-    path = binding_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    now = _utc_now()
     expires_at = now + timedelta(hours=max(1, int(ttl_hours)))
     data = _load_bindings(path)
     sessions = _prune_sessions(data.get("sessions", {}), now)
@@ -168,7 +183,5 @@ def bind_session(
         entry["caller_context"] = caller.to_metadata()
     sessions[session_id] = entry
     data["sessions"] = sessions
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
-    tmp_path.replace(path)
+    _write_bindings(path, data)
     return True

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -161,6 +161,38 @@ def test_session_handler_passes_configured_claude_cli_path(monkeypatch, tmp_path
     assert getattr(client, "_vibe_runtime_session_key") == f"slack_C123:{tmp_path}"
 
 
+def test_session_handler_injects_vendored_git_into_gitless_child_env(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            return None
+
+    def inject_git(env, *, base_env, working_dir):
+        assert "PATH" not in env
+        assert base_env is session_handler_module.os.environ
+        assert working_dir == str(tmp_path)
+        env["PATH"] = "/managed/git/bin"
+        return True
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module, "prepend_vendored_git_to_path", inject_git)
+
+    _run_session(
+        SessionHandler(_Controller(tmp_path)),
+        MessageContext(user_id="U123", channel_id="C123"),
+    )
+
+    assert captured["options"].env["PATH"] == "/managed/git/bin"
+
+
 def test_session_handler_moves_claude_process_into_agent_cgroup(monkeypatch, tmp_path: Path) -> None:
     calls: list[tuple[int, str]] = []
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import core.handlers.session_handler as session_handler_module
 from config.v2_compat import to_app_config
 from config.v2_config import AgentsConfig, ClaudeConfig, RuntimeConfig, SlackConfig, V2Config
+from core import git_runtime as git_runtime_module
 from core.handlers.session_handler import SessionHandler
 from modules.claude_sdk_compat import CLAUDE_SDK_MAX_BUFFER_SIZE
 from modules.im import MessageContext
@@ -183,7 +184,7 @@ def test_session_handler_injects_vendored_git_into_gitless_child_env(
 
     monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
     monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
-    monkeypatch.setattr(session_handler_module, "prepend_vendored_git_to_path", inject_git)
+    monkeypatch.setattr(git_runtime_module, "prepend_vendored_git_to_path", inject_git)
 
     _run_session(
         SessionHandler(_Controller(tmp_path)),

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -860,6 +860,49 @@ def test_session_handler_does_not_repeat_claude_model_control_request(monkeypatc
     assert first_client.model_calls == []
 
 
+def test_session_handler_recreates_cached_client_when_git_path_changes(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    clients: list[Any] = []
+    runtime_ready = {"value": False}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.options = options
+            self.disconnects = 0
+            clients.append(self)
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    def inject_git(env, *, base_env, working_dir):
+        if runtime_ready["value"]:
+            env["PATH"] = f"/managed/git/bin{session_handler_module.os.pathsep}{base_env['PATH']}"
+            return True
+        return False
+
+    monkeypatch.setenv("PATH", "/gitless/bin")
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(git_runtime_module, "prepend_vendored_git_to_path", inject_git)
+    handler = SessionHandler(_Controller(tmp_path))
+    context = MessageContext(user_id="U123", channel_id="C123")
+
+    first_client = _run_session(handler, context)
+    runtime_ready["value"] = True
+    second_client = _run_session(handler, context)
+
+    assert first_client is not second_client
+    assert first_client.disconnects == 1
+    assert len(clients) == 2
+    assert "PATH" not in first_client.options.env
+    assert second_client.options.env["PATH"] == "/managed/git/bin:/gitless/bin"
+
+
 def test_session_handler_recreates_cached_claude_client_when_caller_env_changes(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2602,6 +2602,98 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(second_params["threadId"], "thread-existing")
 
+    async def test_refresh_thread_developer_instructions_refreshes_git_path_state(self):
+        agent = object.__new__(CodexAgent)
+        agent.sessions = SimpleNamespace(ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"))
+        agent._resolve_resume_model_provider_override = AsyncMock(return_value=None)
+        agent._build_thread_developer_instructions = Mock(return_value="stable instructions")
+        agent._thread_developer_instructions = {
+            "session-1": ("thread-existing", "stable instructions")
+        }
+        agent._thread_caller_env_configs = {}
+        agent._thread_git_path_configs = {
+            "session-1": ("thread-existing", "/gitless/bin")
+        }
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            session_key="slack::channel::C1::thread::171717.123",
+            base_session_id="session-1",
+            context=SimpleNamespace(platform_specific={}),
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-existing"}}))
+
+        def inject_git(env, *, base_env, working_dir):
+            env["PATH"] = "/managed/git/bin:/gitless/bin"
+            return True
+
+        with patch.dict(os.environ, {"PATH": "/gitless/bin"}), patch(
+            "core.git_runtime.prepend_vendored_git_to_path",
+            side_effect=inject_git,
+        ):
+            await agent._refresh_thread_developer_instructions_if_needed(
+                transport,
+                request,
+                "thread-existing",
+            )
+            await agent._refresh_thread_developer_instructions_if_needed(
+                transport,
+                request,
+                "thread-existing",
+            )
+
+        transport.send_request.assert_awaited_once()
+        method, params = transport.send_request.await_args.args
+        self.assertEqual(method, "thread/resume")
+        self.assertNotIn("developerInstructions", params)
+        self.assertEqual(
+            params["config"]["shell_environment_policy"]["set"]["PATH"],
+            "/managed/git/bin:/gitless/bin",
+        )
+        self.assertEqual(
+            agent._thread_git_path_configs["session-1"],
+            ("thread-existing", "/managed/git/bin:/gitless/bin"),
+        )
+
+    async def test_refresh_thread_developer_instructions_clears_stale_vendored_path(self):
+        agent = object.__new__(CodexAgent)
+        agent.sessions = SimpleNamespace(ensure_agent_session_id=Mock(return_value="sesk8m4q2p7x"))
+        agent._resolve_resume_model_provider_override = AsyncMock(return_value=None)
+        agent._build_thread_developer_instructions = Mock(return_value="stable instructions")
+        agent._thread_developer_instructions = {
+            "session-1": ("thread-existing", "stable instructions")
+        }
+        agent._thread_caller_env_configs = {}
+        agent._thread_git_path_configs = {
+            "session-1": ("thread-existing", "/managed/git/bin:/usr/bin")
+        }
+        request = SimpleNamespace(
+            working_path="/tmp/work",
+            session_key="slack::channel::C1::thread::171717.123",
+            base_session_id="session-1",
+            context=SimpleNamespace(platform_specific={}),
+        )
+        transport = SimpleNamespace(send_request=AsyncMock(return_value={"thread": {"id": "thread-existing"}}))
+
+        with patch.dict(os.environ, {"PATH": "/usr/bin"}), patch(
+            "core.git_runtime.prepend_vendored_git_to_path",
+            return_value=False,
+        ):
+            await agent._refresh_thread_developer_instructions_if_needed(
+                transport,
+                request,
+                "thread-existing",
+            )
+
+        _, params = transport.send_request.await_args.args
+        self.assertEqual(
+            params["config"]["shell_environment_policy"]["set"]["PATH"],
+            "/usr/bin",
+        )
+        self.assertEqual(
+            agent._thread_git_path_configs["session-1"],
+            ("thread-existing", "/usr/bin"),
+        )
+
     async def test_refresh_thread_developer_instructions_preserves_resume_model_provider_override(self):
         agent = object.__new__(CodexAgent)
         agent.controller = SimpleNamespace(config=SimpleNamespace(platform="slack", reply_enhancements=True))

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1086,6 +1086,27 @@ class CodexAgentHandleMessageTests(unittest.IsolatedAsyncioTestCase):
 
 
 class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
+    def test_inject_caller_env_config_adds_vendored_git_for_gitless_session(self):
+        agent = object.__new__(CodexAgent)
+        params = {"config": {"shell_environment_policy": {"set": {"PATH": ""}}}}
+        request = SimpleNamespace(
+            working_path="/tmp/workspace",
+            context=SimpleNamespace(platform_specific={}),
+        )
+
+        def inject_git(env, *, base_env, working_dir):
+            self.assertEqual(env["PATH"], "")
+            self.assertIs(base_env, os.environ)
+            self.assertEqual(working_dir, "/tmp/workspace")
+            env["PATH"] = "/managed/git/bin"
+            return True
+
+        with patch.object(_MODULE, "prepend_vendored_git_to_path", side_effect=inject_git):
+            agent._inject_caller_env_config(params, request)
+
+        set_env = params["config"]["shell_environment_policy"]["set"]
+        self.assertEqual(set_env, {"PATH": "/managed/git/bin"})
+
     def test_inject_caller_env_config_merges_shell_environment_policy(self):
         agent = object.__new__(CodexAgent)
         params = {"config": {"shell_environment_policy": {"set": {"KEEP": "1"}}}}

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1124,7 +1124,8 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             )
         )
 
-        agent._inject_caller_env_config(params, request)
+        with patch("core.git_runtime.prepend_vendored_git_to_path", return_value=False):
+            agent._inject_caller_env_config(params, request)
 
         set_env = params["config"]["shell_environment_policy"]["set"]
         self.assertEqual(set_env["KEEP"], "1")
@@ -1134,6 +1135,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(set_env["AVIBE_CALLER_BACKEND"], "codex")
         self.assertEqual(set_env["AVIBE_NATIVE_SESSION_ID"], "thread-parent")
         self.assertTrue(set_env["BASH_ENV"].endswith("/codex-caller-env/ses-parent.sh"))
+        self.assertNotIn("PATH", set_env)
 
     def test_write_caller_env_script_refreshes_reused_thread_run_id(self):
         agent = object.__new__(CodexAgent)
@@ -2612,7 +2614,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         }
         agent._thread_caller_env_configs = {}
         agent._thread_git_path_configs = {
-            "session-1": ("thread-existing", "/gitless/bin")
+            "session-1": ("thread-existing", "/gitless/bin", False)
         }
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -2651,7 +2653,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             agent._thread_git_path_configs["session-1"],
-            ("thread-existing", "/managed/git/bin:/gitless/bin"),
+            ("thread-existing", "/managed/git/bin:/gitless/bin", True),
         )
 
     async def test_refresh_thread_developer_instructions_clears_stale_vendored_path(self):
@@ -2664,7 +2666,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         }
         agent._thread_caller_env_configs = {}
         agent._thread_git_path_configs = {
-            "session-1": ("thread-existing", "/managed/git/bin:/usr/bin")
+            "session-1": ("thread-existing", "/managed/git/bin:/usr/bin", True)
         }
         request = SimpleNamespace(
             working_path="/tmp/work",
@@ -2691,7 +2693,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             agent._thread_git_path_configs["session-1"],
-            ("thread-existing", "/usr/bin"),
+            ("thread-existing", "/usr/bin", True),
         )
 
     async def test_refresh_thread_developer_instructions_preserves_resume_model_provider_override(self):

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1101,7 +1101,7 @@ class CodexAgentPayloadTests(unittest.IsolatedAsyncioTestCase):
             env["PATH"] = "/managed/git/bin"
             return True
 
-        with patch.object(_MODULE, "prepend_vendored_git_to_path", side_effect=inject_git):
+        with patch("core.git_runtime.prepend_vendored_git_to_path", side_effect=inject_git):
             agent._inject_caller_env_config(params, request)
 
         set_env = params["config"]["shell_environment_policy"]["set"]

--- a/tests/test_git_binary.py
+++ b/tests/test_git_binary.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
-from core import git_binary
+from core import git_binary, git_runtime
 from core.git_binary import ResolvedGit
 
 
@@ -15,7 +15,7 @@ def test_resolve_vendored_uses_managed_git_runtime(monkeypatch):
         def resolve_git_path() -> Path:
             return vendored
 
-    monkeypatch.setattr(git_binary, "get_git_runtime_manager", lambda: FakeManager())
+    monkeypatch.setattr(git_runtime, "get_git_runtime_manager", lambda: FakeManager())
 
     assert git_binary._resolve_vendored() == ResolvedGit(path=vendored, source="vendored")
 
@@ -26,7 +26,7 @@ def test_resolve_vendored_degrades_when_runtime_is_not_installed(monkeypatch):
         def resolve_git_path() -> None:
             return None
 
-    monkeypatch.setattr(git_binary, "get_git_runtime_manager", lambda: FakeManager())
+    monkeypatch.setattr(git_runtime, "get_git_runtime_manager", lambda: FakeManager())
 
     assert git_binary._resolve_vendored() is None
 

--- a/tests/test_git_binary.py
+++ b/tests/test_git_binary.py
@@ -7,6 +7,30 @@ from core import git_binary
 from core.git_binary import ResolvedGit
 
 
+def test_resolve_vendored_uses_managed_git_runtime(monkeypatch):
+    vendored = Path("/managed/runtime/git/bin/git")
+
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            return vendored
+
+    monkeypatch.setattr(git_binary, "get_git_runtime_manager", lambda: FakeManager())
+
+    assert git_binary._resolve_vendored() == ResolvedGit(path=vendored, source="vendored")
+
+
+def test_resolve_vendored_degrades_when_runtime_is_not_installed(monkeypatch):
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> None:
+            return None
+
+    monkeypatch.setattr(git_binary, "get_git_runtime_manager", lambda: FakeManager())
+
+    assert git_binary._resolve_vendored() is None
+
+
 def test_resolve_git_prefers_vendored(monkeypatch):
     vendored = ResolvedGit(path=Path("/managed/git"), source="vendored")
     monkeypatch.setattr(git_binary, "_resolve_vendored", lambda: vendored)

--- a/tests/test_git_runtime.py
+++ b/tests/test_git_runtime.py
@@ -82,6 +82,32 @@ def test_manifest_parses_and_exposes_archive(tmp_path: Path, monkeypatch: pytest
     ][managed_runtime.runtime_platform_tag()]["binary_sha256"]
 
 
+def test_packaged_manifest_matches_published_four_platform_release(tmp_path: Path) -> None:
+    manager = GitRuntimeManager(runtime_dir=tmp_path / "runtime", offline=True)
+
+    manifest = manager._load_manifest(allow_network=False)
+
+    assert manifest is not None
+    assert manifest.runtime_version == "2.55.0"
+    assert manifest.payload["release_state"] == "published"
+    assert manifest.payload["release_tag"] == "git-runtime-v2.55.0-1"
+    assert manifest.payload["local_ops_only"] is True
+    assert set(manifest.archives) == {
+        "darwin-arm64",
+        "darwin-x64",
+        "linux-arm64",
+        "linux-x64",
+    }
+    for platform_tag, archive in manifest.archives.items():
+        assert archive.size is not None and archive.size > 0
+        assert archive.sha256 != "0" * 64
+        assert archive.binary_sha256 != "0" * 64
+        assert archive.url == (
+            "https://github.com/avibe-bot/avibe/releases/download/"
+            f"git-runtime-v2.55.0-1/git-2.55.0-{platform_tag}.tar.gz"
+        )
+
+
 def test_manifest_requires_pinned_binary_sha256(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     archive = _write_git_archive(tmp_path)
@@ -522,3 +548,196 @@ def test_macos_non_system_git_is_classified_without_execution(monkeypatch: pytes
         "/opt/homebrew/bin/git"
     )
     assert calls == []
+
+
+def test_agent_path_injection_uses_explicit_fallback_when_path_is_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vendored = tmp_path / "runtime" / "bin" / "git"
+
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            return vendored
+
+    seen_paths: list[str] = []
+
+    def missing_system_git(*, env):
+        seen_paths.append(env["PATH"])
+        return None
+
+    monkeypatch.setattr(git_runtime, "resolve_system_git_path", missing_system_git)
+    env: dict[str, str] = {}
+    base_path = os.pathsep.join(["/usr/local/bin", "/usr/bin"])
+
+    changed = git_runtime.prepend_vendored_git_to_path(
+        env,
+        base_env={"PATH": base_path},
+        working_dir=tmp_path / "workspace",
+        manager=FakeManager(),  # type: ignore[arg-type]
+    )
+
+    assert changed is True
+    assert seen_paths == ["/usr/local/bin", "/usr/bin"]
+    assert env["PATH"] == f"{vendored.parent}{os.pathsep}{base_path}"
+
+
+def test_agent_path_injection_preserves_empty_path_and_never_leaks_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vendored = tmp_path / "runtime" / "bin" / "git"
+
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            return vendored
+
+    monkeypatch.setenv("PATH", "/parent/process/bin")
+    monkeypatch.setattr(
+        git_runtime,
+        "resolve_system_git_path",
+        lambda **kwargs: pytest.fail("empty target PATH must not probe parent PATH"),
+    )
+    env = {"PATH": ""}
+
+    changed = git_runtime.prepend_vendored_git_to_path(
+        env,
+        base_env={"PATH": "/explicit/base/bin"},
+        working_dir=tmp_path / "workspace",
+        manager=FakeManager(),  # type: ignore[arg-type]
+    )
+
+    assert changed is True
+    assert env["PATH"] == str(vendored.parent)
+
+
+def test_agent_path_injection_absent_path_does_not_leak_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vendored = tmp_path / "runtime" / "bin" / "git"
+
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            return vendored
+
+    monkeypatch.setenv("PATH", "/parent/process/bin")
+    monkeypatch.setattr(
+        git_runtime,
+        "resolve_system_git_path",
+        lambda **kwargs: pytest.fail("explicit empty fallback must not probe parent PATH"),
+    )
+    env: dict[str, str] = {}
+
+    changed = git_runtime.prepend_vendored_git_to_path(
+        env,
+        base_env={},
+        working_dir=tmp_path / "workspace",
+        manager=FakeManager(),  # type: ignore[arg-type]
+    )
+
+    assert changed is True
+    assert env["PATH"] == str(vendored.parent)
+
+
+def test_agent_path_injection_never_shadows_safe_system_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        git_runtime,
+        "resolve_system_git_path",
+        lambda *, env: Path("/usr/local/bin/git") if env["PATH"] == "/usr/local/bin" else None,
+    )
+
+    class UnexpectedManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            pytest.fail("vendored Git must not resolve when safe system Git is first")
+
+    env: dict[str, str] = {}
+
+    changed = git_runtime.prepend_vendored_git_to_path(
+        env,
+        base_env={"PATH": "/usr/local/bin:/usr/bin"},
+        working_dir=tmp_path / "workspace",
+        manager=UnexpectedManager(),  # type: ignore[arg-type]
+    )
+
+    assert changed is False
+    assert "PATH" not in env
+
+
+def test_agent_path_injection_shadows_workspace_prefix_before_system_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace_bin = workspace / "bin"
+    vendored = tmp_path / "runtime" / "bin" / "git"
+
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            return vendored
+
+    monkeypatch.setattr(
+        git_runtime,
+        "resolve_system_git_path",
+        lambda **kwargs: pytest.fail("workspace prefix must fail closed before probing later PATH entries"),
+    )
+    original_path = f"{workspace_bin}{os.pathsep}/usr/bin"
+    env = {"PATH": original_path}
+
+    changed = git_runtime.prepend_vendored_git_to_path(
+        env,
+        base_env={},
+        working_dir=workspace,
+        manager=FakeManager(),  # type: ignore[arg-type]
+    )
+
+    assert changed is True
+    assert env["PATH"] == f"{vendored.parent}{os.pathsep}{original_path}"
+
+
+def test_agent_path_injection_treats_macos_shim_as_gitless_without_clt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vendored = tmp_path / "runtime" / "bin" / "git"
+    calls: list[list[str]] = []
+
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            return vendored
+
+    monkeypatch.setattr(git_runtime.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(git_runtime.shutil, "which", lambda name, path=None: "/usr/bin/git")
+
+    def missing_clt(argv, **kwargs):
+        calls.append(argv)
+
+        class Result:
+            returncode = 1
+            stdout = ""
+            stderr = "missing"
+
+        return Result()
+
+    monkeypatch.setattr(git_runtime.subprocess, "run", missing_clt)
+    env = {"PATH": "/usr/bin"}
+
+    changed = git_runtime.prepend_vendored_git_to_path(
+        env,
+        base_env={},
+        working_dir=tmp_path / "workspace",
+        manager=FakeManager(),  # type: ignore[arg-type]
+    )
+
+    assert changed is True
+    assert calls == [["/usr/bin/xcode-select", "-p"]]
+    assert env["PATH"] == f"{vendored.parent}{os.pathsep}/usr/bin"

--- a/tests/test_git_runtime.py
+++ b/tests/test_git_runtime.py
@@ -703,6 +703,40 @@ def test_agent_path_injection_shadows_workspace_prefix_before_system_git(
     assert env["PATH"] == f"{vendored.parent}{os.pathsep}{original_path}"
 
 
+def test_agent_path_injection_rejects_workspace_symlink_to_system_bin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    workspace_bin = workspace / "bin"
+    workspace_bin.symlink_to("/usr/bin", target_is_directory=True)
+    vendored = tmp_path / "runtime" / "bin" / "git"
+
+    class FakeManager:
+        @staticmethod
+        def resolve_git_path() -> Path:
+            return vendored
+
+    monkeypatch.setattr(
+        git_runtime,
+        "resolve_system_git_path",
+        lambda **kwargs: pytest.fail("workspace symlink must be rejected before Git lookup"),
+    )
+    original_path = f"{workspace_bin}{os.pathsep}/usr/bin"
+    env = {"PATH": original_path}
+
+    changed = git_runtime.prepend_vendored_git_to_path(
+        env,
+        base_env={},
+        working_dir=workspace,
+        manager=FakeManager(),  # type: ignore[arg-type]
+    )
+
+    assert changed is True
+    assert env["PATH"] == f"{vendored.parent}{os.pathsep}{original_path}"
+
+
 def test_agent_path_injection_treats_macos_shim_as_gitless_without_clt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_opencode_caller_context.py
+++ b/tests/test_opencode_caller_context.py
@@ -25,6 +25,7 @@ def test_ensure_plugin_installed_writes_global_opencode_plugin(tmp_path: Path, m
 def test_bind_session_writes_env_binding(tmp_path: Path, monkeypatch) -> None:
     avibe_home = tmp_path / "avibe"
     monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
+    monkeypatch.setattr(bridge, "prepend_vendored_git_to_path", lambda *args, **kwargs: False)
 
     ok = bridge.bind_session(
         "oc-session",
@@ -37,6 +38,8 @@ def test_bind_session_writes_env_binding(tmp_path: Path, monkeypatch) -> None:
                 "native_session_id": "oc-session",
             },
         },
+        base_env={"PATH": "/usr/bin"},
+        working_dir=tmp_path / "workspace",
     )
 
     assert ok is True
@@ -55,6 +58,39 @@ def test_bind_session_writes_env_binding(tmp_path: Path, monkeypatch) -> None:
 
 def test_bind_session_skips_without_resolved_caller_context(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe"))
+    monkeypatch.setattr(bridge, "prepend_vendored_git_to_path", lambda *args, **kwargs: False)
 
-    assert bridge.bind_session("oc-session", {"platform": "slack"}) is False
+    assert bridge.bind_session(
+        "oc-session",
+        {"platform": "slack"},
+        base_env={"PATH": "/usr/bin"},
+        working_dir=tmp_path / "workspace",
+    ) is False
     assert not bridge.binding_path().exists()
+
+
+def test_bind_session_writes_vendored_path_without_caller_context(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe"))
+
+    def inject_git(env, *, base_env, working_dir):
+        assert env == {}
+        assert base_env == {"PATH": ""}
+        assert working_dir == tmp_path / "workspace"
+        env["PATH"] = "/managed/git/bin"
+        return True
+
+    monkeypatch.setattr(bridge, "prepend_vendored_git_to_path", inject_git)
+
+    assert bridge.bind_session(
+        "oc-session",
+        {"platform": "slack"},
+        base_env={"PATH": ""},
+        working_dir=tmp_path / "workspace",
+    ) is True
+    data = json.loads(bridge.binding_path().read_text(encoding="utf-8"))
+    entry = data["sessions"]["oc-session"]
+    assert entry["env"] == {"PATH": "/managed/git/bin"}
+    assert "caller_context" not in entry

--- a/tests/test_opencode_caller_context.py
+++ b/tests/test_opencode_caller_context.py
@@ -95,3 +95,30 @@ def test_bind_session_writes_vendored_path_without_caller_context(
     entry = data["sessions"]["oc-session"]
     assert entry["env"] == {"PATH": "/managed/git/bin"}
     assert "caller_context" not in entry
+
+
+def test_bind_session_clears_stale_path_when_git_override_disappears(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe"))
+    inject = {"enabled": True}
+
+    def inject_git(env, *, base_env, working_dir):
+        if inject["enabled"]:
+            env["PATH"] = "/managed/git/bin"
+            return True
+        return False
+
+    monkeypatch.setattr(git_runtime, "prepend_vendored_git_to_path", inject_git)
+    kwargs = {
+        "base_env": {"PATH": "/usr/bin"},
+        "working_dir": tmp_path / "workspace",
+    }
+    assert bridge.bind_session("oc-session", {"platform": "slack"}, **kwargs) is True
+
+    inject["enabled"] = False
+
+    assert bridge.bind_session("oc-session", {"platform": "slack"}, **kwargs) is False
+    data = json.loads(bridge.binding_path().read_text(encoding="utf-8"))
+    assert "oc-session" not in data["sessions"]

--- a/tests/test_opencode_caller_context.py
+++ b/tests/test_opencode_caller_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from core import git_runtime
 from modules.agents.opencode import caller_context as bridge
 
 
@@ -25,7 +26,7 @@ def test_ensure_plugin_installed_writes_global_opencode_plugin(tmp_path: Path, m
 def test_bind_session_writes_env_binding(tmp_path: Path, monkeypatch) -> None:
     avibe_home = tmp_path / "avibe"
     monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
-    monkeypatch.setattr(bridge, "prepend_vendored_git_to_path", lambda *args, **kwargs: False)
+    monkeypatch.setattr(git_runtime, "prepend_vendored_git_to_path", lambda *args, **kwargs: False)
 
     ok = bridge.bind_session(
         "oc-session",
@@ -58,7 +59,7 @@ def test_bind_session_writes_env_binding(tmp_path: Path, monkeypatch) -> None:
 
 def test_bind_session_skips_without_resolved_caller_context(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe"))
-    monkeypatch.setattr(bridge, "prepend_vendored_git_to_path", lambda *args, **kwargs: False)
+    monkeypatch.setattr(git_runtime, "prepend_vendored_git_to_path", lambda *args, **kwargs: False)
 
     assert bridge.bind_session(
         "oc-session",
@@ -82,7 +83,7 @@ def test_bind_session_writes_vendored_path_without_caller_context(
         env["PATH"] = "/managed/git/bin"
         return True
 
-    monkeypatch.setattr(bridge, "prepend_vendored_git_to_path", inject_git)
+    monkeypatch.setattr(git_runtime, "prepend_vendored_git_to_path", inject_git)
 
     assert bridge.bind_session(
         "oc-session",

--- a/vibe/git_runtime_manifest.json
+++ b/vibe/git_runtime_manifest.json
@@ -1,44 +1,44 @@
 {
-  "schema_version": 1,
-  "git_version": "2.55.0",
-  "source": "kernel.org/git",
-  "source_url": "https://www.kernel.org/pub/software/scm/git/git-2.55.0.tar.xz",
-  "source_sha256": "457fdb04dc8728e007d4688695e6912e6f680727920f2a40bf11eacc17505357",
-  "release_tag": "git-runtime-v2.55.0-1",
-  "release_state": "pending",
-  "local_ops_only": true,
   "archives": {
     "darwin-arm64": {
+      "bin_path": "bin/git",
+      "binary_sha256": "e1ce5618cd911b2d061166c99a661423e1d0b04cf91e1923a2d15d449f309f97",
       "name": "git-2.55.0-darwin-arm64.tar.gz",
-      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-darwin-arm64.tar.gz",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "binary_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "size": null,
-      "bin_path": "bin/git"
+      "sha256": "02477119b1dd0f19a10c2ec5a443417f1697b83b1b18dbca874c0b72efedebae",
+      "size": 1684366,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-darwin-arm64.tar.gz"
     },
     "darwin-x64": {
+      "bin_path": "bin/git",
+      "binary_sha256": "bb56a429c630db4bc189be3c040c8778315fd98ac44de7944371d939b1987cbc",
       "name": "git-2.55.0-darwin-x64.tar.gz",
-      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-darwin-x64.tar.gz",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "binary_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "size": null,
-      "bin_path": "bin/git"
+      "sha256": "0b2ecec1102314bb7e0ff246b7bcaef4efbeb588041df02c3feb753e078503d8",
+      "size": 1806168,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-darwin-x64.tar.gz"
     },
     "linux-arm64": {
+      "bin_path": "bin/git",
+      "binary_sha256": "5d42eac7f08d7cc283d6d6a58e46425244e4e95556575d3eaa9305234fa6feda",
       "name": "git-2.55.0-linux-arm64.tar.gz",
-      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-linux-arm64.tar.gz",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "binary_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "size": null,
-      "bin_path": "bin/git"
+      "sha256": "f6448fb05073895e6fd965b331624d02fc10b008f0c7d1456bf6ee03e3c8f4d4",
+      "size": 1790222,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-linux-arm64.tar.gz"
     },
     "linux-x64": {
+      "bin_path": "bin/git",
+      "binary_sha256": "3716deb614474b7c5ac5d7aa23e3301d22420c0065bcf12034ca8568c60a08f4",
       "name": "git-2.55.0-linux-x64.tar.gz",
-      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-linux-x64.tar.gz",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "binary_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "size": null,
-      "bin_path": "bin/git"
+      "sha256": "fb8a4e5fa67e6ff4a543cb5b04cc849fafb38e38ecb443a4763b923a5a2e58d9",
+      "size": 1765892,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/git-runtime-v2.55.0-1/git-2.55.0-linux-x64.tar.gz"
     }
-  }
+  },
+  "git_version": "2.55.0",
+  "local_ops_only": true,
+  "release_state": "published",
+  "release_tag": "git-runtime-v2.55.0-1",
+  "schema_version": 1,
+  "source": "kernel.org/git",
+  "source_sha256": "457fdb04dc8728e007d4688695e6912e6f680727920f2a40bf11eacc17505357",
+  "source_url": "https://www.kernel.org/pub/software/scm/git/git-2.55.0.tar.xz"
 }


### PR DESCRIPTION
## Capability

- Finalize the packaged Git 2.55.0 runtime manifest from successful four-platform run `29165285903` and release `git-runtime-v2.55.0-1`, including the published URLs, archive sizes, archive SHA-256 values, and immutable final-binary SHA-256 values.
- Connect `core/git_binary.py::_resolve_vendored()` to `GitRuntimeManager.resolve_git_path()` while preserving `ResolvedGit(source="vendored")` and the vendored -> system -> degrade contract consumed by #669.
- Add one explicit-base PATH composition contract and apply it at the concrete Claude SDK, Codex per-thread shell policy, and OpenCode per-session `shell.env` boundaries. An effective system Git remains first; a verified vendored Git is prepended only when no safe system candidate exists. macOS `/usr/bin/git` remains gated by absolute `/usr/bin/xcode-select`.

## #867 Acceptance

- [x] `GitRuntimeManager` provides manifest/versioned install/archive and binary SHA-256 verification/offline behavior.
- [x] The four-platform static local-only Git workflow completed and published the release artifacts and finalized manifest.
- [x] `vibe runtime status` reports vendored/system/none for both the platform and Agent resolution orders.
- [x] Agent PATH injection is wired for Claude, Codex, and OpenCode only when the effective PATH has no safe system Git.
- [x] #669's `core/git_binary.py` resolution seam now consumes the vendored manager with `source="vendored"`.

## Contract And Boundaries

- PATH key presence wins, including `PATH=""`; only an absent key uses the caller-supplied `base_env`. The shared helper never reads `os.environ` implicitly.
- Relative, empty/current-directory, and workspace-owned PATH prefixes are not accepted as system Git ahead of the verified runtime. Absolute developer/system Git outside the workspace remains unshadowed.
- System classification is path-only and never executes a PATH-selected Git binary. The only support-tool probe is absolute `/usr/bin/xcode-select -p` for the macOS system shim.
- Caller context remains provenance-only. The Git helper is shared, but injection occurs at each backend's actual child-environment boundary rather than adding PATH to `CallerContext`.
- Codex leaves an existing effective user/system PATH policy untouched until Avibe must add vendored Git; once Avibe owns that per-thread override, later state changes replace it with the current effective PATH instead of leaving a stale vendored prefix.
- No scenario catalog IDs apply to this infrastructure integration.

## Evidence

- **Unit:** 271 focused tests passed across managed Git, the #669 resolver seam, Show Git, Claude, Codex, and OpenCode. Coverage includes the real packaged manifest, installed/missing vendored resolution, explicit empty and absent PATH semantics, no parent-PATH leak, safe-system preservation, lexical and symlinked workspace-prefix hardening, CLT-missing macOS behavior, cached-client/thread PATH transitions in both directions, stale OpenCode binding removal, and the lightweight session-import contract with SQLite blocked.
- **Contract:** Ruff passed on every changed Python file; `actionlint` v1.7.12 passed; `git diff --check` passed. Runtime-heavy imports are delayed until an Agent environment is actually composed, while backend caches converge on effective Git PATH changes. The built wheel contains the runtime modules and a packaged manifest byte-identical to the published workflow artifact.
- **Build:** With a temporary `AVIBE_HOME`, `GitRuntimeManager.ensure()` downloaded and verified the real darwin-arm64 release asset. The installed Git 2.55.0 binary passed `init/add/commit/status/log/diff/restore/gc` with isolated Git config.
- **Scenario:** The previously gated workflow run passed all four platform jobs and its hardened local-only smoke suite. This integration adds no new scenario catalog entry.

## Known By Design

- A mutable workspace PATH prefix before a later system Git is treated as unsafe and the vendored binary is prepended. This closes the trust-boundary finding that caused the helper exit ramp in #871 while preserving an already-effective absolute developer/system Git.
- Runtime installation remains explicit through `vibe runtime prepare`; Agent sessions consume an already-installed, manifest-verified binary and never download from a turn path. Existing Claude/Codex/OpenCode sessions converge on the new effective PATH on their next turn.
- tmux and Show Runtime remain on their existing managers. Migrating them to the shared managed-runtime base is still a separate follow-up.

## Residual Manual Check

- The orchestrator owns the gitless Incus end-to-end pass for vendored resolution plus Show Page checkpointing under #669.

Completes #867
Consumed by #669
