### PR TITLE
fix(chat): soften background activity status

### DIFF
--- a/ui/src/components/visual/StatusPill.tsx
+++ b/ui/src/components/visual/StatusPill.tsx
@@ -5,7 +5,8 @@ type Tone = 'running' | 'stopped' | 'warning' | 'idle';
 
 interface StatusPillProps extends React.HTMLAttributes<HTMLSpanElement> {
   tone?: Tone;
-  label: string;
+  label: React.ReactNode;
+  indicator?: React.ReactNode;
 }
 
 const TONE_CLASSES: Record<Tone, { wrapper: string; dot: string }> = {
@@ -15,7 +16,7 @@ const TONE_CLASSES: Record<Tone, { wrapper: string; dot: string }> = {
   idle: { wrapper: 'border-border bg-surface text-muted', dot: 'bg-muted' },
 };
 
-export const StatusPill: React.FC<StatusPillProps> = ({ tone = 'idle', label, className, ...props }) => {
+export const StatusPill: React.FC<StatusPillProps> = ({ tone = 'idle', label, indicator, className, ...props }) => {
   const tones = TONE_CLASSES[tone];
   return (
     <span
@@ -26,7 +27,7 @@ export const StatusPill: React.FC<StatusPillProps> = ({ tone = 'idle', label, cl
       )}
       {...props}
     >
-      <span className={cn('h-2 w-2 rounded-full', tones.dot)} />
+      {indicator ?? <span className={cn('h-2 w-2 rounded-full', tones.dot)} />}
       {label}
     </span>
   );

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -31,6 +31,7 @@ import { FileViewerProvider } from '../ui/file-viewer';
 import { Input } from '../ui/input';
 import { Markdown } from '../ui/markdown';
 import { VaultApprovalFloat, VaultChatRequests } from '../ui/vault-chat-requests';
+import { StatusPill } from '../visual';
 import { usePendingVaultRequests } from '../../lib/usePendingVaultRequests';
 import { Composer, type ComposerAttachment, type ComposerHandle, type ComposerProps } from './Composer';
 import type { MentionReference } from '../../lib/mentions';
@@ -1636,20 +1637,36 @@ const ActivityStrip: React.FC<{ state: SessionRuntimeState }> = ({ state }) => {
     active.length > 0 &&
     (state.connection === 'reconnecting' || state.connection === 'disconnected');
   return (
-    <div className="shrink-0 border-t border-border/70 bg-surface-2/60 px-4 py-1.5 md:px-8">
-      <div className="mx-auto flex min-h-7 w-full max-w-[1080px] items-center gap-2 text-[11px] text-muted">
-        <Activity className="size-3.5 shrink-0 text-mint" aria-hidden="true" />
-        <span className="min-w-0 truncate" title={firstDescription ?? undefined}>
-          {active.length > 0
-            ? t('chat.activities.running', { count: active.length })
-            : t('chat.activities.delivering', { count: pendingOutputs })}
-          {firstDescription ? ` · ${firstDescription}` : ''}
-        </span>
-        {connectionVisible ? (
-          <span className="ml-auto shrink-0 text-gold">
-            {t(`chat.activities.connection.${state.connection}`)}
-          </span>
-        ) : null}
+    <div className="shrink-0 px-4 pt-2 md:px-8">
+      <div className="mx-auto flex w-full max-w-[1080px]">
+        <StatusPill
+          tone="running"
+          role="status"
+          aria-live="polite"
+          className="min-h-7 min-w-0 max-w-full gap-2 px-3 py-1 text-[11px] font-normal shadow-sm shadow-mint/5"
+          indicator={
+            active.length > 0 ? (
+              <Activity className="size-3.5 shrink-0 text-mint" aria-hidden="true" />
+            ) : (
+              <Loader2 className="size-3.5 shrink-0 animate-spin text-mint" aria-hidden="true" />
+            )
+          }
+          label={
+            <>
+              <span className="min-w-0 truncate text-muted" title={firstDescription ?? undefined}>
+                {active.length > 0
+                  ? t('chat.activities.running', { count: active.length })
+                  : t('chat.activities.delivering', { count: pendingOutputs })}
+                {firstDescription ? ` · ${firstDescription}` : ''}
+              </span>
+              {connectionVisible ? (
+                <span className="shrink-0 border-l border-border-strong pl-2 text-gold">
+                  {t(`chat.activities.connection.${state.connection}`)}
+                </span>
+              ) : null}
+            </>
+          }
+        />
       </div>
     </div>
   );

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1637,7 +1637,7 @@ const ActivityStrip: React.FC<{ state: SessionRuntimeState }> = ({ state }) => {
     active.length > 0 &&
     (state.connection === 'reconnecting' || state.connection === 'disconnected');
   return (
-    <div className="shrink-0 px-4 pt-2 md:px-8">
+    <div className="shrink-0 px-4 py-2 md:px-8">
       <div className="mx-auto flex w-full max-w-[1080px]">
         <StatusPill
           tone="running"


### PR DESCRIPTION
## Capability

Refines the Workbench Chat background-activity status so it reads as a compact, contextual state instead of a full-width system banner.

## What changed

- Reuses the shared `StatusPill` visual primitive for background activity and output delivery.
- Removes the full-width surface fill and divider from the activity row.
- Uses an activity icon while work is running and a spinner while completed output is being delivered.
- Keeps long activity descriptions truncatable and connection warnings visible within the compact pill.

## Scenario impact

- Scenario IDs: none. The scenario catalog has no matching visual-only Workbench status scenario, and the Activity lifecycle/turn-state contract is unchanged.

## Evidence

- Unit: no behavior logic changed; the shared primitive passes focused ESLint.
- Contract: unchanged (`SessionRuntimeState` and `/turn-state` payload are untouched).
- Scenario: rendered against a live session reporting `pending_activity_output_count: 1` at 1416x708 and 390x844; the status remained compact with no horizontal overflow. Dark theme was also rendered and inspected.
- Build: `npm run build` passed.
- Theme: `npm run validate:theme` passed.
- Residual manual checks: none for this visual-only change.

## Notes

The repository-wide ESLint command still reports the existing baseline backlog; the changed reusable primitive passes focused lint, and the full TypeScript/Vite build is green.
