### PR TITLE
feat(editor): hide dead activity-bar icons, show real indentation status

### DIFF
--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
-import { Blocks, Bug, Clock, CodeXml, FilePlus, Files, FileText, FolderOpen, GitBranch, Image as ImageIcon, Search, Settings, X } from 'lucide-react';
+import { Clock, CodeXml, FilePlus, Files, FileText, FolderOpen, Image as ImageIcon, Search, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -70,6 +70,11 @@ type PickerState = {
 // couldn't be reached right now (leave the row — it may still exist).
 type RecentOpenResult = 'opened' | 'gone' | 'unavailable';
 
+// One tab's status-bar data: the 1-based cursor position plus the model's resolved indentation
+// (Monaco's detected insertSpaces / tabSize). Stored per tab so switching tabs shows the target
+// file's real values immediately, without waiting for its cursor to move.
+type PaneStatus = { line: number; col: number; insertSpaces: boolean; tabSize: number };
+
 // Human language label for the status bar (design dnYPx shows e.g. "TypeScript React").
 const LANGUAGE_LABEL: Record<string, string> = {
   ts: 'TypeScript',
@@ -134,7 +139,10 @@ export const EditorApp: React.FC<{
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [active, setActive] = useState<string | null>(null); // active tab id
   const [dirty, setDirty] = useState<Record<string, boolean>>({}); // keyed by tab id
-  const [cursor, setCursor] = useState<{ line: number; col: number } | null>(null);
+  // Status-bar data (cursor + resolved indentation) keyed by tab id. Every open pane reports its
+  // own — including inactive ones (all panes are mounted) — so switching tabs reads the target's
+  // cached values instantly instead of showing stale data until its cursor next moves.
+  const [status, setStatus] = useState<Record<string, PaneStatus>>({});
   const [picker, setPicker] = useState<PickerState | null>(null);
   const [view, setView] = useState<'files' | 'search'>('files');
   // A pending Monaco jump (from a cross-file search result), scoped to one tab. The nonce makes a
@@ -167,7 +175,6 @@ export const EditorApp: React.FC<{
       // so a reload doesn't re-stamp restored files as freshly opened.
       rememberRecentFile(path, name);
       setRoot((r) => r ?? parentDir(path));
-      if (!target) setCursor(null);
       setTabs((ts) => {
         // Dedup inside the updater so two concurrent opens of the same file (e.g. a fast double-click
         // firing two fileMeta requests) can't both append a tab — both see the same current `ts`.
@@ -197,7 +204,6 @@ export const EditorApp: React.FC<{
       const existing = ts.find((x) => x.path === path);
       const id = existing ? existing.id : `t${++tabSeq.current}`;
       setActive(id);
-      setCursor(null);
       if (existing) return ts;
       return [...ts, { id, path, name, mtime: null, kind: 'preview' }];
     });
@@ -306,6 +312,11 @@ export const EditorApp: React.FC<{
       setActive((cur) => (cur && closeIds.has(cur) ? (rest.length ? rest[rest.length - 1].id : null) : cur));
       setDirty((d) => {
         const n = { ...d };
+        closeIds.forEach((id) => delete n[id]);
+        return n;
+      });
+      setStatus((s) => {
+        const n = { ...s };
         closeIds.forEach((id) => delete n[id]);
         return n;
       });
@@ -442,6 +453,12 @@ export const EditorApp: React.FC<{
       delete n[id];
       return n;
     });
+    setStatus((s) => {
+      if (!(id in s)) return s;
+      const n = { ...s };
+      delete n[id];
+      return n;
+    });
   };
 
   // Open Folder: pick a folder via the in-window FilePicker (no manual path typing), set it as the
@@ -464,7 +481,6 @@ export const EditorApp: React.FC<{
     const id = `t${++tabSeq.current}`;
     setTabs((ts) => [...ts, { id, path: null, name: t('apps.editor.untitled', { n: ++untitledSeq.current }), mtime: null }]);
     setActive(id);
-    setCursor(null);
   }, [t]);
 
   // Save As (for an untitled buffer): pick a folder + filename, write create-only (so it can't
@@ -581,11 +597,14 @@ export const EditorApp: React.FC<{
   const showWelcome = root == null && tabs.length === 0;
   const activeTab = tabs.find((x) => x.id === active);
   const activeName = activeTab?.name;
+  const activeStatus = active ? status[active] : undefined;
 
   return (
     <div className="relative flex h-full min-h-0 w-full flex-col bg-surface">
       <div className="flex min-h-0 flex-1">
-        {/* Activity bar — Files / Search switch the left panel; the rest are inert placeholders. */}
+        {/* Activity bar — Files / Search switch the left panel. Dead placeholder icons (Git / Bug /
+            Blocks / Settings) were removed as honest chrome; a real Git view slots back into this
+            column when Git integration lands (out of scope here). */}
         <div className="flex w-12 shrink-0 flex-col items-center justify-between border-r border-border bg-surface-3 py-3">
           <div className="flex flex-col items-center gap-[18px]">
             {([
@@ -618,11 +637,9 @@ export const EditorApp: React.FC<{
                 <Icon className="size-5" />
               </button>
             ))}
-            {[GitBranch, Bug, Blocks].map((Icon, i) => (
-              <Icon key={i} className="size-5 text-muted" />
-            ))}
           </div>
-          <Settings className="size-5 text-muted" />
+          {/* Bottom slot (Settings / SCM status) intentionally empty until wired — the column keeps
+              its two-slot layout so a future control can slot back in here. */}
         </div>
 
         {/* Left panel — Explorer (Files view) or the cross-file Search view. Collapses via the
@@ -710,10 +727,7 @@ export const EditorApp: React.FC<{
                     >
                       <button
                         type="button"
-                        onClick={() => {
-                          if (tab.id !== active) setCursor(null);
-                          setActive(tab.id);
-                        }}
+                        onClick={() => setActive(tab.id)}
                         className="flex items-center gap-1.5"
                       >
                         {tab.kind === 'preview' ? (
@@ -753,7 +767,7 @@ export const EditorApp: React.FC<{
                             mtime={tab.mtime}
                             chromeless
                             onDirtyChange={(d) => setDirty((prev) => (prev[tab.id] === d ? prev : { ...prev, [tab.id]: d }))}
-                            onCursor={active === tab.id ? (line, col) => setCursor({ line, col }) : undefined}
+                            onCursor={(line, col, indent) => setStatus((s) => ({ ...s, [tab.id]: { line, col, insertSpaces: indent.insertSpaces, tabSize: indent.tabSize } }))}
                             onSaveAs={(textValue) => saveAs(tab.id, textValue)}
                             reveal={reveal?.tabId === tab.id ? { line: reveal.line, column: reveal.column, endColumn: reveal.endColumn, nonce: reveal.nonce } : null}
                             reloadNonce={tab.reload}
@@ -785,8 +799,16 @@ export const EditorApp: React.FC<{
           <span className="ml-auto truncate">{t('preview.title')}</span>
         ) : active ? (
           <>
-            <span className="ml-auto tabular-nums">{t('apps.editor.lineCol', { line: cursor?.line ?? 1, col: cursor?.col ?? 1 })}</span>
-            <span>{t('apps.editor.spaces', { n: 2 })}</span>
+            <span className="ml-auto tabular-nums">{t('apps.editor.lineCol', { line: activeStatus?.line ?? 1, col: activeStatus?.col ?? 1 })}</span>
+            {/* Real, live indentation from the active model — spaces show "Spaces: N", tabs show
+                "Tab Size: N" (VS Code wording). Omitted until Monaco reports, rather than guessing. */}
+            {activeStatus && (
+              <span>
+                {activeStatus.insertSpaces
+                  ? t('apps.editor.spaces', { n: activeStatus.tabSize })
+                  : t('apps.editor.tabSize', { n: activeStatus.tabSize })}
+              </span>
+            )}
             <span className="truncate">{languageLabel(activeName) ?? t('apps.editor.plainText')}</span>
           </>
         ) : (

--- a/ui/src/components/workbench/FileEditorPane.tsx
+++ b/ui/src/components/workbench/FileEditorPane.tsx
@@ -103,8 +103,9 @@ export const FileEditorPane: React.FC<{
    * be a redundant second header. Standalone uses keep the header (default).
    */
   chromeless?: boolean;
-  /** Live 1-based cursor position, surfaced in the IDE status bar. */
-  onCursor?: (line: number, column: number) => void;
+  /** Live status for the IDE status bar: 1-based cursor position plus the model's resolved
+   *  indentation (insertSpaces / tabSize). Forwarded straight to Monaco's onCursorChange. */
+  onCursor?: (line: number, column: number, indent: { insertSpaces: boolean; tabSize: number }) => void;
   /**
    * Untitled buffers (path === null) call this with the buffer text on save; the parent runs the
    * save-as picker + write, then re-points this pane at the chosen path.

--- a/ui/src/components/workbench/MonacoEditor.tsx
+++ b/ui/src/components/workbench/MonacoEditor.tsx
@@ -100,14 +100,26 @@ export interface MonacoEditorProps {
   onChange?: (value: string) => void;
   /** Save the file — bound to ⌘S / Ctrl+S inside the editor (the IDE has no visible save button). */
   onSave?: () => void;
-  /** Live 1-based cursor position, for an IDE status bar (`Ln x, Col y`). */
-  onCursorChange?: (line: number, column: number) => void;
+  /**
+   * Live status for an IDE status bar: the 1-based cursor position (`Ln x, Col y`) plus the model's
+   * RESOLVED indentation (`insertSpaces` / `tabSize`) after Monaco's `detectIndentation` runs. Fires
+   * on mount, on cursor moves, and when the model's indentation is (re)detected.
+   */
+  onCursorChange?: (line: number, column: number, indent: { insertSpaces: boolean; tabSize: number }) => void;
   /**
    * Jump to + select a match (from cross-file search). `line` is 1-based; `column`/`endColumn`
    * are 0-based offsets within the line (the search backend's convention). `nonce` makes a
    * repeated jump to the same spot re-fire.
    */
   reveal?: { line: number; column: number; endColumn: number; nonce: number } | null;
+}
+
+// The model's RESOLVED indentation (post-`detectIndentation`), for the IDE status bar. Reads the
+// model's own options rather than the construction defaults, so a tabs file reports tabs and a
+// 4-space file reports 4. Falls back to Monaco's defaults only in the (unreachable here) no-model case.
+function readIndent(editor: monaco.editor.IStandaloneCodeEditor): { insertSpaces: boolean; tabSize: number } {
+  const opts = editor.getModel()?.getOptions();
+  return { insertSpaces: opts?.insertSpaces ?? true, tabSize: opts?.tabSize ?? 4 };
 }
 
 function applyReveal(editor: monaco.editor.IStandaloneCodeEditor, reveal: { line: number; column: number; endColumn: number }) {
@@ -140,9 +152,16 @@ export default function MonacoEditor({ value, language, path, readOnly, dark = t
   const handleMount: OnMount = (editor) => {
     editorRef.current = editor;
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => onSaveRef.current?.());
+    // Report the initial cursor + detected indentation, then keep both live: the cursor on every
+    // move, and indentation whenever Monaco (re)detects it (detectIndentation resolves the model's
+    // options at creation, and a manual indentation change fires onDidChangeModelOptions too).
     const pos = editor.getPosition();
-    if (pos) onCursorRef.current?.(pos.lineNumber, pos.column);
-    editor.onDidChangeCursorPosition((e) => onCursorRef.current?.(e.position.lineNumber, e.position.column));
+    if (pos) onCursorRef.current?.(pos.lineNumber, pos.column, readIndent(editor));
+    editor.onDidChangeCursorPosition((e) => onCursorRef.current?.(e.position.lineNumber, e.position.column, readIndent(editor)));
+    editor.onDidChangeModelOptions(() => {
+      const p = editor.getPosition();
+      onCursorRef.current?.(p?.lineNumber ?? 1, p?.column ?? 1, readIndent(editor));
+    });
     if (revealRef.current) applyReveal(editor, revealRef.current);
   };
 
@@ -211,7 +230,9 @@ export default function MonacoEditor({ value, language, path, readOnly, dark = t
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
             automaticLayout: true,
-            tabSize: 2,
+            // Detect indentation from the file's own content (VS Code default) instead of forcing a
+            // fixed tab size — the status bar then reports the model's real resolved insertSpaces/tabSize.
+            detectIndentation: true,
             renderWhitespace: 'selection',
             smoothScrolling: true,
             cursorBlinking: 'smooth',

--- a/ui/src/components/workbench/MonacoEditor.tsx
+++ b/ui/src/components/workbench/MonacoEditor.tsx
@@ -116,10 +116,11 @@ export interface MonacoEditorProps {
 
 // The model's RESOLVED indentation (post-`detectIndentation`), for the IDE status bar. Reads the
 // model's own options rather than the construction defaults, so a tabs file reports tabs and a
-// 4-space file reports 4. Falls back to Monaco's defaults only in the (unreachable here) no-model case.
+// 4-space file reports 4. The `?? 2` guards only the unreachable no-model case (mount / cursor /
+// options events always have a model); it mirrors the editor's own 2-space fallback below.
 function readIndent(editor: monaco.editor.IStandaloneCodeEditor): { insertSpaces: boolean; tabSize: number } {
   const opts = editor.getModel()?.getOptions();
-  return { insertSpaces: opts?.insertSpaces ?? true, tabSize: opts?.tabSize ?? 4 };
+  return { insertSpaces: opts?.insertSpaces ?? true, tabSize: opts?.tabSize ?? 2 };
 }
 
 function applyReveal(editor: monaco.editor.IStandaloneCodeEditor, reveal: { line: number; column: number; endColumn: number }) {
@@ -230,9 +231,12 @@ export default function MonacoEditor({ value, language, path, readOnly, dark = t
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
             automaticLayout: true,
-            // Detect indentation from the file's own content (VS Code default) instead of forcing a
-            // fixed tab size — the status bar then reports the model's real resolved insertSpaces/tabSize.
+            // Detect indentation from the file's own content so the status bar reports the model's
+            // real resolved insertSpaces/tabSize. `tabSize: 2` is only the FALLBACK for content with
+            // no detectable indentation (new/empty buffers) — detectIndentation always overrides it
+            // when the file has real indentation, so this keeps the 2-space default without lying.
             detectIndentation: true,
+            tabSize: 2,
             renderWhitespace: 'selection',
             smoothScrolling: true,
             cursorBlinking: 'smooth',

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -643,6 +643,7 @@
       "selectFileHint": "Select a file from the explorer to edit",
       "lineCol": "Ln {{line}}, Col {{col}}",
       "spaces": "Spaces: {{n}}",
+      "tabSize": "Tab Size: {{n}}",
       "plainText": "Plain Text",
       "source": "Source",
       "preview": "Preview",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -643,6 +643,7 @@
       "selectFileHint": "从左侧资源管理器选择文件进行编辑",
       "lineCol": "行 {{line}}，列 {{col}}",
       "spaces": "空格：{{n}}",
+      "tabSize": "制表符宽度：{{n}}",
       "plainText": "纯文本",
       "source": "源码",
       "preview": "预览",


### PR DESCRIPTION
## Editor polish — honest chrome (frontend only)

Two small honesty fixes to the Editor IDE (`ui/src/components/workbench`). No backend, no new deps, no behavior beyond the editor chrome.

### 1. Hide the dead activity-bar icons
The activity bar rendered `GitBranch` / `Bug` / `Blocks` placeholders and a `Settings` icon that did nothing on click. Removed them from the render; **only the working Files + Search views remain**. The column keeps its two-slot (top group + reserved bottom) structure with a comment, so a real Git/SCM view can slot back in when Git integration lands — that integration is **out of scope** here.

### 2. Real indentation display
Monaco hardcoded the status bar to `"Spaces: 2"` — a lie for any file that isn't 2-space.
- Enabled Monaco's `detectIndentation: true` so the file's own content drives indentation. Kept `tabSize: 2` as the **fallback** for content with no detectable indentation (new/empty buffers) — per Monaco's `modelService`, `detectIndentation` always re-detects and **overrides** `tabSize`/`insertSpaces` from content when indentation is present, so detection still wins for real files while the prior 2-space default is preserved.
- The status bar now reads the model's **resolved** `insertSpaces` / `tabSize` (`editor.getModel().getOptions()`), live, via the **existing cursor callback** (`MonacoEditor.onCursorChange` → `FileEditorPane.onCursor` → `EditorApp`) — no new context. It re-reports on mount, cursor move, and `onDidChangeModelOptions`.
- A space file shows `Spaces: N`; a **tabs file shows `Tab Size: N`** (new i18n key `apps.editor.tabSize`, VS Code wording) instead of lying "Spaces".
- Status is stored **per tab id** in `EditorApp`, so switching tabs updates the bar immediately (each mounted pane reports its own values).

### Evidence layers
- **Build**: `cd ui && npm run build` → exit 0 (`tsc -b` clean + vite build). `eslint` on the changed files → 0 errors (one pre-existing `exhaustive-deps` warning on an untouched effect, identical on master).
- **Unit / contract / scenario**: none applicable — the change is React-component + Monaco-integration + i18n. All existing UI tests are pure-logic tests under `ui/src/lib/`; there is no component/Monaco render-test harness, and AGENTS.md advises against introducing a new test pattern here.
- **Residual manual checks** (deferred to the integration pass): a 4-space file shows `Spaces: 4`; a tab-indented file shows `Tab Size: N`; a new/empty buffer shows `Spaces: 2`; switching between a spaces tab and a tabs tab updates the status bar without moving the cursor; the activity bar shows only Files + Search.

### Dependencies
None. (Sibling PRs in this batch also touch `en.json`/`zh.json`; my change is purely additive — one new key in each — so conflicts resolve additively.)

### Known-by-design ledger
- **`justify-between` on the activity-bar column with one rendered child** — intentional: the bottom slot is reserved (documented by comment) for a future Settings/SCM control; the single child renders at the top exactly as before.
- **Indentation span omitted until Monaco first reports** (`activeStatus` undefined) — intentional honesty: we show real indentation or nothing, never a guess. The gap is sub-frame once the (already-mounted) pane reports.
- **New/empty/undetectable buffers show `Spaces: 2`** — `tabSize: 2` is kept as the detection fallback; `detectIndentation` overrides it for files with real indentation, so this preserves the prior default rather than lying.
- **`onDidChangeModelOptions` / `onDidChangeCursorPosition` listeners not explicitly disposed** — matches the existing pattern; Monaco disposes them with the editor on unmount.

### Review rounds
- **r1** (Codex P2, resolved): dropping `tabSize` entirely regressed the undetectable-file fallback from `Spaces: 2` → `Spaces: 4`. Fixed in `eeff446` by restoring `tabSize: 2` as the fallback alongside `detectIndentation: true`.
