### PR TITLE
fix(show): polish scaffold placeholder — pulsing dot + delayed nudge

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -1058,27 +1058,81 @@ export function RouterView() {
 
 
 def _default_page_home_tsx() -> str:
-    # Default landing page: a placeholder shown while the agent builds the real
-    # page (this is what the user sees right after clicking "Visualize"). It also
-    # hints the built-in UI — it renders one component (Card) and leaves a couple
-    # of others as commented imports so the agent sees what is available. The agent
-    # replaces this file with the real content.
-    return """import { Card, CardContent } from "@/components/ui/card"
-// More built-in UI is available, e.g.:
-// import { Button } from "@/components/ui/button"
+    # Default landing page: a live "building" placeholder the user sees right after
+    # clicking "Visualize". A pulsing dot signals work in progress; after a delay
+    # (only if it is genuinely taking a while) it reveals a copy-able nudge prompt.
+    # It also hints the built-in UI — it renders Card + Button and leaves Badge as a
+    # commented import. The agent replaces this file with the real content.
+    return """import { useEffect, useRef, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+// More built-in UI is available too, e.g.:
 // import { Badge } from "@/components/ui/badge"
 
+const NUDGE_PROMPT = "Please visualize this session as a Show Page."
+// Only offer the nudge if it is genuinely taking a while — don't nag on arrival.
+const NUDGE_AFTER_MS = 90_000
+
 export default function Home() {
+  const [showNudge, setShowNudge] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const codeRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setShowNudge(true), NUDGE_AFTER_MS)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  async function copyPrompt() {
+    try {
+      await navigator.clipboard.writeText(NUDGE_PROMPT)
+    } catch {
+      // Clipboard may be unavailable (e.g. insecure context) — select the text
+      // so the viewer can copy it manually.
+      const node = codeRef.current
+      if (node) {
+        const range = document.createRange()
+        range.selectNodeContents(node)
+        const selection = window.getSelection()
+        selection?.removeAllRanges()
+        selection?.addRange(range)
+      }
+      return
+    }
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 2000)
+  }
+
   return (
-    <Card className="mx-auto mt-24 max-w-md text-center">
-      <CardContent className="space-y-3 py-10">
-        <p className="text-lg font-medium">Your page is being generated…</p>
-        <p className="text-sm text-muted-foreground">
-          The agent is turning this session into a page. It will appear here as soon as it is ready.
-        </p>
-        {/* Drop a component in, e.g. <Button>Action</Button> or <Badge>New</Badge> */}
-      </CardContent>
-    </Card>
+    <div className="flex min-h-[70vh] items-center justify-center">
+      <Card className="w-full max-w-md">
+        <CardContent className="flex flex-col items-center gap-4 px-8 py-12 text-center">
+          <span className="relative flex h-3.5 w-3.5" aria-hidden="true">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+            <span className="relative inline-flex h-3.5 w-3.5 rounded-full bg-emerald-500" />
+          </span>
+          <div className="space-y-1.5">
+            <h1 className="text-lg font-semibold tracking-tight">Building your Show Page</h1>
+            <p className="text-sm text-muted-foreground">
+              Your agent is turning this session into a visual page. It will appear here automatically once it is ready.
+            </p>
+          </div>
+          {showNudge && (
+            <div className="w-full space-y-2 border-t border-border pt-4 text-left duration-500 animate-in fade-in slide-in-from-bottom-1">
+              <p className="text-xs text-muted-foreground">Taking a while? Send this to your agent:</p>
+              <div className="flex items-center gap-2">
+                <code ref={codeRef} className="flex-1 truncate rounded bg-muted px-2 py-1.5 font-mono text-xs">
+                  {NUDGE_PROMPT}
+                </code>
+                <Button size="sm" variant="secondary" onClick={copyPrompt}>
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   )
 }
 """
@@ -1086,19 +1140,34 @@ export default function Home() {
 
 def _default_page_second_tsx() -> str:
     # A second page, only to show that adding a file under src/pages/ adds a route
-    # (a folder becomes a nested path; a [param] file a dynamic one). Delete or
-    # replace it.
-    return """import { Link } from "../router"
+    # (a folder becomes a nested path; a [param] file a dynamic one) and to model a
+    # tidy page using the built-in UI. Delete or replace it.
+    return """import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Link } from "../router"
+
+const code = "rounded bg-muted px-1.5 py-0.5 font-mono text-xs"
 
 export default function SecondPage() {
   return (
-    <div className="space-y-3">
-      <h1 className="text-xl font-semibold">Second page</h1>
-      <p className="text-sm text-muted-foreground">
-        Add a file under <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">src/pages/</code> and it
-        becomes a route. Delete or replace these starter pages.
-      </p>
-      <Link to="/" className="text-sm underline underline-offset-4">← Home</Link>
+    <div className="mx-auto max-w-2xl space-y-6 py-10">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">A second page</h1>
+        <p className="text-muted-foreground">
+          This is <code className={code}>src/pages/second.tsx</code>. Any file under{" "}
+          <code className={code}>src/pages/</code> becomes a route — a folder nests it, a{" "}
+          <code className={code}>[id]</code> file makes it dynamic. Delete or replace it.
+        </p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Use the built-in UI</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Import from <code className={code}>@/components/ui/*</code> — Card, Button, Badge, and more — and Tailwind
+          classes work anywhere.
+        </CardContent>
+      </Card>
+      <Link to="/" className="text-sm underline underline-offset-4">← Back</Link>
     </div>
   )
 }

--- a/docs/plans/show-page-multipage-scaffold.md
+++ b/docs/plans/show-page-multipage-scaffold.md
@@ -30,6 +30,12 @@ fake demo instead of a progress state. The scaffold was slimmed back to the affo
 - The file-based hash router (discovery, nesting, `[param]`, deep-link/refresh) is
   unchanged; the starter is English-only and minimal.
 
+A follow-up polish (owner feedback, same day) restored the "live" feel the flat
+card had lost: the placeholder now shows a pulsing emerald dot (`animate-ping`),
+and — only after ~90s (so it never nags on arrival) — reveals a copy-able nudge
+prompt (`Button`, with a manual-select fallback when the clipboard is blocked). The
+example `second.tsx` became a tidy Card-based page. Both stay English-only.
+
 ## Serving model (verified against current code)
 
 - avibe proxies **both** private `/show/<id>/` and public `/p/<share>/` to the **same**

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -762,19 +762,22 @@ def test_fresh_workspace_scaffolds_placeholder_and_minimal_router(monkeypatch, t
     assert "activeLocale" not in router
     assert "navItems" not in router
 
-    # The home page is the user-facing placeholder, and it hints the built-in UI by
-    # rendering one component (Card) with a couple more as commented imports.
+    # The home page is the user-facing "building" placeholder: a pulsing dot, and a
+    # nudge prompt revealed only after a delay. It hints the built-in UI by rendering
+    # Card + Button, leaving Badge as a commented import.
     home = (page_dir / "src" / "pages" / "index.tsx").read_text(encoding="utf-8")
     assert "export default function" in home
-    assert "being generated" in home
+    assert "Building your Show Page" in home
+    assert "animate-ping" in home  # the pulsing "working" dot
+    assert "NUDGE_AFTER_MS = 90_000" in home  # nudge only after ~90s, no nagging on arrival
     assert "@/components/ui/card" in home
-    assert "// import { Button }" in home
-    assert "// import { Badge }" in home
+    assert "@/components/ui/button" in home  # Button is a live import now
+    assert "// import { Badge }" in home  # Badge stays a commented hint
 
     # One extra page demonstrates "add a file = add a route"; the old items demo is gone.
     second = page_dir / "src" / "pages" / "second.tsx"
     assert second.exists()
-    assert "Second page" in second.read_text(encoding="utf-8")
+    assert "A second page" in second.read_text(encoding="utf-8")
     assert not (page_dir / "src" / "pages" / "items").exists()
 
     # App is a minimal shell that renders the router — no hardcoded nav/route table.


### PR DESCRIPTION
## Capability

Polishes the fresh Show Page placeholder from #896. The flat "being generated" card lost the *live* "working" feel of the older placeholder; this restores it **without** returning to the heavy demo #896 removed.

## What changed

- **Placeholder** (`src/pages/index.tsx`): a pulsing emerald dot (`animate-ping`) signals work in progress. After **~90s** — and only then, so it never nags on arrival — it reveals a copy-able **nudge prompt** ("Taking a while? Send this to your agent:") with a `Copy` button. Uses `Card` + `Button` live (`Badge` stays a commented hint); the copy handler falls back to selecting the text when the clipboard API is blocked (insecure context).
- **Example page** (`src/pages/second.tsx`): a tidy `Card`-based page instead of a bare line.
- English-only. The dependency-free file-based **hash router** (discovery, nesting, `[param]`, deep-link/refresh in `/show/` and `/p/`) is **unchanged**.
- Existing single-page workspaces stay **byte-for-byte untouched** (fresh-only gating).

## Scenario IDs

None — no scenario catalog covers the Show Page scaffold.

## Evidence layers

- **Unit**: `tests/test_show_pages.py` (55 pass) — updated the fresh-workspace test to assert the placeholder copy, the pulsing dot (`animate-ping`), the 90s nudge gate (`NUDGE_AFTER_MS = 90_000`), live `Card`+`Button` imports, and the `Badge` comment; keeps the English-only / no-CJK guard. `ruff` clean.
- **Contract**: all generated TSX/TS files `esbuild`-parse clean.
- **Scenario**: n/a.
- **Manual**: the exact design (dot + delayed nudge revealing after the timer + the Card subpage) was rendered against the **real Show Runtime** in local Incus regression and screenshotted for owner sign-off before this PR.