### PR TITLE
feat(apps): App Library — apps + show pages views

### DIFF
--- a/core/dock_store.py
+++ b/core/dock_store.py
@@ -7,7 +7,7 @@ versioned key, alongside the other cross-device workbench state. v1 knows two
 kinds of dock item:
 
 - built-in apps, keyed by their app id verbatim (``files`` / ``terminal`` /
-  ``editor``). They are reorderable but not unpinnable.
+  ``editor`` / ``library``). They are reorderable but not unpinnable.
 - pinned Show Pages, keyed ``show:<session_id>``.
 
 Future item kinds (``app:<id>`` …) slot into the same ``order`` list without a
@@ -44,7 +44,7 @@ _DOCK_MUTATION_LOCK = threading.Lock()
 # Built-in resident apps, in their canonical Dock order. Mirrors the frontend
 # APP_LIST ids (ui/src/apps/registry.tsx); these ids are a stable contract
 # shared across the client/server boundary — keep the two in sync.
-BUILTIN_DOCK_IDS: tuple[str, ...] = ("files", "terminal", "editor")
+BUILTIN_DOCK_IDS: tuple[str, ...] = ("files", "terminal", "editor", "library")
 
 # Namespace prefix for a pinned Show Page dock id.
 SHOW_PREFIX = "show:"

--- a/core/dock_store.py
+++ b/core/dock_store.py
@@ -50,8 +50,11 @@ BUILTIN_DOCK_IDS: tuple[str, ...] = ("files", "terminal", "editor", "library")
 SHOW_PREFIX = "show:"
 
 # Defensive cap on the resident-tile count so one corrupt/hostile write can't
-# balloon the order list. Far above any real Dock (built-ins + pinned pages).
-MAX_DOCK_ITEMS = 200
+# balloon the order list. Expressed as built-ins + a FIXED pin budget (not a flat
+# constant) so adding a built-in never shrinks the pin budget or drops an existing
+# valid pin on reconcile. Far above any real Dock (built-ins + pinned pages).
+MAX_PINNED_PAGES = 197
+MAX_DOCK_ITEMS = len(BUILTIN_DOCK_IDS) + MAX_PINNED_PAGES
 
 
 class DockError(ValueError):

--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -1,0 +1,261 @@
+# Dock-Pinned Show Page Apps
+
+Status: design approved-pending-owner-review · Plan created 2026-07-13
+Owner: PM session `sesf875xc5svz` · Design frames: `design.pen` (see §8)
+
+## 1. Background & Goal
+
+Show Pages today are per-session visualizations opened from the chat header.
+The product direction is: **a Show Page is an app the agent built for the
+user**. This feature makes that literal — the user can pin a session's Show
+Page to the workbench Dock, where it behaves like any other app: a Dock tile,
+a Mac-style window, minimize/maximize/close, open-in-browser-tab.
+
+This is deliberately the seed of the "Avibe as Agent OS installs apps" model
+(§7): the v1 data model (ordered dock list + param-driven app windows) must
+survive that evolution.
+
+Non-goals (v1): mobile window management (windows stay desktop-only, ≥ md),
+publishing a session page as a standalone/detached app, third-party app
+installation, per-app permissions.
+
+## 2. UX Spec
+
+### 2.1 Pin from the share popover
+- `ShowPageShareControl` (chat header, visible in show-page mode) gains a
+  **Pin to Dock** section: icon + label + `Switch`, with a one-line caption
+  ("Shown in the Dock and opens as an app").
+- Pinning is **independent of share visibility** — a private page can be
+  pinned. Pin/unpin never changes visibility, never deletes the page.
+- The popover already calls `ensureShowPage` on open, so the page exists by
+  the time the toggle renders. Toggle is optimistic with server round-trip.
+
+### 2.2 Dock tile
+- Pinned pages appear in the Dock after the built-in tiles, in user order.
+- Tile visual: rounded-square **letter avatar** — first grapheme of the app
+  title (supports CJK/emoji) on an accent tint **derived by hashing
+  `session_id`** into the brand accent set (mint/cyan/violet/gold), so
+  multiple pinned apps are distinguishable without an icon pipeline.
+- Label + running indicator + minimized thumbnails behave exactly like
+  built-in apps (same `Dock.tsx` tile anatomy).
+- Title = live session title when loadable, else `title_snapshot` from the
+  pin record, else `session_id` prefix.
+
+### 2.3 Window behavior
+- Click tile → focus existing window for that `session_id` if one is open,
+  else `openApp('showpage', { params: { sessionId, title } })`.
+- Window = existing `AppWindow` chrome: traffic lights (close / min / max),
+  drag, 8-dir resize, persistence — all inherited, no new window code.
+- **New:** title-bar **right side** gets an "open in new tab" icon button
+  (generalized as `AppDefinition.externalHref?(params)`; only `showpage`
+  defines it in v1). Opens the private URL in a browser tab.
+- Body = same-origin `<iframe src="/show/<session_id>/">` — always the
+  **owner (authed) surface**, regardless of visibility (authed workbench
+  context; HMR means the app updates live while the agent keeps building
+  it). Copy the sandbox attrs from `ChatPage.tsx`; per the standing decision
+  the workbench show-page iframe is intentionally same-origin-trusted — do
+  not harden.
+- **Amendment (2026-07-13, review round 1-6 root cause):** the existing
+  `serve_private_show_page` route 404s when `visibility == "public"`, which
+  would break pinned public pages. Decision: **extend the authed `/show/
+  <session_id>/` route to serve `private` AND `public` pages** (identical
+  surface); `offline` keeps returning not-found (window placeholder covers
+  it). No new exposure: the route stays behind workbench auth, and a public
+  page is already anonymously readable via `/p/`; anonymous access still has
+  exactly one surface (`/p/`). ChatPage's public→`/p/` switch is untouched.
+- Missing/archived/offline page → window body renders a friendly placeholder
+  (never a dead button): explain + "Unpin" shortcut. Opening a pinned app
+  must **not** auto-create/ensure a page.
+
+### 2.4 Dock management
+- **Drag to reorder**: the resident tile row (built-ins + pinned) is
+  reorderable via `framer-motion` `Reorder` (already a dependency; do not add
+  dnd-kit). Order persists server-side on drop. Minimized-window thumbnails
+  section is not reorderable.
+- **Right-click menu**: converge the Dock's inline menu onto the shared
+  `ui/context-menu.tsx` primitive (reuse ladder: promote the near-duplicate).
+  Pinned tiles add **Unpin from Dock**; built-ins (`files`/`terminal`/
+  `editor`) have no unpin item in v1. All tiles keep New Window / Show All
+  Windows; pinned tiles also get Open in New Tab.
+- Unpinning while a window is open leaves the window open; the tile then
+  behaves like `preview` (transient tile while any window exists).
+
+## 3. Data Model & Persistence
+
+Pins are **durable product state, not per-browser UI state** → server-side,
+in the existing `state_meta` KV (`get_state_meta`/`set_state_meta`), single
+key:
+
+```
+state_meta["workbench.dock.v1"] = {
+  "order": ["files", "terminal", "editor", "show:<session_id>", ...],
+  "pins":  [{ "session_id": str, "title_snapshot": str, "pinned_at": iso8601 }]
+}
+```
+
+- `DockItemId` namespace: builtin ids verbatim; pinned pages as
+  `show:<session_id>`; future kinds get new prefixes (`app:<id>`), so the
+  order list survives the §7 evolution.
+- `order` covers **all resident tiles including built-ins** (built-ins are
+  reorderable, just not unpinnable).
+- Reconciliation on read (client): drop unknown ids, append missing built-ins
+  and missing pins at the end. Server validates writes (set-equality against
+  known ids, caps list size, rejects duplicates).
+- Window layout stays in localStorage as today (`workbenchPersistence.ts`);
+  `showpage` windows rehydrate because the registry knows the appId and
+  `params` are persisted already.
+
+## 4. API Contract (freeze before implementation)
+
+All under the existing authed `/api` surface (native FastAPI routes must go
+through `CompatApp.dispatch_native_request` so they inherit
+`enforce_remote_access_cookie` + CSRF — see the #659 lesson).
+
+```
+GET    /api/dock                     → { ok: true, dock: DockDoc }
+POST   /api/dock/pins                { session_id }        → { ok, dock }   # idempotent
+DELETE /api/dock/pins/{session_id}                          → { ok, dock }   # idempotent
+PUT    /api/dock/order               { order: string[] }    → { ok, dock }
+
+DockDoc = { order: string[], pins: DockPin[] }
+DockPin = { session_id: string, title_snapshot: string, pinned_at: string }
+```
+
+- `POST pins` appends `show:<sid>` to the end of `order`; captures
+  `title_snapshot` from the session's current title server-side.
+- Errors: 404 unknown session / no show page on pin; 400 invalid order.
+
+## 5. Frontend Changes (map to real files)
+
+| Change | Where |
+| --- | --- |
+| `showpage` app registration (non-resident, param-driven like `preview`; `lockTheme` unset) | `ui/src/apps/registry.tsx` |
+| Iframe window body + placeholder state + letter-avatar icon helper | new `ui/src/apps/ShowPageApp.tsx` (+ small pure helper w/ vitest) |
+| Title-bar right-side external-link button via `AppDefinition.externalHref?` | `ui/src/components/apps/AppWindow.tsx` |
+| Dock: render pinned tiles from context; Reorder wrapper; shared context menu; unpin item | `ui/src/components/apps/Dock.tsx` |
+| `DockProvider` (fetch/reconcile/actions; optimistic) mounted in `AppShell` | new `ui/src/context/DockContext.tsx` |
+| Pin section in share popover | `ui/src/components/workbench/ShowPageShareControl.tsx` |
+| API methods `getDock` / `pinDockShowPage` / `unpinDockShowPage` / `setDockOrder` | `ui/src/context/ApiContext.tsx` |
+| i18n strings (en + zh) | `ui/src/i18n/en.json`, `zh.json` |
+
+Backend: `vibe/api.py` handlers + `vibe/ui_server.py` routes + a small
+`core/dock_store.py` (or colocated helpers) over `state_meta`; pytest
+coverage for round-trip, idempotency, order validation, unknown-session pin.
+
+## 6. Edge Cases & Rules
+
+- Pin survives session archive; window shows placeholder; unpin always works.
+- Never surface `/p/<share_id>` inside the workbench app window (private
+  surface only); external-tab open also uses `/show/<sid>/`.
+- Two browser tabs: dock doc is last-write-wins on order; pins idempotent.
+- Multiple windows of the same pinned app allowed (New Window), matching
+  built-ins; tile click focuses the most recent.
+- Mobile (< md): windows don't exist; v1 ships desktop-only and files a
+  follow-up to surface pinned apps in the mobile Apps surface.
+
+## 7. Future: the OS model (direction, not v1 scope)
+
+1. **App = manifest, not code.** `AppManifest { id, kind: builtin | showpage
+   | remote | package, name, icon, entry (component key | url), source,
+   permissions? }`. Registry = static built-ins ∪ server-registered
+   manifests (`GET /api/apps`). Dock, launcher, and windows consume manifests
+   uniformly. Pinned show pages are the first dynamic kind — this PR.
+2. **Install = registering a manifest.** Sources: agent-built show pages
+   (now), skill-bundled web apps (`askill` ships a `ui` entry), user-added
+   remote URLs, later a store. "Publish" flow detaches a session page into a
+   standalone app (stable id, own icon/name, copied workspace) — the full
+   "agent ships an app to its user" story.
+3. **App Library.** A management surface (Settings → Apps, or a built-in
+   Library app): installed list w/ kind badges, show-in-Dock toggle, order,
+   uninstall, per-app permission tier (third-party kinds get the sandbox
+   work: realpath-gate + kernel sandbox). Dock = pinned ⊆ installed + running
+   transients.
+4. **Compatibility guarantee.** v1's `order` id namespace, pin records, and
+   param-driven windows all carry over; nothing here needs re-migration.
+
+### 7.1 Phase 2 (owner decision 2026-07-13): App Library subsumes the Show Pages admin page
+
+The existing `/admin/show-pages` page (`ui/src/components/ShowPagesPage.tsx`,
+control-panel nav) does two jobs: full show-page inventory + visibility/link
+management. Once pins ship, keeping it standalone would leave two lists over
+the same objects. Decision: fold it into the App Library.
+
+- **Library = one built-in app, two views.**
+  - *Apps*: exactly the docked set — **one state bit: being an app ≡ being
+    in the Dock; no installed-but-undocked middle state** (owner-confirmed
+    2026-07-13 evening after the toggle-vs-delete ambiguity). Row actions by
+    kind: reorder (all) · remove-from-Dock (showpage — the page itself stays
+    in the inventory) · uninstall (remote/package — actually removes) ·
+    built-ins locked · Add App (remote URL, §7.3). NO per-row Dock toggle
+    here; the Show Pages view's toggle is the single promote/demote gesture.
+    (Not every Show Page is an app; every session has a page, so the full
+    inventory must not masquerade as the app list.)
+  - *Show Pages*: the full inventory (today's admin page content: status,
+    visibility private/public/offline, link + share-id, open) **plus a
+    per-row "Pin to Dock" toggle** — pinning is the "install" gesture.
+  - Same data sources (`/api/show-pages` + `/api/dock`), two projections; no
+    new backend.
+- **Library ships as built-in app #4** (like Launchpad/App Store: the app
+  manager is itself an app) — reorderable, not unpinnable, same as the other
+  built-ins.
+- **Remove** the `/admin/show-pages` route + nav item; redirect the old route.
+  Control panel returns to pure ops/config.
+- **Mobile**: windows are desktop-only, so the Library body must also render
+  as a full-screen route on mobile (same component, two shells) — no
+  capability regression vs. the old admin page.
+- **Sequencing**: v1 pin PR (in flight) is scope-frozen and unaffected.
+  Phase 2 is a separate lane/PR after v1 merges.
+- **Concept frames**: `xCSqW` (Apps view, tabbed, one-bit model) + `td17F` (Show Pages view —
+  tabs, filters, expanded row w/ visibility+link+suffix mgmt, per-row Dock
+  toggle), both in design.pen right of `NbPMq`.
+
+### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
+
+Pinning **is** installing — no separate ceremony. Two entrances, one action:
+the share-popover switch (v1) and the per-row Dock toggle in the Library's
+Show Pages view (Phase 2). The full ladder: **page (session byproduct) → pin
+(lightweight app, one switch) → publish (standalone app, stable id/icon,
+detached from the session lifecycle — future)**.
+
+### 7.3 User-added URL apps (kind: remote) — Phase 3
+
+Owner confirmed the bookmark-style want: Add App → name + URL → appears in
+the Apps list, pinnable to Dock, opens as a window. Requirements settled now
+so Phase 2 leaves no dead end:
+
+- **Embedding fallback is mandatory**: many sites refuse framing
+  (X-Frame-Options / CSP `frame-ancestors`). A remote app window must detect
+  failure and degrade to "open in new tab" (and/or a per-app "opens in:
+  window | tab" setting).
+- **Sandbox required**: unlike same-origin-trusted Show Pages, remote
+  content gets a sandboxed iframe — this is the on-ramp to third-party app
+  permission tiers.
+- **Data model**: already compatible — a new `DockItemId` prefix (e.g.
+  `app:<id>`/`url:<id>`) and an `apps`/manifest list alongside `pins`; no
+  migration of v1 state.
+- **Sequencing**: Phase 3, right after Phase 2 (kept out of Phase 2 to keep
+  that lane small: Library + migration only).
+
+## 8. Design Frames (design.pen)
+
+Dark-theme frames alongside the Apps v2 set (right of `NbPMq`, y=-2315):
+
+| Frame | id | Content |
+| --- | --- | --- |
+| Apps · Pin Show Page — Share Popover | `s2YOlP` | popover w/ Pin to Dock switch + rules legend |
+| Apps · Dock — Pinned Show Page Apps | `zn8tz` | pinned letter-avatar tiles, context menu, reorder scene, menu rules |
+| Apps · Show Page App Window | `vxbaK` | `X7d3Ev` AppWindow instance + title-bar external-open + iframe dashboard body |
+| Apps · Future — App Library / Apps View | `xCSqW` | manifest model, kinds, show-in-Dock toggles, evolution path (not v1) |
+
+## 9. Delivery
+
+Single lane, single PR (frontend-heavy + small backend), per
+`.agents/skills/pr-delivery-loop/SKILL.md`. Evidence: pytest (dock API),
+vitest (reconcile + avatar helpers), `npm run build`, manual checklist in a
+local Incus regression. Docs follow-up in `avibe-docs` after merge.
+
+Owner decisions embodied in the design (flag if you want them changed):
+1. Pins are server-side/cross-device (`state_meta`), not per-browser.
+2. Pinned-tile icon = letter avatar + hashed accent (no icon pipeline in v1).
+3. Built-ins are reorderable but not unpinnable.
+4. App window always uses the private `/show/` surface.

--- a/tests/test_dock_api.py
+++ b/tests/test_dock_api.py
@@ -138,12 +138,12 @@ def test_pin_rejects_when_dock_is_full(monkeypatch, tmp_path):
     # can grow past it and every later reorder is rejected.
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
-    monkeypatch.setattr("core.dock_store.MAX_DOCK_ITEMS", 4)  # 3 built-ins + room for one pin
+    monkeypatch.setattr("core.dock_store.MAX_DOCK_ITEMS", 5)  # 4 built-ins + room for one pin
     for sid in ("ses_full1", "ses_full2"):
         _seed_session(sid)
         _make_show_page(sid)
 
-    api.pin_dock_show_page("ses_full1")  # fills the Dock (3 built-ins + 1 pin = 4)
+    api.pin_dock_show_page("ses_full1")  # fills the Dock (4 built-ins + 1 pin = 5)
     with pytest.raises(DockError) as excinfo:
         api.pin_dock_show_page("ses_full2")
     assert excinfo.value.code == "dock_full"
@@ -157,7 +157,7 @@ def test_load_dock_clamps_oversized_corrupt_pins(monkeypatch, tmp_path):
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
-    monkeypatch.setattr("core.dock_store.MAX_DOCK_ITEMS", 4)  # 3 built-ins + room for one pin
+    monkeypatch.setattr("core.dock_store.MAX_DOCK_ITEMS", 5)  # 4 built-ins + room for one pin
     set_state_meta(
         DOCK_STATE_KEY,
         {"order": [], "pins": [{"session_id": f"ses_{i}", "title_snapshot": "", "pinned_at": ""} for i in range(10)]},
@@ -165,7 +165,31 @@ def test_load_dock_clamps_oversized_corrupt_pins(monkeypatch, tmp_path):
 
     dock = api.get_dock()["dock"]
     assert len(dock["pins"]) == 1  # clamped to MAX_DOCK_ITEMS - built-ins
-    assert len(dock["order"]) == 4  # 3 built-ins + 1 pin
+    assert len(dock["order"]) == 5  # 4 built-ins + 1 pin
+
+
+def test_load_dock_appends_library_to_pre_phase2_order(monkeypatch, tmp_path):
+    # A dock doc persisted before ``library`` became a built-in (its ``order``
+    # lacks it) must gain it on read via the reconcile rule (spec §3: missing
+    # built-ins appended), without dropping the pin or reordering existing tiles.
+    from core.chat_discovery import set_state_meta
+    from core.dock_store import DOCK_STATE_KEY
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    set_state_meta(
+        DOCK_STATE_KEY,
+        {
+            "order": ["files", "terminal", "editor", _show("ses_legacy")],
+            "pins": [{"session_id": "ses_legacy", "title_snapshot": "Legacy", "pinned_at": "2026-01-01T00:00:00+00:00"}],
+        },
+    )
+
+    dock = api.get_dock()["dock"]
+
+    # Existing tiles keep their order, the pin survives, and library is appended.
+    assert dock["order"] == ["files", "terminal", "editor", _show("ses_legacy"), "library"]
+    assert [pin["session_id"] for pin in dock["pins"]] == ["ses_legacy"]
 
 
 def test_pin_unknown_show_page_is_404(monkeypatch, tmp_path):
@@ -213,7 +237,24 @@ def test_set_order_persists_valid_permutation(monkeypatch, tmp_path):
     _make_show_page("ses_o")
     api.pin_dock_show_page("ses_o")
 
-    new_order = [_show("ses_o"), "editor", "files", "terminal"]
+    new_order = [_show("ses_o"), "library", "editor", "files", "terminal"]
+    dock = api.set_dock_order(new_order)["dock"]
+
+    assert dock["order"] == new_order
+    assert api.get_dock()["dock"]["order"] == new_order
+
+
+def test_set_order_accepts_library_builtin(monkeypatch, tmp_path):
+    # ``library`` is a built-in Dock tile (Phase 2), so a full-set reorder that
+    # includes it is accepted and persists — the same reorder path #892 shipped,
+    # now covering the 4th built-in.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _seed_session("ses_lib", title="Ordered")
+    _make_show_page("ses_lib")
+    api.pin_dock_show_page("ses_lib")
+
+    new_order = [_show("ses_lib"), "library", "editor", "terminal", "files"]
     dock = api.set_dock_order(new_order)["dock"]
 
     assert dock["order"] == new_order

--- a/tests/test_dock_api.py
+++ b/tests/test_dock_api.py
@@ -168,6 +168,15 @@ def test_load_dock_clamps_oversized_corrupt_pins(monkeypatch, tmp_path):
     assert len(dock["order"]) == 5  # 4 built-ins + 1 pin
 
 
+def test_pin_budget_survives_new_builtin():
+    # Adding library (the 4th built-in) must not shrink the pin budget: the cap is
+    # built-ins + a fixed budget, so a valid pre-Phase-2 dock (up to 197 pins)
+    # never loses a pin on reconcile when a built-in is added.
+    from core.dock_store import BUILTIN_DOCK_IDS, MAX_DOCK_ITEMS
+
+    assert MAX_DOCK_ITEMS - len(BUILTIN_DOCK_IDS) == 197
+
+
 def test_load_dock_appends_library_to_pre_phase2_order(monkeypatch, tmp_path):
     # A dock doc persisted before ``library`` became a built-in (its ``order``
     # lacks it) must gain it on read via the reconcile rule (spec §3: missing

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -320,7 +320,11 @@ const LibraryRoute = () => {
   const isDesktop = useIsDesktop();
   const wm = useWindowManager();
   const navigate = useNavigate();
+  const location = useLocation();
   const handledRef = useRef(false);
+  // The retired /admin/show-pages redirect carries ?view=pages so the Library
+  // opens on the Show Pages inventory the bookmark asked for, not the Apps tab.
+  const initialTab = new URLSearchParams(location.search).get('view') === 'pages' ? ('showpages' as const) : undefined;
 
   useEffect(() => {
     if (!isDesktop || handledRef.current) return;
@@ -329,15 +333,15 @@ const LibraryRoute = () => {
     const visible = own.find((w) => !w.minimized);
     if (visible) wm.focus(visible.id);
     else if (own.length > 0) wm.restore(own[0].id);
-    else wm.openApp('library');
+    else wm.openApp('library', { params: { initialTab } });
     navigate('/', { replace: true });
-  }, [isDesktop, wm, navigate]);
+  }, [isDesktop, wm, navigate, initialTab]);
 
   if (isDesktop) return null; // transient: the effect hands back to the workbench canvas
   return (
     <div className="flex h-[calc(100dvh-9.5rem)] min-h-[420px] flex-col overflow-hidden rounded-xl border border-border bg-surface">
       <Suspense fallback={<AppsRouteFallback />}>
-        <LibraryAppBody />
+        <LibraryAppBody initialTab={initialTab} />
       </Suspense>
     </div>
   );
@@ -428,8 +432,9 @@ const router = createBrowserRouter(
         <Route path="/admin/groups" element={<ChannelList isPage />} />
         <Route path="/admin/users" element={<UserList />} />
         {/* Show Pages moved into the App Library (workbench). Redirect the old
-            control-panel page so bookmarks + external links keep working. */}
-        <Route path="/admin/show-pages" element={<Navigate to="/apps/library" replace />} />
+            control-panel page (?view=pages so it lands on the Show Pages tab the
+            bookmark asked for) so bookmarks + external links keep working. */}
+        <Route path="/admin/show-pages" element={<Navigate to="/apps/library?view=pages" replace />} />
         <Route path="/admin/logs" element={<SettingsLogsPage standalone />} />
         {/* No client-side route at /admin/settings: Flask owns GET /settings as
             a JSON API. The Flask handler redirects browser-Accept hits to

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,7 +24,6 @@ import { MorePage } from './components/workbench/MorePage';
 import { Dashboard } from './components/Dashboard';
 import { ChannelList } from './components/steps/ChannelList';
 import { UserList } from './components/steps/UserList';
-import { ShowPagesPage } from './components/ShowPagesPage';
 import { RemoteAccessPage } from './components/RemoteAccessPage';
 import { SettingsDiagnosticsPage } from './components/settings/SettingsDiagnosticsPage';
 import { SettingsBackendsPage } from './components/settings/SettingsBackendsPage';
@@ -38,6 +37,7 @@ import { SettingsPlatformsPage } from './components/settings/SettingsPlatformsPa
 import { SettingsServicePage } from './components/settings/SettingsServicePage';
 import { StatusProvider } from './context/StatusContext';
 import { ApiProvider, useApi, ApiError } from './context/ApiContext';
+import { useWindowManager } from './context/WindowManagerContext';
 import { ToastProvider } from './context/ToastContext';
 import { ThemeProvider } from './context/ThemeContext';
 import { VaultSandboxAppearanceBridge } from './components/VaultSandboxAppearanceBridge';
@@ -61,6 +61,7 @@ const AppsTerminalPage = lazy(() =>
 const AppsEditorPage = lazy(() =>
   import('./components/workbench/AppsEditorPage').then((m) => ({ default: m.AppsEditorPage })),
 );
+const LibraryAppBody = lazy(() => import('./apps/LibraryApp').then((m) => ({ default: m.LibraryApp })));
 import { hasConfiguredPlatformCredentials } from './lib/platforms';
 import { applyAppTitle } from './lib/documentTitle';
 import { useTranslation } from 'react-i18next';
@@ -296,6 +297,52 @@ const AppsRouteFallback = () => {
   return <div className="grid min-h-[40vh] place-items-center text-[12px] text-muted">{t('common.loading')}</div>;
 };
 
+// Reactive desktop (≥ md) check for the mobile-vs-window split.
+function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(
+    () => typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(min-width: 768px)').matches,
+  );
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(min-width: 768px)');
+    const onChange = () => setIsDesktop(mql.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return isDesktop;
+}
+
+// /apps/library — the App Library route and the redirect target for the retired
+// /admin/show-pages page. On desktop the Library is a workbench window, so open
+// (or focus) it and hand back to the canvas; on mobile there are no windows, so
+// render the Library body full-screen (the same component, its page shell).
+const LibraryRoute = () => {
+  const isDesktop = useIsDesktop();
+  const wm = useWindowManager();
+  const navigate = useNavigate();
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (!isDesktop || handledRef.current) return;
+    handledRef.current = true;
+    const own = wm.windows.filter((w) => w.appId === 'library');
+    const visible = own.find((w) => !w.minimized);
+    if (visible) wm.focus(visible.id);
+    else if (own.length > 0) wm.restore(own[0].id);
+    else wm.openApp('library');
+    navigate('/', { replace: true });
+  }, [isDesktop, wm, navigate]);
+
+  if (isDesktop) return null; // transient: the effect hands back to the workbench canvas
+  return (
+    <div className="flex h-[calc(100dvh-9.5rem)] min-h-[420px] flex-col overflow-hidden rounded-xl border border-border bg-surface">
+      <Suspense fallback={<AppsRouteFallback />}>
+        <LibraryAppBody />
+      </Suspense>
+    </div>
+  );
+};
+
 // Sets the browser tab title to "Avibe - <name>" from config (configured
 // instance name, else system hostname). Config is cached in ApiContext, so this
 // mount-time fetch is deduplicated with the AuthGuard's own config read.
@@ -371,6 +418,7 @@ const router = createBrowserRouter(
             </Suspense>
           }
         />
+        <Route path="/apps/library" element={<LibraryRoute />} />
         <Route path="/chat/:sessionId" element={<ChatPage />} />
 
         {/* Control Panel mode — existing pages moved under /admin/* */}
@@ -379,7 +427,9 @@ const router = createBrowserRouter(
         <Route path="/admin/remote-access" element={<RemoteAccessPage />} />
         <Route path="/admin/groups" element={<ChannelList isPage />} />
         <Route path="/admin/users" element={<UserList />} />
-        <Route path="/admin/show-pages" element={<ShowPagesPage />} />
+        {/* Show Pages moved into the App Library (workbench). Redirect the old
+            control-panel page so bookmarks + external links keep working. */}
+        <Route path="/admin/show-pages" element={<Navigate to="/apps/library" replace />} />
         <Route path="/admin/logs" element={<SettingsLogsPage standalone />} />
         {/* No client-side route at /admin/settings: Flask owns GET /settings as
             a JSON API. The Flask handler redirects browser-Accept hits to

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -330,12 +330,18 @@ const LibraryRoute = () => {
     if (!isDesktop || handledRef.current) return;
     handledRef.current = true;
     const own = wm.windows.filter((w) => w.appId === 'library');
-    const visible = own.find((w) => !w.minimized);
-    if (visible) wm.focus(visible.id);
-    else if (own.length > 0) wm.restore(own[0].id);
-    else wm.openApp('library', { params: { initialTab } });
+    const target = own.find((w) => !w.minimized) ?? own[0];
+    if (target) {
+      if (target.minimized) wm.restore(target.id);
+      else wm.focus(target.id);
+      // Honor the requested tab on an already-open window (its LibraryApp reads
+      // navKey/navTab), so an old /admin/show-pages link still lands on Show Pages.
+      if (initialTab) wm.setParams(target.id, { navTab: initialTab, navKey: location.key });
+    } else {
+      wm.openApp('library', { params: { initialTab } });
+    }
     navigate('/', { replace: true });
-  }, [isDesktop, wm, navigate, initialTab]);
+  }, [isDesktop, wm, navigate, initialTab, location.key]);
 
   if (isDesktop) return null; // transient: the effect hands back to the workbench canvas
   return (

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -1,0 +1,192 @@
+import { useMemo, useState } from 'react';
+import { Lock, PinOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+
+import { APP_LIST, APP_REGISTRY, type AppDefinition, type AppId } from './registry';
+import { deriveAppRows, type AppRow } from './appLibrary';
+import { ShowPageAvatarTile } from './showPageAvatarTile';
+import { useDock } from '../context/DockContext';
+import { ShowPagesView } from '../components/ShowPagesPage';
+import { useShowPages, type ShowPage } from '../components/useShowPages';
+import { Badge } from '../components/ui/badge';
+import { SearchField } from '../components/settings/SettingsPrimitives';
+
+// The App Library: the app manager, itself a built-in app (§7.1). Two views over
+// the same data — the docked set (Apps) and the full Show Pages inventory — with
+// ONE state bit between them: being an app ≡ being in the Dock. The Show Pages
+// view's per-row Dock switch is the single promote/demote gesture; the Apps view
+// only lists + removes. Renders as a window body (desktop) and as a full-screen
+// route (mobile), so `windowId`/`params` are accepted but unused.
+
+// The Library never lists itself among the apps it manages.
+const LIBRARY_APP_ID: AppId = 'library';
+// The client's built-in Dock ids (files / terminal / editor / library), the set
+// deriveAppRows classifies against. Mirrors DockContext's BUILTIN_DOCK_IDS.
+const BUILTIN_IDS = new Set<string>(APP_LIST.map((app) => app.id));
+
+type LibraryTab = 'apps' | 'showpages';
+
+export const LibraryApp: React.FC<{ windowId?: string; params?: Record<string, unknown> }> = () => {
+  const { t } = useTranslation();
+  const controller = useShowPages();
+  const { order } = useDock();
+  const [tab, setTab] = useState<LibraryTab>('apps');
+
+  const appsCount = useMemo(() => deriveAppRows(order, BUILTIN_IDS, LIBRARY_APP_ID).length, [order]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-surface text-foreground">
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-3 py-2.5 sm:px-4">
+        <TabButton active={tab === 'apps'} onClick={() => setTab('apps')} label={t('library.tab.apps')} count={appsCount} />
+        <TabButton
+          active={tab === 'showpages'}
+          onClick={() => setTab('showpages')}
+          label={t('library.tab.showPages')}
+          count={controller.pages.length}
+        />
+      </div>
+      <div className="min-h-0 flex-1">
+        {tab === 'apps' ? <AppsView pages={controller.pages} /> : <ShowPagesView {...controller} />}
+      </div>
+    </div>
+  );
+};
+
+const TabButton: React.FC<{ active: boolean; onClick: () => void; label: string; count: number }> = ({
+  active,
+  onClick,
+  label,
+  count,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={active}
+    className={clsx(
+      'flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] transition-colors',
+      active ? 'bg-foreground/[0.06] font-semibold text-foreground' : 'font-medium text-muted hover:text-foreground',
+    )}
+  >
+    <span>{label}</span>
+    <span className={clsx('font-mono text-[11px]', active ? 'text-muted' : 'text-muted/70')}>· {count}</span>
+  </button>
+);
+
+interface ResolvedRow {
+  row: AppRow;
+  name: string;
+  subtitle: string;
+  /** The built-in app definition (icon + accent) when this row is a built-in. */
+  def?: AppDefinition;
+}
+
+// Apps view: the docked set, in order, minus the Library itself. Built-ins show
+// their icon + a locked badge (not removable); pinned Show Pages show a letter
+// avatar + a remove-from-Dock action that unpins without deleting the page. No
+// per-row toggles, no reorder (that lives on the Dock), no Add App (Phase 3).
+const AppsView: React.FC<{ pages: ShowPage[] }> = ({ pages }) => {
+  const { t } = useTranslation();
+  const { order, pins, unpin } = useDock();
+  const [query, setQuery] = useState('');
+
+  const pinBySession = useMemo(() => new Map(pins.map((p) => [p.session_id, p])), [pins]);
+  const pageBySession = useMemo(() => new Map(pages.map((p) => [p.session_id, p])), [pages]);
+  const rows = useMemo(() => deriveAppRows(order, BUILTIN_IDS, LIBRARY_APP_ID), [order]);
+
+  const resolved = useMemo<ResolvedRow[]>(
+    () =>
+      rows.map((row) => {
+        if (row.kind === 'builtin') {
+          const def = APP_REGISTRY[row.builtinId as AppId];
+          return { row, name: def ? t(def.titleKey) : (row.builtinId ?? row.dockId), subtitle: t('library.apps.system'), def };
+        }
+        const sid = row.sessionId ?? '';
+        const page = pageBySession.get(sid);
+        const name = page?.title?.trim() || pinBySession.get(sid)?.title_snapshot?.trim() || sid;
+        const subtitle = page
+          ? [page.platform ? t(`platform.${page.platform}.title`, { defaultValue: page.platform }) : null, page.agent]
+              .filter(Boolean)
+              .join(' · ')
+          : '';
+        return { row, name, subtitle };
+      }),
+    [rows, pageBySession, pinBySession, t],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return q ? resolved.filter((item) => item.name.toLowerCase().includes(q)) : resolved;
+  }, [resolved, query]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center border-b border-border px-4 py-3 sm:px-5">
+        <SearchField
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t('library.searchApps')}
+          className="w-full sm:w-[240px]"
+        />
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <div className="m-4 rounded-xl border border-dashed border-border bg-surface-3/60 p-8 text-center text-[13px] text-muted">
+            {t('library.apps.empty')}
+          </div>
+        ) : (
+          filtered.map(({ row, name, subtitle, def }) => {
+            const Icon = def?.icon;
+            return (
+              <div
+                key={row.dockId}
+                className="flex items-center gap-3 border-b border-border px-4 py-3 last:border-b-0 sm:gap-4 sm:px-5"
+              >
+                {def && Icon ? (
+                  <span
+                    className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border"
+                    style={{ color: `var(${def.accent})`, backgroundColor: `color-mix(in srgb, var(${def.accent}) 14%, transparent)` }}
+                  >
+                    <Icon className="size-[18px]" />
+                  </span>
+                ) : (
+                  <ShowPageAvatarTile sessionId={row.sessionId ?? ''} title={name} />
+                )}
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-[13px] font-semibold text-foreground">{name}</span>
+                  {subtitle ? <span className="truncate font-mono text-[11px] text-muted">{subtitle}</span> : null}
+                </span>
+                {row.kind === 'builtin' ? (
+                  <Badge variant="outline" className="font-mono text-[10px] uppercase tracking-wide">
+                    {t('library.kind.builtin')}
+                  </Badge>
+                ) : (
+                  <Badge variant="success">{t('library.kind.showPage')}</Badge>
+                )}
+                {row.removable ? (
+                  <button
+                    type="button"
+                    title={t('library.apps.remove')}
+                    aria-label={t('library.apps.remove')}
+                    onClick={() => row.sessionId && unpin(row.sessionId)}
+                    className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-destructive/10 hover:text-destructive"
+                  >
+                    <PinOff size={15} />
+                  </button>
+                ) : (
+                  <span
+                    className="grid size-8 shrink-0 place-items-center text-muted/60"
+                    title={t('library.apps.locked')}
+                    aria-label={t('library.apps.locked')}
+                  >
+                    <Lock size={14} />
+                  </span>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -27,11 +27,17 @@ const BUILTIN_IDS = new Set<string>(APP_LIST.map((app) => app.id));
 
 type LibraryTab = 'apps' | 'showpages';
 
-export const LibraryApp: React.FC<{ windowId?: string; params?: Record<string, unknown> }> = () => {
+export const LibraryApp: React.FC<{ windowId?: string; params?: Record<string, unknown>; initialTab?: LibraryTab }> = ({
+  params,
+  initialTab,
+}) => {
   const { t } = useTranslation();
   const controller = useShowPages();
   const { order } = useDock();
-  const [tab, setTab] = useState<LibraryTab>('apps');
+  // The legacy /admin/show-pages redirect (mobile via prop, desktop window via
+  // params) can request the Show Pages tab up front; default to Apps otherwise.
+  const startTab: LibraryTab = initialTab === 'showpages' || params?.initialTab === 'showpages' ? 'showpages' : 'apps';
+  const [tab, setTab] = useState<LibraryTab>(startTab);
 
   const appsCount = useMemo(() => deriveAppRows(order, BUILTIN_IDS, LIBRARY_APP_ID).length, [order]);
 

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -39,6 +39,16 @@ export const LibraryApp: React.FC<{ windowId?: string; params?: Record<string, u
   const startTab: LibraryTab = initialTab === 'showpages' || params?.initialTab === 'showpages' ? 'showpages' : 'apps';
   const [tab, setTab] = useState<LibraryTab>(startTab);
 
+  // Honor an external tab request — the /admin/show-pages redirect focusing an
+  // already-open window bumps params.navKey — by adjusting state during render
+  // (React's recommended alternative to a prop-syncing effect).
+  const [seenNavKey, setSeenNavKey] = useState(params?.navKey);
+  if (params?.navKey !== seenNavKey) {
+    setSeenNavKey(params?.navKey);
+    const navTab = params?.navTab;
+    if (navTab === 'apps' || navTab === 'showpages') setTab(navTab);
+  }
+
   const appsCount = useMemo(() => deriveAppRows(order, BUILTIN_IDS, LIBRARY_APP_ID).length, [order]);
 
   return (

--- a/ui/src/apps/appLibrary.test.ts
+++ b/ui/src/apps/appLibrary.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveAppRows, filterShowPages, type FilterablePage } from './appLibrary';
+
+const BUILTINS = new Set(['files', 'terminal', 'editor', 'library']);
+
+describe('deriveAppRows', () => {
+  it('keeps the docked set in order, resolving kinds', () => {
+    const rows = deriveAppRows(['files', 'terminal', 'editor', 'show:s1', 'show:s2'], BUILTINS, 'library');
+    expect(rows.map((r) => r.dockId)).toEqual(['files', 'terminal', 'editor', 'show:s1', 'show:s2']);
+    expect(rows.map((r) => r.kind)).toEqual(['builtin', 'builtin', 'builtin', 'showpage', 'showpage']);
+    expect(rows[3]).toMatchObject({ kind: 'showpage', sessionId: 's1', removable: true });
+    expect(rows[0]).toMatchObject({ kind: 'builtin', builtinId: 'files', removable: false });
+  });
+
+  it('excludes the Library app itself from the list', () => {
+    const rows = deriveAppRows(['files', 'library', 'show:s1'], BUILTINS, 'library');
+    expect(rows.map((r) => r.dockId)).toEqual(['files', 'show:s1']);
+  });
+
+  it('drops unknown ids and de-duplicates', () => {
+    const rows = deriveAppRows(['files', 'files', 'app:remote1', 'show:s1'], BUILTINS, 'library');
+    expect(rows.map((r) => r.dockId)).toEqual(['files', 'show:s1']);
+  });
+});
+
+describe('filterShowPages', () => {
+  const pages: FilterablePage[] = [
+    { session_id: 'sess-a', visibility: 'public', title: 'Sales Dashboard' },
+    { session_id: 'sess-b', visibility: 'private', title: '旅行计划' },
+    { session_id: 'sess-c', visibility: 'offline', title: 'Weekly Report' },
+    { session_id: 'sess-untitled', visibility: 'private', title: null },
+  ];
+
+  it('all keeps every visibility including offline', () => {
+    expect(filterShowPages(pages, 'all', '').map((p) => p.session_id)).toEqual(['sess-a', 'sess-b', 'sess-c', 'sess-untitled']);
+  });
+
+  it('filters by a single visibility bucket', () => {
+    expect(filterShowPages(pages, 'private', '').map((p) => p.session_id)).toEqual(['sess-b', 'sess-untitled']);
+    expect(filterShowPages(pages, 'offline', '').map((p) => p.session_id)).toEqual(['sess-c']);
+  });
+
+  it('matches the query against title and session id', () => {
+    expect(filterShowPages(pages, 'all', 'sales').map((p) => p.session_id)).toEqual(['sess-a']);
+    expect(filterShowPages(pages, 'all', '旅行').map((p) => p.session_id)).toEqual(['sess-b']);
+    // A page with no title still matches on its session id.
+    expect(filterShowPages(pages, 'all', 'untitled').map((p) => p.session_id)).toEqual(['sess-untitled']);
+  });
+
+  it('combines visibility and query', () => {
+    expect(filterShowPages(pages, 'private', 'zzz')).toEqual([]);
+    expect(filterShowPages(pages, 'private', '旅行').map((p) => p.session_id)).toEqual(['sess-b']);
+  });
+});

--- a/ui/src/apps/appLibrary.ts
+++ b/ui/src/apps/appLibrary.ts
@@ -1,0 +1,66 @@
+// Pure projections for the App Library's two views. Kept free of React/DOM so
+// the row derivation + page filtering are unit-testable in isolation; the view
+// layer (LibraryApp / ShowPagesView) resolves each row's icon, title, and badge
+// from the registry + loaded Show Pages.
+
+import { dockIdToSession } from '../context/DockContext';
+
+export type AppRowKind = 'builtin' | 'showpage';
+
+export interface AppRow {
+  /** The persisted Dock id: a built-in app id verbatim, or `show:<session_id>`. */
+  dockId: string;
+  kind: AppRowKind;
+  /** Built-in app id (files / terminal / editor …) when kind === 'builtin'. */
+  builtinId?: string;
+  /** Session id when kind === 'showpage'. */
+  sessionId?: string;
+  /** Show Pages can be removed from the Dock (the page survives); built-ins can't. */
+  removable: boolean;
+}
+
+/**
+ * Project the Dock order into the Apps-view rows: the docked set, in order,
+ * minus the Library app itself (a manager never lists itself) and any ids this
+ * client doesn't know (a future kind not yet shipped). Built-ins are matched
+ * against ``builtinIds``; every ``show:<id>`` is a pinned Show Page.
+ */
+export function deriveAppRows(order: string[], builtinIds: ReadonlySet<string>, selfId: string): AppRow[] {
+  const rows: AppRow[] = [];
+  const seen = new Set<string>();
+  for (const dockId of order) {
+    if (seen.has(dockId)) continue;
+    seen.add(dockId);
+    if (dockId === selfId) continue; // the Library app is not listed among the apps it manages
+    const sessionId = dockIdToSession(dockId);
+    if (sessionId !== null) {
+      rows.push({ dockId, kind: 'showpage', sessionId, removable: true });
+    } else if (builtinIds.has(dockId)) {
+      rows.push({ dockId, kind: 'builtin', builtinId: dockId, removable: false });
+    }
+    // else: an id this client can't resolve (unknown/future kind) → skip it
+  }
+  return rows;
+}
+
+export type ShowPageFilter = 'all' | 'public' | 'private' | 'offline';
+
+export interface FilterablePage {
+  session_id: string;
+  visibility: 'public' | 'private' | 'offline';
+  title: string | null;
+}
+
+/**
+ * Filter the Show Pages inventory by visibility bucket + a free-text query over
+ * title and session id. ``'all'`` keeps every visibility (including offline);
+ * an empty query matches everything.
+ */
+export function filterShowPages<T extends FilterablePage>(pages: T[], filter: ShowPageFilter, query: string): T[] {
+  const q = query.trim().toLowerCase();
+  return pages.filter((page) => {
+    if (filter !== 'all' && page.visibility !== filter) return false;
+    if (!q) return true;
+    return (page.title || '').toLowerCase().includes(q) || page.session_id.toLowerCase().includes(q);
+  });
+}

--- a/ui/src/apps/registry.tsx
+++ b/ui/src/apps/registry.tsx
@@ -154,4 +154,4 @@ export const APP_REGISTRY: Record<AppId, AppDefinition> = {
 
 // Dock launcher tiles — the resident apps. `preview` and `showpage` are intentionally excluded
 // (opened on demand / while pinned).
-export const APP_LIST: AppDefinition[] = [APP_REGISTRY.files, APP_REGISTRY.terminal, APP_REGISTRY.editor];
+export const APP_LIST: AppDefinition[] = [APP_REGISTRY.files, APP_REGISTRY.terminal, APP_REGISTRY.editor, APP_REGISTRY.library];

--- a/ui/src/apps/registry.tsx
+++ b/ui/src/apps/registry.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { CodeXml, Eye, Folder, MonitorPlay, SquareTerminal } from 'lucide-react';
+import { CodeXml, Eye, Folder, LayoutGrid, MonitorPlay, SquareTerminal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { LucideIcon } from 'lucide-react';
 
@@ -11,7 +11,7 @@ import { showPagePrivatePath } from './showPageAvatar';
 // so opening the workbench doesn't pull file-browser / xterm code into the main
 // bundle — each loads only when its window first opens.
 
-export type AppId = 'files' | 'terminal' | 'editor' | 'preview' | 'showpage';
+export type AppId = 'files' | 'terminal' | 'editor' | 'preview' | 'showpage' | 'library';
 
 export interface AppDefinition {
   id: AppId;
@@ -55,6 +55,7 @@ const PreviewBody = lazy(() =>
   import('../components/workbench/AppsPreviewPage').then((m) => ({ default: m.AppsPreviewPage })),
 );
 const ShowPageBody = lazy(() => import('./ShowPageApp').then((m) => ({ default: m.ShowPageApp })));
+const LibraryBody = lazy(() => import('./LibraryApp').then((m) => ({ default: m.LibraryApp })));
 
 export const APP_REGISTRY: Record<AppId, AppDefinition> = {
   files: {
@@ -133,6 +134,21 @@ export const APP_REGISTRY: Record<AppId, AppDefinition> = {
       const sessionId = params?.sessionId;
       return typeof sessionId === 'string' && sessionId ? showPagePrivatePath(sessionId) : undefined;
     },
+  },
+  // The App Library — the app manager, itself a built-in app (§7.1). Two views
+  // (Apps + Show Pages) over the Dock + Show Pages data. Opened from its Dock
+  // tile on desktop and the /apps/library route (full-screen on mobile).
+  library: {
+    id: 'library',
+    titleKey: 'library.title',
+    icon: LayoutGrid,
+    accent: '--gold',
+    defaultSize: { width: 940, height: 640 },
+    Component: ({ windowId, params }) => (
+      <Suspense fallback={<Loading />}>
+        <LibraryBody windowId={windowId} params={params} />
+      </Suspense>
+    ),
   },
 };
 

--- a/ui/src/apps/showPageAvatarTile.tsx
+++ b/ui/src/apps/showPageAvatarTile.tsx
@@ -1,0 +1,31 @@
+import clsx from 'clsx';
+
+import { showPageAvatar } from './showPageAvatar';
+
+// The icon-free tile for a Show Page: the first grapheme of the title on a tint
+// hashed from the session id (the same letter avatar the Dock renders). Shared
+// by both App Library views so a pinned page reads identically in the Dock, the
+// Apps view, and the Show Pages view.
+export const ShowPageAvatarTile: React.FC<{ sessionId: string; title: string; className?: string }> = ({
+  sessionId,
+  title,
+  className,
+}) => {
+  const { letter, accentVar } = showPageAvatar(sessionId, title);
+  return (
+    <span
+      aria-hidden
+      className={clsx(
+        'flex size-9 shrink-0 items-center justify-center rounded-lg border text-[14px] font-bold leading-none',
+        className,
+      )}
+      style={{
+        color: `var(${accentVar})`,
+        backgroundColor: `color-mix(in srgb, var(${accentVar}) 16%, transparent)`,
+        borderColor: `color-mix(in srgb, var(${accentVar}) 34%, transparent)`,
+      }}
+    >
+      {letter}
+    </span>
+  );
+};

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
-import { ArrowLeft, Bot, ChevronDown, FolderTree, Globe, Hash, Inbox, LayoutDashboard, LayoutGrid, Link as LinkIcon, Menu, MessageCircle, MonitorPlay, PlugZap, Plus, Settings, Sparkles, X } from 'lucide-react';
+import { ArrowLeft, Bot, ChevronDown, FolderTree, Globe, Hash, Inbox, LayoutDashboard, LayoutGrid, Link as LinkIcon, Menu, MessageCircle, PlugZap, Plus, Settings, Sparkles, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -295,7 +295,6 @@ export const AppShell: React.FC = () => {
       icon: Bot,
       match: (p) => p.startsWith('/admin/settings/backends'),
     },
-    { to: '/admin/show-pages', label: t('nav.showPages'), icon: MonitorPlay },
     {
       // 高级设置: the remaining Settings tabs (messaging leads). Platforms +
       // backends moved out to their own sidebar destinations above, so exclude

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -1,82 +1,72 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Check,
   ChevronDown,
   ChevronUp,
-  CloudOff,
   Copy,
   ExternalLink,
-  Globe,
   Link2,
-  Lock,
   RefreshCw,
   RotateCw,
   TriangleAlert,
-  type LucideIcon,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import clsx from 'clsx';
 
-import { useApi } from '../context/ApiContext';
-import { useToast } from '../context/ToastContext';
+import { useDock } from '../context/DockContext';
 import { copyTextToClipboard } from '../lib/utils';
 import { copyHref, displayLink, type ShowPageLinkInfo } from '../lib/showPageLinks';
+import { type ShowPage, type ShowPagesController, type Visibility } from './useShowPages';
+import { filterShowPages, type ShowPageFilter } from '../apps/appLibrary';
+import { ShowPageAvatarTile } from '../apps/showPageAvatarTile';
 import { ShowPageShareIdField } from './workbench/ShowPageShareIdField';
 import { SearchField } from './settings/SettingsPrimitives';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
+import { Switch } from './ui/switch';
 import { SegmentedRadio, type SegmentedTone } from './ui/segmented';
-
-type Visibility = 'private' | 'public' | 'offline';
-type Filter = 'online' | Visibility;
-
-interface ShowPage {
-  session_id: string;
-  visibility: Visibility;
-  title: string | null;
-  platform: string | null;
-  agent: string | null;
-  path: string;
-  active_url: string | null;
-  private_url: string | null;
-  public_url: string | null;
-  url_available: boolean;
-  share_id: string | null;
-  offline: boolean;
-  offline_at: string | null;
-  created_at: string;
-  updated_at: string;
-}
 
 const LABEL = 'font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted';
 
-const STATUS: Record<
-  Visibility,
-  { Icon: LucideIcon; badge: 'warning' | 'info' | 'secondary'; tone: SegmentedTone; dot: string; tile: string; iconColor: string }
-> = {
-  public: { Icon: Globe, badge: 'warning', tone: 'gold', dot: 'bg-gold', tile: 'border-gold/40 bg-gold/10', iconColor: 'text-gold' },
-  private: { Icon: Lock, badge: 'info', tone: 'cyan', dot: 'bg-cyan', tile: 'border-cyan/40 bg-cyan-soft', iconColor: 'text-cyan' },
-  offline: { Icon: CloudOff, badge: 'secondary', tone: 'muted', dot: 'bg-muted', tile: 'border-border-strong bg-foreground/[0.04]', iconColor: 'text-muted' },
+// Visibility → badge variant, active segmented tone, and status dot. The row
+// tile is now a letter avatar (hashed by session), so visibility reads from the
+// badge rather than a per-state icon.
+const STATUS: Record<Visibility, { badge: 'warning' | 'info' | 'secondary'; tone: SegmentedTone; dot: string }> = {
+  public: { badge: 'warning', tone: 'gold', dot: 'bg-gold' },
+  private: { badge: 'info', tone: 'cyan', dot: 'bg-cyan' },
+  offline: { badge: 'secondary', tone: 'muted', dot: 'bg-muted' },
 };
-
 
 interface RowProps {
   page: ShowPage;
   expanded: boolean;
   busy: boolean;
   copied: boolean;
+  pinned: boolean;
   onToggle: () => void;
+  onTogglePin: (next: boolean) => void;
   onSetVisibility: (visibility: Visibility) => void;
   onRotate: () => void;
   onCopy: () => void;
   onShareIdSaved: (payload: ShowPageLinkInfo) => void;
 }
 
-function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, onRotate, onCopy, onShareIdSaved }: RowProps) {
+function ShowPageRow({
+  page,
+  expanded,
+  busy,
+  copied,
+  pinned,
+  onToggle,
+  onTogglePin,
+  onSetVisibility,
+  onRotate,
+  onCopy,
+  onShareIdSaved,
+}: RowProps) {
   const { t, i18n } = useTranslation();
   const status = STATUS[page.visibility];
-  const { Icon } = status;
   const label = page.title || page.session_id;
   const sub = [page.platform ? t(`platform.${page.platform}.title`, { defaultValue: page.platform }) : null, page.agent]
     .filter(Boolean)
@@ -109,23 +99,18 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
         tabIndex={0}
         onClick={onToggle}
         onKeyDown={(e) => {
-          // Only the row itself toggles via keyboard; let Enter/Space on nested
-          // interactives (the live-link anchor) activate them normally instead
-          // of being swallowed by the row toggle.
           if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
             e.preventDefault();
             onToggle();
           }
         }}
         className={clsx(
-          'flex w-full cursor-pointer items-center gap-4 px-6 py-3.5 text-left transition-colors',
-          expanded ? 'bg-surface-2' : 'hover:bg-foreground/[0.02]'
+          'flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors sm:gap-4 sm:px-5',
+          expanded ? 'bg-surface-2' : 'hover:bg-foreground/[0.02]',
         )}
       >
         <span className="flex min-w-0 flex-1 items-center gap-3">
-          <span className={clsx('flex size-8 shrink-0 items-center justify-center rounded-lg border', status.tile)}>
-            <Icon size={16} className={status.iconColor} />
-          </span>
+          <ShowPageAvatarTile sessionId={page.session_id} title={page.title || ''} />
           <span className="min-w-0">
             <span className={clsx('block truncate text-[13px] font-semibold text-foreground', !page.title && 'font-mono')}>
               {label}
@@ -134,42 +119,38 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
           </span>
         </span>
 
-        <span className="w-[120px] shrink-0">
-          <Badge variant={status.badge}>
-            <span className={clsx('size-1.5 rounded-full', status.dot)} />
-            {t(`showPages.status.${page.visibility}`)}
-          </Badge>
+        <Badge variant={status.badge} className="hidden sm:inline-flex">
+          <span className={clsx('size-1.5 rounded-full', status.dot)} />
+          {t(`showPages.status.${page.visibility}`)}
+        </Badge>
+
+        {/* The single promote/demote gesture: the Dock switch pins (installs) or
+            unpins the page. Stop propagation so toggling it never expands the row. */}
+        <span className="flex shrink-0 flex-col items-center gap-1" onClick={(e) => e.stopPropagation()}>
+          <Switch checked={pinned} onCheckedChange={onTogglePin} label={t('library.dock.toggle')} />
+          <span className="font-mono text-[9px] font-bold uppercase tracking-[0.1em] text-muted">{t('library.dock.label')}</span>
         </span>
 
-        <span className="hidden w-[280px] shrink-0 items-center gap-1.5 lg:flex">
-          {shown && href ? (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              title={href}
-              className="flex min-w-0 items-center gap-1 font-mono text-[12px] text-muted transition-colors hover:text-foreground hover:underline"
-            >
-              <span className="truncate">{shown}</span>
-              <ExternalLink size={12} className="shrink-0" />
-            </a>
-          ) : shown ? (
-            <span className="truncate font-mono text-[12px] text-muted">{shown}</span>
-          ) : (
-            <span className="text-[13px] text-muted">—</span>
-          )}
-        </span>
+        <button
+          type="button"
+          title={t('showPages.open')}
+          disabled={!href}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (href) window.open(href, '_blank', 'noopener,noreferrer');
+          }}
+          className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.05] hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted"
+        >
+          <ExternalLink size={15} />
+        </button>
 
-        <span className="hidden w-[96px] shrink-0 text-[12px] text-muted sm:block">{relative(page.updated_at)}</span>
-
-        <span className="flex w-[24px] shrink-0 justify-end">
+        <span className="flex w-[20px] shrink-0 justify-end">
           {expanded ? <ChevronUp size={18} className="text-foreground" /> : <ChevronDown size={18} className="text-muted" />}
         </span>
       </div>
 
       {expanded ? (
-        <div className="bg-surface-2 px-6 pb-6 pt-2">
+        <div className="bg-surface-2 px-5 pb-6 pt-2">
           <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_300px]">
             <div className="flex flex-col gap-5">
               <div className="flex flex-col gap-2">
@@ -284,66 +265,17 @@ function ShowPageRow({ page, expanded, busy, copied, onToggle, onSetVisibility, 
   );
 }
 
-export function ShowPagesPage() {
+// The full Show Pages inventory view: search + visibility filter + expandable
+// rows, each with the Dock switch that pins/unpins the page. Shared by the App
+// Library window and the mobile full-screen route; the caller owns the pages
+// state via useShowPages so both projections stay consistent.
+export function ShowPagesView({ pages, busyId, setVisibility, rotate, onShareIdSaved, reload }: ShowPagesController) {
   const { t } = useTranslation();
-  const api = useApi();
-  const { showToast } = useToast();
-  const [pages, setPages] = useState<ShowPage[]>([]);
+  const { isPinned, pin, unpin } = useDock();
   const [search, setSearch] = useState('');
-  const [filter, setFilter] = useState<Filter>('online');
+  const [filter, setFilter] = useState<ShowPageFilter>('all');
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [busyId, setBusyId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
-
-  const load = useCallback(() => {
-    api
-      .getShowPages()
-      .then((res: any) => setPages(Array.isArray(res?.pages) ? res.pages : []))
-      .catch(() => {});
-  }, [api]);
-
-  useEffect(() => {
-    load();
-  }, [load, refreshTrigger]);
-
-  const mergePage = (next: ShowPage) =>
-    setPages((prev) => prev.map((page) => (page.session_id === next.session_id ? { ...page, ...next } : page)));
-
-  const setVisibility = async (page: ShowPage, visibility: Visibility) => {
-    if (page.visibility === visibility || busyId) return;
-    setBusyId(page.session_id);
-    try {
-      const res = await api.setShowPageVisibility(page.session_id, visibility);
-      mergePage(res);
-      showToast(t('showPages.toast.updated'));
-    } catch {
-      // ApiContext surfaces a toast on failure.
-    } finally {
-      setBusyId(null);
-    }
-  };
-
-  const rotate = async (page: ShowPage) => {
-    if (busyId) return;
-    setBusyId(page.session_id);
-    try {
-      const res = await api.rotateShowPageShare(page.session_id);
-      mergePage(res);
-      showToast(t('showPages.toast.rotated'));
-    } catch {
-      // handled by ApiContext
-    } finally {
-      setBusyId(null);
-    }
-  };
-
-  // The custom-link field owns its own request/validation; the page only merges
-  // the returned payload (new share_id, updated_at) and confirms.
-  const onShareIdSaved = (next: ShowPageLinkInfo) => {
-    mergePage(next as ShowPage);
-    showToast(t('showPages.shareId.toast.saved'));
-  };
 
   const copy = async (page: ShowPage) => {
     const href = copyHref(page);
@@ -353,93 +285,64 @@ export function ShowPagesPage() {
     window.setTimeout(() => setCopiedId((id) => (id === page.session_id ? null : id)), 1600);
   };
 
-  const visible = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    return pages.filter((page) => {
-      // "online" = live pages (private + public), i.e. everything but offline.
-      if (filter === 'online' ? page.visibility === 'offline' : page.visibility !== filter) return false;
-      if (!query) return true;
-      return (page.title || '').toLowerCase().includes(query) || page.session_id.toLowerCase().includes(query);
-    });
-  }, [pages, filter, search]);
+  const visible = useMemo(() => filterShowPages(pages, filter, search), [pages, filter, search]);
 
   return (
-    <div className="flex h-full flex-col gap-5">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex flex-col gap-1.5">
-          <h1 className="text-[28px] font-bold leading-tight tracking-[-0.4px] text-foreground">{t('showPages.title')}</h1>
-          <p className="text-[14px] leading-[1.55] text-muted">{t('showPages.subtitle')}</p>
-        </div>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3 sm:px-5">
         <div className="flex items-center gap-2">
           <SearchField
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder={t('showPages.searchPlaceholder')}
-            className="w-full sm:w-[280px]"
+            placeholder={t('library.searchPages')}
+            className="w-full sm:w-[240px]"
           />
           <Button
             type="button"
             variant="secondary"
             size="sm"
-            onClick={() => setRefreshTrigger((v) => v + 1)}
+            onClick={reload}
             title={t('common.refresh', { defaultValue: 'Refresh' })}
-            className="px-3"
+            className="px-2.5"
           >
             <RefreshCw size={14} />
           </Button>
         </div>
-      </div>
-
-      <div className="flex flex-wrap items-center justify-between gap-3 px-1 py-2">
-        <div className="flex items-center gap-2">
-          <span className="text-[15px] font-semibold text-foreground">{t('showPages.allPages')}</span>
-          <span className="rounded-full bg-foreground/[0.08] px-1.5 py-0.5 font-mono text-[11px] font-bold text-muted">
-            {pages.length}
-          </span>
-          <span className="text-[12px] text-muted">· {t('showPages.sortedRecent')}</span>
-        </div>
-        <SegmentedRadio<Filter>
+        <SegmentedRadio<ShowPageFilter>
           value={filter}
           onChange={setFilter}
           ariaLabel={t('showPages.filterAria')}
           options={[
-            { id: 'online', label: t('showPages.filter.online') },
-            { id: 'private', label: t('showPages.filter.private') },
+            { id: 'all', label: t('showPages.filter.all') },
             { id: 'public', label: t('showPages.filter.public') },
+            { id: 'private', label: t('showPages.filter.private') },
             { id: 'offline', label: t('showPages.filter.offline') },
           ]}
         />
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto">
         {visible.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-border bg-surface-3/60 p-8 text-center text-[13px] text-muted">
+          <div className="m-4 rounded-xl border border-dashed border-border bg-surface-3/60 p-8 text-center text-[13px] text-muted">
             {pages.length === 0 ? t('showPages.empty') : t('showPages.emptyFiltered')}
           </div>
         ) : (
-          <div className="overflow-hidden rounded-xl border border-border bg-background">
-            <div className="flex items-center gap-4 border-b border-border bg-surface px-6 py-3">
-              <span className={clsx(LABEL, 'flex-1')}>{t('showPages.col.session')}</span>
-              <span className={clsx(LABEL, 'w-[120px] shrink-0')}>{t('showPages.col.visibility')}</span>
-              <span className={clsx(LABEL, 'hidden w-[280px] shrink-0 lg:block')}>{t('showPages.col.link')}</span>
-              <span className={clsx(LABEL, 'hidden w-[96px] shrink-0 sm:block')}>{t('showPages.col.updated')}</span>
-              <span className="w-[24px] shrink-0" />
-            </div>
-            {visible.map((page) => (
-              <ShowPageRow
-                key={page.session_id}
-                page={page}
-                expanded={expandedId === page.session_id}
-                busy={busyId === page.session_id}
-                copied={copiedId === page.session_id}
-                onToggle={() => setExpandedId((id) => (id === page.session_id ? null : page.session_id))}
-                onSetVisibility={(visibility) => setVisibility(page, visibility)}
-                onRotate={() => rotate(page)}
-                onCopy={() => copy(page)}
-                onShareIdSaved={onShareIdSaved}
-              />
-            ))}
-          </div>
+          visible.map((page) => (
+            <ShowPageRow
+              key={page.session_id}
+              page={page}
+              expanded={expandedId === page.session_id}
+              busy={busyId === page.session_id}
+              copied={copiedId === page.session_id}
+              pinned={isPinned(page.session_id)}
+              onToggle={() => setExpandedId((id) => (id === page.session_id ? null : page.session_id))}
+              onTogglePin={(next) => (next ? pin(page.session_id) : unpin(page.session_id))}
+              onSetVisibility={(visibility) => setVisibility(page, visibility)}
+              onRotate={() => rotate(page)}
+              onCopy={() => copy(page)}
+              onShareIdSaved={onShareIdSaved}
+            />
+          ))
         )}
       </div>
     </div>

--- a/ui/src/components/useShowPages.ts
+++ b/ui/src/components/useShowPages.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useApi } from '../context/ApiContext';
+import { useToast } from '../context/ToastContext';
+import type { ShowPageLinkInfo } from '../lib/showPageLinks';
+
+export type Visibility = 'private' | 'public' | 'offline';
+
+export interface ShowPage {
+  session_id: string;
+  visibility: Visibility;
+  title: string | null;
+  platform: string | null;
+  agent: string | null;
+  path: string;
+  active_url: string | null;
+  private_url: string | null;
+  public_url: string | null;
+  url_available: boolean;
+  share_id: string | null;
+  offline: boolean;
+  offline_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// The Show Pages inventory: fetch + the visibility / share-id / rotate mutations,
+// with their toasts. Lifted out of the view so the App Library owns one copy of
+// the pages state and projects it into both the Apps and Show Pages views (kept
+// in a hook module so the view file exports only components — fast-refresh safe).
+export function useShowPages() {
+  const api = useApi();
+  const { showToast } = useToast();
+  const { t } = useTranslation();
+  const [pages, setPages] = useState<ShowPage[]>([]);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  const load = useCallback(() => {
+    api
+      .getShowPages()
+      .then((res: any) => setPages(Array.isArray(res?.pages) ? res.pages : []))
+      .catch(() => {});
+  }, [api]);
+
+  useEffect(() => {
+    load();
+  }, [load, refreshTrigger]);
+
+  const mergePage = (next: ShowPage) =>
+    setPages((prev) => prev.map((page) => (page.session_id === next.session_id ? { ...page, ...next } : page)));
+
+  const setVisibility = async (page: ShowPage, visibility: Visibility) => {
+    if (page.visibility === visibility || busyId) return;
+    setBusyId(page.session_id);
+    try {
+      const res = await api.setShowPageVisibility(page.session_id, visibility);
+      mergePage(res);
+      showToast(t('showPages.toast.updated'));
+    } catch {
+      // ApiContext surfaces a toast on failure.
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const rotate = async (page: ShowPage) => {
+    if (busyId) return;
+    setBusyId(page.session_id);
+    try {
+      const res = await api.rotateShowPageShare(page.session_id);
+      mergePage(res);
+      showToast(t('showPages.toast.rotated'));
+    } catch {
+      // handled by ApiContext
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  // The custom-link field owns its own request/validation; we only merge the
+  // returned payload (new share_id, updated_at) and confirm.
+  const onShareIdSaved = (next: ShowPageLinkInfo) => {
+    mergePage(next as ShowPage);
+    showToast(t('showPages.shareId.toast.saved'));
+  };
+
+  const reload = useCallback(() => setRefreshTrigger((v) => v + 1), []);
+
+  return { pages, busyId, setVisibility, rotate, onShareIdSaved, reload };
+}
+
+export type ShowPagesController = ReturnType<typeof useShowPages>;

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, CodeXml, FolderTree, Link as LinkIcon, LogOut, SlidersHorizontal, SquareTerminal } from 'lucide-react';
+import { ArrowRight, CodeXml, FolderTree, LayoutGrid, Link as LinkIcon, LogOut, SlidersHorizontal, SquareTerminal } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -109,6 +109,22 @@ export const MorePage: React.FC = () => {
           <span className="min-w-0 flex-1">
             <span className="block text-[15px] font-semibold">{t('apps.editor.label')}</span>
             <span className="block truncate text-[11.5px] text-muted">{t('apps.editor.desc')}</span>
+          </span>
+          <ArrowRight className="size-[18px] shrink-0 text-muted" />
+        </Link>
+        {/* App Library — the mobile entry to apps + the Show Pages inventory
+            (there is no Dock on mobile, and the control-panel Show Pages entry
+            was retired), so phone users keep a discoverable path. */}
+        <Link
+          to="/apps/library"
+          className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
+        >
+          <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-gold/[0.12]">
+            <LayoutGrid className="size-[18px] text-gold" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-[15px] font-semibold">{t('library.title')}</span>
+            <span className="block truncate text-[11.5px] text-muted">{t('library.desc')}</span>
           </span>
           <ArrowRight className="size-[18px] shrink-0 text-muted" />
         </Link>

--- a/ui/src/context/DockContext.test.ts
+++ b/ui/src/context/DockContext.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { dockIdToSession, reconcileDock, showDockId, type DockDoc } from './DockContext';
+import { dockIdToSession, MAX_PINNED_PAGES, reconcileDock, showDockId, type DockDoc } from './DockContext';
 
 const BUILTINS = ['files', 'terminal', 'editor'];
 
@@ -93,12 +93,14 @@ describe('reconcileDock', () => {
     expect(out.order).toEqual(['files', 'terminal', 'editor']);
   });
 
-  it('clamps oversized pins to the cap, always keeping the built-ins', () => {
-    // Far more pins than the 200 cap allows; only the first (cap - built-ins) survive.
+  it('clamps oversized pins to the fixed pin budget, always keeping the built-ins', () => {
+    // Far more pins than the budget allows; only the first MAX_PINNED_PAGES survive.
+    // The budget is FIXED (independent of the built-in count), so adding a built-in
+    // never shrinks it — a valid pre-Phase-2 dock keeps all its pins.
     const pins = Array.from({ length: 250 }, (_, i) => ({ session_id: `ses_${i}`, title_snapshot: '', pinned_at: '' }));
     const out = reconcileDock({ order: [], pins }, BUILTINS);
-    expect(out.pins).toHaveLength(200 - BUILTINS.length); // 197
-    expect(out.order).toHaveLength(200);
+    expect(out.pins).toHaveLength(MAX_PINNED_PAGES); // 197, regardless of built-in count
+    expect(out.order).toHaveLength(BUILTINS.length + MAX_PINNED_PAGES);
     expect(out.order.slice(0, BUILTINS.length)).toEqual(BUILTINS);
   });
 

--- a/ui/src/context/DockContext.tsx
+++ b/ui/src/context/DockContext.tsx
@@ -27,11 +27,11 @@ export type DockDoc = {
 
 export const SHOW_DOCK_PREFIX = 'show:';
 
-// Defensive cap on resident tiles, mirroring the backend: built-ins (4) + a
-// FIXED 197-pin budget = 201 (core/dock_store.py derives the same). Keeping the
-// pin budget fixed means adding a built-in never shrinks it or drops a valid pin
-// on reconcile — bump this in step with the backend if a built-in is added.
-export const MAX_DOCK_ITEMS = 201;
+// Fixed defensive cap on PINNED Show Pages, mirroring core/dock_store.py's
+// MAX_PINNED_PAGES. reconcile clamps pins to this FIXED budget (independent of
+// the built-in count) so a corrupt/oversized doc stays bounded AND adding a
+// built-in never shrinks the budget or drops an existing valid pin on reconcile.
+export const MAX_PINNED_PAGES = 197;
 
 /** The Dock id for a pinned Show Page session. */
 export function showDockId(sessionId: string): string {
@@ -71,8 +71,9 @@ export function reconcileDock(doc: DockDoc | null | undefined, builtinIds: strin
   }
 
   // Clamp on read (mirrors the backend): built-ins are always kept; excess pins
-  // beyond the cap are dropped so a corrupt/oversized doc stays bounded.
-  const maxPins = Math.max(0, MAX_DOCK_ITEMS - builtinIds.length);
+  // beyond the FIXED pin budget are dropped so a corrupt/oversized doc stays
+  // bounded (the budget doesn't shrink when a built-in is added).
+  const maxPins = MAX_PINNED_PAGES;
   const clampedPins = pins.length > maxPins ? pins.slice(0, maxPins) : pins;
 
   const pinIds = clampedPins.map((pin) => showDockId(pin.session_id));

--- a/ui/src/context/DockContext.tsx
+++ b/ui/src/context/DockContext.tsx
@@ -27,9 +27,11 @@ export type DockDoc = {
 
 export const SHOW_DOCK_PREFIX = 'show:';
 
-// Defensive cap on resident tiles, mirroring the backend MAX_DOCK_ITEMS — so a
-// corrupt/oversized server (or optimistic) doc can't render unbounded tiles.
-export const MAX_DOCK_ITEMS = 200;
+// Defensive cap on resident tiles, mirroring the backend: built-ins (4) + a
+// FIXED 197-pin budget = 201 (core/dock_store.py derives the same). Keeping the
+// pin budget fixed means adding a built-in never shrinks it or drops a valid pin
+// on reconcile — bump this in step with the backend if a built-in is added.
+export const MAX_DOCK_ITEMS = 201;
 
 /** The Dock id for a pinned Show Page session. */
 export function showDockId(sessionId: string): string {

--- a/ui/src/context/WindowManagerContext.tsx
+++ b/ui/src/context/WindowManagerContext.tsx
@@ -55,6 +55,9 @@ export interface WindowManagerValue {
   /** Set (or clear) a window's title — e.g. the Editor reflecting its active file so several open
    *  windows are distinguishable in the Dock + titlebar. No-op when the title is unchanged. */
   setTitle: (id: string, title: string | undefined) => void;
+  /** Merge a patch into a window's launch params — lets an external navigation
+   *  (e.g. the /admin/show-pages redirect) hand an already-open app a request. */
+  setParams: (id: string, params: Record<string, unknown>) => void;
   /**
    * Register (or clear, by passing null) a guard a window body uses to veto closing.
    * The getter returns a confirm message when closing would lose work, else null.
@@ -284,6 +287,10 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   }, []);
 
+  const setParams = useCallback((id: string, patch: Record<string, unknown>) => {
+    setWindows((prev) => prev.map((w) => (w.id === id ? { ...w, params: { ...w.params, ...patch } } : w)));
+  }, []);
+
   // If the shell mounted below md (initializer skipped restore), restore the saved layout the first
   // time the viewport crosses to desktop — BEFORE the now-enabled saves could persist an empty list
   // over it. The window list is still empty while narrow (windowed apps open only from the
@@ -341,12 +348,13 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
       toggleMaximize,
       setBounds,
       setTitle,
+      setParams,
       setCloseGuard,
       setStateProvider,
       markClosing,
       confirmClose,
     }),
-    [windows, focusedId, openApp, close, focus, minimize, restore, toggleMaximize, setBounds, setTitle, setCloseGuard, setStateProvider, markClosing, confirmClose],
+    [windows, focusedId, openApp, close, focus, minimize, restore, toggleMaximize, setBounds, setTitle, setParams, setCloseGuard, setStateProvider, markClosing, confirmClose],
   );
 
   return <WindowManagerContext.Provider value={value}>{children}</WindowManagerContext.Provider>;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -152,6 +152,7 @@
     "sortedRecent": "Sorted by most recent",
     "filterAria": "Filter by visibility",
     "filter": {
+      "all": "All",
       "online": "Online",
       "private": "Private",
       "public": "Public",
@@ -205,6 +206,29 @@
     "toast": {
       "updated": "Show Page updated",
       "rotated": "Share link rotated"
+    }
+  },
+  "library": {
+    "title": "App Library",
+    "tab": {
+      "apps": "Apps",
+      "showPages": "Show Pages"
+    },
+    "searchApps": "Search apps…",
+    "searchPages": "Search pages…",
+    "kind": {
+      "builtin": "Built-in",
+      "showPage": "Show Page"
+    },
+    "dock": {
+      "label": "Dock",
+      "toggle": "Show in Dock"
+    },
+    "apps": {
+      "system": "system",
+      "remove": "Remove from Dock",
+      "locked": "Built-in apps can't be removed",
+      "empty": "No apps match your search."
     }
   },
   "settings": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -210,6 +210,7 @@
   },
   "library": {
     "title": "App Library",
+    "desc": "Your apps and Show Pages",
     "tab": {
       "apps": "Apps",
       "showPages": "Show Pages"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -152,6 +152,7 @@
     "sortedRecent": "按最近活动排序",
     "filterAria": "按可见性筛选",
     "filter": {
+      "all": "全部",
       "online": "在线",
       "private": "私有",
       "public": "公开",
@@ -205,6 +206,29 @@
     "toast": {
       "updated": "展示页面已更新",
       "rotated": "分享链接已更换"
+    }
+  },
+  "library": {
+    "title": "应用库",
+    "tab": {
+      "apps": "应用",
+      "showPages": "展示页面"
+    },
+    "searchApps": "搜索应用…",
+    "searchPages": "搜索页面…",
+    "kind": {
+      "builtin": "内置",
+      "showPage": "展示页面"
+    },
+    "dock": {
+      "label": "Dock",
+      "toggle": "显示在 Dock"
+    },
+    "apps": {
+      "system": "系统",
+      "remove": "移出 Dock",
+      "locked": "内置应用不可移除",
+      "empty": "没有匹配的应用。"
     }
   },
   "settings": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -210,6 +210,7 @@
   },
   "library": {
     "title": "应用库",
+    "desc": "你的应用与展示页面",
     "tab": {
       "apps": "应用",
       "showPages": "展示页面"


### PR DESCRIPTION
## What & why

Phase 2 of dock-pinned Show Page apps: fold the `/admin/show-pages` inventory into a new built-in **App Library** app — two projections over the existing `/api/show-pages` + `/api/dock` data. Implements spec §7.1 (two views, one-bit model) + §7.2 (the pin = install ladder). Phase 3 (remote-URL apps / "Add App") is out of scope.

Spec: `docs/plans/dock-pinned-show-page-apps.md` §7.1 (committed as the first commit of this PR).

## Changed capability

- **App Library** built-in app — a window on desktop, a full-screen route on mobile, a reorderable Dock tile (built-in #4), plus a mobile launcher entry (`MorePage`):
  - **Apps view** — the docked set in order (built-ins + pinned Show Pages), minus the Library itself. Built-ins lock; Show Page rows *remove-from-Dock* (the page survives). No per-row toggle, no in-list reorder, no Add App.
  - **Show Pages view** — the full inventory, preserving every capability of the retired admin page (All/Public/Private/Offline filter, visibility 3-way, public link + custom `/p/` suffix, rotate, open) **plus** a per-row **Dock** switch — the single promote/demote gesture, wired to `POST`/`DELETE /api/dock/pins`.
- `/admin/show-pages` → redirects to `/apps/library?view=pages` (lands on the Show Pages tab); its control-panel nav item is removed.
- `ShowPagesPage` split into `useShowPages` (data hook) + `ShowPagesView` (view), reused by both the Library window and the mobile route — one source of truth.

## Evidence

- **unit (vitest)** — `appLibrary.test.ts` (Apps-row derivation + Show Pages filter) + `DockContext.test.ts` (reconcile, fixed pin budget). **Full suite 213/213.**
- **backend (pytest)** — `tests/test_dock_api.py` **19/19**, incl. 3 new: pre-Phase-2 order gains `library` on reconcile; full-set reorder incl. `library` accepted; the pin budget stays 197 across the new built-in.
- **build / lint** — `cd ui && npm run build` (tsc + vite) clean; `ruff` clean; **net-new eslint 0** (only pre-existing, un-gated master patterns remain).
- **contract** — reuses existing `/api/show-pages` + `/api/dock*` shapes unchanged.
- **residual manual (deferred to the integration / Incus pass)** — window tab switching + counts; `/apps/library` full-screen on mobile + the `MorePage` entry; `/admin/show-pages` → Show Pages tab (fresh + already-open window); the Show Pages **Dock** switch ↔ Dock tile round-trip (pin/unpin, cross-device); the `library` tile reorders + persists among the built-ins; an offline-page pin shows the placeholder. No scenario catalog covers this surface.

## Codex review — passed on `ef2ef1c9`

Three rounds, all threads resolved:
- **R1** — P2: mobile launcher (added the Library to `MorePage`); P3: redirect lands on Show Pages tab; P3: pin cap shouldn't shrink with a new built-in.
- **R2** — P2: honor the tab for an *already-open* Library window (new `WindowManager.setParams` + render-time tab sync); P2: the **client** reconcile clamped `MAX_DOCK_ITEMS − builtinIds.length` (shrank the budget) → fixed `MAX_PINNED_PAGES = 197` mirroring the backend. (This second one was a real test failure I'd missed by running only one vitest file — now the full suite runs every round.)
- **R3** — clean pass, `+1` on the PR body.

## Backend / scope notes (orchestrator-approved)

- `core/dock_store.py` — `library` added to `BUILTIN_DOCK_IDS` (the client/server "keep in sync" contract) and the cap expressed as built-ins + a fixed `MAX_PINNED_PAGES` budget. Only backend change; no new endpoints/data sources. (Approved scope amendment.)
- Review-driven files beyond the original brief allowlist, each required to fix a finding: `ui/src/components/workbench/MorePage.tsx` (mobile launcher entry, R1) and `ui/src/context/WindowManagerContext.tsx` (a small general `setParams`, R2).

## Known-by-design ledger

- **One-bit model** — no installed-but-undocked state: being an app ≡ being in the Dock ≡ appearing in the Apps view.
- **Add App deferred to Phase 3** — no dead button; only `Built-in` + `Show Page` kinds this phase.
- **Reorder lives on the Dock, not the list** — the Apps view is management-only (remove-from-Dock / lock).
- **Fixed pin budget** — the dock cap is built-ins + a fixed 197-pin budget on both sides, so adding a built-in never shrinks the budget or drops an existing valid pin on reconcile.
- **`library` appended for pre-Phase-2 docs** — an existing user's persisted order lacks `library`; the §3 reconcile appends it (after pins, one-time) until they reorder. Covered by a test.

## Dependencies

Builds on #892 (dock pin/reorder + `DockContext` + `/api/dock`), already merged. No stacked PR.

Handing back for your review + Incus pass — **not merging.**
