### PR TITLE
feat(ui): terminal font-size hotkeys, mobile paste key, plain disabled copy

### DIFF
--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -5,10 +5,16 @@ import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
-import { ChevronDown, ChevronUp, RotateCw, Search, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, ClipboardPaste, RotateCw, Search, X } from 'lucide-react';
 
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import {
+  adjustTerminalFontSize,
+  getTerminalFontSize,
+  resetTerminalFontSize,
+  subscribeTerminalFontSize,
+} from '../../lib/terminalFontSize';
 
 // xterm.js wired to the /api/terminal/{id} WebSocket. Protocol (locked with the
 // backend): client sends raw stdin as BINARY frames and JSON control as TEXT
@@ -90,6 +96,36 @@ const isFindHotkey = (e: {
   (e.key === 'f' || e.key === 'F') &&
   (IS_APPLE ? e.metaKey && !e.ctrlKey : e.ctrlKey && e.shiftKey && !e.metaKey);
 
+// The font-zoom chord: ⌘ +/-/0 on Apple, Ctrl +/-/0 elsewhere — exactly what native terminal emulators
+// (Terminal.app, iTerm, GNOME Terminal) and browsers bind for zoom. We claim it only while the terminal
+// has focus (see the custom key handler), so it resizes the terminal font instead of the page; anywhere
+// else in the app the browser's own zoom stays untouched. '+' and '=' are the same physical key (Shift
+// decides which), so both mean zoom-in. Mirrors isFindHotkey: the modifier is ⌘ on Apple / Ctrl elsewhere
+// and never both. All of -, =, +, 0 are non-control keys, so swallowing them steals nothing from the PTY;
+// notably we do NOT match '_' (Ctrl+_ is 0x1f, readline's undo), leaving that control key for the shell.
+type FontZoom = 'in' | 'out' | 'reset';
+const fontZoomIntent = (e: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  key: string;
+}): FontZoom | null => {
+  if (e.altKey) return null;
+  const modifier = IS_APPLE ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+  if (!modifier) return null;
+  switch (e.key) {
+    case '+':
+    case '=':
+      return 'in';
+    case '-':
+      return 'out';
+    case '0':
+      return 'reset';
+    default:
+      return null;
+  }
+};
+
 export const TerminalView: React.FC<{
   sessionId: string;
   /** Start directory for a newly created session (from "Open Terminal Here"). Stable per tab. */
@@ -107,6 +143,8 @@ export const TerminalView: React.FC<{
   const ctrlStickyRef = useRef(false);
   const busyRetriesRef = useRef(0);
   const retryTimerRef = useRef<number | null>(null);
+  // Auto-dismiss timer for the mobile Paste key's "clipboard blocked" hint.
+  const pasteHintTimerRef = useRef<number | null>(null);
   // Report actual session persistence (from the backend 'ready' frame) up to the tab bar, so its
   // badge reflects reality — tmux-backed = persistent, plain-shell fallback = not. Held in a ref so
   // the WS effect (which doesn't depend on the prop) always calls the latest callback.
@@ -120,6 +158,9 @@ export const TerminalView: React.FC<{
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [matches, setMatches] = useState<{ index: number; count: number }>({ index: -1, count: 0 });
+  // Brief inline hint when the mobile Paste key can't read the clipboard (permission denied or an
+  // insecure context) — a graceful notice instead of a silent failure or a crash.
+  const [pasteBlocked, setPasteBlocked] = useState(false);
 
   // Surface connection status to the parent (tab bar). The standalone status row inside the
   // body was removed — only the terminating states render an in-body overlay (below).
@@ -131,7 +172,7 @@ export const TerminalView: React.FC<{
 
   useEffect(() => {
     const term = new Terminal({
-      fontSize: 13,
+      fontSize: getTerminalFontSize(), // shared, persisted preference — see terminalFontSize.ts
       fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
       cursorBlink: true,
       theme: TERMINAL_THEME,
@@ -161,7 +202,8 @@ export const TerminalView: React.FC<{
     // terminal key events), so the browser's own find stays available everywhere else in the app.
     // Returning false stops xterm forwarding the key to the PTY; preventDefault stops the browser find.
     term.attachCustomKeyEventHandler((e) => {
-      if (e.type === 'keydown' && isFindHotkey(e)) {
+      if (e.type !== 'keydown') return true;
+      if (isFindHotkey(e)) {
         e.preventDefault();
         setSearchOpen(true);
         // Focus once the bar has mounted (first open) or refocus it (already open); rAF waits for commit.
@@ -169,6 +211,16 @@ export const TerminalView: React.FC<{
           searchInputRef.current?.focus();
           searchInputRef.current?.select();
         });
+        return false;
+      }
+      const zoom = fontZoomIntent(e);
+      if (zoom) {
+        // Adjust the shared font size and swallow the key: preventDefault stops the browser zooming the
+        // whole page, `return false` stops xterm forwarding ⌘=/⌘- to the PTY. Every mounted terminal
+        // re-fits through the subscription below (so all tabs track one size) — this one included.
+        e.preventDefault();
+        if (zoom === 'reset') resetTerminalFontSize();
+        else adjustTerminalFontSize(zoom === 'in' ? 1 : -1);
         return false;
       }
       return true;
@@ -227,6 +279,14 @@ export const TerminalView: React.FC<{
       term.open(containerRef.current);
       settle();
     }
+
+    // Apply later font-size changes — this terminal's own zoom hotkey, or another terminal's — to this
+    // instance: set the size, then reuse the existing refit path so the new cols/rows reach the PTY. The
+    // starting size is read once in the constructor above; subscribe fires only on subsequent changes.
+    const unsubscribeFontSize = subscribeTerminalFontSize((size) => {
+      term.options.fontSize = size;
+      refit();
+    });
 
     const onData = term.onData((data: string) => {
       const ws = wsRef.current;
@@ -301,6 +361,7 @@ export const TerminalView: React.FC<{
       ro.disconnect();
       onData.dispose();
       searchResults.dispose();
+      unsubscribeFontSize();
       // Detach handlers before closing. A closing socket's onclose can fire asynchronously
       // *after* its replacement has already reported 'ready' (reconnect / effect remount);
       // left attached, the stale onclose would mark the live terminal 'closed' or schedule a
@@ -321,6 +382,14 @@ export const TerminalView: React.FC<{
     };
   }, [sessionId, cwd, reconnectKey]);
 
+  // Clear the paste-hint auto-dismiss timer if the view unmounts before it fires.
+  useEffect(
+    () => () => {
+      if (pasteHintTimerRef.current != null) window.clearTimeout(pasteHintTimerRef.current);
+    },
+    [],
+  );
+
   const sendKey = (k: { seq?: string; ctrl?: boolean }) => {
     if (k.ctrl) {
       ctrlStickyRef.current = !ctrlStickyRef.current;
@@ -329,6 +398,26 @@ export const TerminalView: React.FC<{
     const ws = wsRef.current;
     if (k.seq && ws && ws.readyState === WebSocket.OPEN) ws.send(ENC.encode(k.seq));
     termRef.current?.focus();
+  };
+
+  // Mobile Paste key: read the clipboard and feed it to the PTY through xterm's paste(), which applies
+  // bracketed-paste framing when the running program asked for it (so a multi-line paste isn't executed
+  // line by line in shells/editors that opted in). Exists because the touch key bar has no paste; desktop
+  // users paste with the hardware keyboard. The read is intentionally un-guarded (no `?.`) so a blocked
+  // clipboard — permission denied, or a non-secure context where the API is absent — throws into the
+  // catch and surfaces a brief hint, rather than failing silently.
+  const pasteFromClipboard = async () => {
+    const term = termRef.current;
+    try {
+      const text = await navigator.clipboard.readText();
+      const ws = wsRef.current;
+      if (text && term && ws && ws.readyState === WebSocket.OPEN) term.paste(text);
+      term?.focus();
+    } catch {
+      setPasteBlocked(true);
+      if (pasteHintTimerRef.current != null) window.clearTimeout(pasteHintTimerRef.current);
+      pasteHintTimerRef.current = window.setTimeout(() => setPasteBlocked(false), 3200);
+    }
   };
 
   const reconnect = () => {
@@ -470,6 +559,16 @@ export const TerminalView: React.FC<{
               </div>
             </div>
           )}
+          {pasteBlocked && (
+            // The mobile Paste key couldn't read the clipboard — float a brief, non-blocking notice above
+            // the key bar. Fixed-dark like the find widget (the terminal body is theme-locked dark);
+            // pointer-events-none so it never intercepts a tap. Only the touch-only Paste key sets this.
+            <div className="pointer-events-none absolute inset-x-0 bottom-2 z-10 flex justify-center px-3">
+              <span className="rounded-md bg-zinc-900/95 px-3 py-1.5 text-center text-[11px] text-zinc-200 shadow-lg ring-1 ring-zinc-700/70">
+                {t('apps.terminal.pasteBlocked')}
+              </span>
+            </div>
+          )}
         </div>
       )}
 
@@ -479,6 +578,15 @@ export const TerminalView: React.FC<{
         // hardware keyboard already has these keys and the bar just costs a row. Keyed off
         // pointer type rather than the md: viewport breakpoint so tablets keep it.
         <div className="hidden gap-1 overflow-x-auto border-t border-border bg-surface px-2 py-1.5 pointer-coarse:flex">
+          <button
+            type="button"
+            onClick={pasteFromClipboard}
+            aria-label={t('apps.terminal.keys.paste')}
+            className="flex shrink-0 items-center gap-1 rounded-md border border-border-strong px-2.5 py-1.5 text-[12px] text-foreground active:bg-foreground/[0.08]"
+          >
+            <ClipboardPaste className="size-3.5" aria-hidden />
+            {t('apps.terminal.keys.paste')}
+          </button>
           {KEYS.map((k) => (
             <button
               key={k.labelKey}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -794,7 +794,8 @@
       "newTab": "New tab",
       "reconnect": "Reconnect",
       "exitCode": "exit {{code}}",
-      "disabled": "Terminal unavailable: it may be turned off on the server (VIBE_UI_ENABLE_TERMINAL=0) or this session isn't authorized.",
+      "disabled": "The terminal is turned off for this service, or this session isn't authorized to use it. Whoever runs the service can turn it on in the service configuration.",
+      "pasteBlocked": "Couldn't read the clipboard — check your browser's clipboard permission and try again.",
       "status": {
         "connecting": "Connecting…",
         "ready": "Connected",
@@ -803,6 +804,7 @@
         "error": "Disconnected"
       },
       "keys": {
+        "paste": "Paste",
         "esc": "Esc",
         "tab": "Tab",
         "ctrl": "Ctrl",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -794,7 +794,8 @@
       "newTab": "新建标签",
       "reconnect": "重新连接",
       "exitCode": "退出码 {{code}}",
-      "disabled": "终端不可用:可能在服务端被关掉(VIBE_UI_ENABLE_TERMINAL=0),或当前会话未获授权。",
+      "disabled": "本服务已关闭终端,或当前会话无权使用。运行本服务的人可以在服务配置中开启它。",
+      "pasteBlocked": "无法读取剪贴板,请检查浏览器的剪贴板权限后重试。",
       "status": {
         "connecting": "连接中…",
         "ready": "已连接",
@@ -803,6 +804,7 @@
         "error": "已断开"
       },
       "keys": {
+        "paste": "粘贴",
         "esc": "Esc",
         "tab": "Tab",
         "ctrl": "Ctrl",

--- a/ui/src/lib/terminalFontSize.test.ts
+++ b/ui/src/lib/terminalFontSize.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  TERMINAL_FONT_DEFAULT,
+  TERMINAL_FONT_MAX,
+  TERMINAL_FONT_MIN,
+  adjustTerminalFontSize,
+  getTerminalFontSize,
+  resetTerminalFontSize,
+  subscribeTerminalFontSize,
+  _resetTerminalFontSize,
+} from './terminalFontSize';
+
+afterEach(() => _resetTerminalFontSize());
+
+describe('terminal font size preference', () => {
+  it('starts at the default size', () => {
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT);
+  });
+
+  it('adjusts up and down by whole steps', () => {
+    adjustTerminalFontSize(1);
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT + 1);
+    adjustTerminalFontSize(-2);
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT - 1);
+  });
+
+  it('clamps to the [MIN, MAX] bounds instead of running away', () => {
+    adjustTerminalFontSize(100);
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_MAX);
+    adjustTerminalFontSize(-100);
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_MIN);
+  });
+
+  it('resets to the default', () => {
+    adjustTerminalFontSize(5);
+    resetTerminalFontSize();
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT);
+  });
+
+  it('notifies subscribers so every open terminal re-fits to the new size', () => {
+    const seen: number[] = [];
+    const unsubscribe = subscribeTerminalFontSize((size) => seen.push(size));
+    adjustTerminalFontSize(1);
+    adjustTerminalFontSize(1);
+    unsubscribe();
+    adjustTerminalFontSize(1); // no longer listening
+    expect(seen).toEqual([TERMINAL_FONT_DEFAULT + 1, TERMINAL_FONT_DEFAULT + 2]);
+  });
+
+  it('does not notify when a change is a no-op at a bound', () => {
+    adjustTerminalFontSize(100); // pin to MAX
+    const listener = vi.fn();
+    subscribeTerminalFontSize(listener);
+    adjustTerminalFontSize(1); // already at MAX → clamped to the same value
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/terminalFontSize.ts
+++ b/ui/src/lib/terminalFontSize.ts
@@ -1,0 +1,76 @@
+// Global terminal font-size preference.
+//
+// One value shared by every open terminal — the /apps/terminal route, every
+// windowed terminal, and every tab within them — so a zoom applies everywhere at
+// once instead of per-instance. Persisted to localStorage under a versioned key so
+// the choice survives reloads and new tabs open at the same size.
+//
+// Kept as a tiny module-level store with a subscriber set (mirrors terminalSlots.ts)
+// because terminals don't share a common React parent: the route terminal and each
+// windowed terminal mount independently, so a change from one must reach the others
+// through a shared store, not props. All window/localStorage access is guarded so the
+// module is safe to import in a non-DOM (test) environment.
+const STORAGE_KEY = 'avibe.terminal.fontSize.v1';
+
+export const TERMINAL_FONT_MIN = 9;
+export const TERMINAL_FONT_MAX = 24;
+export const TERMINAL_FONT_DEFAULT = 13;
+
+const clamp = (n: number): number =>
+  Math.min(TERMINAL_FONT_MAX, Math.max(TERMINAL_FONT_MIN, Math.round(n)));
+
+function read(): number {
+  try {
+    if (typeof window === 'undefined') return TERMINAL_FONT_DEFAULT;
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw == null || raw === '') return TERMINAL_FONT_DEFAULT;
+    const n = Number(raw);
+    return Number.isFinite(n) ? clamp(n) : TERMINAL_FONT_DEFAULT;
+  } catch {
+    // Storage blocked (private mode, disabled cookies) — fall back to the default.
+    return TERMINAL_FONT_DEFAULT;
+  }
+}
+
+let current = read();
+const listeners = new Set<(size: number) => void>();
+
+export function getTerminalFontSize(): number {
+  return current;
+}
+
+function set(size: number): void {
+  const next = clamp(size);
+  if (next === current) return; // already there (e.g. ⌘+ at the max) — no refit, no churn
+  current = next;
+  try {
+    if (typeof window !== 'undefined') window.localStorage.setItem(STORAGE_KEY, String(next));
+  } catch {
+    // Persistence is best-effort; keep the in-memory value even if the write fails.
+  }
+  for (const listener of listeners) listener(next);
+}
+
+/** Nudge the shared size by `delta` steps (clamped to [MIN, MAX]); notifies every terminal. */
+export function adjustTerminalFontSize(delta: number): void {
+  set(current + delta);
+}
+
+/** Restore the default size (⌘0). */
+export function resetTerminalFontSize(): void {
+  set(TERMINAL_FONT_DEFAULT);
+}
+
+/** Subscribe to size changes; returns an unsubscribe fn. Does not fire on subscribe. */
+export function subscribeTerminalFontSize(listener: (size: number) => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Test-only: reset the shared preference between cases.
+export function _resetTerminalFontSize(): void {
+  current = TERMINAL_FONT_DEFAULT;
+  listeners.clear();
+}


### PR DESCRIPTION
## Capability

Three frontend-only quality-of-life improvements to the Web Terminal (`TerminalView` / `TerminalTabs`).

### 1. Font-size hotkeys (persisted, global)
- **⌘+ / ⌘- / ⌘0** (Ctrl on non-Apple) increase / decrease / reset the terminal font size, bounds **9–24**, default **13**.
- One global preference persisted to `localStorage` under a **versioned key** (`avibe.terminal.fontSize.v1`), applied to **every terminal and every new tab** via a small module-level pub/sub store (`ui/src/lib/terminalFontSize.ts`, mirroring `terminalSlots.ts`) — terminals don't share a React parent, so a shared store is how a zoom in one reaches the others live.
- A change sets `term.options.fontSize` and re-runs the **existing `refit()` path**, so the new `cols/rows` are pushed to the PTY.
- Keydown is scoped to a **focused terminal** via `attachCustomKeyEventHandler` (the PR #838 search-bar pattern). `preventDefault()` suppresses page zoom only inside the terminal; elsewhere the browser's own zoom is untouched.

### 2. Mobile Paste key
- The touch accessory key bar gains a **Paste** button: reads `navigator.clipboard.readText()` and feeds it to the PTY via **`term.paste()`** (so bracketed-paste framing is honored — a multi-line paste isn't executed line-by-line where the program opted in).
- A blocked clipboard (denied permission / insecure context) shows a **brief inline hint**, not a crash or silent no-op.

### 3. Humanized disabled copy
- `apps.terminal.disabled` no longer leaks the internal `VIBE_UI_ENABLE_TERMINAL` env var to end users. Rewritten to plain language in **en + zh**. Backend gating untouched.

## Evidence layers
- **Unit**: `ui/src/lib/terminalFontSize.test.ts` — clamp/adjust/reset/subscribe + no-op-at-bound (6 cases, node-safe; all `window` access guarded). `terminalSlots.test.ts` still green.
- **Build**: `cd ui && npm run build` (tsc -b + vite) green.
- **Scenario**: n/a — no scenario catalog covers terminal UI QoL.
- **Residual manual checks** (deferred to the integration pass):
  - font size change persists across reload and applies to a second tab;
  - paste on an iOS Safari viewport;
  - disabled copy reads clean in both locales.

## Dependencies
None. Branched from latest `origin/master`.

## Known-by-design ledger
- **Only non-control keys are swallowed for zoom** (`-`, `=`, `+`, `0`). `_` is intentionally **not** matched: `Ctrl+_` is `0x1f` (readline `undo`), so it stays with the shell. `-`/`=`/`+`/`0` are not C0 control chars and are exactly what native terminals (GNOME Terminal, iTerm) bind for zoom.
- **Paste read is intentionally un-guarded** (no `?.`) so a missing/blocked Clipboard API throws into the `catch` and surfaces the hint, rather than optional-chaining into a silent no-op.
- **Cross-*browser*-tab live sync is out of scope**: a new browser tab reads the persisted size on load; the live pub/sub covers all terminals/tabs within one document (the stated requirement).
- Two pre-existing `react-hooks/refs` lint errors in `TerminalView.tsx` (`onPersistentRef.current = …`) are untouched by this PR; eslint is not a CI gate here.