### PR TITLE
feat(apps): §7.1h Phase 2.4 acceptance — badge anchor, ↗ open icon, Dock drag fix, icon fallback + guidance

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -704,20 +704,23 @@ def _extract_icon_path(page_dir: Path) -> str | None:
     return _resolve_show_page_icon_href(href, finder.base_href)
 
 
-def resolve_show_page_icon(session_id: str) -> tuple[Path, str] | None:
-    """The absolute path + Content-Type of a Show Page's own icon, or None.
+# Workspace-conventional favicon locations, tried IN ORDER when the page declares no
+# usable <link rel="icon"> (§7.1h): most agent-built pages ship no link tag at all, so
+# these give them an icon from the common spots — root first, then Vite's public/.
+_CONVENTIONAL_ICON_RELATIVES: tuple[str, ...] = (
+    "favicon.svg",
+    "favicon.ico",
+    "favicon.png",
+    "public/favicon.svg",
+    "public/favicon.ico",
+    "public/favicon.png",
+)
 
-    The single serving chokepoint for ``GET /api/show-pages/<sid>/icon``: combines
-    :func:`_extract_icon_path` (document-semantics resolution + policy) with the
-    same-workspace realpath guard, regular-file check, and extension whitelist, so
-    the serving layer just streams the file. Returns None for any missing workspace
-    / no icon / policy rejection — the caller answers 404 and the frontend falls
-    back to the letter avatar.
-    """
-    page_dir = show_page_dir(session_id)
-    relative = _extract_icon_path(page_dir)
-    if relative is None:
-        return None
+
+def _resolve_icon_candidate(page_dir: Path, relative: str) -> tuple[Path, str] | None:
+    """Resolve ONE already-policy-safe relative icon path to (abs path, Content-Type),
+    or None when it isn't a servable regular file inside the workspace within the size
+    cap. Shared by the explicit ``<link>`` href and the conventional-file fallback."""
     try:
         candidate = (page_dir / relative).resolve()
         root = page_dir.resolve()
@@ -740,6 +743,29 @@ def resolve_show_page_icon(session_id: str) -> tuple[Path, str] | None:
     if content_type is None:
         return None
     return candidate, content_type
+
+
+def resolve_show_page_icon(session_id: str) -> tuple[Path, str] | None:
+    """The absolute path + Content-Type of a Show Page's own icon, or None.
+
+    The single serving chokepoint for ``GET /api/show-pages/<sid>/icon``: combines
+    :func:`_extract_icon_path` (document-semantics resolution + policy) with the
+    same-workspace realpath guard, regular-file check, and extension whitelist, so
+    the serving layer just streams the file. An explicit ``<link rel="icon">`` WINS;
+    when the page declares none, it falls back to the workspace-conventional favicon
+    files (root then ``public/``) so agent-built pages — which rarely add a link —
+    still get an icon (§7.1h). Returns None for any missing workspace / no icon /
+    policy rejection — the caller answers 404 and the frontend uses the letter avatar.
+    """
+    page_dir = show_page_dir(session_id)
+    link = _extract_icon_path(page_dir)
+    # Link wins; only when there is no usable link do we consult the conventions.
+    relatives = (link,) if link else _CONVENTIONAL_ICON_RELATIVES
+    for relative in relatives:
+        resolved = _resolve_icon_candidate(page_dir, relative)
+        if resolved is not None:
+            return resolved
+    return None
 
 
 def show_page_icon_version(session_id: str) -> str | None:

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -759,8 +759,11 @@ def resolve_show_page_icon(session_id: str) -> tuple[Path, str] | None:
     """
     page_dir = show_page_dir(session_id)
     link = _extract_icon_path(page_dir)
-    # Link wins; only when there is no usable link do we consult the conventions.
-    relatives = (link,) if link else _CONVENTIONAL_ICON_RELATIVES
+    # A USABLE link wins (it's first, so it's returned before any convention); but an
+    # explicit link that resolves to nothing (missing file / rejected) must not strand
+    # the page icon-less when a conventional favicon exists — fall through to the
+    # conventions after it, so coverage is maximized (Codex §7.1h).
+    relatives = (link, *_CONVENTIONAL_ICON_RELATIVES) if link else _CONVENTIONAL_ICON_RELATIVES
     for relative in relatives:
         resolved = _resolve_icon_candidate(page_dir, relative)
         if resolved is not None:

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -104,6 +104,7 @@ Guidance:
 - Design for user understanding, not just for moving text onto a webpage. Choose the visual form that best helps the user inspect, compare, confirm, and continue the discussion.
 - Use diagrams or mind maps for relationships, flowcharts or state machines for processes, timelines for sequences, charts or dashboards for metrics, and side-by-side views for tradeoffs.
 - Make the page visually polished: use clear hierarchy, spacing, typography, contrast, and consistent components. Avoid rough default-looking pages.
+- Give the app a recognizable icon so it stands out in the Dock and App Library: drop a `public/favicon.svg` (or `favicon.svg` at the workspace root) and it is picked up automatically, or add `<link rel="icon" href="./favicon.svg">` to `index.html` (an icon edit to the shell is fine).
 - Make the page work reasonably on mobile because users may open links from an IM app on their phone.
 - Prefer React component implementations. Useful visualization libraries include React Flow, Mermaid, Markmap, Chart.js, and Cytoscape.js.
 - Keep pages private by default. Publish publicly only when the user asks for a shareable or public link.

--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -564,6 +564,44 @@ in the event path (window → document → element) — so a page's own
 `stopPropagation()` (even a capture-phase one) cannot swallow ⌥W; only the
 `inTextEntrySurface` exemption suppresses it._
 
+### 7.1h Phase 2.4 — owner acceptance fixes (owner 2026-07-14)
+
+Four acceptance items from the merged §7.1f/g work, one PR.
+
+1. **AI badge hard right anchor.** The kind/status badge floated after
+   variable-width content, so its x jumped row-to-row (toggle label width,
+   presence of 移出). Fixed by wrapping each row's trailing action controls in a
+   FIXED-width, right-justified zone (`SHARED_ACTION_ZONE` in
+   `ui/src/apps/rowLayout.ts`, `sm:w-36`), used by BOTH the Apps view
+   (`LibraryApp`) and the Show Pages view (`ShowPagesPage`); the badge sits
+   immediately left of that zone, so its right-edge column is identical across
+   every row and both views regardless of button contents.
+2. **Title open icon → `arrow-up-right`.** The ShowPage-row open affordance
+   swapped `AppWindow` → lucide `ArrowUpRight` (same hover affordance).
+3. **BUG: Dock AI-page tiles couldn't drag** (built-ins reordered fine). Root
+   cause (git-bisected to #906): the tile's favicon `<img>` — added by §7.1f —
+   has default `pointer-events: auto`, so it captured the pointerdown and
+   framer-motion's `Reorder.Item` drag never initiated (`draggable={false}`
+   disables only native image DnD, not pointer capture). Letter tiles (bare
+   text) were unaffected. Fix at the shared avatar: `pointer-events-none
+   select-none` on the decorative `<img>` so the press passes through to the
+   tile/row (every surface that shares `ShowPageAvatarContent` inherits it).
+4. **Icon coverage gap** — agent-built pages ship no `<link rel=icon>`, so
+   nothing showed.
+   - **(a) Conventional-file fallback** (`core/show_pages.py`): when index.html
+     has no usable `<link rel=icon>`, `resolve_show_page_icon` tries the
+     workspace-conventional favicons IN ORDER — `favicon.{svg,ico,png}` at root,
+     then `public/favicon.{svg,ico,png}` — via one shared `_resolve_icon_candidate`
+     (same realpath/size/type policy as the link) and read through
+     `_read_workspace_file_safely`; `icon_version` covers them identically. An
+     explicit link WINS. Tests: each fallback, root-before-public + svg>ico>png
+     order, link-wins, none.
+   - **(b) Authoring guidance** (`core/system_prompt_injection.py`, the `##
+     Show Pages` section injected into the agent system prompt): one line telling
+     the agent to give the app an icon (drop `public/favicon.svg` — auto-picked
+     up by 4a — or add a `<link rel=icon>` to index.html; the scaffold head
+     comment already sanctions icon edits to the shell).
+
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 
 Pinning **is** installing — no separate ceremony. Two entrances, one action:

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -1136,6 +1136,17 @@ def test_resolve_icon_falls_back_when_link_is_unusable(monkeypatch, tmp_path):
     assert resolved[0] == (page_dir / "favicon.png").resolve()
 
 
+def test_resolve_icon_unusable_link_and_no_conventional_is_none(monkeypatch, tmp_path):
+    # Broken explicit link AND no conventional favicon on disk → None (letter avatar)
+    # — the fall-through must not invent an icon (§7.1h Codex, adjudicated case 3).
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sesbroken2")
+    (page_dir / "index.html").write_text('<link rel="icon" href="missing.svg">', encoding="utf-8")
+    assert resolve_show_page_icon("sesbroken2") is None
+
+
 def test_resolve_icon_none_without_link_or_conventional(monkeypatch, tmp_path):
     # No link and no conventional favicon → None (letter avatar).
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -1051,6 +1051,85 @@ def test_resolve_show_page_icon_rejects_oversized_icon(monkeypatch, tmp_path):
     assert resolve_show_page_icon("sesbig") is not None
 
 
+_CONVENTIONAL_ICONS = (
+    ("favicon.svg", "image/svg+xml"),
+    ("favicon.ico", "image/x-icon"),
+    ("favicon.png", "image/png"),
+    ("public/favicon.svg", "image/svg+xml"),
+    ("public/favicon.ico", "image/x-icon"),
+    ("public/favicon.png", "image/png"),
+)
+
+
+def test_resolve_icon_falls_back_to_each_conventional_file(monkeypatch, tmp_path):
+    # When index.html declares NO <link rel=icon>, each workspace-conventional favicon
+    # location resolves + serves identically (§7.1h item 4a) — most agent-built pages
+    # ship no link, so this is what gives them an icon.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon, show_page_icon_version
+
+    page_dir = ensure_show_page_dir("sesconv")
+    (page_dir / "index.html").write_text("<title>no icon link</title>", encoding="utf-8")
+    for rel, ctype in _CONVENTIONAL_ICONS:
+        for existing, _ in _CONVENTIONAL_ICONS:  # isolate: only `rel` present this pass
+            existing_path = page_dir / existing
+            if existing_path.exists():
+                existing_path.unlink()
+        target = page_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"<svg/>" if rel.endswith(".svg") else b"\x00icon")
+
+        resolved = resolve_show_page_icon("sesconv")
+        assert resolved is not None, rel
+        assert resolved[0] == (page_dir / rel).resolve(), rel
+        assert resolved[1] == ctype, rel
+        # icon_version covers conventional icons identically (non-null token).
+        assert show_page_icon_version("sesconv"), rel
+
+
+def test_resolve_icon_conventional_order_root_before_public(monkeypatch, tmp_path):
+    # Precedence within the conventions: root wins over public/, and svg > ico > png.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sesorder")
+    (page_dir / "index.html").write_text("<title>x</title>", encoding="utf-8")
+    (page_dir / "public").mkdir()
+    (page_dir / "public" / "favicon.svg").write_bytes(b"<svg/>")
+    (page_dir / "favicon.png").write_bytes(b"png")
+    (page_dir / "favicon.ico").write_bytes(b"ico")
+    (page_dir / "favicon.svg").write_bytes(b"<svg/>")
+
+    resolved = resolve_show_page_icon("sesorder")
+    assert resolved is not None
+    assert resolved[0] == (page_dir / "favicon.svg").resolve()  # root svg wins
+
+
+def test_resolve_icon_link_tag_wins_over_conventional(monkeypatch, tmp_path):
+    # An explicit, valid <link rel=icon> beats the conventional favicon files (§7.1h).
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("seslink")
+    (page_dir / "index.html").write_text('<link rel="icon" href="brand.svg">', encoding="utf-8")
+    (page_dir / "brand.svg").write_bytes(b"<svg>brand</svg>")
+    (page_dir / "favicon.svg").write_bytes(b"<svg>fallback</svg>")  # NOT chosen
+
+    resolved = resolve_show_page_icon("seslink")
+    assert resolved is not None
+    assert resolved[0] == (page_dir / "brand.svg").resolve()
+
+
+def test_resolve_icon_none_without_link_or_conventional(monkeypatch, tmp_path):
+    # No link and no conventional favicon → None (letter avatar).
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sesnone")
+    (page_dir / "index.html").write_text("<title>nothing</title>", encoding="utf-8")
+    assert resolve_show_page_icon("sesnone") is None
+
+
 def test_read_show_page_icon_enforces_the_token(monkeypatch, tmp_path):
     # ?v= is a content assertion: the correct token yields the bytes; a wrong/empty
     # token is None (→ 404), so `immutable` caching is honest (URL ⇒ one content).

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -1120,6 +1120,22 @@ def test_resolve_icon_link_tag_wins_over_conventional(monkeypatch, tmp_path):
     assert resolved[0] == (page_dir / "brand.svg").resolve()
 
 
+def test_resolve_icon_falls_back_when_link_is_unusable(monkeypatch, tmp_path):
+    # An explicit <link rel=icon> pointing at a MISSING file must not strand the page
+    # icon-less — fall through to a conventional favicon (§7.1h Codex). A usable link
+    # still wins (covered above); this covers the unusable-link case.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sesbroken")
+    (page_dir / "index.html").write_text('<link rel="icon" href="missing.svg">', encoding="utf-8")
+    (page_dir / "favicon.png").write_bytes(b"png")  # the conventional fallback
+
+    resolved = resolve_show_page_icon("sesbroken")
+    assert resolved is not None
+    assert resolved[0] == (page_dir / "favicon.png").resolve()
+
+
 def test_resolve_icon_none_without_link_or_conventional(monkeypatch, tmp_path):
     # No link and no conventional favicon → None (letter avatar).
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 
 import { APP_LIST, APP_REGISTRY, type AppDefinition, type AppId } from './registry';
 import { deriveAppRows, partitionByDock, type AppRow } from './appLibrary';
+import { SHARED_ACTION_ZONE } from './rowLayout';
 import { ShowPageAvatarTile } from './showPageAvatarTile';
 import { showAppRoutePath } from '../components/apps/mobileDock';
 import { useDock } from '../context/DockContext';
@@ -216,8 +217,10 @@ const AppLibraryRow: React.FC<AppLibraryRowProps> = ({ item, leading, last, onOp
         <span className="truncate text-[13px] font-semibold text-foreground">{name}</span>
         {subtitle ? <span className="truncate font-mono text-[11px] text-muted">{subtitle}</span> : null}
       </span>
-      {/* Kind badge — right-aligned at the info area's right edge (§7.1e); the AI
-          badge replaces the former Show Page badge. */}
+      {/* Kind badge — sits immediately left of the fixed-width action zone below,
+          so its right-edge column stays put across ALL rows (and matches the
+          ShowPage view) no matter the toggle label width or whether 移出 shows
+          (§7.1h item 1). The AI badge replaces the former Show Page badge. */}
       {row.kind === 'builtin' ? (
         <Badge variant="outline" className="hidden font-mono text-[10px] uppercase tracking-wide sm:inline-flex">
           {t('library.kind.builtin')}
@@ -227,35 +230,41 @@ const AppLibraryRow: React.FC<AppLibraryRowProps> = ({ item, leading, last, onOp
           {t('library.kind.showPage')}
         </Badge>
       )}
-      {/* State-aware Dock toggle — the row stays in the list either way. */}
-      <Button
-        type="button"
-        variant={row.docked ? 'secondary' : 'outline'}
-        size="xs"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDockToggle();
-        }}
-      >
-        {row.docked ? <PinOff /> : <Pin />}
-        <span className="hidden sm:inline">{row.docked ? t('library.apps.undock') : t('library.apps.dock')}</span>
-      </Button>
-      {/* 移出 — uninstall (AI rows only; the page itself is untouched). A minus,
-          not a trash: this removes the app from the list, it is not a delete. */}
-      {row.kind === 'showpage' && onRemove ? (
-        <button
+      {/* Fixed-width, right-justified action zone (§7.1h item 1) — the SHARED_ACTION_ZONE
+          width matches the ShowPage view, so the badge column above is identical in
+          both. Buttons right-align within it, so a longer/shorter label never shifts
+          the badge. */}
+      <div className={SHARED_ACTION_ZONE}>
+        {/* State-aware Dock toggle — the row stays in the list either way. */}
+        <Button
           type="button"
-          title={t('library.apps.remove')}
-          aria-label={t('library.apps.remove')}
+          variant={row.docked ? 'secondary' : 'outline'}
+          size="xs"
           onClick={(e) => {
             e.stopPropagation();
-            onRemove();
+            onDockToggle();
           }}
-          className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-destructive/10 hover:text-destructive"
         >
-          <Minus size={15} />
-        </button>
-      ) : null}
+          {row.docked ? <PinOff /> : <Pin />}
+          <span className="hidden sm:inline">{row.docked ? t('library.apps.undock') : t('library.apps.dock')}</span>
+        </Button>
+        {/* 移出 — uninstall (AI rows only; the page itself is untouched). A minus,
+            not a trash: this removes the app from the list, it is not a delete. */}
+        {row.kind === 'showpage' && onRemove ? (
+          <button
+            type="button"
+            title={t('library.apps.remove')}
+            aria-label={t('library.apps.remove')}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-destructive/10 hover:text-destructive"
+          >
+            <Minus size={15} />
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/ui/src/apps/rowLayout.ts
+++ b/ui/src/apps/rowLayout.ts
@@ -1,0 +1,7 @@
+// Shared trailing action-zone class for App Library rows — the Apps view
+// (LibraryApp) and the Show Pages view (ShowPagesPage). A FIXED width so the
+// kind/status badge that sits immediately to its left keeps a stable right-edge
+// column across every row AND both views (§7.1h item 1): the buttons right-justify
+// within the zone, so a longer/shorter toggle label — or a conditional 移出 —
+// never shifts the badge. One constant, so the two views can't drift apart.
+export const SHARED_ACTION_ZONE = 'flex shrink-0 items-center justify-end gap-2 sm:w-36';

--- a/ui/src/apps/showPageAvatarTile.tsx
+++ b/ui/src/apps/showPageAvatarTile.tsx
@@ -32,7 +32,14 @@ export const ShowPageAvatarContent: React.FC<{ iconUrl: string | null; letter: s
         src={iconUrl}
         alt=""
         draggable={false}
-        className="size-full object-cover"
+        // Decorative: `pointer-events-none` lets a press pass THROUGH to the tile
+        // behind it. In the Dock a tile is a framer-motion Reorder.Item; without
+        // this the `<img>` captures the pointerdown and the drag never initiates
+        // (`draggable={false}` only disables native image DnD, not pointer capture),
+        // so AI-page tiles with an icon couldn't be reordered (§7.1h item 3). All
+        // interaction (click-open, drag) belongs to the parent tile/row, so this is
+        // safe on every surface sharing this avatar (Dock, Library, search, chip).
+        className="pointer-events-none size-full select-none object-cover"
         onError={() => setFailure({ url: iconUrl, attempts: attempts + 1 })}
       />
     );

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
-  AppWindow as AppWindowIcon,
+  ArrowUpRight,
   Check,
   ChevronDown,
   ChevronUp,
@@ -25,6 +25,7 @@ import { copyTextToClipboard } from '../lib/utils';
 import { copyHref, displayLink, type ShowPageLinkInfo } from '../lib/showPageLinks';
 import { type ShowPage, type ShowPagesController, type Visibility } from './useShowPages';
 import { filterShowPages, type ShowPageFilter } from '../apps/appLibrary';
+import { SHARED_ACTION_ZONE } from '../apps/rowLayout';
 import { ShowPageAvatarTile } from '../apps/showPageAvatarTile';
 import { ShowPageShareIdField } from './workbench/ShowPageShareIdField';
 import { SearchField } from './settings/SettingsPrimitives';
@@ -137,8 +138,8 @@ function ShowPageRow({
                 >
                   {label}
                 </span>
-                {/* Open affordance beside the title. */}
-                <AppWindowIcon
+                {/* Open affordance beside the title — a diagonal ↗ (§7.1h item 2). */}
+                <ArrowUpRight
                   size={13}
                   aria-hidden
                   className="shrink-0 text-muted/60 transition-colors group-hover:text-cyan"
@@ -149,34 +150,40 @@ function ShowPageRow({
           </button>
         </div>
 
+        {/* Status badge — immediately left of the fixed-width action zone, so its
+            right-edge column matches the Apps view exactly (§7.1h item 1). */}
         <Badge variant={status.badge} className="hidden sm:inline-flex">
           <span className={clsx('size-1.5 rounded-full', status.dot)} />
           {t(`showPages.status.${page.visibility}`)}
         </Badge>
 
-        {/* Install toggle — adds the page to the Apps list (and docks it) or
-            removes it from both. A sibling of the open button now, so no
-            propagation guard is needed. */}
-        <Button
-          type="button"
-          variant={installed ? 'secondary' : 'accent'}
-          size="xs"
-          onClick={() => onToggleInstall(!installed)}
-        >
-          {installed ? <Minus /> : <Plus />}
-          <span className="hidden sm:inline">{installed ? t('library.apps.remove') : t('library.ai.add')}</span>
-        </Button>
+        {/* Fixed-width, right-justified action zone (shared with the Apps view) so
+            the badge column above never shifts with the toggle label width. */}
+        <div className={SHARED_ACTION_ZONE}>
+          {/* Install toggle — adds the page to the Apps list (and docks it) or
+              removes it from both. A sibling of the open button now, so no
+              propagation guard is needed. */}
+          <Button
+            type="button"
+            variant={installed ? 'secondary' : 'accent'}
+            size="xs"
+            onClick={() => onToggleInstall(!installed)}
+          >
+            {installed ? <Minus /> : <Plus />}
+            <span className="hidden sm:inline">{installed ? t('library.apps.remove') : t('library.ai.add')}</span>
+          </Button>
 
-        {/* Explicit expand affordance for the management panel. */}
-        <button
-          type="button"
-          aria-label={t('showPages.details')}
-          aria-expanded={expanded}
-          onClick={() => onToggleExpand()}
-          className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.05] hover:text-foreground"
-        >
-          {expanded ? <ChevronUp size={18} className="text-foreground" /> : <ChevronDown size={18} />}
-        </button>
+          {/* Explicit expand affordance for the management panel. */}
+          <button
+            type="button"
+            aria-label={t('showPages.details')}
+            aria-expanded={expanded}
+            onClick={() => onToggleExpand()}
+            className="grid size-8 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.05] hover:text-foreground"
+          >
+            {expanded ? <ChevronUp size={18} className="text-foreground" /> : <ChevronDown size={18} />}
+          </button>
+        </div>
       </div>
 
       {expanded ? (


### PR DESCRIPTION
## Capability

Phase 2.4 (§7.1h) — four owner acceptance fixes on the merged §7.1f/g Show Page icon + Library work, in one PR.

### 1. AI badge — hard right anchor (`ui/src/apps/LibraryApp.tsx`, `ui/src/components/ShowPagesPage.tsx`, new `ui/src/apps/rowLayout.ts`)
The kind/status badge floated after variable-width content, so its x-position jumped row-to-row (toggle label width; whether 移出 shows). Each row's trailing action controls are now wrapped in a **fixed-width, right-justified zone** (`SHARED_ACTION_ZONE`, `sm:w-36`) used by BOTH the Apps view and the Show Pages view; the badge sits immediately left of it, so its **right-edge column is identical across every row and both views** regardless of button contents. Verify with very short and very long titles/buttons.

### 2. Title open icon → `arrow-up-right` (`ShowPagesPage.tsx`)
The ShowPage-row open affordance swapped `AppWindow` → lucide `ArrowUpRight` (↗), same hover affordance.

### 3. BUG — Dock AI-page tiles couldn't drag (`ui/src/apps/showPageAvatarTile.tsx`)
**Root cause (git-traced to #906):** #906 replaced the tile's plain letter `<span>` with `ShowPageAvatarContent`, which renders a favicon `<img>` for icon tiles. That `<img>` has default `pointer-events: auto`, so it **captured the pointerdown and framer-motion's `Reorder.Item` drag never initiated** — `draggable={false}` disables only native image DnD, not pointer capture. Letter tiles (bare text) were structurally unchanged and dragged fine, which is why built-ins and icon-less pages were unaffected. **Fix at the shared avatar:** `pointer-events-none select-none` on the decorative `<img>` so the press passes through to the tile/row (all surfaces sharing `ShowPageAvatarContent` — Dock, Library, search, window-title chip — inherit it). Both tile kinds still drag AND click-open discriminated (the `dragClick` guard is unchanged).

### 4. Icon coverage gap — agent pages ship no icon
- **(a) Conventional-file fallback** (`core/show_pages.py`): when `index.html` has no usable `<link rel=icon>`, `resolve_show_page_icon` falls back to workspace-conventional favicons **in order** — `favicon.{svg,ico,png}` at root, then `public/favicon.{svg,ico,png}` — via one shared `_resolve_icon_candidate` (same realpath/size/type policy as the link) read through the existing `_read_workspace_file_safely` chokepoint; `icon_version` covers them identically. An explicit `<link>` **wins**.
- **(b) Authoring guidance** — file: **`core/system_prompt_injection.py`** (the `## Show Pages` section injected into the agent system prompt). One line telling the agent to give the app an icon (drop `public/favicon.svg` — auto-picked up by 4a — or add a `<link rel=icon>` to `index.html`; the scaffold head comment already sanctions icon edits to the shell).

## Evidence
- **unit (pytest 252)**: 4a — each conventional fallback resolves+serves, root-before-public + svg>ico>png order, link-tag-wins, no-link-no-conventional→None; full `test_show_pages` + `test_ui_show_pages` green.
- **frontend**: `vitest` 249, `tsc -b && vite build` clean, `ruff` clean.
- **residual manual (owner Incus regression)**: badge column stable across short/long rows and across the Apps↔ShowPages tabs; ↗ icon on ShowPage rows; a pinned AI-page tile drags to reorder AND still click-opens; agent pages with a `public/favicon.svg` / `<link rel=icon>` show their icon in Dock/Library.

## Scope note
- No i18n copy changes. No backend API/contract change (icon endpoint unchanged; only the resolver's fallback source). Item 3 drag is a runtime pointer behavior (no jsdom in this vitest setup), so it is covered by the root-cause analysis + build and verified in Incus.
