### PR TITLE
fix(regression): prepare Show Runtime before restart

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1420,8 +1420,10 @@ def cmd_up(args: argparse.Namespace) -> int:
         run_prepare_state(runner, target, reset_mode=args.reset_mode, remote=args.remote)
         normalize_runtime_config(runner, target, remote=args.remote)
         write_metadata(runner, target, repo_root, fingerprints, remote=args.remote)
-        restart_and_verify(runner, target, remote=args.remote)
+        # Install updated runtime sources while the service is stopped so the
+        # restarted process cannot keep serving code loaded before preparation.
         prepare_show_runtime(runner, target, remote=args.remote)
+        restart_and_verify(runner, target, remote=args.remote)
         if not args.dry_run:
             update_worktree_mapping(repo_root, target)
     print_summary(target)

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -1549,6 +1549,7 @@ def test_up_stops_old_service_before_mutating_runtime(tmp_path: Path, monkeypatc
     assert calls[:3] == ["ensure_project_and_instance", "stop_service_for_update", "write_runtime_env"]
     assert calls.index("sync_source") < calls.index("update_dependencies_and_build")
     assert calls.index("normalize_runtime_config") < calls.index("restart_and_verify")
+    assert calls.index("prepare_show_runtime") < calls.index("restart_and_verify")
 
 
 def test_up_preserves_runtime_env_when_existing_target_has_no_env_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- prepare the configured Show Runtime source while the regression service is stopped
- start and health-check Avibe only after runtime preparation completes
- lock the lifecycle ordering in the Incus regression runner test

## Why

The previous order restarted Avibe before `vibe runtime prepare --strict`. For `github-source`, an existing Show Runtime process could load the old checkout, then preparation updated the files underneath it. The regression environment therefore needed a second restart before it actually exercised the new runtime commit.

## Evidence

- Unit: `uv run pytest tests/test_incus_regression.py -q` (68 passed)
- Contract: the lifecycle test now requires `prepare_show_runtime` before `restart_and_verify`
- Scenario: reproduced on the master Incus environment while validating vibe-show-runtime#37; the first update served the old runtime and the second restart loaded the merged commit
- Lint: `uv run ruff check scripts/incus_regression.py tests/test_incus_regression.py`
- Build prerequisite: `npm ci && npm run build` in `ui/`

## Known by design

- Runtime preparation remains strict. If it cannot install a usable runtime after its existing cleanup/retry path, the update fails before starting the service instead of deliberately serving stale runtime code.

## Residual manual check

- After merge, run one master regression update and verify the first restarted Show Runtime process serves the current configured source commit.
