### PR TITLE
feat(apps): jump to session chat from Show Page app windows

### DIFF
--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -49,6 +49,15 @@ installation, per-app permissions.
 - **New:** title-bar **right side** gets an "open in new tab" icon button
   (generalized as `AppDefinition.externalHref?(params)`; only `showpage`
   defines it in v1). Opens the private URL in a browser tab.
+- **v1.1 (owner ask 2026-07-13 21:49, ships as a follow-up PR after #899):**
+  a **chat-bubble button to the LEFT of the external-open button** — click
+  navigates the workbench to the owning session's Chat page and minimizes
+  the window (chat visible immediately; the Dock thumbnail brings the app
+  back). Showpage-only, via the same optional-hook pattern as
+  `externalHref` (or a small generalization to a title-bar-actions hook —
+  implementer's choice, keep it idiomatic). Archived/missing session: still
+  navigate; the chat surface owns its own not-found state. Design frame
+  updated (`q4E5yl`).
 - Body = same-origin `<iframe src="/show/<session_id>/">` — always the
   **owner (authed) surface**, regardless of visibility (authed workbench
   context; HMR means the app updates live while the agent keeps building
@@ -209,6 +218,23 @@ the same objects. Decision: fold it into the App Library.
   tabs, filters, expanded row w/ visibility+link+suffix mgmt, per-row Dock
   toggle), both in design.pen right of `NbPMq`.
 
+### 7.1b Mobile Dock — Option B locked (owner decision 2026-07-13 22:22)
+
+- The mobile 更多 tab becomes **Apps** (grid icon). Tapping summons a bottom
+  drawer = the mobile Dock: same tiles, same server-side order as desktop
+  (pin anywhere → appears everywhere). One tap to any app; apps open
+  full-screen (existing `/apps/*` routes; pinned pages via a full-screen
+  show-page route). Long-press tile = manage/unpin; built-ins locked.
+- Former More-page content compresses into a drawer footer chip row:
+  **设置** (RENAMED from 控制台 — copy alignment with desktop, owner ask),
+  账号 (signed-in / sign-out), 外观, remaining items under 更多….
+- **Copy rename ships early**: `more.controlPanel` zh 控制台→设置 (en
+  aligned to "Settings") goes into the v1.1 micro-lane (2 i18n lines) so the
+  interim UI is aligned before the drawer lands.
+- Evolution: this drawer grows into the Option-C home-screen page when the
+  app count justifies it (same tab slot, same mental model).
+- Design frame `Zb74E` (final, chips updated). Own lane after v1.1.
+
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 
 Pinning **is** installing — no separate ceremony. Two entrances, one action:
@@ -216,6 +242,25 @@ the share-popover switch (v1) and the per-row Dock toggle in the Library's
 Show Pages view (Phase 2). The full ladder: **page (session byproduct) → pin
 (lightweight app, one switch) → publish (standalone app, stable id/icon,
 detached from the session lifecycle — future)**.
+
+### 7.3a Chat as an App — windowed chat (owner-approved direction 2026-07-13 22:06)
+
+The chat-bubble button's end state is **opening a Chat window beside the app
+window** (watch the dashboard while instructing the agent; HMR shows the
+change live) — not navigating away. Approved plan, two steps:
+
+1. **v1.1 ships navigate+minimize** (§2.3 v1.1) — usable immediately, zero
+   risk; its click handler is later swapped for the window-open call, nothing
+   wasted.
+2. **Chat-as-an-App is its own milestone** (after Phase 2): extract a
+   container-relative `ChatSurface` from `ChatPage` (page and window render
+   the same component — the exact one-source/two-shells pattern used for
+   `ShowPagesView` in #899), register a `chat` app kind (param `sessionId`,
+   multi-instance), and upgrade the chat-bubble to open the chat window
+   adjacent to the app window. The routed Chat page stays canonical (deep
+   links, notifications, mobile). Design frames before kickoff. Product
+   significance: chat itself becomes an app in the OS — the Agent-OS metaphor
+   completes.
 
 ### 7.3 User-added URL apps (kind: remote) — Phase 3
 
@@ -244,7 +289,7 @@ Dark-theme frames alongside the Apps v2 set (right of `NbPMq`, y=-2315):
 | --- | --- | --- |
 | Apps · Pin Show Page — Share Popover | `s2YOlP` | popover w/ Pin to Dock switch + rules legend |
 | Apps · Dock — Pinned Show Page Apps | `zn8tz` | pinned letter-avatar tiles, context menu, reorder scene, menu rules |
-| Apps · Show Page App Window | `vxbaK` | `X7d3Ev` AppWindow instance + title-bar external-open + iframe dashboard body |
+| Apps · Show Page App Window | `q4E5yl` | `X7d3Ev` AppWindow instance + title-bar external-open + iframe dashboard body |
 | Apps · Future — App Library / Apps View | `xCSqW` | manifest model, kinds, show-in-Dock toggles, evolution path (not v1) |
 
 ## 9. Delivery

--- a/ui/src/apps/registry.tsx
+++ b/ui/src/apps/registry.tsx
@@ -3,7 +3,7 @@ import { CodeXml, Eye, Folder, LayoutGrid, MonitorPlay, SquareTerminal } from 'l
 import { useTranslation } from 'react-i18next';
 import type { LucideIcon } from 'lucide-react';
 
-import { showPagePrivatePath } from './showPageAvatar';
+import { sessionChatPath, showPagePrivatePath } from './showPageAvatar';
 
 // The catalogue of windowed apps. The WindowManager + Dock are headless of any
 // specific app; everything app-specific (title, icon, default window size, body)
@@ -35,6 +35,14 @@ export interface AppDefinition {
    * params can't resolve one. Only `showpage` defines this in v1.
    */
   externalHref?: (params?: Record<string, unknown>) => string | undefined;
+  /**
+   * When set, the title bar shows a chat-bubble button (left of the external-open button) that
+   * navigates the workbench to this in-app route and minimizes the window — the app was built by an
+   * agent in a session, and this jumps back to that session's chat. Returns undefined when the params
+   * can't resolve one. Only `showpage` defines this in v1; §7.3a later upgrades the click to open a
+   * chat window beside the app instead of navigating away.
+   */
+  chatHref?: (params?: Record<string, unknown>) => string | undefined;
 }
 
 const Loading: React.FC = () => {
@@ -133,6 +141,10 @@ export const APP_REGISTRY: Record<AppId, AppDefinition> = {
     externalHref: (params) => {
       const sessionId = params?.sessionId;
       return typeof sessionId === 'string' && sessionId ? showPagePrivatePath(sessionId) : undefined;
+    },
+    chatHref: (params) => {
+      const sessionId = params?.sessionId;
+      return typeof sessionId === 'string' && sessionId ? sessionChatPath(sessionId) : undefined;
     },
   },
   // The App Library — the app manager, itself a built-in app (§7.1). Two views

--- a/ui/src/apps/registry.tsx
+++ b/ui/src/apps/registry.tsx
@@ -144,7 +144,9 @@ export const APP_REGISTRY: Record<AppId, AppDefinition> = {
     },
     chatHref: (params) => {
       const sessionId = params?.sessionId;
-      return typeof sessionId === 'string' && sessionId ? sessionChatPath(sessionId) : undefined;
+      // showChat appends ?view=chat so ChatPage leaves Show Page mode even when the
+      // target is the session already open in Show Page mode (a same-path no-op nav).
+      return typeof sessionId === 'string' && sessionId ? sessionChatPath(sessionId, { showChat: true }) : undefined;
     },
   },
   // The App Library — the app manager, itself a built-in app (§7.1). Two views

--- a/ui/src/apps/showPageAvatar.test.ts
+++ b/ui/src/apps/showPageAvatar.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { SHOW_PAGE_ACCENTS, accentForSession, firstGrapheme, showPageAvatar, showPagePrivatePath } from './showPageAvatar';
+import {
+  SHOW_PAGE_ACCENTS,
+  accentForSession,
+  firstGrapheme,
+  sessionChatPath,
+  showPageAvatar,
+  showPagePrivatePath,
+} from './showPageAvatar';
 
 describe('firstGrapheme', () => {
   it('takes the first letter of an ASCII title', () => {
@@ -70,5 +77,12 @@ describe('showPagePrivatePath', () => {
   it('always points at the private /show/ surface, url-encoded', () => {
     expect(showPagePrivatePath('ses_1')).toBe('/show/ses_1/');
     expect(showPagePrivatePath('a/b')).toBe('/show/a%2Fb/');
+  });
+});
+
+describe('sessionChatPath', () => {
+  it('points at the in-app chat route for the session, url-encoded', () => {
+    expect(sessionChatPath('ses_1')).toBe('/chat/ses_1');
+    expect(sessionChatPath('a/b')).toBe('/chat/a%2Fb');
   });
 });

--- a/ui/src/apps/showPageAvatar.test.ts
+++ b/ui/src/apps/showPageAvatar.test.ts
@@ -85,4 +85,12 @@ describe('sessionChatPath', () => {
     expect(sessionChatPath('ses_1')).toBe('/chat/ses_1');
     expect(sessionChatPath('a/b')).toBe('/chat/a%2Fb');
   });
+
+  it('appends the ?view=chat show-me-the-chat signal only when requested', () => {
+    expect(sessionChatPath('ses_1', { showChat: true })).toBe('/chat/ses_1?view=chat');
+    expect(sessionChatPath('a/b', { showChat: true })).toBe('/chat/a%2Fb?view=chat');
+    // Omitted / falsy keeps the plain canonical route (no stray query).
+    expect(sessionChatPath('ses_1', {})).toBe('/chat/ses_1');
+    expect(sessionChatPath('ses_1', { showChat: false })).toBe('/chat/ses_1');
+  });
 });

--- a/ui/src/apps/showPageAvatar.ts
+++ b/ui/src/apps/showPageAvatar.ts
@@ -46,9 +46,14 @@ export function showPagePrivatePath(sessionId: string): string {
   return `/show/${encodeURIComponent(sessionId)}/`;
 }
 
-/** The in-app route to the owning session's Chat page (`/chat/:sessionId`). The
- *  Show Page window's chat-bubble button navigates here (SPA nav, not a new tab)
- *  and minimizes the window. Pure. */
-export function sessionChatPath(sessionId: string): string {
-  return `/chat/${encodeURIComponent(sessionId)}`;
+/** The in-app route to the owning session's Chat page (`/chat/:sessionId`). The Show
+ *  Page window's chat-bubble navigates here (SPA nav, not a new tab) and minimizes the
+ *  window. Pass `{ showChat: true }` to append the `?view=chat` signal that tells
+ *  ChatPage to leave Show Page mode — required when the target is the SAME session
+ *  already open in Show Page mode (the `:sessionId` path alone wouldn't change, so the
+ *  navigation would otherwise be a no-op). Reusable by any "show me the chat" entry
+ *  point (inbox, deep links). Pure. */
+export function sessionChatPath(sessionId: string, opts?: { showChat?: boolean }): string {
+  const path = `/chat/${encodeURIComponent(sessionId)}`;
+  return opts?.showChat ? `${path}?view=chat` : path;
 }

--- a/ui/src/apps/showPageAvatar.ts
+++ b/ui/src/apps/showPageAvatar.ts
@@ -45,3 +45,10 @@ export function showPageAvatar(sessionId: string, title: string): { letter: stri
 export function showPagePrivatePath(sessionId: string): string {
   return `/show/${encodeURIComponent(sessionId)}/`;
 }
+
+/** The in-app route to the owning session's Chat page (`/chat/:sessionId`). The
+ *  Show Page window's chat-bubble button navigates here (SPA nav, not a new tab)
+ *  and minimizes the window. Pure. */
+export function sessionChatPath(sessionId: string): string {
+  return `/chat/${encodeURIComponent(sessionId)}`;
+}

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -6,6 +6,7 @@ import { ExternalLink, MessageCircle, Minus, Plus, X, type LucideIcon } from 'lu
 
 import { APP_REGISTRY } from '../../apps/registry';
 import { useWindowManager, type WindowInstance } from '../../context/WindowManagerContext';
+import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesActionGuard';
 import { clampToLayer, resizeBounds, type ResizeDir } from '../../lib/windowBounds';
 import { ErrorBoundary } from '../ui/error-boundary';
 
@@ -28,6 +29,9 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
   const { t } = useTranslation();
   const wm = useWindowManager();
   const navigate = useNavigate();
+  // Gate the chat-bubble's SPA navigation through the same unsaved-changes guard the
+  // sidebar uses, so a route-level dirty blocker can veto it (and the minimize) as one.
+  const authorizeRouteAction = useUnsavedChangesActionGuard();
   const def = APP_REGISTRY[win.appId];
   const rootRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef(false);
@@ -246,9 +250,14 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
               onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation();
+                // A route-level unsaved-changes blocker can veto this navigation; authorize
+                // first so a cancelled prompt aborts the WHOLE action instead of half-applying
+                // (window minimized into the Dock while the route never left the dirty page).
+                const authorization = authorizeRouteAction();
+                if (!authorization) return;
                 // Jump to the owning session's chat and drop the window to the Dock
                 // (chat visible immediately; the Dock thumbnail brings the app back).
-                navigate(chatHref);
+                authorization.runNavigation(() => navigate(chatHref));
                 wm.minimize(win.id);
               }}
               className="grid size-6 place-items-center rounded-md text-muted transition hover:bg-foreground/[0.06] hover:text-foreground"

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
-import { ExternalLink, Minus, Plus, X, type LucideIcon } from 'lucide-react';
+import { ExternalLink, MessageCircle, Minus, Plus, X, type LucideIcon } from 'lucide-react';
 
 import { APP_REGISTRY } from '../../apps/registry';
 import { useWindowManager, type WindowInstance } from '../../context/WindowManagerContext';
@@ -26,6 +27,7 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
 }) => {
   const { t } = useTranslation();
   const wm = useWindowManager();
+  const navigate = useNavigate();
   const def = APP_REGISTRY[win.appId];
   const rootRef = useRef<HTMLDivElement | null>(null);
   const draggingRef = useRef(false);
@@ -109,6 +111,9 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
   // A standalone-surface app (v1: showpage) exposes an external URL for its own
   // browser tab; the title bar then shows an open-in-new-tab button.
   const externalHref = def.externalHref?.(win.params);
+  // The same app may own a session chat (v1: showpage) — the title bar then also
+  // shows a chat-bubble button that jumps there and minimizes this window.
+  const chatHref = def.chatHref?.(win.params);
 
   const style: React.CSSProperties = win.maximized
     ? { left: 0, top: 0, width: layerWidth, height: layerHeight, zIndex: win.z }
@@ -229,8 +234,28 @@ export const AppWindow: React.FC<{ win: WindowInstance; layerWidth: number; laye
           <span className="truncate text-[13px] font-semibold text-foreground">{win.title ?? t(def.titleKey)}</span>
         </div>
         {/* Right cluster balances the traffic lights so the title stays centered; a
-            standalone-surface app also gets an open-in-new-tab button here. */}
-        <div className="flex w-[52px] shrink-0 items-center justify-end">
+            standalone-surface app (showpage) also gets a chat-bubble + open-in-new-tab
+            pair here — two size-6 buttons + gap-1 fill the 52px box exactly. */}
+        <div className="flex w-[52px] shrink-0 items-center justify-end gap-1">
+          {chatHref && (
+            <button
+              type="button"
+              title={t('apps.window.openChat')}
+              aria-label={t('apps.window.openChat')}
+              // Stop the titlebar drag/focus gesture from starting on this click.
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                // Jump to the owning session's chat and drop the window to the Dock
+                // (chat visible immediately; the Dock thumbnail brings the app back).
+                navigate(chatHref);
+                wm.minimize(win.id);
+              }}
+              className="grid size-6 place-items-center rounded-md text-muted transition hover:bg-foreground/[0.06] hover:text-foreground"
+            >
+              <MessageCircle className="size-3.5" />
+            </button>
+          )}
           {externalHref && (
             <a
               href={externalHref}

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -109,6 +109,9 @@ export const ChatPage: React.FC = () => {
   // re-render / visibility gap-recovery can't re-trigger the jump.
   const [searchParams, setSearchParams] = useSearchParams();
   const deepLinkMessageId = searchParams.get('msg');
+  // A "show me the chat" navigation carries ?view=chat (see sessionChatPath({ showChat:
+  // true })) — a general signal that this navigation must leave Show Page mode.
+  const showChatSignal = searchParams.get('view') === 'chat';
   const api = useApi();
   const { unreadBySession, markRead: markInboxRead } = useWorkbenchInbox();
   // The mobile chat surface is a fixed full-screen flex column; this keeps the
@@ -151,6 +154,18 @@ export const ChatPage: React.FC = () => {
     setShowPageUrl(null);
     setShowPageBusy(false);
   }, [sessionId]);
+
+  // Honor the ?view=chat "show me the chat" signal ONCE: leave Show Page mode and strip
+  // the param. This makes the intent work even for a same-session jump (where the
+  // :sessionId path doesn't change, so the reset-on-sessionId effect above never fires);
+  // stripping it (like the ?msg jump below) keeps it a no-op on every render afterwards.
+  useEffect(() => {
+    if (!showChatSignal) return;
+    setShowPageMode(false);
+    const next = new URLSearchParams(window.location.search);
+    next.delete('view');
+    setSearchParams(next, { replace: true });
+  }, [showChatSignal, setSearchParams]);
 
   // Publish this chat's composer to the ComposerBridge so the sidebar's
   // "reference this session" action can insert a #<session> mention into the

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -119,7 +119,7 @@
   "more": {
     "title": "More",
     "controlPanel": "Settings",
-    "controlPanelDesc": "Channels · Users · Show Pages · Settings · Logs",
+    "controlPanelDesc": "Dashboard · Remote Access · Messaging Platforms · Backends · Advanced Settings",
     "appearance": "Appearance",
     "connection": "Connection",
     "host": "Local address"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -118,7 +118,7 @@
   },
   "more": {
     "title": "More",
-    "controlPanel": "Control Panel",
+    "controlPanel": "Settings",
     "controlPanelDesc": "Channels · Users · Show Pages · Settings · Logs",
     "appearance": "Appearance",
     "connection": "Connection",
@@ -738,7 +738,8 @@
       "minimize": "Minimize",
       "maximize": "Maximize",
       "restore": "Restore",
-      "openInNewTab": "Open in New Tab"
+      "openInNewTab": "Open in New Tab",
+      "openChat": "Open Chat"
     },
     "preview": {
       "label": "Preview",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -118,7 +118,7 @@
   },
   "more": {
     "title": "更多",
-    "controlPanel": "控制面板",
+    "controlPanel": "设置",
     "controlPanelDesc": "频道 · 用户 · 展示页面 · 设置 · 日志",
     "appearance": "外观",
     "connection": "连接",
@@ -738,7 +738,8 @@
       "minimize": "最小化",
       "maximize": "最大化",
       "restore": "还原",
-      "openInNewTab": "在新标签页打开"
+      "openInNewTab": "在新标签页打开",
+      "openChat": "打开聊天"
     },
     "preview": {
       "label": "预览",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -119,7 +119,7 @@
   "more": {
     "title": "更多",
     "controlPanel": "设置",
-    "controlPanelDesc": "频道 · 用户 · 展示页面 · 设置 · 日志",
+    "controlPanelDesc": "控制台 · 远程访问 · 通讯平台 · 后端 · 高级设置",
     "appearance": "外观",
     "connection": "连接",
     "host": "本机地址"


### PR DESCRIPTION
## What & why

Two small v1.1 follow-ups after #899, per `docs/plans/dock-pinned-show-page-apps.md` (§2.3 v1.1, §7.1b):

**1. Chat-bubble title-bar button on Show Page app windows.** A Show Page opened as a workbench app now shows a chat-bubble button to the **left** of the open-in-new-tab button (showpage-only). Clicking it navigates the workbench to the owning session's Chat page and minimizes the window — the chat is visible immediately and the Dock thumbnail brings the app back. Archived/missing session: it navigates anyway (the chat surface owns its own not-found state).

- Implemented via a new `AppDefinition.chatHref?(params)` hook that mirrors the existing `externalHref` hook; `AppWindow` owns the navigate + minimize behavior. Only `showpage` defines it.
- The navigation is gated through the existing `useUnsavedChangesActionGuard`, so a route-level dirty blocker vetoes navigate **and** minimize as one (no half-applied state).
- The route is built by a pure `sessionChatPath()` helper next to `showPagePrivatePath()` in `showPageAvatar.ts` (unit-tested).
- Per spec §7.3a this click later upgrades to opening a Chat window beside the app; the hook is forward-compatible.

**2. Copy alignment.** Mobile More-page bridge:
- Label `more.controlPanel`: `Control Panel` / `控制面板` → `Settings` / `设置` (en + zh). Admin dashboard nav label `nav.dashboard` (`控制台`) intentionally unchanged.
- Subtitle `more.controlPanelDesc`: refreshed to the **live** top-level control-panel sections from `AppShell.tsx` `adminItems` — `Dashboard · Remote Access · Messaging Platforms · Backends · Advanced Settings` (zh: `控制台 · 远程访问 · 通讯平台 · 后端 · 高级设置`). The old list named `Show Pages`/`展示页面`, which #899 removed (redirected into the App Library), so the string was factually stale.

Also syncs the owner-approved spec doc (v1.1, mobile-dock Option B, chat-as-app milestone) in its own commit.

## Review findings addressed (Codex round 2)

- **P2 "Gate minimizing on accepted chat navigation"** — the click now routes through `useUnsavedChangesActionGuard` (same pattern as `WorkbenchSidebar`/`NewSessionSheet`): a cancelled unsaved-changes prompt aborts both navigate and minimize.
- **P2 "Force chat mode on same-session jumps"** — added a general `?view=chat` "show me the chat" signal to **ChatPage's navigation contract** (scope-expanded with orchestrator sign-off). ChatPage consumes it once (leave Show Page mode, strip the param; no-op on later renders); the chat-bubble carries it via `sessionChatPath({ showChat: true })`. This fixes the highest-likelihood bubble context (user already on that session's chat in Show Page mode) and is reusable by other entry points — not a bubble-specific patch.

## Scope

Frontend-only. Files: `ui/src/apps/registry.tsx`, `ui/src/components/apps/AppWindow.tsx`, `ui/src/apps/showPageAvatar.ts` (+ its test), `ui/src/i18n/en.json` + `zh.json`, `ui/src/components/workbench/ChatPage.tsx` (scope-expanded for the shared nav signal), and the spec doc. Lockfile untouched.

**Observation (NOT in scope here):** other same-session navigations — e.g. an inbox click while the target session is in Show Page mode — hit the same "no-op keeps Show Page mode" gap and can adopt the same `?view=chat` signal in a follow-up.

## Evidence

- **Unit**: `npx vitest run` — 22 files / 215 tests green, incl. `sessionChatPath` (plain + `?view=chat` variants, url-encoding).
- **Build**: `cd ui && npm run build` passes (pre-existing `@hpke` / chunk-size warnings only).
- **i18n**: en + zh JSON valid; `apps.window.openChat` added both; `more.controlPanel` renamed; `more.controlPanelDesc` refreshed against the live admin nav.
- **Static verification**: `WindowLayer`/`AppWindow` mount inside `AppShell` (route element) under `WindowManagerProvider` + `UnsavedChangesProvider`, so `useNavigate()`/`useUnsavedChangesActionGuard()` are in context and the window layer persists across `/`→`/chat`.
- **Scenario**: no scenario catalog covers workbench app-window chrome (N/A).
- **Residual manual (deferred to the orchestrator's integration pass)**: on a desktop workbench — two-button cluster placement + click-through; chat-bubble from a window while on the SAME session's chat in Show Page mode (should reveal chat); cancel path of a dirty-editor blocker (window stays). Via local Incus regression (plan §9).

## Known-by-design

- The right title-bar cluster keeps its fixed `w-[52px]` (mirrors the traffic-light cluster so the title stays centered). For showpage, two `size-6` buttons + `gap-1` fill it exactly (24+4+24=52) — intentional, commented in code.
