### PR TITLE
feat(apps): Library polish — ShowPage tab, AI badges, list reorder, minus icons

### DIFF
--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -317,6 +317,33 @@ shows an App Library shortcut hint (never a dead surface).
    the pins list ordered later if full-order is wanted.
 3. **移出 icon**: trash → **minus** (trash reads as delete); applied to every
    移出 affordance in the Library (Apps view + ShowPage view button state).
+4. **(owner 13:35) Dock drag-vs-click**: releasing a tile after a drag that
+   moved beyond a threshold must NOT trigger click-open; genuine clicks
+   still open. Same discrimination anywhere whole-element drag coexists
+   with click-open.
+5. **(owner 13:38) ShowPage-tab open trigger**: click-to-open is limited to
+   the title+icon cluster (with a hover affordance), NOT the whole row —
+   whole-row click conflicts with expand. The Apps tab keeps whole-row
+   open (no expand panel there).
+
+### 7.1f Phase 2.3 — app icons sync from the page's HTML icon (owner 2026-07-14 13:36)
+
+- AI-page app icons (Dock tile, mobile drawer, Library rows, window
+  title-bar, search rows) prefer the **page's own HTML icon** (`<link
+  rel="icon">` in the workspace `index.html`), falling back to the letter
+  avatar when the page has none or only the stock scaffold icon (e.g.
+  vite.svg — a generic default is worse than the letter avatar).
+- Implementation shape: **server extracts, browser fetches** — the
+  show-pages payload gains an `icon_path` field: the server reads ONLY the
+  session workspace's `index.html` and extracts the icon href as a path
+  RELATIVE to `/show/<sid>/` (it never fetches the icon itself; the browser
+  loads it through the existing gated serving path, so all fs-gate/auth
+  rules keep applying). No new endpoints.
+- UI adoption via the single avatar chokepoint (`showPageAvatarTile` /
+  avatar helper): icon URL prop with letter-avatar fallback and onerror
+  fallback — every surface inherits.
+- Freshness: rides the existing inventory refresh cycles; no push channel.
+- Sequenced AFTER Phase 2.2 (file overlap on Dock/Library surfaces).
 
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 

--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -294,6 +294,29 @@ shows an App Library shortcut hint (never a dead surface).
   title everywhere; `title_snapshot` remains a fallback only. Built-ins not
   renamable. (Idea 1 — agent-suggested pinning — deliberately deferred;
   idea 2 — update dots — not scheduled yet.)
+- **Inventory lifecycle closure (review-driven, 2026-07-14)**: the
+  show-pages inventory hook guarantees that any revision-invalidated
+  in-flight fetch schedules an authoritative follow-up (no dangling
+  loading/loaded states — state-based invariant, unit-tested); rename merges
+  are compare-and-set; window titles project from the single inventory
+  source. A **shared inventory context** was evaluated and deferred by the
+  rule of three — revisit when a third consumer of the inventory appears
+  (e.g. update-dots or agent-suggested pinning).
+
+### 7.1e Phase 2.2 polish (owner hands-on feedback, 2026-07-14 13:32)
+
+1. **Tab naming settled**: the Library's second tab is **"ShowPage"** (en+zh,
+   keeps the count) — reverses the 7.1c "AI" tab rename. The **kind badge**
+   on rows is what says **"AI"** now (replaces 展示页面/Show Page badge), and
+   the badge is **right-aligned** in the row.
+2. **Apps view drag-reorder**: rows get a **grip handle at the row front**;
+   dragging reorders and **syncs with the Dock order** (existing
+   `PUT /api/dock/order`, optimistic + stale_order resync). PM default
+   (flag to owner): only DOCKED rows carry handles — installed-but-undocked
+   rows are not part of the Dock order and sort below the docked group; make
+   the pins list ordered later if full-order is wanted.
+3. **移出 icon**: trash → **minus** (trash reads as delete); applied to every
+   移出 affordance in the Library (Apps view + ShowPage view button state).
 
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useMemo, useState } from 'react';
-import { Pin, PinOff, Trash2 } from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Reorder, useDragControls } from 'framer-motion';
+import { GripVertical, Minus, Pin, PinOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 
 import { APP_LIST, APP_REGISTRY, type AppDefinition, type AppId } from './registry';
-import { deriveAppRows, type AppRow } from './appLibrary';
+import { deriveAppRows, partitionByDock, type AppRow } from './appLibrary';
 import { ShowPageAvatarTile } from './showPageAvatarTile';
 import { showAppRoutePath } from '../components/apps/mobileDock';
 import { useDock } from '../context/DockContext';
@@ -137,15 +138,171 @@ interface ResolvedRow {
   def?: AppDefinition;
 }
 
-// Apps view: the INSTALLED set (built-ins + pinned Show Pages), in canonical
-// order. Every row opens the app on click and carries a state-aware Dock toggle
-// (固定到 Dock ↔ 取消固定) that never removes it from the list; Show Page rows add a
-// 移出 that uninstalls the app (the page itself is untouched). Built-ins have no
-// 移出 and no lock — they simply can't leave the list.
+// A drag handle for a docked row (§7.1e). Handle-only drag: the Reorder.Item is
+// `dragListener={false}`, so a drag starts ONLY from this grip — a plain click
+// on the row still opens the app. `touch-none` stops a touch-drag from being
+// stolen by the scroll container.
+const GripHandle: React.FC<{ controls: ReturnType<typeof useDragControls> }> = ({ controls }) => {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      aria-label={t('library.apps.reorder')}
+      title={t('library.apps.reorder')}
+      onPointerDown={(e) => {
+        e.stopPropagation();
+        controls.start(e);
+      }}
+      onClick={(e) => e.stopPropagation()}
+      className="grid size-6 shrink-0 cursor-grab touch-none place-items-center rounded-md text-muted/50 transition-colors hover:text-foreground active:cursor-grabbing"
+    >
+      <GripVertical size={15} />
+    </button>
+  );
+};
+
+interface AppLibraryRowProps {
+  item: ResolvedRow;
+  /** Leading slot: a drag handle for docked rows in reorder mode, or a matching
+   *  spacer for undocked rows so both groups keep one aligned icon column. */
+  leading?: React.ReactNode;
+  /** The last row overall carries no bottom divider (single-list look). */
+  last?: boolean;
+  onOpen: () => void;
+  onDockToggle: () => void;
+  onRemove?: () => void;
+}
+
+// One Apps-view row: icon/avatar, then the info area (name + subtitle) as the
+// flex-1 column so the kind badge is right-aligned at the info area's right edge,
+// before the action controls (§7.1e); then the kind badge, a state-aware Dock
+// toggle (row stays listed either way), and — AI rows only — a 移出 (uninstall;
+// the page itself is untouched). Shared by the reorder path (wrapped in a
+// Reorder.Item) and the search path (static).
+const AppLibraryRow: React.FC<AppLibraryRowProps> = ({ item, leading, last, onOpen, onDockToggle, onRemove }) => {
+  const { t } = useTranslation();
+  const { row, name, subtitle, def } = item;
+  const Icon = def?.icon;
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className={clsx(
+        'flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-foreground/[0.02] sm:gap-4 sm:px-5',
+        !last && 'border-b border-border',
+      )}
+    >
+      {leading}
+      {def && Icon ? (
+        <span
+          className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border"
+          style={{ color: `var(${def.accent})`, backgroundColor: `color-mix(in srgb, var(${def.accent}) 14%, transparent)` }}
+        >
+          <Icon className="size-[18px]" />
+        </span>
+      ) : (
+        <ShowPageAvatarTile sessionId={row.sessionId ?? ''} title={name} />
+      )}
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-[13px] font-semibold text-foreground">{name}</span>
+        {subtitle ? <span className="truncate font-mono text-[11px] text-muted">{subtitle}</span> : null}
+      </span>
+      {/* Kind badge — right-aligned at the info area's right edge (§7.1e); the AI
+          badge replaces the former Show Page badge. */}
+      {row.kind === 'builtin' ? (
+        <Badge variant="outline" className="hidden font-mono text-[10px] uppercase tracking-wide sm:inline-flex">
+          {t('library.kind.builtin')}
+        </Badge>
+      ) : (
+        <Badge variant="success" className="hidden sm:inline-flex">
+          {t('library.kind.showPage')}
+        </Badge>
+      )}
+      {/* State-aware Dock toggle — the row stays in the list either way. */}
+      <Button
+        type="button"
+        variant={row.docked ? 'secondary' : 'outline'}
+        size="xs"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDockToggle();
+        }}
+      >
+        {row.docked ? <PinOff /> : <Pin />}
+        <span className="hidden sm:inline">{row.docked ? t('library.apps.undock') : t('library.apps.dock')}</span>
+      </Button>
+      {/* 移出 — uninstall (AI rows only; the page itself is untouched). A minus,
+          not a trash: this removes the app from the list, it is not a delete. */}
+      {row.kind === 'showpage' && onRemove ? (
+        <button
+          type="button"
+          title={t('library.apps.remove')}
+          aria-label={t('library.apps.remove')}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-destructive/10 hover:text-destructive"
+        >
+          <Minus size={15} />
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+// A docked row wrapped for drag-reorder: the Reorder.Item is handle-only
+// (`dragListener={false}` + this row's own dragControls, started from the grip),
+// so dragging reorders the docked group while a plain click still opens the app.
+// The dockId is the Reorder value, so the group's order IS the Dock order.
+const DockedReorderRow: React.FC<{
+  item: ResolvedRow;
+  last?: boolean;
+  onOpen: () => void;
+  onDockToggle: () => void;
+  onRemove?: () => void;
+  onCommit: () => void;
+}> = ({ item, last, onOpen, onDockToggle, onRemove, onCommit }) => {
+  const controls = useDragControls();
+  return (
+    <Reorder.Item value={item.row.dockId} as="div" dragListener={false} dragControls={controls} onDragEnd={onCommit}>
+      <AppLibraryRow
+        item={item}
+        last={last}
+        leading={<GripHandle controls={controls} />}
+        onOpen={onOpen}
+        onDockToggle={onDockToggle}
+        onRemove={onRemove}
+      />
+    </Reorder.Item>
+  );
+};
+
+// Apps view: the INSTALLED set (built-ins + installed Show Pages). Rows split
+// into the DOCKED group — drag-reorderable via a front grip handle, its order
+// persisted straight through the Dock's `setOrder` (PUT /api/dock/order,
+// optimistic + stale_order resync) — and the installed-but-undocked group below
+// (no handle, stable order). Every row opens the app on click and carries a
+// state-aware Dock toggle (固定到 Dock ↔ 取消固定) that never removes it from the
+// list; AI rows add a 移出 that uninstalls the app (the page itself is untouched).
+// Searching disables reorder (a filtered subset can't safely rewrite the whole
+// Dock order) and falls back to a flat static list.
 const AppsView: React.FC<{ pages: ShowPage[]; openApp: ReturnType<typeof useOpenApp> }> = ({ pages, openApp }) => {
   const { t } = useTranslation();
-  const { order, pins, dock, undock, unpin } = useDock();
+  const { order, pins, dock, undock, unpin, setOrder } = useDock();
   const [query, setQuery] = useState('');
+
+  // Local, drag-mutable copy of the docked order; framer's Reorder mutates it
+  // live during a drag, and we persist on drop — same pattern as Dock.tsx.
+  const [dragOrder, setDragOrder] = useState<string[] | null>(null);
+  const dragRef = useRef<string[] | null>(null);
 
   const pinBySession = useMemo(() => new Map(pins.map((p) => [p.session_id, p])), [pins]);
   const pageBySession = useMemo(() => new Map(pages.map((p) => [p.session_id, p])), [pages]);
@@ -170,11 +327,33 @@ const AppsView: React.FC<{ pages: ShowPage[]; openApp: ReturnType<typeof useOpen
       }),
     [rows, pageBySession, pinBySession, t],
   );
+  const resolvedById = useMemo(() => new Map(resolved.map((item) => [item.row.dockId, item])), [resolved]);
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return q ? resolved.filter((item) => item.name.toLowerCase().includes(q)) : resolved;
-  }, [resolved, query]);
+  const { docked, undocked } = useMemo(() => partitionByDock(rows, order), [rows, order]);
+  const dockedIds = useMemo(() => docked.map((r) => r.dockId), [docked]);
+
+  const q = query.trim().toLowerCase();
+  const searching = q.length > 0;
+  const searchResults = useMemo(
+    () => (searching ? resolved.filter((item) => item.name.toLowerCase().includes(q)) : []),
+    [resolved, searching, q],
+  );
+
+  // framer's Reorder mutates this local order live; persist on drop. Because the
+  // docked group's values ARE the Dock order, `next` is the full new order.
+  const localOrder = dragOrder ?? dockedIds;
+  const reorder = (next: string[]) => {
+    dragRef.current = next;
+    setDragOrder(next);
+  };
+  const commitOrder = () => {
+    const next = dragRef.current;
+    dragRef.current = null;
+    setDragOrder(null);
+    // No-op an unchanged reorder (a stray drag-end on a plain click).
+    if (!next || (next.length === dockedIds.length && next.every((id, i) => id === dockedIds[i]))) return;
+    void setOrder(next);
+  };
 
   const openRow = (row: AppRow) =>
     row.kind === 'builtin'
@@ -183,6 +362,16 @@ const AppsView: React.FC<{ pages: ShowPage[]; openApp: ReturnType<typeof useOpen
           sessionId: row.sessionId ?? '',
           title: pageBySession.get(row.sessionId ?? '')?.title ?? undefined,
         });
+  const handlers = (item: ResolvedRow) => ({
+    onOpen: () => openRow(item.row),
+    onDockToggle: () => void (item.row.docked ? undock(item.row.dockId) : dock(item.row.dockId)),
+    onRemove: item.row.kind === 'showpage' && item.row.sessionId ? () => void unpin(item.row.sessionId!) : undefined,
+  });
+
+  // The last row overall (search list, else undocked tail, else docked tail).
+  const lastDockId = searching
+    ? searchResults.at(-1)?.row.dockId
+    : (undocked.at(-1)?.dockId ?? localOrder.at(-1));
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -195,81 +384,49 @@ const AppsView: React.FC<{ pages: ShowPage[]; openApp: ReturnType<typeof useOpen
         />
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {filtered.length === 0 ? (
-          <div className="m-4 rounded-xl border border-dashed border-border bg-surface-3/60 p-8 text-center text-[13px] text-muted">
-            {t('library.apps.empty')}
-          </div>
+        {searching ? (
+          searchResults.length === 0 ? (
+            <div className="m-4 rounded-xl border border-dashed border-border bg-surface-3/60 p-8 text-center text-[13px] text-muted">
+              {t('library.apps.empty')}
+            </div>
+          ) : (
+            searchResults.map((item) => (
+              <AppLibraryRow key={item.row.dockId} item={item} last={item.row.dockId === lastDockId} {...handlers(item)} />
+            ))
+          )
         ) : (
-          filtered.map(({ row, name, subtitle, def }) => {
-            const Icon = def?.icon;
-            return (
-              <div
-                key={row.dockId}
-                role="button"
-                tabIndex={0}
-                onClick={() => openRow(row)}
-                onKeyDown={(e) => {
-                  if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
-                    e.preventDefault();
-                    openRow(row);
-                  }
-                }}
-                className="flex w-full cursor-pointer items-center gap-3 border-b border-border px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-foreground/[0.02] sm:gap-4 sm:px-5"
-              >
-                {def && Icon ? (
-                  <span
-                    className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border"
-                    style={{ color: `var(${def.accent})`, backgroundColor: `color-mix(in srgb, var(${def.accent}) 14%, transparent)` }}
-                  >
-                    <Icon className="size-[18px]" />
-                  </span>
-                ) : (
-                  <ShowPageAvatarTile sessionId={row.sessionId ?? ''} title={name} />
-                )}
-                <span className="flex min-w-0 flex-1 flex-col">
-                  <span className="truncate text-[13px] font-semibold text-foreground">{name}</span>
-                  {subtitle ? <span className="truncate font-mono text-[11px] text-muted">{subtitle}</span> : null}
-                </span>
-                {row.kind === 'builtin' ? (
-                  <Badge variant="outline" className="hidden font-mono text-[10px] uppercase tracking-wide sm:inline-flex">
-                    {t('library.kind.builtin')}
-                  </Badge>
-                ) : (
-                  <Badge variant="success" className="hidden sm:inline-flex">
-                    {t('library.kind.showPage')}
-                  </Badge>
-                )}
-                {/* State-aware Dock toggle — the row stays in the list either way. */}
-                <Button
-                  type="button"
-                  variant={row.docked ? 'secondary' : 'outline'}
-                  size="xs"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void (row.docked ? undock(row.dockId) : dock(row.dockId));
-                  }}
-                >
-                  {row.docked ? <PinOff /> : <Pin />}
-                  <span className="hidden sm:inline">{row.docked ? t('library.apps.undock') : t('library.apps.dock')}</span>
-                </Button>
-                {/* 移出 — uninstall (Show Pages only; the page itself is untouched). */}
-                {row.kind === 'showpage' ? (
-                  <button
-                    type="button"
-                    title={t('library.apps.remove')}
-                    aria-label={t('library.apps.remove')}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (row.sessionId) void unpin(row.sessionId);
-                    }}
-                    className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-destructive/10 hover:text-destructive"
-                  >
-                    <Trash2 size={15} />
-                  </button>
-                ) : null}
-              </div>
-            );
-          })
+          <>
+            {localOrder.length > 0 ? (
+              <Reorder.Group axis="y" values={localOrder} onReorder={reorder} as="div">
+                {localOrder.map((id) => {
+                  const item = resolvedById.get(id);
+                  if (!item) return null;
+                  return (
+                    <DockedReorderRow
+                      key={id}
+                      item={item}
+                      last={id === lastDockId}
+                      onCommit={commitOrder}
+                      {...handlers(item)}
+                    />
+                  );
+                })}
+              </Reorder.Group>
+            ) : null}
+            {undocked.map((r) => {
+              const item = resolvedById.get(r.dockId);
+              if (!item) return null;
+              return (
+                <AppLibraryRow
+                  key={r.dockId}
+                  item={item}
+                  last={r.dockId === lastDockId}
+                  leading={<span className="size-6 shrink-0" aria-hidden />}
+                  {...handlers(item)}
+                />
+              );
+            })}
+          </>
         )}
       </div>
     </div>

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -271,13 +271,36 @@ const DockedReorderRow: React.FC<{
   onCommit: () => void;
 }> = ({ item, last, onOpen, onDockToggle, onRemove, onCommit }) => {
   const controls = useDragControls();
+  // A handle drag can end with its trailing click landing on the row (the common
+  // ancestor of the grip and the release point), which would open the app right
+  // after a reorder (Codex P2). Set on drag start, consumed by the row click; a
+  // fresh row-body press resets it (a grip press stopPropagations, so it won't).
+  const draggedRef = useRef(false);
   return (
-    <Reorder.Item value={item.row.dockId} as="div" dragListener={false} dragControls={controls} onDragEnd={onCommit}>
+    <Reorder.Item
+      value={item.row.dockId}
+      as="div"
+      dragListener={false}
+      dragControls={controls}
+      onPointerDown={() => {
+        draggedRef.current = false;
+      }}
+      onDragStart={() => {
+        draggedRef.current = true;
+      }}
+      onDragEnd={onCommit}
+    >
       <AppLibraryRow
         item={item}
         last={last}
         leading={<GripHandle controls={controls} />}
-        onOpen={onOpen}
+        onOpen={() => {
+          if (draggedRef.current) {
+            draggedRef.current = false;
+            return;
+          }
+          onOpen();
+        }}
         onDockToggle={onDockToggle}
         onRemove={onRemove}
       />

--- a/ui/src/apps/appLibrary.test.ts
+++ b/ui/src/apps/appLibrary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { deriveAppRows, filterShowPages, type FilterablePage } from './appLibrary';
+import { deriveAppRows, filterShowPages, partitionByDock, type FilterablePage } from './appLibrary';
 
 const BUILTINS = ['files', 'terminal', 'editor', 'library'];
 const pin = (id: string) => ({ session_id: id });
@@ -42,6 +42,38 @@ describe('deriveAppRows (installed set)', () => {
   it('de-duplicates a pin that repeats', () => {
     const rows = deriveAppRows(['files'], [pin('s1'), pin('s1')], []);
     expect(rows.map((r) => r.dockId)).toEqual(['files', 'show:s1']);
+  });
+});
+
+describe('partitionByDock (docked / undocked split for the Apps view)', () => {
+  it('orders docked rows by the Dock order and keeps undocked below in stable order', () => {
+    const order = ['show:s1', 'files', 'library'];
+    const rows = deriveAppRows(BUILTINS, [pin('s1'), pin('s2')], order);
+    const { docked, undocked } = partitionByDock(rows, order);
+    // Docked rows follow the Dock order exactly, regardless of derivation order.
+    expect(docked.map((r) => r.dockId)).toEqual(['show:s1', 'files', 'library']);
+    // Undocked rows keep derivation order: built-ins canonical, then pins.
+    expect(undocked.map((r) => r.dockId)).toEqual(['terminal', 'editor', 'show:s2']);
+  });
+
+  it('produces a docked sequence equal to the Dock order (a reorder maps 1:1 onto it)', () => {
+    const order = ['editor', 'files', 'show:s1'];
+    const rows = deriveAppRows(BUILTINS, [pin('s1')], order);
+    expect(partitionByDock(rows, order).docked.map((r) => r.dockId)).toEqual(order);
+  });
+
+  it('empty order → nothing docked, every row undocked in derivation order', () => {
+    const rows = deriveAppRows(BUILTINS, [pin('s1')], []);
+    const { docked, undocked } = partitionByDock(rows, []);
+    expect(docked).toEqual([]);
+    expect(undocked.map((r) => r.dockId)).toEqual([...BUILTINS, 'show:s1']);
+  });
+
+  it('does not mutate the input rows array', () => {
+    const rows = deriveAppRows(BUILTINS, [], ['library', 'files']);
+    const before = rows.map((r) => r.dockId);
+    partitionByDock(rows, ['library', 'files']);
+    expect(rows.map((r) => r.dockId)).toEqual(before);
   });
 });
 

--- a/ui/src/apps/appLibrary.ts
+++ b/ui/src/apps/appLibrary.ts
@@ -55,6 +55,34 @@ export function deriveAppRows(
   return rows;
 }
 
+export interface PartitionedAppRows {
+  /** Docked rows, ordered to match the Dock `order`, so this group's dockId
+   *  sequence IS the Dock order — a drag-reorder maps 1:1 onto the existing
+   *  `PUT /api/dock/order`. Carries the drag handles (§7.1e). */
+  docked: AppRow[];
+  /** Installed-but-undocked rows, kept in their incoming (stable) derivation
+   *  order — built-ins canonical, then pins by install order. Rendered below the
+   *  docked group with no handle; not part of the Dock order. */
+  undocked: AppRow[];
+}
+
+/**
+ * Split the Apps-view rows (from deriveAppRows) into the DOCKED group and the
+ * installed-but-undocked group (§7.1e work item 2). Docked rows are sorted by
+ * their index in the Dock `order`, so the group's dockId sequence equals
+ * `order` and a framer-motion reorder of it can persist straight through
+ * `PUT /api/dock/order`. Undocked rows keep their incoming stable order. Pure —
+ * no React/DOM, no input mutation — so the partition is unit-testable.
+ */
+export function partitionByDock(rows: readonly AppRow[], order: readonly string[]): PartitionedAppRows {
+  const rank = new Map(order.map((id, index) => [id, index] as const));
+  const docked = rows
+    .filter((row) => row.docked)
+    .sort((a, b) => (rank.get(a.dockId) ?? 0) - (rank.get(b.dockId) ?? 0));
+  const undocked = rows.filter((row) => !row.docked);
+  return { docked, undocked };
+}
+
 export type ShowPageFilter = 'all' | 'public' | 'private' | 'offline';
 
 export interface FilterablePage {

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -106,32 +106,35 @@ function ShowPageRow({
 
   return (
     <div className={clsx('border-b border-border last:border-b-0', expanded && 'border-y border-mint/30')}>
-      {/* The row itself opens the page as an app window (not a browser tab) —
-          click the row or its title. Expand (share-link management) is a separate,
-          explicit affordance: the chevron on the right. */}
+      {/* Open-click is limited to the title+icon cluster (§7.1e item 5): the row
+          owns the expand panel, so a whole-row click would fight the chevron. The
+          rest of the row is inert except its explicit controls. */}
       <div
-        role="button"
-        tabIndex={0}
-        onClick={onOpen}
-        onKeyDown={(e) => {
-          if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
-            e.preventDefault();
-            onOpen();
-          }
-        }}
         className={clsx(
-          'group flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors sm:gap-4 sm:px-5',
-          expanded ? 'bg-surface-2' : 'hover:bg-foreground/[0.02]',
+          'flex w-full items-center gap-3 px-4 py-3 sm:gap-4 sm:px-5',
+          expanded && 'bg-surface-2',
         )}
       >
-        <span className="flex min-w-0 flex-1 items-center gap-3">
+        {/* The app-open target: avatar + title + open icon, with a hover
+            affordance so openability stays discoverable. */}
+        <button
+          type="button"
+          onClick={onOpen}
+          title={t('showPages.openApp')}
+          className="group flex min-w-0 flex-1 items-center gap-3 rounded-lg text-left transition-colors hover:bg-foreground/[0.03]"
+        >
           <ShowPageAvatarTile sessionId={page.session_id} title={page.title || ''} />
           <span className="min-w-0">
             <span className="flex items-center gap-1.5">
-              <span className={clsx('truncate text-[13px] font-semibold text-foreground', !page.title && 'font-mono')}>
+              <span
+                className={clsx(
+                  'truncate text-[13px] font-semibold text-foreground transition-colors group-hover:text-cyan',
+                  !page.title && 'font-mono',
+                )}
+              >
                 {label}
               </span>
-              {/* Open affordance beside the title — the row opens the app window. */}
+              {/* Open affordance beside the title. */}
               <AppWindowIcon
                 size={13}
                 aria-hidden
@@ -140,7 +143,7 @@ function ShowPageRow({
             </span>
             {sub ? <span className="block truncate text-[11px] text-muted">{sub}</span> : null}
           </span>
-        </span>
+        </button>
 
         <Badge variant={status.badge} className="hidden sm:inline-flex">
           <span className={clsx('size-1.5 rounded-full', status.dot)} />
@@ -148,15 +151,13 @@ function ShowPageRow({
         </Badge>
 
         {/* Install toggle — adds the page to the Apps list (and docks it) or
-            removes it from both. Stop propagation so it never opens the app. */}
+            removes it from both. A sibling of the open button now, so no
+            propagation guard is needed. */}
         <Button
           type="button"
           variant={installed ? 'secondary' : 'accent'}
           size="xs"
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleInstall(!installed);
-          }}
+          onClick={() => onToggleInstall(!installed)}
         >
           {installed ? <Minus /> : <Plus />}
           <span className="hidden sm:inline">{installed ? t('library.apps.remove') : t('library.ai.add')}</span>
@@ -167,10 +168,7 @@ function ShowPageRow({
           type="button"
           aria-label={t('showPages.details')}
           aria-expanded={expanded}
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleExpand();
-          }}
+          onClick={() => onToggleExpand()}
           className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.05] hover:text-foreground"
         >
           {expanded ? <ChevronUp size={18} className="text-foreground" /> : <ChevronDown size={18} />}

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -8,11 +8,11 @@ import {
   ExternalLink,
   Link2,
   Loader2,
+  Minus,
   Pencil,
   Plus,
   RefreshCw,
   RotateCw,
-  Trash2,
   TriangleAlert,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -158,7 +158,7 @@ function ShowPageRow({
             onToggleInstall(!installed);
           }}
         >
-          {installed ? <Trash2 /> : <Plus />}
+          {installed ? <Minus /> : <Plus />}
           <span className="hidden sm:inline">{installed ? t('library.apps.remove') : t('library.ai.add')}</span>
         </Button>
 

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -115,35 +115,39 @@ function ShowPageRow({
           expanded && 'bg-surface-2',
         )}
       >
-        {/* The app-open target: avatar + title + open icon, with a hover
-            affordance so openability stays discoverable. */}
-        <button
-          type="button"
-          onClick={onOpen}
-          title={t('showPages.openApp')}
-          className="group flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-lg text-left transition-colors hover:bg-foreground/[0.03]"
-        >
-          <ShowPageAvatarTile sessionId={page.session_id} title={page.title || ''} />
-          <span className="min-w-0">
-            <span className="flex items-center gap-1.5">
-              <span
-                className={clsx(
-                  'truncate text-[13px] font-semibold text-foreground transition-colors group-hover:text-cyan',
-                  !page.title && 'font-mono',
-                )}
-              >
-                {label}
+        {/* flex-1 lives on this inert wrapper; the open button sizes to its
+            content (avatar+title+icon cluster) so the blank space to its right
+            does NOT open the app — only the cluster does (§7.1e item 5). The
+            cluster carries a hover affordance so openability stays discoverable. */}
+        <div className="flex min-w-0 flex-1">
+          <button
+            type="button"
+            onClick={onOpen}
+            title={t('showPages.openApp')}
+            className="group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg text-left transition-colors hover:bg-foreground/[0.03]"
+          >
+            <ShowPageAvatarTile sessionId={page.session_id} title={page.title || ''} />
+            <span className="min-w-0">
+              <span className="flex items-center gap-1.5">
+                <span
+                  className={clsx(
+                    'truncate text-[13px] font-semibold text-foreground transition-colors group-hover:text-cyan',
+                    !page.title && 'font-mono',
+                  )}
+                >
+                  {label}
+                </span>
+                {/* Open affordance beside the title. */}
+                <AppWindowIcon
+                  size={13}
+                  aria-hidden
+                  className="shrink-0 text-muted/60 transition-colors group-hover:text-cyan"
+                />
               </span>
-              {/* Open affordance beside the title. */}
-              <AppWindowIcon
-                size={13}
-                aria-hidden
-                className="shrink-0 text-muted/60 transition-colors group-hover:text-cyan"
-              />
+              {sub ? <span className="block truncate text-[11px] text-muted">{sub}</span> : null}
             </span>
-            {sub ? <span className="block truncate text-[11px] text-muted">{sub}</span> : null}
-          </span>
-        </button>
+          </button>
+        </div>
 
         <Badge variant={status.badge} className="hidden sm:inline-flex">
           <span className={clsx('size-1.5 rounded-full', status.dot)} />

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -121,7 +121,7 @@ function ShowPageRow({
           type="button"
           onClick={onOpen}
           title={t('showPages.openApp')}
-          className="group flex min-w-0 flex-1 items-center gap-3 rounded-lg text-left transition-colors hover:bg-foreground/[0.03]"
+          className="group flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-lg text-left transition-colors hover:bg-foreground/[0.03]"
         >
           <ShowPageAvatarTile sessionId={page.session_id} title={page.title || ''} />
           <span className="min-w-0">

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -10,6 +10,7 @@ import { dockIdToSession, useDock } from '../../context/DockContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
 import { ContextMenu, ContextMenuItem } from '../ui/context-menu';
 import { useShowPageInventory } from '../useShowPages';
+import { isDragRelease } from './dragClick';
 
 // A resident Dock tile resolved from a persisted Dock id: either a built-in app
 // (files/terminal/editor) or a pinned Show Page (`show:<session_id>`).
@@ -58,6 +59,9 @@ export const Dock: React.FC = () => {
   // it re-syncs whenever the server order changes (load / pin / unpin elsewhere).
   const [dragOrder, setDragOrder] = useState<string[] | null>(null);
   const dragRef = useRef<string[] | null>(null);
+  // Last pointer-press point on a tile, to tell a reorder drag from a click on
+  // release (§7.1e item 4b): the whole tile is BOTH draggable and click-openable.
+  const pressPtRef = useRef<{ x: number; y: number } | null>(null);
   const localOrder = dragOrder ?? order;
   const reorder = (next: string[]) => {
     dragRef.current = next;
@@ -174,7 +178,17 @@ export const Dock: React.FC = () => {
                       index < 9 ? `${label} · ${t('apps.dock.switchShortcut', { number: index + 1 })}` : label
                     }
                     aria-label={label}
-                    onClick={(e) => (e.metaKey || e.ctrlKey || e.altKey ? openNew(item) : activate(item))}
+                    onPointerDown={(e) => {
+                      pressPtRef.current = { x: e.clientX, y: e.clientY };
+                    }}
+                    onClick={(e) => {
+                      // After a reorder drag the browser still fires a click on
+                      // release; swallow it past the drag threshold so the tile
+                      // doesn't spuriously open. A genuine click still opens.
+                      if (isDragRelease(pressPtRef.current, { x: e.clientX, y: e.clientY })) return;
+                      if (e.metaKey || e.ctrlKey || e.altKey) openNew(item);
+                      else activate(item);
+                    }}
                     onContextMenu={(e) => {
                       e.preventDefault();
                       setMenu({ x: e.clientX, y: e.clientY, item });

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -184,8 +184,12 @@ export const Dock: React.FC = () => {
                     onClick={(e) => {
                       // After a reorder drag the browser still fires a click on
                       // release; swallow it past the drag threshold so the tile
-                      // doesn't spuriously open. A genuine click still opens.
-                      if (isDragRelease(pressPtRef.current, { x: e.clientX, y: e.clientY })) return;
+                      // doesn't spuriously open. Read-and-null the press point, and
+                      // skip the check for keyboard/synthetic activation (detail 0,
+                      // clientX/Y 0, no fresh pointerdown) so Enter/Space still opens.
+                      const press = pressPtRef.current;
+                      pressPtRef.current = null;
+                      if (e.detail !== 0 && isDragRelease(press, { x: e.clientX, y: e.clientY })) return;
                       if (e.metaKey || e.ctrlKey || e.altKey) openNew(item);
                       else activate(item);
                     }}

--- a/ui/src/components/apps/MobileDockDrawer.tsx
+++ b/ui/src/components/apps/MobileDockDrawer.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { LayoutGrid, MoreHorizontal, PinOff, Settings, Sun, Trash2, UserRound, X } from 'lucide-react';
+import { LayoutGrid, Minus, MoreHorizontal, PinOff, Settings, Sun, UserRound, X } from 'lucide-react';
 
 import { APP_REGISTRY, type AppDefinition, type AppId } from '../../apps/registry';
 import { showPageAvatar } from '../../apps/showPageAvatar';
@@ -263,7 +263,7 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
                 }}
                 className="flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-[14px] font-medium text-destructive transition hover:bg-destructive/[0.08]"
               >
-                <Trash2 className="size-[18px] shrink-0" />
+                <Minus className="size-[18px] shrink-0" />
                 {t('library.apps.remove')}
               </button>
             )}

--- a/ui/src/components/apps/dragClick.test.ts
+++ b/ui/src/components/apps/dragClick.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { DRAG_CLICK_THRESHOLD_PX, isDragRelease } from './dragClick';
+
+describe('isDragRelease (drag-vs-click discrimination)', () => {
+  it('treats a near-stationary release as a click (opens)', () => {
+    expect(isDragRelease({ x: 100, y: 100 }, { x: 103, y: 102 })).toBe(false);
+    expect(isDragRelease({ x: 100, y: 100 }, { x: 100, y: 100 })).toBe(false);
+  });
+
+  it('treats a release past the threshold on either axis as a drag (suppresses click)', () => {
+    expect(isDragRelease({ x: 100, y: 100 }, { x: 120, y: 100 })).toBe(true);
+    expect(isDragRelease({ x: 100, y: 100 }, { x: 100, y: 140 })).toBe(true);
+    // Negative direction counts the same (absolute travel).
+    expect(isDragRelease({ x: 100, y: 100 }, { x: 80, y: 100 })).toBe(true);
+  });
+
+  it('is inclusive at the threshold boundary', () => {
+    expect(isDragRelease({ x: 0, y: 0 }, { x: DRAG_CLICK_THRESHOLD_PX, y: 0 })).toBe(true);
+    expect(isDragRelease({ x: 0, y: 0 }, { x: DRAG_CLICK_THRESHOLD_PX - 1, y: 0 })).toBe(false);
+  });
+
+  it('treats a missing press point as not-a-drag so the click still opens', () => {
+    expect(isDragRelease(null, { x: 999, y: 999 })).toBe(false);
+    expect(isDragRelease(undefined, { x: 999, y: 999 })).toBe(false);
+  });
+
+  it('honors a custom threshold', () => {
+    expect(isDragRelease({ x: 0, y: 0 }, { x: 8, y: 0 }, 10)).toBe(false);
+    expect(isDragRelease({ x: 0, y: 0 }, { x: 12, y: 0 }, 10)).toBe(true);
+  });
+});

--- a/ui/src/components/apps/dragClick.ts
+++ b/ui/src/components/apps/dragClick.ts
@@ -1,0 +1,31 @@
+// Drag-vs-click discrimination for surfaces where a whole element is BOTH
+// draggable (framer-motion Reorder) and click-openable (§7.1e item 4b). After a
+// reorder drag the browser still fires a click on release; without this guard
+// that click spuriously opens the app. Kept pure + framework-free so the Dock
+// (and any future whole-element-drag surface) shares one testable rule.
+
+/** Pointer travel (px) at/beyond which a release ends a drag, not a click. A
+ *  hair above natural pointer jitter so a genuine tap still opens, while a
+ *  reorder drag — which travels much further — is swallowed. */
+export const DRAG_CLICK_THRESHOLD_PX = 6;
+
+export interface PointerXY {
+  x: number;
+  y: number;
+}
+
+/**
+ * Whether a press→release traveled far enough to count as the end of a drag (so
+ * a whole-element click-open must be suppressed) rather than a genuine click.
+ * Uses Chebyshev distance (max axis delta) against `threshold`. A missing press
+ * point counts as "not a drag", so the click still opens. Pure — no DOM, no
+ * framework — so it is unit-testable and reusable across surfaces.
+ */
+export function isDragRelease(
+  press: PointerXY | null | undefined,
+  release: PointerXY,
+  threshold: number = DRAG_CLICK_THRESHOLD_PX,
+): boolean {
+  if (!press) return false;
+  return Math.max(Math.abs(release.x - press.x), Math.abs(release.y - press.y)) >= threshold;
+}

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -183,6 +183,7 @@
     "copy": "Copy",
     "copied": "Copied",
     "open": "Open",
+    "openApp": "Open app",
     "shareLink": "Share link",
     "rotate": "Rotate link",
     "rotateHint": "Generates a new link and disables the current one.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -218,19 +218,20 @@
     "desc": "Your apps and Show Pages",
     "tab": {
       "apps": "Apps",
-      "ai": "AI"
+      "ai": "ShowPage"
     },
     "searchApps": "Search apps…",
     "searchPages": "Search pages…",
     "kind": {
       "builtin": "Built-in",
-      "showPage": "Show Page"
+      "showPage": "AI"
     },
     "apps": {
       "system": "system",
       "dock": "Dock",
       "undock": "Undock",
       "remove": "Remove",
+      "reorder": "Reorder",
       "empty": "No apps match your search."
     },
     "ai": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -183,6 +183,7 @@
     "copy": "复制",
     "copied": "已复制",
     "open": "打开",
+    "openApp": "打开应用",
     "shareLink": "分享链接",
     "rotate": "更换链接",
     "rotateHint": "生成新链接并使当前链接立即失效。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -218,19 +218,20 @@
     "desc": "你的应用与展示页面",
     "tab": {
       "apps": "应用",
-      "ai": "AI"
+      "ai": "ShowPage"
     },
     "searchApps": "搜索应用…",
     "searchPages": "搜索页面…",
     "kind": {
       "builtin": "内置",
-      "showPage": "展示页面"
+      "showPage": "AI"
     },
     "apps": {
       "system": "系统",
       "dock": "固定到 Dock",
       "undock": "取消固定",
       "remove": "移出",
+      "reorder": "重新排序",
       "empty": "没有匹配的应用。"
     },
     "ai": {


### PR DESCRIPTION
## Capability

App Library polish, spec `docs/plans/dock-pinned-show-page-apps.md` §7.1e (owner hands-on feedback 2026-07-14). Builds on the shipped two-layer install/dock model (§7.1c/§7.1d). Frontend-only, no new deps.

### Shipped
**Round 1 (§7.1e items 1–3):**
1. **Tab rename** — Library's second tab reads **ShowPage** (was "AI"), en+zh, count preserved.
2. **Kind badge → "AI", right-aligned** — rows badge AI pages as **AI** (was 展示页面/"Show Page"), en+zh, at the info area's right edge before the controls (existing `flex-1` info column). The shared key also updates the ⌘K search kind badge (consistent — PM-confirmed).
3. **Apps view drag-reorder** — docked rows get a front **grip handle** (`grip-vertical`); handle-only drag via framer-motion `Reorder` + `useDragControls` (row-click still opens); order persists through the Dock's `setOrder` → `PUT /api/dock/order` (optimistic + stale_order resync). Undocked rows: no handle, below the docked group in stable order.
4. **移出 → minus** (not trash: it uninstalls the app, not a delete), muted coloring.

**Round 2 (§7.1e items 4b + 5, + PM-granted scope):**
5. **§7.1e 4b — Dock tile drag-vs-click** — a whole-tile Reorder drag ended with a click on release, spuriously opening the app. New pure `isDragRelease(press, release, threshold)` helper (Chebyshev distance, unit-tested) gates the tile click via a press-point ref: a drag past the threshold is swallowed, a genuine click still opens. The Apps-list reorder rows are **handle-only** (whole-row drag impossible), so they need no guard — verified.
6. **§7.1e item 5 — ShowPage-tab open trigger** — whole-row click fought the expand chevron. Open-click now lives only on the avatar+title+icon cluster (a button with a hover affordance: title/icon go cyan + subtle bg + tooltip); the rest of the row is inert except its explicit controls (expand chevron, install button). The **Apps tab keeps whole-row open** (no expand panel there) — unchanged.
7. **Mobile Dock 移出 → minus** (PM-granted scope) — aligns `MobileDockDrawer` with the desktop icon.

## Evidence
- **Unit**: `partitionByDock` (docked/undocked split, 4 cases) + `isDragRelease` (drag-vs-click threshold, 5 cases). Full suite **239 passed (27 files)**.
- **Build**: `tsc -b && vite build` clean; eslint clean on changed files.
- **i18n**: en+zh (tab, kind badge, `library.apps.reorder`, `showPages.openApp`).
- **Residual manual (deferred to the orchestrator's Incus regression pass)**: interactive drag-reorder persistence; Dock drag-vs-click behavior across mouse/touch; ShowPage-tab title-cluster open + hover affordance; minus icons + AI badge in light/dark. Framer `Reorder` runs without `layoutScroll` (matching the shipped Dock, #904); the reorderable groups are small so a scrolled-mid-drag offset is unlikely — flagged for the regression pass.

No scenario catalog applies (UI polish). No backend / lockfile changes.

## Notes / scope boundaries
- PM confirmations applied: handles only on docked rows; badge copy→AI incl. the ⌘K search badge; plain `minus`; mobile 移出 icon aligned.
- **Out of this PR**: §7.1f (Phase 2.3 — app icons sync from the page's HTML icon) is captured in the synced spec doc but is a separate later phase — not implemented here.
