### PR TITLE
fix(vaults): repair mobile header layout

### DIFF
--- a/ui/src/components/workbench/CapabilityTabs.tsx
+++ b/ui/src/components/workbench/CapabilityTabs.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Activity, Bot, KeyRound, WandSparkles } from 'lucide-react';
@@ -17,6 +18,12 @@ const TABS = [
 export const CapabilityTabs: React.FC = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
+  const activeTabRef = useRef<HTMLAnchorElement | null>(null);
+
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [pathname]);
+
   return (
     <div className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-0.5 md:hidden">
       {TABS.map(({ to, icon: Icon, key }) => {
@@ -24,6 +31,7 @@ export const CapabilityTabs: React.FC = () => {
         return (
           <NavLink
             key={to}
+            ref={active ? activeTabRef : undefined}
             to={to}
             className={clsx(
               'flex shrink-0 items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-[12.5px] font-medium transition',

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -783,24 +783,38 @@ export const VaultsPage: React.FC = () => {
         icon={<KeyRound className="size-6" />}
         title={t('vaults.title')}
         subtitle={t('vaults.subtitle')}
+        stackActionsOnMobile
         actions={
           <>
-            <VaultLockIndicator />
-            <Button variant={showAudit ? 'secondary' : 'ghost'} size="icon" onClick={toggleAudit} aria-label={t('vaults.history')}>
+            <VaultLockIndicator className="max-sm:order-last max-sm:w-full max-sm:justify-between" />
+            <Button
+              variant={showAudit ? 'secondary' : 'ghost'}
+              size="icon"
+              className="max-sm:border max-sm:border-border max-sm:bg-surface"
+              onClick={toggleAudit}
+              aria-label={t('vaults.history')}
+            >
               <History className="size-4" />
             </Button>
             <Button
               variant={showSettings ? 'secondary' : 'ghost'}
               size="icon"
+              className="max-sm:border max-sm:border-border max-sm:bg-surface"
               onClick={() => setShowSettings(true)}
               aria-label={t('vaults.settings.title')}
             >
               <Settings className="size-4" />
             </Button>
-            <Button variant="ghost" size="icon" onClick={refresh} aria-label={t('vaults.refresh')}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="max-sm:border max-sm:border-border max-sm:bg-surface"
+              onClick={refresh}
+              aria-label={t('vaults.refresh')}
+            >
               <RefreshCw className="size-4" />
             </Button>
-            <Button onClick={() => setAdding(true)}>
+            <Button className="max-sm:flex-1" onClick={() => setAdding(true)}>
               <Plus className="size-4" />
               {t('vaults.add')}
             </Button>

--- a/ui/src/components/workbench/WorkbenchPageHeader.tsx
+++ b/ui/src/components/workbench/WorkbenchPageHeader.tsx
@@ -19,6 +19,8 @@ export interface WorkbenchPageHeaderProps {
   accent?: Accent;
   /** Right-aligned actions (buttons). */
   actions?: ReactNode;
+  /** Move a dense action group below the title on narrow mobile screens. */
+  stackActionsOnMobile?: boolean;
 }
 
 /**
@@ -27,9 +29,16 @@ export interface WorkbenchPageHeaderProps {
  * headers are identical bar the icon + copy). Extracted so capability pages
  * reuse one header instead of re-rolling the markup.
  */
-export function WorkbenchPageHeader({ icon, title, subtitle, accent = 'mint', actions }: WorkbenchPageHeaderProps) {
+export function WorkbenchPageHeader({
+  icon,
+  title,
+  subtitle,
+  accent = 'mint',
+  actions,
+  stackActionsOnMobile = false,
+}: WorkbenchPageHeaderProps) {
   return (
-    <div className="flex items-center gap-4">
+    <div className={clsx('flex items-center gap-4', stackActionsOnMobile && 'flex-wrap')}>
       <div
         className={clsx(
           'flex size-10 shrink-0 items-center justify-center rounded-[10px] border',
@@ -38,11 +47,20 @@ export function WorkbenchPageHeader({ icon, title, subtitle, accent = 'mint', ac
       >
         {icon}
       </div>
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         <h1 className="text-[24px] font-bold text-foreground">{title}</h1>
-        {subtitle ? <p className="text-[12px] text-muted">{subtitle}</p> : null}
+        {subtitle ? <p className="text-[12px] leading-snug text-muted">{subtitle}</p> : null}
       </div>
-      {actions}
+      {actions ? (
+        <div
+          className={clsx(
+            'flex shrink-0 items-center gap-2',
+            stackActionsOnMobile && 'w-full min-w-0 flex-wrap justify-end sm:w-auto sm:flex-nowrap',
+          )}
+        >
+          {actions}
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- stack the dense Vaults action group below the page title on narrow screens
- give the three mobile tool actions stable touch targets and let Add secret fill the remaining row
- keep the active capability tab visible when the mobile tab strip overflows
- preserve the existing single-row desktop header behavior through the shared header primitive

## Design

- added the missing light mobile Vaults frame to the project `design.pen` (`wPJy0`)
- the target separates title/subtitle from actions and uses the same 40 px action row implemented here

## Evidence

- **Unit:** no new unit test; this is responsive layout behavior without a component-test harness
- **Contract:** not applicable; no API or data contract changed
- **Scenario:** no catalog scenario ID applies
- **Manual:** rendered `/vaults` at 390x844 and 320x760; title/subtitle and actions do not overlap, document width equals viewport width, and the active Vaults tab remains visible
- **Design:** Pencil layout snapshot reports no clipping or overlap problems for the new mobile frame
- **Checks:** `npm run build`; ESLint on the three changed components; `git diff --check`

## Residual checks

- the unlocked-window pill was not activated during browser verification because doing so requires the protected-vault unlock flow; its mobile state is explicitly ordered onto a full-width row

## Known by design

- none
