### PR TITLE
feat(apps): mobile Dock drawer — Apps tab + full-screen show pages

### DIFF
--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -246,6 +246,10 @@ integrated:
    dockable/undockable like the rest), and a **permanent 应用库 entry lives
    in the control-panel sidebar** (undismissable escape hatch; links to the
    existing /apps/library route).
+8. **(owner 23:38)** The bottom-left Apps launcher button gets a
+   **right-click context menu** (shared primitive): 打开应用库 (+ 显示所有
+   窗口 only if trivially supported). Third Library escape hatch alongside
+   the sidebar entry and the empty-dock hint.
 
 Data model (compatible evolution, no migration): `pins` = installed AI
 pages; `order` = docked ids and becomes a **SUBSET** of {built-ins ∪ pins}
@@ -272,6 +276,24 @@ shows an App Library shortcut hint (never a dead surface).
 - Evolution: this drawer grows into the Option-C home-screen page when the
   app count justifies it (same tab slot, same mental model).
 - Design frame `Zb74E` (final, chips updated). Own lane after v1.1.
+
+### 7.1d Ideas 3+4 approved (owner 2026-07-14 02:32)
+
+- **⌘K search reaches apps**: the global search adds an "Apps" result
+  section — built-ins + installed apps + ALL AI pages (inventory; searching
+  an uninstalled page and opening it is a feature). Enter/click: desktop →
+  open the app window (showpage window for pages); mobile → the existing
+  mobile open behavior. Additive to existing result sections.
+- **Keyboard dock switching**: desktop-only chord to focus/launch the Nth
+  Dock tile in current order. NOTE: browsers reserve ⌘/Ctrl+1-9 for tab
+  switching (not interceptable) — use **⌥/Alt+1-9** (verify interceptability
+  in-code; follow the existing ⌘W/⌘M chord pattern in WindowLayer).
+- **AI-view inline rename**: rename affordance in the AI row's expanded
+  management panel; saves the SESSION title via the existing session PATCH
+  (same as the chat header TitleField). Display already prefers the live
+  title everywhere; `title_snapshot` remains a fallback only. Built-ins not
+  renamable. (Idea 1 — agent-suggested pinning — deliberately deferred;
+  idea 2 — update dots — not scheduled yet.)
 
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,7 +20,6 @@ import { HarnessPage } from './components/workbench/HarnessPage';
 import { VaultsPage } from './components/workbench/VaultsPage';
 import { ChatPage } from './components/workbench/ChatPage';
 import { ProjectsPage } from './components/workbench/ProjectsPage';
-import { MorePage } from './components/workbench/MorePage';
 import { Dashboard } from './components/Dashboard';
 import { ChannelList } from './components/steps/ChannelList';
 import { UserList } from './components/steps/UserList';
@@ -62,6 +61,11 @@ const AppsEditorPage = lazy(() =>
   import('./components/workbench/AppsEditorPage').then((m) => ({ default: m.AppsEditorPage })),
 );
 const LibraryAppBody = lazy(() => import('./apps/LibraryApp').then((m) => ({ default: m.LibraryApp })));
+// The mobile full-screen Show Page route body. Lazy so the iframe frame + session
+// lookup load only when a pinned page is opened, not into the main entry.
+const ShowPageRoute = lazy(() =>
+  import('./components/apps/ShowPageRoute').then((m) => ({ default: m.ShowPageRoute })),
+);
 import { hasConfiguredPlatformCredentials } from './lib/platforms';
 import { applyAppTitle } from './lib/documentTitle';
 import { useTranslation } from 'react-i18next';
@@ -400,7 +404,10 @@ const router = createBrowserRouter(
         <Route path="/harness" element={<HarnessPage />} />
         <Route path="/vaults" element={<VaultsPage />} />
         <Route path="/projects" element={<ProjectsPage />} />
-        <Route path="/more" element={<MorePage />} />
+        {/* /more retired: the workbench Apps tab now summons the Dock drawer
+            (§7.1b), which absorbed the old More-page content. Redirect any
+            lingering link/bookmark home. */}
+        <Route path="/more" element={<Navigate to="/" replace />} />
         {/* Apps layer — File Browser (Phase 1) + Terminal (Phase 2). The
             sidebar Apps launcher opens these; /apps lands on the file browser. */}
         <Route path="/apps" element={<Navigate to="/apps/files" replace />} />
@@ -429,6 +436,16 @@ const router = createBrowserRouter(
           }
         />
         <Route path="/apps/library" element={<LibraryRoute />} />
+        {/* A pinned Show Page opened as an app. Desktop opens a window and hands
+            back to the canvas; mobile frames it full-screen (§7.1b). */}
+        <Route
+          path="/apps/show/:sessionId"
+          element={
+            <Suspense fallback={<AppsRouteFallback />}>
+              <ShowPageRoute />
+            </Suspense>
+          }
+        />
         <Route path="/chat/:sessionId" element={<ChatPage />} />
 
         {/* Control Panel mode — existing pages moved under /admin/* */}

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { APP_LIST, APP_REGISTRY, type AppDefinition, type AppId } from './registry';
 import { deriveAppRows, type AppRow } from './appLibrary';
 import { ShowPageAvatarTile } from './showPageAvatarTile';
-import { showPagePrivatePath } from './showPageAvatar';
+import { showAppRoutePath } from '../components/apps/mobileDock';
 import { useDock } from '../context/DockContext';
 import { useWindowManager } from '../context/WindowManagerContext';
 import { ShowPagesView } from '../components/ShowPagesPage';
@@ -34,12 +34,10 @@ type LibraryTab = 'apps' | 'showpages';
 
 /**
  * Open an app the way the current surface can show it. On desktop that's a
- * workbench window (`openApp`). On mobile there is no window layer: built-ins
- * have in-shell `/apps/*` routes, so navigate there (keeping the AppShell). A
- * Show Page has no in-shell mobile route yet (that lands with the §7.1b mobile
- * Dock), so open its private `/show/` surface in a NEW TAB rather than replacing
- * the current one — this tab keeps the AppShell / Library / Dock chrome instead
- * of dropping the user onto the raw page.
+ * workbench window (`openApp`). On mobile there is no window layer, so built-ins
+ * navigate to their in-shell `/apps/*` route and a Show Page navigates to the
+ * full-screen `/apps/show/:sessionId` route (§7.1b) — both keep the AppShell
+ * chrome instead of dropping the user onto the raw page or a new browser tab.
  */
 function useOpenApp() {
   const wm = useWindowManager();
@@ -55,7 +53,7 @@ function useOpenApp() {
         return;
       }
       if (appId === 'showpage') {
-        if (opts?.sessionId) window.open(showPagePrivatePath(opts.sessionId), '_blank', 'noopener,noreferrer');
+        if (opts?.sessionId) navigate(showAppRoutePath(opts.sessionId));
       } else {
         navigate(`/apps/${appId}`);
       }

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
-import { ArrowLeft, Bot, ChevronDown, FolderTree, Globe, Hash, Inbox, LayoutDashboard, LayoutGrid, Link as LinkIcon, Menu, MessageCircle, PlugZap, Plus, Settings, Sparkles, X } from 'lucide-react';
+import { ArrowLeft, Bot, ChevronDown, FolderTree, Globe, Grid2x2, Hash, Inbox, LayoutDashboard, LayoutGrid, Link as LinkIcon, Menu, MessageCircle, PlugZap, Plus, Settings, Sparkles, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
@@ -17,6 +17,7 @@ import { ErrorBoundary } from './ui/error-boundary';
 import { WindowManagerProvider } from '../context/WindowManagerContext';
 import { DockProvider } from '../context/DockContext';
 import { WindowLayer } from './apps/WindowLayer';
+import { MobileDockDrawer } from './apps/MobileDockDrawer';
 import { NewSessionSheet } from './workbench/NewSessionSheet';
 import { SearchPalette } from './workbench/search/SearchPalette';
 import { Button } from './ui/button';
@@ -222,6 +223,9 @@ export const AppShell: React.FC = () => {
   // The mobile admin nav sheet (opened from the 更多 tab). Close it whenever the
   // route changes so tapping any item in the sheet dismisses it.
   const [adminMenuOpen, setAdminMenuOpen] = useState(false);
+  // The mobile Dock drawer (opened from the workbench Apps tab). Like the admin
+  // sheet it closes on any route change — tapping a tile navigates + dismisses.
+  const [appsDrawerOpen, setAppsDrawerOpen] = useState(false);
   // Mirror the iOS visual-viewport height into --app-vvh. The MOBILE shell is a
   // static locked column that does NOT read it (resizing the shell mid-focus
   // fought iOS's scroll-into-view and flung the input off-screen); only the md+
@@ -250,10 +254,11 @@ export const AppShell: React.FC = () => {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, []);
 
-  // Close the mobile admin nav sheet on any route change (tapping an item in it
-  // navigates, which should dismiss the sheet).
+  // Close the mobile transient surfaces (admin nav sheet + Apps Dock drawer) on
+  // any route change — tapping an item in either navigates, which dismisses it.
   useEffect(() => {
     setAdminMenuOpen(false);
+    setAppsDrawerOpen(false);
   }, [location.pathname]);
 
   const hasChannelPlatforms = enabledPlatforms.some((platform) => platformSupportsChannels(config, platform));
@@ -356,7 +361,10 @@ export const AppShell: React.FC = () => {
       icon: LayoutGrid,
       match: (p) => ['/agents', '/skills', '/harness', '/vaults'].some((x) => p.startsWith(x)),
     },
-    { to: '/more', label: t('nav.more'), icon: Menu, match: (p) => p.startsWith('/more') },
+    // Apps (§7.1b): replaces the old 更多 route tab. Tapping toggles the Dock
+    // drawer (the mobile Dock) rather than navigating; `grid-2x2` distinguishes
+    // it from Capabilities' `layout-grid`.
+    { label: t('nav.apps'), icon: Grid2x2, onClick: () => setAppsDrawerOpen((v) => !v), match: () => appsDrawerOpen },
   ];
 
   // Chat is a full-screen detail (own composer) and Search is a full-screen
@@ -581,6 +589,13 @@ export const AppShell: React.FC = () => {
             </nav>
           </div>
         </div>
+      )}
+
+      {/* Mobile Dock drawer — the workbench Apps tab summons it (§7.1b). Mobile-only
+          (md:hidden internally); mounted inside DockProvider so it reads the same
+          docked tiles + order as the desktop Dock. */}
+      {shellMode === 'workbench' && (
+        <MobileDockDrawer open={appsDrawerOpen} onClose={() => setAppsDrawerOpen(false)} />
       )}
 
       <NewSessionSheet

--- a/ui/src/components/apps/MobileDockDrawer.tsx
+++ b/ui/src/components/apps/MobileDockDrawer.tsx
@@ -7,7 +7,6 @@ import { APP_REGISTRY, type AppDefinition, type AppId } from '../../apps/registr
 import { showPageAvatar } from '../../apps/showPageAvatar';
 import { dockIdToSession, useDock } from '../../context/DockContext';
 import { useAuthAccount } from '../../lib/useAuthAccount';
-import { ContextMenu, ContextMenuItem } from '../ui/context-menu';
 import { MoreAccountSection, MoreAppearanceSection, MoreConnectionSection } from '../workbench/MorePage';
 import { mobileRouteForDockId } from './mobileDock';
 
@@ -32,9 +31,11 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
   const { order, pins, undock, unpin } = useDock();
   const { email } = useAuthAccount();
 
-  // Long-press context menu (touch) on the shared ContextMenu primitive,
-  // positioned at the press point. Tap opens the app; long-press manages the tile.
-  const [menu, setMenu] = useState<{ x: number; y: number; item: ResidentTile } | null>(null);
+  // Long-press manage sheet (touch): a bottom action sheet keyed to a tile. Tap
+  // opens the app; a press-hold opens the sheet. A cursor-positioned ContextMenu
+  // isn't used here — its close backdrop is z-40, below this z-50 drawer, so taps
+  // outside the menu would fall through to the tiles instead of dismissing it.
+  const [menu, setMenu] = useState<{ item: ResidentTile; label: string } | null>(null);
   // Which footer overflow sheet is open (账号 / 外观 / 更多) — one reusable shell.
   const [sheet, setSheet] = useState<FooterSheet | null>(null);
 
@@ -78,13 +79,12 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
     onClose();
   };
 
-  const onTilePointerDown = (e: React.PointerEvent, item: ResidentTile) => {
-    const { clientX, clientY } = e;
+  const onTilePointerDown = (item: ResidentTile, label: string) => {
     clearTimer();
     timerRef.current = window.setTimeout(() => {
       timerRef.current = null;
       suppressClickRef.current = true;
-      setMenu({ x: clientX, y: clientY, item });
+      setMenu({ item, label });
     }, 480);
   };
 
@@ -155,7 +155,7 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
                   type="button"
                   aria-label={label}
                   onClick={() => onTileClick(item)}
-                  onPointerDown={(e) => onTilePointerDown(e, item)}
+                  onPointerDown={() => onTilePointerDown(item, label)}
                   onPointerUp={clearTimer}
                   onPointerMove={clearTimer}
                   onPointerLeave={clearTimer}
@@ -179,6 +179,24 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
               );
             })}
           </div>
+        )}
+
+        {/* Library is undockable (§7.1c); when it isn't docked but other tiles are,
+            keep a route back to it here. The drawer is the only mobile Apps surface,
+            so it must never strand the user with no way to re-dock apps (the empty
+            state's hint covers the all-undocked case above). */}
+        {order.length > 0 && !order.includes('library') && (
+          <button
+            type="button"
+            onClick={() => {
+              navigate('/apps/library');
+              onClose();
+            }}
+            className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border px-3 py-3 text-[12.5px] font-medium text-muted transition-colors hover:border-cyan/60 hover:text-foreground"
+          >
+            <LayoutGrid className="size-4 shrink-0 text-cyan" />
+            <span>{t('apps.launcher.openLibrary')}</span>
+          </button>
         )}
 
         {/* Footer chip row — the absorbed More-page content. 设置 navigates; the
@@ -205,36 +223,46 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
         </div>
       </div>
 
-      {/* Long-press manage menu — reuses the shared cursor-positioned primitive. */}
+      {/* Long-press manage sheet — a bottom action sheet with its OWN backdrop
+          above the drawer (z-[60]), so a tap outside the actions dismisses it
+          instead of falling through to the tiles/chips below. */}
       {menu && (
-        <ContextMenu
-          x={menu.x}
-          y={menu.y}
-          onClose={() => setMenu(null)}
-          width={200}
-          itemCount={menu.item.kind === 'showpage' ? 2 : 1}
-        >
-          <ContextMenuItem
-            icon={<PinOff className="size-[15px]" />}
-            label={t('apps.dock.unpin')}
-            danger
-            onClick={() => {
-              void undock(menu.item.id);
-              setMenu(null);
-            }}
+        <div className="fixed inset-0 z-[60]" role="dialog" aria-modal="true">
+          <button
+            type="button"
+            aria-label={t('common.close')}
+            onClick={() => setMenu(null)}
+            className="absolute inset-0 bg-background/70 backdrop-blur-sm"
           />
-          {menu.item.kind === 'showpage' && (
-            <ContextMenuItem
-              icon={<Trash2 className="size-[15px]" />}
-              label={t('library.apps.remove')}
-              danger
+          <div className="absolute inset-x-0 bottom-0 rounded-t-3xl border-t border-border bg-surface px-3 pb-[calc(1rem+env(safe-area-inset-bottom))] pt-2">
+            <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-border" />
+            <div className="truncate px-2 pb-1 text-center text-[12px] font-medium text-muted">{menu.label}</div>
+            <button
+              type="button"
               onClick={() => {
-                if (menu.item.kind === 'showpage') void unpin(menu.item.sessionId);
+                void undock(menu.item.id);
                 setMenu(null);
               }}
-            />
-          )}
-        </ContextMenu>
+              className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-[14px] font-medium text-destructive transition hover:bg-destructive/[0.08]"
+            >
+              <PinOff className="size-[18px] shrink-0" />
+              {t('apps.dock.unpin')}
+            </button>
+            {menu.item.kind === 'showpage' && (
+              <button
+                type="button"
+                onClick={() => {
+                  if (menu.item.kind === 'showpage') void unpin(menu.item.sessionId);
+                  setMenu(null);
+                }}
+                className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-[14px] font-medium text-destructive transition hover:bg-destructive/[0.08]"
+              >
+                <Trash2 className="size-[18px] shrink-0" />
+                {t('library.apps.remove')}
+              </button>
+            )}
+          </div>
+        </div>
       )}
 
       {/* Footer overflow sheet (账号 / 外观 / 更多) — a focused bottom modal above

--- a/ui/src/components/apps/MobileDockDrawer.tsx
+++ b/ui/src/components/apps/MobileDockDrawer.tsx
@@ -1,0 +1,273 @@
+import { useMemo, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { LayoutGrid, MoreHorizontal, PinOff, Settings, Sun, Trash2, UserRound, X } from 'lucide-react';
+
+import { APP_REGISTRY, type AppDefinition, type AppId } from '../../apps/registry';
+import { showPageAvatar } from '../../apps/showPageAvatar';
+import { dockIdToSession, useDock } from '../../context/DockContext';
+import { useAuthAccount } from '../../lib/useAuthAccount';
+import { ContextMenu, ContextMenuItem } from '../ui/context-menu';
+import { MoreAccountSection, MoreAppearanceSection, MoreConnectionSection } from '../workbench/MorePage';
+import { mobileRouteForDockId } from './mobileDock';
+
+// The mobile Dock — a bottom drawer summoned from the Apps tab (§7.1b, Option B).
+// It is the mobile projection of the desktop Dock: the SAME server-side docked
+// tiles in the SAME order (pin anywhere → appears everywhere). One tap opens an
+// app full-screen (built-ins via their /apps/* route, pinned Show Pages via the
+// /apps/show/:sessionId route — no window layer on mobile); a long-press manages
+// the tile (取消固定 for every tile, 移出 additionally for AI pages). The former
+// More-page content compresses into the footer chip row. Mobile-only: the whole
+// surface is `md:hidden` and mounted only in the workbench shell.
+
+type ResidentTile =
+  | { kind: 'builtin'; id: string; def: AppDefinition }
+  | { kind: 'showpage'; id: string; sessionId: string; title: string };
+
+type FooterSheet = 'account' | 'appearance' | 'more';
+
+export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { order, pins, undock, unpin } = useDock();
+  const { email } = useAuthAccount();
+
+  // Long-press context menu (touch) on the shared ContextMenu primitive,
+  // positioned at the press point. Tap opens the app; long-press manages the tile.
+  const [menu, setMenu] = useState<{ x: number; y: number; item: ResidentTile } | null>(null);
+  // Which footer overflow sheet is open (账号 / 外观 / 更多) — one reusable shell.
+  const [sheet, setSheet] = useState<FooterSheet | null>(null);
+
+  // Long-press detection: a press-hold opens the manage menu and suppresses the
+  // click that would otherwise fire on release; a plain tap falls through to click.
+  const timerRef = useRef<number | null>(null);
+  const suppressClickRef = useRef(false);
+  const clearTimer = () => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const pinBySession = useMemo(() => new Map(pins.map((pin) => [pin.session_id, pin])), [pins]);
+
+  // Reset transient sub-surfaces while closed so a reopen starts clean — the
+  // codebase's effect-free "adjust state during render" pattern (cf. LibraryApp's
+  // navKey sync), guarded so it can't loop.
+  if (!open) {
+    if (menu) setMenu(null);
+    if (sheet) setSheet(null);
+    return null;
+  }
+
+  // Resolve a persisted Dock id to a renderable tile: a built-in app (icon +
+  // accent from the registry) or a pinned Show Page (letter avatar). Mirrors the
+  // desktop Dock's resolveItem; an unknown id is dropped.
+  const resolveTile = (id: string): ResidentTile | null => {
+    const sessionId = dockIdToSession(id);
+    if (sessionId !== null) {
+      const title = pinBySession.get(sessionId)?.title_snapshot?.trim() || sessionId;
+      return { kind: 'showpage', id, sessionId, title };
+    }
+    const def = APP_REGISTRY[id as AppId];
+    return def ? { kind: 'builtin', id, def } : null;
+  };
+
+  const openTile = (item: ResidentTile) => {
+    navigate(mobileRouteForDockId(item.id));
+    onClose();
+  };
+
+  const onTilePointerDown = (e: React.PointerEvent, item: ResidentTile) => {
+    const { clientX, clientY } = e;
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      suppressClickRef.current = true;
+      setMenu({ x: clientX, y: clientY, item });
+    }, 480);
+  };
+
+  const onTileClick = (item: ResidentTile) => {
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return; // this click was the release of a long-press that opened the menu
+    }
+    openTile(item);
+  };
+
+  const chipClass =
+    'flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-xl border border-border bg-surface-2/40 px-2.5 py-2.5 text-[12px] font-medium text-muted transition-colors hover:text-foreground active:bg-foreground/[0.05]';
+
+  const sheetTitle: Record<FooterSheet, string> = {
+    account: t('more.account'),
+    appearance: t('more.appearance'),
+    more: t('nav.more'),
+  };
+
+  return (
+    <div className="md:hidden" role="dialog" aria-modal="true" aria-label={t('nav.apps')}>
+      {/* Scrim from the top of the screen down to the tab bar — the tab bar stays
+          visible + tappable below it (tapping Apps again toggles the drawer shut). */}
+      <button
+        type="button"
+        aria-label={t('common.close')}
+        onClick={onClose}
+        className="fixed inset-x-0 top-0 bottom-[calc(4.75rem+env(safe-area-inset-bottom))] z-40 bg-background/70 backdrop-blur-sm"
+      />
+
+      {/* The drawer sheet: sits directly above the bottom tab bar. */}
+      <div className="fixed inset-x-0 bottom-[calc(4.75rem+env(safe-area-inset-bottom))] z-50 max-h-[72dvh] overflow-y-auto rounded-t-3xl border border-border bg-surface px-4 pb-4 pt-2 shadow-[0_-16px_40px_-12px_rgba(0,0,0,0.55)]">
+        {/* Grabber. */}
+        <div className="mx-auto mb-3 h-1 w-10 shrink-0 rounded-full bg-border" />
+
+        {/* Header: title + "synced with desktop Dock" caption. */}
+        <div className="mb-3 flex items-baseline justify-between gap-3">
+          <h2 className="text-[17px] font-bold text-foreground">{t('nav.apps')}</h2>
+          <span className="truncate text-[11.5px] text-muted">{t('apps.dock.syncedCaption')}</span>
+        </div>
+
+        {/* Tile grid — the docked set, in server order. */}
+        {order.length === 0 ? (
+          <button
+            type="button"
+            onClick={() => {
+              navigate('/apps/library');
+              onClose();
+            }}
+            className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border px-3 py-6 text-[12.5px] font-medium text-muted transition-colors hover:border-cyan/60 hover:text-foreground"
+          >
+            <LayoutGrid className="size-4 shrink-0 text-cyan" />
+            <span>{t('apps.dock.emptyHint')}</span>
+          </button>
+        ) : (
+          <div className="grid grid-cols-4 gap-x-2 gap-y-4">
+            {order.map((id) => {
+              const item = resolveTile(id);
+              if (!item) return null;
+              const label = item.kind === 'builtin' ? t(item.def.titleKey) : item.title;
+              const avatar = item.kind === 'showpage' ? showPageAvatar(item.sessionId, item.title) : null;
+              const Icon = item.kind === 'builtin' ? item.def.icon : null;
+              const accentVar = item.kind === 'builtin' ? item.def.accent : avatar!.accentVar;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  aria-label={label}
+                  onClick={() => onTileClick(item)}
+                  onPointerDown={(e) => onTilePointerDown(e, item)}
+                  onPointerUp={clearTimer}
+                  onPointerMove={clearTimer}
+                  onPointerLeave={clearTimer}
+                  onPointerCancel={clearTimer}
+                  onContextMenu={(e) => e.preventDefault()}
+                  style={{ touchAction: 'manipulation' }}
+                  className="flex select-none flex-col items-center gap-1.5"
+                >
+                  <span
+                    className="grid size-14 place-items-center rounded-2xl border text-[20px] font-bold leading-none"
+                    style={{
+                      color: `var(${accentVar})`,
+                      backgroundColor: `color-mix(in srgb, var(${accentVar}) ${item.kind === 'builtin' ? 14 : 16}%, transparent)`,
+                      borderColor: `color-mix(in srgb, var(${accentVar}) ${item.kind === 'builtin' ? 30 : 34}%, transparent)`,
+                    }}
+                  >
+                    {Icon ? <Icon className="size-6" /> : avatar!.letter}
+                  </span>
+                  <span className="max-w-full truncate text-[11px] font-medium text-muted">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Footer chip row — the absorbed More-page content. 设置 navigates; the
+            rest open a small overflow sheet. */}
+        <div className="mt-4 flex items-stretch gap-2 border-t border-border pt-3">
+          <Link to="/admin/dashboard" onClick={onClose} className={chipClass}>
+            <Settings className="size-4 shrink-0" />
+            <span className="truncate">{t('more.controlPanel')}</span>
+          </Link>
+          {email && (
+            <button type="button" onClick={() => setSheet('account')} className={chipClass}>
+              <UserRound className="size-4 shrink-0" />
+              <span className="truncate">{t('more.account')}</span>
+            </button>
+          )}
+          <button type="button" onClick={() => setSheet('appearance')} className={chipClass}>
+            <Sun className="size-4 shrink-0" />
+            <span className="truncate">{t('more.appearance')}</span>
+          </button>
+          <button type="button" onClick={() => setSheet('more')} className={chipClass}>
+            <MoreHorizontal className="size-4 shrink-0" />
+            <span className="truncate">{t('nav.more')}</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Long-press manage menu — reuses the shared cursor-positioned primitive. */}
+      {menu && (
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          onClose={() => setMenu(null)}
+          width={200}
+          itemCount={menu.item.kind === 'showpage' ? 2 : 1}
+        >
+          <ContextMenuItem
+            icon={<PinOff className="size-[15px]" />}
+            label={t('apps.dock.unpin')}
+            danger
+            onClick={() => {
+              void undock(menu.item.id);
+              setMenu(null);
+            }}
+          />
+          {menu.item.kind === 'showpage' && (
+            <ContextMenuItem
+              icon={<Trash2 className="size-[15px]" />}
+              label={t('library.apps.remove')}
+              danger
+              onClick={() => {
+                if (menu.item.kind === 'showpage') void unpin(menu.item.sessionId);
+                setMenu(null);
+              }}
+            />
+          )}
+        </ContextMenu>
+      )}
+
+      {/* Footer overflow sheet (账号 / 外观 / 更多) — a focused bottom modal above
+          the drawer. Backdrop closes only the sheet, returning to the drawer. */}
+      {sheet && (
+        <div className="fixed inset-0 z-[60]" role="dialog" aria-modal="true">
+          <button
+            type="button"
+            aria-label={t('common.close')}
+            onClick={() => setSheet(null)}
+            className="absolute inset-0 bg-background/70 backdrop-blur-sm"
+          />
+          <div className="absolute inset-x-0 bottom-0 max-h-[82dvh] overflow-y-auto rounded-t-3xl border-t border-border bg-surface px-4 pb-[calc(1.25rem+env(safe-area-inset-bottom))] pt-2">
+            <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-border" />
+            <div className="relative flex items-center justify-center py-1">
+              <span className="text-[13px] font-semibold text-foreground">{sheetTitle[sheet]}</span>
+              <button
+                type="button"
+                aria-label={t('common.close')}
+                onClick={() => setSheet(null)}
+                className="absolute right-0 top-0 grid size-8 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+            <div className="pt-2">
+              {sheet === 'account' && <MoreAccountSection />}
+              {sheet === 'appearance' && <MoreAppearanceSection />}
+              {sheet === 'more' && <MoreConnectionSection />}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft, ExternalLink, MonitorX, PinOff } from 'lucide-react';
+
+import { useApi } from '../../context/ApiContext';
+import { useDock } from '../../context/DockContext';
+import { useWindowManager } from '../../context/WindowManagerContext';
+import { showPageAvatar, showPagePrivatePath } from '../../apps/showPageAvatar';
+
+// The `/apps/show/:sessionId` route — a pinned Show Page opened as an app on the
+// current surface. Desktop keeps windows (mirrors LibraryRoute): focus an
+// existing Show Page window for this session, else open one, then hand back to
+// the workbench canvas. Mobile has no window layer, so it renders the page
+// full-screen inside the AppShell chrome, framing the authed /show/<id>/ surface
+// with a back affordance — the same private, same-origin-trusted surface the
+// desktop window uses. Opening only READS: a missing/archived page shows a
+// friendly placeholder, never a dead frame or an auto-created page.
+
+// Reactive desktop (≥ md) check — the same media query the whole shell splits on
+// (App.tsx's LibraryRoute uses the identical private hook).
+function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(min-width: 768px)').matches,
+  );
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia('(min-width: 768px)');
+    const onChange = () => setIsDesktop(mql.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return isDesktop;
+}
+
+export const ShowPageRoute: React.FC = () => {
+  const { sessionId = '' } = useParams();
+  const isDesktop = useIsDesktop();
+  const wm = useWindowManager();
+  const navigate = useNavigate();
+  const handledRef = useRef(false);
+
+  // Desktop: open (or focus) the Show Page window for this session and hand back
+  // to the canvas. Guarded so the effect runs once even as window state ticks.
+  useEffect(() => {
+    if (!isDesktop || handledRef.current || !sessionId) return;
+    handledRef.current = true;
+    const own = wm.windows.filter((w) => w.appId === 'showpage' && w.params?.sessionId === sessionId);
+    const target = own.find((w) => !w.minimized) ?? own[0];
+    if (target) {
+      if (target.minimized) wm.restore(target.id);
+      else wm.focus(target.id);
+    } else {
+      wm.openApp('showpage', { params: { sessionId } });
+    }
+    navigate('/', { replace: true });
+  }, [isDesktop, sessionId, wm, navigate]);
+
+  if (isDesktop) return null; // transient: the effect hands back to the workbench canvas
+  return <MobileShowPage sessionId={sessionId} />;
+};
+
+// Full-screen mobile body: a back-affordance header over the framed Show Page.
+// Sized like the mobile Library route so it fits within the AppShell header +
+// bottom-nav chrome (100dvh − header − tab bar).
+const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
+  const { t } = useTranslation();
+  const api = useApi();
+  const navigate = useNavigate();
+  const { unpin } = useDock();
+
+  const [state, setState] = useState<'loading' | 'ready' | 'missing'>(sessionId ? 'loading' : 'missing');
+  const [title, setTitle] = useState('');
+
+  // Read the session once (error-suppressed — a gone session must NOT toast) to
+  // upgrade the header to the LIVE title and to detect missing/archived, exactly
+  // like the desktop Show Page window body.
+  useEffect(() => {
+    if (!sessionId) return;
+    let cancelled = false;
+    api
+      .getSession(sessionId, { cache: true, handleError: false })
+      .then((session) => {
+        if (cancelled) return;
+        if (!session || typeof session.id !== 'string' || session.status === 'archived') {
+          setState('missing');
+          return;
+        }
+        setState('ready');
+        const live = (session.title ?? '').trim();
+        if (live) setTitle(live);
+      })
+      .catch(() => {
+        if (!cancelled) setState('missing');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, api]);
+
+  const avatar = sessionId ? showPageAvatar(sessionId, title) : null;
+  const label = title || t('apps.showPage.label');
+  const missing = !sessionId || state === 'missing';
+
+  return (
+    <div className="flex h-[calc(100dvh-9.5rem)] min-h-[420px] flex-col overflow-hidden rounded-xl border border-border bg-surface">
+      <header className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-2">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          aria-label={t('common.back')}
+          className="grid size-9 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+        >
+          <ArrowLeft className="size-[18px]" />
+        </button>
+        {avatar && (
+          <span
+            aria-hidden
+            className="grid size-7 shrink-0 place-items-center rounded-lg border text-[13px] font-bold leading-none"
+            style={{
+              color: `var(${avatar.accentVar})`,
+              backgroundColor: `color-mix(in srgb, var(${avatar.accentVar}) 16%, transparent)`,
+              borderColor: `color-mix(in srgb, var(${avatar.accentVar}) 34%, transparent)`,
+            }}
+          >
+            {avatar.letter}
+          </span>
+        )}
+        <span className="min-w-0 flex-1 truncate text-[14px] font-semibold text-foreground">{label}</span>
+        {state === 'ready' && (
+          <a
+            href={showPagePrivatePath(sessionId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={t('apps.window.openInNewTab')}
+            title={t('apps.window.openInNewTab')}
+            className="grid size-9 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+          >
+            <ExternalLink className="size-[17px]" />
+          </a>
+        )}
+      </header>
+
+      {missing ? (
+        <div className="grid flex-1 place-items-center px-6 text-center">
+          <div className="flex max-w-[320px] flex-col items-center gap-3">
+            <span className="grid size-12 place-items-center rounded-2xl border border-border bg-foreground/[0.03] text-muted">
+              <MonitorX className="size-6" />
+            </span>
+            <div className="space-y-1">
+              <div className="text-[14px] font-semibold text-foreground">{t('apps.showPage.missingTitle')}</div>
+              <p className="text-[12.5px] leading-relaxed text-muted">{t('apps.showPage.missingBody')}</p>
+            </div>
+            {sessionId && (
+              <button
+                type="button"
+                onClick={() => {
+                  void unpin(sessionId);
+                  navigate(-1);
+                }}
+                className="mt-1 inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-[12.5px] font-medium text-foreground transition hover:bg-foreground/[0.05]"
+              >
+                <PinOff className="size-3.5" />
+                {t('apps.showPage.unpin')}
+              </button>
+            )}
+          </div>
+        </div>
+      ) : (
+        // Sandbox copied verbatim from the desktop Show Page window / ChatPage: the
+        // workbench Show Page frame is intentionally same-origin-trusted — not hardened.
+        <iframe
+          title={t('chat.showPage.title')}
+          src={showPagePrivatePath(sessionId)}
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
+          allow="clipboard-write"
+          className="min-h-0 w-full flex-1 border-0 bg-background"
+        />
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -60,7 +60,10 @@ export const ShowPageRoute: React.FC = () => {
   }, [isDesktop, sessionId, wm, navigate]);
 
   if (isDesktop) return null; // transient: the effect hands back to the workbench canvas
-  return <MobileShowPage sessionId={sessionId} />;
+  // Key by sessionId: React Router keeps this route element mounted across param
+  // changes, so remount on a new session to reset loading state + title — a fresh
+  // fetch with no stale title or missing/archived frame from the previous page.
+  return <MobileShowPage key={sessionId} sessionId={sessionId} />;
 };
 
 // Full-screen mobile body: a back-affordance header over the framed Show Page.

--- a/ui/src/components/apps/mobileDock.test.ts
+++ b/ui/src/components/apps/mobileDock.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { showDockId } from '../../context/DockContext';
+import { mobileRouteForDockId, showAppRoutePath } from './mobileDock';
+
+describe('showAppRoutePath', () => {
+  it('builds the full-screen Show Page route', () => {
+    expect(showAppRoutePath('abc123')).toBe('/apps/show/abc123');
+  });
+
+  it('URL-encodes ids with slashes and spaces', () => {
+    expect(showAppRoutePath('a b/c')).toBe('/apps/show/a%20b%2Fc');
+  });
+});
+
+describe('mobileRouteForDockId', () => {
+  it('maps every built-in id to its /apps route', () => {
+    expect(mobileRouteForDockId('files')).toBe('/apps/files');
+    expect(mobileRouteForDockId('terminal')).toBe('/apps/terminal');
+    expect(mobileRouteForDockId('editor')).toBe('/apps/editor');
+    expect(mobileRouteForDockId('library')).toBe('/apps/library');
+  });
+
+  it('maps a show:<id> pin to the full-screen Show Page route', () => {
+    expect(mobileRouteForDockId(showDockId('sess42'))).toBe('/apps/show/sess42');
+  });
+
+  it('encodes the session id embedded in a pin dock id', () => {
+    expect(mobileRouteForDockId(showDockId('s/p ace'))).toBe('/apps/show/s%2Fp%20ace');
+  });
+});

--- a/ui/src/components/apps/mobileDock.ts
+++ b/ui/src/components/apps/mobileDock.ts
@@ -1,0 +1,29 @@
+// Pure route helpers for the mobile Dock drawer + the mobile Show Page surface.
+// Kept free of React/DOM so the id → route mapping is unit-testable in isolation
+// (the drawer component and the Library open-path both consume these). On mobile
+// there is no window layer, so every Dock tile opens as a full-screen `/apps/*`
+// route instead of a workbench window (§7.1b).
+
+import { dockIdToSession } from '../../context/DockContext';
+
+/**
+ * The in-shell route that frames a pinned Show Page full-screen on mobile
+ * (`/apps/show/:sessionId`). This is the mobile counterpart to the desktop
+ * Show Page window; the Dock drawer and the Library AI rows navigate here
+ * instead of opening the raw `/show/` surface in a new tab. Pure.
+ */
+export function showAppRoutePath(sessionId: string): string {
+  return `/apps/show/${encodeURIComponent(sessionId)}`;
+}
+
+/**
+ * The full-screen route a Dock tile opens on mobile. A built-in id maps to its
+ * `/apps/<id>` route (files / terminal / editor / library — the routes declared
+ * in App.tsx); a `show:<session_id>` pin maps to the full-screen Show Page
+ * route. Mirrors the desktop Dock's per-kind open behavior, minus the window
+ * layer. Pure — no DOM, unit-testable.
+ */
+export function mobileRouteForDockId(dockId: string): string {
+  const sessionId = dockIdToSession(dockId);
+  return sessionId !== null ? showAppRoutePath(sessionId) : `/apps/${dockId}`;
+}

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowRight, CodeXml, FolderTree, LayoutGrid, Link as LinkIcon, LogOut, SlidersHorizontal, SquareTerminal } from 'lucide-react';
+import { Link as LinkIcon, LogOut } from 'lucide-react';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
@@ -11,39 +10,87 @@ import { LanguageSwitcher } from '../LanguageSwitcher';
 import { ThemeToggle } from '../ThemeToggle';
 import { VersionBadge } from '../VersionBadge';
 
-// Mobile-only "More" tab (workbench). The bridge to the Control Panel plus
-// appearance / connection / account. Per product decision the service
-// start/stop control lives ONLY in the Control Panel, so this screen shows a
-// read-only status line. Design: design.pen `Nxnja`.
-export const MorePage: React.FC = () => {
+// The former mobile "More" page has been absorbed into the mobile Dock drawer
+// (§7.1b): its Apps list is now the drawer's tile grid, its Control Panel bridge
+// is the drawer's 设置 chip, and the remaining bits — appearance, account, and the
+// read-only connection/status — are these three reusable sections, surfaced from
+// the drawer footer chips. Extracting them keeps the capability intact while the
+// `/more` route retires (redirects home). No standalone page component remains.
+
+/** Appearance controls (theme + language). The drawer's 外观 chip. */
+export const MoreAppearanceSection: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-xl border border-border bg-surface">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <span className="flex-1 text-sm font-medium">{t('more.appearance')}</span>
+        <ThemeToggle />
+        <LanguageSwitcher openUpward />
+      </div>
+    </div>
+  );
+};
+
+/** Signed-in account + sign out. Renders null when this isn't a remote,
+ *  authenticated session (local setups have no account). The drawer's 账号 chip. */
+export const MoreAccountSection: React.FC = () => {
+  const { t } = useTranslation();
+  const { email, signingOut, signOut } = useAuthAccount();
+
+  if (!email) return null;
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <span className="grid size-9 shrink-0 place-items-center rounded-full border border-cyan/35 bg-cyan/[0.08] text-[13px] font-semibold text-cyan">
+          {(email.split('@')[0]?.[0] ?? '?').toUpperCase()}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-muted">{t('appShell.signedInAs')}</div>
+          <div className="truncate text-sm font-medium">{email}</div>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={signOut}
+        disabled={signingOut}
+        className="flex w-full items-center gap-2 border-t border-border px-4 py-3 text-left text-sm font-medium text-destructive transition hover:bg-destructive/[0.06] disabled:opacity-60"
+      >
+        <LogOut className="size-4" />
+        {signingOut ? t('appShell.signingOut') : t('appShell.signOut')}
+      </button>
+    </div>
+  );
+};
+
+/** Read-only service status + version, plus the host address. The drawer's 更多
+ *  overflow — everything that didn't earn its own chip. */
+export const MoreConnectionSection: React.FC = () => {
   const { t } = useTranslation();
   const { status } = useStatus();
   const api = useApi();
-  const { email, signingOut, signOut } = useAuthAccount();
-  const [config, setConfig] = useState<any>(null);
+  const [config, setConfig] = useState<{ runtime?: { hostname?: string } } | null>(null);
 
   useEffect(() => {
     api.getConfig().then(setConfig).catch(() => {});
   }, [api]);
 
   const isRunning = status.state === 'running';
-  const hostname = config?.runtime?.hostname as string | undefined;
+  const hostname = config?.runtime?.hostname;
 
   return (
-    <div className="mx-auto flex max-w-xl flex-col gap-4">
-      <h1 className="text-xl font-bold">{t('more.title')}</h1>
-
+    <div className="flex flex-col gap-3">
       {/* Read-only service status — control lives in the Control Panel. */}
       <div
         className={clsx(
           'flex items-center gap-2.5 rounded-xl border px-4 py-3.5',
-          isRunning ? 'border-mint/30 bg-mint/[0.08]' : 'border-border bg-surface'
+          isRunning ? 'border-mint/30 bg-mint/[0.08]' : 'border-border bg-surface',
         )}
       >
         <span
           className={clsx(
             'size-2.5 shrink-0 rounded-full',
-            isRunning ? 'bg-mint shadow-[0_0_9px_rgba(91,255,160,0.9)]' : 'bg-muted'
+            isRunning ? 'bg-mint shadow-[0_0_9px_rgba(91,255,160,0.9)]' : 'bg-muted',
           )}
         />
         <span className="flex-1 text-sm font-semibold">
@@ -51,118 +98,6 @@ export const MorePage: React.FC = () => {
         </span>
         <VersionBadge />
       </div>
-
-      {/* Bridge to the Control Panel (admin shell). */}
-      <Link
-        to="/admin/dashboard"
-        className="flex items-center gap-3 rounded-xl border border-cyan/35 bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
-      >
-        <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-cyan/[0.14]">
-          <SlidersHorizontal className="size-[18px] text-cyan" />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-[15px] font-semibold">{t('more.controlPanel')}</span>
-          <span className="block truncate text-[11.5px] text-muted">{t('more.controlPanelDesc')}</span>
-        </span>
-        <ArrowRight className="size-[18px] shrink-0 text-cyan" />
-      </Link>
-
-      {/* Apps — the desktop sidebar's Apps launcher, surfaced for mobile where
-          there is no sidebar. */}
-      <div className="flex flex-col gap-2">
-        <div className="px-1 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-muted">
-          {t('apps.title')}
-        </div>
-        <Link
-          to="/apps/files"
-          className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
-        >
-          <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-mint/[0.12]">
-            <FolderTree className="size-[18px] text-mint" />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="block text-[15px] font-semibold">{t('apps.fileBrowser.label')}</span>
-            <span className="block truncate text-[11.5px] text-muted">{t('apps.fileBrowser.desc')}</span>
-          </span>
-          <ArrowRight className="size-[18px] shrink-0 text-muted" />
-        </Link>
-        <Link
-          to="/apps/terminal"
-          className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
-        >
-          <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-foreground/[0.05]">
-            <SquareTerminal className="size-[18px] text-foreground" />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="block text-[15px] font-semibold">{t('apps.terminal.label')}</span>
-            <span className="block truncate text-[11.5px] text-muted">{t('apps.terminal.desc')}</span>
-          </span>
-          <ArrowRight className="size-[18px] shrink-0 text-muted" />
-        </Link>
-        <Link
-          to="/apps/editor"
-          className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
-        >
-          <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-violet/[0.12]">
-            <CodeXml className="size-[18px] text-violet" />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="block text-[15px] font-semibold">{t('apps.editor.label')}</span>
-            <span className="block truncate text-[11.5px] text-muted">{t('apps.editor.desc')}</span>
-          </span>
-          <ArrowRight className="size-[18px] shrink-0 text-muted" />
-        </Link>
-        {/* App Library — the mobile entry to apps + the Show Pages inventory
-            (there is no Dock on mobile, and the control-panel Show Pages entry
-            was retired), so phone users keep a discoverable path. */}
-        <Link
-          to="/apps/library"
-          className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3.5 transition hover:bg-foreground/[0.04]"
-        >
-          <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-gold/[0.12]">
-            <LayoutGrid className="size-[18px] text-gold" />
-          </span>
-          <span className="min-w-0 flex-1">
-            <span className="block text-[15px] font-semibold">{t('library.title')}</span>
-            <span className="block truncate text-[11.5px] text-muted">{t('library.desc')}</span>
-          </span>
-          <ArrowRight className="size-[18px] shrink-0 text-muted" />
-        </Link>
-      </div>
-
-      {/* Appearance — reuse the existing toggles as touch rows. */}
-      <div className="rounded-xl border border-border bg-surface">
-        <div className="flex items-center gap-3 px-4 py-3">
-          <span className="flex-1 text-sm font-medium">{t('more.appearance')}</span>
-          <ThemeToggle />
-          <LanguageSwitcher />
-        </div>
-      </div>
-
-      {/* Account — moved here from the mobile header. Only shown for an
-          authenticated remote session (local setups have no sign-out). */}
-      {email && (
-        <div className="overflow-hidden rounded-xl border border-border bg-surface">
-          <div className="flex items-center gap-3 px-4 py-3">
-            <span className="grid size-9 shrink-0 place-items-center rounded-full border border-cyan/35 bg-cyan/[0.08] text-[13px] font-semibold text-cyan">
-              {(email.split('@')[0]?.[0] ?? '?').toUpperCase()}
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-muted">{t('appShell.signedInAs')}</div>
-              <div className="truncate text-sm font-medium">{email}</div>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={signOut}
-            disabled={signingOut}
-            className="flex w-full items-center gap-2 border-t border-border px-4 py-3 text-left text-sm font-medium text-destructive transition hover:bg-destructive/[0.06] disabled:opacity-60"
-          >
-            <LogOut className="size-4" />
-            {signingOut ? t('appShell.signingOut') : t('appShell.signOut')}
-          </button>
-        </div>
-      )}
 
       {/* Connection — host only. The version badge already lives in the status
           card above, so a second version row here would be redundant. */}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -115,6 +115,7 @@
     "projects": "Projects",
     "capabilities": "Capabilities",
     "more": "More",
+    "apps": "Apps",
     "workbench": "Workbench"
   },
   "more": {
@@ -122,6 +123,7 @@
     "controlPanel": "Settings",
     "controlPanelDesc": "Dashboard · Remote Access · Messaging Platforms · Backends · Advanced Settings",
     "appearance": "Appearance",
+    "account": "Account",
     "connection": "Connection",
     "host": "Local address"
   },
@@ -734,6 +736,7 @@
       "showAllWindows": "Show All Windows",
       "openInNewTab": "Open in New Tab",
       "unpin": "Unpin from Dock",
+      "syncedCaption": "Synced with desktop Dock",
       "emptyHint": "Dock is empty · Open App Library"
     },
     "launcher": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -115,6 +115,7 @@
     "projects": "项目",
     "capabilities": "能力",
     "more": "更多",
+    "apps": "Apps",
     "workbench": "工作台"
   },
   "more": {
@@ -122,6 +123,7 @@
     "controlPanel": "设置",
     "controlPanelDesc": "控制台 · 远程访问 · 通讯平台 · 后端 · 高级设置",
     "appearance": "外观",
+    "account": "账号",
     "connection": "连接",
     "host": "本机地址"
   },
@@ -734,6 +736,7 @@
       "showAllWindows": "显示所有窗口",
       "openInNewTab": "在新标签页打开",
       "unpin": "从 Dock 取消固定",
+      "syncedCaption": "与桌面 Dock 同步",
       "emptyHint": "Dock 为空 · 打开应用库"
     },
     "launcher": {


### PR DESCRIPTION
## Capability

Ships spec **§7.1b (Mobile Dock, Option B)**: the workbench mobile **更多 tab becomes an Apps tab** (`grid-2x2`) that toggles a **bottom Dock drawer** — the mobile projection of the desktop Dock. Same server-side docked tiles, same order (pin anywhere → appears everywhere). Desktop is untouched.

## What shipped (mobile `< md` only)

- **Apps tab + Dock drawer** (`ui/src/components/apps/MobileDockDrawer.tsx`): grabber, "Apps" title + "与桌面 Dock 同步" caption, a tile grid rendered from `DockContext.order` (built-ins by icon/accent, docked AI pages as letter avatars — same anatomy as the desktop Dock). **Tap** a tile → open; **long-press** → context actions (`取消固定` for every tile; AI pages also `移出`) via the shared `ContextMenu` primitive. Empty Dock → the `打开应用库` hint (parity with the desktop popover).
- **Full-screen Show Page route** `/apps/show/:sessionId` (`ShowPageRoute.tsx`): mobile frames the authed `/show/<id>/` surface (sandbox copied verbatim from the desktop window / ChatPage) with a back affordance + missing/archived placeholder; desktop opens/focuses a Show Page **window** and hands back to the canvas (mirrors `LibraryRoute`). All mobile Show Page entry points — the drawer **and** the Library AI rows — now use this route, replacing Phase 2.1's interim "open in new tab".
- **More-page content absorbed** into the drawer footer chip row: **设置** (Control Panel) · **账号** (signed-in + sign out) · **外观** (theme + language) · **更多…** (service status + version + host). `MorePage.tsx` refactored into three reusable sections; the `/more` route redirects home. No capability lost vs. the old MorePage (audited item-by-item).
- **i18n** en+zh for all new copy (`nav.apps`, `apps.dock.syncedCaption`, `more.account`); everything else reuses existing keys.

## Evidence layers

- **Unit**: `ui/src/components/apps/mobileDock.test.ts` — pure route mapping (`showAppRoutePath`, `mobileRouteForDockId`: built-in → `/apps/<id>`, pin → `/apps/show/<id>`, URL-encoding). Full suite green: **223 passed / 23 files**.
- **Build**: `cd ui && npm run build` (`tsc -b && vite build`) clean; lockfile untouched.
- **Contract / scenario**: no backend change (reuses `/api/dock` + `DockContext`, unchanged); no scenario catalog covers the mobile apps surface.
- **Residual manual checks (deferred to the orchestrator's regression pass — real phone-width walkthrough)**: Apps tab toggles the drawer (not a route); tile tap opens built-ins + AI pages full-screen; long-press manage (取消固定 / 移出); empty-Dock hint; footer chips (设置/账号/外观/更多) preserve every MorePage capability; back affordance + missing-page placeholder on the Show Page route; Library AI-row open on mobile routes in-shell instead of a new tab.

## Scope

Desktop Dock / `AppWindow` / `registry` internals untouched (only the mobile open target in `LibraryApp`'s `useOpenApp` was swapped). Coordinated with the parallel **§7.1d** lane (⌘K search + keyboard chords + AI-row rename) — only trivial i18n adjacency is expected; whoever lands second rebases.
