### PR TITLE
fix(show): correct @fs gate — mount the private surface + confine public symlink escapes

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1011,6 +1011,29 @@ def test_public_show_page_denies_at_fs_symlinked_home_ancestor_escape(monkeypatc
     assert manager.calls == []
 
 
+def test_public_show_page_denies_at_fs_extra_leading_slash_symlink_escape(monkeypatch, tmp_path):
+    # An `@fs///<ws>/x` request (one extra slash) must not dodge the workspace
+    # confinement: redundant leading slashes are collapsed before the prefix check.
+    # Assert on the gate directly so the exact `//` spelling reaches it regardless
+    # of any client URL normalization.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "public")
+    workspace = paths.get_show_page_dir("ses123")
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("TOPSECRET", encoding="utf-8")
+    os.symlink(outside, workspace / "pwn.txt")
+
+    decoded = f"@fs//{workspace.as_posix()}/pwn.txt"  # `@fs///<ws>/pwn.txt`
+    assert ui_server._is_show_page_runtime_denied_path(
+        decoded, session_id="ses123", public=True
+    )
+    # The same request stays allowed on the private authoring surface.
+    assert not ui_server._is_show_page_runtime_denied_path(
+        decoded, session_id="ses123", public=False
+    )
+
+
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -927,6 +927,60 @@ def test_private_show_page_allows_at_fs_workspace_symlink(monkeypatch, tmp_path)
     assert manager.calls
 
 
+def test_public_show_page_denies_at_fs_workspace_dir_symlink_escape(monkeypatch, tmp_path):
+    # A symlinked DIRECTORY inside the workspace (assets -> outside) must be confined
+    # on the public surface too, not only symlinked files.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    workspace = paths.get_show_page_dir("ses123")
+    outside_dir = tmp_path / "outside_dir"
+    outside_dir.mkdir()
+    (outside_dir / "secret.txt").write_text("TOPSECRET", encoding="utf-8")
+    os.symlink(outside_dir, workspace / "assets")
+    manager = _FakeShowRuntimeManager(body=b"TOPSECRET")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/@fs{(workspace / 'assets' / 'secret.txt').as_posix()}",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert manager.calls == []
+
+
+def test_public_show_page_denies_at_fs_vite_cache_named_workspace_symlink(monkeypatch, tmp_path):
+    # A workspace path that merely contains `vite-cache/deps` must not skip the
+    # public symlink confinement: the relocated-cache exception no longer bypasses
+    # the absolute @fs checks.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    workspace = paths.get_show_page_dir("ses123")
+    (workspace / "vite-cache" / "deps").mkdir(parents=True)
+    secret = tmp_path / "cache_secret.txt"
+    secret.write_text("TOPSECRET", encoding="utf-8")
+    link = workspace / "vite-cache" / "deps" / "link.js"
+    os.symlink(secret, link)
+    manager = _FakeShowRuntimeManager(body=b"TOPSECRET")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/@fs{link.as_posix()}",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert manager.calls == []
+
+
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -846,6 +846,87 @@ def test_private_show_page_proxies_relative_relocated_vite_cache_at_fs(monkeypat
     assert manager.calls[0][1].endswith("/@fs/.vite-cache/deps/react.js")
 
 
+def test_public_show_page_denies_at_fs_workspace_symlink_escape(monkeypatch, tmp_path):
+    # A workspace file that symlinks OUT of the workspace must NOT be served on the
+    # public surface — otherwise a share link could read any host file the service
+    # can read. It is denied before proxying. (The private surface keeps it; below.)
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    workspace = paths.get_show_page_dir("ses123")
+    secret = tmp_path / "outside_secret.txt"
+    secret.write_text("TOPSECRET", encoding="utf-8")
+    link = workspace / "evil.txt"
+    os.symlink(secret, link)
+    manager = _FakeShowRuntimeManager(body=b"TOPSECRET")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/@fs{link.as_posix()}",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert manager.calls == []
+
+
+def test_public_show_page_allows_at_fs_dependency_outside_workspace(monkeypatch, tmp_path):
+    # The public confinement targets workspace symlink escapes only; a genuine
+    # dependency @fs path (its parent is literally outside the workspace) is still
+    # deferred to the runtime, so public pages keep loading their deps.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    dep = tmp_path / "runtime" / "node_modules" / "vite" / "dist" / "client" / "env.mjs"
+    dep.parent.mkdir(parents=True, exist_ok=True)
+    dep.write_text("export const x = 1", encoding="utf-8")
+    manager = _FakeShowRuntimeManager(
+        body=b"export const x = 1", extra_headers={"content-type": "text/javascript"}
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/@fs{dep.as_posix()}",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert manager.calls
+
+
+def test_private_show_page_allows_at_fs_workspace_symlink(monkeypatch, tmp_path):
+    # The private authoring surface intentionally allows a workspace symlink to a
+    # disk file (a supported feature). Only the public surface confines it.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    workspace = paths.get_show_page_dir("ses123")
+    data = tmp_path / "outside_data.txt"
+    data.write_text("linked data", encoding="utf-8")
+    link = workspace / "data.txt"
+    os.symlink(data, link)
+    manager = _FakeShowRuntimeManager(
+        body=b"linked data", extra_headers={"content-type": "text/plain"}
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/show/ses123/@fs{link.as_posix()}",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert manager.calls
+
+
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -759,6 +759,69 @@ def test_private_show_page_denies_workspace_dot_path_through_at_fs(monkeypatch, 
     assert manager.calls == []
 
 
+def test_private_show_page_proxies_single_slash_at_fs_external_dep(monkeypatch, tmp_path):
+    # Real Vite emits `/@fs/<abs>` with a SINGLE slash (e.g. the HMR client's
+    # env.mjs under the shared runtime node_modules). The gate must treat it as an
+    # absolute path; being outside the workspace it defers to the runtime's own
+    # allowlist instead of denying it. Previously `removeprefix("@fs/")` dropped
+    # the leading slash, mis-read it as relative, and denied it — which blanked the
+    # private /show/ surface (react-refresh preamble could not load env.mjs).
+    avibe_home = tmp_path / ".avibe"
+    monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
+    _save_config(avibe_home)
+    _create_show_page("ses123", "private")
+    dep_path = (
+        paths.get_runtime_dir()
+        / "show-runtime"
+        / "source"
+        / "node_modules"
+        / "vite"
+        / "dist"
+        / "client"
+        / "env.mjs"
+    )
+    manager = _FakeShowRuntimeManager(
+        body=b"export const context = {}",
+        extra_headers={"content-type": "text/javascript"},
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        # Single slash: "@fs" + an absolute posix path -> ".../@fs/private/...".
+        response = app.test_client().get(
+            f"/show/ses123/@fs{dep_path.as_posix()}",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.content == b"export const context = {}"
+    assert manager.calls
+    assert manager.calls[0][1].endswith(f"/@fs{dep_path.as_posix()}")
+
+
+def test_private_show_page_denies_single_slash_at_fs_workspace_dot_path(monkeypatch, tmp_path):
+    # The single-slash normalization must still deny a workspace-relative dot path
+    # reached through @fs (a hidden draft), not only the double-slash spelling.
+    avibe_home = tmp_path / ".avibe"
+    monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
+    _save_config(avibe_home)
+    _create_show_page("ses123", "private")
+    hidden_path = paths.get_show_page_dir("ses123") / ".draft" / "secret.ts"
+    manager = _FakeShowRuntimeManager(body=b"export const secret = true")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/show/ses123/@fs{hidden_path.as_posix()}",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert manager.calls == []
+
+
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -981,6 +981,36 @@ def test_public_show_page_denies_at_fs_vite_cache_named_workspace_symlink(monkey
     assert manager.calls == []
 
 
+def test_public_show_page_denies_at_fs_symlinked_home_ancestor_escape(monkeypatch, tmp_path):
+    # AVIBE_HOME reached through a symlinked ancestor: a request spelled with the
+    # UNRESOLVED (symlink) workspace prefix whose real target escapes must still be
+    # denied — the confinement checks both the resolved and unresolved spelling.
+    real_home = tmp_path / "real_home"
+    real_home.mkdir()
+    link_home = tmp_path / "link_home"
+    os.symlink(real_home, link_home)
+    monkeypatch.setenv("AVIBE_HOME", str(link_home))
+    _save_config(link_home)
+    share_id = _create_show_page("ses123", "public")
+    workspace = paths.get_show_page_dir("ses123")  # unresolved link_home spelling
+    outside = tmp_path / "outside_secret.txt"
+    outside.write_text("TOPSECRET", encoding="utf-8")
+    os.symlink(outside, workspace / "pwn.txt")
+    manager = _FakeShowRuntimeManager(body=b"TOPSECRET")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/@fs{(workspace / 'pwn.txt').as_posix()}",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert manager.calls == []
+
+
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -761,24 +761,20 @@ def test_private_show_page_denies_workspace_dot_path_through_at_fs(monkeypatch, 
 
 def test_private_show_page_proxies_single_slash_at_fs_external_dep(monkeypatch, tmp_path):
     # Real Vite emits `/@fs/<abs>` with a SINGLE slash (e.g. the HMR client's
-    # env.mjs under the shared runtime node_modules). The gate must treat it as an
-    # absolute path; being outside the workspace it defers to the runtime's own
-    # allowlist instead of denying it. Previously `removeprefix("@fs/")` dropped
-    # the leading slash, mis-read it as relative, and denied it — which blanked the
-    # private /show/ surface (react-refresh preamble could not load env.mjs).
+    # env.mjs under the runtime's node_modules). The gate must treat it as an
+    # absolute path and, being outside the workspace, defer to the runtime's own
+    # allowlist. Use a dep under a custom hidden runtime root (an nvm/global-bin
+    # provider), NOT the default `~/.avibe/runtime`, so the gate cannot rely on a
+    # hardcoded root. Previously `removeprefix("@fs/")` dropped the leading slash,
+    # mis-read it as relative, and denied it — which blanked the private /show/
+    # surface (react-refresh preamble could not load env.mjs).
     avibe_home = tmp_path / ".avibe"
     monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
     _save_config(avibe_home)
     _create_show_page("ses123", "private")
     dep_path = (
-        paths.get_runtime_dir()
-        / "show-runtime"
-        / "source"
-        / "node_modules"
-        / "vite"
-        / "dist"
-        / "client"
-        / "env.mjs"
+        tmp_path / ".nvm" / "versions" / "node" / "v20" / "lib" / "node_modules"
+        / "vite" / "dist" / "client" / "env.mjs"
     )
     manager = _FakeShowRuntimeManager(
         body=b"export const context = {}",
@@ -822,27 +818,32 @@ def test_private_show_page_denies_single_slash_at_fs_workspace_dot_path(monkeypa
     assert manager.calls == []
 
 
-def test_private_show_page_denies_at_fs_dot_path_outside_runtime_root(monkeypatch, tmp_path):
-    # An absolute @fs dot path that is neither in the workspace nor under the
-    # shared runtime dependency root (e.g. `~/.ssh`) is denied here, before
-    # proxying — avibe does not defer such paths to the runtime's allowlist.
+def test_private_show_page_proxies_relative_relocated_vite_cache_at_fs(monkeypatch, tmp_path):
+    # The synthetic relative relocated-cache form `@fs/.vite-cache/deps/...` must
+    # stay allowed (proxied). The normalization must NOT force it to an absolute
+    # path (`/.vite-cache/...`) that then looks like an out-of-tree request; it is
+    # recognized as a relocated Vite dep and passed through to the runtime.
     avibe_home = tmp_path / ".avibe"
     monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
     _save_config(avibe_home)
     _create_show_page("ses123", "private")
-    outside_path = tmp_path / ".ssh" / "known_hosts"
-    manager = _FakeShowRuntimeManager(body=b"secret")
+    manager = _FakeShowRuntimeManager(
+        body=b"export const react = true",
+        extra_headers={"content-type": "text/javascript"},
+    )
     set_show_runtime_manager_for_tests(manager)
     try:
         response = app.test_client().get(
-            f"/show/ses123/@fs{outside_path.as_posix()}",
+            "/show/ses123/@fs/.vite-cache/deps/react.js",
             base_url="http://127.0.0.1:5123",
         )
     finally:
         set_show_runtime_manager_for_tests(None)
 
-    assert response.status_code == 404
-    assert manager.calls == []
+    assert response.status_code == 200
+    assert response.content == b"export const react = true"
+    assert manager.calls
+    assert manager.calls[0][1].endswith("/@fs/.vite-cache/deps/react.js")
 
 
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -822,6 +822,29 @@ def test_private_show_page_denies_single_slash_at_fs_workspace_dot_path(monkeypa
     assert manager.calls == []
 
 
+def test_private_show_page_denies_at_fs_dot_path_outside_runtime_root(monkeypatch, tmp_path):
+    # An absolute @fs dot path that is neither in the workspace nor under the
+    # shared runtime dependency root (e.g. `~/.ssh`) is denied here, before
+    # proxying — avibe does not defer such paths to the runtime's allowlist.
+    avibe_home = tmp_path / ".avibe"
+    monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
+    _save_config(avibe_home)
+    _create_show_page("ses123", "private")
+    outside_path = tmp_path / ".ssh" / "known_hosts"
+    manager = _FakeShowRuntimeManager(body=b"secret")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/show/ses123/@fs{outside_path.as_posix()}",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert manager.calls == []
+
+
 def test_show_page_recovery_loading_holds_before_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7853,27 +7853,29 @@ def _is_show_runtime_sensitive_file_segment(segment: str) -> bool:
     )
 
 
-def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str) -> bool:
+def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str, public: bool = False) -> bool:
     decoded = _decode_show_page_asset_path(asset_path)
     segments = [segment for segment in decoded.split("/") if segment]
     if any(_is_show_runtime_sensitive_file_segment(segment) for segment in segments):
         return True
+    if any(segment in {".", ".."} for segment in segments):
+        return True
+    # Vite `@fs/<abs>` paths can be non-dot (e.g. a workspace symlink `evil.txt`),
+    # so classify them fully here rather than through the dot-segment fast path.
+    if decoded.startswith("@fs/"):
+        return _is_denied_show_page_at_fs_path(decoded, session_id=session_id, public=public)
     dot_segments = [index for index, segment in enumerate(segments) if segment.startswith(".")]
     if not dot_segments:
         return False
-    if any(segment in {".", ".."} for segment in segments):
-        return True
-
+    # A non-@fs dot path is private unless it is an optimized Vite dependency.
     vite_dependency = (
         (len(segments) >= 4 and segments[:3] == ["node_modules", ".vite", "deps"] and dot_segments == [1])
         or (len(segments) >= 3 and segments[:2] == [".vite", "deps"] and dot_segments == [0])
     )
-    if vite_dependency:
-        return False
+    return not vite_dependency
 
-    if not decoded.startswith("@fs/"):
-        return True
 
+def _is_denied_show_page_at_fs_path(decoded: str, *, session_id: str, public: bool) -> bool:
     # Recover the absolute filesystem path from Vite's `/@fs/<abs>` convention,
     # mirroring Vite's own fsPathFromId. This route stripped the URL's single
     # leading slash, so a POSIX request arrives as `@fs/home/...` (restore the
@@ -7881,10 +7883,10 @@ def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str) -> bo
     # already carry an absolute path, so leave those intact — prepending a slash
     # to `C:/...` would corrupt the Windows path. Leave the synthetic relative
     # relocated-cache form (e.g. `@fs/.vite-cache/deps/...`) relative so the
-    # allowance below handles it. Parsing with `removeprefix("@fs/")` alone
-    # dropped the single POSIX slash and mis-read a real request as relative,
-    # denying legitimate external deps (notably the Vite HMR client's `env.mjs`)
-    # so nothing mounted on the private `/show/` surface.
+    # allowance below handles it. Parsing with `removeprefix("@fs/")` alone dropped
+    # the single POSIX slash and mis-read a real request as relative, denying
+    # legitimate external deps (notably the Vite HMR client's `env.mjs`) so nothing
+    # mounted on the private `/show/` surface.
     fs_remainder = decoded.removeprefix("@fs/")
     if (
         fs_remainder
@@ -7899,18 +7901,31 @@ def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str) -> bo
         # Vite cache deps; otherwise deny so a hidden path can't be proxied here.
         return not _is_relocated_vite_dep_path(decoded)
 
-    target = fs_path.resolve(strict=False)
     workspace = paths.get_show_page_dir(session_id).resolve(strict=False)
+    target = fs_path.resolve(strict=False)  # follows symlinks, like the runtime will
     try:
         workspace_relative = target.relative_to(workspace)
     except ValueError:
+        # The resolved target is outside the workspace. On the PUBLIC surface,
+        # untrusted viewers must not read through a workspace file that symlinks OUT
+        # of the workspace (a symlink escape), so confine them to the workspace. The
+        # private authoring surface keeps this — an agent may legitimately symlink a
+        # disk file into its own page — and a genuine dependency path (its parent is
+        # literally outside the workspace) is still deferred to the Show Runtime's
+        # fs allowlist on both surfaces.
+        if public:
+            try:
+                fs_path.parent.resolve(strict=False).relative_to(workspace)
+                return True
+            except ValueError:
+                pass
         # Outside the workspace: defer to the Show Runtime, which owns the
         # authoritative fs allowlist for its dependency/cache roots — the default
         # `~/.avibe/runtime`, a custom `VIBE_SHOW_RUNTIME_BIN` provider (e.g. an
         # nvm/global install), per-session extras — and still denies sensitive
         # filenames and non-allowlisted paths there. avibe cannot enumerate those
-        # roots without breaking supported providers, so here it enforces only what
-        # it can decide authoritatively: the sensitive-filename check above and the
+        # roots without breaking supported providers, so it enforces only what it
+        # can decide authoritatively: the sensitive-filename check (caller) and the
         # workspace-internal dot-path check below.
         return False
     return any(part.startswith(".") for part in workspace_relative.parts)
@@ -8954,7 +8969,7 @@ async def serve_public_show_page(share_id, asset_path):
             return _show_page_offline_response()
         if page.visibility != "public":
             return _show_page_not_found_response()
-        if _is_show_page_runtime_denied_path(asset_path, session_id=page.session_id):
+        if _is_show_page_runtime_denied_path(asset_path, session_id=page.session_id, public=True):
             return _show_page_file_not_found_response()
         if asset_path.strip("/") in {"__show/events", "__events"}:
             if request.method != "GET":

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7895,6 +7895,13 @@ def _is_denied_show_page_at_fs_path(decoded: str, *, session_id: str, public: bo
         and not re.match(r"^[A-Za-z]:", fs_remainder)
     ):
         fs_remainder = "/" + fs_remainder
+    # Collapse redundant leading POSIX slashes (e.g. an `@fs///<ws>/x` request
+    # arrives here as `//<ws>/x`). pathlib keeps a `//` prefix in its parts and
+    # os.path.normpath preserves it, so without this the workspace-prefix checks
+    # below would miss both spellings while Vite still serves the collapsed path —
+    # reopening the escape. A Windows drive/UNC path never starts with `/`.
+    if fs_remainder.startswith("//"):
+        fs_remainder = "/" + fs_remainder.lstrip("/")
     fs_path = Path(fs_remainder)
     if not fs_path.is_absolute():
         # A synthetic/relative @fs form (prewarming/tests). Allow only relocated

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7874,23 +7874,39 @@ def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str) -> bo
     if not decoded.startswith("@fs/"):
         return True
 
-    # Vite's `/@fs/<abs>` convention: everything after `@fs` is the absolute
-    # filesystem path. This route strips the URL's leading slash, so a real Vite
-    # request arrives as `@fs/home/...` (one slash) while some callers/tests spell
-    # it `@fs//home/...` (two). Parsing with `removeprefix("@fs/")` dropped the
-    # single leading slash and mis-read a real request as a relative path, which
-    # denied legitimate external deps — notably the Vite HMR client's `env.mjs`
-    # under the shared runtime `node_modules`, so nothing mounted on the private
-    # `/show/` surface. Normalize both spellings to the absolute path.
-    raw_fs_path = "/" + decoded[len("@fs"):].lstrip("/")
-    target = Path(raw_fs_path).resolve(strict=False)
+    # Recover the absolute filesystem path from Vite's `/@fs/<abs>` convention,
+    # mirroring Vite's own fsPathFromId. This route strips the URL's single
+    # leading slash, so a POSIX request arrives as `@fs/home/...` (restore the
+    # slash); a double-slash spelling `@fs//home/...` and a Windows drive letter
+    # `@fs/C:/...` already carry an absolute path, so leave those intact —
+    # prepending a slash to `C:/...` would corrupt the Windows path. Parsing with
+    # `removeprefix("@fs/")` alone dropped the single POSIX slash and mis-read a
+    # real request as relative, denying legitimate external deps (notably the Vite
+    # HMR client's `env.mjs`) so nothing mounted on the private `/show/` surface.
+    fs_remainder = decoded.removeprefix("@fs/")
+    if fs_remainder and not fs_remainder.startswith("/") and not re.match(r"^[A-Za-z]:", fs_remainder):
+        fs_remainder = "/" + fs_remainder
+    fs_path = Path(fs_remainder)
+    if not fs_path.is_absolute():
+        # A synthetic/relative @fs form (prewarming/tests). Allow only relocated
+        # Vite cache deps; otherwise deny so a hidden path can't be proxied here.
+        return not _is_relocated_vite_dep_path(decoded)
+
+    target = fs_path.resolve(strict=False)
     workspace = paths.get_show_page_dir(session_id).resolve(strict=False)
     try:
         workspace_relative = target.relative_to(workspace)
     except ValueError:
-        # Outside the workspace (e.g. the shared runtime install below ~/.avibe).
-        # The Show Runtime owns its own allowlist and still denies sensitive
-        # filenames; only workspace-relative dot paths are private here.
+        # Outside the workspace: allow ONLY the shared runtime dependency root.
+        # The Vite HMR client `env.mjs`, the vendor bundle, and optimized deps all
+        # live below `~/.avibe/runtime`; the Show Runtime enforces its own
+        # allowlist and sensitive-file denial there. Anything else outside the
+        # workspace (a stray dot path, `/etc`, ...) is denied here before proxying.
+        runtime_root = paths.get_runtime_dir().resolve(strict=False)
+        try:
+            target.relative_to(runtime_root)
+        except ValueError:
+            return True
         return False
     return any(part.startswith(".") for part in workspace_relative.parts)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7917,13 +7917,18 @@ def _is_denied_show_page_at_fs_path(decoded: str, *, session_id: str, public: bo
             # Compare the requested path lexically (symlinks NOT followed here;
             # `..` was already rejected): a request ROOTED in the workspace whose
             # real target escapes it is a symlink escape — via a symlinked file OR
-            # a symlinked directory in the path — so deny it. A genuine dependency
-            # (rooted outside the workspace) still defers to the runtime.
-            try:
-                Path(os.path.normpath(str(fs_path))).relative_to(workspace)
-                return True
-            except ValueError:
-                pass
+            # a symlinked directory in the path — so deny it. Match against the
+            # workspace under both its resolved and unresolved spelling so a
+            # symlinked AVIBE_HOME ancestor can't be used to dodge the prefix test.
+            # A genuine dependency (rooted outside the workspace under either
+            # spelling) still defers to the runtime.
+            requested = Path(os.path.normpath(str(fs_path)))
+            for ws_spelling in {workspace, paths.get_show_page_dir(session_id)}:
+                try:
+                    requested.relative_to(ws_spelling)
+                    return True
+                except ValueError:
+                    continue
         # Outside the workspace: defer to the Show Runtime, which owns the
         # authoritative fs allowlist for its dependency/cache roots — the default
         # `~/.avibe/runtime`, a custom `VIBE_SHOW_RUNTIME_BIN` provider (e.g. an

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7875,16 +7875,23 @@ def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str) -> bo
         return True
 
     # Recover the absolute filesystem path from Vite's `/@fs/<abs>` convention,
-    # mirroring Vite's own fsPathFromId. This route strips the URL's single
+    # mirroring Vite's own fsPathFromId. This route stripped the URL's single
     # leading slash, so a POSIX request arrives as `@fs/home/...` (restore the
-    # slash); a double-slash spelling `@fs//home/...` and a Windows drive letter
-    # `@fs/C:/...` already carry an absolute path, so leave those intact —
-    # prepending a slash to `C:/...` would corrupt the Windows path. Parsing with
-    # `removeprefix("@fs/")` alone dropped the single POSIX slash and mis-read a
-    # real request as relative, denying legitimate external deps (notably the Vite
-    # HMR client's `env.mjs`) so nothing mounted on the private `/show/` surface.
+    # slash); `@fs//home/...` (double slash) and `@fs/C:/...` (Windows drive)
+    # already carry an absolute path, so leave those intact — prepending a slash
+    # to `C:/...` would corrupt the Windows path. Leave the synthetic relative
+    # relocated-cache form (e.g. `@fs/.vite-cache/deps/...`) relative so the
+    # allowance below handles it. Parsing with `removeprefix("@fs/")` alone
+    # dropped the single POSIX slash and mis-read a real request as relative,
+    # denying legitimate external deps (notably the Vite HMR client's `env.mjs`)
+    # so nothing mounted on the private `/show/` surface.
     fs_remainder = decoded.removeprefix("@fs/")
-    if fs_remainder and not fs_remainder.startswith("/") and not re.match(r"^[A-Za-z]:", fs_remainder):
+    if (
+        fs_remainder
+        and not fs_remainder.startswith("/")
+        and not re.match(r"^[A-Za-z]:", fs_remainder)
+        and not _is_relocated_vite_dep_path(decoded)
+    ):
         fs_remainder = "/" + fs_remainder
     fs_path = Path(fs_remainder)
     if not fs_path.is_absolute():
@@ -7897,16 +7904,14 @@ def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str) -> bo
     try:
         workspace_relative = target.relative_to(workspace)
     except ValueError:
-        # Outside the workspace: allow ONLY the shared runtime dependency root.
-        # The Vite HMR client `env.mjs`, the vendor bundle, and optimized deps all
-        # live below `~/.avibe/runtime`; the Show Runtime enforces its own
-        # allowlist and sensitive-file denial there. Anything else outside the
-        # workspace (a stray dot path, `/etc`, ...) is denied here before proxying.
-        runtime_root = paths.get_runtime_dir().resolve(strict=False)
-        try:
-            target.relative_to(runtime_root)
-        except ValueError:
-            return True
+        # Outside the workspace: defer to the Show Runtime, which owns the
+        # authoritative fs allowlist for its dependency/cache roots — the default
+        # `~/.avibe/runtime`, a custom `VIBE_SHOW_RUNTIME_BIN` provider (e.g. an
+        # nvm/global install), per-session extras — and still denies sensitive
+        # filenames and non-allowlisted paths there. avibe cannot enumerate those
+        # roots without breaking supported providers, so here it enforces only what
+        # it can decide authoritatively: the sensitive-filename check above and the
+        # workspace-internal dot-path check below.
         return False
     return any(part.startswith(".") for part in workspace_relative.parts)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7881,18 +7881,18 @@ def _is_denied_show_page_at_fs_path(decoded: str, *, session_id: str, public: bo
     # leading slash, so a POSIX request arrives as `@fs/home/...` (restore the
     # slash); `@fs//home/...` (double slash) and `@fs/C:/...` (Windows drive)
     # already carry an absolute path, so leave those intact — prepending a slash
-    # to `C:/...` would corrupt the Windows path. Leave the synthetic relative
-    # relocated-cache form (e.g. `@fs/.vite-cache/deps/...`) relative so the
-    # allowance below handles it. Parsing with `removeprefix("@fs/")` alone dropped
-    # the single POSIX slash and mis-read a real request as relative, denying
-    # legitimate external deps (notably the Vite HMR client's `env.mjs`) so nothing
-    # mounted on the private `/show/` surface.
+    # to `C:/...` would corrupt the Windows path. Parsing with `removeprefix("@fs/")`
+    # alone dropped the single POSIX slash and mis-read a real request as relative,
+    # denying legitimate external deps (notably the Vite HMR client's `env.mjs`) so
+    # nothing mounted on the private `/show/` surface. Every genuine @fs URL is
+    # absolute, so restore the slash unconditionally — a workspace path that merely
+    # contains `vite-cache/deps` must still reach the workspace/escape checks below,
+    # not slip through the relative allowance.
     fs_remainder = decoded.removeprefix("@fs/")
     if (
         fs_remainder
         and not fs_remainder.startswith("/")
         and not re.match(r"^[A-Za-z]:", fs_remainder)
-        and not _is_relocated_vite_dep_path(decoded)
     ):
         fs_remainder = "/" + fs_remainder
     fs_path = Path(fs_remainder)
@@ -7914,8 +7914,13 @@ def _is_denied_show_page_at_fs_path(decoded: str, *, session_id: str, public: bo
         # literally outside the workspace) is still deferred to the Show Runtime's
         # fs allowlist on both surfaces.
         if public:
+            # Compare the requested path lexically (symlinks NOT followed here;
+            # `..` was already rejected): a request ROOTED in the workspace whose
+            # real target escapes it is a symlink escape — via a symlinked file OR
+            # a symlinked directory in the path — so deny it. A genuine dependency
+            # (rooted outside the workspace) still defers to the runtime.
             try:
-                fs_path.parent.resolve(strict=False).relative_to(workspace)
+                Path(os.path.normpath(str(fs_path))).relative_to(workspace)
                 return True
             except ValueError:
                 pass

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7874,23 +7874,25 @@ def _is_show_page_runtime_denied_path(asset_path: str, *, session_id: str) -> bo
     if not decoded.startswith("@fs/"):
         return True
 
-    raw_fs_path = decoded.removeprefix("@fs/")
-    fs_path = Path(raw_fs_path)
-    if fs_path.is_absolute():
-        target = fs_path.resolve(strict=False)
-        workspace = paths.get_show_page_dir(session_id).resolve(strict=False)
-        try:
-            workspace_relative = target.relative_to(workspace)
-        except ValueError:
-            # Runtime dependency roots can legitimately live below dot directories
-            # such as ~/.avibe. The Show Runtime owns their allowlist and still denies
-            # sensitive filenames; only workspace-relative dot paths are all private.
-            return False
-        return any(part.startswith(".") for part in workspace_relative.parts)
-
-    # A Vite @fs path is normally absolute. Retain the synthetic relative cache
-    # form used by prewarming/tests, but do not generally relax relative dot paths.
-    return not _is_relocated_vite_dep_path(decoded)
+    # Vite's `/@fs/<abs>` convention: everything after `@fs` is the absolute
+    # filesystem path. This route strips the URL's leading slash, so a real Vite
+    # request arrives as `@fs/home/...` (one slash) while some callers/tests spell
+    # it `@fs//home/...` (two). Parsing with `removeprefix("@fs/")` dropped the
+    # single leading slash and mis-read a real request as a relative path, which
+    # denied legitimate external deps — notably the Vite HMR client's `env.mjs`
+    # under the shared runtime `node_modules`, so nothing mounted on the private
+    # `/show/` surface. Normalize both spellings to the absolute path.
+    raw_fs_path = "/" + decoded[len("@fs"):].lstrip("/")
+    target = Path(raw_fs_path).resolve(strict=False)
+    workspace = paths.get_show_page_dir(session_id).resolve(strict=False)
+    try:
+        workspace_relative = target.relative_to(workspace)
+    except ValueError:
+        # Outside the workspace (e.g. the shared runtime install below ~/.avibe).
+        # The Show Runtime owns its own allowlist and still denies sensitive
+        # filenames; only workspace-relative dot paths are private here.
+        return False
+    return any(part.startswith(".") for part in workspace_relative.parts)
 
 
 def _show_page_recovery_response(session_id: str):


### PR DESCRIPTION
## Capability

Fixes the private `/show/<id>/` Show Page surface, which failed to mount **any** React app — the browser showed the "Ready to visualize" recovery shell with an empty `#root`.

## Root cause

Vite's HMR client loads its env module via `/@fs/<abs>` — on POSIX a **single** slash, e.g. `/@fs/home/<user>/.avibe/runtime/.../node_modules/vite/dist/client/env.mjs` (the shared runtime `node_modules`). `_is_show_page_runtime_denied_path` extracted the path with `removeprefix("@fs/")`, which **dropped the single leading slash** (`home/...`), so `Path(...).is_absolute()` was `False`. The code then skipped the intended "absolute path outside the workspace → defer to the runtime's own allowlist" branch and fell through to a blanket deny → **404**.

Without `env.mjs`, `@vitejs/plugin-react`'s refresh preamble never installed, the app entry threw, and nothing mounted. The public `/p/` surface was unaffected because it rewrites the HMR client to inert shims, so it never requests `env.mjs`.

The existing `@fs` tests only used the non-canonical **double**-slash spelling (`@fs//abs`, from `f"@fs/{path.as_posix()}"`), where `removeprefix("@fs/")` happens to yield an absolute path — so the bug was never exercised. Real Vite uses one slash.

The runtime serves `env.mjs` correctly (its `server.fs.allow` covers the shared `node_modules`); the over-block was **entirely avibe-side**. Single-repo fix.

## Fix

Normalize both `@fs` spellings to the absolute path: `raw = "/" + decoded[len("@fs"):].lstrip("/")`. Genuine external deps (outside the workspace, e.g. under `~/.avibe/runtime`) are then allowed through to the runtime's allowlist; workspace-relative dot paths and sensitive filenames stay denied exactly as before.

## Evidence layers

- **Unit** (`tests/test_ui_show_pages.py`, 186 passed in the show group): two new tests using the real **single-slash** `@fs` form — `test_private_show_page_proxies_single_slash_at_fs_external_dep` (external dep allowed/proxied) and `test_private_show_page_denies_single_slash_at_fs_workspace_dot_path` (workspace dot-path still denied). All existing `@fs`/deny/vite-dependency/relocated tests still pass.
- **Contract / scenario**: N/A (single-repo; no scenario catalog for this path).
- **Manual (real Incus regression, master env, runtime github-source `main`)**: deployed the fix; the exact request that was 404 — `GET .../@fs/home/<user>/.avibe/runtime/.../vite/dist/client/env.mjs` — now returns **200**; the private `/show/` surface mounts (`#root` non-empty, nav renders), nested route `#/items/2` renders with its param, and **refresh on the nested route works**; network is all-200 with zero 404s. Public `/p/` remains correct.

## Compatibility

Pure gate-parsing fix. No behavior change for the double-slash form, workspace source `@fs` paths, `.vite/deps` dependency paths, relocated vite-cache deps, or sensitive-file denial. No runtime change and no release chain.

## How found

Surfaced while running the local Incus regression for #877 (default multi-page Show Page scaffold): the multi-page demo rendered on `/p/` but the private `/show/` surface showed the recovery shell — traced to this pre-existing gate bug (an old single-page workspace failed identically), independent of #877.

## Residual manual checks

None outstanding — the failing symptom is verified fixed end-to-end in regression on both the private and public surfaces.


## Known-by-design ledger

- **Outside-workspace `@fs` paths are deferred to the Show Runtime, not pre-denied by an avibe root allowlist.** An earlier revision tried to allow only paths under `~/.avibe/runtime`, but that enumeration cannot cover supported custom runtime providers (`VIBE_SHOW_RUNTIME_BIN` / nvm / global-bin) or the relative relocated-cache form without denying legitimate deps (both were flagged in review). The runtime owns the authoritative `server.fs.allow` for its real dependency/cache roots and independently denies sensitive filenames and non-allowlisted paths (e.g. `/etc/...`, `~/.ssh/...`), so a hidden path that isn't a real runtime dep is still refused — one layer later, by the component that actually knows its roots. avibe enforces only what it can decide authoritatively: sensitive filenames (anywhere) and workspace-internal dot paths. This restores master's long-standing behavior; the net change here is just the Vite single-slash / Windows-drive normalization.


## Added: confine public `@fs` to the workspace (symlink-escape hardening)

Adversarial regression probing surfaced a pre-existing issue: an agent-planted **workspace symlink** (e.g. `pwn.txt -> /etc/passwd`) is served through `@fs`, so a **public share** could read arbitrary host files the service can read (direct out-of-tree reads and `..` traversal were already blocked; only symlink escape leaked). It requires workspace write (agent), not a remote plant, and a compromised agent could exfiltrate directly anyway — so severity is low — but a public share widens exposure to untrusted viewers.

Surface-aware fix (the trust boundary is *who can view*):
- **Public `/p/`**: an `@fs` request whose real (symlink-resolved) target escapes the workspace is denied at the gate, before proxying.
- **Private `/show/`**: unchanged — an agent may legitimately symlink a disk file into its own page (a feature), and you are the only viewer.
- Genuine dependency `@fs` paths (parent literally outside the workspace) are still deferred to the runtime on both surfaces, so pages keep loading their deps.

The gate was also restructured to classify `@fs` paths fully regardless of dot segments (a non-dot symlink name previously skipped the `@fs` checks; a dot-less `AVIBE_HOME` was also uncovered).

**Verified in regression:** public `/p/` symlink → 404 (no file contents); private `/show/` symlink → served (feature kept); both surfaces render normally.

Not covered here (separate, lower priority): the same symlink is still served on the **private** surface and, ideally, the Show Runtime itself would `realpath`-deny escapes at its fs boundary (a runtime-side follow-up) or be confined by a kernel FS sandbox (Landlock/Seatbelt). The `node --permission` model was prototyped and rejected — it does not block symlink escape and can't run Vite without model-invalidating flags.
