### PR TITLE
fix(remote-access): allow 30-second OAuth clock skew

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -6,6 +6,7 @@ import threading
 import time
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from config import paths
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
@@ -203,6 +204,62 @@ def test_exchange_oauth_code_reports_immature_token_as_clock_mismatch(monkeypatc
         remote_access.exchange_oauth_code(config, "code-1", "verifier-1")
 
     assert exc_info.value.reason == "immature_id_token"
+
+
+@pytest.mark.parametrize(
+    ("issued_at_offset", "expected_reason"),
+    (
+        pytest.param(30, None, id="within-leeway"),
+        pytest.param(60, "immature_id_token", id="beyond-leeway"),
+    ),
+)
+def test_exchange_oauth_code_allows_30_seconds_of_clock_skew(
+    monkeypatch,
+    issued_at_offset: int,
+    expected_reason: str | None,
+) -> None:
+    config = _config()
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    issued_at = int(time.time()) + issued_at_offset
+    id_token = remote_access.jwt.encode(
+        {
+            "sub": "user-1",
+            "aud": config.remote_access.vibe_cloud.client_id,
+            "iss": config.remote_access.vibe_cloud.issuer,
+            "iat": issued_at,
+            "exp": issued_at + 300,
+            "vibe_instance_id": config.remote_access.vibe_cloud.instance_id,
+            "email_verified": True,
+        },
+        private_key,
+        algorithm="RS256",
+    )
+
+    class ResponseStub:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"id_token": id_token}
+
+    class JwkClientStub:
+        def __init__(self, uri):
+            self.uri = uri
+
+        def get_signing_key_from_jwt(self, token):
+            assert token == id_token
+            return type("SigningKey", (), {"key": private_key.public_key()})()
+
+    monkeypatch.setattr(remote_access.requests, "post", lambda *args, **kwargs: ResponseStub())
+    monkeypatch.setattr(remote_access, "PyJWKClient", JwkClientStub)
+
+    if expected_reason is None:
+        result = remote_access.exchange_oauth_code(config, "code-1", "verifier-1")
+        assert result["claims"]["sub"] == "user-1"
+    else:
+        with pytest.raises(remote_access.OAuthCodeExchangeError) as exc_info:
+            remote_access.exchange_oauth_code(config, "code-1", "verifier-1")
+        assert exc_info.value.reason == expected_reason
 
 
 def test_pair_redeems_key_and_starts_connector(monkeypatch, tmp_path) -> None:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 CLOUDFLARED_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/latest/download"
 SESSION_COOKIE_NAME = "__Host-vibe_remote_session"
 SESSION_TTL_SECONDS = 24 * 60 * 60
+OAUTH_ID_TOKEN_CLOCK_LEEWAY_SECONDS = 30
 _CONNECTOR_LOCK = threading.RLock()
 _STATUS_HEARTBEAT_LOCK = threading.Lock()
 _STATUS_HEARTBEAT_STARTED = False
@@ -1214,6 +1215,7 @@ def exchange_oauth_code(config: V2Config, code: str, code_verifier: str) -> dict
             algorithms=["RS256"],
             audience=cloud.client_id,
             issuer=cloud.issuer,
+            leeway=OAUTH_ID_TOKEN_CLOCK_LEEWAY_SECONDS,
         )
     except jwt.InvalidIssuerError as exc:
         raise OAuthCodeExchangeError("invalid_issuer", str(exc)) from exc


### PR DESCRIPTION
## What

- allow a fixed 30-second clock-skew leeway when validating Avibe Cloud ID tokens
- retain signature, issuer, audience, instance, email-verification, and expiry validation
- cover a real RS256 token inside the leeway and one beyond it

## Why

Avibe currently uses PyJWT's zero-leeway default, so even a very small clock difference can transiently reject a valid Cloud login as `immature_id_token`. This implements the bounded-tolerance portion of #882 without expanding scope into the separate diagnostics and Cloud observability work.

## Evidence

- Unit: `233 passed` across the remote-access OAuth exchange and callback suites
- Contract: real PyJWT RS256 validation accepts a token issued 30 seconds ahead and rejects one issued 60 seconds ahead
- Scenario: no scenario ID; the auth/setup catalog does not currently cover Remote Access OAuth token validation
- Residual manual: live Cloud OAuth login was not exercised; validation stayed hermetic and did not touch local service or Cloud state

## Known By Design

- PyJWT applies `leeway` to all temporal claims (`iat`, `nbf`, and `exp`). The fixed 30-second bound is intentionally symmetric so either validator or issuer clock skew can be tolerated; all non-temporal OIDC checks remain mandatory.

Refs #882
