### PR TITLE
fix(show): keep the demo detail badge from stretching full-width

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -1272,7 +1272,9 @@ export default function ItemDetail({ params }: PageProps) {
 
       <Card>
         <CardHeader>
-          <Badge>{t("Nested route", "嵌套路由")}</Badge>
+          {/* w-fit: CardHeader is a flex column (align-items: stretch), which
+              blockifies an inline-flex Badge and stretches it to full width. */}
+          <Badge className="w-fit">{t("Nested route", "嵌套路由")}</Badge>
           <CardTitle>{t("Item", "条目")} {params.id}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2 text-sm text-muted-foreground">

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -767,8 +767,12 @@ def test_fresh_workspace_scaffolds_multipage_demo(monkeypatch, tmp_path):
     assert (page_dir / "src" / "pages" / "items" / "index.tsx").exists()
     detail = page_dir / "src" / "pages" / "items" / "[id].tsx"
     assert detail.exists()
+    detail_src = detail.read_text(encoding="utf-8")
     # The dynamic route reads its captured param.
-    assert "params.id" in detail.read_text(encoding="utf-8")
+    assert "params.id" in detail_src
+    # The Badge sits in a flex-column CardHeader; w-fit keeps it from stretching
+    # to full width (see the demo detail page).
+    assert '<Badge className="w-fit">' in detail_src
 
     # App composes the router and its nav; it does not hardcode a route table.
     app_tsx = (page_dir / "src" / "App.tsx").read_text(encoding="utf-8")


### PR DESCRIPTION
## Capability

Fixes a cosmetic defect in the default multi-page Show Page demo (avibe#877): the item detail page's "Nested route" badge rendered as a **full-width dark bar** instead of a pill.

## Root cause

The demo detail page (`src/pages/items/[id].tsx` in the scaffold) placed `<Badge>` directly inside `<CardHeader>`, which is a **flex column**. A flex item is blockified (`inline-flex` → `flex`), and with the default `align-items: stretch` a Badge with no explicit width stretches to the full card width.

## Fix

Add `w-fit` to that Badge so it hugs its content. One-line, scoped to the emitted demo scaffold.

## Evidence layers

- **Unit** (`tests/test_show_pages.py`): `test_fresh_workspace_scaffolds_multipage_demo` now asserts the detail page emits `<Badge className="w-fit">`. Show group green.
- **Manual (local build)**: built the scaffolded workspace and measured the badge — **66px** (fit-content) inside a **734px** card (was 702px / full width). The Home badge is unaffected (it sits in a block container, not a flex one).

## Compatibility

Only the demo scaffold changes; existing workspaces are untouched. Ships to users with #877's scaffold at the next avibe tag.

## Note on the deeper layer

The underlying cause is that `@avibe/show-ui`'s `Badge` lacks the `w-fit` that upstream shadcn's Badge carries — so any `Badge` placed as a direct flex/grid child stretches. Fixing it there (a small `vibe-show-runtime` change) would cover every usage class-wide; this scoped fix keeps the shipped demo correct without a cross-repo runtime release. Happy to follow up on the show-ui Badge default if wanted.

## How found

Surfaced during the local Incus regression of #877 while verifying the private `/show/` surface.
