### PR TITLE
fix(apps): Dock & window drag fixes — avatar filling child (§7.1h) + iframe pointer capture/shield (§7.1i)

### DIFF
--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -614,6 +614,33 @@ Four acceptance items from the merged §7.1f/g work, one PR.
      up by 4a — or add a `<link rel=icon>` to index.html; the scaffold head
      comment already sanctions icon edits to the shell).
 
+### 7.1i Window drag/resize over an iframe freezes (owner 2026-07-15)
+
+Windows whose body is an iframe (showpage windows) dragged jankily and FROZE
+mid-drag; built-in windows were fine. **Mechanism (adjudicated):** during a
+title-bar drag or 8-dir resize, once the pointer crosses over the iframe (or
+outruns the window), pointer events start targeting the IFRAME's document — the
+parent's gesture `pointermove`/`pointerup` handlers stop receiving them and the
+drag freezes. Two-part fix (both shipped in the "Dock & window drag fixes" PR
+alongside §7.1h item 3), in `AppWindow.tsx` + `WindowManagerContext.tsx`:
+
+1. **Pointer capture (primary).** `startGesture` calls `setPointerCapture` on the
+   gesture element (title bar / resize handle) at gesture start. The browser then
+   retargets ALL pointer events for that pointer to the capturing element — even
+   over iframes — so the existing `window`-level listeners keep firing (captured
+   events dispatch to the element and bubble to `window`). Cleanup is idempotent
+   and runs on BOTH `pointerup` AND `lostpointercapture` (releasing the capture),
+   so a missed/stolen release can't leave the gesture stuck.
+2. **Iframe shield (belt-and-braces).** A shared `gestureActive` flag on
+   `WindowManagerContext` is set for the duration of ANY window gesture; while set,
+   each window renders `WindowBodyGestureShield` — a transparent `absolute inset-0`
+   overlay (below the z-30 resize grips) over its body — so a stray pointer event
+   can't reach an iframe and the cursor can't flicker over it on edge cases
+   (capture unsupported/lost). `shouldShieldWindowBody(gestureActive, minimized)`
+   is a pure predicate (skips minimized windows); both it and the shield have
+   vitest DOM-structure coverage. The real gesture FEEL is verified by the owner
+   via CDP on the regression env post-merge (residual manual check).
+
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 
 Pinning **is** installing — no separate ceremony. Two entrances, one action:

--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -578,14 +578,26 @@ Four acceptance items from the merged §7.1f/g work, one PR.
    every row and both views regardless of button contents.
 2. **Title open icon → `arrow-up-right`.** The ShowPage-row open affordance
    swapped `AppWindow` → lucide `ArrowUpRight` (same hover affordance).
-3. **BUG: Dock AI-page tiles couldn't drag** (built-ins reordered fine). Root
-   cause (git-bisected to #906): the tile's favicon `<img>` — added by §7.1f —
-   has default `pointer-events: auto`, so it captured the pointerdown and
-   framer-motion's `Reorder.Item` drag never initiated (`draggable={false}`
-   disables only native image DnD, not pointer capture). Letter tiles (bare
-   text) were unaffected. Fix at the shared avatar: `pointer-events-none
-   select-none` on the decorative `<img>` so the press passes through to the
-   tile/row (every surface that shares `ShowPageAvatarContent` inherits it).
+3. **BUG: Dock AI-page tiles couldn't drag** (built-ins reordered fine).
+   **CORRECTED root cause (2026-07-15, proven by live CDP real-input on the
+   regression env — the earlier `<img>` pointer-events theory was WRONG and its
+   fix made things worse):** framer-motion `Reorder.Item` pan does NOT start when
+   the real press target is the interactive `<button>` itself; it starts only when
+   the press lands on a non-interactive CHILD. Evidence: (a) a builtin press hit-
+   tests to the `<svg>` child and drags; a pinned press hit-tests to the button
+   itself and never starts a drag (no move, no `onReorder`, no PUT); (b) the letter
+   rendered as a BARE TEXT NODE (`ShowPageAvatarContent` returned a string), so
+   there was no child to land on; (c) injecting an `<svg>` child into a pinned
+   tile's button made the same gesture work instantly (order changed + `PUT
+   /api/dock/order` 200). The §7.1h(#907) `pointer-events-none` on the `<img>` was
+   counter-productive — it pushed the press back onto the button, re-breaking drag
+   for icon tiles. **Fix (§7.1h follow-up):** in `ShowPageAvatarContent`, wrap the
+   letter in a FILLING `<span aria-hidden>` (never a bare text node) and REVERT the
+   `<img>` `pointer-events-none` (keep `draggable={false}` — that alone stops native
+   image DnD, #906's concern — + `select-none`). Invariant: the tile button must
+   never be the direct press target; the avatar content must be a filling child
+   element, with no `pointer-events-none` anywhere in the chain. Verified live by
+   the owner via the same CDP method post-merge (residual manual check).
 4. **Icon coverage gap** — agent-built pages ship no `<link rel=icon>`, so
    nothing showed.
    - **(a) Conventional-file fallback** (`core/show_pages.py`): when index.html

--- a/ui/src/apps/showPageAvatarTile.test.tsx
+++ b/ui/src/apps/showPageAvatarTile.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { ShowPageAvatarContent } from './showPageAvatarTile';
+
+// Guards the Dock-drag invariant (§7.1h item 3): a Dock tile is a framer-motion
+// Reorder.Item whose drag pan starts ONLY when the press lands on a non-interactive
+// CHILD, never on the interactive <button> itself. So the avatar content must render
+// as a FILLING child element (never a bare text node) and must NOT be
+// `pointer-events-none` (which would push the press back to the button).
+describe('ShowPageAvatarContent — Dock-drag press-target invariant', () => {
+  it('renders the letter as a filling wrapping element, not a bare text node', () => {
+    const html = renderToStaticMarkup(<ShowPageAvatarContent iconUrl={null} letter="S" />);
+    expect(html.startsWith('<span')).toBe(true); // a real element, not the bare string "S"
+    expect(html).toContain('>S</span>'); // the letter lives inside that element
+    expect(html).toContain('size-full'); // it FILLS the tile → any press lands on the child
+    expect(html).not.toContain('pointer-events-none');
+  });
+
+  it('renders the icon as a filling <img draggable="false"> with no pointer-events-none', () => {
+    const html = renderToStaticMarkup(
+      <ShowPageAvatarContent iconUrl="/api/show-pages/ses_1/icon?v=abc" letter="S" />,
+    );
+    expect(html).toContain('<img');
+    expect(html).toContain('draggable="false"'); // native image DnD stays disabled (#906)
+    expect(html).toContain('size-full'); // the img is the filling press target
+    // The #907 pointer-events-none is reverted: it pushed the press back to the
+    // button and re-broke drag for icon tiles.
+    expect(html).not.toContain('pointer-events-none');
+  });
+});

--- a/ui/src/apps/showPageAvatarTile.tsx
+++ b/ui/src/apps/showPageAvatarTile.tsx
@@ -22,6 +22,14 @@ import { showPageAvatar, showPageIconUrl } from './showPageAvatar';
 // bytes-or-404 race window, a network blip), exactly the case worth retrying. The
 // count is keyed to the URL, so a new versioned URL retries with a fresh budget.
 const MAX_ICON_LOAD_ATTEMPTS = 3;
+// INVARIANT (proven by live CDP real-input on the regression env, §7.1h item 3): in
+// the Dock a tile is a framer-motion Reorder.Item, and its drag pan does NOT start
+// when the real press target is the interactive <button> itself — only when the press
+// lands on a non-interactive CHILD element. So the tile button must never be the
+// direct press target: the avatar content MUST render as a FILLING child element —
+// never a bare text node, and never `pointer-events-none` (which pushes the press
+// back through to the button and re-breaks drag). Built-in tiles already render an
+// <svg> child; here both the icon <img> and the letter fill the tile as real children.
 export const ShowPageAvatarContent: React.FC<{ iconUrl: string | null; letter: string }> = ({ iconUrl, letter }) => {
   const [failure, setFailure] = useState<{ url: string; attempts: number } | null>(null);
   const attempts = failure && failure.url === iconUrl ? failure.attempts : 0;
@@ -31,20 +39,22 @@ export const ShowPageAvatarContent: React.FC<{ iconUrl: string | null; letter: s
         key={`${iconUrl}#${attempts}`}
         src={iconUrl}
         alt=""
+        // `draggable={false}` disables native image DnD (#906's real concern). NO
+        // `pointer-events-none`: the filling <img> must itself BE the press target,
+        // or the Dock Reorder pan can't start (see invariant above).
         draggable={false}
-        // Decorative: `pointer-events-none` lets a press pass THROUGH to the tile
-        // behind it. In the Dock a tile is a framer-motion Reorder.Item; without
-        // this the `<img>` captures the pointerdown and the drag never initiates
-        // (`draggable={false}` only disables native image DnD, not pointer capture),
-        // so AI-page tiles with an icon couldn't be reordered (§7.1h item 3). All
-        // interaction (click-open, drag) belongs to the parent tile/row, so this is
-        // safe on every surface sharing this avatar (Dock, Library, search, chip).
-        className="pointer-events-none size-full select-none object-cover"
+        className="size-full select-none object-cover"
         onError={() => setFailure({ url: iconUrl, attempts: attempts + 1 })}
       />
     );
   }
-  return <>{letter}</>;
+  // A FILLING element, never a bare text node: a raw string leaves the <button>
+  // itself as the press target and the Dock drag won't start (see invariant above).
+  return (
+    <span aria-hidden className="grid size-full place-items-center select-none">
+      {letter}
+    </span>
+  );
 };
 
 // The avatar tile for a Show Page: an accent-tinted rounded box (first grapheme

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -10,6 +10,7 @@ import { ShowPageAvatarContent } from '../../apps/showPageAvatarTile';
 import { useWindowManager, type WindowInstance } from '../../context/WindowManagerContext';
 import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesActionGuard';
 import { clampToLayer, resizeBounds, type ResizeDir } from '../../lib/windowBounds';
+import { WindowBodyGestureShield, shouldShieldWindowBody } from './windowGesture';
 import { ErrorBoundary } from '../ui/error-boundary';
 
 const RESIZE_HANDLES: { dir: ResizeDir; className: string }[] = [
@@ -77,9 +78,17 @@ export const AppWindow: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wm.focusedId, win.minimized]);
 
-  // One pointer gesture (move or resize): attach window-level listeners on down,
-  // tear them down on up. Capturing `win.bounds` at gesture start keeps the math
-  // stable even as state updates re-render mid-drag.
+  // One pointer gesture (move or resize). Capturing `win.bounds` at gesture start
+  // keeps the math stable even as state updates re-render mid-drag.
+  //
+  // §7.1i: the gesture element captures the pointer (setPointerCapture) so the browser
+  // retargets ALL subsequent pointer events to it — even when the pointer crosses (or
+  // outruns the window into) a showpage window's IFRAME. Without capture the iframe's
+  // document steals the moves and the drag/resize FREEZES. Window-level listeners still
+  // fire because captured events dispatch to the element and bubble to `window`. We also
+  // arm a global shield flag (per-window iframe overlays, belt-and-braces + no cursor
+  // flicker). Cleanup is idempotent + runs on BOTH pointerup and lostpointercapture, so
+  // a missed/stolen release can never leave the shield or listeners stuck.
   const startGesture = (e: React.PointerEvent, kind: 'move' | ResizeDir) => {
     if (win.maximized) return;
     e.preventDefault();
@@ -90,6 +99,15 @@ export const AppWindow: React.FC<{
     rootRef.current?.focus({ preventScroll: true });
     draggingRef.current = true;
     setDragging(true);
+    const el = e.currentTarget;
+    const pointerId = e.pointerId;
+    try {
+      el.setPointerCapture(pointerId);
+    } catch {
+      // Rare: the pointer is already gone. The window listeners below still drive
+      // the gesture as a fallback.
+    }
+    wm.setGestureActive(true);
     const startX = e.clientX;
     const startY = e.clientY;
     const start = { ...win.bounds };
@@ -104,14 +122,25 @@ export const AppWindow: React.FC<{
         wm.setBounds(win.id, clampToLayer(resizeBounds(start, kind, dx, dy), layerWidth, layerHeight));
       }
     };
-    const onUp = () => {
+    let ended = false;
+    const end = () => {
+      if (ended) return; // idempotent: pointerup AND lostpointercapture both call this
+      ended = true;
       draggingRef.current = false;
       setDragging(false);
+      wm.setGestureActive(false);
       window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointerup', end);
+      el.removeEventListener('lostpointercapture', end);
+      try {
+        el.releasePointerCapture(pointerId);
+      } catch {
+        // Already released (pointerup releases implicitly) — fine.
+      }
     };
     window.addEventListener('pointermove', onMove);
-    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointerup', end);
+    el.addEventListener('lostpointercapture', end);
   };
 
   const Body = def.Component;
@@ -307,12 +336,16 @@ export const AppWindow: React.FC<{
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
         {/* A crashing app only takes down its own window — the shell + other windows stay usable, and
             "Retry" remounts just this app. */}
         <ErrorBoundary variant="inline">
           <Body windowId={win.id} params={win.params} />
         </ErrorBoundary>
+        {/* §7.1i: while ANY window is mid drag/resize, cover this body (its iframe) with a
+            transparent overlay so a gesture's pointer can't be stolen by the iframe and the
+            cursor doesn't flicker over it — belt-and-braces with the gesture's pointer capture. */}
+        <WindowBodyGestureShield active={shouldShieldWindowBody(wm.gestureActive, win.minimized)} />
       </div>
 
       {!win.maximized &&

--- a/ui/src/components/apps/windowGesture.test.tsx
+++ b/ui/src/components/apps/windowGesture.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { WindowBodyGestureShield, shouldShieldWindowBody } from './windowGesture';
+
+describe('shouldShieldWindowBody (§7.1i arm/disarm predicate)', () => {
+  it('shields only a visible window while a gesture is active', () => {
+    expect(shouldShieldWindowBody(true, false)).toBe(true); // gesture + visible → shield
+    expect(shouldShieldWindowBody(true, true)).toBe(false); // minimized → no body to shield
+    expect(shouldShieldWindowBody(false, false)).toBe(false); // no gesture → no shield
+    expect(shouldShieldWindowBody(false, true)).toBe(false);
+  });
+});
+
+describe('WindowBodyGestureShield', () => {
+  it('renders a filling transparent overlay when active', () => {
+    const html = renderToStaticMarkup(<WindowBodyGestureShield active />);
+    expect(html).toContain('data-gesture-shield');
+    expect(html).toContain('absolute');
+    expect(html).toContain('inset-0');
+    // It must CATCH stray pointer events (shield the iframe), so NOT pointer-events-none.
+    expect(html).not.toContain('pointer-events-none');
+  });
+
+  it('renders nothing when inactive', () => {
+    expect(renderToStaticMarkup(<WindowBodyGestureShield active={false} />)).toBe('');
+  });
+});

--- a/ui/src/components/apps/windowGesture.tsx
+++ b/ui/src/components/apps/windowGesture.tsx
@@ -1,0 +1,21 @@
+// Window drag/resize gesture helpers (§7.1i). An in-window iframe (a showpage
+// window body) steals pointer events once a title-bar/resize gesture drags over it —
+// the parent's move handlers stop firing and the drag freezes. The primary fix is
+// pointer capture on the gesture element (AppWindow.startGesture); this module is the
+// belt-and-braces shield: a transparent overlay over each window body while ANY
+// window is mid-gesture, so a stray pointer event can't reach an iframe and the
+// cursor can't flicker over it.
+
+/** Whether a window should shield its body while a gesture is active. Only visible
+ *  windows have a body to shield — a minimized window is hidden, so skip it. Pure. */
+export function shouldShieldWindowBody(gestureActive: boolean, minimized: boolean): boolean {
+  return gestureActive && !minimized;
+}
+
+/** A transparent, non-iframe overlay filling the window body during a drag/resize.
+ *  Any pointer event over the body lands here (a plain div, no handlers) instead of
+ *  the iframe document, and the iframe's cursor can't show through. Sits below the
+ *  z-30 resize grips and the title bar, so those stay grabbable. Renders nothing when
+ *  inactive. */
+export const WindowBodyGestureShield: React.FC<{ active: boolean }> = ({ active }) =>
+  active ? <div aria-hidden data-gesture-shield className="absolute inset-0 z-20" /> : null;

--- a/ui/src/context/WindowManagerContext.tsx
+++ b/ui/src/context/WindowManagerContext.tsx
@@ -77,6 +77,14 @@ export interface WindowManagerValue {
   markClosing: (id: string) => void;
   /** Run a window's close guard (confirm if it has a message); true = may close. */
   confirmClose: (id: string) => boolean;
+  /**
+   * True while ANY window is mid drag/resize gesture. Windows shield their body
+   * (iframe) with a transparent overlay while it's set, so a gesture whose pointer
+   * crosses an iframe can't have its events stolen by the iframe document (§7.1i).
+   * Set true at gesture start, false on gesture end (unconditional cleanup).
+   */
+  gestureActive: boolean;
+  setGestureActive: (active: boolean) => void;
 }
 
 const WindowManagerContext = createContext<WindowManagerValue | null>(null);
@@ -336,6 +344,10 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
     return visible.reduce((top, w) => (w.z > top.z ? w : top)).id;
   }, [windows]);
 
+  // True while ANY window is mid drag/resize. A transient shared flag (not persisted)
+  // that arms the per-window iframe shield during a gesture (§7.1i).
+  const [gestureActive, setGestureActive] = useState(false);
+
   const value = useMemo<WindowManagerValue>(
     () => ({
       windows,
@@ -353,8 +365,10 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
       setStateProvider,
       markClosing,
       confirmClose,
+      gestureActive,
+      setGestureActive,
     }),
-    [windows, focusedId, openApp, close, focus, minimize, restore, toggleMaximize, setBounds, setTitle, setParams, setCloseGuard, setStateProvider, markClosing, confirmClose],
+    [windows, focusedId, openApp, close, focus, minimize, restore, toggleMaximize, setBounds, setTitle, setParams, setCloseGuard, setStateProvider, markClosing, confirmClose, gestureActive],
   );
 
   return <WindowManagerContext.Provider value={value}>{children}</WindowManagerContext.Provider>;


### PR DESCRIPTION
## Capability

Fixes the Dock pinned-tile drag bug at its **proven** root cause (§7.1h item 3 follow-up). The earlier two attempts (the `isDragRelease` guard, then `pointer-events-none` on the favicon `<img>`) did **not** address it — the `<img>` theory was wrong, and `pointer-events-none` actively made icon tiles worse.

## Root cause (proven by live CDP real-input on the regression env)

**Invariant:** framer-motion `Reorder.Item` pan does NOT start when the real-input press target is the interactive `<button>` itself; it starts only when the press lands on a **non-interactive CHILD** element.

Experiment (PM-run, CDP real input):
1. Builtin tiles drag fine; pinned tiles NEVER start a drag — no visual move, no `onReorder`, no `PUT /api/dock/order` — reproduced across positions/directions.
2. Hit-test: a builtin press lands on the `<svg>` CHILD; a pinned press lands on the `<button>` ITSELF — because the letter rendered as a **bare text node** (`ShowPageAvatarContent` returned a string).
3. Controlled experiment: injecting an inline `<svg>` child into a pinned tile's button (replacing the text node) made the SAME gesture work instantly — order changed AND `PUT /api/dock/order` fired (200).

So the Dock tile's avatar content must always render as a **filling child element**.

## Fix (`ui/src/apps/showPageAvatarTile.tsx`)

- **Letter** → wrapped in a filling `<span aria-hidden className="grid size-full place-items-center select-none">` (never a bare text node).
- **Icon `<img>`** → REVERT the #907 `pointer-events-none` (it pushed the press back onto the button, re-breaking drag). Keep `draggable={false}` (that alone stops native image DnD — #906's real concern) + `select-none`.
- No `pointer-events-none` anywhere in the avatar chain.
- Invariant stated in a code comment: *"the tile button must never be the direct press target — framer Reorder pan will not start; avatar content must be a filling child element."*

Shared component, so every surface (Dock, Library rows, ⌘K search, window-title chip) inherits it; the fix is scoped to the avatar only.

## Evidence
- **unit (vitest 251)**: new `showPageAvatarTile.test.tsx` uses `renderToStaticMarkup` for DOM-structure assertions — the letter renders a filling wrapping element (not a bare string), the icon keeps `draggable="false"`, and neither has `pointer-events-none`.
- `tsc -b && vite build` clean.
- **residual manual (owner)**: the drag GESTURE itself will be verified by the owner post-merge with the same CDP real-input method on the regression env (framer pan behavior is not reproducible in the jsdom-less vitest setup).

## Scope
Only `ui/src/apps/showPageAvatarTile.tsx` (+ test) and the `docs/plans` §7.1h item 3 spec correction. No i18n, no other files.


---

## Added in this PR — §7.1i: window drag/resize over an iframe freezes

**Bug:** windows whose body is an iframe (showpage windows) drag jankily and FREEZE mid-drag; built-in windows are fine.

**Mechanism (owner-adjudicated):** during a title-bar drag / 8-dir resize, once the pointer crosses over the iframe (or outruns the window), pointer events start targeting the IFRAME's document — the parent's `pointermove`/`pointerup` handlers stop firing → freeze.

**Two-part fix** (`AppWindow.tsx` + `WindowManagerContext.tsx` + new `windowGesture.tsx`):
1. **Pointer capture (primary):** `startGesture` calls `setPointerCapture` on the gesture element; the browser retargets all pointer events to it even over iframes, so the window-level listeners keep firing (captured events bubble to `window`). Cleanup is idempotent + runs on BOTH `pointerup` AND `lostpointercapture` (releasing capture) — a missed release can't leave the gesture/shield stuck.
2. **Iframe shield (belt-and-braces):** a shared `gestureActive` flag on `WindowManagerContext` is set for the duration of ANY window gesture; while set, each window renders `WindowBodyGestureShield` — a transparent `absolute inset-0` overlay (below the z-30 resize grips) over its body — so a stray pointer event can't reach an iframe and the cursor can't flicker on edge cases. `shouldShieldWindowBody(gestureActive, minimized)` is a pure predicate (skips minimized windows).

**Evidence:** vitest 254 — `shouldShieldWindowBody` predicate + `WindowBodyGestureShield` DOM assertions (`renderToStaticMarkup`); build clean. The gesture FEEL (drag/resize over an iframe no longer freezes) is verified by the owner via CDP on the regression env post-merge (residual manual check).

This ships together with the §7.1h item-3 avatar fix as **"Dock & window drag fixes"**.
