### PR TITLE
feat(files): unify preview-first open routing

### DIFF
--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -9,6 +9,7 @@ import {
   ClipboardPaste,
   Copy,
   Download,
+  Eye,
   FileCode2,
   FileSearch,
   FileText,
@@ -37,7 +38,7 @@ import clsx from 'clsx';
 
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
-import { isEditableFile, isEditableMeta, previewOverlayKind, previewWindowKind } from '../../lib/filePreview';
+import { isEditableFile, isEditableMeta, previewWindowKind } from '../../lib/filePreview';
 import {
   contentUrl,
   copyPath,
@@ -64,6 +65,7 @@ import {
   type Favorite,
   type FsEntry,
   type FsListing,
+  type FsMeta,
   type NameHit,
   type SearchFileResult,
 } from '../../lib/filesApi';
@@ -247,10 +249,9 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
       setSort((s) => (s?.col !== col ? { col, dir: 'asc' } : s.dir === 'asc' ? { col, dir: 'desc' } : null)),
     [],
   );
-  // Quick-look image preview: a raster image opens in an in-window overlay (Finder-style) instead
-  // of downloading. Kept in-window (not a portaled Dialog) so it stays inside the window's dark
-  // data-theme scope and bounds.
-  const [preview, setPreview] = useState<{ path: string; name: string } | null>(null);
+  // Mobile quick look stays inside the Files surface because phones have no window layer. Keep the
+  // edit capability with the preview so editable formats can switch surfaces from its toolbar.
+  const [preview, setPreview] = useState<{ path: string; name: string; mtime: number | null; editable: boolean } | null>(null);
   useEffect(() => {
     if (!preview) return;
     const onKey = (ev: KeyboardEvent) => {
@@ -398,6 +399,19 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
     [wm, routerNavigate],
   );
 
+  // Preview capability is shared across breakpoints; only its presentation differs. The caller
+  // supplies resolved metadata when it has already been fetched (content hits / ambiguous names).
+  const openPreview = useCallback(
+    (item: RowItem, entry: FsEntry = item.entry, editable = isEditableFile(entry), mtime = entry.mtime) => {
+      if (window.matchMedia('(min-width: 768px)').matches) {
+        wm.openApp('preview', { title: entry.name, params: { path: item.full, name: entry.name } });
+      } else {
+        setPreview({ path: item.full, name: entry.name, mtime, editable });
+      }
+    },
+    [wm],
+  );
+
   // Open a terminal rooted at a folder ("Open Terminal Here"): desktop opens a Terminal window
   // whose first tab starts in `dir`; mobile — which has no window layer — navigates to the terminal
   // route with the dir in router state. Mirrors openInEditor.
@@ -421,9 +435,8 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
       navigate(item.full);
       return;
     }
-    const desktop = window.matchMedia('(min-width: 768px)').matches;
     // Content-search hits carry no size (the search API omits it), so the synchronous size gates in
-    // previewWindowKind / previewOverlayKind would treat them as unbounded and could route an
+    // previewWindowKind would treat them as unbounded and could route an
     // oversized file (e.g. a >1 MB Markdown) into a preview the listing path would refuse. For those,
     // fetch metadata up front and route with the REAL size + text sniff — so a content hit opens
     // exactly like the same file from a listing/name row.
@@ -431,10 +444,8 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
       try {
         const m = await fileMeta(item.full);
         const sized: FsEntry = { ...item.entry, size: m.size };
-        if (desktop && previewWindowKind(sized)) {
-          wm.openApp('preview', { title: sized.name, params: { path: item.full, name: sized.name } });
-        } else if (!desktop && previewOverlayKind(sized)) {
-          setPreview({ path: item.full, name: sized.name });
+        if (previewWindowKind(sized)) {
+          openPreview(item, sized, isEditableMeta(m), m.mtime);
         } else if (isEditableMeta(m)) {
           openInEditor(item.full, sized.name, m.mtime);
         } else {
@@ -442,22 +453,14 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
         }
       } catch {
         // Meta unavailable: best-effort by name, mirroring the fallback in the listing path below.
-        if (isEditableFile(item.entry)) openInEditor(item.full, item.entry.name, item.entry.mtime);
+        if (previewWindowKind(item.entry)) openPreview(item);
+        else if (isEditableFile(item.entry)) openInEditor(item.full, item.entry.name, item.entry.mtime);
         else downloadFile(item.full);
       }
       return;
     }
-    if (desktop) {
-      // Desktop: image / PDF / Office / Markdown open the dedicated, resizable Preview window.
-      if (previewWindowKind(item.entry)) {
-        wm.openApp('preview', { title: item.entry.name, params: { path: item.full, name: item.entry.name } });
-        return;
-      }
-    } else if (previewOverlayKind(item.entry)) {
-      // Mobile has no window layer: only NON-editable rich files (image / PDF / Office) open the
-      // in-page overlay. Markdown/SVG are previewable too but ALSO editable, so they fall through to
-      // the editor below (it has its own Source⇄Preview toggle) instead of a read-only overlay.
-      setPreview({ path: item.full, name: item.entry.name });
+    if (previewWindowKind(item.entry)) {
+      openPreview(item);
       return;
     }
     // Fetch CURRENT metadata (content-sniffs `text`) and decide by CONTENT, not just the extension —
@@ -704,13 +707,36 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
 
   // ---- Context menu ----------------------------------------------------------------------------
   // `item` is null for blank space (offers New File/Folder only).
-  const [menu, setMenu] = useState<{ x: number; y: number; item: RowItem | null; items: RowItem[] } | null>(null);
+  const [menu, setMenu] = useState<{ x: number; y: number; item: RowItem | null; items: RowItem[]; meta?: FsMeta | null } | null>(null);
+  const menuRequest = useRef(0);
   const openMenu = useCallback((ev: React.MouseEvent, item: RowItem | null, items: RowItem[] = []) => {
     ev.preventDefault();
     ev.stopPropagation();
-    setMenu({ x: ev.clientX, y: ev.clientY, item, items });
+    const request = ++menuRequest.current;
+    const next = { x: ev.clientX, y: ev.clientY, item, items };
+    // Listing metadata is enough for named formats. Resolve only ambiguous/content-search files so
+    // extensionless text gets an Editor action while binaries never advertise one.
+    const needsMeta =
+      item?.entry.kind === 'file' &&
+      items.length <= 1 &&
+      (item.matchCount != null || (!previewWindowKind(item.entry) && !isEditableFile(item.entry)));
+    if (!needsMeta) {
+      setMenu(next);
+      return;
+    }
+    setMenu(null);
+    void fileMeta(item.full)
+      .then((meta) => {
+        if (menuRequest.current === request) setMenu({ ...next, meta });
+      })
+      .catch(() => {
+        if (menuRequest.current === request) setMenu({ ...next, meta: null });
+      });
   }, []);
-  const closeMenu = useCallback(() => setMenu(null), []);
+  const closeMenu = useCallback(() => {
+    menuRequest.current += 1;
+    setMenu(null);
+  }, []);
 
   // ---- Drag-and-drop move ----------------------------------------------------------------------
   // The dragged row is held in a ref (no re-render mid-drag); `dropTarget` (a folder path) drives the
@@ -1276,13 +1302,21 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
 
   const showInitialSpinner = inSearch ? searchBusy && searchRows === null : loading && !listing;
   const showEmpty = inSearch ? !searchBusy && (searchRows?.length ?? 0) === 0 : !!listing && rows.length === 0 && newEntry === null;
-  // Single row keeps its original four actions plus Copy/Duplicate; a batch has four batch actions.
+  const menuEntry = menu?.item && menu.meta ? { ...menu.item.entry, size: menu.meta.size, mtime: menu.meta.mtime } : menu?.item?.entry;
+  const menuPreviewable = menuEntry ? previewWindowKind(menuEntry) != null : false;
+  const menuEditable = menu?.item
+    ? menu.meta
+      ? isEditableMeta(menu.meta)
+      : isEditableFile(menu.item.entry)
+    : false;
+
+  // Single-file menus add only the explicit routes the selected entry actually supports.
   // Blank space keeps New File/Folder + Terminal and gains Paste while the in-app clipboard is set.
   const menuItemCount = menu
     ? menu.item
       ? menu.items.length > 1
         ? 4
-        : 6
+        : 6 + (menuPreviewable ? 1 : 0) + (menuEditable ? 1 : 0)
       : (cwd ? 3 : 2) + (clipboard.length > 0 && cwd ? 1 : 0)
     : 0;
 
@@ -1737,6 +1771,23 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
           <div className="flex items-center gap-2 border-b border-border bg-surface-2/60 px-3 py-2">
             <FileText className="size-4 shrink-0 text-muted" />
             <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-foreground">{preview.name}</span>
+            {preview.editable && (
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="size-7 shrink-0 text-muted"
+                aria-label={t('apps.fileBrowser.openInEditor')}
+                title={t('apps.fileBrowser.openInEditor')}
+                onClick={() => {
+                  const current = preview;
+                  setPreview(null);
+                  openInEditor(current.path, current.name, current.mtime);
+                }}
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+            )}
             <Button
               type="button"
               size="icon"
@@ -1872,6 +1923,31 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
                     void openItem(it);
                   }}
                 />
+                {menuPreviewable && menuEntry && (
+                  <ContextMenuItem
+                    icon={<Eye className="size-3.5 text-cyan" />}
+                    label={t('apps.fileBrowser.preview')}
+                    onClick={() => {
+                      const it = menu.item as RowItem;
+                      const editable = menu.meta ? isEditableMeta(menu.meta) : isEditableFile(menuEntry);
+                      const mtime = menu.meta?.mtime ?? menuEntry.mtime;
+                      closeMenu();
+                      openPreview(it, menuEntry, editable, mtime);
+                    }}
+                  />
+                )}
+                {menuEditable && (
+                  <ContextMenuItem
+                    icon={<FileCode2 className="size-3.5 text-mint" />}
+                    label={t('apps.fileBrowser.openInEditor')}
+                    onClick={() => {
+                      const it = menu.item as RowItem;
+                      const mtime = menu.meta?.mtime ?? it.entry.mtime;
+                      closeMenu();
+                      openInEditor(it.full, it.entry.name, mtime);
+                    }}
+                  />
+                )}
                 {menu.item.entry.kind === 'dir' && (
                   <ContextMenuItem
                     icon={<SquareTerminal className="size-3.5 text-mint" />}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -734,6 +734,8 @@
       "uploadNoFolders": "Folders can't be uploaded — drop files only.",
       "uploadError": "{{name}}: {{message}}",
       "open": "Open",
+      "preview": "Preview",
+      "openInEditor": "Open in Editor",
       "openTerminalHere": "Open Terminal Here",
       "copy": "Copy",
       "paste": "Paste",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -734,6 +734,8 @@
       "uploadNoFolders": "无法上传文件夹，只能拖放文件。",
       "uploadError": "{{name}}：{{message}}",
       "open": "打开",
+      "preview": "预览",
+      "openInEditor": "用编辑器打开",
       "openTerminalHere": "在此处打开终端",
       "copy": "复制",
       "paste": "粘贴",

--- a/ui/src/lib/filePreview.test.ts
+++ b/ui/src/lib/filePreview.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEditableFile, isEditableMeta, PREVIEW_MAX_BYTES, previewOverlayKind, previewWindowKind } from './filePreview';
+
+const entry = (name: string, size = 100) => ({ kind: 'file', name, size });
+
+describe('File Browser open classification', () => {
+  it.each([
+    ['photo.png', 'image'],
+    ['document.pdf', 'pdf'],
+    ['document.docx', 'docx'],
+    ['notes.md', 'markdown'],
+    ['drawing.svg', 'svg'],
+    ['data.csv', 'csv'],
+    ['data.tsv', 'csv'],
+  ])('routes %s to the shared preview set', (name, kind) => {
+    expect(previewWindowKind(entry(name))).toBe(kind);
+  });
+
+  it.each(['notes.md', 'drawing.svg', 'data.csv', 'data.tsv'])('keeps editable preview %s out of Editor read-only tabs', (name) => {
+    expect(previewOverlayKind(entry(name))).toBeNull();
+  });
+
+  it.each(['settings.json', 'script.py', 'notes.txt'])('keeps %s editor-first', (name) => {
+    expect(previewWindowKind(entry(name))).toBeNull();
+    expect(isEditableFile(entry(name))).toBe(true);
+  });
+
+  it('uses content sniffing for extensionless text without previewing it', () => {
+    expect(previewWindowKind(entry('LICENSE'))).toBeNull();
+    expect(isEditableMeta({ ...entry('LICENSE'), text: true })).toBe(true);
+  });
+
+  it('downloads an unknown binary and oversized text-derived previews', () => {
+    expect(previewWindowKind(entry('archive.bin'))).toBeNull();
+    expect(isEditableMeta({ ...entry('archive.bin'), text: false })).toBe(false);
+    expect(previewWindowKind(entry('large.csv', PREVIEW_MAX_BYTES + 1))).toBeNull();
+  });
+});

--- a/ui/src/lib/filePreview.ts
+++ b/ui/src/lib/filePreview.ts
@@ -216,9 +216,8 @@ export function editorPreviewKind(name: string): EditorPreviewKind | null {
   return null;
 }
 
-// What opens in the File Browser's read-only PREVIEW overlay (vs. the editor): a non-editable rich
-// file — raster image, PDF, or Office doc — within the content cap. Editable text (incl. svg / html /
-// markdown / code / json / csv) opens in the editor instead, which carries its own preview toggle.
+// Non-editable rich files that use a read-only preview tab inside Editor. Keep editable formats out
+// of this set so "Open in Editor" always lands on a source tab.
 export type PreviewOverlayKind = 'image' | 'pdf' | 'docx' | 'xlsx' | 'pptx';
 export function previewOverlayKind(entry: { kind: string; name: string; size: number | null }): PreviewOverlayKind | null {
   if (entry.kind !== 'file') return null;
@@ -227,17 +226,19 @@ export function previewOverlayKind(entry: { kind: string; name: string; size: nu
   return rk === 'image' || rk === 'pdf' || rk === 'docx' || rk === 'xlsx' || rk === 'pptx' ? rk : null;
 }
 
-// What opens in the standalone Preview WINDOW: everything previewOverlayKind covers (image / PDF /
-// Office) PLUS Markdown, which renders to a read-only document view. Editable code / plain-text /
-// json / csv / svg / html still open in the editor (which carries its own preview toggle). The File
-// Browser routes a double-click here on desktop (a real window) and to an in-page overlay on mobile.
-export type PreviewWindowKind = PreviewOverlayKind | 'markdown';
+// What the Files app opens in Preview: a standalone window on desktop and its in-page overlay on
+// mobile. Alongside rich files, Markdown and SVG stay preview-first, and CSV/TSV render as tables
+// through the shared papaparse-backed kernel. Those text-derived formats still expose an explicit
+// editor action. JSON deliberately stays editor-first because config-file opens usually carry edit
+// intent. Desktop and mobile intentionally share this set; only the presentation surface differs.
+export type PreviewWindowKind = PreviewOverlayKind | 'markdown' | 'svg' | 'csv';
 export function previewWindowKind(entry: { kind: string; name: string; size: number | null }): PreviewWindowKind | null {
   const overlay = previewOverlayKind(entry);
   if (overlay) return overlay;
   if (entry.kind !== 'file') return null;
   if (entry.size != null && entry.size > PREVIEW_MAX_BYTES) return null;
-  return previewRenderKind(entry.name) === 'markdown' ? 'markdown' : null;
+  const rk = previewRenderKind(entry.name);
+  return rk === 'markdown' || rk === 'svg' || rk === 'csv' ? rk : null;
 }
 
 // Shiki language id for the 'code'/'source' kinds; 'text' (no highlight) otherwise.


### PR DESCRIPTION
## What changed

- use one Files-app preview-first route on desktop and phone
- add CSV/TSV to Preview while keeping JSON editor-first
- add explicit Preview and Open in Editor context-menu actions when applicable
- let editable mobile previews switch directly into the Editor
- resolve metadata for ambiguous context-menu files so extensionless text gets an Editor action while binaries do not

## Manual routing matrix

| File | Desktop double-click | Desktop context menu | Phone tap |
| --- | --- | --- | --- |
| PNG | Preview window | Preview | Preview overlay |
| PDF | Preview window | Preview | Preview overlay |
| DOCX | Preview window | Preview | Preview overlay |
| Markdown | Preview window, with Open in Editor | Preview and Open in Editor | Preview overlay, with Open in Editor |
| CSV | Preview window, with Open in Editor | Preview and Open in Editor | Preview overlay, with Open in Editor |
| Python | Editor window | Open in Editor | Editor route |
| extensionless text | Editor window after content sniff | Open in Editor after content sniff | Editor route after content sniff |
| binary | Download | Download only | Download |

The Markdown and CSV Preview-to-Editor transitions were exercised on both desktop and phone and landed on editable Monaco tabs.

## Evidence

- Unit: `filePreview.test.ts`, 16 passing cases covering preview-first, editor-first, extensionless text, binary, and size gates
- Contract: no backend/API contract changes
- Scenario IDs: none; no matching catalog entry for this frontend interaction
- UI gate: `npm run build`
- Lint: focused ESLint on the changed TypeScript files
- Browser: automated Chrome interaction matrix across all 24 requested file/surface combinations, plus four Preview-to-Editor transitions; desktop and phone CSV surfaces visually checked
- Residual manual checks: none for routing; full integration rendering remains covered by the existing shared preview kernel

## Dependencies

None.

## Known by design

- JSON remains editor-first because config-file opens usually carry edit intent.
- Editor's internal read-only preview-tab classifier stays limited to non-editable rich files, so Open in Editor for Markdown, SVG, CSV, and TSV always opens editable source.
